### PR TITLE
Add Teleport 1.2.2

### DIFF
--- a/Casks/abyssoft-teleport.rb
+++ b/Casks/abyssoft-teleport.rb
@@ -12,9 +12,6 @@ cask "abyssoft-teleport" do
 
   zap trash: [
     "~/Library/Caches/com.abyssoft.teleport",
-    "~/Library/Caches/com.abyssoft.teleport/Cache.db-shm",
-    "~/Library/Caches/com.abyssoft.teleport/Cache.db-wal",
-    "~/Library/Caches/com.abyssoft.teleport/Cache.db"
     "~/Library/Preferences/com.abyssoft.teleport.plist",
   ]
 end

--- a/Casks/abyssoft-teleport.rb
+++ b/Casks/abyssoft-teleport.rb
@@ -1,0 +1,20 @@
+cask "abyssoft-teleport" do
+  version "1.2.2"
+  sha256 "b087e5309ae64a51fb8d1f0ded2a2795dee9d77134022df05bb48da413c3968a"
+
+  url "https://github.com/abyssoft/teleport/releases/download/v#{version}/teleport-v#{version}.zip"
+  appcast "https://github.com/abyssoft/teleport/releases.atom"
+  name "teleport"
+  desc "Virtual KVM"
+  homepage "https://github.com/abyssoft/teleport"
+
+  app "teleport.app"
+
+  zap trash: [
+    "~/Library/Caches/com.abyssoft.teleport",
+    "~/Library/Caches/com.abyssoft.teleport/Cache.db-shm",
+    "~/Library/Caches/com.abyssoft.teleport/Cache.db-wal",
+    "~/Library/Caches/com.abyssoft.teleport/Cache.db"
+    "~/Library/Preferences/com.abyssoft.teleport.plist",
+  ]
+end


### PR DESCRIPTION
This adds the cask `abyssoft-teleport` which previously existed as `teleport` (renamed to not conflict with the brew package `teleport`) and was removed in https://github.com/Homebrew/homebrew-cask/pull/39558 because the homepage was inactive. The application has since been re-released as open source at https://github.com/abyssoft/teleport.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
