### PR TITLE
Zoomus: Allow Homebrew to update

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -9,7 +9,6 @@ cask "zoomus" do
   desc "Video communication and virtual meeting platform"
   homepage "https://www.zoom.us/"
 
-  auto_updates true
   conflicts_with cask: "zoom-for-it-admins"
 
   pkg "Zoom.pkg"


### PR DESCRIPTION
To say that Zoom auto-updates is a bit of a stretch: it has a menu option that checks for updates, downloads a new installer, and runs it, requiring extensive user intervention. It would be far quicker to have Homebrew update it.

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
