### PR TITLE
Update ableton-live-standard from 10.1.25 to 10.1.30

### DIFF
--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-standard" do
-  version "10.1.25"
-  sha256 "03a4786cdb16a9d01d4e8701f1bba20d32a4b761b2bdaf1399ea54ffa7cbce3a"
+  version "10.1.30"
+  sha256 "736b80d967db98dda5c4a897157f0e96c6d23a9879cae0348e13cab789016a37"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).