### PR TITLE
Update adguard from 2.5.1.916 to 2.5.1.928

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -1,6 +1,6 @@
 cask "adguard" do
-  version "2.5.1.918"
-  sha256 "2b6d81a44803e0cd517bbaa6b16ce0d33d5618868a2dcbbb6661304ef8c90f17"
+  version "2.5.1.928"
+  sha256 "8b7749dcd1146e99f47a501b18804730aad47954f859796f7a701c8185eb119a"
 
   url "https://static.adguard.com/mac/release/AdGuard-#{version}.dmg"
   appcast "https://static.adguard.com/mac/adguard-release-appcast.xml"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
