### PR TITLE
Update onlyoffice from 6.0.0 to 6.0.2

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,6 +1,6 @@
 cask "onlyoffice" do
-  version "6.0.0"
-  sha256 "d82c5623e814a3df939fa039945b76b38af35bdf0ce06f6da85cb94891a8e3f2"
+  version "6.0.2"
+  sha256 "1305a226cb4fea5e1a3ff84e8846caf3d3d220788dd4a5c46a7b28a6e2441f74"
 
   # github.com/ONLYOFFICE/DesktopEditors/ was verified as official when first introduced to the cask
   url "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-#{version}/ONLYOFFICE.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).