### PR TITLE
Update dmm-player from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/dmm-player.rb
+++ b/Casks/dmm-player.rb
@@ -1,6 +1,6 @@
 cask "dmm-player" do
-  version "2.1.1"
-  sha256 "a1ddedd5dc85cb89d46f35ad6a13c21ba3c1c4bd426566a444acd316cafe0f68"
+  version "2.1.2"
+  sha256 "001f0f27895032ddd8e1449823f088cffdbea73b82c6931d5750052affbc35d8"
 
   url "https://portalapp.dmm.com/dmmplayerv#{version.major}/dmm/#{version.dots_to_underscores}/DMMPlayerV#{version.major}Installer_#{version.dots_to_underscores}.pkg"
   name "DMM Player"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).