### PR TITLE
Update syncthing from 1.10.0-1 to 1.11.1-1

### DIFF
--- a/Casks/syncthing.rb
+++ b/Casks/syncthing.rb
@@ -1,6 +1,6 @@
 cask "syncthing" do
-  version "1.10.0-1"
-  sha256 "071b727eb30338b5b6b2687d2733a95a3bdaaa152f928217cdc56e3bb641651c"
+  version "1.11.1-1"
+  sha256 "6d5d0d7f2c91eeff5ee5508d2084a6fbf4e4aeca995dddbefe8f9273c057d525"
 
   # github.com/syncthing/syncthing-macos/ was verified as official when first introduced to the cask
   url "https://github.com/syncthing/syncthing-macos/releases/download/v#{version}/Syncthing-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).