### PR TITLE
firefox.rb: remove cross-platform from desc

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -110,7 +110,7 @@ cask "firefox" do
   url "https://download-installer.cdn.mozilla.net/pub/firefox/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg"
   appcast "https://www.macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://download.mozilla.org/%3Fproduct=firefox-latest-ssl%26os=osx"
   name "Mozilla Firefox"
-  desc "Cross-platform web browser"
+  desc "Web browser"
   homepage "https://www.mozilla.org/firefox/"
 
   auto_updates true


### PR DESCRIPTION
It’s irrelevant what platforms it runs on; we only support one.