### PR TITLE
Bump zerotier-one to 1.6.0

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -1,10 +1,11 @@
 cask "zerotier-one" do
-  version "1.4.6"
-  sha256 "7adfa8a149e20b8649fff805f3af7b2f37b981219b31f7375c2cc3452f9f30a7"
+  version "1.6.0"
+  sha256 "8dd5377f3105f4a443b71ace3421c88c5b448227b4e69eff5d910d8da3ebc6f5"
 
   url "https://download.zerotier.com/dist/ZeroTier%20One.pkg"
   appcast "https://github.com/zerotier/ZeroTierOne/releases.atom"
   name "ZeroTier One"
+  desc "Mesh VPN client"
   homepage "https://www.zerotier.com/download.shtml"
 
   pkg "ZeroTier One.pkg"


### PR DESCRIPTION
Upstream release notes: https://github.com/zerotier/ZeroTierOne/blob/565bef05afd7bf8fd8bf80d7bc0dace9bd2b67f0/RELEASE-NOTES.md

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
