### PR TITLE
Update beekeeper-studio from 1.8.10 to 1.8.11

### DIFF
--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,6 +1,6 @@
 cask "beekeeper-studio" do
-  version "1.8.10"
-  sha256 "c7e5ecb06044e5e1f2430241af255a8cf6a05b67368c6782a5158db8e5dc5db9"
+  version "1.8.11"
+  sha256 "b893ac504b634647a58d4fea7b16c7fabcb9ac7c944a3e8ec0314e2d1596896d"
 
   # github.com/beekeeper-studio/beekeeper-studio/ was verified as official when first introduced to the cask
   url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).