### PR TITLE
Switch google-chrome to Universal App build

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,8 +1,8 @@
 cask "google-chrome" do
   version "87.0.4280.67"
-  sha256 "d768f823e56b0dde4e68fd785db0c535ceb9fb1b4d5a5e9bf673e5b4a59e8ea4"
+  sha256 "c3e771740a0e9398d188b9cf9c7806f61a7d5775b056abec8f608a3561d4cf35"
 
-  url "https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"
+  url "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
   appcast "https://omahaproxy.appspot.com/history?os=mac;channel=stable"
   name "Google Chrome"
   desc "Web browser"


### PR DESCRIPTION
I've tested & confirmed this DMG installs & runs on both Apple Silicon Big Sur & Intel Catalina. Should probably confirm Yosemite can run Universal Apps. If not, update `depends_on macos:` to `">= catalina"`.

Also wasn't sure if `appcast` should be updated to `https://omahaproxy.appspot.com/history?os=mac_arm64;channel=stable` to show only Apple Silicon-compatible build history. Left as-is for now.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download google-chrome` is error-free.
- [x] `brew cask style --fix google-chrome` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
