### PR TITLE
update metasploit to 6.0.18,20201122112901

### DIFF
--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -1,6 +1,6 @@
 cask "metasploit" do
-  version "6.0.17,20201113112909"
-  sha256 "7245d3454bcbc30835d128acc9b850ddd2229dc164bf8d3325afa0baebc9a963"
+  version "6.0.18,20201122112901"
+  sha256 "2fa0c208fc729d90f744475c8732bcce3eaa59b2d6b2e8ef601f4ecf9bb98460"
 
   url "https://osx.metasploit.com/metasploit-framework-#{version.before_comma}%2B#{version.after_comma}-1rapid7-1.pkg"
   appcast "https://osx.metasploit.com/LATEST"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).