### PR TITLE
Update tower from 6.0,256:90c50e48 to 6.1,258:9c97138e

### DIFF
--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -1,6 +1,6 @@
 cask "tower" do
-  version "6.0,256:90c50e48"
-  sha256 "492da21c4f46e95b68bc768bda1fcd01ba00ea9ccd604680cb333b2d000346ba"
+  version "6.1,258:9c97138e"
+  sha256 "55e9e9ecab7f9315dc0b367ddb61e444ed88eb20f0f133de0d2c0b13e5b848ad"
 
   # fournova-app-updates.s3.amazonaws.com/ was verified as official when first introduced to the cask
   url "https://fournova-app-updates.s3.amazonaws.com/apps/tower3-mac/#{version.after_comma.before_colon}-#{version.after_colon}/Tower-#{version.before_comma}-#{version.after_comma.before_colon}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).