### PR TITLE
Added autoupdate to Unity Hub

### DIFF
--- a/Casks/unity-hub.rb
+++ b/Casks/unity-hub.rb
@@ -8,6 +8,8 @@ cask "unity-hub" do
   desc "Management tool for Unity"
   homepage "https://unity3d.com/get-unity/download"
 
+  auto_updates true
+
   app "Unity Hub.app"
 
   uninstall quit: "com.unity3d.unityhub"


### PR DESCRIPTION
Unity Hub has an auto update functionality.

As it updates itself it is not necessary to update the installation with Homebrew. This commit set auto_update to true.

---

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
