### PR TITLE
Revert "Update linphone from 4.2.3 to 4.2.4"

### DIFF
--- a/Casks/linphone.rb
+++ b/Casks/linphone.rb
@@ -1,6 +1,6 @@
 cask "linphone" do
-  version "4.2.4"
-  sha256 "8b4bc64b6986e9c435b5f3f3256ebfdb3496a15bbec3eac60da8842801af69ef"
+  version "4.2.3"
+  sha256 "0e6d219262062d87fdceafcc085a339682c07c1e2cf3f4747148ad4fd57ca39e"
 
   url "https://www.linphone.org/releases/macosx/app/Linphone-#{version}-mac.dmg"
   appcast "https://www.linphone.org/releases/macosx/RELEASE"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#93300

Release has been pulled.

Closes https://github.com/Homebrew/homebrew-cask/issues/93379.