### PR TITLE
Add ReverseImageSearch.app v1.3

### DIFF
--- a/Casks/reverse-image-search-safari.rb
+++ b/Casks/reverse-image-search-safari.rb
@@ -1,0 +1,19 @@
+cask "reverse-image-search-safari" do
+  version "1.3"
+  sha256 "82eb9178544f2c7299cc2870dd7c146bd00d2916837f69bad154b6dc3a08a835"
+
+  url "https://github.com/yimingliu/reverse-image-search-safari/releases/download/#{version}/ReverseImageSearch.app.zip"
+  appcast "https://github.com/yimingliu/reverse-image-search-safari/releases.atom"
+  name "Reverse Image Search"
+  desc "Allows reverse image searches directly from a web page"
+  homepage "https://github.com/yimingliu/reverse-image-search-safari"
+
+  app "ReverseImageSearch.app"
+
+  zap delete: [
+    "~/Library/Application Scripts/com.yimingliu.ReverseImageSearch",
+    "~/Library/Application Scripts/com.yimingliu.ReverseImageSearchExt",
+    "~/Library/Containers/com.yimingliu.ReverseImageSearch",
+    "~/Library/Containers/com.yimingliu.ReverseImageSearchExt",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
-----
- Named the cask differently based on `refined-github-safari.rb` and the fact the .app name differs from the name used in the repository.
- Failed audit due to lower than desired statistics although no similar software available through core/cask. Other popular alternatives such as [Backtrack](https://sidetree.com/backtrack.html) are no longer supported.
- /cc https://github.com/yimingliu/reverse-image-search-safari/issues/18