### PR TITLE
zoomus.rb: add comment on auto_updates

### DIFF
--- a/Casks/zoom-for-it-admins.rb
+++ b/Casks/zoom-for-it-admins.rb
@@ -9,6 +9,9 @@ cask "zoom-for-it-admins" do
   desc "Video communication and virtual meeting platform"
   homepage "https://support.zoom.us/hc/en-us/articles/115001799006-Mass-Deployment-with-Preconfigured-Settings-for-Mac"
 
+  # Do not add `auto_updates`. While supporting an auto-update mechanism, this software is more inconvenient than most
+  # See https://github.com/Homebrew/homebrew-cask/pull/93083
+
   conflicts_with cask: "zoomus"
 
   pkg "ZoomInstallerIT.pkg"

--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -9,6 +9,9 @@ cask "zoomus" do
   desc "Video communication and virtual meeting platform"
   homepage "https://www.zoom.us/"
 
+  # Do not add `auto_updates`. While supporting an auto-update mechanism, this software is more inconvenient than most
+  # See https://github.com/Homebrew/homebrew-cask/pull/93083
+
   conflicts_with cask: "zoom-for-it-admins"
 
   pkg "Zoom.pkg"


### PR DESCRIPTION
The alternative to this comment is to readd `auto_updates`.

From https://github.com/Homebrew/homebrew-cask/pull/93083:

> To say that Zoom auto-updates is a bit of a stretch: it has a menu option that checks for updates, downloads a new installer, and runs it, requiring extensive user intervention. It would be far quicker to have Homebrew update it.

Some discussion going on at https://github.com/Homebrew/homebrew-cask/pull/93121.