### PR TITLE
Update gpg-suite to 2020.2

### DIFF
--- a/Casks/gpg-suite.rb
+++ b/Casks/gpg-suite.rb
@@ -3,7 +3,7 @@ cask "gpg-suite" do
   sha256 "e2ede6b317d53d1e321342a6f7dd5ab6b123a4900aa8f1eab89b29051a2a4742"
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
-  appcast "https://gpgtools.org/releases/gka/appcast.xml"
+  appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://gpgtools.org/download"
   name "GPG Suite"
   desc "Tools to protect your emails and files"
   homepage "https://gpgtools.org/"

--- a/Casks/gpg-suite.rb
+++ b/Casks/gpg-suite.rb
@@ -1,6 +1,6 @@
 cask "gpg-suite" do
-  version "2020.1"
-  sha256 "43d7becb7faaeafcffaf6a2723cea7ea004265a79e2df9a1a9687916a694a131"
+  version "2020.2"
+  sha256 "e2ede6b317d53d1e321342a6f7dd5ab6b123a4900aa8f1eab89b29051a2a4742"
 
   url "https://releases.gpgtools.org/GPG_Suite-#{version}.dmg"
   appcast "https://gpgtools.org/releases/gka/appcast.xml"
@@ -10,7 +10,7 @@ cask "gpg-suite" do
 
   auto_updates true
   conflicts_with cask: "gpg-suite-nightly"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   pkg "Install.pkg"
 


### PR DESCRIPTION
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Updated to version 2020.2 (Big Sur compatible), upping the required MacOS release: only 10.14 and up are supported now.