### PR TITLE
choosy 2.2 is unsupported on mojave; add conditional to install 2.1

### DIFF
--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -9,6 +9,11 @@ cask "choosy" do
     sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
 
     prefpane "Choosy.prefPane"
+  elsif MacOS.version <= :mojave
+    version "2.1"
+    sha256 "758da621d3a92358885333b767d64b024197a8147a339b1a0d14e938673452f9"
+
+    pkg "Choosy.pkg"
   else
     version "2.2"
     sha256 "baaaf7666e6f5412ef1310f6d26c660f59845ccf464079405f2aa0598fb85c43"

--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -24,6 +24,7 @@ cask "choosy" do
   url "https://downloads.choosyosx.com/choosy_#{version}.zip"
   appcast "https://www.choosyosx.com/sparkle/feed"
   name "Choosy"
+  desc "Open links in any browser"
   homepage "https://www.choosyosx.com/"
 
   depends_on macos: ">= :yosemite"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.
- [X] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).