### PR TITLE
Update toggl-track from 7.5.363 to 7.5.386

### DIFF
--- a/Casks/toggl-track.rb
+++ b/Casks/toggl-track.rb
@@ -1,6 +1,6 @@
 cask "toggl-track" do
-  version "7.5.363"
-  sha256 "eff4d6f27c555b93c5681788c9b93e5a31d3dff130f39e9227b432cf9455e4a9"
+  version "7.5.386"
+  sha256 "8c45c5ee596b6089d09c4409f78f6f0e98558842e11644e7edce19b707b4dd47"
 
   # github.com/toggl-open-source/toggldesktop/ was verified as official when first introduced to the cask
   url "https://github.com/toggl-open-source/toggldesktop/releases/download/v#{version}/TogglDesktop-#{version.dots_to_underscores}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).