### PR TITLE
Update avocode from 4.10.2 to 4.10.3

### DIFF
--- a/Casks/avocode.rb
+++ b/Casks/avocode.rb
@@ -1,6 +1,6 @@
 cask "avocode" do
-  version "4.10.2"
-  sha256 "5c27309612e9c634986699dedd12ceac65acfb0f0f0487a4c63167a15c784524"
+  version "4.10.3"
+  sha256 "96048b229217af2b648b8c854497550ee9c3a6a9d59f23f3a8ed6b531411c0a4"
 
   url "https://media.avocode.com/download/avocode-app/#{version}/Avocode-#{version}-mac.zip"
   appcast "https://macupdater.net/cgi-bin/check_urls/check_url_redirect.cgi?url=https://manager.avocode.com/download/avocode-app/mac-dmg/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).