### PR TITLE
Update mochi from 1.6.15 to 1.7.0

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask "mochi" do
-  version "1.6.15"
-  sha256 "75c6879084508b861c6c1c3900a913aaa73d6b4d37d0c670f1c33b6bd28ed351"
+  version "1.7.0"
+  sha256 "87c1e5d65298809f868fbec3c0d35f696b5114ffb24f53d3c71bd867c3a9887b"
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   appcast "https://mochi.cards/"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.