### PR TITLE
Add Nota.app v0.19

### DIFF
--- a/Casks/nota.rb
+++ b/Casks/nota.rb
@@ -2,7 +2,7 @@ cask "nota" do
   version "0.19.0"
   sha256 "8a886aff583d66b82bfbe1925f83376c30d5bb8fca5755f14c010f7944b8bea0"
 
-  # github.com/notaapp/ was verified as official when first introduced to the cask
+  # github.com/notaapp/releases/ was verified as official when first introduced to the cask
   url "https://github.com/notaapp/releases/releases/download/#{version}/Nota-#{version}-mac.zip"
   appcast "https://github.com/notaapp/releases/releases.atom"
   name "Nota"

--- a/Casks/nota.rb
+++ b/Casks/nota.rb
@@ -12,6 +12,7 @@ cask "nota" do
   auto_updates true
 
   app "Nota.app"
+  binary "#{appdir}/Nota.app/Contents/Resources/app.asar.unpacked/assets/nota.sh", target: "nota"
 
   zap trash: [
     "~/Library/Application Support/Nota",

--- a/Casks/nota.rb
+++ b/Casks/nota.rb
@@ -1,0 +1,24 @@
+cask "nota" do
+  version "0.19.0"
+  sha256 "8a886aff583d66b82bfbe1925f83376c30d5bb8fca5755f14c010f7944b8bea0"
+
+  # github.com/notaapp/ was verified as official when first introduced to the cask
+  url "https://github.com/notaapp/releases/releases/download/#{version}/Nota-#{version}-mac.zip"
+  appcast "https://github.com/notaapp/releases/releases.atom"
+  name "Nota"
+  desc "Markdown files editor"
+  homepage "https://nota.md/"
+
+  auto_updates true
+
+  app "Nota.app"
+
+  zap trash: [
+    "~/Library/Application Support/Nota",
+    "~/Library/Caches/md.nota.macos",
+    "~/Library/Caches/md.nota.macos.ShipIt",
+    "~/Library/Logs/Nota",
+    "~/Library/Preferences/md.nota.macos.plist",
+    "~/Library/Saved Application State/md.nota.macos.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] `brew cask audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).

Audit has failed, because GitHub repository is not notable enough. However I think Nota should be treated as a new version of [Caret](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/caret.rb), which already has its cask. It is created by the same people, it serves the same purpose and **Caret licenses work with Nota**.
