### PR TITLE
Update btcpayserver-vault from 1.0.5 to 1.0.6

### DIFF
--- a/Casks/btcpayserver-vault.rb
+++ b/Casks/btcpayserver-vault.rb
@@ -1,6 +1,6 @@
 cask "btcpayserver-vault" do
-  version "1.0.5"
-  sha256 "0e232bc305c8507cfbf7cb62188c66eae14f786981f698bf0ec4610bab10f668"
+  version "1.0.6"
+  sha256 "3bb66a00a58dd639de49d16c647c3e19c4dea47e6f48a56afc7facbcd53dce51"
 
   url "https://github.com/btcpayserver/BTCPayServer.Vault/releases/download/Vault%2Fv#{version}/BTCPayServerVault-osx-x64-#{version}.dmg"
   appcast "https://github.com/btcpayserver/BTCPayServer.Vault/releases.atom"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
