### PR TITLE
Update audiobook-builder from 2.1.1 to 2.1.2

### DIFF
--- a/Casks/audiobook-builder.rb
+++ b/Casks/audiobook-builder.rb
@@ -1,6 +1,6 @@
 cask "audiobook-builder" do
-  version "2.1.1"
-  sha256 "6caed55f195c8c05ed72b067020d32c3c7ac3534953e4d73cdcee1ea9b7a6e52"
+  version "2.1.2"
+  sha256 "acf96a39171df286a039e88e4e9b9fa20b7fc10c6ab96ed90c308e8cfdc99cd9"
 
   url "https://www.splasm.com/downloads/audiobookbuilder/Audiobook%20Builder%20#{version}.dmg"
   appcast "https://www.splasm.com/audiobookbuilder/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).