### PR TITLE
Update transcribe.rb

### DIFF
--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -1,7 +1,7 @@
 cask "transcribe" do
   if MacOS.version <= :catalina
     version "8.75.2"
-    sha "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
+    sha256 "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
     url "https://www.seventhstring.com/xscribe/downmac_old/transcribe#{version.no_dots}.dmg"
   else
     version "8.80.0"

--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -9,7 +9,7 @@ cask "transcribe" do
   desc "Transcribes recorded music"
   homepage "https://www.seventhstring.com/xscribe/overview.html"
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :big_sur"
 
   app "Transcribe!.app"
 

--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -1,15 +1,19 @@
 cask "transcribe" do
-  version "8.80.0"
-  sha256 "2c32b81ebe15115550c74f6d758facac05acbd20d1da16237e1fe3fc60b04215"
+  if MacOS.version <= :catalina
+    version "8.75.2"
+    sha "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
+    url "https://www.seventhstring.com/xscribe/downmac_old/transcribe#{version.no_dots}.dmg"
+  else
+    version "8.80.0"
+    sha256 "2c32b81ebe15115550c74f6d758facac05acbd20d1da16237e1fe3fc60b04215"
+    url "https://www.seventhstring.com/xscribe/transcribe.dmg"
+  end
 
-  url "https://www.seventhstring.com/xscribe/transcribe.dmg"
   appcast "https://www.seventhstring.com/xscribe/history.html",
           must_contain: version.major_minor
   name "Transcribe!"
   desc "Transcribes recorded music"
   homepage "https://www.seventhstring.com/xscribe/overview.html"
-
-  depends_on macos: ">= :big_sur"
 
   app "Transcribe!.app"
 


### PR DESCRIPTION
> Version 8.80 for Windows, Mac, and Linux was released 11 Nov 2020. In terms of features this is a minor update, however on the Mac it is the first version to specifically target macOS 11 (Big Sur) on both Intel and Apple Silicon processors. We will keep version 8.75.2 available for people running earlier versions of macOS. 