### PR TITLE
Update tinkerwell from 2.10.2 to 2.10.3

### DIFF
--- a/Casks/tinkerwell.rb
+++ b/Casks/tinkerwell.rb
@@ -1,6 +1,6 @@
 cask "tinkerwell" do
-  version "2.10.2"
-  sha256 "cdb04e90b3bca3e0d08bafc5d3e940022f9ebea230364f3e8715ddd91477d1ab"
+  version "2.10.3"
+  sha256 "39f8ee02faa5ac46f1d621f2618d63d3a25ce7e43d78e0648c5f50a645f61526"
 
   # tinkerwell.fra1.digitaloceanspaces.com/ was verified as official when first introduced to the cask
   url "https://tinkerwell.fra1.digitaloceanspaces.com/tinkerwell/Tinkerwell-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).