### PR TITLE
family-tree-builder: update version, sha256 and homepage, remove appcast

### DIFF
--- a/Casks/family-tree-builder.rb
+++ b/Casks/family-tree-builder.rb
@@ -1,13 +1,12 @@
 cask "family-tree-builder" do
-  version "8.2.0.8516"
-  sha256 "babd0029c007932e0339a97e080608a06ffbc64f77c49879a2b8fd0a93f956c5"
+  version "8.2.0.8521"
+  sha256 "37d553af39747800a9f8b2bfd745ffae2ab521a5894364e377a8be496f36063e"
 
   # mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/ was verified as official when first introduced to the cask
   url "https://mhcache-myheritage.netdna-ssl.com/FP/FamilyTreeBuilder/family_tree_builder_#{version.split(".").last}.dmg"
-  appcast "https://www.myheritage.com/FP/FamilyTreeBuilder/appcast.xml"
   name "MyHeritage Family Tree Builder"
   desc "Family tree creator"
-  homepage "https://www.myheritage.com/"
+  homepage "https://www.myheritage.com/family-tree-builder"
 
   depends_on macos: "<= :catalina"
 


### PR DESCRIPTION
The `appcast` is quite out-of-date:
```
|-> curl -sLI https://www.myheritage.com/FP/FamilyTreeBuilder/appcast.xml
HTTP/1.1 200 OK
Date: Sat, 28 Nov 2020 07:40:26 GMT
Server: Apache
Last-Modified: Thu, 04 Apr 2019 11:50:26 GMT
ETag: "28b-585b2f9dba8af"
Accept-Ranges: bytes
Content-Length: 651
Cache-Control: max-age=31536000, public
Pragma: public
Content-Type: text/xml
Set-Cookie: visid_incap_292987=5S1sqToVTQa7mgI2ASl4C+r+wV8AAAAAQUIPAAAAAAB8nXKelRe2H3JOgSJPTX8J; expires=Sat, 27 Nov 2021 07:59:04 GMT; HttpOnly; path=/; Domain=.myheritage.com
Set-Cookie: incap_ses_608_292987=3h56KJcGExqb+CDq9QxwCOr+wV8AAAAA5wMuMcIS1ZtE/tcHeLtnTQ==; path=/; Domain=.myheritage.com
X-CDN: Incapsula
X-Iinfo: 5-58844402-58842250 PNNy RT(1606549225966 144) q(0 0 0 -1) r(1 1) U6
```
Notice the line:
```
Last-Modified: Thu, 04 Apr 2019 11:50:26 GMT
```
I have not been able to find an alternative `appcast`.