### PR TITLE
Update Iconizer from v2020.11 to v2020.11.0

### DIFF
--- a/Casks/iconizer.rb
+++ b/Casks/iconizer.rb
@@ -1,6 +1,6 @@
 cask "iconizer" do
-  version "2020.11"
-  sha256 "400211fbbf0c587efb9c388346513fea52a9f0809e7acbe8f02abb877bb3058b"
+  version "2020.11.0"
+  sha256 "abaffdea473f4d3cd7d763fcb3846fbb752b87949e6ef7d273a95b6f5c5c1e06"
 
   # github.com/raphaelhanneken/iconizer/ was verified as official when first introduced to the cask
   url "https://github.com/raphaelhanneken/iconizer/releases/download/#{version}/Iconizer.dmg"


### PR DESCRIPTION
Update Iconizer from v2020.11 to v2020.11.0

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).