### PR TITLE
Update aether from 2.0.0-dev.14,1912161354.a1a015e to 2.0.0-dev.15,2011262249.19338c93

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -1,6 +1,6 @@
 cask "aether" do
-  version "2.0.0-dev.14,1912161354.a1a015e"
-  sha256 "cd3a722137891601cd2f2103f2ea57f76b88bd1b930f28ba5877b26372abde06"
+  version "2.0.0-dev.15,2011262249.19338c93"
+  sha256 "87bb9f70525025dadb1d00328f37ee075fe3866044d092a9533e7df71653aca7"
 
   url "https://static.getaether.net/Releases/Aether-#{version.before_comma}/#{version.after_comma}/mac/Aether-#{version.before_comma}%2B#{version.after_comma}.dmg"
   appcast "https://static.getaether.net/WebsiteReleaseLinks/Latest/LatestReleaseLinks.json"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).