### PR TITLE
Update command-tab-plus: add description, fix SHA 256

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -5,6 +5,7 @@ cask "command-tab-plus" do
   url "https://noteifyapp.com/download/Command-Tab%20Plus.dmg"
   appcast "https://macplus-software.com/downloads/Command-Tab.xml"
   name "Command-Tab Plus"
+  desc "Keyboard-centric application and window switcher"
   homepage "https://noteifyapp.com/command-tab-plus/"
 
   app "Command-Tab Plus.app"

--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,6 +1,6 @@
 cask "command-tab-plus" do
   version "1.122"
-  sha256 "fe8cafd5cb1c96c4ee8c41f12738e510d9ac67dd93f51ba22f85bf8e9f089aab"
+  sha256 "0e639b011d35b6feb323e9ddfb2424ba53a9138f741911cfface4e5cb6ef4c2c"
 
   url "https://noteifyapp.com/download/Command-Tab%20Plus.dmg"
   appcast "https://macplus-software.com/downloads/Command-Tab.xml"


### PR DESCRIPTION
2 changes:
- Description added to pass `brew audit`. The description is taken from [official webpage](https://noteifyapp.com/command-tab-plus/).
- Command-Tab Plus changed the file without updating the version. This happened before. I've updated the SHA 256 sum.

Verified:

- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).