### PR TITLE
qv2ray: add depends_on v2ray

### DIFF
--- a/Casks/qv2ray.rb
+++ b/Casks/qv2ray.rb
@@ -9,6 +9,7 @@ cask "qv2ray" do
   desc "V2Ray GUI client with extensive protocol support"
   homepage "https://qv2ray.net/"
 
+  depends_on formula: "v2ray"
   depends_on macos: ">= :mojave"
 
   app "qv2ray.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
- [x] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

---
qv2ray.app doesn't ship the v2ray core, add it to `depends_on`.
