### PR TITLE
PULL_REQUEST_TEMPLATE.md: move technical commands for last

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,16 +2,15 @@
 
 After making all changes to a cask, verify:
 
+- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
 - [ ] `brew audit --cask {{cask_file}}` is error-free.
 - [ ] `brew style --fix {{cask_file}}` reports no offenses.
-- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
-- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
 
 Additionally, **if adding a new cask**:
 
 - [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
+- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
+- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
 - [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
 - [ ] `brew install --cask {{cask_file}}` worked successfully.
 - [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
-- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
-- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).


### PR DESCRIPTION
Reasonings:

* I doubt most people do the check for “[t]here are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update”. Even if they do, with `bump-cask-pr` doing that check and our fast merge time, that’s less relevant. Fewer points equals higher likelihood people will do the ones that exist. 
* The technical commands are handled by CI and errors are shown in the PR itself, so they’re not as pressing as the ones which can’t be automated, thus should come later.