### PR TITLE
Update praat from 6.1.34 to 6.1.35

### DIFF
--- a/Casks/praat.rb
+++ b/Casks/praat.rb
@@ -1,6 +1,6 @@
 cask "praat" do
-  version "6.1.34"
-  sha256 "d4b060cc5aa52e44085a7f34e0cd938b3528620c5136def030be29cc91110965"
+  version "6.1.35"
+  sha256 "bd0dafb0af18345dbd61f60837986f91e9bd1bcc97a271160b8f1bc83ddbdc99"
 
   # github.com/praat/praat/ was verified as official when first introduced to the cask
   url "https://github.com/praat/praat/releases/download/v#{version}/praat#{version.no_dots}_mac.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).