### PR TITLE
Update qtox from 1.17.2 to 1.17.3

### DIFF
--- a/Casks/qtox.rb
+++ b/Casks/qtox.rb
@@ -1,6 +1,6 @@
 cask "qtox" do
-  version "1.17.2"
-  sha256 "bfe2033d42b78e8b1f40a0276c806df33e221b208b15eb5ce6dda445f764cc6d"
+  version "1.17.3"
+  sha256 "63ee6eb013487a86abbaeb23ad61eca7b74c6ceed0e56fa7e7d9bee6522615b4"
 
   # github.com/qTox/qTox/ was verified as official when first introduced to the cask
   url "https://github.com/qTox/qTox/releases/download/v#{version}/qTox.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).