### PR TITLE
Update zerotier-one from 1.6.1 to 1.6.2

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -1,5 +1,5 @@
 cask "zerotier-one" do
-  version "1.6.1"
+  version "1.6.2"
   sha256 "9b87cf8f502bead3df6a9702ad94b29c13329405b6963328f8f05c3749cfe07a"
 
   url "https://download.zerotier.com/dist/ZeroTier%20One.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).