### PR TITLE
Update jcryptool from 1.0.0,2020-11-01 to 1.0.1

### DIFF
--- a/Casks/jcryptool.rb
+++ b/Casks/jcryptool.rb
@@ -1,9 +1,9 @@
 cask "jcryptool" do
-  version "1.0.0,2020-11-01"
-  sha256 "4284466b7cee5e0d3f14a4b134d70dec197752b77c34fd4c38dd5d15033d51c2"
+  version "1.0.1"
+  sha256 "6e63d68b2d2fd4600368f6e325bfeb6b3fae56397c54d119f67accf41cc8268c"
 
   # github.com/jcryptool/core/ was verified as official when first introduced to the cask
-  url "https://github.com/jcryptool/core/releases/download/Weekly-Build--#{version.after_comma}/jcryptool-#{version.before_comma}-macosx.cocoa.x86_64.tar.gz"
+  url "https://github.com/jcryptool/core/releases/download/#{version}/JCrypTool-#{version}-macOS-64bit.tar.gz"
   appcast "https://github.com/jcryptool/core/releases.atom",
           must_contain: version.after_comma
   name "JCrypTool"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).