### PR TITLE
Update cityofzion-neon from 2.6.0 to 2.6.1

### DIFF
--- a/Casks/cityofzion-neon.rb
+++ b/Casks/cityofzion-neon.rb
@@ -1,6 +1,6 @@
 cask "cityofzion-neon" do
-  version "2.6.0"
-  sha256 "2f102ebfc3815d804acaaa852b59ecd0ee709a0aa87c883ecd95ed98b3618a80"
+  version "2.6.1"
+  sha256 "260f136bd5ebad053e5454a97fa35fb848b610de658ea7549fdf5719fac4c29f"
 
   url "https://github.com/CityOfZion/neon-wallet/releases/download/v#{version}/Neon.#{version}.dmg"
   appcast "https://github.com/CityOfZion/neon-wallet/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).