### PR TITLE
Update apptrap from 1.2.3 to 1.2.4

### DIFF
--- a/Casks/apptrap.rb
+++ b/Casks/apptrap.rb
@@ -1,6 +1,6 @@
 cask "apptrap" do
-  version "1.2.3"
-  sha256 "39a8923698c2e1a38ff3fd7fc2c12b7a847566cf1f31f965d0fb57e2280aaa5c"
+  version "1.2.4"
+  sha256 "54c01bca14a521513e5a90dee282a635a766e02b87e363df494a4bf7c220f0d1"
 
   url "http://onnati.net/apptrap/download/AppTrap#{version.dots_to_hyphens}.zip"
   appcast "http://onnati.net/apptrap/ReleaseNotes.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).