### PR TITLE
Update eaccess from 1.13.3 to 1.13.2

### DIFF
--- a/Casks/eaccess.rb
+++ b/Casks/eaccess.rb
@@ -1,5 +1,5 @@
 cask "eaccess" do
-  version "1.13.3"
+  version "1.13.2"
   sha256 "edb3eb022f2147e12d722f234ef12c7ec5c3f937004f3dd6e0165883fc5e7de1"
 
   url "https://glutz.com/service/downloads/?dwnldid=97676"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).

Automatically created and submitted by muUpdateStaticHomebrewCask