### PR TITLE
Update cyberduck from 7.7.1.33788 to 7.7.2.33862

### DIFF
--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,6 +1,6 @@
 cask "cyberduck" do
-  version "7.7.1.33788"
-  sha256 "4a8d05abe9fb599ad1d551eb396f0c4dbda7be24ed71b34109afe6eb8a44d9b1"
+  version "7.7.2.33862"
+  sha256 "3becbea9d43261e8b8ddc139164c5744bb5535602bf994d400aedf8767fc1f44"
 
   url "https://update.cyberduck.io/Cyberduck-#{version}.zip"
   appcast "https://version.cyberduck.io/changelog.rss"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
