### PR TITLE
Update flrig from 1.3.52 to 1.3.53

### DIFF
--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -1,6 +1,6 @@
 cask "flrig" do
-  version "1.3.52"
-  sha256 "2cb4e59e92f27fb32c9514ad2cc51f5430d9fa1cfb61023ba8a330dbaf176b89"
+  version "1.3.53"
+  sha256 "b39c156d4cdbfe0c26fbb2693957f8856c6b8ddfbc9ba88f2b58c1337d567815"
 
   url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version.before_comma}_x86_64.dmg"
   appcast "https://sourceforge.net/projects/fldigi/rss?path=/flrig"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).