### PR TITLE
oversight.rb: remove protocol from verified

### DIFF
--- a/Casks/oversight.rb
+++ b/Casks/oversight.rb
@@ -3,7 +3,7 @@ cask "oversight" do
   sha256 "786eea6de3da8a15919159b51a7753ef7ecb26a0ed638725f7925fd0392a6fa9"
 
   url "https://bitbucket.org/objective-see/deploy/downloads/OverSight_#{version}.zip",
-      verified: "https://bitbucket.org/objective-see/deploy/downloads/"
+      verified: "bitbucket.org/objective-see/deploy/downloads/"
   appcast "https://objective-see.com/products/changelogs/OverSight.txt"
   name "OverSight"
   desc "Monitors computer mic and webcam"


### PR DESCRIPTION
Remove the protocol from the `verified:` parameter.