### PR TITLE
Bump stand to 2.1.1

### DIFF
--- a/Casks/stand.rb
+++ b/Casks/stand.rb
@@ -2,9 +2,10 @@ cask "stand" do
   version "2.1.1"
   sha256 "5fce7d525ea7154d1df58b25d1902731f533a18656330593a7d3d2456fc1f314"
 
-  # f001.backblazeb2.com/file/stand-app/ was verified as official when first introduced to the cask
-  url "https://f001.backblazeb2.com/file/stand-app/#{version}/Stand.zip"
-  appcast "https://getstandapp.com/"
+  url "https://f001.backblazeb2.com/file/stand-app/#{version}/Stand.zip",
+      verified: "f001.backblazeb2.com/file/stand-app/"
+  appcast "https://getstandapp.com/",
+          must_contain: version.major_minor
   name "Stand"
   desc "Reminds you to stand up once an hour"
   homepage "https://getstandapp.com/"
@@ -13,12 +14,10 @@ cask "stand" do
 
   app "Stand.app"
 
-  uninstall quit: [
-    "com.reddavis.Stand",
-  ]
+  uninstall quit: "com.reddavis.Stand"
 
   zap trash: [
-    "~/Library/Preferences/com.reddavis.Stand.plist",
     "~/Library/Caches/com.reddavis.Stand",
+    "~/Library/Preferences/com.reddavis.Stand.plist",
   ]
 end

--- a/Casks/stand.rb
+++ b/Casks/stand.rb
@@ -1,6 +1,6 @@
 cask "stand" do
-  version "2.1"
-  sha256 "e7cc1237f50d9f6991ced65e598e02015174b98e69e90298bc42e4759bc40e4e"
+  version "2.1.1"
+  sha256 "5fce7d525ea7154d1df58b25d1902731f533a18656330593a7d3d2456fc1f314"
 
   # f001.backblazeb2.com/file/stand-app/ was verified as official when first introduced to the cask
   url "https://f001.backblazeb2.com/file/stand-app/#{version}/Stand.zip"


### PR DESCRIPTION
`brew audit --cask stand` returned a warning:
```
audit for stand: warning
 - f001.backblazeb2.com does not match getstandapp.com, a `verified` parameter of the `url` has to be added.  See https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-verified
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.