### PR TITLE
Update macbreakz from 5.40 to 5.41

### DIFF
--- a/Casks/macbreakz.rb
+++ b/Casks/macbreakz.rb
@@ -1,6 +1,6 @@
 cask "macbreakz" do
-  version "5.40"
-  sha256 "4c0aeb1368fe5dae8a17991e1397f3917e21d6601b7d837526af880f4077ce3b"
+  version "5.41"
+  sha256 "941d07cc1a6e0c134f01147a69456b771719ad106be8ecd65d488a2a9fc8ff5d"
 
   url "https://www.publicspace.net/download/MacBreakZ#{version.major}.dmg"
   appcast "https://www.publicspace.net/app/signed_mb#{version.major}.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).

Automatically created and submitted by muUpdateStaticHomebrewCask