### PR TITLE
Update clash-for-windows from 0.13.5 to 0.13.6

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,6 +1,6 @@
 cask "clash-for-windows" do
-  version "0.13.5"
-  sha256 "e016c462d559c33c8ca0c434a2fbe5b9f4df9f3021f9b3d0ecbf11192ef7daae"
+  version "0.13.6"
+  sha256 "69ff62759bbab457bce1f066408ae81ee231156bcbf3cd95557d941cc32f61d6"
 
   url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
   appcast "https://github.com/Fndroid/clash_for_windows_pkg/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).