### PR TITLE
Update zettlr from 1.8.0 to 1.8.1

### DIFF
--- a/Casks/zettlr.rb
+++ b/Casks/zettlr.rb
@@ -1,6 +1,6 @@
 cask "zettlr" do
-  version "1.8.0"
-  sha256 "534ea5ca5a9fe288ecf512aabf0363ba01739a2ab96bd54be70e2cd40e5afb00"
+  version "1.8.1"
+  sha256 "2b6c22c93cb73c9b650abb437e28c86a2a902f8a805f90bdefa67acfb4251b5e"
 
   # github.com/Zettlr/Zettlr/ was verified as official when first introduced to the cask
   url "https://github.com/Zettlr/Zettlr/releases/download/v#{version}/Zettlr-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).