### PR TITLE
Update gqrx from 2.11.5 to 2.14.2

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -2,31 +2,14 @@ cask "gqrx" do
   version "2.14.2"
   sha256 "679143fb2860d8ddbb9e8d88c58477a5cca6064ca47392d87461da497b18f857"
 
-  # github.com/csete/gqrx/ was verified as official when first introduced to the cask
-  url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg"
+  url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg",
+      verified: "github.com/csete/gqrx/"
   appcast "https://github.com/csete/gqrx/releases.atom"
   name "Gqrx"
   desc "Software-defined radio receiver powered by GNU Radio and Qt"
   homepage "https://gqrx.dk/"
 
   app "Gqrx.app"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/airspy_info"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/airspy_rx"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/airspy_spiflash"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/hackrf_cpldjtag"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/hackrf_debug"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/hackrf_info"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/hackrf_spiflash"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/hackrf_transfer"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_adsb"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_eeprom"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_fm"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_power"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_sdr"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_tcp"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/rtl_test"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/SoapySDRUtil", target: "soapysdrutil"
-  binary "#{appdir}/Gqrx.app/Contents/MacOS/volk_profile"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/gqrx.wrapper.sh"
   binary shimscript, target: "gqrx"

--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,6 +1,6 @@
 cask "gqrx" do
-  version "2.11.5"
-  sha256 "896cefcb2825840178b6dbfb894b01543b1c8225539e6969052133223a59ffee"
+  version "2.14.2"
+  sha256 "679143fb2860d8ddbb9e8d88c58477a5cca6064ca47392d87461da497b18f857"
 
   # github.com/csete/gqrx/ was verified as official when first introduced to the cask
   url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).