### PR TITLE
Update netxms-console from 3.6.252 to 3.6.302

### DIFF
--- a/Casks/netxms-console.rb
+++ b/Casks/netxms-console.rb
@@ -1,6 +1,6 @@
 cask "netxms-console" do
-  version "3.6.252"
-  sha256 "e6a74fa5d6141e80404bbf9c96c4e6917a5bf214a3268944415d50348348a92e"
+  version "3.6.302"
+  sha256 "c1a6ae2b94b7579f43f5552ed8d011678396f41ea90bbed633687477e8bebb05"
 
   url "https://netxms.org/download/releases/#{version.major_minor}/nxmc-#{version}.dmg"
   appcast "https://netxms.org/download/releases/#{version.major_minor}/"

--- a/Casks/teamdrive.rb
+++ b/Casks/teamdrive.rb
@@ -1,9 +1,9 @@
 cask "teamdrive" do
-  version "4.6.11.2725"
-  sha256 "176328653faf9a9ee2e723a6b0c5ee03667b48b6e98c2f90d75ae48a5a1c06e7"
+  version "4.6.12.2788"
+  sha256 "5e7d84ba4a184438dddbbbd25fc67b0adc16ef2dcecf8e4051b369d9252ad884"
 
   # teamdrive.net/ was verified as official when first introduced to the cask
-  url "https://download.teamdrive.net/#{version.major_minor}.#{version.split(".").last}/TMDR/mac-10.14.6/Install-TeamDrive-#{version}_TMDR.dmg"
+  url "https://download.teamdrive.net/#{version.major_minor}.#{version.split(".").last}/TMDR/mac-10.15.7/Install-TeamDrive-#{version}_TMDR.dmg"
   appcast "https://teamdrive.com/en/downloads/",
           must_contain: version.major_minor_patch
   name "TeamDrive"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).