### PR TITLE
Update refined-github-safari from 2.1.22 to 2.1.23

### DIFF
--- a/Casks/refined-github-safari.rb
+++ b/Casks/refined-github-safari.rb
@@ -1,6 +1,6 @@
 cask "refined-github-safari" do
-  version "2.1.22"
-  sha256 "9f3e222ffacadfba34427808a5bcde76157399bf448d56646db4f8e697334772"
+  version "2.1.23"
+  sha256 "c972e3f2880a8c8966f954d9700f54776721a49b6d361350a63b0354316ce4d1"
 
   url "https://github.com/lautis/refined-github-safari/releases/download/v#{version}/Refined-GitHub-for-Safari.zip"
   appcast "https://github.com/lautis/refined-github-safari/releases.atom"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).