### PR TITLE
Bad SHA256 hash was provided

### DIFF
--- a/Casks/meshlab.rb
+++ b/Casks/meshlab.rb
@@ -1,6 +1,6 @@
 cask "meshlab" do
   version "2020.12"
-  sha256 "580581d720d7b611531389f419c550257585432c022e43465587be77da3984ff"
+  sha256 "f3ffe7132b37a44a8017a4bf5d52ff271c27fe3dd316245694e96bd30920ceae"
 
   # github.com/cnr-isti-vclab/meshlab/ was verified as official when first introduced to the cask
   url "https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-#{version}/MeshLab#{version}-macos.dmg"


### PR DESCRIPTION
Someone updated to the new version but didn't update SHA256 hash.

```
==> Upgrading meshlab
==> Downloading https://github.com/cnr-isti-vclab/meshlab/releases/download/Meshlab-2020.12/MeshLab2020.12-macos.dmg
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/73027304/99ac6e80-3620-11eb-805a-f0c485f80f99?X-Amz-Algorithm=AWS4-HMAC-SHA
######################################################################## 100.0%
==> Purging files for version 2020.12 of Cask meshlab
Error: meshlab: SHA256 mismatch
Expected: 580581d720d7b611531389f419c550257585432c022e43465587be77da3984ff
  Actual: f3ffe7132b37a44a8017a4bf5d52ff271c27fe3dd316245694e96bd30920ceae
    File: /Users/nikola/Library/Caches/Homebrew/downloads/513c0f753907909f2e730dd96c1500f943fd7acf11cb5960773fc5166f0d1309--MeshLab2020.12-macos.dmg
To retry an incomplete download, remove the file above.
```