### PR TITLE
Remove borgbackup dependency

### DIFF
--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -18,11 +18,11 @@ cask "vorta" do
   caveats <<~EOS
     Also requires BorgBackup to run. If you don't need mount support, use the official formula:
 
-    $ brew install borgbackup
+      brew install borgbackup
 
     If you plan on mounting archives using macFUSE, consider using the Tap maintained by the Borg team:
 
-    $ brew install --cask osxfuse
-    $ brew install borgbackup/tap/borgbackup-fuse
+      brew install --cask osxfuse
+      brew install borgbackup/tap/borgbackup-fuse
   EOS
 end

--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -16,7 +16,7 @@ cask "vorta" do
   zap trash: "~/Library/Application Support/Vorta"
 
   caveats <<~EOS
-    Also requires BorgBackup to run. If you don't need mount support, use the official formula:
+    #{token} requires BorgBackup to run. If you do not need mount support, use the official formula:
 
       brew install borgbackup
 

--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -14,4 +14,15 @@ cask "vorta" do
   app "Vorta.app"
 
   zap trash: "~/Library/Application Support/Vorta"
+
+  caveats <<~EOS
+    Also requires BorgBackup to run. If you don't need mount support, use the official formula:
+
+    $ brew install borgbackup
+
+    If you plan on mounting archives using macFUSE, consider using the Tap maintained by the Borg team:
+
+    $ brew install --cask osxfuse
+    $ brew install borgbackup/tap/borgbackup-fuse
+  EOS
 end

--- a/Casks/vorta.rb
+++ b/Casks/vorta.rb
@@ -10,7 +10,6 @@ cask "vorta" do
 
   auto_updates true
   depends_on macos: ">= :mojave"
-  depends_on formula: "borgbackup"
 
   app "Vorta.app"
 


### PR DESCRIPTION
With support for `osxfuse` [removed](https://github.com/Homebrew/homebrew-core/issues/65525) from the official `borgbackup` formula, users need to decide if they want to go with the official `borgbackup` formula (no mount/FUSE support) or the [new external Tap](https://github.com/borgbackup/homebrew-tap) `borgbackup-fuse` (includes FUSE support).

To avoid conflicts and confusion, I'd like to remove the dependency on `borgbackup` from Vorta and add a caveat instead. 

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.