### PR TITLE
Update sherlock from 1.11.0 to 1.12.0

### DIFF
--- a/Casks/sherlock.rb
+++ b/Casks/sherlock.rb
@@ -1,6 +1,6 @@
 cask "sherlock" do
-  version "1.11.0"
-  sha256 "b95096c5a791532161b521d4d8e406805899f1a72e5f7c0e4144dff700c446a4"
+  version "1.12.0"
+  sha256 "a5c970647240a195a079e5194cc6f87d3674f6dd1a243c7e73f6becfa2d4c626"
 
   # dl.devmate.com/io.inspiredcode.Sherlock/ was verified as official when first introduced to the cask
   url "https://dl.devmate.com/io.inspiredcode.Sherlock/Sherlock.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).

Automatically created and submitted by muUpdateStaticHomebrewCask