### PR TITLE
Update get-iplayer-automator from 1.19.2,b20201018001 to 1.19.3,b20201206001

### DIFF
--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -1,6 +1,6 @@
 cask "get-iplayer-automator" do
-  version "1.19.2,b20201018001"
-  sha256 "b63cbac122b7e8ec4a195b96b9f8366ffd974c311b468765e18fbf00184f0e72"
+  version "1.19.3,b20201206001"
+  sha256 "30da84680361723e950f40e70eff55ff21e184a57c351856c6e5c36247be1254"
 
   url "https://github.com/Ascoware/get-iplayer-automator/releases/download/v#{version.before_comma}/Get.iPlayer.Automator.v#{version.before_comma}.#{version.after_comma}.zip"
   appcast "https://github.com/Ascoware/get-iplayer-automator/releases.atom",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).