### PR TITLE
Update deepl from 1.12.0 to 1.13.1

### DIFF
--- a/Casks/deepl.rb
+++ b/Casks/deepl.rb
@@ -1,6 +1,6 @@
 cask "deepl" do
-  version "1.12.0"
-  sha256 "edb21b8e2df1e63d790e262c7da6719c0048c4c6ebc82998f93c00ec4ccf2a82"
+  version "1.13.1"
+  sha256 "d34fd843fad9556ec319d63a09cd7bb1281ba000e7d0b0de46cc350c433c9904"
 
   url "https://appdownload.deepl.com/macos/DeepL.dmg"
   name "DeepL"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [ ] There are no [open pull requests](https://github.com/Homebrew/homebrew-cask/pulls) for the same update.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Created with [`cask-repair`](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#updating-a-cask).

Automatically created and submitted by muUpdateStaticHomebrewCask