### PR TITLE
Update Unite to v4.0 – New download URL and Appcast

### DIFF
--- a/Casks/unite.rb
+++ b/Casks/unite.rb
@@ -2,9 +2,8 @@ cask "unite" do
   version "4.0,sWbXL0HYRsWzxwrH8Zw1"
   sha256 "80bef525cdbeee5d35da93d0aa71a42dd268b039ce4f61f242ee18f103538ff9"
 
-  # paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/ was verified as official when first introduced to the cask
   url "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/#{version.after_comma}_Unite.zip",
-      verified: "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/"
+      verified: "paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/"
   appcast "https://drive.google.com/uc?export=download&id=1gb_luG8qUL6XZu8tdI-9zrUE9I_oFBmo"
   name "Unite"
   desc "Turn websites into apps"

--- a/Casks/unite.rb
+++ b/Casks/unite.rb
@@ -1,10 +1,11 @@
 cask "unite" do
-  version "3.1,WiusgeYwTKaK9HQ7XWkT"
-  sha256 "9a16c4fdcfbd63c301102fb024a9a2d47301eb63d24d52cd307c38bbbe2bb685"
+  version "4.0,sWbXL0HYRsWzxwrH8Zw1"
+  sha256 "80bef525cdbeee5d35da93d0aa71a42dd268b039ce4f61f242ee18f103538ff9"
 
   # paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/ was verified as official when first introduced to the cask
-  url "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/576531/#{version.after_comma}_Unite.zip"
-  appcast "https://drive.google.com/uc?export=download&id=1pPlm8G1yluV7ipcRh-2pmXP-nATWsjTK"
+  url "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/#{version.after_comma}_Unite.zip",
+      verified: "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/"
+  appcast "https://drive.google.com/uc?export=download&id=1gb_luG8qUL6XZu8tdI-9zrUE9I_oFBmo"
   name "Unite"
   desc "Turn websites into apps"
   homepage "https://bzgapps.com/unite"


### PR DESCRIPTION
The latest version of Unite has a new download link, and also a new appcast.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
