### PR TITLE
wine-stable: remove conflicts_with formula

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -12,7 +12,7 @@ cask "wine-stable" do
     "wine-devel",
     "wine-staging",
   ]
-  depends_on cask: xquartz
+  depends_on cask: "xquartz"
 
   pkg "winehq-stable-#{version}.pkg",
       choices: [

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -7,8 +7,7 @@ cask "wine-stable" do
   name "WineHQ-stable"
   homepage "https://wiki.winehq.org/MacOS"
 
-  conflicts_with formula: "wine",
-                 cask:    [
+  conflicts_with cask:    [
                    "wine-devel",
                    "wine-staging",
                  ]

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -9,9 +9,9 @@ cask "wine-stable" do
   homepage "https://wiki.winehq.org/MacOS"
 
   conflicts_with cask: [
-                   "wine-devel",
-                   "wine-staging",
-                 ]
+    "wine-devel",
+    "wine-staging",
+  ]
   depends_on cask: xquartz
 
   pkg "winehq-stable-#{version}.pkg",

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -5,13 +5,14 @@ cask "wine-stable" do
   url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-stable-#{version}.pkg"
   appcast "https://dl.winehq.org/wine-builds/macosx/download.html"
   name "WineHQ-stable"
+  desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
 
-  conflicts_with cask:    [
+  conflicts_with cask: [
                    "wine-devel",
                    "wine-staging",
                  ]
-  depends_on x11: true
+  depends_on cask: xquartz
 
   pkg "winehq-stable-#{version}.pkg",
       choices: [


### PR DESCRIPTION
There is no longer a `wine` formula.