### PR TITLE
Update trainerroad from 2020.47.112 to 2020.47.3.117

### DIFF
--- a/Casks/trainerroad.rb
+++ b/Casks/trainerroad.rb
@@ -1,6 +1,6 @@
 cask "trainerroad" do
-  version "2020.47.112"
-  sha256 "371a2014e0c1c9cba159acf7dae606f7e6e265f8bf4d4a06eea549b23349b52d"
+  version "2020.47.117"
+  sha256 "0bd5555d8d5d51cf55cad7d197f0c6d2a31542ba5997cf428a573c5f74cad33f"
 
   # trainrdtrcmn01un1softw01.blob.core.windows.net/ was verified as official when first introduced to the cask
   url "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/TrainerRoad.dmg"

--- a/Casks/trainerroad.rb
+++ b/Casks/trainerroad.rb
@@ -1,9 +1,9 @@
 cask "trainerroad" do
-  version "2020.47.117"
+  version "2020.47.3.117"
   sha256 "0bd5555d8d5d51cf55cad7d197f0c6d2a31542ba5997cf428a573c5f74cad33f"
 
-  # trainrdtrcmn01un1softw01.blob.core.windows.net/ was verified as official when first introduced to the cask
-  url "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/TrainerRoad.dmg"
+  url "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/TrainerRoad-#{version}.dmg",
+      verified: "trainrdtrcmn01un1softw01.blob.core.windows.net/"
   appcast "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/latest-mac.yml"
   name "TrainerRoad"
   desc "Cycling training system"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask