### PR TITLE
Add auto_updates true to Dropbox

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -7,6 +7,7 @@ cask "dropbox" do
   desc "Client for the Dropbox cloud storage service"
   homepage "https://www.dropbox.com/"
 
+  auto_updates true
   conflicts_with cask: "homebrew/cask-versions/dropbox-beta"
 
   app "Dropbox.app"


### PR DESCRIPTION
Now that `version` is no longer `:latest`, add `auto_updates true` since Dropbox auto-updates in background.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
