### PR TITLE
Update and rename waterfox-current from 2020.10,6820.10.20 to waterfox 3.0.1,7820.11.27

### DIFF
--- a/Casks/waterfox-current.rb
+++ b/Casks/waterfox-current.rb
@@ -1,8 +1,8 @@
 cask "waterfox-current" do
-  version "2020.10,6820.10.20"
-  sha256 "4bbeb0210e75f33959cb60e4ef8b35176c4f01d9bc684d4f217255d3b7ecfb30"
+  version "3.0.1,7820.11.27"
+  sha256 "ec122142b75e678d2246e4ad273b5e54ce9f998b117312e203e5f7631cf503e0"
 
-  url "https://cdn.waterfox.net/releases/osx64/installer/Waterfox%20Current%20#{version.before_comma}%20Setup.dmg"
+  url "https://cdn.waterfox.net/releases/osx64/installer/Waterfox%20G#{version.before_comma}%20Setup.dmg"
   appcast "https://www.waterfox.net/download/"
   name "Waterfox Current"
   desc "Web browser"

--- a/Casks/waterfox-current.rb
+++ b/Casks/waterfox-current.rb
@@ -8,7 +8,7 @@ cask "waterfox-current" do
   desc "Web browser"
   homepage "https://www.waterfox.net/"
 
-  app "Waterfox Current.app"
+  app "Waterfox.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.mozilla.waterfox.sfl*",

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -4,7 +4,7 @@ cask "waterfox" do
 
   url "https://cdn.waterfox.net/releases/osx64/installer/Waterfox%20G#{version.before_comma}%20Setup.dmg"
   appcast "https://www.waterfox.net/download/"
-  name "Waterfox Current"
+  name "Waterfox"
   desc "Web browser"
   homepage "https://www.waterfox.net/"
 

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,4 +1,4 @@
-cask "waterfox-current" do
+cask "waterfox" do
   version "3.0.1,7820.11.27"
   sha256 "ec122142b75e678d2246e4ad273b5e54ce9f998b117312e203e5f7631cf503e0"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.