### PR TITLE
Update bitbar.rb

### DIFF
--- a/Casks/bitbar.rb
+++ b/Casks/bitbar.rb
@@ -1,8 +1,8 @@
 cask "bitbar" do
-  version "1.9.2"
+  version "1.10.0"
   sha256 "9e317d58143f544ab3b2b35e4d0ef2f11b9578fe6872cec1415da961acb1aee4"
 
-  url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBar-v#{version}.zip"
+  url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBarDistro.app.zip"
   appcast "https://github.com/matryer/bitbar/releases.atom"
   name "BitBar"
   desc "Utility to display the output from any script or program in the menu bar"

--- a/Casks/bitbar.rb
+++ b/Casks/bitbar.rb
@@ -1,6 +1,6 @@
 cask "bitbar" do
   version "1.10.0"
-  sha256 "9e317d58143f544ab3b2b35e4d0ef2f11b9578fe6872cec1415da961acb1aee4"
+  sha256 "d0e023583d443f98f2adb3c307da01de608abc98d03887e5fd85d3004716d0fb"
 
   url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBar.app.zip"
   appcast "https://github.com/matryer/bitbar/releases.atom"

--- a/Casks/bitbar.rb
+++ b/Casks/bitbar.rb
@@ -2,7 +2,7 @@ cask "bitbar" do
   version "1.10.0"
   sha256 "9e317d58143f544ab3b2b35e4d0ef2f11b9578fe6872cec1415da961acb1aee4"
 
-  url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBarDistro.app.zip"
+  url "https://github.com/matryer/bitbar/releases/download/v#{version}/BitBar.app.zip"
   appcast "https://github.com/matryer/bitbar/releases.atom"
   name "BitBar"
   desc "Utility to display the output from any script or program in the menu bar"


### PR DESCRIPTION
Update to v1.10.0, update release asset path
See https://github.com/matryer/bitbar/releases

Note: I didn't commit the style changes, they didn't seem relevant to my change?

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
