### PR TITLE
Update dialpad from 18.78.6 to 18.80.4

### DIFF
--- a/Casks/dialpad.rb
+++ b/Casks/dialpad.rb
@@ -1,5 +1,5 @@
 cask "dialpad" do
-  version "18.78.6"
+  version "18.80.4"
   sha256 :no_check
 
   # storage.googleapis.com/dialpad_native/osx/ was verified as official when first introduced to the cask


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask