### PR TITLE
Mark Gitfox.app as auto-updating

### DIFF
--- a/Casks/gitfox.rb
+++ b/Casks/gitfox.rb
@@ -2,7 +2,6 @@ cask "gitfox" do
   version "1.4910"
   sha256 :no_check
 
-  # storage.googleapis.com/gitfox/ was verified as official when first introduced to the cask
   url "https://storage.googleapis.com/gitfox/Gitfox.latest.stable.zip",
       verified: "storage.googleapis.com/gitfox/"
   name "Gitfox"

--- a/Casks/gitfox.rb
+++ b/Casks/gitfox.rb
@@ -3,10 +3,13 @@ cask "gitfox" do
   sha256 :no_check
 
   # storage.googleapis.com/gitfox/ was verified as official when first introduced to the cask
-  url "https://storage.googleapis.com/gitfox/Gitfox.latest.stable.zip"
+  url "https://storage.googleapis.com/gitfox/Gitfox.latest.stable.zip",
+      verified: "storage.googleapis.com/gitfox/"
   name "Gitfox"
   desc "Git client"
   homepage "https://www.gitfox.app/"
+
+  auto_updates true
 
   app "Gitfox.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.