### PR TITLE
Enable auto_updates for Spotify

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -7,6 +7,8 @@ cask "spotify" do
   name "Spotify"
   desc "Music streaming service"
   homepage "https://www.spotify.com/"
+  
+  auto_updates true
 
   app "Spotify.app"
 

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -7,7 +7,7 @@ cask "spotify" do
   name "Spotify"
   desc "Music streaming service"
   homepage "https://www.spotify.com/"
-  
+
   auto_updates true
 
   app "Spotify.app"


### PR DESCRIPTION
Add `auto_updates true` the Spotify cask.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

