### PR TITLE
symlink to nova CLI tool, not app bundle

### DIFF
--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -3,7 +3,8 @@ cask "nova" do
   sha256 "f399a2af01360057b0f314ac3945b233a24a8d4b24e5972ce093190cc8cc4918"
 
   # download-cdn.panic.com/ was verified as official when first introduced to the cask
-  url "https://download-cdn.panic.com/nova/Nova%20#{version}.zip"
+  url "https://download-cdn.panic.com/nova/Nova%20#{version}.zip",
+      verified: "https://download-cdn.panic.com/nova/"
   name "Panic Nova"
   desc "Native code editor"
   homepage "https://nova.app/"
@@ -12,7 +13,7 @@ cask "nova" do
   depends_on macos: ">= :mojave"
 
   app "Nova.app"
-  binary "#{appdir}/Nova.app/Contents/MacOS/Nova", target: "nova"
+  binary "#{appdir}/Nova.app/Contents/SharedSupport/nova", target: "nova"
 
   zap trash: "~/Library/Application Support/Nova"
 end

--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -2,7 +2,6 @@ cask "nova" do
   version "3.1"
   sha256 "f399a2af01360057b0f314ac3945b233a24a8d4b24e5972ce093190cc8cc4918"
 
-  # download-cdn.panic.com/ was verified as official when first introduced to the cask
   url "https://download-cdn.panic.com/nova/Nova%20#{version}.zip",
       verified: "https://download-cdn.panic.com/nova/"
   name "Panic Nova"

--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -12,7 +12,7 @@ cask "nova" do
   depends_on macos: ">= :mojave"
 
   app "Nova.app"
-  binary "#{appdir}/Nova.app/Contents/SharedSupport/nova", target: "nova"
+  binary "#{appdir}/Nova.app/Contents/SharedSupport/nova"
 
   zap trash: "~/Library/Application Support/Nova"
 end


### PR DESCRIPTION
Nova.app provides a CLI tool to launch an editor session from a terminal.  Currently, this Cask symlinks to the app itself rather than the CLI binary.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
