### PR TITLE
Update aerial from 2.2.3 to 2.2.4

### DIFF
--- a/Casks/aerial.rb
+++ b/Casks/aerial.rb
@@ -1,6 +1,6 @@
 cask "aerial" do
-  version "2.2.3"
-  sha256 "cc8b177334e30169d57c0837716958066f324a3453c6793fe0164049d9f11bbb"
+  version "2.2.4"
+  sha256 "6858529edd298faa806e8c7acc224fdad232a0fc6c205d993c1e5caa2518a768"
 
   url "https://github.com/JohnCoates/Aerial/releases/download/v#{version}/Aerial.saver.zip"
   appcast "https://github.com/JohnCoates/Aerial/releases.atom"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.