### PR TITLE
Revert "Update purevpn from 3.0.11 to 1.6.2"

### DIFF
--- a/Casks/purevpn.rb
+++ b/Casks/purevpn.rb
@@ -1,5 +1,5 @@
 cask "purevpn" do
-  version "1.6.2"
+  version "3.0.11"
   sha256 :no_check
 
   url "https://purevpn-dialer-assets.s3.amazonaws.com/mac-2.0/packages/Production/PureVPN.pkg",


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#95284

@reitermarkus - i think there is a problem with the pkg download - the correct version is 3.0.11