### PR TITLE
Update clockify from 2.5.10,177 to 2.6.1,186

### DIFF
--- a/Casks/clockify.rb
+++ b/Casks/clockify.rb
@@ -1,5 +1,5 @@
 cask "clockify" do
-  version "2.5.10,177"
+  version "2.6.1,186"
   sha256 :no_check
 
   url "https://clockify-resources.s3.eu-central-1.amazonaws.com/downloads/ClockifyDesktop.zip",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask