### PR TITLE
Update whoozle-android-file-transfer from 4.0 to 4.1

### DIFF
--- a/Casks/whoozle-android-file-transfer.rb
+++ b/Casks/whoozle-android-file-transfer.rb
@@ -1,6 +1,6 @@
 cask "whoozle-android-file-transfer" do
-  version "4.0"
-  sha256 "5bd55683d71d3c3ced260705da4b4b4c4fccf34865f5d006468156f3355a2b9b"
+  version "4.1"
+  sha256 "ac197fbe3800b6c2adb55332da4eecbcc5a322028bdd584a3d4b7e963c89abbb"
 
   url "https://github.com/whoozle/android-file-transfer-linux/releases/download/v#{version}/AndroidFileTransferForLinux.dmg",
       verified: "github.com/whoozle/android-file-transfer-linux/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.