### PR TITLE
Remove depends on x11

### DIFF
--- a/Casks/brl-cad-mged.rb
+++ b/Casks/brl-cad-mged.rb
@@ -8,7 +8,7 @@ cask "brl-cad-mged" do
   name "BRL-CAD"
   homepage "https://brlcad.org/"
 
-  depends_on x11: true
+  depends_on cask: "xquartz"
 
   app "BRL-CAD : MGED #{version}.app"
 end

--- a/Casks/dia.rb
+++ b/Casks/dia.rb
@@ -8,7 +8,7 @@ cask "dia" do
   name "Dia"
   homepage "http://dia-installer.de/"
 
-  depends_on x11: true
+  depends_on cask: "xquartz"
 
   app "Dia.app"
 end

--- a/Casks/gtkwave.rb
+++ b/Casks/gtkwave.rb
@@ -9,8 +9,6 @@ cask "gtkwave" do
   desc "GTK+ based wave viewer"
   homepage "https://gtkwave.sourceforge.io/"
 
-  depends_on x11: true
-
   app "gtkwave.app"
   binary "#{appdir}/gtkwave.app/Contents/Resources/bin/gtkwave_bin_launcher.sh", target: "gtkwave"
 

--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -17,7 +17,7 @@ cask "ncar-ncl" do
   desc "Interpreted language for scientific data analysis and visualization"
   homepage "https://www.ncl.ucar.edu/"
 
-  depends_on x11: true
+  depends_on cask: "xquartz"
   depends_on formula: "gcc"
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/x2goclient.rb
+++ b/Casks/x2goclient.rb
@@ -12,8 +12,6 @@ cask "x2goclient" do
   name "X2Go Client"
   homepage "https://wiki.x2go.org/doku.php"
 
-  depends_on x11: true
-
   app "x2goclient.app"
 
   zap trash: [


### PR DESCRIPTION
Remove `depends_on :x11` from all Casks.

This is needed for https://github.com/Homebrew/brew/pull/9403

- `brl-cad-mged`: this needs XQuartz specifically (tried with formulae but couldn't get it to work)
- `dia`: this prompts for XQuartz to be installed on startup (tried with formulae but couldn't get it to work)
- `gtkwave`: this doesn't need XQuartz at all (I don't have it installed and worked without)
- `near-ncl`: this needs XQuartz specifically (tried with formulae but couldn't get it to work)
- `x2goclient`: this doesn't need XQuartz at all (I don't have it installed and worked without)
