### PR TITLE
Update zappy from 2.7.2 to 2.8.0

### DIFF
--- a/Casks/zappy.rb
+++ b/Casks/zappy.rb
@@ -1,5 +1,5 @@
 cask "zappy" do
-  version "2.7.2"
+  version "2.8.0"
   sha256 :no_check
 
   url "https://zappy.zapier.com/releases/zappy-latest.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask