### PR TITLE
depends_on.md: remove reference to x11

### DIFF
--- a/doc/cask_language_reference/stanzas/depends_on.md
+++ b/doc/cask_language_reference/stanzas/depends_on.md
@@ -90,5 +90,4 @@ Since as of now all the macOS versions we support only run on 64-bit Intel, `dep
 | `cask:`    | a Cask token
 | `macos:`   | a symbol, string, array, or comparison expression defining macOS release requirements
 | `arch:`    | a symbol or array defining hardware requirements
-| `x11:`     | a Boolean indicating a dependency on X11
 | `java:`    | *stub - not yet functional*


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-cask/pull/95475.