### PR TITLE
Revert "Update mobirise from 5.2.0.68 to 5.2.2.19"

### DIFF
--- a/Casks/mobirise.rb
+++ b/Casks/mobirise.rb
@@ -1,5 +1,5 @@
 cask "mobirise" do
-  version "5.2.2.19"
+  version "5.2.0.68"
   sha256 :no_check
 
   url "https://download.mobirise.com/MobiriseSetup.dmg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#95459

wrong update @reitermarkus 