### PR TITLE
Update obs zap and appcast

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -3,7 +3,7 @@ cask "obs" do
   sha256 "f3713d629e1c9cda98b630fd11bfd25dbd4d0ba4fcf5fe85a2978da616981472"
 
   url "https://cdn-fastly.obsproject.com/downloads/obs-mac-#{version}.dmg"
-  appcast "https://obsproject.com/osx_update/stable/updates.xml"
+  appcast "https://github.com/obsproject/obs-studio/releases.atom"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -3,7 +3,7 @@ cask "obs" do
   sha256 "f3713d629e1c9cda98b630fd11bfd25dbd4d0ba4fcf5fe85a2978da616981472"
 
   url "https://cdn-fastly.obsproject.com/downloads/obs-mac-#{version}.dmg"
-  appcast "https://github.com/obsproject/obs-studio/releases.atom"
+  appcast "https://obsproject.com/osx_update/stable/updates.xml"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"
@@ -13,6 +13,7 @@ cask "obs" do
   app "OBS.app"
 
   zap trash: [
+    "/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin",
     "~/Library/Application Support/obs-studio",
     "~/Library/Preferences/com.obsproject.obs-studio.plist",
     "~/Library/Saved Application State/com.obsproject.obs-studio.savedState",


### PR DESCRIPTION
Virtual camera feature has been added to OBS macOS version and when started for the first time it creates DAL driver in `/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin` and this appcast is in the Info.plist from original app package.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
