### PR TITLE
Update purei-play from 0.35-31-g7c7f85aa to 0.35-33-gf14334b2

### DIFF
--- a/Casks/purei-play.rb
+++ b/Casks/purei-play.rb
@@ -1,5 +1,5 @@
 cask "purei-play" do
-  version "0.35-31-g7c7f85aa"
+  version "0.35-33-gf14334b2"
   sha256 :no_check
 
   url "https://purei.org/download_latest.php?platform=macos"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask