### PR TITLE
Update dcommander from 3.8.8,3881 to 3.8.9,3891

### DIFF
--- a/Casks/dcommander.rb
+++ b/Casks/dcommander.rb
@@ -1,5 +1,5 @@
 cask "dcommander" do
-  version "3.8.8,3881"
+  version "3.8.9,3891"
   sha256 :no_check
 
   url "https://devstorm-apps.com/dc/download.php"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask