### PR TITLE
[google-cloud-sdk] Get rid of python@3.8 requirement

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -7,8 +7,6 @@ cask "google-cloud-sdk" do
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
 
-  depends_on formula: "python@3.8"
-
   stage_only true
 
   postflight do
@@ -16,8 +14,7 @@ cask "google-cloud-sdk" do
                    args: [
                      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
                      "--rc-path", "false", "--quiet"
-                   ],
-                   env:  { "CLOUDSDK_PYTHON" => "#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python" }
+                   ]
   end
 
   # Not actually necessary, since it would be deleted anyway.
@@ -28,17 +25,14 @@ cask "google-cloud-sdk" do
     #{token} is installed at #{staged_path}/#{token}. Add your profile:
 
       for bash users
-        export CLOUDSDK_PYTHON="#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         source "#{staged_path}/#{token}/path.bash.inc"
         source "#{staged_path}/#{token}/completion.bash.inc"
 
       for zsh users
-        export CLOUDSDK_PYTHON="#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
         source "#{staged_path}/#{token}/path.zsh.inc"
         source "#{staged_path}/#{token}/completion.zsh.inc"
 
       for fish users
-        set -g -x "CLOUDSDK_PYTHON" "#{HOMEBREW_PREFIX}/opt/python@3.8/libexec/bin/python"
-        source "#{staged_path}/#{token}/path.fish.inc"
+        set -g fish_user_paths "#{staged_path}/#{token}/path.fish.inc" $fish_user_paths
   EOS
 end

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -33,6 +33,6 @@ cask "google-cloud-sdk" do
         source "#{staged_path}/#{token}/completion.zsh.inc"
 
       for fish users
-        set -g fish_user_paths "#{staged_path}/#{token}/path.fish.inc" $fish_user_paths
+        source "#{staged_path}/#{token}/path.fish.inc"
   EOS
 end


### PR DESCRIPTION
google-cloud-sdk now works with python 3.9. There is no need for a dep on 3.8 anymore.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
