### PR TITLE
adding_a_cask.md: remove < and >

### DIFF
--- a/doc/development/adding_a_cask.md
+++ b/doc/development/adding_a_cask.md
@@ -97,17 +97,17 @@ If the `generate_cask_token` script does not work for you, see [Cask Token Detai
 Once you know the token, create your Cask with the handy-dandy `brew create --cask` command:
 
 ```bash
-$ brew create --cask <cask-download-url> --set-name <my-new-cask>
+$ brew create --cask download-url --set-name my-new-cask
 ```
 
-This will open `$EDITOR` with a template for your new Cask, to be stored in the file `<my-new-cask>.rb`. Running the `create` command above will get you a template that looks like this:
+This will open `$EDITOR` with a template for your new Cask, to be stored in the file `my-new-cask.rb`. Running the `create` command above will get you a template that looks like this:
 
 ```ruby
-cask "<my-new-cask>" do
+cask "my-new-cask" do
   version ""
   sha256 ""
 
-  url "<cask-download-url>"
+  url "download-url"
   name ""
   desc ""
   homepage ""


### PR DESCRIPTION
Added these to a recent PR for consistency, but then noticed this document doesn’t use it. So it’s inconsistent with others, but until that’s fixed it should be consistent within itself.