### PR TITLE
Update fly from 6.5.1 to 6.7.2

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -5,7 +5,7 @@ cask "fly" do
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   appcast "https://github.com/concourse/concourse/releases.atom"
   name "fly"
-  desc "fly is the official CLI tool for Concourse CI"
+  desc "Official CLI tool for Concourse CI"
   homepage "https://github.com/concourse/concourse"
 
   binary "fly"

--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,10 +1,11 @@
 cask "fly" do
-  version "6.5.1"
-  sha256 "17b87c775dda5106118f080748b3526de88859c4c0fd7bf0d5a90ea4e4174569"
+  version "6.7.2"
+  sha256 "e095e0d631cd42a28b63e7101819840bad1b255d8b6d31ceb1fc0220c055605d"
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   appcast "https://github.com/concourse/concourse/releases.atom"
   name "fly"
+  desc "fly is the official CLI tool for Concourse CI"
   homepage "https://github.com/concourse/concourse"
 
   binary "fly"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.