### PR TITLE
Update safeincloud-password-manager from 20.3.2,200302 to 20.5.3,200503

### DIFF
--- a/Casks/safeincloud-password-manager.rb
+++ b/Casks/safeincloud-password-manager.rb
@@ -1,5 +1,5 @@
 cask "safeincloud-password-manager" do
-  version "20.3.2,200302"
+  version "20.5.3,200503"
   sha256 :no_check
 
   url "https://www.safe-in-cloud.com/download/SafeInCloud.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask