### PR TITLE
Update yak yak from 1.5.10 to 1.5.11

### DIFF
--- a/Casks/yakyak.rb
+++ b/Casks/yakyak.rb
@@ -1,8 +1,14 @@
 cask "yakyak" do
-  version "1.5.10"
-  sha256 "1e25fe66846153579626bacdf30bea712ed6e81216baf94c0ac89a681a4ca611"
+  version "1.5.11"
 
-  url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx.zip"
+  if Hardware::CPU.intel?
+    url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx-x64.zip"
+    sha256 "c5b8c079d7ba076dc5c03cd00c8950cb5f7ce6400b33dc3ef58d271c0700502b"
+  elsif Hardware::CPU.arm?
+    url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx-arm64.zip"
+    sha256 "8bf88599c2a8fa57fb103265a509269f51a498cc71867dcfa041d652a2e12d32"
+  end
+
   appcast "https://github.com/yakyak/yakyak/releases.atom"
   name "Yakyak"
   desc "Desktop chat client for Google Hangouts"

--- a/Casks/yakyak.rb
+++ b/Casks/yakyak.rb
@@ -1,14 +1,8 @@
 cask "yakyak" do
   version "1.5.11"
+  sha256 "c5b8c079d7ba076dc5c03cd00c8950cb5f7ce6400b33dc3ef58d271c0700502b"
 
-  if Hardware::CPU.intel?
-    url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx-x64.zip"
-    sha256 "c5b8c079d7ba076dc5c03cd00c8950cb5f7ce6400b33dc3ef58d271c0700502b"
-  elsif Hardware::CPU.arm?
-    url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx-arm64.zip"
-    sha256 "8bf88599c2a8fa57fb103265a509269f51a498cc71867dcfa041d652a2e12d32"
-  end
-
+  url "https://github.com/yakyak/yakyak/releases/download/v#{version}/yakyak-#{version}-osx-x64.zip"
   appcast "https://github.com/yakyak/yakyak/releases.atom"
   name "Yakyak"
   desc "Desktop chat client for Google Hangouts"


### PR DESCRIPTION
There is no universal version of YakYak, so I had to test the hardware to determine which version to install. Unfortunately, I could not find any other casks doing this type of check, yet, so hopefully I did it right. I modeled it after some logic I found in the openssl@1.1 formula.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
