### PR TITLE
Add python dependency to google-cloud-sdk

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -17,7 +17,7 @@ cask "google-cloud-sdk" do
                      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
                      "--rc-path", "false", "--quiet"
                    ],
-                   env: { "CLOUDSDK_PYTHON" => Formula["python"].opt_bin/"python" }
+                   env:  { "CLOUDSDK_PYTHON" => Formula["python"].libexec/"bin/python" }
   end
 
   # Not actually necessary, since it would be deleted anyway.

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -17,7 +17,7 @@ cask "google-cloud-sdk" do
                      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
                      "--rc-path", "false", "--quiet"
                    ],
-                   env:  { "CLOUDSDK_PYTHON" => Formula["python"].libexec/"bin/python" }
+                   env:  { "CLOUDSDK_PYTHON" => Formula["python"].opt_bin/"python3" }
   end
 
   # Not actually necessary, since it would be deleted anyway.

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -7,7 +7,7 @@ cask "google-cloud-sdk" do
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
 
-  depends_on formula: "python@3.9"
+  depends_on formula: "python"
 
   stage_only true
 

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -16,7 +16,8 @@ cask "google-cloud-sdk" do
                    args: [
                      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
                      "--rc-path", "false", "--quiet"
-                   ]
+                   ],
+                   env: { "CLOUDSDK_PYTHON" => Formula["python"].opt_bin/"python" }
   end
 
   # Not actually necessary, since it would be deleted anyway.

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -7,6 +7,8 @@ cask "google-cloud-sdk" do
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
 
+  depends_on formula: "python@3.9"
+
   stage_only true
 
   postflight do


### PR DESCRIPTION
The previous PR I wrote for this was intended to update to use the
current version of python considered default by homebrew. While much of
the PR was correct I inadvertently removed the dependency on python
instead of allowing the default.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
