### PR TITLE
Add auto_updates flag to gimp 2.10.22

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -9,6 +9,8 @@ cask "gimp" do
   desc "Free and open-source image editor"
   homepage "https://www.gimp.org/"
 
+  auto_updates true
+
   app "GIMP-#{version.major_minor}.app"
   binary "#{appdir}/GIMP-#{version.major_minor}.app/Contents/MacOS/gimp"
 


### PR DESCRIPTION
GIMP has had this functionality [since version 2.10.18](https://www.gimp.org/news/2020/02/24/gimp-2-10-18-released/), but it wasn't available for macOS users until version 2.10.22.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.