### PR TITLE
Fixed uninstallation behaviour for the Blackhole-16ch cask.

### DIFF
--- a/Casks/blackhole-16ch.rb
+++ b/Casks/blackhole-16ch.rb
@@ -10,5 +10,20 @@ cask "blackhole-16ch" do
 
   pkg "BlackHole16ch.v#{version}.pkg"
 
-  uninstall pkgutil: "audio.existential.BlackHole"
+  uninstall_postflight do
+    system_command "/bin/launchctl",
+                   args:         [
+                     "kickstart",
+                     "-kp",
+                     "system/com.apple.audio.coreaudiod",
+                   ],
+                   sudo:         true,
+                   must_succeed: true
+  end
+
+  uninstall quit:    [
+    "com.apple.audio.AudioMIDISetup",
+    "com.apple.systempreferences",
+  ],
+            pkgutil: "audio.existential.BlackHole"
 end


### PR DESCRIPTION
Changed uninstall stanza to also quit Audio MIDI setup app and the  System Preference app before using pkgutil.
Added uninstall_postflight stanza to restart coreaudio daemon.

These steps are the official instructions from Blackhole's Wiki, [here](https://github.com/ExistentialAudio/BlackHole/wiki/Uninstallation).

related: #96262 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
