### PR TITLE
Update river-sparkle from 3.0.5,8378 to 3.0.6,8392

### DIFF
--- a/Casks/river-sparkle.rb
+++ b/Casks/river-sparkle.rb
@@ -1,5 +1,5 @@
 cask "river-sparkle" do
-  version "3.0.5,8378"
+  version "3.0.6,8392"
   sha256 :no_check
 
   url "https://sparkleapp.com/update/Sparkle.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Automatically created and submitted by muUpdateStaticHomebrewCask