### PR TITLE
Update `url do` example.

### DIFF
--- a/doc/cask_language_reference/stanzas/url.md
+++ b/doc/cask_language_reference/stanzas/url.md
@@ -97,11 +97,10 @@ Similar to the `preflight`, `postflight`, `uninstall_preflight`, and `uninstall_
 ```rb
 url do
   require "open-uri"
-  # No known stable URL; fetching disposable URL from landing site
-  URI("https://example.com/app/landing").open do |landing_page|
-    content = landing_page.read
-    parse(content) # => https://example.com/download?23309800482283
-  end
+  base_url = "https://handbrake.fr/nightly.php"
+  content = URI(base_url).read
+  file_path = content[/href=["']?([^"' >]*Handbrake[._-][^"' >]+\.dmg)["' >]/i, 1]
+  file_path ? URI.join(base_url, file_path) : nil
 end
 ```
 


### PR DESCRIPTION
Use `handbrake-nightly` as example, which also needs `URI.join`: https://github.com/Homebrew/homebrew-cask-versions/pull/10128