### PR TITLE
Update Simple Comic to a community maintained fork

### DIFF
--- a/Casks/simple-comic.rb
+++ b/Casks/simple-comic.rb
@@ -1,13 +1,13 @@
 cask "simple-comic" do
-  version "1.7_252"
-  sha256 "4ddd18a02a79fc8201824e6ab99291c6d4c8680f79f94bc372bf71f0535def35"
+  version "1.9.1"
+  sha256 "d86e95504106718cd73f2eea8505428cabfdcfa42bc0cc7028807aa865e1d9b3"
 
-  url "https://github.com/dancingtortoise/Simple-Comic/releases/download/#{version}/SimpleComic_#{version}.zip",
-      verified: "github.com/dancingtortoise/Simple-Comic/"
-  appcast "https://github.com/dancingtortoise/Simple-Comic/releases.atom"
+  url "https://github.com/MaddTheSane/Simple-Comic/releases/download/#{version}/Simple.Comic.app.zip",
+      verified: "https://github.com/MaddTheSane/Simple-Comic"
+  appcast "https://github.com/MaddTheSane/Simple-Comic/releases.atom"
   name "Simple Comic"
-  desc "Comic viewer/reader"
-  homepage "https://dancingtortoise.github.io/"
+  desc "Streamlined comic viewer for macOS"
+  homepage "https://github.com/MaddTheSane/Simple-Comic"
 
   app "Simple Comic.app"
 end

--- a/Casks/simple-comic.rb
+++ b/Casks/simple-comic.rb
@@ -2,8 +2,7 @@ cask "simple-comic" do
   version "1.9.1"
   sha256 "d86e95504106718cd73f2eea8505428cabfdcfa42bc0cc7028807aa865e1d9b3"
 
-  url "https://github.com/MaddTheSane/Simple-Comic/releases/download/#{version}/Simple.Comic.app.zip",
-      verified: "https://github.com/MaddTheSane/Simple-Comic"
+  url "https://github.com/MaddTheSane/Simple-Comic/releases/download/#{version}/Simple.Comic.app.zip"
   appcast "https://github.com/MaddTheSane/Simple-Comic/releases.atom"
   name "Simple Comic"
   desc "Streamlined comic viewer"

--- a/Casks/simple-comic.rb
+++ b/Casks/simple-comic.rb
@@ -6,7 +6,7 @@ cask "simple-comic" do
       verified: "https://github.com/MaddTheSane/Simple-Comic"
   appcast "https://github.com/MaddTheSane/Simple-Comic/releases.atom"
   name "Simple Comic"
-  desc "Streamlined comic viewer for macOS"
+  desc "Streamlined comic viewer"
   homepage "https://github.com/MaddTheSane/Simple-Comic"
 
   app "Simple Comic.app"


### PR DESCRIPTION
Simple Comic homepage (http://dancingtortoise.com/simplecomic/) used to link to https://github.com/arauchfuss/Simple-Comic. However the last commit happened in Apr 2017 and after a discussion community has created a new modern maintained fork: https://github.com/MaddTheSane/Simple-Comic

Here is the issue where the discussion happened with more details: https://github.com/arauchfuss/Simple-Comic/issues/126

In this PR, I'm intentionally redirecting download and other links to this new community maintained fork. Let me know if there is other information that would help here.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
