### PR TITLE
Switch CI to use Big Sur.

### DIFF
--- a/.github/workflows/bump-unversioned-casks.yml
+++ b/.github/workflows/bump-unversioned-casks.yml
@@ -2,8 +2,8 @@ name: Bump unversioned casks
 
 on:
   push:
-    branches:
-      - debug-bump-unversioned-casks
+    paths:
+      - .github/workflows/bump-unversioned-casks.yml
   schedule:
     - cron: '*/30 * * * *'
   workflow_dispatch:
@@ -20,7 +20,7 @@ env:
 jobs:
   bump-unversioned-casks:
     if: startsWith(github.repository, 'Homebrew/')
-    runs-on: macos-latest
+    runs-on: macos-11.0
     steps:
       - name: Check if another run already exists
         id: skip

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -2,8 +2,8 @@ name: Cache
 
 on:
   push:
-    branches:
-      - debug-cache
+    paths:
+      - .github/workflows/cache.yml
   schedule:
     - cron: '0 */6 * * *' # every 6 hours
 
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-11.0
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   test:
     name: ${{ matrix.name }}
     needs: generate-matrix
-    runs-on: macos-latest
+    runs-on: macos-11.0
     strategy:
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}


### PR DESCRIPTION
Should prevent `Homebrew/brew` CI failing in cases where an audit error is only present on Big Sur.