### PR TITLE
Add IntelliJ idea ignore attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@
 /.bundle/
 /bin/
 /vendor/
+/.idea/
+*.iml
 
 # anywhere in the tree
 *~
 .DS_Store
 .ruby-version
 coverage
+/venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 # toplevel
 /.bundle/
+/.idea/
 /bin/
 /vendor/
 /venv/
-/.idea/
 
 # anywhere in the tree
 *~
+*.iml
 .DS_Store
 .ruby-version
 coverage
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,10 @@
 /vendor/
 /venv/
 /.idea/
-*.iml
 
 # anywhere in the tree
 *~
 .DS_Store
 .ruby-version
 coverage
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.bundle/
 /bin/
 /vendor/
+/venv/
 /.idea/
 *.iml
 
@@ -10,4 +11,3 @@
 .DS_Store
 .ruby-version
 coverage
-/venv


### PR DESCRIPTION
This update purely adds some extra lines to the standard gitignore file to remove extraneous files from being committed to the repository if modifying using IntelliJ based products

- [x] N/A The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] N/A `brew audit --cask {{cask_file}}` is error-free.
- [x] N/A `brew style --fix {{cask_file}}` reports no offenses.
