### PR TITLE
flutter: remove depends_on

### DIFF
--- a/Casks/flutter.rb
+++ b/Casks/flutter.rb
@@ -9,7 +9,6 @@ cask "flutter" do
   homepage "https://flutter.dev/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   binary "flutter/bin/dart"
   binary "flutter/bin/flutter"


### PR DESCRIPTION
Minimum OS is simply a 64-bit version of macOS.

Closes https://github.com/Homebrew/homebrew-cask/issues/96852.