### PR TITLE
Update stretchly from 1.3.0 to 1.4.0

### DIFF
--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -1,6 +1,6 @@
 cask "stretchly" do
-  version "1.3.0"
-  sha256 "cae31b31a419ce49d45cb15b749d41ccd108c678a08d4c4fe0728b9bcbf029c5"
+  version "1.4.0"
+  sha256 "837b796f07545fdd67a2c6b5f76f7ee0d9eea0af52a09360d7abeed1c80d732d"
 
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}.dmg",
       verified: "github.com/hovancik/stretchly/"


### PR DESCRIPTION
Created with brew bump-cask-pr.