### PR TITLE
Remove conda symlink on CI before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
             echo '::warning::Removing `cocoapods` symlink is no longer necessary.'
           fi
 
+          if ! rm /usr/local/bin/conda; then
+            echo '::warning::Removing `conda` symlink is no longer necessary.'
+          fi
+
           if brew tap-info adoptopenjdk/openjdk; then
             brew untap adoptopenjdk/openjdk
           else


### PR DESCRIPTION
On GitHub Actions runners, Miniconda is [installed using a non-Homebrew method](https://github.com/actions/virtual-environments/blob/64c9751269fda5e0d4a93407a59e0ed8c421ab87/images/macos/provision/core/miniconda.sh#L9) and then symlinked to `/usr/local/bin/conda`. This causes a conflict when running the CI tests for the `miniconda` cask, which is supposed to be symlinked to the same location (see [error](https://github.com/Homebrew/homebrew-cask/runs/1613209640#step:17:175) on CI). 

This PR should resolve the CI test failure encountered in #96911 by using the same approach used for `cocoapods` (#88948) and `dotnet` (#88476).