### PR TITLE
Add Operator.app v0.9.9

### DIFF
--- a/Casks/operator.rb
+++ b/Casks/operator.rb
@@ -1,0 +1,21 @@
+cask "operator" do
+  version "0.9.9"
+  sha256 :no_check
+
+  url "https://download.prelude.org/latest?platform=darwin&variant=zip"
+  appcast "https://s3.amazonaws.com/operator.versions/dist/latest-mac.yml"
+  name "Operator"
+  desc "Prelude Operator is a desktop adversary emulation platform"
+  homepage "https://www.prelude.org/"
+
+  app "Operator.app"
+
+  zap trash: [
+    "~/Library/Application Support/Operator",
+    "~/Library/Caches/com.prelude.operator",
+    "~/Library/Caches/com.prelude.operator.ShipIt",
+    "~/Library/Logs/Operator",
+    "~/Library/Preferences/com.prelude.operator.plist",
+    "~/Library/Saved Application State/com.prelude.operator.savedState",
+  ]
+end


### PR DESCRIPTION
Adds a cask for the Prelude Operator application. It is a desktop-based adversary emulation platform.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew install --cask {{cask_file}}` worked successfully.
- [X] `brew uninstall --cask {{cask_file}}` worked successfully.
