### PR TITLE
Fix HEY app stanza

### DIFF
--- a/Casks/hey.rb
+++ b/Casks/hey.rb
@@ -5,12 +5,12 @@ cask "hey" do
   url "https://hey-desktop.s3.amazonaws.com/HEY-#{version}.dmg",
       verified: "hey-desktop.s3.amazonaws.com/"
   appcast "https://hey-desktop.s3.amazonaws.com/latest-mac.yml"
-  name "Hey"
+  name "HEY"
   homepage "https://hey.com/"
 
   auto_updates true
 
-  app "Hey.app"
+  app "HEY.app"
 
   zap trash: [
     "~/Library/Application Support/HEY",

--- a/Casks/hey.rb
+++ b/Casks/hey.rb
@@ -6,6 +6,7 @@ cask "hey" do
       verified: "hey-desktop.s3.amazonaws.com/"
   appcast "https://hey-desktop.s3.amazonaws.com/latest-mac.yml"
   name "HEY"
+  desc "Email's new heyday"
   homepage "https://hey.com/"
 
   auto_updates true

--- a/Casks/hey.rb
+++ b/Casks/hey.rb
@@ -6,7 +6,7 @@ cask "hey" do
       verified: "hey-desktop.s3.amazonaws.com/"
   appcast "https://hey-desktop.s3.amazonaws.com/latest-mac.yml"
   name "HEY"
-  desc "Email's new heyday"
+  desc "Access the HEY email service"
   homepage "https://hey.com/"
 
   auto_updates true


### PR DESCRIPTION
This fixes an issue with the HEY cask where the app stanza had the incorrect capitalization.

***

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
