### PR TITLE
Update printrun from 18Nov2017(cannot run in catalina) to 2.0.0rc7

### DIFF
--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -6,6 +6,7 @@ cask "printrun" do
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
   homepage "https://github.com/kliment/Printrun"
+  caveats "You MUST run 'chmod a+x /Applications/pronterface.app/Contents/MacOS/pronterface' in shell after install."
 
   app "pronterface.app"
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,6 +1,6 @@
 cask "printrun" do
   version "2.0.0rc7"
-  sha256 "426229043a2a33a6768dcca12135f0751c007595af078665eb854cf87e4e2999"
+  sha256 "c2c6c2d519b5a224b67e6b9fa7be2a70aac83839f9acc6309c4f70f3c40e4858"
 
   url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-#{version}-macos.zip"
   appcast "https://github.com/kliment/Printrun/releases.atom"

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -2,10 +2,10 @@ cask "printrun" do
   version "2.0.0rc7"
   sha256 "426229043a2a33a6768dcca12135f0751c007595af078665eb854cf87e4e2999"
 
-  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-Mac-#{version}.zip"
+  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-#{version}-macos.zip"
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
   homepage "https://github.com/kliment/Printrun"
 
-  app "pronterface.app"
+  app "Printrun-#{version}-macos/pronterface.app"
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -7,5 +7,5 @@ cask "printrun" do
   name "Printrun"
   homepage "https://github.com/kliment/Printrun"
 
-  app "Printrun-#{version}-macos/pronterface.app"
+  app "pronterface.app"
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -6,6 +6,7 @@ cask "printrun" do
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
   homepage "https://github.com/kliment/Printrun"
+  desc "It have stable version (1.6.0,18Nov2017), but it's 32-bit (cannot run in catalina). I replaced old 18Nov2017 to 2.0.0rc7."
   caveats "You MUST run 'chmod a+x /Applications/pronterface.app/Contents/MacOS/pronterface' in shell after install."
 
   app "pronterface.app"

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -5,7 +5,7 @@ cask "printrun" do
   url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-#{version}-macos.zip"
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
-  desc "It have stable version (1.6.0,18Nov2017), but it cannot run in catalina."
+  desc "It have stable version (1.6.0,18Nov2017), but it cannot run in catalina"
   homepage "https://github.com/kliment/Printrun"
 
   app "pronterface.app"

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,11 +1,11 @@
 cask "printrun" do
-  version "1.6.0,18Nov2017"
+  version "2.0.0rc7"
   sha256 "426229043a2a33a6768dcca12135f0751c007595af078665eb854cf87e4e2999"
 
-  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version.before_comma}/Printrun-Mac-#{version.after_comma}.zip"
+  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-Mac-#{version}.zip"
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
   homepage "https://github.com/kliment/Printrun"
 
-  app "Printrun-Mac-#{version.after_comma}.app"
+  app "pronterface.app"
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -5,9 +5,10 @@ cask "printrun" do
   url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-#{version}-macos.zip"
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
+  desc "It have stable version (1.6.0,18Nov2017), but it cannot run in catalina."
   homepage "https://github.com/kliment/Printrun"
-  desc "It have stable version (1.6.0,18Nov2017), but it's 32-bit (cannot run in catalina). I replaced old 18Nov2017 to 2.0.0rc7."
-  caveats "You MUST run 'chmod a+x /Applications/pronterface.app/Contents/MacOS/pronterface' in shell after install."
 
   app "pronterface.app"
+
+  caveats "You MUST run 'chmod a+x /Applications/pronterface.app/Contents/MacOS/pronterface' in shell after install."
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -8,6 +8,14 @@ cask "printrun" do
   desc "Python 3d printing host software"
   homepage "https://github.com/kliment/Printrun"
 
+  livecheck do
+    url "https://github.com/kliment/Printrun/releases/latest"
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/printrun-(\d+(?:\.\d+)*)/Printrun-Mac-(.*?)\.zip}i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
   app "Printrun-#{version}-macos/pronterface.app"
 
   caveats "You MUST run 'chmod a+x /Applications/pronterface.app/Contents/MacOS/pronterface' in shell after install."

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -5,10 +5,10 @@ cask "printrun" do
   url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/Printrun-#{version}-macos.zip"
   appcast "https://github.com/kliment/Printrun/releases.atom"
   name "Printrun"
-  desc "It have stable version (1.6.0,18Nov2017), but it cannot run in catalina"
+  desc "Python 3d printing host software"
   homepage "https://github.com/kliment/Printrun"
 
-  app "pronterface.app"
+  app "Printrun-#{version}-macos/pronterface.app"
 
   caveats "You MUST run 'chmod a+x /Applications/pronterface.app/Contents/MacOS/pronterface' in shell after install."
 end


### PR DESCRIPTION
Same to title. *This exception looks to not documented but stable version **cannot** run in catalina.*

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
