### PR TITLE
steam: auto_updates

### DIFF
--- a/Casks/steam.rb
+++ b/Casks/steam.rb
@@ -1,5 +1,5 @@
 cask "steam" do
-  version :latest
+  version "2020-12-21"
   sha256 :no_check
 
   url "https://steamcdn-a.akamaihd.net/client/installer/steam.dmg",
@@ -7,6 +7,14 @@ cask "steam" do
   name "Steam"
   desc "Video game digital distribution service"
   homepage "https://store.steampowered.com/about/"
+
+  livecheck do
+    url "https://store.steampowered.com/oldnews/?feed=steam_client"
+    strategy :page_match do |page|
+      date = Time.parse(page[/class=["']?date["']?[^>]*>([^<]+)/i, 1])
+      date.strftime("%Y-%m-%d")
+    end
+  end
 
   auto_updates true
 

--- a/Casks/steam.rb
+++ b/Casks/steam.rb
@@ -1,5 +1,5 @@
 cask "steam" do
-  version "2.0"
+  version :latest
   sha256 :no_check
 
   url "https://steamcdn-a.akamaihd.net/client/installer/steam.dmg",
@@ -7,6 +7,8 @@ cask "steam" do
   name "Steam"
   desc "Video game digital distribution service"
   homepage "https://store.steampowered.com/about/"
+
+  auto_updates true
 
   app "Steam.app"
 


### PR DESCRIPTION
@reitermarkus The version for this one is dead wrong. It should be excluded from automated checks because I don’t think they care about having the proper version in the app. The DMG also doesn’t necessarily contain the latest version of the app; this one is very dependent on updating itself.