### PR TITLE
Upgrade Wavebox.app to v10.0.389.2 and update the urls from core to s…

### DIFF
--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -5,6 +5,7 @@ cask "wavebox" do
   url "https://download.wavebox.app/stable/mac/Install%20Wavebox%20#{version}.dmg",
       verified: "download.wavebox.app/"
   name "Wavebox"
+  desc "Powerful productivity browser like no other"
   homepage "https://wavebox.io/"
 
   livecheck do

--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -5,7 +5,7 @@ cask "wavebox" do
   url "https://download.wavebox.app/stable/mac/Install%20Wavebox%20#{version}.dmg",
       verified: "download.wavebox.app/"
   name "Wavebox"
-  desc "Powerful productivity browser like no other"
+  desc "Web browser"
   homepage "https://wavebox.io/"
 
   livecheck do

--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -1,14 +1,14 @@
 cask "wavebox" do
-  version "10.0.265.1"
-  sha256 "112427c4fec39fcbe958434eafe9ce97906492d2e8413b45e450abec5cc48ccd"
+  version "10.0.389.2"
+  sha256 "3168af8abe08cc6e02dbed093118d7c2743eea0b33367b33c3df57af0306a82b"
 
-  url "https://download.wavebox.app/core/mac/Install%20Wavebox%20#{version}.dmg",
+  url "https://download.wavebox.app/stable/mac/Install%20Wavebox%20#{version}.dmg",
       verified: "download.wavebox.app/"
   name "Wavebox"
   homepage "https://wavebox.io/"
 
   livecheck do
-    url "https://download.wavebox.app/core/mac/appcast.xml"
+    url "https://download.wavebox.app/stable/mac/appcast.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
…table. Core was deprecated & frozen mid-2020 and when installing the core version it immediately prompts to update to the stable version. Add a description to the cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.