### PR TITLE
Update rq from 0.10.4 to 1.0.2

### DIFF
--- a/Casks/rq.rb
+++ b/Casks/rq.rb
@@ -1,11 +1,11 @@
 cask "rq" do
-  version "0.10.4"
-  sha256 "cae9ee8589dfb4fd0ab13ac7991d372fc2531f7c69374257b943dc2e096b750a"
+  version "1.0.2"
+  sha256 "49f732b2aabf4eaff231e425edf710ca34e6bf730cff9a71adf79d11e630f883"
 
-  url "https://github.com/dflemstr/rq/releases/download/v#{version}/record-query-v#{version}-x86_64-apple-darwin.tar.gz"
+  url "https://github.com/dflemstr/rq/releases/download/v#{version}/rq-v#{version}-x86_64-apple-darwin.tar.gz"
   appcast "https://github.com/dflemstr/rq/releases.atom"
   name "rq"
   homepage "https://github.com/dflemstr/rq"
 
-  binary "x86_64-apple-darwin/rq"
+  binary "rq"
 end


### PR DESCRIPTION
Update to version 1.0.2.
`url` and `binary` stanza updated to new format.

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

`brew audit --cask {{cask_file}}` returns a single error related to the `desc` stanza. I didn't add a description because the focus of this PR is a version update. 