### PR TITLE
Update strawberry from 0.8.4 to 0.8.5

### DIFF
--- a/Casks/strawberry.rb
+++ b/Casks/strawberry.rb
@@ -1,12 +1,11 @@
 cask "strawberry" do
   version "0.8.5"
 
-  case MacOS.version
-  when :mojave
+  if MacOS.version <= :mojave
     sha256 "05351f24c29eb4f5a5cee9da1272e4c034e2d9277091aa1f9cb40d7f655c8fba"
     url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}-mojave.dmg",
         verified: "github.com/strawberrymusicplayer/strawberry/"
-  when :catalina
+  elsif MacOS.version <= :catalina
     sha256 "abadc6ebb4c6431e5c6b127ec4509b56a2918fe641adcf0b96c90c4fb94e184e"
     url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}-catalina.dmg",
         verified: "github.com/strawberrymusicplayer/strawberry/"

--- a/Casks/strawberry.rb
+++ b/Casks/strawberry.rb
@@ -1,15 +1,27 @@
 cask "strawberry" do
-  version "0.8.4"
-  sha256 "23982f1f8b94cb2abf3d8d9e277abd0a0580ea3fa5673c0632970192ecea7bf9"
+  version "0.8.5"
 
-  url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}.dmg",
-      verified: "github.com/strawberrymusicplayer/strawberry/"
+  case MacOS.version
+  when :mojave
+    sha256 "05351f24c29eb4f5a5cee9da1272e4c034e2d9277091aa1f9cb40d7f655c8fba"
+    url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}-mojave.dmg",
+        verified: "github.com/strawberrymusicplayer/strawberry/"
+  when :catalina
+    sha256 "abadc6ebb4c6431e5c6b127ec4509b56a2918fe641adcf0b96c90c4fb94e184e"
+    url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}-catalina.dmg",
+        verified: "github.com/strawberrymusicplayer/strawberry/"
+  else
+    sha256 "82746e7c784c837aa614ff011c337323d0b087f76da3567b53b543ddcf258b28"
+    url "https://github.com/strawberrymusicplayer/strawberry/releases/download/#{version}/strawberry-#{version}-bigsur.dmg",
+        verified: "github.com/strawberrymusicplayer/strawberry/"
+  end
+
   appcast "https://github.com/strawberrymusicplayer/strawberry/releases.atom"
   name "Strawberry"
   desc "Music player and music collection organizer"
   homepage "https://www.strawberrymusicplayer.org/"
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :mojave"
 
   app "strawberry.app"
 


### PR DESCRIPTION
Strawberry now distributed in three separate ways depending on OS version. 

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.