### PR TITLE
github_prerelease_allowlist.json: remove home-assistant

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -3,7 +3,6 @@
   "freetube": "all",
   "graphsketcher": "all",
   "haptickey": "all",
-  "home-assistant": "all",
   "lidarr": "all",
   "nuclear": "all",
   "pock": "all",


### PR DESCRIPTION
Required for https://github.com/Homebrew/homebrew-cask/pull/97249 to pass `audit`.