### PR TITLE
Update smultron from 12.2.5 to 12.2.6

### DIFF
--- a/Casks/smultron.rb
+++ b/Casks/smultron.rb
@@ -1,6 +1,6 @@
 cask "smultron" do
   version "12.2.5,12250"
-  sha256 "4fd4a60746bf49bab5aeff124ff36e5506e71dd3ab768d72cdcd817bb0147c6e"
+  sha256 :no_check
 
   url "https://www.peterborgapps.com/downloads/Smultron#{version.before_comma.major}.zip"
   name "Smultron"

--- a/Casks/smultron.rb
+++ b/Casks/smultron.rb
@@ -1,6 +1,6 @@
 cask "smultron" do
   version "12.2.6"
-  sha256 :no_check
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.peterborgapps.com/downloads/Smultron#{version.major}.zip"
   name "Smultron"

--- a/Casks/smultron.rb
+++ b/Casks/smultron.rb
@@ -11,5 +11,8 @@ cask "smultron" do
 
   app "Smultron.app"
 
-  zap trash: "~/Library/Containers/com.peterborgapps.Smultron#{version.before_comma.major}"
+  zap trash: [
+    "~/Library/Application Scripts/com.peterborgapps.Smultron#{version.before_comma.major}",
+    "~/Library/Containers/com.peterborgapps.Smultron#{version.before_comma.major}",
+  ]
 end

--- a/Casks/smultron.rb
+++ b/Casks/smultron.rb
@@ -1,8 +1,8 @@
 cask "smultron" do
-  version "12.2.5,12250"
+  version "12.2.6"
   sha256 :no_check
 
-  url "https://www.peterborgapps.com/downloads/Smultron#{version.before_comma.major}.zip"
+  url "https://www.peterborgapps.com/downloads/Smultron#{version.major}.zip"
   name "Smultron"
   desc "General-purpose text editor"
   homepage "https://www.peterborgapps.com/smultron/"
@@ -12,7 +12,7 @@ cask "smultron" do
   app "Smultron.app"
 
   zap trash: [
-    "~/Library/Application Scripts/com.peterborgapps.Smultron#{version.before_comma.major}",
-    "~/Library/Containers/com.peterborgapps.Smultron#{version.before_comma.major}",
+    "~/Library/Application Scripts/com.peterborgapps.Smultron#{version.major}",
+    "~/Library/Containers/com.peterborgapps.Smultron#{version.major}",
   ]
 end

--- a/Casks/smultron.rb
+++ b/Casks/smultron.rb
@@ -7,6 +7,7 @@ cask "smultron" do
   desc "General-purpose text editor"
   homepage "https://www.peterborgapps.com/smultron/"
 
+  auto_updates true
   depends_on macos: ">= :mojave"
 
   app "Smultron.app"


### PR DESCRIPTION
This is a draft at the moment because I want some input.

Smultron has releases going back to version 7 to support 10.10+. So I added these.

I'm unable to test these older releases because apparently `MACOS_VERSION` environment variable no longer works (or maybe this is just on Big Sur).

Nonetheless, I'd like input on the style. Starting at version 10, the app name changed to just `Smultron.app` instead of the previously used `Smultron #{version.major}.app`. I didn't want to triple code in `app "Smultron.app"`, so I put it outside of the if-elsif statement, and only included it in version 7 and 8 (yosemite and el capitan versions).
Is this the correct way to do it or should each if-elsif statement include the `app` stanza?