### PR TITLE
visual-paradigm: Update to 16.2,20210101; add desc; new url scheme

### DIFF
--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -1,6 +1,6 @@
 cask "visual-paradigm" do
-  version "16.2,20201219"
-  sha256 "0267bd9990795c93793c47b91dc754f5834c33806007d81f27f464b01fe978e9"
+  version "16.2,20210101"
+  sha256 "667ab269575783f16e37b167407dbac43c33087fa035b7ba24b6b97bdedc0ec8"
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   name "Visual Paradigm"

--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -4,6 +4,7 @@ cask "visual-paradigm" do
 
   url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   name "Visual Paradigm"
+  desc "UML CASE Tool supporting UML 2, SysML and Business Process Modeling Notation"
   homepage "https://www.visual-paradigm.com/"
 
   livecheck do

--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -2,7 +2,7 @@ cask "visual-paradigm" do
   version "16.2,20210101"
   sha256 "667ab269575783f16e37b167407dbac43c33087fa035b7ba24b6b97bdedc0ec8"
 
-  url "https://eu8.dl.visual-paradigm.com/visual-paradigm/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
+  url "https://www.visual-paradigm.com/downloads/vp#{version.before_comma}/#{version.after_comma}/Visual_Paradigm_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   name "Visual Paradigm"
   desc "UML CASE Tool supporting UML 2, SysML and Business Process Modeling Notation"
   homepage "https://www.visual-paradigm.com/"


### PR DESCRIPTION
Update from 16.2,20201219 to 16.2,20210101.
Added `desc`.
New `url` scheme to allow for faster downloads. Originally was using the eu9 mirror, now it will download from the appropriate mirror for the user.

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.