### PR TITLE
visual-paradigmce: Update to 16.2,20210101; add livecheck; add desc

### DIFF
--- a/Casks/visual-paradigm-ce.rb
+++ b/Casks/visual-paradigm-ce.rb
@@ -1,6 +1,6 @@
 cask "visual-paradigm-ce" do
-  version "16.2,20201219"
-  sha256 "3a5abf036e364136ac18251d987bc0caf7239d36cf8da9f548b46f55afa8f72e"
+  version "16.2,20210101"
+  sha256 "78f671377908497ba73451e9a183c80418032716a2551ba7c2e4b99c01f9e008"
 
   url "https://www.visual-paradigm.com/downloads/vpce/Visual_Paradigm_CE_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   name "Visual Paradigm Community Edition"

--- a/Casks/visual-paradigm-ce.rb
+++ b/Casks/visual-paradigm-ce.rb
@@ -4,6 +4,7 @@ cask "visual-paradigm-ce" do
 
   url "https://www.visual-paradigm.com/downloads/vpce/Visual_Paradigm_CE_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
   name "Visual Paradigm Community Edition"
+  desc "All-in-one UML, SysML, BPMN Modeling Platform for Agile"
   homepage "https://www.visual-paradigm.com/"
 
   livecheck do

--- a/Casks/visual-paradigm-ce.rb
+++ b/Casks/visual-paradigm-ce.rb
@@ -3,10 +3,16 @@ cask "visual-paradigm-ce" do
   sha256 "3a5abf036e364136ac18251d987bc0caf7239d36cf8da9f548b46f55afa8f72e"
 
   url "https://www.visual-paradigm.com/downloads/vpce/Visual_Paradigm_CE_#{version.before_comma.dots_to_underscores}_#{version.after_comma}_OSX_WithJRE.dmg"
-  appcast "https://www.visual-paradigm.com/downloads/vpce/checksum.html",
-          must_contain: "#{version.before_comma.dots_to_underscores}_#{version.after_comma}"
   name "Visual Paradigm Community Edition"
   homepage "https://www.visual-paradigm.com/"
+
+  livecheck do
+    url "https://www.visual-paradigm.com/downloads/vpce/checksum.html"
+    strategy :header_match do |headers|
+      match = headers["location"].match(%r{/vpce(\d+(?:\.\d+)*)/(\d+)/checksum\.html}i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
 
   # Renamed to avoid conflict with visual-paradigm.
   app "Visual Paradigm.app", target: "Visual Paradigm CE.app"


### PR DESCRIPTION
Added `dec` and `livecheck`.
Updated from 16.2,20201219 to 16.2,20210101.

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.