### PR TITLE
electron-fiddle: ARM support 0.19.0

### DIFF
--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -3,10 +3,12 @@ cask "electron-fiddle" do
 
   if Hardware::CPU.intel?
     sha256 "83deb7f48349c09522d9d23458f0f38e87aa727f42e68842a36a270c64d1adf2"
+
     url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip",
         verified: "github.com/electron/fiddle/"
   else
     sha256 "2b12187b561a98ccb8fe191ab89531cf7d21f35021fd0807d5a06046f8cdf084"
+
     url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-arm64-#{version}.zip",
         verified: "github.com/electron/fiddle/"
   end

--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -1,9 +1,16 @@
 cask "electron-fiddle" do
-  version "0.18.0"
-  sha256 "5e2a7090fe9237eb9b132ad383ff5b94cd2dc4a836608949b6d5fd330ee7b281"
+  version "0.19.0"
 
-  url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip",
-      verified: "github.com/electron/fiddle/"
+  if Hardware::CPU.intel?
+    sha256 "83deb7f48349c09522d9d23458f0f38e87aa727f42e68842a36a270c64d1adf2"
+    url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-x64-#{version}.zip",
+        verified: "github.com/electron/fiddle/"
+  else
+    sha256 "2b12187b561a98ccb8fe191ab89531cf7d21f35021fd0807d5a06046f8cdf084"
+    url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-arm64-#{version}.zip",
+        verified: "github.com/electron/fiddle/"
+  end
+
   appcast "https://github.com/electron/fiddle/releases.atom"
   name "Electron Fiddle"
   desc "Easiest way to get started with Electron"


### PR DESCRIPTION
Update from 0.18.0 to 0.19.0.
Added ARM support.