### PR TITLE
Update Ray.app to 1.0.7

### DIFF
--- a/Casks/ray.rb
+++ b/Casks/ray.rb
@@ -1,5 +1,5 @@
 cask "ray" do
-  version "1.0.1"
+  version "1.0.7"
   sha256 "316fbfc6c012d4f965a04b859731f0bdde5575e010034fdfac3a296c70cc7509"
 
   url "https://ray-app.s3.eu-west-1.amazonaws.com/Ray-#{version}.dmg",

--- a/Casks/ray.rb
+++ b/Casks/ray.rb
@@ -1,6 +1,6 @@
 cask "ray" do
   version "1.0.7"
-  sha256 "316fbfc6c012d4f965a04b859731f0bdde5575e010034fdfac3a296c70cc7509"
+  sha256 "359007ee68c4c6fe7b2814acd808958a3bd59db4f15c9c1f353380d4e764d55d"
 
   url "https://ray-app.s3.eu-west-1.amazonaws.com/Ray-#{version}.dmg",
       verified: "ray-app.s3.eu-west-1.amazonaws.com/"


### PR DESCRIPTION
Updated Ray to 1.0.7. 

Question: At Spatie/Ray, they also provide this url: `https://spatie.be/products/ray/download/macos/latest`. This will always download the latest version. Is this something that's possible in Homebrew Cask, or is a version in the ask file always required?

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
