### PR TITLE
sitesucker-pro: add

### DIFF
--- a/Casks/sitesucker-pro.rb
+++ b/Casks/sitesucker-pro.rb
@@ -2,7 +2,7 @@ cask "sitesucker-pro" do
   if MacOS.version <= :mojave
     version "3.2.7"
     sha256 "dd61a113ad86b580e0faf97b4aa86290e038bb3e098f2d19e67fc9e194ce1a3e"
-  elsif MacOS.version <= :big_sur
+  else
     version "4.0.3"
     sha256 "5c5b2af9eb2a35ec116786c52eb4774e8163071a53b65c101ab54496a2a77614"
   end

--- a/Casks/sitesucker-pro.rb
+++ b/Casks/sitesucker-pro.rb
@@ -1,0 +1,25 @@
+cask "sitesucker-pro" do
+  if MacOS.version <= :mojave
+    version "3.2.7"
+    sha256 "dd61a113ad86b580e0faf97b4aa86290e038bb3e098f2d19e67fc9e194ce1a3e"
+  elsif MacOS.version <= :big_sur
+    version "4.0.3"
+    sha256 "5c5b2af9eb2a35ec116786c52eb4774e8163071a53b65c101ab54496a2a77614"
+  end
+
+  url "https://ricks-apps.com/osx/sitesucker/archive/#{version.major}.x/#{version.major_minor}.x/#{version}/SiteSucker_Pro_#{version}.dmg"
+  appcast "https://ricks-apps.com/osx/sitesucker/history.html"
+  name "SiteSucker Pro"
+  desc "Website downloader tool"
+  homepage "https://ricks-apps.com/osx/sitesucker/index.html"
+
+  auto_updates true
+  depends_on macos: ">= :mojave"
+
+  app "SiteSucker Pro.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/us.sitesucker.mac.sitesucker-pro",
+    "~/Library/Containers/us.sitesucker.mac.sitesucker-pro",
+  ]
+end


### PR DESCRIPTION
sitesucker was removed (https://github.com/Homebrew/homebrew-cask/pull/37268) due to it being a Mac App Store - only release. SiteSucker Pro is released outside of the app store.

I've added the changelog webpage for `appcast` but I notice the app's built-in updater uses [this url](https://ricks-apps.com/osx/sitesucker/pro-versions.plist) for checking version. I'm not sure how to create a `livecheck` for this plist. 

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
