### PR TITLE
Adds foobar2000 v2.2.14

### DIFF
--- a/Casks/foobar2000.rb
+++ b/Casks/foobar2000.rb
@@ -1,0 +1,11 @@
+cask "foobar2000" do
+  version "2.2.14"
+  sha256 "95caf9edca5757273ce6292db3ef51dca9c7ac777fb8800e17b6eb65683a82c7"
+
+  url "https://www.foobar2000.org/files/ede8d4e2668cb128ecd46b260e37dab9/foobar2000-v#{version}.dmg"
+  name "foobar2000"
+  desc "Advanced freeware audio player"
+  homepage "https://www.foobar2000.org/mac"
+
+  app "foobar2000.app"
+end


### PR DESCRIPTION
foobar2000 was a very popular music player on windows, it's main benefit was it's low footprint while handling 10s of thousand music files.

Since quite some time foobar2000 has been ported to macOS, and has even support for the Apple M1 (see their [changelog](https://www.foobar2000.org/changelog-mac)).

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
