### PR TITLE
Remove appcast from zenmap.

### DIFF
--- a/Casks/zenmap.rb
+++ b/Casks/zenmap.rb
@@ -3,13 +3,12 @@ cask "zenmap" do
   sha256 "6446cc4d52ac3c2818f6c9cbf34473be726d3fdbb7fb8c315f0149787b7303d0"
 
   url "https://nmap.org/dist/nmap-#{version}.dmg"
-  appcast "https://nmap.org/dist/?C=M&O=D"
   name "Zenmap"
   desc "Multi-platform graphical interface for official Nmap Security Scanner"
   homepage "https://nmap.org/zenmap/"
 
   livecheck do
-    url "https://nmap.org/dist/"
+    url "https://nmap.org/dist/?C=M;O=D"
     regex(/href=.*?nmap[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
Needed for https://github.com/Homebrew/brew/pull/10260.