### PR TITLE
github_prerelease_allowlist: add irccloud

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -4,6 +4,7 @@
   "freetube": "all",
   "graphsketcher": "all",
   "haptickey": "all",
+  "irccloud": "all",
   "lidarr": "all",
   "nuclear": "all",
   "pock": "all",


### PR DESCRIPTION
Required for https://github.com/Homebrew/homebrew-cask/pull/98156 to pass `audit`.