### PR TITLE
Update Chef Workstation from 20.12.205 to 21.1.233

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask "chef-workstation" do
-  version "20.12.205"
-  sha256 "0ceb90162e35858ec35c987a3c00a8d1d557e490fdd4fb4dcbf13ab111488db2"
+  version "21.1.233"
+  sha256 "ec817ceabea09b6f1f438107f65217f105b5acd6bf2dc994397e404ff231d44c"
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.15/chef-workstation-#{version}-1.dmg"
   appcast "https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=10.15&m=x86_64&v=latest"


### PR DESCRIPTION
Update to the latest release.

Signed-off-by: Tim Smith <tsmith@chef.io>