### PR TITLE
netron: update to 4.7.2, add livecheck

### DIFF
--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -1,12 +1,17 @@
 cask "netron" do
-  version "4.7.1"
-  sha256 "8f21d16418c8395aad764931792286274ba247a8bfaf0e6486f8848704964b9b"
+  version "4.7.2"
+  sha256 "dc1e613419775505518e362f92d4fb2e7d0a822147cb92480d2f79ba79f724a7"
 
   url "https://github.com/lutzroeder/netron/releases/download/v#{version}/Netron-#{version}-mac.zip"
-  appcast "https://github.com/lutzroeder/netron/releases.atom"
   name "Netron"
   desc "Visualizer for neural network, deep learning, and machine learning models"
   homepage "https://github.com/lutzroeder/netron"
+
+  livecheck do
+    url :url
+    strategy :git
+    regex(/^v(\d+(?:\.\d+)*)$/)
+  end
 
   auto_updates true
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
