### PR TITLE
Update surge-synthesizer.rb to 1.8.0

### DIFF
--- a/Casks/surge-synthesizer.rb
+++ b/Casks/surge-synthesizer.rb
@@ -1,6 +1,6 @@
 cask "surge-synthesizer" do
-  version "1.7.1"
-  sha256 "4a1020bf4f5606c541c28e6def2d282a4fb13c29cfa39f1094b02cc94e335d9c"
+  version "1.8.0"
+  sha256 "ceca8ad00bc41bbec9f379881e2b0ec3707f4a0fbeebc581d4202f6c1bb589a0"
 
   url "https://github.com/surge-synthesizer/releases/releases/download/#{version}/Surge-#{version}-Setup.dmg",
       verified: "github.com/surge-synthesizer/releases/"


### PR DESCRIPTION
This updates the surge-synthesizer cask to release 1.8.0

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
