### PR TITLE
Updating QLMarkdown to use new repo

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -8,5 +8,5 @@ cask "qlmarkdown" do
   desc "Quick Look extension to preview Markdown files"
   homepage "https://github.com/sbarex/QLMarkdown"
 
-  app  "QLMarkdown.app"
+  app "QLMarkdown.app"
 end

--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -1,12 +1,12 @@
 cask "qlmarkdown" do
-  version "1.3.6"
-  sha256 "810853c000dd5c3e18978070abb7f595ad52ddfa568fccb428d28b513d1810ab"
+  version "1.0b16"
+  sha256 "ade60fd3fbb6276f6175c0ab8965e124cac6501868caadc12082b56321dfe4d9"
 
-  url "https://github.com/toland/qlmarkdown/releases/download/v#{version}/QLMarkdown.qlgenerator.zip"
-  appcast "https://github.com/toland/qlmarkdown/releases.atom"
+  url "https://github.com/sbarex/QLMarkdown/releases/download/#{version}/QLMarkdown.zip"
+  appcast "https://github.com/sbarex/QLMarkdown/releases.atom"
   name "QLMarkdown"
-  desc "QuickLook generator for Markdown files"
-  homepage "https://github.com/toland/qlmarkdown"
+  desc "Quick Look extension to preview Markdown files"
+  homepage "https://github.com/sbarex/QLMarkdown"
 
-  qlplugin "QLMarkdown.qlgenerator"
+  app  "QLMarkdown.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

According to [this thread](https://github.com/toland/qlmarkdown/issues/102), development on [the original QLMarkdown](https://github.com/toland/qlmarkdown) has been abandoned and development has been moved to a [new maintainer](https://github.com/sbarex/QLMarkdown).