### PR TITLE
Fix for homebrew installing incorrect version of CotEditor on Mojave, High Sierra and El Capitan 

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -2,6 +2,12 @@ cask "coteditor" do
   if MacOS.version <= :yosemite
     version "3.2.8"
     sha256 "73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6"
+  elsif MacOS.version <= :el_capitan
+    version "3.5.4"
+    sha256 "0b2cbf38cc531268e3691f307445e05ae5da64b48ceaf86c4d16b993c9be3e9f"
+  elsif MacOS.version <= :mojave
+    version "3.9.7"
+    sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
   else
     version "4.0.1"
     sha256 "879fa6ef8199c10c8b42b6adaa4a528b41295b97457c7e06fd1a412f65f0ffb9"


### PR DESCRIPTION
Version 4.0.1 of CotEditor doesn't run on Mojave ( https://coteditor.com/archives ) it requires 10.15. Homebrew would previously install that version which doesn't launch on Mojave.
Installs last working version for Mojave and High Sierra,as well as for El Capitan as previously done for Yosemite.


- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.


Not sure brew style is working properly all offenses have to do with the unchanged first line and last line.

coteditor.rb:1:1: C: Block has too many lines. [29/25]
cask "coteditor" do ...
^^^^^^^^^^^^^^^^^^^
coteditor.rb:1:1: C: [Correctable] No Sorbet sigil found in file. Try a typed: false to start (you can also use rubocop -a to automatically add this).
cask "coteditor" do
^^^^
coteditor.rb:1:1: C: [Correctable] Missing frozen string literal comment.
cask "coteditor" do
^
coteditor.rb:35:4: C: [Correctable] Final newline missing.
end
