### PR TITLE
electron.rb: no cross-platform in desc

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -6,7 +6,7 @@ cask "electron" do
       verified: "github.com/electron/electron/"
   appcast "https://www.electronjs.org/releases/stable"
   name "Electron"
-  desc "Build cross-platform desktop apps with JavaScript, HTML, and CSS"
+  desc "Build desktop apps with JavaScript, HTML, and CSS"
   homepage "https://electronjs.org/"
 
   app "Electron.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.