### PR TITLE
scihubeva.rb: no cross-platform in desc

### DIFF
--- a/Casks/scihubeva.rb
+++ b/Casks/scihubeva.rb
@@ -5,7 +5,7 @@ cask "scihubeva" do
   url "https://github.com/leovan/SciHubEVA/releases/download/#{version}/SciHubEVA-#{version}.dmg"
   appcast "https://github.com/leovan/SciHubEVA/releases.atom"
   name "SciHubEVA"
-  desc "Cross-platform Sci-Hub GUI app"
+  desc "Sci-Hub GUI app"
   homepage "https://github.com/leovan/SciHubEVA"
 
   app "SciHubEVA.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.