### PR TITLE
textadept.rb: no cross-platform in desc

### DIFF
--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -5,7 +5,7 @@ cask "textadept" do
   url "https://github.com/orbitalquark/textadept/releases/download/textadept_#{version}/textadept_#{version}.macOS.zip",
       verified: "github.com/orbitalquark/textadept/"
   name "Textadept"
-  desc "Cross-platform text editor"
+  desc "Text editor"
   homepage "https://orbitalquark.github.io/textadept/"
 
   livecheck do


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.