### PR TITLE
gopass-ui.rb: no cross-platform in desc

### DIFF
--- a/Casks/gopass-ui.rb
+++ b/Casks/gopass-ui.rb
@@ -5,7 +5,7 @@ cask "gopass-ui" do
   url "https://github.com/codecentric/gopass-ui/releases/download/v#{version}/Gopass.UI-#{version}.dmg"
   appcast "https://github.com/codecentric/gopass-ui/releases.atom"
   name "Gopass UI"
-  desc "Cross-platform password manager for teams"
+  desc "Password manager for teams"
   homepage "https://github.com/codecentric/gopass-ui"
 
   app "Gopass UI.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.