### PR TITLE
qgroundcontrol.rb: no cross-platform in desc

### DIFF
--- a/Casks/qgroundcontrol.rb
+++ b/Casks/qgroundcontrol.rb
@@ -5,7 +5,7 @@ cask "qgroundcontrol" do
   url "https://qgroundcontrol.s3.amazonaws.com/latest/QGroundControl.dmg",
       verified: "qgroundcontrol.s3.amazonaws.com/latest/"
   name "QGroundControl"
-  desc "Cross-platform ground control station for drones"
+  desc "Ground control station for drones"
   homepage "http://qgroundcontrol.com/"
 
   app "qgroundcontrol.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.