### PR TITLE
deluge.rb: no cross-platform in desc

### DIFF
--- a/Casks/deluge.rb
+++ b/Casks/deluge.rb
@@ -6,7 +6,7 @@ cask "deluge" do
       verified: "ftp.osuosl.org/"
   appcast "https://ftp.osuosl.org/pub/deluge/mac_osx/?C=M;O=D"
   name "Deluge"
-  desc "Cross-platform BitTorrent client"
+  desc "BitTorrent client"
   homepage "https://deluge-torrent.org/"
 
   app "Deluge.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.