### PR TITLE
dotnet-sdk.rb: no cross-platform in desc

### DIFF
--- a/Casks/dotnet-sdk.rb
+++ b/Casks/dotnet-sdk.rb
@@ -10,7 +10,7 @@ cask "dotnet-sdk" do
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-sdk-#{version.before_comma}-osx-x64.pkg"
   appcast "https://github.com/dotnet/sdk/releases.atom"
   name ".NET SDK"
-  desc "Free, cross-platform, open-source developer platform"
+  desc "Developer platform"
   homepage "https://www.microsoft.com/net/core#macos"
 
   conflicts_with cask: [


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.