### PR TITLE
libreoffice.rb: no cross-platform in desc

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -6,7 +6,7 @@ cask "libreoffice" do
       verified: "documentfoundation.org/"
   appcast "https://download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice"
-  desc "Free cross-platform office suite"
+  desc "Office suite"
   homepage "https://www.libreoffice.org/"
 
   conflicts_with cask: "homebrew/cask-versions/libreoffice-still"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.