### PR TITLE
signal.rb: no cross-platform in desc

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -5,7 +5,7 @@ cask "signal" do
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
   appcast "https://github.com/signalapp/Signal-Desktop/releases.atom"
   name "Signal"
-  desc "Cross-platform instant messaging application focusing on security"
+  desc "Instant messaging application focusing on security"
   homepage "https://signal.org/"
 
   auto_updates true


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.