### PR TITLE
codelite.rb: no cross-platform in desc

### DIFF
--- a/Casks/codelite.rb
+++ b/Casks/codelite.rb
@@ -6,7 +6,7 @@ cask "codelite" do
   appcast "https://github.com/eranif/codelite/releases.atom",
           must_contain: version.chomp(".0")
   name "CodeLite"
-  desc "Cross-platform IDE for C, C++, PHP and Node.js"
+  desc "IDE for C, C++, PHP and Node.js"
   homepage "https://codelite.org/"
 
   app "codelite.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.