### PR TITLE
atom.rb: no cross-platform in desc

### DIFF
--- a/Casks/atom.rb
+++ b/Casks/atom.rb
@@ -6,7 +6,7 @@ cask "atom" do
       verified: "github.com/atom/atom/"
   appcast "https://github.com/atom/atom/releases.atom"
   name "Github Atom"
-  desc "Cross-platform text editor"
+  desc "Text editor"
   homepage "https://atom.io/"
 
   auto_updates true


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.