### PR TITLE
filemaker-pro.rb: no cross-platform in desc

### DIFF
--- a/Casks/filemaker-pro.rb
+++ b/Casks/filemaker-pro.rb
@@ -1,6 +1,6 @@
 cask "filemaker-pro" do
-  version "19.0.1.116"
-  sha256 "b561a0ebc62f7b6f50bc5e1b7c05660e5a1ead2027dd296907b3ff644f0b51dc"
+  version "19.2.1.14"
+  sha256 "7e57f30e4f1a72063824240eff78b795de148a5233bfbfc6aaf10c101a269496"
 
   url "https://downloads.claris.com/esd/fmp_#{version}.dmg"
   appcast "https://www.filemaker.com/redirects/ss.txt"

--- a/Casks/filemaker-pro.rb
+++ b/Casks/filemaker-pro.rb
@@ -5,7 +5,7 @@ cask "filemaker-pro" do
   url "https://downloads.claris.com/esd/fmp_#{version}.dmg"
   appcast "https://www.filemaker.com/redirects/ss.txt"
   name "FileMaker Pro"
-  desc "Cross-platform relational database and rapid application development platform"
+  desc "Relational database and rapid application development platform"
   homepage "https://www.claris.com/filemaker/"
 
   auto_updates true


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.