### PR TITLE
alacritty.rb: no cross-platform in desc

### DIFF
--- a/Casks/alacritty.rb
+++ b/Casks/alacritty.rb
@@ -5,7 +5,7 @@ cask "alacritty" do
   url "https://github.com/alacritty/alacritty/releases/download/v#{version}/Alacritty-v#{version}.dmg"
   appcast "https://github.com/alacritty/alacritty/releases.atom"
   name "Alacritty"
-  desc "Cross-platform, GPU-accelerated terminal emulator"
+  desc "GPU-accelerated terminal emulator"
   homepage "https://github.com/alacritty/alacritty/"
 
   app "Alacritty.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.