### PR TITLE
flying-carpet.rb: no cross-platform in desc

### DIFF
--- a/Casks/flying-carpet.rb
+++ b/Casks/flying-carpet.rb
@@ -5,7 +5,7 @@ cask "flying-carpet" do
   url "https://github.com/spieglt/FlyingCarpet/releases/download/#{version}/Flying.Carpet.Mac.zip"
   appcast "https://github.com/spieglt/flyingcarpet/releases.atom"
   name "Flying Carpet"
-  desc "Cross-platform file transfer over ad-hoc wifi"
+  desc "File transfer over ad-hoc wifi"
   homepage "https://github.com/spieglt/flyingcarpet"
 
   app "Flying Carpet.app"


### PR DESCRIPTION
Homebrew Cask only works and only aims to work on macOS. Being cross-platform is an irrelevant description.