### PR TITLE
Update coqide to 8.13.0,1

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,11 +1,12 @@
 cask "coqide" do
-  version "8.13.0"
-  sha256 "fa02786729169e8a86f478839088a2c045a3e18a4ac6b5339a23558c3aef72fb"
+  version "8.13.0,1"
+  sha256 "718fc214d2b36bae440942e8a2615c4f9ab84545b505c7d421e17b742bbdd1b8"
 
-  url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version}-installer-macos.dmg",
+  url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version.major_minor_patch}-installer-macos.dmg",
       verified: "github.com/coq/coq/"
   appcast "https://github.com/coq/coq/releases.atom"
   name "Coq"
+  desc "Formal proof management system"
   homepage "https://coq.inria.fr/"
 
   depends_on macos: ">= :sierra"

--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -1,8 +1,8 @@
 cask "coqide" do
-  version "8.13.0,1"
+  version "8.13.0"
   sha256 "718fc214d2b36bae440942e8a2615c4f9ab84545b505c7d421e17b742bbdd1b8"
 
-  url "https://github.com/coq/coq/releases/download/V#{version.major_minor_patch}/coq-#{version.major_minor_patch}-installer-macos.dmg",
+  url "https://github.com/coq/coq/releases/download/V#{version}/coq-#{version}-installer-macos.dmg",
       verified: "github.com/coq/coq/"
   appcast "https://github.com/coq/coq/releases.atom"
   name "Coq"


### PR DESCRIPTION
The coqide 8.13.0 installer package has been updated after initial release without
a version bump.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
