### PR TITLE
github_prerelease_allowlist: add crypter and mongotron

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,4 +1,5 @@
 {
+  "crypter": "all",
   "duplicati": "all",
   "extraterm": "all",
   "freetube": "all",
@@ -6,6 +7,7 @@
   "haptickey": "all",
   "irccloud": "all",
   "lidarr": "all",
+  "mongotron": "all",
   "my-budget": "all",
   "nuclear": "all",
   "pock": "all",


### PR DESCRIPTION
Required for https://github.com/Homebrew/homebrew-cask/pull/98417 and https://github.com/Homebrew/homebrew-cask/pull/98418 to pass `audit`.