### PR TITLE
Ensure `homebrew/cask` is tapped.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Generate CI matrix
         id: generate-matrix
         run: |
+          brew tap homebrew/cask
           brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" "${{ github.event.pull_request.url }}"
 
   test:


### PR DESCRIPTION
Allows reusing `ci.yml` in taps which don't start with `cask-`.