### PR TITLE
Add zap to folding-at-home

### DIFF
--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -15,9 +15,6 @@ cask "folding-at-home" do
             quit:      [
               "org.foldingathome.fahviewer",
               "org.foldingathome.fahcontrol",
-            ]
-
-  zap trash: [
-    "/Library/Application Support/FAHClient",
-  ]
+            ],
+            rmdir:     "/Library/Application Support/FAHClient"
 end

--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -17,4 +17,8 @@ cask "folding-at-home" do
               "org.foldingathome.fahcontrol",
             ],
             rmdir:     "/Library/Application Support/FAHClient"
+
+  zap trash: [
+    "/Library/Application Support/FAHClient",
+  ]
 end

--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -18,7 +18,5 @@ cask "folding-at-home" do
             ],
             rmdir:     "/Library/Application Support/FAHClient"
 
-  zap trash: [
-    "/Library/Application Support/FAHClient",
-  ]
+  zap trash: "/Library/Application Support/FAHClient"
 end

--- a/Casks/folding-at-home.rb
+++ b/Casks/folding-at-home.rb
@@ -16,4 +16,8 @@ cask "folding-at-home" do
               "org.foldingathome.fahviewer",
               "org.foldingathome.fahcontrol",
             ]
+
+  zap trash: [
+    "/Library/Application Support/FAHClient",
+  ]
 end


### PR DESCRIPTION
Followup to #98465: I believe this should be added to the `zap` stanza, as it is a folder the installation process creates that is not currently deleted on uninstall. I defer to others whether the `rmdir` (which only deletes empty dirs) still belongs in the `uninstall` stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.