### PR TITLE
Bump pritunl and add Apple Silicon version

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,20 +1,27 @@
 cask "pritunl" do
-  if MacOS.version <= :catalina
-    version "1.2.2615.73"
-    sha256 "275f8498fb736a0a1ddebcbfcb6f03e82b8eb4fedf9b7eb61b0e306cb6de4a71"
+  if Hardware::CPU.intel?
+    if MacOS.version <= :catalina
+      version "1.2.2615.73"
+      sha256 "275f8498fb736a0a1ddebcbfcb6f03e82b8eb4fedf9b7eb61b0e306cb6de4a71"
+    else
+      version "1.2.2685.61"
+      sha256 "ae88691be2a4a2c07a87e6a5441fa7c99755418830e70ac52fb2d2ca557f402c"
+    end
+    url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip",
+        verified: "github.com/pritunl/pritunl-client-electron/"
+    pkg "Pritunl.pkg"
   else
-    version "1.2.2653.1"
-    sha256 "af0170b1641ea9cdb79f030c0e15a8cf00eddf43d906fd68b5566cea4bc3111c"
+    version "1.2.2685.61"
+    sha256 "daa6871edc484bbfc7e8035f6844b2dffa340ebd3e0f92e8a5b3a8d94092d257"
+    url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.arm64.pkg.zip",
+        verified: "github.com/pritunl/pritunl-client-electron/"
+    pkg "Pritunl.arm64.pkg"
   end
 
-  url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip",
-      verified: "github.com/pritunl/pritunl-client-electron/"
   appcast "https://github.com/pritunl/pritunl-client-electron/releases.atom"
   name "Pritunl"
   desc "OpenVPN client"
   homepage "https://client.pritunl.com/"
-
-  pkg "Pritunl.pkg"
 
   uninstall pkgutil:   "com.pritunl.pkg.Pritunl",
             launchctl: [

--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -7,14 +7,18 @@ cask "pritunl" do
       version "1.2.2685.61"
       sha256 "ae88691be2a4a2c07a87e6a5441fa7c99755418830e70ac52fb2d2ca557f402c"
     end
+
     url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.pkg.zip",
         verified: "github.com/pritunl/pritunl-client-electron/"
+
     pkg "Pritunl.pkg"
   else
     version "1.2.2685.61"
     sha256 "daa6871edc484bbfc7e8035f6844b2dffa340ebd3e0f92e8a5b3a8d94092d257"
+
     url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl.arm64.pkg.zip",
         verified: "github.com/pritunl/pritunl-client-electron/"
+
     pkg "Pritunl.arm64.pkg"
   end
 


### PR DESCRIPTION
The different in names between the two architectures means that I had to move
more fields into the if/else statement than I would have liked, but I didn't
find an easy way to differentiate between them otherwise.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
