### PR TITLE
fly: remove removal of quarantine

### DIFF
--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -9,9 +9,4 @@ cask "fly" do
   homepage "https://github.com/concourse/concourse"
 
   binary "fly"
-
-  preflight do
-    system_command "xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{staged_path}/fly"]
-  end
 end


### PR DESCRIPTION
We (HBC) are the ones who add the quarantine, so we should never be the ones removing it. That breaks expectations. Removing quarantine ourselves in one cask means users who rely on it being active have to check every cask installation to see if it’s there.

[We explain how to remove quarantine when needed](https://github.com/Homebrew/homebrew-cask/blob/master/doc/faq/app_cant_be_opened.md) and have `--no-quarantine`, both of those need to be explicitly called by users thus indicating explicit consent. That’s the way it should be. Either that or we [remove quarantining altogether](https://github.com/Homebrew/homebrew-cask/issues/70798), but we should never say we do something and then do the reverse (bugs excluded).

Refs https://github.com/Homebrew/homebrew-cask/issues/98458.

cc @miccal @todd-a-jacobs.