### PR TITLE
Update SaveHollywood to 2.5

### DIFF
--- a/Casks/save-hollywood.rb
+++ b/Casks/save-hollywood.rb
@@ -7,5 +7,11 @@ cask "save-hollywood" do
   desc "Screen saver for custom video files"
   homepage "http://s.sudre.free.fr/Software/SaveHollywood/about.html"
 
+  livecheck do
+    url "http://s.sudre.free.fr/Software/SaveHollywood/release_notes.html"
+    strategy :page_match
+    regex(/Release_notes_Version.*?(\d+(?:\.\d+)*)/i)
+  end
+
   screen_saver "SaveHollywood.saver"
 end

--- a/Casks/save-hollywood.rb
+++ b/Casks/save-hollywood.rb
@@ -1,9 +1,10 @@
 cask "save-hollywood" do
-  version :latest
+  version "2.5"
   sha256 :no_check
 
   url "http://s.sudre.free.fr/Software/files/SaveHollywood.dmg"
   name "SaveHollywood Screensaver"
+  desc "Screen saver for custom video files"
   homepage "http://s.sudre.free.fr/Software/SaveHollywood/about.html"
 
   screen_saver "SaveHollywood.saver"


### PR DESCRIPTION
Added description and current version instead of using :latest

The version history is available in the project's release notes - http://s.sudre.free.fr/Software/SaveHollywood/release_notes.html

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
