### PR TITLE
visual-studio-code: add livecheck

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -11,7 +11,7 @@ cask "visual-studio-code" do
   livecheck do
     url "https://update.code.visualstudio.com/api/update/darwin/stable/VERSION"
     strategy :page_match
-    regex(/"name":"(\d+(:?\.\d+)*)"/)
+    regex(/"productVersion":"(\d+(:?\.\d+)*)"/)
   end
 
   auto_updates true

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -3,11 +3,16 @@ cask "visual-studio-code" do
   sha256 "99c8c559971862eb8532b30507d1930b939a17b2e067bcdf9e9f16264a6deae1"
 
   url "https://update.code.visualstudio.com/#{version}/darwin/stable"
-  appcast "https://update.code.visualstudio.com/api/update/darwin/stable/VERSION"
   name "Microsoft Visual Studio Code"
   name "VS Code"
   desc "Open-source code editor"
   homepage "https://code.visualstudio.com/"
+
+  livecheck do
+    url "https://update.code.visualstudio.com/api/update/darwin/stable/VERSION"
+    strategy :page_match
+    regex(/"name":"(\d+(:?\.\d+)*)"/)
+  end
 
   auto_updates true
 

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -11,7 +11,7 @@ cask "visual-studio-code" do
   livecheck do
     url "https://update.code.visualstudio.com/api/update/darwin/stable/VERSION"
     strategy :page_match
-    regex(/"productVersion":"(\d+(:?\.\d+)*)"/)
+    regex(/"productVersion"\s*:\s*"(\d+(:?\.\d+)*)"/)
   end
 
   auto_updates true


### PR DESCRIPTION
Before
```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask visual-studio-code --debug

Cask:             visual-studio-code
Livecheckable?:   No

URL:              https://update.code.visualstudio.com/api/update/darwin/stable/VERSION
Strategy:         None

URL:              https://update.code.visualstudio.com/1.52.1/darwin/stable
Strategy:         None

URL:              https://code.visualstudio.com/
Strategy:         None
Error: visual-studio-code: Unable to get versions
```

After
```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask visual-studio-code --debug

Cask:             visual-studio-code
Livecheckable?:   Yes

URL:              https://update.code.visualstudio.com/api/update/darwin/stable/VERSION
Strategy:         PageMatch
Regex:            /"name":"(\d+(:?\.\d+)*)"/

Matched Versions:
1.52.1
visual-studio-code : 1.52.1 ==> 1.52.1
```

There are two fields in the JSON which contain version number that are named `"name"` and `"productVersion"`, couldn't sure which one to use so I used the first one.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
