### PR TITLE
loopback: add livecheck

### DIFF
--- a/Casks/loopback.rb
+++ b/Casks/loopback.rb
@@ -4,10 +4,14 @@ cask "loopback" do
 
   url "https://d2oxtzozd38ts8.cloudfront.net/loopback/download/Loopback.zip",
       verified: "d2oxtzozd38ts8.cloudfront.net/loopback/"
-  appcast "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.loopback&system=10141&platform=osx&arch=x86_64&version=2008000"
   name "Loopback"
   desc "Cable-free audio router"
   homepage "https://rogueamoeba.com/loopback/"
+
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.loopback&system=10141&platform=osx&arch=x86_64&version=2008000"
+    strategy :sparkle
+  end
 
   auto_updates true
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
This [appcast URL](https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.loopback&system=10141&platform=osx&arch=x86_64&version=2008000) does not contain a proper Sparkle XML but it works with sparkle strategy.

```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask loopback --debug

Cask:             loopback
Livecheckable?:   Yes

URL:              https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.loopback&system=10141&platform=osx&arch=x86_64&version=2008000
Strategy:         Sparkle

Matched Versions:
2.2.1
loopback : 2.2.1 ==> 2.2.1
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
