### PR TITLE
Upgrade Phoenix to 2.6.6

### DIFF
--- a/Casks/phoenix.rb
+++ b/Casks/phoenix.rb
@@ -1,6 +1,6 @@
 cask "phoenix" do
-  version "2.6.5"
-  sha256 "bdaddd3c66710679397e620278b30eff09fe4be3fd0ecda30ccb537e04dc82dd"
+  version "2.6.6"
+  sha256 "d860328b044518a609b8b29cd38b505d63840eed79f67f68b7453b5dda12999f"
 
   url "https://github.com/kasper/phoenix/releases/download/#{version}/phoenix-#{version}.tar.gz"
   appcast "https://github.com/kasper/phoenix/releases.atom"


### PR DESCRIPTION
Upgrade Phoenix to 2.6.6. Thanks!

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
