### PR TITLE
Update OpenInTerminal-Lite from 1.2.0 to 1.2.1

### DIFF
--- a/Casks/openinterminal-lite.rb
+++ b/Casks/openinterminal-lite.rb
@@ -1,6 +1,6 @@
 cask "openinterminal-lite" do
-  version "1.2.0"
-  sha256 "89b7c88b5e477fbfbf3263d93272768865f22e4e99d3bb29ce853ab12886f5fc"
+  version "1.2.1"
+  sha256 "76b7db05ddac30b1487cff72bf41b914ad6c4bdebebf6ab354e1c9bdb8f2fcd1"
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/v#{version}/OpenInTerminal-Lite.app.zip"
   appcast "https://github.com/Ji4n1ng/OpenInTerminal/releases.atom"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
