### PR TITLE
Update brave-browser.rb

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -12,7 +12,7 @@ cask "brave-browser" do
       strategy :sparkle
     end
   else
-    sha256 "511fea68a3b40e55676badcbee982c65b2a9d81d77a4eae902c927ea735803d6"
+    sha256 "2926f302109e4fb7b2eedff5bc506fa46110df4d4f621c17a95ce2036ee35998"
 
     url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/#{version.after_comma}/Brave-Browser-universal.dmg",
         verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"


### PR DESCRIPTION
SHA256 is not correct. I have manually downloaded the universal DMG and calculated the SHA256. I didn't find any official checksums to check against.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
