### PR TITLE
Update osquery to 4.6.0

### DIFF
--- a/Casks/osquery.rb
+++ b/Casks/osquery.rb
@@ -1,6 +1,6 @@
 cask "osquery" do
-  version "4.5.1"
-  sha256 "1d687b00c8e27f68e95c624bd1ade9b79311321c0ce905ee35860b2c4e825d56"
+  version "4.6.0"
+  sha256 "c037742f9f7e416955c0a38cf450e00989fad07f34aef60aba8d3a923502177c"
 
   url "https://pkg.osquery.io/darwin/osquery-#{version}.pkg"
   appcast "https://github.com/osquery/osquery/releases.atom"

--- a/Casks/osquery.rb
+++ b/Casks/osquery.rb
@@ -1,6 +1,3 @@
-# typed: false
-# frozen_string_literal: true
-
 cask "osquery" do
   version "4.6.0"
   sha256 "c037742f9f7e416955c0a38cf450e00989fad07f34aef60aba8d3a923502177c"

--- a/Casks/osquery.rb
+++ b/Casks/osquery.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 cask "osquery" do
   version "4.6.0"
   sha256 "c037742f9f7e416955c0a38cf450e00989fad07f34aef60aba8d3a923502177c"


### PR DESCRIPTION
The osquery 4.6.0 release is now considered stable.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
