### PR TITLE
Update mounty.rb

### DIFF
--- a/Casks/mounty.rb
+++ b/Casks/mounty.rb
@@ -1,8 +1,8 @@
 cask "mounty" do
   if MacOS.version <= :catalina
-    version "1.9"
-    sha256 :no_check
-    url "https://mounty.app/releases/Mounty-#{version}.dmg"
+    version "1.9,13"
+    sha256 "5fcedfe712f59c14f39c3385dfed9aebc99d4e8d88f6e870f364cc48624590ef"
+    url "https://mounty.app/releases/Mounty-#{version.before_comma}.dmg"
   else
     version "1.11,16"
     sha256 :no_check

--- a/Casks/mounty.rb
+++ b/Casks/mounty.rb
@@ -1,13 +1,17 @@
 cask "mounty" do
-  version "1.10,14"
-  sha256 :no_check
+  if MacOS.version <= :catalina
+    version "1.9"
+    sha256 :no_check
+    url "https://mounty.app/releases/Mounty-#{version}.dmg"
+  else
+    version "1.11,16"
+    sha256 :no_check
+    url "https://mounty.app/releases/Mounty.dmg"
+  end
 
-  url "https://mounty.app/releases/Mounty.dmg"
   name "Mounty for NTFS"
   desc "Re-mounts write-protected NTFS volumes"
   homepage "https://mounty.app/"
-
-  depends_on macos: ">= :big_sur"
 
   app "Mounty.app"
 end


### PR DESCRIPTION
- Remove depends_on Big Sur stanza.
- Added MacOS version comparison.
- Bump up version from 1.10 to 1.11 for Big Sur.

```
Version 1.9 - 21th of Sep 2018, last version compatible with macOS Catalina and earlier
```
from https://mounty.app/#versions

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
