### PR TITLE
Fix hash in playonmac.rb

### DIFF
--- a/Casks/playonmac.rb
+++ b/Casks/playonmac.rb
@@ -1,6 +1,6 @@
 cask "playonmac" do
   version "4.4.2"
-  sha256 "5c7300ca7115335a732cd4c02d07ed80aea1d5b11126677bfbce96a408ff48fb"
+  sha256 "8f458bcf14ed7431acfec1dc79d0e917bf450da89c78a13b5a6f3deeddbe4a8b"
 
   url "https://repository.playonmac.com/PlayOnMac/PlayOnMac_#{version}.dmg"
   appcast "https://repository.playonmac.com/PlayOnMac/"


### PR DESCRIPTION
I've been unable to update this cask since the 4.4.2 version bump in #98641 because of a hash mismatch error. This version is what I have gotten consistently from the file for the last two days, and is the same as I get when downloading the .dmg directly from playonmac.com in my browser.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
