### PR TITLE
Update itch.io to use notarized installer rather than Gatekeeper-blocked itch-setup

### DIFF
--- a/Casks/itch.rb
+++ b/Casks/itch.rb
@@ -1,14 +1,15 @@
 cask "itch" do
-  version "1.24.0"
-  sha256 "21fce1377d66a3bcb84c0e8be6d9f16a7149e52980690c8fc5e8663074d4d32e"
+  version :latest
+  sha256 :no_check
 
-  url "https://broth.itch.ovh/itch-setup/darwin-amd64/#{version}/archive/default",
+  url "https://broth.itch.ovh/install-itch/darwin-amd64/LATEST/archive/default",
       verified: "broth.itch.ovh/"
-  appcast "https://github.com/itchio/itch-setup/releases.atom"
   name "itch.io"
   homepage "https://itch.io/app"
 
-  installer script: "itch-setup"
+  auto_updates true
+
+  installer script: "Install itch.app/Contents/MacOS/itch-setup"
 
   uninstall delete: [
     "~/Applications/itch.app",

--- a/Casks/itch.rb
+++ b/Casks/itch.rb
@@ -1,5 +1,5 @@
 cask "itch" do
-  version :latest
+  version "25.4.1"
   sha256 :no_check
 
   url "https://broth.itch.ovh/install-itch/darwin-amd64/LATEST/archive/default",
@@ -7,6 +7,13 @@ cask "itch" do
   name "itch.io"
   desc "Game client for itch.io"
   homepage "https://itch.io/app"
+
+  livecheck do
+    url "https://github.com/itchio/itch/releases"
+    strategy :github_latest
+  end
+
+  auto_updates true
 
   installer script: "Install itch.app/Contents/MacOS/itch-setup"
 

--- a/Casks/itch.rb
+++ b/Casks/itch.rb
@@ -5,9 +5,8 @@ cask "itch" do
   url "https://broth.itch.ovh/install-itch/darwin-amd64/LATEST/archive/default",
       verified: "broth.itch.ovh/"
   name "itch.io"
+  desc "Game client for itch.io"
   homepage "https://itch.io/app"
-
-  auto_updates true
 
   installer script: "Install itch.app/Contents/MacOS/itch-setup"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

---

**Reason for changes**
On my M1 MacBook Pro running Big Sur 11.1, the current Homebrew Cask Itch.io install fails due to directly downloading `itch-setup`, which triggers Gatekeeper without any workaround to override (since unzipped file is deleted upon failure).
```
✖ brew install --cask --force itch
==> Downloading https://broth.itch.ovh/itch-setup/darwin-amd64/1.24.0/archive/default
Already downloaded: /Users/cho-m/Library/Caches/Homebrew/downloads/157419dc1bf20e856afa1fc3fef51ca48df1a21303f523ca778c9536e17fe87a--itch-setup-darwin-amd64.zip
==> Installing Cask itch
==> Running installer script 'itch-setup'
```
<img width="263" alt="Install-Fail-Due-to-Gatekeeper" src="https://user-images.githubusercontent.com/20700669/105894084-bfbf1100-5fc8-11eb-8512-990ae865248f.png">

```
==> Purging files for version 1.24.0 of Cask itch
Error: Failure while executing; `/usr/bin/env PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/Library/Homebrew/shims/scm:/usr/bin:/bin:/usr/sbin:/sbin /opt/homebrew/Caskroom/itch/1.24.0/itch-setup` was terminated by uncaught signal KILL.
```

I updated Cask to try and get install working on latest MacOS.
Changes include the following items. Please review and/or modify as necessary:
- **URL** - Using `https://broth.itch.ovh/install-itch/darwin-amd64/.../archive/default`, which is the official installer that is downloaded at https://itch.io/app, rather than the direct script `https://broth.itch.ovh/itch-setup/darwin-amd64/.../archive/default`
- **version/sha256** - set to `latest` installer. I felt that since the version of app (v25.4.1) is separate from bootstrap installer version (_32) and `itch-setup` version (1.24.0), it made more sense to avoid labeling the version on Cask.
- **appcast** - I didn't find an appcast option for bootstrap installer script (_32)
  - There is appcast for Itch app (v25.4.1) - https://github.com/itchio/itch/releases.atom
  - There is appcast for itch-setup (v1.24.0) - https://github.com/itchio/itch-setup/releases.atom

---

**Install Result**
```
❯ brew install --cask itch
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> Updated Casks
Updated 1 cask.

==> Downloading https://broth.itch.ovh/install-itch/darwin-amd64/LATEST/archive/
Already downloaded: /Users/cho-m/Library/Caches/Homebrew/downloads/0cdb81dd2569eaf4d281622053bb22da535e50997b9bb2e9b4ce942fa41946eb--install-itch-darwin-amd64.zip
Warning: No checksum defined for cask 'itch', skipping verification.
==> Installing Cask itch
==> Running installer script 'Install itch.app/Contents/MacOS/itch-setup'
2021/01/26 11:15:26 itch-setup will log to /tmp/itch-setup-log.txt

... SNIPPED ...

2021/01/26 11:15:41 Renaming (/Users/cho-m/Library/Application Support/itch-setup/app-25.4.1) to (/Users/cho-m/Applications/itch.app)
2021/01/26 11:15:41 Launching (25.4.1) from (/Users/cho-m/Applications/itch.app)
2021-01-26 11:15:41.538 itch-setup[47035:1559180] Opening bundle /Users/cho-m/Applications/itch.app
2021-01-26 11:15:51.722 itch-setup[47035:1559180] Success? yes
2021/01/26 11:15:51 Bundle launched successfully, getting out of the way
🍺  itch was successfully installed!
```