### PR TITLE
blackhole-16ch: add livecheck

### DIFF
--- a/Casks/blackhole-16ch.rb
+++ b/Casks/blackhole-16ch.rb
@@ -3,10 +3,14 @@ cask "blackhole-16ch" do
   sha256 "9cd3ed37e7d3ed29074487ff40f4c3698b5c780372c9d27c928d4b5d04766ca4"
 
   url "https://existential.audio/downloads/BlackHole16ch.v#{version}.pkg"
-  appcast "https://github.com/ExistentialAudio/BlackHole/releases.atom"
   name "BlackHole 16ch"
   desc "Virtual Audio Driver"
   homepage "https://existential.audio/blackhole/"
+
+  livecheck do
+    url "https://github.com/ExistentialAudio/BlackHole"
+    strategy :github_latest
+  end
 
   pkg "BlackHole16ch.v#{version}.pkg"
 


### PR DESCRIPTION
```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask blackhole-16ch --debug   

Cask:             blackhole-16ch
Livecheckable?:   Yes

URL:              https://github.com/ExistentialAudio/BlackHole
Strategy:         GithubLatest
URL (strategy):   https://github.com/ExistentialAudio/BlackHole/releases/latest
URL (final):      https://github.com/ExistentialAudio/BlackHole/releases/tag/v0.2.9
Regex (strategy): /href=.*?\/tag\/v?(\d+(?:\.\d+)+)["' >]/i

Matched Versions:
0.2.9
blackhole-16ch : 0.2.9 ==> 0.2.9
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
