### PR TITLE
blackhole-2ch: add livecheck

### DIFF
--- a/Casks/blackhole-2ch.rb
+++ b/Casks/blackhole-2ch.rb
@@ -3,10 +3,14 @@ cask "blackhole-2ch" do
   sha256 "ae7a405afc224bf0f6df2f58f4826e77c2b51fcbaba11561ba0c63616858e432"
 
   url "https://existential.audio/downloads/BlackHole2ch.v#{version}.pkg"
-  appcast "https://github.com/ExistentialAudio/BlackHole/releases.atom"
   name "BlackHole 2ch"
   desc "Virtual Audio Driver"
   homepage "https://existential.audio/blackhole/"
+
+  livecheck do
+    url "https://github.com/ExistentialAudio/BlackHole"
+    strategy :github_latest
+  end
 
   pkg "BlackHole2ch.v#{version}.pkg"
 


### PR DESCRIPTION
```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask blackhole-2ch --debug

Cask:             blackhole-2ch
Livecheckable?:   Yes

URL:              https://github.com/ExistentialAudio/BlackHole
Strategy:         GithubLatest
URL (strategy):   https://github.com/ExistentialAudio/BlackHole/releases/latest
URL (final):      https://github.com/ExistentialAudio/BlackHole/releases/tag/v0.2.9
Regex (strategy): /href=.*?\/tag\/v?(\d+(?:\.\d+)+)["' >]/i

Matched Versions:
0.2.9
blackhole-2ch : 0.2.9 ==> 0.2.9

```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
