### PR TITLE
bitwarden: add livecheck

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -4,10 +4,14 @@ cask "bitwarden" do
 
   url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-mac.zip",
       verified: "github.com/bitwarden/desktop/"
-  appcast "https://github.com/bitwarden/desktop/releases.atom"
   name "Bitwarden"
   desc "Desktop password and login vault"
   homepage "https://bitwarden.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.


**Notes**
Original `appcast` was showing incorrect version of `1.31.2` so added `livecheck` section.

```
❯ brew livecheck --debug bitwarden 

Cask:             bitwarden
Livecheckable?:   Yes

URL (url):        https://github.com/bitwarden/desktop/releases/download/v1.24.6/Bitwarden-1.24.6-mac.zip
Strategy:         GithubLatest
URL (strategy):   https://github.com/bitwarden/desktop/releases/latest
URL (final):      https://github.com/bitwarden/desktop/releases/tag/v1.24.6
Regex (strategy): /href=.*?\/tag\/v?(\d+(?:\.\d+)+)["' >]/i

Matched Versions:
1.24.6
bitwarden : 1.24.6 ==> 1.24.6

❯ brew audit --cask bitwarden
audit for bitwarden: passed

❯ brew style --fix bitwarden

1 file inspected, no offenses detected
```