### PR TITLE
rar: add livecheck and remove unrar conflict

### DIFF
--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -13,8 +13,6 @@ cask "rar" do
     regex(%r{href=.*?/rarosx-(\d+(:?\.\d+)*)\.tar\.gz}i)
   end
 
-  conflicts_with formula: "unrar"
-
   binary "rar/rar"
   binary "rar/unrar"
   artifact "rar/default.sfx", target: "#{HOMEBREW_PREFIX}/lib/default.sfx"

--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -7,6 +7,12 @@ cask "rar" do
   desc "Archive manager for data compression and backups"
   homepage "https://www.rarlab.com/"
 
+  livecheck do
+    url "https://www.rarlab.com/download.htm"
+    strategy :page_match
+    regex(%r{href=.*?/rarosx-(\d+(:?\.\d+)*)\.tar\.gz}i)
+  end
+
   conflicts_with formula: "unrar"
 
   binary "rar/rar"


### PR DESCRIPTION
unrar has been removed from [homebrew-core](https://github.com/Homebrew/homebrew-core), see [https://github.com/Homebrew/homebrew-core/pull/66609](https://github.com/Homebrew/homebrew-core/pull/66609)

```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask rar --debug   

Cask:             rar
Livecheckable?:   Yes

URL:              https://www.rarlab.com/download.htm
Strategy:         PageMatch
Regex:            /href=.*?\/rarosx-(\d+(:?\.\d+)*)\.tar\.gz/i

Matched Versions:
6.0.0
rar : 6.0.0 ==> 6.0.0
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
