### PR TITLE
github_prerelease_allowlist: remove lidarr

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -6,7 +6,6 @@
   "graphsketcher": "all",
   "haptickey": "all",
   "irccloud": "all",
-  "lidarr": "all",
   "mongotron": "all",
   "my-budget": "all",
   "nuclear": "all",


### PR DESCRIPTION
Required for https://github.com/Homebrew/homebrew-cask/pull/98893 to pass `audit`.