### PR TITLE
Add postflight, desc, and zap for Xonotic

### DIFF
--- a/Casks/xonotic.rb
+++ b/Casks/xonotic.rb
@@ -15,9 +15,9 @@ cask "xonotic" do
 
   suite "Xonotic"
 
-  zap trash: "~/Library/Application Support/xonotic"
+  postflight do
+    system_command "#{appdir}/Xonotic/misc/tools/rsync-updater/update-to-autobuild.sh"
+  end
 
-  caveats "This version has not been updated since April 2017. "\
-    "Run '/Applications/Xonotic/misc/tools/rsync-updater/update-to-autobuild.sh' "\
-    "after install for the latest release with improved performance and compatibility."
+  zap trash: "~/Library/Application Support/xonotic"
 end

--- a/Casks/xonotic.rb
+++ b/Casks/xonotic.rb
@@ -4,6 +4,7 @@ cask "xonotic" do
 
   url "https://dl.xonotic.org/xonotic-#{version}.zip"
   name "Xonotic"
+  desc "Quake-inspired arena-style first person shooter game"
   homepage "https://www.xonotic.org/"
 
   livecheck do
@@ -13,4 +14,10 @@ cask "xonotic" do
   end
 
   suite "Xonotic"
+
+  zap trash: "~/Library/Application Support/xonotic"
+
+  caveats "This version has not been updated since April 2017. "\
+    "Run '/Applications/Xonotic/misc/tools/rsync-updater/update-to-autobuild.sh' "\
+    "after install for the latest release with improved performance and compatibility."
 end


### PR DESCRIPTION
Hi all!

Xonotic stable is _extremely_ out of date, and the vast majority of players use the autobuild. This PR adds a caveat to that effect plus a zap and desc per `brew audit`. I'm assuming there's no desire/ability to integrate the rsync updater into the install/upgrade process.

Thank you for Homebrew!

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
