### PR TITLE
Fix pokerstars install url

### DIFF
--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -10,10 +10,11 @@ cask "pokerstars" do
 
   app "PokerStars.net.app"
 
-  uninstall quit: [
+  uninstall quit:   [
     "com.pokerstars.PokerStars.net",
     "com.pokerstars.PokerStarsBrowse",
-  ]
+  ],
+            delete: "#{appdir}/PokerStars.net.app"
 
   zap trash: [
     "~/Library/Preferences/com.pokerstars.NetworkStatus.plist",

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -16,10 +16,10 @@ cask "pokerstars" do
   app "PokerStars.net.app"
 
   uninstall quit: [
-                      "com.pokerstars.PokerStars.net",
-                      "com.pokerstars.PokerStarsBrowse"
-                  ]
-  
+    "com.pokerstars.PokerStars.net",
+    "com.pokerstars.PokerStarsBrowse",
+  ]
+
   zap trash: [
     "~/Library/Preferences/com.pokerstars.NetworkStatus.plist",
     "~/Library/Preferences/com.pokerstars.PokerStars.net.plist",

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -3,8 +3,8 @@ cask "pokerstars" do
   sha256 :no_check
 
   url "https://download.pokerstars.net/client/download/"
-  homepage "https://www.pokerstars.net/"
   name "PokerStars"
+  homepage "https://www.pokerstars.net/"
 
   container nested: "PokerStars.net/PokerStars.net.dmg"
 

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -3,54 +3,28 @@ cask "pokerstars" do
   sha256 :no_check
 
   language "US", default: true do
-    url "https://www.pokerstars.net/PokerStars.net.app.zip"
+    url "https://download.pokerstars.net/client/download/"
     homepage "https://www.pokerstars.net/"
 
     ".net"
   end
-  language "DK" do
-    url "https://www.pokerstars.net/PokerStars.net.app.zip",
-        verified: "pokerstars.net/"
-    homepage "https://www.pokerstars.dk/"
-
-    ".net"
-  end
-  language "GR" do
-    url "https://www.pokerstars.net/PokerStars.net.app.zip",
-        verified: "pokerstars.net/"
-    homepage "https://www.pokerstars.gr/"
-
-    ".net"
-  end
-  language "IT" do
-    url "https://www.pokerstars.net/PokerStars.net.app.zip",
-        verified: "pokerstars.net/"
-    homepage "https://www.pokerstars.it/"
-
-    ".net"
-  end
-  language "GB" do
-    url "https://www.pokerstars.uk/PokerStarsUK.app.zip"
-    homepage "https://www.pokerstars.uk/"
-
-    "UK"
-  end
-  language "PT" do
-    url "https://www.pokerstars.pt/PokerStarsPT.app.zip"
-    homepage "https://www.pokerstars.pt/"
-
-    "PT"
-  end
 
   name "PokerStars"
 
-  container nested: "PokerStars#{language}/PokerStars#{language}.dmg"
+  container nested: "PokerStars.net/PokerStars.net.dmg"
 
-  app "PokerStars#{language}.app"
+  app "PokerStars.net.app"
 
+  uninstall quit: [
+                      "com.pokerstars.PokerStars.net",
+                      "com.pokerstars.PokerStarsBrowse"
+                  ]
+  
   zap trash: [
-    "~/Library/Preferences/com.pokerstars#{language[1]}.user.ini",
-    "~/Library/Preferences/com.pokerstars.PokerStars#{language[1]}.plist",
-    "~/Library/Application Support/PokerStars#{language[1]}",
+    "~/Library/Preferences/com.pokerstars.NetworkStatus.plist",
+    "~/Library/Preferences/com.pokerstars.PokerStars.net.plist",
+    "~/Library/Preferences/com.pokerstars.PokerStarsBrowse.plist",
+    "~/Library/Preferences/com.pokerstars.net.user.ini",
+    "~/Library/Application Support/PokerStars.net",
   ]
 end

--- a/Casks/pokerstars.rb
+++ b/Casks/pokerstars.rb
@@ -2,13 +2,8 @@ cask "pokerstars" do
   version :latest
   sha256 :no_check
 
-  language "US", default: true do
-    url "https://download.pokerstars.net/client/download/"
-    homepage "https://www.pokerstars.net/"
-
-    ".net"
-  end
-
+  url "https://download.pokerstars.net/client/download/"
+  homepage "https://www.pokerstars.net/"
   name "PokerStars"
 
   container nested: "PokerStars.net/PokerStars.net.dmg"


### PR DESCRIPTION
url used before was not valid and now it seems installing is the same
for all languages

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

## Problems

Since the installation of pokers requires a update upon opening, (shown in pics below). `brew uninstall --cask pokerstars` does not go well after this update and show the following error.

```bash
Error: It seems there is already an App at '/usr/local/Caskroom/pokerstars/latest/PokerStars.net.app'.
#or 
Error: Directory not empty @ dir_s_rmdir - /Applications/PokerStars.net.app
```

![Screen Shot 2021-01-30 at 6 52 27 PM](https://user-images.githubusercontent.com/27303600/106364206-99cd9f80-632d-11eb-969c-7527f35c5c93.png)

Also, it also prompts to install a helper tools upon opening but I couldm't find how to find/uninstall/stop in [this guide](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/uninstall.md#uninstall-key-quit).

I personally dont know how to fix that so it would be helpful if someone could help with that.

Thanks

Done:
- Change download url
- Limit language to 'US', remove other
- Add `uninstall quit`

Not done:
- Uninstall the helper tool
- Fix uninstall
