### PR TITLE
Add auto_updates flag to raycast 1.6.0

### DIFF
--- a/Casks/raycast.rb
+++ b/Casks/raycast.rb
@@ -7,6 +7,8 @@ cask "raycast" do
   desc "Control your tools with a few keystrokes"
   homepage "https://raycast.app/"
 
+  auto_updates true
+
   app "Raycast.app"
 
   zap trash: [


### PR DESCRIPTION
Raycast has its own update mechanism.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
