### PR TITLE
Replace appcast with livecheck for Insomnia Designer

### DIFF
--- a/Casks/insomnia-designer.rb
+++ b/Casks/insomnia-designer.rb
@@ -4,10 +4,14 @@ cask "insomnia-designer" do
 
   url "https://github.com/Kong/insomnia/releases/download/designer%40#{version}/Insomnia.Designer-#{version}.dmg",
       verified: "github.com/Kong/insomnia/"
-  appcast "https://api.insomnia.rest/changelog.json?app=com.insomnia.designer"
   name "Insomnia Designer"
   desc "API design platform for GraphQL and REST"
   homepage "https://insomnia.rest/"
+
+  livecheck do
+    url :url
+    regex(/^designer@?(\d+(?:\.\d+)+)$/i)
+  end
 
   auto_updates true
 

--- a/Casks/insomnia-designer.rb
+++ b/Casks/insomnia-designer.rb
@@ -10,7 +10,6 @@ cask "insomnia-designer" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(/^designer@?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/insomnia-designer.rb
+++ b/Casks/insomnia-designer.rb
@@ -10,6 +10,7 @@ cask "insomnia-designer" do
 
   livecheck do
     url :url
+    strategy :github_latest
     regex(/^designer@?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
Hello,

I am one of the engineers working on Insomnia and Insomnia Designer.
We are removing the endpoint used for the appcast from our API shortly, so I have replaced it with the new `livecheck` stanza, using the git repo as the source.

The same change but for Insomnia can be found in this PR: https://github.com/Homebrew/homebrew-cask/pull/99191

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
