### PR TITLE
Add HHKB Keymap Tool v1.1.0

### DIFF
--- a/Casks/hhkb-keymap-tool.rb
+++ b/Casks/hhkb-keymap-tool.rb
@@ -1,0 +1,16 @@
+cask "hhkb-keymap-tool" do
+  version "1.1.0"
+  sha256 "b4544c9a0ab53f69739a056ddf6e3b7edb784889a5dcd32b42572ade985fa9db"
+
+  url "https://origin.pfultd.com/downloads/hhkb/mac/HHKBkeymapTool_#{version.no_dots}ma.dmg",
+      verified: "origin.pfultd.com"
+  name "HHKB Keymap Tool"
+  desc "Keymap tool for Happy Hacking Keyboard Professional (Hybrid models only)"
+  homepage "https://happyhackingkb.com/download/"
+
+  depends_on macos: ">= :sierra"
+
+  pkg "HHKBkeymapTool_#{version.no_dots}ma.pkg"
+
+  uninstall pkgutil: "jp.co.pfu.hhkb-keymap-tool.pkg.V#{version}"
+end


### PR DESCRIPTION
Key remapping and firmware flashing tool for Happy Hacking Keyboard
Professional Hybrid.

Installs nicely, uninstall doesn't work as expected (yet). It looks
like the pkg copies it contents to system Application folder and
doesn't remove them when uninstalled.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
