### PR TITLE
update popo from 3.17.1 to 3.18.0

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask "popo" do
-  version "3.17.1"
-  sha256 "dd96bbfa18d59d35d4cbfed8615c940d2a58315d61c098392d01edaa67b9b081"
+  version "3.18.0"
+  sha256 "455064ae25573c58585373cc8d1067c94d4dc22cc6c8b924f067a0a3c339c6db"
 
   url "https://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   appcast "http://http.popo.netease.com:8080/api/open/jsonp/check_version?device=4",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.