### PR TITLE
Add Gather.app v0.0.6

### DIFF
--- a/Casks/gather.rb
+++ b/Casks/gather.rb
@@ -9,11 +9,7 @@ cask "gather" do
   desc "Virtual video-calling space"
   homepage "https://gather.town/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{href=.*?/Gather-(\d+(?:\.\d+)*)-mac\.zip}i)
-  end
-
   app "Gather.app"
+
+  zap trash: "~/Library/Application Support/Gather"
 end

--- a/Casks/gather.rb
+++ b/Casks/gather.rb
@@ -1,0 +1,19 @@
+cask "gather" do
+  version "0.0.6"
+  sha256 "d5de3b7b8f36d58c323052b88de549187a324b9486f8aed5269f71a269e83460"
+
+  url "https://github.com/gathertown/gather-town-desktop-releases/releases/download/v#{version}/Gather-#{version}-mac.zip",
+      verified: "github.com/gathertown/gather-town-desktop-releases"
+  name "Gather"
+  name "Gather Town"
+  desc "Virtual video-calling space"
+  homepage "https://gather.town/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(%r{href=.*?/Gather-(\d+(?:\.\d+)*)-mac\.zip}i)
+  end
+
+  app "Gather.app"
+end

--- a/Casks/gather.rb
+++ b/Casks/gather.rb
@@ -4,7 +4,6 @@ cask "gather" do
 
   url "https://github.com/gathertown/gather-town-desktop-releases/releases/download/v#{version}/Gather-#{version}-mac.zip",
       verified: "github.com/gathertown/gather-town-desktop-releases"
-  name "Gather"
   name "Gather Town"
   desc "Virtual video-calling space"
   homepage "https://gather.town/"


### PR DESCRIPTION
This is the official Gather Town app (https://gather.town/download). `brew audit --new-cask gather` fails because the github repository is not popular enough. However, this repository only contains a README and is solely used for serving releases.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
