### PR TITLE
Set safe permissions when ngrok is installed

### DIFF
--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -11,4 +11,9 @@ cask "ngrok" do
   binary "ngrok"
 
   zap trash: "~/.ngrok2"
+
+
+  postflight do
+    FileUtils.chmod 0755, Dir.glob("#{staged_path}/ngrok")
+  end
 end

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -10,10 +10,9 @@ cask "ngrok" do
 
   binary "ngrok"
 
-  zap trash: "~/.ngrok2"
-
-
   postflight do
     FileUtils.chmod 0755, Dir.glob("#{staged_path}/ngrok")
   end
+
+  zap trash: "~/.ngrok2"
 end

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -11,7 +11,7 @@ cask "ngrok" do
   binary "ngrok"
 
   postflight do
-    set_permissions Dir.glob("#{staged_path}/ngrok"), '0755'
+    set_permissions Dir.glob("#{staged_path}/ngrok"), "0755"
   end
 
   zap trash: "~/.ngrok2"

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -11,7 +11,7 @@ cask "ngrok" do
   binary "ngrok"
 
   postflight do
-    FileUtils.chmod 0755, Dir.glob("#{staged_path}/ngrok")
+    set_permissions Dir.glob("#{staged_path}/ngrok"), '0755'
   end
 
   zap trash: "~/.ngrok2"

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -11,7 +11,7 @@ cask "ngrok" do
   binary "ngrok"
 
   postflight do
-    set_permissions Dir.glob("#{staged_path}/ngrok"), "0755"
+    set_permissions "#{staged_path}/ngrok", "0755"
   end
 
   zap trash: "~/.ngrok2"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

`ngrok` is installed as a world-writeable file, which is insecure. On a shared system, a malicious unprivileged user could replace `ngrok` with malware, which could be then executed by other users.