### PR TITLE
google-drive-file-stream.rb: fix wrong package name

### DIFF
--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 cask "google-drive-file-stream" do
   version "44.0.14"
   sha256 :no_check
@@ -34,7 +37,6 @@ cask "google-drive-file-stream" do
 
   caveats <<~EOS
     Although #{token} may be installed alongside Google Backup and Sync, you should not use the same account with both.
-
-      https://support.google.com/a/answer/7496409#allowboth
+    https://support.google.com/a/answer/7496409#allowboth
   EOS
 end

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -8,7 +8,7 @@ cask "google-drive-file-stream" do
 
   depends_on macos: ">= :el_capitan"
 
-  pkg "GoogleDriveFileStream.pkg"
+  pkg "GoogleDrive.pkg"
 
   uninstall login_item: "Google Drive File Stream",
             quit:       "com.google.drivefs",


### PR DESCRIPTION
This fixes the following error:
```
$ brew install --cask google-drive-file-stream
==> Caveats
Although google-drive-file-stream may be installed alongside Google Backup and Sync, you should not use the same account with both.

  https://support.google.com/a/answer/7496409#allowboth

==> Downloading https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg
Already downloaded: /Users/stangri/Library/Caches/Homebrew/downloads/d5f08a1a3b8601f139cd0e8ed521b7af28253f558c40aee3edb9d00332f65590--GoogleDriveFileStream.dmg
Warning: No checksum defined for cask 'google-drive-file-stream', skipping verification.
==> Installing Cask google-drive-file-stream
==> Running installer for google-drive-file-stream; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
==> Purging files for version 44.0.14 of Cask google-drive-file-stream
Error: Could not find PKG source file 'GoogleDriveFileStream.pkg', found 'GoogleDrive.pkg' instead.
```

Sadly, it still produces an offense on the audit, I have no idea how to fix it:
```
$ brew style --fix ./google-drive-file-stream.rb 
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
google-drive-file-stream.rb:4:1: C: Block has too many lines. [28/25]
cask "google-drive-file-stream" do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
