### PR TITLE
Rename google-drive-file-stream to google-drive

### DIFF
--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -10,9 +10,9 @@ cask "google-drive-file-stream" do
   stage_only true
 
   postflight do
-    system_commad "brew",
+    system_command HOMEBREW_BREW_FILE,
       args: ["install", "google-drive"]
-    system_commad "brew",
+    system_command HOMEBREW_BREW_FILE,
       args: ["uninstall", "google-drive-file-stream"]
   end
 

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -7,6 +7,7 @@ cask "google-drive-file-stream" do
   homepage "https://www.google.com/drive/"
 
   depends_on macos: ">= :el_capitan"
+
   stage_only true
 
   postflight do

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -1,5 +1,5 @@
 cask "google-drive-file-stream" do
-  version "44.0.14.1" # So it triggers an update for users of the cask
+  version "44.0.14.1" # So it triggers an upgrade for users of the cask
   sha256 :no_check
 
   url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -7,26 +7,21 @@ cask "google-drive-file-stream" do
   desc "Client for the Google Drive storage service"
   homepage "https://www.google.com/drive/"
 
-  depends_on macos: ">= :el_capitan"
+  depends_on cask: "google-drive"
 
   stage_only true
-
-  postflight do
-    system_command HOMEBREW_BREW_FILE,
-                   args: ["install", "google-drive"]
-    system_command HOMEBREW_BREW_FILE,
-                   args: ["uninstall", "google-drive-file-stream"]
-    FileUtils.rm_r(staged_path.to_s)
-  end
 
   caveats <<~EOS
     RENAME WARNING
 
-    Google Drive File Stream has been renamed to Google Drive.
-
-    `#{cask}` has been renamed `google-drive`. We will uninstall the former and install the latter. but you should update your scripts. `#{cask}` will be deleted on August 1, 2021.
+    `#{cask}` will be renamed `google-drive`.
+    In the meantime, `#{cask}` will install `google-drive` for you as a dependency, but you should update your scripts.
 
     We’re aware this solution is subpar. If you’d like to help us improve it,
     we accept PRs and need the equivalent of formula_renames.json for casks: https://docs.brew.sh/Rename-A-Formula
+
+    To migrate now, do:
+      brew uninstall #{cask}
+      brew install google-drive
   EOS
 end

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -1,5 +1,5 @@
 cask "google-drive-file-stream" do
-  version "44.0.14"
+  version "44.0.14.1" # So it triggers an update for users of the cask
   sha256 :no_check
 
   url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
@@ -7,34 +7,23 @@ cask "google-drive-file-stream" do
   homepage "https://www.google.com/drive/"
 
   depends_on macos: ">= :el_capitan"
+  stage_only true
 
-  pkg "GoogleDriveFileStream.pkg"
-
-  uninstall login_item: "Google Drive File Stream",
-            quit:       "com.google.drivefs",
-            pkgutil:    [
-              "com.google.drivefs",
-              "com.google.drivefs.shortcuts",
-              "com.google.pkg.Keystone",
-            ],
-            launchctl:  [
-              "com.google.keystone.agent",
-              "com.google.keystone.system.agent",
-              "com.google.keystone.daemon",
-              "com.google.keystone.xpcservice",
-              "com.google.keystone.system.xpcservice",
-            ]
-
-  zap trash: [
-    "~/Library/Application Support/Google/DriveFS",
-    "~/Library/Caches/com.google.drivefs",
-    "~/Library/Preferences/Google Drive File Stream Helper.plist",
-    "~/Library/Preferences/com.google.drivefs.plist",
-  ]
+  postflight do
+    system_commad "brew",
+      args: ["install", "google-drive"]
+    system_commad "brew",
+      args: ["uninstall", "google-drive-file-stream"]
+  end
 
   caveats <<~EOS
-    Although #{token} may be installed alongside Google Backup and Sync, you should not use the same account with both.
+    RENAME WARNING
 
-      https://support.google.com/a/answer/7496409#allowboth
+    Google Drive File Stream has been renamed to Google Drive.
+
+    `#{cask}` has been renamed `google-drive`. We will uninstall the former and install the latter. but you should update your scripts. `#{cask}` will be deleted on August 1, 2021.
+
+    We’re aware this solution is subpar. If you’d like to help us improve it,
+    we accept PRs and need the equivalent of formula_renames.json for casks: https://docs.brew.sh/Rename-A-Formula
   EOS
 end

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -2,7 +2,7 @@ cask "google-drive-file-stream" do
   version "44.0.14.1" # So it triggers an upgrade for users of the cask
   sha256 :no_check
 
-  url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
+  url "https://dl.google.com/drive-file-stream/GoogleDrive.dmg"
   name "Google Drive File Stream"
   desc "Client for the Google Drive storage service"
   homepage "https://www.google.com/drive/"

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -4,6 +4,7 @@ cask "google-drive-file-stream" do
 
   url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
   name "Google Drive File Stream"
+  desc "Client for the Google Drive storage service"
   homepage "https://www.google.com/drive/"
 
   depends_on macos: ">= :el_capitan"
@@ -12,9 +13,9 @@ cask "google-drive-file-stream" do
 
   postflight do
     system_command HOMEBREW_BREW_FILE,
-      args: ["install", "google-drive"]
+                   args: ["install", "google-drive"]
     system_command HOMEBREW_BREW_FILE,
-      args: ["uninstall", "google-drive-file-stream"]
+                   args: ["uninstall", "google-drive-file-stream"]
   end
 
   caveats <<~EOS

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -16,6 +16,7 @@ cask "google-drive-file-stream" do
                    args: ["install", "google-drive"]
     system_command HOMEBREW_BREW_FILE,
                    args: ["uninstall", "google-drive-file-stream"]
+    FileUtils.rm_r(staged_path.to_s)
   end
 
   caveats <<~EOS

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -11,6 +11,8 @@ cask "google-drive-file-stream" do
 
   stage_only true
 
+  uninstall login_item: "Google Drive File Stream"
+
   caveats <<~EOS
     RENAME WARNING
 

--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -2,7 +2,7 @@ cask "google-drive" do
   version "44.0.14"
   sha256 :no_check
 
-  url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
+  url "https://dl.google.com/drive-file-stream/GoogleDrive.dmg"
   name "Google Drive"
   desc "Client for the Google Drive storage service"
   homepage "https://www.google.com/drive/"

--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -1,4 +1,4 @@
-cask "google-drive-file-stream" do
+cask "google-drive" do
   version "44.0.14"
   sha256 :no_check
 
@@ -10,7 +10,7 @@ cask "google-drive-file-stream" do
 
   pkg "GoogleDrive.pkg"
 
-  uninstall login_item: "Google Drive File Stream",
+  uninstall login_item: "Google Drive",
             quit:       "com.google.drivefs",
             pkgutil:    [
               "com.google.drivefs",

--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -1,0 +1,41 @@
+cask "google-drive-file-stream" do
+  version "44.0.14"
+  sha256 :no_check
+
+  url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
+  name "Google Drive"
+  homepage "https://www.google.com/drive/"
+
+  depends_on macos: ">= :el_capitan"
+
+  pkg "GoogleDrive.pkg"
+
+  uninstall login_item: "Google Drive File Stream",
+            quit:       "com.google.drivefs",
+            pkgutil:    [
+              "com.google.drivefs",
+              "com.google.drivefs.filesystems.dfsfuse.x86_64",
+              "com.google.drivefs.shortcuts",
+              "com.google.pkg.Keystone",
+            ],
+            launchctl:  [
+              "com.google.keystone.agent",
+              "com.google.keystone.system.agent",
+              "com.google.keystone.daemon",
+              "com.google.keystone.xpcservice",
+              "com.google.keystone.system.xpcservice",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/Google/DriveFS",
+    "~/Library/Caches/com.google.drivefs",
+    "~/Library/Preferences/Google Drive File Stream Helper.plist",
+    "~/Library/Preferences/com.google.drivefs.plist",
+  ]
+
+  caveats <<~EOS
+    Although #{token} may be installed alongside Google Backup and Sync, you should not use the same account with both.
+
+      https://support.google.com/a/answer/7496409#allowboth
+  EOS
+end

--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -4,6 +4,7 @@ cask "google-drive" do
 
   url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
   name "Google Drive"
+  desc "Client for the Google Drive storage service"
   homepage "https://www.google.com/drive/"
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
Can anyone confirm with this changes pulled that `brew install google-drive-file-stream` or `brew upgrade google-drive-file-stream` results in an installation of `google-drive` and no `google-drive-file-stream`?