### PR TITLE
Revert "Update v2rayu from 3.0.0 to 3.0.1"

### DIFF
--- a/Casks/v2rayu.rb
+++ b/Casks/v2rayu.rb
@@ -1,6 +1,6 @@
 cask "v2rayu" do
-  version "3.0.1"
-  sha256 "36c05675e17f6ba2c997184356757552b40274f4e4b6077d648d207f7dd912af"
+  version "2.3.1"
+  sha256 "2e8f132c05a8af3b89bd0dacafd2fc9244636587848453f7cd877ab246a33d52"
 
   url "https://github.com/yanue/V2rayU/releases/download/#{version}/V2rayU.dmg"
   appcast "https://github.com/yanue/V2rayU/releases.atom"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#99426
Release 3.0.1 has been pulled.