### PR TITLE
Update Bisq from 1.5.4 to 1.5.5

### DIFF
--- a/Casks/bisq.rb
+++ b/Casks/bisq.rb
@@ -1,6 +1,6 @@
 cask "bisq" do
-  version "1.5.4"
-  sha256 "cecc8f3da9b66a02fb51b3357442498b5dcd5c93f1a08d7904b2d09abb8cb564"
+  version "1.5.5"
+  sha256 "f4c16aa6299b479b2c633e1ccd023d52375416472d5087c036fae0cf12bdbba1"
 
   url "https://github.com/bisq-network/bisq/releases/download/v#{version}/Bisq-#{version}.dmg",
       verified: "github.com/bisq-network/bisq/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
