### PR TITLE
Add Flinto.app v28.0

### DIFF
--- a/Casks/flinto.rb
+++ b/Casks/flinto.rb
@@ -1,0 +1,13 @@
+cask "flinto" do
+  version "28.0"
+  sha256 "5aec57054098df2f8cc13c505b11c204ccaae97657726e172616f46b1712cd32"
+
+  url "https://www.flinto.com/assets/Flinto-#{version}.dmg"
+  name "Flinto"
+  desc "The App Design App"
+  homepage "https://www.flinto.com/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Flinto.app"
+end


### PR DESCRIPTION
Add missing app cask: Flinto, the App Design app.

**NOTE:** the build errors with `Error: Description shouldn't start with an article.`, but the official description of the app from [the homepage](url) is, “The App Design app.” Please advise on how to handle this conflict.

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions)
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
