### PR TITLE
fix google drive pkg name

### DIFF
--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -4,6 +4,7 @@ cask "google-drive-file-stream" do
 
   url "https://dl.google.com/drive-file-stream/GoogleDriveFileStream.dmg"
   name "Google Drive File Stream"
+  desc "Easy and secure access to all of your content"
   homepage "https://www.google.com/drive/"
 
   depends_on macos: ">= :el_capitan"

--- a/Casks/google-drive-file-stream.rb
+++ b/Casks/google-drive-file-stream.rb
@@ -8,7 +8,7 @@ cask "google-drive-file-stream" do
 
   depends_on macos: ">= :el_capitan"
 
-  pkg "GoogleDriveFileStream.pkg"
+  pkg "GoogleDrive.pkg"
 
   uninstall login_item: "Google Drive File Stream",
             quit:       "com.google.drivefs",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.