### PR TITLE
Update eloston-chromium from 88.0.4324.146-1.1 to 88.0.4324.150-1.1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,8 +1,8 @@
 cask "eloston-chromium" do
-  version "88.0.4324.146-1.1"
-  sha256 "0684016457d75c7926f858cb5e1a0f5f37c62c8a06a74024632f4715247fb6fc"
+  version "88.0.4324.150-1.1"
+  sha256 "523e18e1b0f523f2bcb655808933df2411ec1ef779eb392f77e93d57725cbe4d"
 
-  url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}_macos.dmg",
+  url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}_x86-64/ungoogled-chromium_#{version}_x86-64-macos.dmg",
       verified: "github.com/kramred/ungoogled-chromium-macos/"
   appcast "https://github.com/kramred/ungoogled-chromium-macos/releases.atom"
   name "Ungoogled Chromium"


### PR DESCRIPTION
Minor change to the download URL that now includes the architecture.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.