### PR TITLE
Create citrix-workspace.rb

### DIFF
--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,0 +1,34 @@
+cask 'citrix-workspace' do
+  version '18.12,15579:1545940629_adfa92c83b8b302175ff456856be0e30'
+  sha256 'b5d6e406402ae4f72ba431e60c3c0a390a6cf483be34fbea44c710a8a0c8e1bc'
+
+  url "http://downloadplugins.citrix.com/Mac/CitrixWorkspaceApp.dmg"
+  name 'Citrix Workspace'
+  homepage 'https://www.citrix.com/products/workspace-app/'
+
+  pkg 'Install Citrix Workspace.pkg'
+
+  uninstall launchctl: [
+                         'com.citrix.AuthManager_Mac',
+                         'com.citrix.ReceiverHelper',
+                         'com.citrix.ServiceRecords',
+                         'com.citrix.ctxusbd',
+                       ],
+            quit:      [
+                         'Citrix.ServiceRecords',
+                         'com.citrix.ReceiverHelper',
+                         'com.citrix.receiver.nomas',
+                       ],
+            pkgutil:   'com.citrix.ICAClient'
+
+  zap trash: [
+               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.citrix.receiver.nomas.sfl*',
+               '~/Library/Application Support/com.citrix.receiver.nomas',
+               '~/Library/Caches/com.citrix.receiver.nomas',
+               '~/Library/Logs/Citrix Workspace',
+               '~/Library/Preferences/com.citrix.receiver.nomas.plist',
+               '~/Library/Preferences/com.citrix.receiver.nomas.plist.lockfile',
+               '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist',
+               '~/Library/Preferences/com.citrix.ReceiverFTU.AccountRecords.plist.lockfile',
+             ]
+end


### PR DESCRIPTION
Sorry I'm not sure how brew works, so I'm not sure I've filled in the details here correctly. 

Citrix Workspace was deleted from homebrew in https://github.com/Homebrew/homebrew-cask/pull/56881 but as far as I can tell it's now available from a static URL.

I've not tested the uninstall and zapping part of this specification (it's a copy-paste from the deleted file) so I might be causing a net frustration for the maintainers, close the PR if this isn't the proper way to go about things.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
