### PR TITLE
update termius from 7.4.1 to 7.5.2

### DIFF
--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,5 +1,5 @@
 cask "termius" do
-  version "7.4.1"
+  version "7.5.2"
   sha256 :no_check
 
   if Hardware::CPU.intel?


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.