### PR TITLE
libreoffice: add livecheck to replace appcast

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -4,10 +4,15 @@ cask "libreoffice" do
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/x86_64/LibreOffice_#{version}_MacOS_x86-64.dmg",
       verified: "documentfoundation.org/"
-  appcast "https://download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice"
   desc "Office suite"
   homepage "https://www.libreoffice.org/"
+
+  livecheck do
+    url "https://download.documentfoundation.org/libreoffice/stable/"
+    strategy :page_match
+    regex(%r{href="(\d+(?:\.\d+)*)/"}i)
+  end
 
   conflicts_with cask: "homebrew/cask-versions/libreoffice-still"
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

**Livecheck output**
```zsh
❯ brew livecheck --debug libreoffice

Cask:             libreoffice
Livecheckable?:   Yes

URL:              https://download.documentfoundation.org/libreoffice/stable/
Strategy:         PageMatch
Regex:            /href="(\d+(?:\.\d+)*)\/"/i

Matched Versions:
6.4.7, 7.0.4, 7.1.0
libreoffice : 7.1.0 ==> 7.1.0
```

**Corresponding HTML**
```html
<tr><td valign="top">&nbsp;</td><td><a href="6.4.7/">6.4.7/</a></td><td align="right">21-Oct-2020 11:42  </td><td align="right">  - </td><td>&nbsp;</td></tr>
<tr><td valign="top">&nbsp;</td><td><a href="7.0.4/">7.0.4/</a></td><td align="right">17-Dec-2020 09:26  </td><td align="right">  - </td><td>&nbsp;</td></tr>
<tr><td valign="top">&nbsp;</td><td><a href="7.1.0/">7.1.0/</a></td><td align="right">03-Feb-2021 10:27  </td><td align="right">  - </td><td>&nbsp;</td></tr>
```

**Alternative Regex**
More restrictive regex: `regex(%r{href="(\d+(?:\.\d+)*)/">\1}i)`
This option will check both href and data.

**Alternative URL**
Can also check for versions on: https://www.libreoffice.org/download/download/
With various regex possible.
One example: `regex(%r{mac-x86_64&version=\d+(\.\d+)*}i)`