### PR TITLE
Unquarantine QLMarkdown.qlgenerator after installation

### DIFF
--- a/Casks/qlmarkdown.rb
+++ b/Casks/qlmarkdown.rb
@@ -9,4 +9,10 @@ cask "qlmarkdown" do
   homepage "https://github.com/toland/qlmarkdown"
 
   qlplugin "QLMarkdown.qlgenerator"
+
+  postflight do
+    system_command "xattr",
+                   args: ["-cr", File.join(ENV["HOME"], "Library/QuickLook/QLMarkdown.qlgenerator")],
+                   sudo: false
+  end
 end


### PR DESCRIPTION
Even after Allowing Anyway in Big Sur Privacy PrefPane, the unsigned plugin wouldn't run.

Fixes https://github.com/toland/qlmarkdown/issues/98 when installed via Homebrew

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.