### PR TITLE
github: add livecheck

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -4,10 +4,15 @@ cask "github" do
 
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop.zip",
       verified: "githubusercontent.com/"
-  appcast "https://github.com/desktop/desktop/releases.atom"
   name "GitHub Desktop"
   desc "Desktop client for GitHub repositories"
   homepage "https://desktop.github.com/"
+
+  livecheck do
+    url "https://central.github.com/deployments/desktop/desktop/latest/darwin"
+    strategy :header_match
+    regex(%r{(\d+(?:\.\d+).*)/GitHubDesktop\.zip}i)
+  end
 
   auto_updates true
 


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/99564.
```
|-> brew livecheck github --debug

Cask:             github
Livecheckable?:   Yes

URL:              https://central.github.com/deployments/desktop/desktop/latest/darwin
Strategy:         HeaderMatch
Regex:            /(\d+(?:\.\d+).*)\/GitHubDesktop\.zip/i

Matched Versions:
2.6.3-51b58c36
github : 2.6.3-51b58c36 ==> 2.6.3-51b58c36
```