### PR TITLE
GoodSync continuous delivery breaks checksum almost everyday

### DIFF
--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,6 +1,6 @@
 cask "goodsync" do
-  version "11.4.9.9"
-  sha256 "8651edcbe6722d6c607b4fcdcdcecb70d647ea938aaed4df0900f8c7bdd262b3"
+  version "11.5.6"
+  sha256 :no_check
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
   appcast "https://www.goodsync.com/download?os=macos",

--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -1,13 +1,17 @@
 cask "goodsync" do
   version "11.5.6"
-  sha256 :no_check
+  sha256 "ca407a854c69cfe085247d0811606f6522df02568b1f15f9d3599ab3b0f6ac88"
 
   url "https://www.goodsync.com/download/goodsync-v#{version.major}-mac.dmg"
-  appcast "https://www.goodsync.com/download?os=macos",
-          must_contain: version.major_minor_patch
   name "GoodSync"
   desc "File synchronization and backup software"
   homepage "https://www.goodsync.com/"
+
+  livecheck do
+    url "https://www.goodsync.com/download?os=macos"
+    strategy :page_match
+    regex(/GoodSync\ for\ Mac\ v\ (\d+(?:\.\d+)*)/i)
+  end
 
   depends_on macos: ">= :yosemite"
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask goodsync` is error-free.
- [X] `brew style --fix goodsync` reports no offenses.
