### PR TITLE
home-assistant: Replace appcast with livecheck

### DIFF
--- a/Casks/home-assistant.rb
+++ b/Casks/home-assistant.rb
@@ -4,10 +4,20 @@ cask "home-assistant" do
 
   url "https://github.com/home-assistant/iOS/releases/download/release%2F#{version.before_comma}%2F#{version.after_comma}/home-assistant-mac.zip",
       verified: "github.com/home-assistant/iOS/"
-  appcast "https://github.com/home-assistant/iOS/releases.atom"
   name "Home Assistant"
   desc "Companion app for Home Assistant home automation software"
   homepage "https://companion.home-assistant.io/"
+
+  # We use the GitHubLatest strategy as Home Assistant also tags pre-releases, and
+  # we also specify a regex since tags are unconventional, e.g. `2021.2.2/2021.55`,
+  # and use a custom block to replace the slash with a comma in the resulting version
+  livecheck do
+    url :url
+    strategy :github_latest do |page|
+      version = page.match(%r{href=".+/tree/(?:mac|release)/([\d.]+)/([\d.]+)"}i)
+      "#{version[1]},#{version[2]}"
+    end
+  end
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version). [N/A]
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Added livecheck, which returns the newest stable macOS release ([2021.2.2 (55)][0]) on GitHub, rather than the current latest release ([2021.3 (54)][1]), which is a pre-release.

```
$ brew livecheck home-assistant --debug

Cask:             home-assistant
Livecheckable?:   Yes

URL (url):        https://github.com/home-assistant/iOS/releases/download/release%2F2021.2.2%2F2021.55/home-assistant-mac.zip
Strategy:         GithubLatest
URL (strategy):   https://github.com/home-assistant/iOS/releases/latest
URL (final):      https://github.com/home-assistant/iOS/releases/tag/release/2021.2.2/2021.55
Regex (strategy): /href=.*?\/tag\/v?(\d+(?:\.\d+)+)["' >]/i

Matched Versions:
2021.2.2,2021.55
home-assistant : 2021.2.2,2021.55 ==> 2021.2.2,2021.55
```

```
$ brew audit --cask Casks/home-assistant.rb
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
audit for home-assistant: passed
```

```
$ brew style --fix Casks/home-assistant.rb
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.6-compliant syntax, but you are running 2.6.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

1 file inspected, no offenses detected
```

[0]:https://github.com/home-assistant/iOS/releases/tag/release%2F2021.2.2%2F2021.55
[1]:https://github.com/home-assistant/iOS/releases/tag/release%2F2021.3%2F2021.54