### PR TITLE
New FortiClient-VPN cask, different from FortiClient

### DIFF
--- a/Casks/forticlient-vpn.rb
+++ b/Casks/forticlient-vpn.rb
@@ -11,7 +11,7 @@ cask "forticlient-vpn" do
   installer manual: "FortiClientUpdate.app"
 
   uninstall script: {
-    executable: "/Applications/FortiClientUninstaller.app/Contents/Resources/uninstall_helper",
+    executable: "/Applications/FortiClientUninstaller.app/Contents/MacOS/Uninstall",
     sudo:       true,
   }
 

--- a/Casks/forticlient-vpn.rb
+++ b/Casks/forticlient-vpn.rb
@@ -1,0 +1,23 @@
+cask "forticlient-vpn" do
+  version "6.4"
+  sha256 "a673cc372f4caf90476e6cda4e51c8450ac58e09a8c5218bba537e86792e5d23"
+
+  url "https://filestore.fortinet.com/forticlient/downloads/FortiClientVPNOnlineInstaller_#{version}.dmg",
+      verified: "filestore.fortinet.com/forticlient/"
+  name "FortiClient VPN"
+  desc "Free VPN client for FortiClient"
+  homepage "https://forticlient.com/"
+
+  installer manual: "FortiClientUpdate.app"
+
+  uninstall script: {
+    executable: "/Applications/FortiClientUninstaller.app/Contents/Resources/uninstall_helper",
+    sudo:       true,
+  }
+
+  zap trash: [
+    "/Library/Application Support/Fortinet",
+    "~/Library/Application Support/Fortinet",
+    "~/Library/Application Support/FortiClient",
+  ]
+end


### PR DESCRIPTION
This cask adds support for FortiClient VPN, which is a different software than FortiClient (already available as a cask)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

Additional information:
This is the original cask named forticlient, which recently changed the software from forticlient-vpn to forticlient (another software from the same company) due to cask update #99090 (originating confusion among users of the cask). Since it makes sense from the naming perspective, I created a new cask for forticlient-vpn and I suggest keeping FortiClient on the forticlient cask.