### PR TITLE
update osxfuse from 3.11.2 to 4.0.5

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -1,8 +1,8 @@
 cask "osxfuse" do
-  version "3.11.2"
-  sha256 "0f9fd021810063ded2f9a40347e11961369238af27615842063831568a0860ce"
+  version "4.0.5"
+  sha256 "6365d10c9e388ac7a91fe1e65d54694faad69149f421125eaddfff07d48763ea"
 
-  url "https://github.com/osxfuse/osxfuse/releases/download/osxfuse-#{version}/osxfuse-#{version}.dmg",
+  url "https://github.com/osxfuse/osxfuse/releases/download/macfuse-#{version}/macfuse-#{version}.dmg",
       verified: "github.com/osxfuse/"
   appcast "https://github.com/osxfuse/osxfuse/releases.atom"
   name "OSXFUSE"

--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -9,7 +9,7 @@ cask "osxfuse" do
   desc "File system integration"
   homepage "https://osxfuse.github.io/"
 
-  pkg "Extras/FUSE for macOS #{version}.pkg"
+  pkg "Extras/macFUSE #{version}.pkg"
 
   postflight do
     set_ownership ["/usr/local/include", "/usr/local/lib"]


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.