### PR TITLE
sip: update to 2.5.2,252

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -3,8 +3,8 @@ cask "sip" do
     version "1.2"
     sha256 "93569421eef761ccdd2784d73e5f201d29e5e22ad6814a7a169f459f460bf4ff"
   else
-    version "2.5.1,251"
-    sha256 "b9c3dab9ca147e7e39957fe1ec8a81ae2cb9de5d49c25ed7596d2980fdab3441"
+    version "2.5.2,252"
+    sha256 "bf9988c28ec0fb474f4b7a0330f9140f3a07898240ed01800dfc3dfcc77301b2"
   end
 
   url "https://sipapp.io/updates/v#{version.major}/sip-#{version.before_comma}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

update `sip` to version `2.5.2,252`
