### PR TITLE
Update checksum of dbeaver-community 7.3.5

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,6 +1,6 @@
 cask "dbeaver-community" do
   version "7.3.5"
-  sha256 "953e96c1794f5b58dc10045cba799817136590ab66b88657a6f188d314d5a70b"
+  sha256 "12d7cd6167a411f57ab9ece5f68dbbf0a0c689058836bb52fd0d140e5970217b"
 
   url "https://dbeaver.io/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
   name "DBeaver Community Edition"


### PR DESCRIPTION
Matches checksum posted at https://download.dbeaver.com/community/7.3.5/checksum/dbeaver-ce-7.3.5-macos.dmg.sha256
Somehow a mismatching checksum was introduced with #99907.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
