### PR TITLE
Modify url of discord

### DIFF
--- a/Casks/discord.rb
+++ b/Casks/discord.rb
@@ -2,8 +2,8 @@ cask "discord" do
   version "0.0.261"
   sha256 "f6bed5976d1ee223b42986b185626fbc758d5f918aff27d3d7b0c2212406cba9"
 
-  url "https://cdn.discordapp.com/apps/osx/#{version}/Discord.dmg",
-      verified: "cdn.discordapp.com/"
+  url "https://dl.discordapp.net/apps/osx/#{version}/Discord.dmg",
+      verified: "dl.discordapp.net/"
   name "Discord"
   desc "Voice and text chat software"
   homepage "https://discord.com/"


### PR DESCRIPTION
The official site of Discord (https://discord.com/download) currently downloads dmg file from  `https://dl.discordapp.net/apps/osx/0.0.261/Discord.dmg` , so I modified the `url` of the cask to this.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
