### PR TITLE
Changed logisim-evolution to use .dmg

### DIFF
--- a/Casks/logisim-evolution.rb
+++ b/Casks/logisim-evolution.rb
@@ -1,20 +1,21 @@
 cask "logisim-evolution" do
   version "3.4.1"
-  sha256 "1b72dd3397290b7be95f886b933bd37a2d9182b8d33247fa5f059d0867e8111c"
+  sha256 "253290b94ae1dba6d5528ff2ea478c2750cee4a40c4710f7da6006dc3f0b4b52"
 
-  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution-#{version}-all.jar"
+  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution-#{version}.dmg"
   appcast "https://github.com/reds-heig/logisim-evolution/releases.atom"
   name "Logisim Evolution"
   desc "Digital logic designer and simulator"
   homepage "https://github.com/reds-heig/logisim-evolution"
 
-  container type: :naked
+  app "logisim-evolution.app"
 
-  app "logisim-evolution-#{version}-all.jar", target: "logisim-evolution.jar"
+  postflight do
+    # Fix xattr
+    system_command "/usr/bin/xattr",
+                   args: ["-cr", "#{appdir}/logisim-evolution.app"],
+                   sudo: true
+  end
 
   zap trash: "~/Library/Preferences/com.cburch.logisim.plist"
-
-  caveats do
-    depends_on_java "9+"
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

I've updated this cask to use the Mac-specific `.app/.dmg`, instead of using the Java universal `.jar`. Because of quirks in how the developer packages the disk image, I have to run `xattr -cr` on the application in order for it to launch properly. In addition, I've removed the Java 9 dependency, since the app bundle ships with a compatible version of Java. Finally, I wasn't sure if the application auto-updates; the description states that it does, but I'm not sure if the functionality is built-in or if it just redirects to the GitHub project, so I left it out for now. Thanks for reviewing, and I hope there aren't any issues!
