### PR TITLE
Update android-platform-tools from 30.0.0 to 30.0.5

### DIFF
--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -1,8 +1,8 @@
 cask "android-platform-tools" do
-  version "30.0.0"
-  sha256 "74f3fd31032163c9d83383c266fcecf35a22b86986a7949572737b1aaf91715b"
+  version "30.0.5,eabcd8b4b7ab518c6af9c941af8494072f17ec4b"
+  sha256 "e5780bad71a53cf9d693e1053a0748f49e4a67cc1f71d16a94ab4c943af3345f"
 
-  url "https://dl.google.com/android/repository/platform-tools_r#{version}-darwin.zip",
+  url "https://dl.google.com/android/repository/#{version.after_comma}.platform-tools_r#{version.before_comma}-darwin.zip",
       verified: "google.com/android/repository/"
   name "Android SDK Platform-Tools"
   desc "Android SDK component"

--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -10,8 +10,12 @@ cask "android-platform-tools" do
 
   binary "#{staged_path}/platform-tools/adb"
   binary "#{staged_path}/platform-tools/dmtracedump"
+  binary "#{staged_path}/platform-tools/e2fsdroid"
   binary "#{staged_path}/platform-tools/etc1tool"
   binary "#{staged_path}/platform-tools/fastboot"
   binary "#{staged_path}/platform-tools/hprof-conv"
+  binary "#{staged_path}/platform-tools/make_f2fs"
+  binary "#{staged_path}/platform-tools/make_f2fs_casefold"
   binary "#{staged_path}/platform-tools/mke2fs"
+  binary "#{staged_path}/platform-tools/sload_f2fs"
 end

--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -6,7 +6,7 @@ cask "android-platform-tools" do
       verified: "google.com/android/repository/"
   name "Android SDK Platform-Tools"
   desc "Android SDK component"
-  homepage "https://developer.android.com/studio/releases/platform-tools.html"
+  homepage "https://developer.android.com/studio/releases/platform-tools"
 
   livecheck do
     url "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"

--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -8,6 +8,14 @@ cask "android-platform-tools" do
   desc "Android SDK component"
   homepage "https://developer.android.com/studio/releases/platform-tools.html"
 
+  livecheck do
+    url "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"
+    strategy :header_match do |headers|
+      match = headers["location"].match(%r{/([0-9a-f]{40,}).platform-tools_r([.0-9]+)-darwin})
+      "#{match[2]},#{match[1]}"
+    end
+  end
+
   binary "#{staged_path}/platform-tools/adb"
   binary "#{staged_path}/platform-tools/dmtracedump"
   binary "#{staged_path}/platform-tools/e2fsdroid"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

```
% brew livecheck --debug android-platform-tools

Cask:             android-platform-tools
Livecheckable?:   Yes

URL:              https://dl.google.com/android/repository/platform-tools-latest-darwin.zip
Strategy:         HeaderMatch

Matched Versions:
30.0.5,eabcd8b4b7ab518c6af9c941af8494072f17ec4b
android-platform-tools : 30.0.5,eabcd8b4b7ab518c6af9c941af8494072f17ec4b ==> 30.0.5,eabcd8b4b7ab518c6af9c941af8494072f17ec4b
```
