### PR TITLE
cmd/lib/generate-matrix.rb: update GitHub API call

### DIFF
--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 require "tap"
-require "utils/github"
+require "utils/github/api"
 
 require_relative "ci_matrix"
 
 pr_url, = ARGV
 
 labels = if pr_url
-  pr = GitHub.open_api(pr_url)
+  pr = GitHub::API.open_rest(pr_url)
   pr.fetch("labels").map { |l| l.fetch("name") }
 else
   []


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

This PR updates the usage of Homebrew's GitHub API module as a consequence of Homebrew/brew#10626. Calls to the erstwhile `GitHub.open_api` (now a deprecated wrapper method) have been replaced with `GitHub::API.open_rest`.
