### PR TITLE
coteditor.rb: remove appcast

### DIFF
--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -15,7 +15,6 @@ cask "coteditor" do
 
   url "https://github.com/coteditor/CotEditor/releases/download/#{version}/CotEditor_#{version}.dmg",
       verified: "github.com/coteditor/CotEditor/"
-  appcast "https://github.com/coteditor/CotEditor/releases.atom"
   name "CotEditor"
   desc "Plain-text editor for web pages, program source codes and more"
   homepage "https://coteditor.com/"


### PR DESCRIPTION
Because it uses a Github releases `url`, `livecheck` auto-works.