### PR TITLE
installer.md: installer script: should never be used for interactive installations

### DIFF
--- a/doc/cask_language_reference/stanzas/installer.md
+++ b/doc/cask_language_reference/stanzas/installer.md
@@ -14,7 +14,7 @@ installer manual: "Nutstore Installer.app"
 
 ## installer script:
 
-`installer script:` introduces a series of key-value pairs describing a command which will automate completion of the install. The form is similar to `uninstall script:`:
+`installer script:` introduces a series of key-value pairs describing a command which will automate completion of the install. **It should never be used for interactive installations.** The form is similar to `uninstall script:`:
 
 | key             | value
 | ----------------|------------------------------
@@ -24,18 +24,17 @@ installer manual: "Nutstore Installer.app"
 | `must_succeed:` | set to `false` if the script is allowed to fail
 | `sudo:`         | set to `true` if the script needs `sudo`
 
-The path may be absolute, or relative to the Cask. Example (from [ransomwhere.rb](https://github.com/Homebrew/homebrew-cask/blob/2a7499561420bd375e45e96082c273ca75b600d1/Casks/ransomwhere.rb#L12-L16)):
+The path may be absolute, or relative to the Cask. Example (from [miniforge.rb](https://github.com/Homebrew/homebrew-cask/blob/ed2033fb3578376c3ee58a2cb459ef96fa6eb37d/Casks/miniforge.rb#L15L18)):
 
 ```ruby
   installer script: {
-                      executable: "#{staged_path}/RansomWhere.app/Contents/MacOS/RansomWhere",
-                      args:       ["-install"],
-                      sudo:       true,
-                    }
+    executable: "Miniforge3-#{version}-MacOSX-x86_64.sh",
+    args:       ["-b", "-p", "#{caskroom_path}/base"],
+  }
 ```
 
-If the `installer script:` does not require any of the key-values it can point directly to the path of the install script. Example (from [amazon-drive.rb](https://github.com/Homebrew/homebrew-cask/blob/427c52acdc3ce0ab1e97950e6cee9896480d7353/Casks/amazon-drive.rb#L10)):
+If the `installer script:` does not require any of the key-values it can point directly to the path of the install script:
 
 ```ruby
-installer script: "Amazon Drive Installer.app/Contents/MacOS/Amazon Drive Installer"
+installer script: "#{staged_path}/install.sh"
 ```


### PR DESCRIPTION
The examples we uses aren’t good for this goal, and people frequently submit undesirable `installer script:`s.