### PR TITLE
Update zaps for several casks

### DIFF
--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -24,6 +24,7 @@ cask "alfred" do
   zap trash: [
     "~/Library/Application Support/Alfred",
     "~/Library/Caches/com.runningwithcrayons.Alfred",
+    "~/Library/Cookies/com.runningwithcrayons.Alfred.binarycookies",
     "~/Library/Preferences/com.runningwithcrayons.Alfred.plist",
     "~/Library/Preferences/com.runningwithcrayons.Alfred-Preferences.plist",
     "~/Library/Saved Application State/com.runningwithcrayons.Alfred-Preferences.savedState",

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -33,6 +33,7 @@ cask "iterm2" do
     "~/Library/Application Support/iTerm2",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.iterm2.sfl*",
     "~/Library/Caches/com.googlecode.iterm2",
+    "~/Library/Cookies/com.googlecode.iterm2.binarycookies",
     "~/Library/Preferences/com.googlecode.iterm2.plist",
     "~/Library/Saved Application State/com.googlecode.iterm2.savedState",
   ]

--- a/Casks/pock.rb
+++ b/Casks/pock.rb
@@ -18,9 +18,11 @@ cask "pock" do
   app "Pock.app"
 
   zap trash: [
+    "~/Library/Application Scripts/com.pigigaldi.pock.QLPockWidget",
     "~/Library/Application Support/Pock",
     "~/Library/Application Support/com.pigigaldi.pock",
     "~/Library/Caches/com.pigigaldi.pock",
+    "~/Library/Containers/com.pigigaldi.pock.QLPockWidget",
     "~/Library/Preferences/com.pigigaldi.pock.plist",
   ]
 end

--- a/Casks/scroll-reverser.rb
+++ b/Casks/scroll-reverser.rb
@@ -15,7 +15,9 @@ cask "scroll-reverser" do
   app "Scroll Reverser.app"
 
   zap trash: [
+    "~/Library/Application Scripts/com.pilotmoon.scroll-reverser.launcher",
     "~/Library/Caches/com.pilotmoon.scroll-reverser",
+    "~/Library/Containers/com.pilotmoon.scroll-reverser.launcher",
     "~/Library/Preferences/com.pilotmoon.scroll-reverser.plist",
   ]
 end

--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -22,11 +22,14 @@ cask "suspicious-package" do
   binary "#{appdir}/Suspicious Package.app/Contents/SharedSupport/spkg"
 
   zap trash: [
+    "~/Library/Application Scripts/com.mothersruin.SuspiciousPackageApp.QLPreview",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.mothersruin.suspiciouspackageapp.sfl*",
     "~/Library/Caches/com.mothersruin.SuspiciousPackageApp",
     "~/Library/Caches/com.mothersruin.XPCService.UpdateChecker",
+    "~/Library/Containers/com.mothersruin.SuspiciousPackageApp.QLPreview",
     "~/Library/Preferences/com.mothersruin.SuspiciousPackage.plist",
     "~/Library/Preferences/com.mothersruin.SuspiciousPackageApp.plist",
+    "~/Library/Saved Application State/com.mothersruin.SuspiciousPackageApp.savedState",
     "~/Library/WebKit/com.mothersruin.SuspiciousPackageApp",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

Adds some missed filepaths to the zap stanzas for several casks:
* `pock`
* `suspicious-package`
* `scroll-reverser`
* `alfred`
* `iterm2`