### PR TITLE
Add zap stanzas for several casks

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -15,4 +15,10 @@ cask "amazon-workspaces" do
   pkg "WorkSpaces.pkg"
 
   uninstall pkgutil: "com.amazon.workspaces"
+
+  zap trash: [
+    "~/Library/Caches/com.amazon.workspaces",
+    "~/Library/Preferences/com.amazon.workspaces.plist",
+    "~/Library/Saved Application State/com.amazon.workspaces.savedState",
+  ]
 end

--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -18,4 +18,6 @@ cask "background-music" do
   uninstall pkgutil:   "com.bearisdriving.BGM",
             quit:      "com.bearisdriving.BGM.App",
             launchctl: "com.bearisdriving.BGM.XPCHelper"
+
+  zap trash: "~/Library/Preferences/com.bearisdriving.BGM.App.plist"
 end

--- a/Casks/edex-ui.rb
+++ b/Casks/edex-ui.rb
@@ -8,4 +8,10 @@ cask "edex-ui" do
   homepage "https://github.com/GitSquared/edex-ui"
 
   app "eDEX-UI.app"
+
+  zap trash: [
+    "~/Library/Application Support/eDEX-UI",
+    "~/Library/Saved Application State/com.edex.ui.savedState",
+    "~/Library/Preferences/com.edex.ui.plist",
+  ]
 end

--- a/Casks/parsec.rb
+++ b/Casks/parsec.rb
@@ -15,4 +15,6 @@ cask "parsec" do
 
   uninstall pkgutil: "tv.parsec.www",
             quit:    "tv.parsec.www"
+
+  zap trash: "~/.parsec"
 end

--- a/Casks/pennywise.rb
+++ b/Casks/pennywise.rb
@@ -8,4 +8,11 @@ cask "pennywise" do
   homepage "https://github.com/kamranahmedse/pennywise"
 
   app "Pennywise.app"
+
+  zap trash: [
+    "~/Library/Application Support/Pennywise",
+    "~/Library/Logs/Pennywise",
+    "~/Library/Preferences/info.kamranahmed.pennywise.plist",
+    "~/Library/Saved Application State/info.kamranahmed.pennywise.savedState",
+  ]
 end

--- a/Casks/vanilla.rb
+++ b/Casks/vanilla.rb
@@ -11,4 +11,9 @@ cask "vanilla" do
   depends_on macos: ">= :sierra"
 
   app "Vanilla.app"
+
+  zap trash: [
+    "~/Library/Application Support/Vanilla",
+    "~/Library/Preferences/net.matthewpalmer.Vanilla.plist",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

Adds zap stanzas for several casks in #88469:

* `amazon-workspaces`
* `background-music`
* `edex-ui`
* `parsec`
* `pennywise`
* `vanilla`

Note that most of these casks except for `vanilla` don't have a `desc` stanza, so `brew audit --cask` gives a warning. I was unsure if it was necessary, since they didn't have these stanzas to begin with.