### PR TITLE
sf-symbols: add livecheck and zap

### DIFF
--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -4,28 +4,22 @@ cask "sf-symbols" do
     sha256 "eddca84dde246f358429e47a8a7906b026d892dba97e556b555b27e7070de04e"
 
     url "https://devimages-cdn.apple.com/design/resources/download/SF-Symbols.dmg"
-
-    livecheck do
-      url "https://developer.apple.com/sf-symbols/"
-      strategy :page_match
-      regex(/SF\s*Symbols\s*(\d+(?:\.\d+)*).*?\n?.*?Requires.*?macOS\s*10\.14/i)
-    end
   else
     version "2.1"
     sha256 "97af56dee070ddf7f22cf649aab9bde61edab4aa16021702e51d912a8303c02e"
 
     url "https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-#{version}.dmg"
-
-    livecheck do
-      url "https://developer.apple.com/sf-symbols/"
-      strategy :page_match
-      regex(%r{href=.*?/SF-Symbols-(\d+(?:\.\d+)*)\.dmg}i)
-    end
   end
 
   name "SF Symbols"
   desc "Tool that provides consistent, highly configurable symbols for apps"
   homepage "https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/"
+
+  livecheck do
+    url "https://developer.apple.com/sf-symbols/"
+    strategy :page_match
+    regex(%r{href=.*?/SF-Symbols-(\d+(?:\.\d+)*)\.dmg}i)
+  end
 
   depends_on macos: ">= :mojave"
 

--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -2,11 +2,25 @@ cask "sf-symbols" do
   if MacOS.version <= :mojave
     version "1.1"
     sha256 "eddca84dde246f358429e47a8a7906b026d892dba97e556b555b27e7070de04e"
+
     url "https://devimages-cdn.apple.com/design/resources/download/SF-Symbols.dmg"
+
+    livecheck do
+      url "https://developer.apple.com/sf-symbols/"
+      strategy :page_match
+      regex(/SF\s*Symbols\s*(\d+(?:\.\d+)*).*?\n?.*?Requires.*?macOS\s*10\.14/i)
+    end
   else
     version "2.1"
     sha256 "97af56dee070ddf7f22cf649aab9bde61edab4aa16021702e51d912a8303c02e"
+
     url "https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-#{version}.dmg"
+
+    livecheck do
+      url "https://developer.apple.com/sf-symbols/"
+      strategy :page_match
+      regex(%r{href=.*?/SF-Symbols-(\d+(?:\.\d+)*)\.dmg}i)
+    end
   end
 
   name "SF Symbols"
@@ -19,4 +33,6 @@ cask "sf-symbols" do
 
   uninstall pkgutil: "com.apple.SFSymbols.plist",
             delete:  "/Applications/SF Symbols.app"
+
+  zap trash: "~/Library/Preferences/com.apple.SFSymbols.plist"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

**Zap for leftover files on uninstall**
```zsh
❯ brew uninstall sf-symbols
==> Uninstalling Cask sf-symbols
==> Uninstalling packages:
==> Removing files:
/Applications/SF Symbols.app
Password:
==> Purging files for version 2.1 of Cask sf-symbols

❯ fd sfsymbol
Library/Preferences/com.apple.SFSymbols.plist
```

**Livecheck from https://developer.apple.com/sf-symbols/**
Latest version HTML:
```html
<a href="https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-2.1.dmg" class="icon icon-after icon-downloadcircle">Download (152.9 MB)</a></p>
```

Output
```zsh
❯ brew livecheck --debug sf-symbols

Cask:             sf-symbols
Livecheckable?:   Yes

URL:              https://developer.apple.com/sf-symbols/
Strategy:         PageMatch
Regex:            /href=.*?\/SF-Symbols-(\d+(?:\.\d+)*)\.dmg/i

Matched Versions:
2.1
sf-symbols : 2.1 ==> 2.1
```

Mojave version HTML (multiline):
```html
<h4 class="typography-subbody">SF Symbols 1.1</h4>
<p class="typography-caption">Requires <span class="nowrap">macOS 10.14.4</span> or later</p>
```

Output (temp added livecheck since using Big Sur):
```zsh
❯ brew livecheck --debug sf-symbols

Cask:             sf-symbols
Livecheckable?:   Yes

URL:              https://developer.apple.com/sf-symbols/
Strategy:         PageMatch
Regex:            /SF\s*Symbols\s*(\d+(?:\.\d+)*).*?\n?.*?Requires.*?macOS\s*10\.14/i

Matched Versions:
1.1
sf-symbols : 2.1 ==> 1.1
```