### PR TITLE
dropbox: add livecheck

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -10,7 +10,6 @@ cask "dropbox" do
   livecheck do
     url :url
     strategy :header_match
-    regex(/Dropbox%20(\d+(?:\.\d+)*)\.dmg/i)
   end
 
   auto_updates true

--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -7,6 +7,12 @@ cask "dropbox" do
   desc "Client for the Dropbox cloud storage service"
   homepage "https://www.dropbox.com/"
 
+  livecheck do
+    url :url
+    strategy :header_match
+    regex(/Dropbox%20(\d+(?:\.\d+)*)\.dmg/i)
+  end
+
   auto_updates true
   conflicts_with cask: "homebrew/cask-versions/dropbox-beta"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

**EDIT: 2nd commit**
Based on Firefox Cask, regex wasn't needed.

**New livecheck output**
```zsh
❯ brew livecheck --debug dropbox

Cask:             dropbox
Livecheckable?:   Yes

URL (url):        https://www.dropbox.com/download?plat=mac&full=1
Strategy:         HeaderMatch

Matched Versions:
116.4.368
dropbox : 116.4.368 ==> 116.4.368
```
**Previous livecheck output**
```zsh
❯ brew livecheck --debug dropbox
dropbox : unversioned
```