### PR TITLE
Improved Camo Studio cask

### DIFF
--- a/Casks/camo-studio.rb
+++ b/Casks/camo-studio.rb
@@ -1,6 +1,6 @@
 cask "camo-studio" do
-  version "1.2.3,139"
-  sha256 "dc5983b84f2a0b5500fa44e59acf744228cf03d3e10497b05ba09944d6acfa08"
+  version "1.2.4,144"
+  sha256 "37aea984109f4c8bf6f007a8bd8cb55de2e745773684c8cca3d736b421023ce0"
 
   url "https://reincubate.com/res/labs/camo/Camo%20Studio%20#{version.before_comma}%20%28#{version.after_comma}%29%20%5BRelease%5D.app.zip"
   appcast "https://uds.reincubate.com/release-notes/camo/?format=sparkle"

--- a/Casks/camo-studio.rb
+++ b/Casks/camo-studio.rb
@@ -3,10 +3,14 @@ cask "camo-studio" do
   sha256 "37aea984109f4c8bf6f007a8bd8cb55de2e745773684c8cca3d736b421023ce0"
 
   url "https://reincubate.com/res/labs/camo/Camo%20Studio%20#{version.before_comma}%20%28#{version.after_comma}%29%20%5BRelease%5D.app.zip"
-  appcast "https://uds.reincubate.com/release-notes/camo/?format=sparkle"
   name "Camo Studio"
   desc "Use your phone as a pro webcam to look amazing on video calls"
   homepage "https://reincubate.com/camo/"
+
+  livecheck do
+    url "https://uds.reincubate.com/release-notes/camo/?format=sparkle"
+    strategy :sparkle
+  end
 
   auto_updates true
 

--- a/Casks/camo-studio.rb
+++ b/Casks/camo-studio.rb
@@ -15,6 +15,18 @@ cask "camo-studio" do
   auto_updates true
 
   app "Camo Studio.app"
+  installer script: {
+    executable:   "#{staged_path}/Camo Studio.app/Contents/MacOS/Camo Studio",
+    args:         ["-install"],
+    sudo:         true,
+    must_succeed: false,
+  }
 
-  uninstall delete: "/Library/CoreMediaIO/Plug-Ins/DAL/ReincubateCamoDAL.plugin"
+  uninstall quit:   "com.reincubate.macos.cam",
+            script: {
+              executable:   "/Applications/Camo Studio.app/Contents/MacOS/Camo Studio",
+              args:         ["-uninstall"],
+              sudo:         true,
+              must_succeed: false, # necessary for now as sometimes will exit(9) even on success
+            }
 end

--- a/Casks/camo-studio.rb
+++ b/Casks/camo-studio.rb
@@ -4,7 +4,7 @@ cask "camo-studio" do
 
   url "https://reincubate.com/res/labs/camo/Camo%20Studio%20#{version.before_comma}%20%28#{version.after_comma}%29%20%5BRelease%5D.app.zip"
   name "Camo Studio"
-  desc "Use your phone as a high-quality webcam with advanced controls, custom watermarks, Portrait mode, and more."
+  desc "Use your phone as a high-quality webcam with image tuning controls"
   homepage "https://reincubate.com/camo/"
 
   livecheck do

--- a/Casks/camo-studio.rb
+++ b/Casks/camo-studio.rb
@@ -5,6 +5,7 @@ cask "camo-studio" do
   url "https://reincubate.com/res/labs/camo/Camo%20Studio%20#{version.before_comma}%20%28#{version.after_comma}%29%20%5BRelease%5D.app.zip"
   appcast "https://uds.reincubate.com/release-notes/camo/?format=sparkle"
   name "Camo Studio"
+  desc "Use your phone as a pro webcam to look amazing on video calls"
   homepage "https://reincubate.com/camo/"
 
   auto_updates true

--- a/Casks/camo-studio.rb
+++ b/Casks/camo-studio.rb
@@ -4,7 +4,7 @@ cask "camo-studio" do
 
   url "https://reincubate.com/res/labs/camo/Camo%20Studio%20#{version.before_comma}%20%28#{version.after_comma}%29%20%5BRelease%5D.app.zip"
   name "Camo Studio"
-  desc "Use your phone as a pro webcam to look amazing on video calls"
+  desc "Use your phone as a high-quality webcam with advanced controls, custom watermarks, Portrait mode, and more."
   homepage "https://reincubate.com/camo/"
 
   livecheck do
@@ -27,6 +27,6 @@ cask "camo-studio" do
               executable:   "/Applications/Camo Studio.app/Contents/MacOS/Camo Studio",
               args:         ["-uninstall"],
               sudo:         true,
-              must_succeed: false, # necessary for now as sometimes will exit(9) even on success
+              must_succeed: false, # necessary for now (see https://github.com/Homebrew/homebrew-cask/pull/100248)
             }
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

---

Disclosure: I work on Camo Studio at Reincubate.

This PR improves the `camo-studio` cask by adding full install/uninstall support (which will properly setup the A/V plugins), bumping Camo Studio to today's 1.2.4 release, adding a description, and replacing the `appcast` stanza with `livecheck`.

On uninstall: there is a temporary workaround in this PR which is setting `must_succeed` on the uninstall script to `false`, as we sometimes exit with code 9 after a successful uninstall. This should be resolved in a future Camo Studio release and I will update the cask when that happens, but we figure it is better than the current revision's incomplete uninstall.