### PR TITLE
Update ableton-live-* to 11.0

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,14 +1,15 @@
 cask "ableton-live-intro" do
-  version "10.1.30"
-  sha256 "cf46fd3c8749e5507adbbafaf6bb2de2b6d62555710596528103deccae1442a8"
+  version "11.0"
+  sha256 "a9cd26c93ecf49c778e8a5626564269e3a5404ee520c95e61ed23ba62fc76201"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
   name "Ableton Live Intro"
+  desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Intro.app"
 

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-lite" do
-  version "10.1.30"
-  sha256 "55b2562b61a30af0a5794f2c3c9f846d0189361688568804490ed696ceeb06e3"
+  version "11.0"
+  sha256 "502b4f65eeb44deb7f2dc4d92109e9595d4352dbe7b2b2506371452c8169ffc7"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
@@ -9,7 +9,7 @@ cask "ableton-live-lite" do
   homepage "https://www.ableton.com/en/products/live-lite/"
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Lite.app"
 

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,16 +1,27 @@
 cask "ableton-live-standard" do
-  version "10.1.30"
-  sha256 "736b80d967db98dda5c4a897157f0e96c6d23a9879cae0348e13cab789016a37"
+  version "11.0"
+  sha256 "3940df631b7f117ea5677e79438f9de79302880f43dca5b093702843376dd2f0"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
   name "Ableton Live Standard"
+  desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Standard.app"
 
-  zap trash: "~/Library/*/*[Aa]bleton*",
-      rmdir: "~/Music/Ableton/Factory Packs"
+  uninstall quit: "com.ableton.Live"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
 end

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-suite" do
-  version "10.1.30"
-  sha256 "31a9f793a5aa5aee1258b66c110def3d42317c418e4df5780d15cb383f09c08e"
+  version "11.0"
+  sha256 "dce197a1cfe371aa3c34b424feee61b8c0cef61ba86a28ad1c0f5450c2fa2016"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
@@ -9,7 +9,7 @@ cask "ableton-live-suite" do
   homepage "https://www.ableton.com/en/live/"
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Suite.app"
 

--- a/Casks/ableton-live.rb
+++ b/Casks/ableton-live.rb
@@ -1,6 +1,6 @@
 cask "ableton-live" do
-  version "10.1.30"
-  sha256 "4b3f6d3a74252f6a7e30871e56b43b7879c3e496e73a7b41d3de46b0d5a41e82"
+  version "11.0"
+  sha256 "ca7f0e0e0009ed450b8e6c23e16ef9f82461cf0dacac75cf076dbbef174e3aed"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_trial_#{version}_64.dmg"
   appcast "https://www.ableton.com/en/release-notes/live-#{version.major}/"
@@ -9,7 +9,7 @@ cask "ableton-live" do
   homepage "https://www.ableton.com/en/live/"
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Trial.app"
 


### PR DESCRIPTION
This PR also brings the five separate casks into alignment; notably `ableton-live-standard` seemed to be fairly different to the other four.

I've also migrated four of the five (not the trial version, `ableton-live`) to homebrew-cask-versions (see [#10426](https://github.com/Homebrew/homebrew-cask-versions/pull/10426)).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
