### PR TITLE
Update engine-prime to 1.6.0

### DIFF
--- a/Casks/engine-prime.rb
+++ b/Casks/engine-prime.rb
@@ -1,10 +1,11 @@
 cask "engine-prime" do
-  version "1.5.1"
-  sha256 "a9117a95294515ea70cc4d04715f2a1fe15ead39fe7a7faecdddb3695f69112f"
+  version "1.6.0"
+  sha256 "49927e5500f7ebef12087d8cf38f4848925eeb1d949203307b8b9833a4a53c1f"
 
-  url "https://cdn.inmusicbrands.com/denondj/ep#{version.major_minor.no_dots}/eos/Engine_Prime_#{version}_Setup.dmg",
+  url "https://cdn.inmusicbrands.com/denondj/EnginePrime/Engine_Prime_#{version}_Setup.dmg",
       verified: "inmusicbrands.com/"
   name "Engine Prime"
+  desc "Music Management Software for Denon's Engine OS Hardware"
   homepage "https://www.denondj.com/engineprime"
 
   pkg "Engine Prime_#{version}_Setup.pkg"


### PR DESCRIPTION
They are using a different URL structure again :)

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.


