### PR TITLE
Add ARM64 to eloston-chromium

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,9 +1,18 @@
 cask "eloston-chromium" do
-  version "88.0.4324.182-1.1"
-  sha256 "50ce72d0a7a1782de3f2b8f8d27535d60ce4d585e29bd4ce329eebc34e7ea497"
+  if Hardware::CPU.intel?
+    version "88.0.4324.182-1.1"
+    sha256 "50ce72d0a7a1782de3f2b8f8d27535d60ce4d585e29bd4ce329eebc34e7ea497"
 
-  url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}_x86-64/ungoogled-chromium_#{version}_x86-64-macos.dmg",
-      verified: "github.com/kramred/ungoogled-chromium-macos/"
+    url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}_x86-64/ungoogled-chromium_#{version}_x86-64-macos.dmg",
+        verified: "github.com/kramred/ungoogled-chromium-macos/"
+  else
+    version "88.0.4324.150-1.1"
+    sha256 "2f643e98dd9e8384a40a4c5d0d4bc4d4ef5ea7553fa05fd54a15537a647b846a"
+
+    url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}_arm64/ungoogled-chromium_#{version}_arm64-macos.dmg",
+        verified: "github.com/kramred/ungoogled-chromium-macos/"
+  end
+
   appcast "https://github.com/kramred/ungoogled-chromium-macos/releases.atom"
   name "Ungoogled Chromium"
   homepage "https://ungoogled-software.github.io/ungoogled-chromium-binaries/"


### PR DESCRIPTION
Added latest available Apple Silicon version to eloston-chromium

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.