### PR TITLE
Don't skip `brew audit` with ci-syntax-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,10 @@ jobs:
         id: audit
         run: |
           brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}'${{ matrix.cask.path || matrix.tap }}'
-        if: always() && steps.fetch.outcome == 'success' && !matrix.skip_audit
+        if: >
+          always() && steps.gems.outcome == 'success' &&
+          (!matrix.cask || steps.fetch.outcome == 'success') &&
+          !matrix.skip_audit
 
       - name: Gather cask information
         id: info


### PR DESCRIPTION
When tagging with `ci-syntax-only`, `brew audit` was being skipped.

This was because the `fetch` step outcome will be "skipped" not "success".

I've tweaked the condition so that we only care about the `fetch` outcome when we are dealing with full cask tests.