### PR TITLE
Add gitimoji cask

### DIFF
--- a/Casks/gitimoji.rb
+++ b/Casks/gitimoji.rb
@@ -2,14 +2,13 @@ cask "gitimoji" do
   version "1.1.0"
   sha256 "f5c8b1d924a84701566e223e68ec4d6f318fc76a92e506ab281ccccc6fd004c2"
 
-  url "https://github.com/lovetodream/gitimoji/releases/download/v#{version}/gitimoji.app.zip"
-  appcast "https://github.com/lovetodream/gitimoji/releases"
+  url "https://github.com/lovetodream/gitimoji/releases/download/v#{version}/gitimoji.app.zip",
+      verified: "https://github.com/"
   name "gitimoji"
   desc "Gitmoji on your Mac"
   homepage "https://timozacherl.com/apps/#/gitimoji"
 
   auto_updates false
-  depends_on macos: ">= :high_sierra"
 
   app "gitimoji.app"
 end

--- a/Casks/gitimoji.rb
+++ b/Casks/gitimoji.rb
@@ -1,0 +1,15 @@
+cask "gitimoji" do
+  version "1.1.0"
+  sha256 "f5c8b1d924a84701566e223e68ec4d6f318fc76a92e506ab281ccccc6fd004c2"
+
+  url "https://github.com/lovetodream/gitimoji/releases/download/v#{version}/gitimoji.app.zip"
+  appcast "https://github.com/lovetodream/gitimoji/releases"
+  name "gitimoji"
+  desc "Gitmoji on your Mac"
+  homepage "https://timozacherl.com/apps/#/gitimoji"
+
+  auto_updates false
+  depends_on macos: ">= :high_sierra"
+
+  app "gitimoji.app"
+end

--- a/Casks/gitimoji.rb
+++ b/Casks/gitimoji.rb
@@ -3,7 +3,7 @@ cask "gitimoji" do
   sha256 "f5c8b1d924a84701566e223e68ec4d6f318fc76a92e506ab281ccccc6fd004c2"
 
   url "https://github.com/lovetodream/gitimoji/releases/download/v#{version}/gitimoji.app.zip",
-      verified: "https://github.com/"
+      verified: "https://github.com/lovetodream/gitimoji/"
   name "gitimoji"
   desc "Gitmoji on your computer"
   homepage "https://timozacherl.com/apps/#/gitimoji"

--- a/Casks/gitimoji.rb
+++ b/Casks/gitimoji.rb
@@ -5,7 +5,7 @@ cask "gitimoji" do
   url "https://github.com/lovetodream/gitimoji/releases/download/v#{version}/gitimoji.app.zip",
       verified: "https://github.com/"
   name "gitimoji"
-  desc "Gitmoji on your Mac"
+  desc "Gitmoji on your computer"
   homepage "https://timozacherl.com/apps/#/gitimoji"
 
   auto_updates false


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.


Audit fails with the following message:
```
$ brew audit --cask --new gitimoji
==> Downloading https://github.com/lovetodream/gitimoji/releases/download/v1.1.0/gitimoji.app.zip
Already downloaded: /Users/dudeofawesome/Library/Caches/Homebrew/downloads/227900bb3178c0fcd5ef4d9cf8d891f9a07e51b8884b061af9a80ac8bc673bbd--gitimoji.app.zip
audit for gitimoji: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 cask detected
```