### PR TITLE
espresso: update to 5.6.1

### DIFF
--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -1,6 +1,6 @@
 cask "espresso" do
-  version "5.4.1"
-  sha256 "c28b93b6728869d47d2c277839079c1a1bbd88497d9ae0649800a50f51776072"
+  version "5.6.1"
+  sha256 "f9f044493de83b0d4aebe3ecc9f3b28322563434fbb474739417540728c09bca"
 
   url "https://downloads.kangacode.com/Espresso/Espresso_#{version}.zip",
       verified: "downloads.kangacode.com/"
@@ -14,7 +14,7 @@ cask "espresso" do
     regex(%r{href=.*?/Espresso_(\d+(?:\.\d+)*)\.zip}i)
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "Espresso.app"
 end

--- a/Casks/espresso.rb
+++ b/Casks/espresso.rb
@@ -11,7 +11,7 @@ cask "espresso" do
   livecheck do
     url "https://espressoapp.com/updates/"
     strategy :page_match
-    regex(%r{href=.*?/Espresso_(\d+(?:\.\d+)*)\.zip}i)
+    regex(/data-title="(\d+(?:\.\d+)*)"/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

updated `espresso` to version `5.6.1`, and repaired `depends_on macos:` because [the official](https://www.espressoapp.com/updates/) says `It requires macOS 10.13+ (macOS 11 Big Sur supported) and is recommended for all Espresso users.`