### PR TITLE
docker: upgrade to 3.2.0,61504 and URL change

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -3,11 +3,11 @@ cask "docker" do
     version "18.06.1-ce-mac73,26764"
     sha256 "3429eac38cf0d198039ad6e1adce0016f642cdb914a34c67ce40f069cdb047a5"
   else
-    version "3.1.0,51484"
-    sha256 "9e68684d7d19de90034630ec2127a5d49138dc314857059fa75a99687be2b6b8"
+    version "3.2.0,61504"
+    sha256 "d9753cbedecd47933ddbb0c3c2cf9087fdddbc66e993a91228939611be5f893f"
   end
 
-  url "https://desktop.docker.com/mac/stable/#{version.after_comma}/Docker.dmg"
+  url "https://desktop.docker.com/mac/stable/amd64/#{version.after_comma}/Docker.dmg"
   name "Docker Desktop"
   name "Docker Community Edition"
   name "Docker CE"


### PR DESCRIPTION
Since ARM version of Docker on it's way, upstream changed the download URL to specify CPU arch

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
