### PR TITLE
Update DingTalk to 6.0.3.6

### DIFF
--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,6 +1,6 @@
 cask "dingtalk" do
   version "6.0.3.6"
-  sha256 "efd64fd4ecd4db9c5325b73316010c45ee069587593c7d354a8cec149f72090e"
+  sha256 "dbb1dfed651f0384e1a4fddf6ec4a9da6d92a719f60945647fd78b903e18d3ce"
 
   url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version}.dmg"
   name "DingTalk"

--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,6 +1,6 @@
 cask "dingtalk" do
-  version "5.1.39.8"
-  sha256 "773760d33f40a24e7fd841020fe32853f6dd8549b54540e5fa093ba63222f6d0"
+  version "6.0.3.6"
+  sha256 "efd64fd4ecd4db9c5325b73316010c45ee069587593c7d354a8cec149f72090e"
 
   url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/DingTalk_v#{version}.dmg"
   name "DingTalk"
@@ -9,10 +9,9 @@ cask "dingtalk" do
   homepage "https://www.dingtalk.com/"
 
   livecheck do
-    url "https://im.dingtalk.com/manifest/appcast_en.xml"
-    strategy :sparkle do |item|
-      item.url[/DingTalk_v(\d(?:\.\d+)*)\.dmg/i, 1]
-    end
+    url "https://www.dingtalk.com/mac/d/"
+    strategy :header_match
+    regex(/DingTalk_v(\d+(?:\.\d+)*)\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

And updated the detection rules of `livecheck`.

```bash
$brew livecheck dingtalk
dingtalk : 5.1.39.8 ==> 6.0.3.6
```
