### PR TITLE
update popo from 3.18.1 to 3.19.0

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask "popo" do
-  version "3.18.1"
-  sha256 "3840799e24ad33079eecd9134070189560a58b25e46f6f4539d112859a733139"
+  version "3.19.0"
+  sha256 "ae6392cc43183c0c14f92de89ac40655c17678abf63b9621eb26617a9698db80"
 
   url "https://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   appcast "http://http.popo.netease.com:8080/api/open/jsonp/check_version?device=4",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.