### PR TITLE
Enable auto_updates for nault

### DIFF
--- a/Casks/nault.rb
+++ b/Casks/nault.rb
@@ -7,6 +7,8 @@ cask "nault" do
   desc "Wallet for the Nano cryptocurrency with support for hardware wallets"
   homepage "https://github.com/Nault/Nault"
 
+  auto_updates true
+
   app "Nault.app"
 
   zap trash: [


### PR DESCRIPTION
After adding the Nault cask a few days ago (#100128), I noticed that I missed the auto updating functionality that is built in. This PR adds the stanza to the cask definition.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.