### PR TITLE
Fix `ibm-cloud-cli` uninstall.

### DIFF
--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -19,10 +19,10 @@ cask "ibm-cloud-cli" do
       system_command "/usr/bin/sed",
                      args: [
                        "-E",
-                       "-i", ".bluemix_uninstall_bak",
+                       "-i", "",
                        "-e", "/^### Added by IBM Cloud CLI$/d",
                        "-e", '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
-                       "/etc/profile"
+                       File.realpath("/etc/profile")
                      ],
                      sudo: true
     end
@@ -31,10 +31,10 @@ cask "ibm-cloud-cli" do
       system_command "/usr/bin/sed",
                      args: [
                        "-E",
-                       "-i", ".bluemix_uninstall_bak",
+                       "-i", "",
                        "-e", "/^### Added by IBM Cloud CLI$/d",
                        "-e", '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
-                       "#{ENV["HOME"]}/.bashrc"
+                       File.realpath("#{ENV["HOME"]}/.bashrc")
                      ]
     end
 
@@ -42,10 +42,10 @@ cask "ibm-cloud-cli" do
       system_command "/usr/bin/sed",
                      args: [
                        "-E",
-                       "-i", ".bluemix_uninstall_bak",
+                       "-i", "",
                        "-e", "/^### Added by IBM Cloud CLI$/d",
                        "-e", '/^source \/usr\/local\/Bluemix\/bx\/zsh_autocomplete$/d',
-                       "#{ENV["HOME"]}/.zshrc"
+                       File.realpath("#{ENV["HOME"]}/.zshrc")
                      ]
     end
   end

--- a/Casks/ibm-cloud-cli.rb
+++ b/Casks/ibm-cloud-cli.rb
@@ -14,48 +14,10 @@ cask "ibm-cloud-cli" do
 
   pkg "IBM_Cloud_CLI_#{version}.pkg"
 
-  uninstall_postflight do
-    if File.exist?("/etc/profile")
-      system_command "/usr/bin/sed",
-                     args: [
-                       "-E",
-                       "-i", "",
-                       "-e", "/^### Added by IBM Cloud CLI$/d",
-                       "-e", '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
-                       File.realpath("/etc/profile")
-                     ],
-                     sudo: true
-    end
-
-    if File.exist?("#{ENV["HOME"]}/.bashrc")
-      system_command "/usr/bin/sed",
-                     args: [
-                       "-E",
-                       "-i", "",
-                       "-e", "/^### Added by IBM Cloud CLI$/d",
-                       "-e", '/^source \/usr\/local\/Bluemix\/bx\/bash_autocomplete$/d',
-                       File.realpath("#{ENV["HOME"]}/.bashrc")
-                     ]
-    end
-
-    if File.exist?("#{ENV["HOME"]}/.zshrc")
-      system_command "/usr/bin/sed",
-                     args: [
-                       "-E",
-                       "-i", "",
-                       "-e", "/^### Added by IBM Cloud CLI$/d",
-                       "-e", '/^source \/usr\/local\/Bluemix\/bx\/zsh_autocomplete$/d',
-                       File.realpath("#{ENV["HOME"]}/.zshrc")
-                     ]
-    end
-  end
-
   uninstall pkgutil: "com.ibm.cloud.cli",
             delete:  [
               "/usr/local/bin/bluemix",
               "/usr/local/bin/bx",
-              "/usr/local/bin/bluemix-analytics",
-              "/usr/local/Bluemix",
               "/usr/local/ibmcloud",
             ]
 


### PR DESCRIPTION
Avoid creating `.bluemix_uninstall_bak` backup files and fix uninstall when e.g. `.bashrc` is a symlink.