### PR TITLE
Update yandex-disk from 3.2.1,30 to 3.2.6

### DIFF
--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,13 +1,11 @@
 cask "yandex-disk" do
-  version "3.2.1,30"
-  sha256 "cf69a3ff787ad970715c95aceaeb0e10de4664a8c97e60c314f3735eb44338ec"
+  version :latest
+  sha256 :no_check
 
-  url "https://disk.yandex.ru/download/YandexDisk#{version.after_comma}.dmg/?instant=1"
+  url "https://disk.yandex.ru/download/Yandex.Disk.dmg/?instant=1"
   name "Yandex.Disk"
   desc "Cloud storage"
   homepage "https://disk.yandex.ru/"
-
-  auto_updates true
 
   app "Yandex.Disk.2.app"
 

--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -1,11 +1,13 @@
 cask "yandex-disk" do
-  version :latest
+  version "3.2.6"
   sha256 :no_check
 
   url "https://disk.yandex.ru/download/Yandex.Disk.dmg/?instant=1"
   name "Yandex.Disk"
   desc "Cloud storage"
   homepage "https://disk.yandex.ru/"
+
+  auto_update true
 
   app "Yandex.Disk.2.app"
 

--- a/Casks/yandex-disk.rb
+++ b/Casks/yandex-disk.rb
@@ -7,7 +7,7 @@ cask "yandex-disk" do
   desc "Cloud storage"
   homepage "https://disk.yandex.ru/"
 
-  auto_update true
+  auto_updates true
 
   app "Yandex.Disk.2.app"
 


### PR DESCRIPTION
"30" in the file name was removed some time ago.

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
