### PR TITLE
securid.rb: fix url and homepage

### DIFF
--- a/Casks/securid.rb
+++ b/Casks/securid.rb
@@ -2,9 +2,9 @@ cask "securid" do
   version "4.2.1"
   sha256 "e3d796f263cbdbc4a6c870931e469c64e8c8ffb14aa8ae68b4036cee0eeb0c04"
 
-  url "https://community.rsa.com/servlet/JiveServlet/download/62004-9-60039/RSASecurIDMac#{version.no_dots}.dmg.zip"
+  url "https://community.rsa.com/yfcdo34327/attachments/yfcdo34327/securid-software-token-macos/4/1/RSASecurIDMac#{version.no_dots}.dmg.zip"
   name "RSA SecurID"
-  homepage "https://www.rsa.com/en-us/products/rsa-securid-suite/rsa-securid-access/securid-software-tokens.html"
+  homepage "https://community.rsa.com/t5/rsa-securid-software-token-for/tkb-p/securid-software-token-macos"
 
   pkg "RSASecurIDTokenAutoMac#{version.no_dots}x64.pkg"
 


### PR DESCRIPTION
Someone who uses this might be able to comment on its correctness. Since the package is the same (same `sha256`), I’m guessing it’s OK.

Previous `url` was failing and `homepage` wasn’t very helpful.