### PR TITLE
nvidia-geforce-now: update version, sha256, url and homepage; remove appcast

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,10 +1,8 @@
 cask "nvidia-geforce-now" do
-  version "2.0.26.116,897C99"
-  sha256 "f74cafac283b933d05fcf4957e7faad18de05f2a1169993a223a7bea124c3687"
+  version "2.0.27.147"
+  sha256 :no_check
 
-  url "https://ota-downloads.nvidia.com/ota/GeForceNOW-release.app_#{version.after_comma}.zip"
-  appcast "https://ota.nvidia.com/release/available?product=GFN-mac&version=#{version.before_comma}&channel=OFFICIAL",
-          must_contain: "[]" # Only happens when there are no newer versions
+  url "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg"
   name "NVIDIA GeForce NOW"
   desc "Cloud gaming platform"
   homepage "https://www.nvidia.com/en-us/geforce/products/geforce-now/"

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -5,7 +5,7 @@ cask "nvidia-geforce-now" do
   url "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg"
   name "NVIDIA GeForce NOW"
   desc "Cloud gaming platform"
-  homepage "https://www.nvidia.com/en-us/geforce/products/geforce-now/"
+  homepage "https://www.nvidia.com/en-us/geforce-now/download/"
 
   depends_on macos: ">= :yosemite"
 


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/100698.