### PR TITLE
Update Logisim-evolution to use app .dmg file

### DIFF
--- a/Casks/logisim-evolution.rb
+++ b/Casks/logisim-evolution.rb
@@ -1,16 +1,20 @@
 cask "logisim-evolution" do
   version "3.4.1"
-  sha256 "1b72dd3397290b7be95f886b933bd37a2d9182b8d33247fa5f059d0867e8111c"
+  sha256 "253290b94ae1dba6d5528ff2ea478c2750cee4a40c4710f7da6006dc3f0b4b52"
 
-  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution-#{version}-all.jar"
+  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/Logisim-evolution-#{version}.dmg"
   appcast "https://github.com/reds-heig/logisim-evolution/releases.atom"
   name "Logisim Evolution"
   desc "Digital logic designer and simulator"
   homepage "https://github.com/reds-heig/logisim-evolution"
 
-  container type: :naked
+  app "Logisim-evolution.app"
 
-  app "logisim-evolution-#{version}-all.jar", target: "logisim-evolution.jar"
+  # Address the broken app issue. https://github.com/reds-heig/logisim-evolution/issues/499
+  postflight do
+    system_command "xattr",
+                   args: ["-cr", "#{appdir}/Logisim-evolution.app"]
+  end
 
   zap trash: "~/Library/Preferences/com.cburch.logisim.plist"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

The `logisim-evolution` cask currently use the universal built `.jar` file provided by the maintainer. However, starting from version 3.4.1, the maintainer had provided prebuilt binary for Windows, Linux and macOS. Therefore we can now directly use the `.dmg` file, since it directly produce a `.app` file that can be directly run and placed on the dock.

However, the 3.4.1 `.dmg` file will report `Application “Logisim-evolution.app” is damaged and can’t be opened. You should move it to the Trash.`. This is not due to the dmg file damaged, but due to the fact that it is improperly codesigned. The maintainer decided in [#505](https://github.com/reds-heig/logisim-evolution/issues/505) that in the build process, the codesign will be removed, and resulting in an app file that can be open under `Anywhere` security checks (since it is now unsigned). This fix is already [merged](https://github.com/reds-heig/logisim-evolution/pull/512), and is already included in the pre-release 3.4.2. However, a new stable release containing this fix is not available by now, and therefore I used a `postflight` block to manually remove the codesigns (suggested in [#499](https://github.com/reds-heig/logisim-evolution/issues/499)). That block should be able to be safely deleted when a new stable version come out.
