### PR TITLE
Add foobar2000.app v2.2.16

### DIFF
--- a/Casks/foobar2000.rb
+++ b/Casks/foobar2000.rb
@@ -1,0 +1,16 @@
+cask "foobar2000" do
+  version "2.2.16"
+  sha256 "7e8a18395c96ce0337ffc36592d06f63e6817b15cb95c4de0255b3b6054aa8a4"
+
+  url "https://www.foobar2000.org/files/foobar2000-v#{version}.dmg"
+  name "foobar2000"
+  desc "Advanced freeware audio player"
+  homepage "https://www.foobar2000.org/mac"
+
+  app "foobar2000.app"
+
+  zap trash: [
+    "~/Library/foobar2000",
+    "~/Library/Preferences/com.foobar2000.mac.plist",
+  ]
+end

--- a/Casks/foobar2000.rb
+++ b/Casks/foobar2000.rb
@@ -4,7 +4,7 @@ cask "foobar2000" do
 
   url "https://www.foobar2000.org/files/foobar2000-v#{version}.dmg"
   name "foobar2000"
-  desc "Advanced freeware audio player"
+  desc "Audio player"
   homepage "https://www.foobar2000.org/mac"
 
   app "foobar2000.app"


### PR DESCRIPTION
Cask was removed a while ago (https://github.com/Homebrew/homebrew-cask/pull/73629, https://github.com/Homebrew/homebrew-cask/pull/97990, https://github.com/Homebrew/homebrew-cask/pull/73310) due to unstable download URL.
It seem that this issue is fix by now by the vendor hence I propose adding this cask back.

- [X] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew install --cask {{cask_file}}` worked successfully.
- [X] `brew uninstall --cask {{cask_file}}` worked successfully.