### PR TITLE
Version google-cloud-sdk

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,22 +1,29 @@
 cask "google-cloud-sdk" do
-  version :latest # Must remain unversioned, else all installed gcloud components would be lost on upgrade
-  sha256 :no_check
+  version "331.0.0"
+  sha256 "32c7b961f4c3d18f772a8900c9bc1300e7f81c0c05d71f93b770a222f00490ba"
 
-  url "https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz"
+  url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/#{token}-#{version}-darwin-x86_64.tar.gz"
   name "Google Cloud SDK"
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
 
+  auto_updates true
   depends_on formula: "python"
 
-  stage_only true
+  artifact token, target: "#{HOMEBREW_PREFIX}/share/#{token}"
 
   postflight do
     system_command "#{staged_path}/#{token}/install.sh",
                    args: [
                      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
                      "--rc-path", "false", "--quiet"
-                   ],
+                   ] + (
+                     if ENV.key?("HOMEBREW_GOOGLE_CLOUD_SDK_ADDITIONAL_COMPONENTS")
+                       ["--additional-components"] + ENV["HOMEBREW_GOOGLE_CLOUD_SDK_ADDITIONAL_COMPONENTS"].split(",")
+                     else
+                       []
+                     end
+                   ),
                    env:  { "CLOUDSDK_PYTHON" => Formula["python"].opt_bin/"python3" }
   end
 
@@ -25,17 +32,20 @@ cask "google-cloud-sdk" do
   uninstall delete: "#{staged_path}/#{token}"
 
   caveats <<~EOS
-    #{token} is installed at #{staged_path}/#{token}. Add your profile:
+    #{token} is installed at #{HOMEBREW_PREFIX}/share/#{token}. Add your profile:
 
       for bash users
-        source "#{staged_path}/#{token}/path.bash.inc"
-        source "#{staged_path}/#{token}/completion.bash.inc"
+        source "#{HOMEBREW_PREFIX}/share/#{token}/path.bash.inc"
+        source "#{HOMEBREW_PREFIX}/share/#{token}/completion.bash.inc"
 
       for zsh users
-        source "#{staged_path}/#{token}/path.zsh.inc"
-        source "#{staged_path}/#{token}/completion.zsh.inc"
+        source "#{HOMEBREW_PREFIX}/share/#{token}/path.zsh.inc"
+        source "#{HOMEBREW_PREFIX}/share/#{token}/completion.zsh.inc"
 
       for fish users
-        source "#{staged_path}/#{token}/path.fish.inc"
+        source "#{HOMEBREW_PREFIX}/share/#{token}/path.fish.inc"
+
+    To keep additional components after an upgrade or reinstallation add to your profile:
+      export HOMEBREW_GOOGLE_CLOUD_SDK_ADDITIONAL_COMPONENTS='COMPONENT_ID,COMPONENT_ID'
   EOS
 end

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -2,7 +2,7 @@ cask "google-cloud-sdk" do
   version "332.0.0"
   sha256 "1d158a84dfff8f3aa3cacdbbd3fb9cfbea3178728367b20c986760edc1665026"
 
-  url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/#{token}-#{version}-darwin-x86_64.tar.gz"
+  url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-#{version}-darwin-x86_64.tar.gz"
   name "Google Cloud SDK"
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
@@ -10,10 +10,10 @@ cask "google-cloud-sdk" do
   auto_updates true
   depends_on formula: "python"
 
-  artifact token, target: "#{HOMEBREW_PREFIX}/share/#{token}"
+  artifact "google-cloud-sdk", target: "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 
   postflight do
-    system_command "#{staged_path}/#{token}/install.sh",
+    system_command "#{staged_path}/google-cloud-sdk/install.sh",
                    args: [
                      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
                      "--rc-path", "false", "--quiet"
@@ -29,12 +29,12 @@ cask "google-cloud-sdk" do
 
   # Not actually necessary, since it would be deleted anyway.
   # It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
-  uninstall delete: "#{staged_path}/#{token}"
+  uninstall delete: "#{staged_path}/google-cloud-sdk"
 
   # https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
   zap trash: [
     "~/.config/gcloud",
-    "~/Library/Caches/**/#{token}",
+    "~/Library/Caches/**/google-cloud-sdk",
   ]
 
   caveats <<~EOS

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,6 +1,6 @@
 cask "google-cloud-sdk" do
-  version "331.0.0"
-  sha256 "32c7b961f4c3d18f772a8900c9bc1300e7f81c0c05d71f93b770a222f00490ba"
+  version "332.0.0"
+  sha256 "1d158a84dfff8f3aa3cacdbbd3fb9cfbea3178728367b20c986760edc1665026"
 
   url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/#{token}-#{version}-darwin-x86_64.tar.gz"
   name "Google Cloud SDK"

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -31,6 +31,12 @@ cask "google-cloud-sdk" do
   # It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
   uninstall delete: "#{staged_path}/#{token}"
 
+  # https://cloud.google.com/sdk/docs/uninstall-cloud-sdk
+  zap trash: [
+    "~/.config/gcloud",
+    "~/Library/Caches/**/#{token}",
+  ]
+
   caveats <<~EOS
     #{token} is installed at #{HOMEBREW_PREFIX}/share/#{token}. Add your profile:
 

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,6 +1,6 @@
 cask "google-cloud-sdk" do
-  version "332.0.0"
-  sha256 "1d158a84dfff8f3aa3cacdbbd3fb9cfbea3178728367b20c986760edc1665026"
+  version "333.0.0"
+  sha256 "ed55af0312925a0685fd7d14f459dfb973f826b90ab81eb10ee947413a284c87"
 
   url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-#{version}-darwin-x86_64.tar.gz"
   name "Google Cloud SDK"

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -2,6 +2,11 @@ cask "google-cloud-sdk" do
   version "333.0.0"
   sha256 "ed55af0312925a0685fd7d14f459dfb973f826b90ab81eb10ee947413a284c87"
 
+  livecheck do
+    url "https://dl.google.com/dl/cloudsdk/channels/rapid/components-2.json"
+    regex(/  \"version\": \"(\d+\.\d+\.\d+)\"\n\}$/i)
+  end
+
   url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-#{version}-darwin-x86_64.tar.gz"
   name "Google Cloud SDK"
   desc "Set of tools to manage resources and applications hosted on Google Cloud"

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -2,15 +2,15 @@ cask "google-cloud-sdk" do
   version "333.0.0"
   sha256 "ed55af0312925a0685fd7d14f459dfb973f826b90ab81eb10ee947413a284c87"
 
-  livecheck do
-    url "https://dl.google.com/dl/cloudsdk/channels/rapid/components-2.json"
-    regex(/  \"version\": \"(\d+\.\d+\.\d+)\"\n\}$/i)
-  end
-
   url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-#{version}-darwin-x86_64.tar.gz"
   name "Google Cloud SDK"
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
+
+  livecheck do
+    url "https://dl.google.com/dl/cloudsdk/channels/rapid/components-2.json"
+    regex(/  "version": "(\d+\.\d+\.\d+)"\n\}$/i)
+  end
 
   auto_updates true
   depends_on formula: "python"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

This is an attempt to version `google-cloud-sdk`. This has been tried before (#37317, #45818, #88183), but wasn't accepted for reasons described by @commitay in https://github.com/Homebrew/homebrew-cask/pull/37317#issuecomment-319856337, namely that each upgrade would:
1. require users to update the `$(brew --prefix)/Caskroom/google-cloud-sdk/<version>/google-cloud-sdk/` path in their profile;
2. remove manually installed components (as currently documented near `version`).

This PR proposes to address these concerns by:
1. using a static `#{HOMEBREW_PREFIX}/share/#{token}` path as in other SDKs ([Adobe Air](https://github.com/Homebrew/homebrew-cask/blob/3f07f816a5d8919e14c43fced157684cbf2b0ff7/Casks/adobe-air-sdk.rb), Android [SDK](https://github.com/Homebrew/homebrew-cask/blob/3b53a9694ffdb6e3af14dd3c56a3be8d37b0d721/Casks/android-sdk.rb) and [NDK](https://github.com/Homebrew/homebrew-cask/blob/81ff6deb5c7a752e01a07ff88194d98f10cec683/Casks/android-ndk.rb), [Crystax NDK](https://github.com/Homebrew/homebrew-cask/blob/60f20d3f711eeb0ef023cad662eecbea02b96465/Casks/crystax-ndk.rb));
2. adding a caveat describing how to use a new `HOMEBREW_GOOGLE_CLOUD_SDK_ADDITIONAL_COMPONENTS` environment variable to keep the additional components.

This also adds `auto_updates true` since Google Cloud SDK automatically checks and informs when a new version is available (unless `component_manager.disable_update_check` [config property](https://cloud.google.com/sdk/gcloud/reference/config) is set) and users can run `gcloud components update` to upgrade.

Manually (`gcloud components install`) installed additional components would still be lost after an upgrade unless also added to `HOMEBREW_GOOGLE_CLOUD_SDK_ADDITIONAL_COMPONENTS`, which is admittedly not ideal. However:
- users that don't use `brew upgrade` will not experience that;
- users of `brew upgrade` without `--greedy` will also not experience that as `auto_updates true` casks are not included;
- users of `brew upgrade --greedy` were losing the additional components anyway since `--greedy` includes unversioned casks, and now at least have a way to prevent that, and will only be upgrading the casks when the version actually changed.