### PR TITLE
Update aldente.rb

### DIFF
--- a/Casks/aldente.rb
+++ b/Casks/aldente.rb
@@ -1,13 +1,8 @@
 cask "aldente" do
-  if MacOS.version <= :catalina
-    version "1.2"
-    sha256 "a588dc29faca894b7321e23420ca17d6a944b9b3b46412435f519b96e4ebee7b"
-    url "https://github.com/davidwernhart/AlDente/releases/download/#{version}/AlDente.app.zip"
-  else
-    version "2.1"
-    sha256 "3ba479e2400117e605dce4d4b222a984f36df6ebcd6a554b1f465406af1a0a7d"
-    url "https://github.com/davidwernhart/AlDente/releases/download/v#{version}/AlDente_#{version}.app.zip"
-  end
+
+  version "2.1.2"
+  sha256 "39cebc2db5b75c4217abd42470ecfee8280a35178b0d2581df3857cd8b742880"
+  url "https://github.com/davidwernhart/AlDente/releases/download/#{version}/AlDente_#{version}_Notarized.app.zip"
 
   appcast "https://github.com/davidwernhart/AlDente/releases.atom"
   name "AlDente"

--- a/Casks/aldente.rb
+++ b/Casks/aldente.rb
@@ -1,9 +1,8 @@
 cask "aldente" do
-
   version "2.1.2"
   sha256 "39cebc2db5b75c4217abd42470ecfee8280a35178b0d2581df3857cd8b742880"
+  
   url "https://github.com/davidwernhart/AlDente/releases/download/#{version}/AlDente_#{version}_Notarized.app.zip"
-
   appcast "https://github.com/davidwernhart/AlDente/releases.atom"
   name "AlDente"
   desc "Menu bar tool to limit maximum charging percentage"


### PR DESCRIPTION
AlDente cast update to the new version, removing reference to 1.2 version since Catalina is now also supported by 2.1.2

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.