### PR TITLE
Update timche-gmail-desktop to v2.25.0

### DIFF
--- a/Casks/timche-gmail-desktop.rb
+++ b/Casks/timche-gmail-desktop.rb
@@ -1,6 +1,6 @@
 cask "timche-gmail-desktop" do
-  version "2.24.0"
-  sha256 "0b7f41c8b00c9f06706a186baaeeda086a31774e13db7564217a2bdce4136583"
+  version "2.25.0"
+  sha256 "618d791c157bc7ba06aa6aa8c8dece14298015ca7089fcec1e88259dad96400c"
 
   url "https://github.com/timche/gmail-desktop/releases/download/v#{version}/gmail-desktop-#{version}-mac.dmg"
   appcast "https://github.com/timche/gmail-desktop/releases.atom"

--- a/Casks/timche-gmail-desktop.rb
+++ b/Casks/timche-gmail-desktop.rb
@@ -5,7 +5,7 @@ cask "timche-gmail-desktop" do
   url "https://github.com/timche/gmail-desktop/releases/download/v#{version}/gmail-desktop-#{version}-mac.dmg"
   appcast "https://github.com/timche/gmail-desktop/releases.atom"
   name "Gmail Desktop"
-  desc "Unofficial Gmail Desktop App"
+  desc "Unofficial Gmail desktop app"
   homepage "https://github.com/timche/gmail-desktop"
 
   app "Gmail Desktop.app"

--- a/Casks/timche-gmail-desktop.rb
+++ b/Casks/timche-gmail-desktop.rb
@@ -1,19 +1,22 @@
 cask "timche-gmail-desktop" do
-  version "2.22.0"
-  sha256 "78ba61d2aaa9a42082d6a76181850543abd8c42ad80d22e0ab2f1cb0cc6b6c21"
+  version "2.24.0"
+  sha256 "0b7f41c8b00c9f06706a186baaeeda086a31774e13db7564217a2bdce4136583"
 
-  url "https://github.com/timche/gmail-desktop/releases/download/#{version}/gmail-desktop-#{version}-mac.dmg"
+  url "https://github.com/timche/gmail-desktop/releases/download/v#{version}/gmail-desktop-#{version}-mac.dmg"
   appcast "https://github.com/timche/gmail-desktop/releases.atom"
   name "Gmail Desktop"
-  desc "Gmail client"
+  desc "Unofficial Gmail Desktop App"
   homepage "https://github.com/timche/gmail-desktop"
 
   app "Gmail Desktop.app"
 
   zap trash: [
+    "~/Library/Application Support/Gmail Desktop",
+    "~/Library/Caches/io.cheung.gmail-desktop.ShipIt",
+    "~/Library/Caches/io.cheung.gmail-desktop",
     "~/Library/Logs/Gmail Desktop",
     "~/Library/Preferences/io.cheung.gmail-desktop.plist",
-    "~/Library/Application Support/Gmail Desktop",
     "~/Library/Saved Application State/io.cheung.gmail-desktop.savedState",
+    "~/Library/WebKit/io.cheung.gmail-desktop",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---
Developer of this app here.

The cask on `master` is currently broken, because the `v` has been removed from the `url`: https://github.com/timche/homebrew-cask/commit/0353e37917a3ed9e3215f0d0503e8599a296991d#diff-92a1596c671ef43f45acdf00185475c79eb9f52d581f6a982775a5b824a6f77aL5. Downloading fails with 404.

I've also added missing paths to trash and updated the description. 