### PR TITLE
Update OpenInTerminal-Lite from 1.2.2 to 1.2.3

### DIFF
--- a/Casks/openinterminal-lite.rb
+++ b/Casks/openinterminal-lite.rb
@@ -1,6 +1,6 @@
 cask "openinterminal-lite" do
-  version "1.2.2"
-  sha256 "d36b2359eba2806b458aa130e5dd56bcccf48e396e5e3dc4211fbde6c820f973"
+  version "1.2.3"
+  sha256 "67239f7201fed7457d283add3a4f23320038ff757473a1f2238f986fd413b853"
 
   url "https://github.com/Ji4n1ng/OpenInTerminal/releases/download/v#{version}/OpenInTerminal-Lite.app.zip"
   appcast "https://github.com/Ji4n1ng/OpenInTerminal/releases.atom"


### PR DESCRIPTION

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
