### PR TITLE
SHA256 mismatch -- unable to install via Brew

### DIFF
--- a/Casks/ishowu-instant.rb
+++ b/Casks/ishowu-instant.rb
@@ -1,6 +1,6 @@
 cask "ishowu-instant" do
   version "1.4.2"
-  sha256 "c151aa4fd6d2ff230f3ef1f377780f2bc21b6207d8546ab40d9c98eda5dda1d1"
+  sha256 "fabe0f178a73cd86482a3f9613f088f9d253db18b2e02ecb8cd7bdbf1e2dcbee"
 
   url "https://www.shinywhitebox.com/downloads/instant/iShowU_Instant_#{version}.dmg"
   appcast "https://www.shinywhitebox.com/store/appcast.php?p=14"


### PR DESCRIPTION
Seems there was a new build released using the the same 1.4.2 version number causing a SHA256 mismatch with Homebrew

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
