### PR TITLE
Switch to universal build of RetroArch.app for retroarch-metal package

### DIFF
--- a/Casks/retroarch-metal.rb
+++ b/Casks/retroarch-metal.rb
@@ -1,10 +1,11 @@
 cask "retroarch-metal" do
   version "1.9.0"
-  sha256 "e1f88d0535411eacf1035112a53f732c2bfd8cebbfa4aa9729dc2516ddd7ce24"
+  sha256 "97731e8300e4f94abd9db9296c3ec74c4b68dbc15835ab983225ae47eb764425"
 
-  url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch_Metal.dmg"
+  url "https://buildbot.libretro.com/stable/#{version}/apple/osx/universal/RetroArch_Metal.dmg"
   appcast "https://buildbot.libretro.com/stable/"
-  name "RetroArch Metal"
+  name "RetroArch"
+  desc "Emulator frontend (Metal graphics API version)"
   homepage "https://www.libretro.com/"
 
   conflicts_with cask: [

--- a/Casks/retroarch-metal.rb
+++ b/Casks/retroarch-metal.rb
@@ -10,7 +10,6 @@ cask "retroarch-metal" do
 
   conflicts_with cask: [
     "retroarch",
-    "retroarch-cg",
   ]
 
   app "RetroArch.app"


### PR DESCRIPTION
Switched to the new M1 compatible build of RetroArch.app
Cleaned up the name stanza
Added desc stanza

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.