### PR TITLE
Update Fluor to 2.5 from Github release page

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,15 +1,15 @@
 cask "fluor" do
-  version "2.1.0"
-  sha256 "92034b630bf5a19eca160054c780a3c1767f21def3c02f28787f79fed5fab757"
+  version "2.5.0"
+  sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209"
 
-  url "https://resources.pyrolyse.it/distrib/Fluor/Fluor%20#{version}.dmg",
-      verified: "pyrolyse.it/"
+  url "https://github.com/Pyroh/Fluor/releases/download/#{version}/Fluor.#{version}.dmg"
   name "Fluor"
-  homepage "https://fluorapp.net/"
+  desc "Change the behavior of the fn keys depending on the active application"
+  homepage "https://github.com/Pyroh/Fluor"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?Fluor(?:%20|[._-])v?(\d+(?:\.\d+)+)\.dmg/i)
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -9,7 +9,7 @@ cask "fluor" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    strategy :git
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
