### PR TITLE
Update postgresprefs from v2.4.2 to v2.6

### DIFF
--- a/Casks/postgrespreferencepane.rb
+++ b/Casks/postgrespreferencepane.rb
@@ -1,9 +1,8 @@
 cask "postgrespreferencepane" do
   version "2.6"
-  sha256 "fb3f618321efec12cbad21ec2d77e6a024a35f7a17bb304b421970f85e38337f"
+  sha256 "c04f7d3e2563454292a806c4d67d661e560c61c29fe45b196324e071e60130a9"
 
   url "https://github.com/MaccaTech/PostgresPrefs/releases/download/v#{version}/PostgresPrefs-v#{version}.dmg"
-  appcast "https://github.com/MaccaTech/PostgresPrefs/releases.atom"
   name "PostgresPrefs"
   homepage "https://github.com/MaccaTech/PostgresPrefs"
 

--- a/Casks/postgrespreferencepane.rb
+++ b/Casks/postgrespreferencepane.rb
@@ -1,8 +1,8 @@
 cask "postgrespreferencepane" do
-  version "2.4.2"
+  version "2.6"
   sha256 "fb3f618321efec12cbad21ec2d77e6a024a35f7a17bb304b421970f85e38337f"
 
-  url "https://github.com/MaccaTech/PostgresPrefs/releases/download/v#{version}/PostgreSQL.prefPane-v#{version}.zip"
+  url "https://github.com/MaccaTech/PostgresPrefs/releases/download/v#{version}/PostgresPrefs-v#{version}.dmg"
   appcast "https://github.com/MaccaTech/PostgresPrefs/releases.atom"
   name "PostgresPrefs"
   homepage "https://github.com/MaccaTech/PostgresPrefs"


### PR DESCRIPTION
Version 2.4.2 does not work in Catalina as it is not notarised.