### PR TITLE
burp-suite: add livecheck and desc

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -3,9 +3,15 @@ cask "burp-suite" do
   sha256 "aee5beeded139278c0e4aea19128b1a2682e4197b6c30c5ca5785f011854d31b"
 
   url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=MacOsx"
-  appcast "https://portswigger.net/burp/releases?initialTab=community"
   name "Burp Suite"
+  desc "Web security testing toolkit"
   homepage "https://portswigger.net/burp/"
+
+  livecheck do
+    url "https://portswigger.net/burp/releases?initialTab=community"
+    strategy :page_match
+    regex(%r{Professional\s*/\s*Community\s*(\d+(:?\.\d+)*)})
+  end
 
   installer script: {
     executable: "Burp Suite Community Edition Installer.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -10,7 +10,7 @@ cask "burp-suite" do
   livecheck do
     url "https://portswigger.net/burp/releases?initialTab=community"
     strategy :page_match
-    regex(%r{Professional\s*/\s*Community\s*(\d+(:?\.\d+)*)})
+    regex(%r{Professional\s*/\s*Community\s*(\d+(:?\.\d+)*)}i)
   end
 
   installer script: {


### PR DESCRIPTION
```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask burp-suite --debug

Cask:             burp-suite
Livecheckable?:   Yes

URL:              https://portswigger.net/burp/releases?initialTab=community
Strategy:         PageMatch
Regex:            /Professional\s*\/\s*Community\s*(\d+(:?\.\d+)*)/

Matched Versions:
2021.3.2, 2021.3.1, 2021.3, 2021.2.1, 2021.2, 2020.12.1, 2020.12
burp-suite : 2021.3.2 ==> 2021.3.2
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
