### PR TITLE
Fix .github/actions/sync/templates.rb

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -38,7 +38,7 @@ puts 'Detecting changes…'
   end
 end
 
-FileUtils.rm repo_dir.join('.github/ISSUE_TEMPLATE/02_feature_request.md')
+FileUtils.rm repo_dir.join('.github/ISSUE_TEMPLATE/02_feature_request.yml')
 
 workflow = File.read(repo_dir.join('.github/PULL_REQUEST_TEMPLATE.md'))
 File.write repo_dir.join('.github/PULL_REQUEST_TEMPLATE.md'), workflow.gsub(/Homebrew\/homebrew-cask\/(pulls|issues|search)/, "#{repo}/\\1")


### PR DESCRIPTION
CI seems to be failing because `02_feature_request.md` was renamed to `02_feature_request.yml`