### PR TITLE
Update jamulus from 3.6.2 to 3.7.0

### DIFF
--- a/Casks/jamulus.rb
+++ b/Casks/jamulus.rb
@@ -1,8 +1,8 @@
 cask "jamulus" do
-  version "3.6.2"
-  sha256 "128727f09265bac829d33e0a6316722b3dc635585c53970875c343966e5f93b3"
+  version "3.7.0"
+  sha256 "bdb6cf58b041fc5917937721f6de4a15108c647c9b4440881415b7392c0b5b2d"
 
-  url "https://downloads.sourceforge.net/llcon/Jamulus-#{version}-installer-mac.dmg",
+  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac.dmg",
       verified: "downloads.sourceforge.net/llcon/"
   appcast "https://sourceforge.net/projects/llcon/rss"
   name "Jamulus"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

