### PR TITLE
workflows/ci: tap homebrew/cask-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Gather cask information
         id: info
         run: |
+          brew tap homebrew/cask-versions
           brew ruby <<'EOF'
             require 'cask/cask_loader'
             require 'cask/installer'


### PR DESCRIPTION
PRs such as https://github.com/Homebrew/homebrew-cask/pull/101324 are failing because homebrew/cask-versions isn't tapped. This PR adds `brew tap homebrew/cask-versions` to the "Gather cask information" step, which is where the failure occurs.