### PR TITLE
Update adoptopenjdk from 15.0.2,7 to 16,36

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -17,7 +17,7 @@ cask "adoptopenjdk" do
     end
   end
 
-  pkg "OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.major}.pkg"
+  pkg "OpenJDK#{version.major}-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.major}.pkg"
 
   uninstall pkgutil: "net.adoptopenjdk.#{version.major}.jdk"
 

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -1,6 +1,6 @@
 cask "adoptopenjdk" do
-  version "15.0.2,7"
-  sha256 "f3b867c04a12eec2526492f91a228fade480b1c592ea336eeb9fd66bef86e4c4"
+  version "16,36"
+  sha256 "2d101b7bc4901c1a9554ba158b9eb4bf245b6dc314bd82078b1c9b85953ae5ae"
 
   url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.major}.pkg",
       verified: "github.com/AdoptOpenJDK/"

--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -2,7 +2,7 @@ cask "adoptopenjdk" do
   version "16,36"
   sha256 "2d101b7bc4901c1a9554ba158b9eb4bf245b6dc314bd82078b1c9b85953ae5ae"
 
-  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.major}.pkg",
+  url "https://github.com/AdoptOpenJDK/openjdk#{version.major}-binaries/releases/download/jdk-#{version.before_comma}%2B#{version.after_comma}/OpenJDK#{version.major}-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.major}.pkg",
       verified: "github.com/AdoptOpenJDK/"
   name "AdoptOpenJDK Java Development Kit"
   homepage "https://adoptopenjdk.net/"


### PR DESCRIPTION
See https://github.com/AdoptOpenJDK/homebrew-openjdk/blob/master/Casks/adoptopenjdk16.rb

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.