### PR TITLE
ibm-aspera-connect: fix uninstall script path and move log deletion to zap

### DIFF
--- a/Casks/ibm-aspera-connect.rb
+++ b/Casks/ibm-aspera-connect.rb
@@ -19,6 +19,16 @@ cask "ibm-aspera-connect" do
   uninstall script: {
     executable: "~/Library/Application Support/Aspera/Aspera Connect/uninstall_connect.sh",
     args:       ["-f"],
-  },
-            delete: "~/Library/Logs/Aspera_Connect"
+  }
+
+  zap trash: [
+    "~/Library/Application Scripts/com.aspera.connect.SafariExtension",
+    "~/Library/Application Scripts/com.aspera.drive.SendToExtension",
+    "~/Library/Containers/com.aspera.connect.SafariExtension",
+    "~/Library/Containers/com.aspera.drive.SendToExtension",
+    "~/Library/Group Containers/group.com.aspera.connect",
+    "~/Library/Logs/Aspera_Connect",
+    "~/Library/Preferences/com.aspera.connect.plist",
+    "~/Library/Saved Application State/com.aspera.connect.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

**Uninstall Output**
```console
❯ brew uninstall ibm-aspera-connect
==> Uninstalling Cask ibm-aspera-connect
==> Running uninstall script /Users/cho-m/Library/Application Support/Aspera/Aspera Connect/uninstall_connect.sh
forcing full uninstall
Uninstalling Aspera Connect for user cho-m
Keeping /Users/cho-m/Applications directory since it is not empty
Keeping /Users/cho-m/Library/Logs/Aspera_Connect directory since it is not empty
Aspera Connect has successfully been uninstalled
==> Purging files for version 3.11.1.58 of Cask ibm-aspera-connect
```

**Forced zap cleanup**
```console
❯ brew uninstall --cask --zap --force ibm-aspera-connect
==> Implied `brew uninstall --cask ibm-aspera-connect`
==> Running uninstall script /Users/cho-m/Library/Application Support/Aspera/Aspera Connect/uninstall_connect.sh
Warning: uninstall script /Users/cho-m/Library/Application Support/Aspera/Aspera Connect/uninstall_connect.sh does not exist; skipping.
==> Dispatching zap stanza
==> Trashing files:
~/Library/Application Scripts/com.aspera.connect.SafariExtension
~/Library/Application Scripts/com.aspera.drive.SendToExtension
~/Library/Containers/com.aspera.connect.SafariExtension
~/Library/Containers/com.aspera.drive.SendToExtension
~/Library/Group Containers/group.com.aspera.connect
~/Library/Logs/Aspera_Connect
~/Library/Preferences/com.aspera.connect.plist
~/Library/Saved Application State/com.aspera.connect.savedState
==> Removing all staged versions of Cask 'ibm-aspera-connect'

❯ ls ~/.Trash
 Aspera_Connect
 com.aspera.connect.SafariExtension
'com.aspera.connect.SafariExtension 14-09-39-193.SafariExtension'
 com.aspera.connect.savedState
 com.aspera.drive.SendToExtension
'com.aspera.drive.SendToExtension 14-09-39-194.SendToExtension'
 group.com.aspera.connect
 com.aspera.connect.plist
```

**Audit/Style**
```console
❯ brew audit --cask ibm-aspera-connect
audit for ibm-aspera-connect: passed

❯ brew style --fix ibm-aspera-connect

1 file inspected, no offenses detected
```