### PR TITLE
Add arm64 support to aws-vault

### DIFF
--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,18 +1,20 @@
 cask "aws-vault" do
   version "6.3.0"
 
+  if Hardware::CPU.intel?
+    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
+
+    sha256 "7af98c76d3afcffd60829716d06986224239d2583108fd7669cb660e215ff98e"
+  else
+    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-arm64.dmg"
+
+    sha256 "1e99a2109ad21a30ec0af5004cd3f65c337ac9775a29a3fe1d27c5dd8d0ef703"
+  end
+
   appcast "https://github.com/99designs/aws-vault/releases.atom"
   name "aws-vault"
   desc "Securely stores and accesses AWS credentials in a development environment"
   homepage "https://github.com/99designs/aws-vault"
 
   binary "aws-vault"
-
-  if Hardware::CPU.intel?
-    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
-    sha256 "7af98c76d3afcffd60829716d06986224239d2583108fd7669cb660e215ff98e"
-  else
-    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-arm64.dmg"
-    sha256 "1e99a2109ad21a30ec0af5004cd3f65c337ac9775a29a3fe1d27c5dd8d0ef703"
-  end
 end

--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -1,11 +1,18 @@
 cask "aws-vault" do
   version "6.3.0"
-  sha256 "7af98c76d3afcffd60829716d06986224239d2583108fd7669cb660e215ff98e"
 
-  url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
   appcast "https://github.com/99designs/aws-vault/releases.atom"
   name "aws-vault"
+  desc "Vault for securely storing and accessing AWS credentials in development environments"
   homepage "https://github.com/99designs/aws-vault"
 
   binary "aws-vault"
+
+  if Hardware::CPU.intel?
+    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
+    sha256 "7af98c76d3afcffd60829716d06986224239d2583108fd7669cb660e215ff98e"
+  else
+    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-arm64.dmg"
+    sha256 "1e99a2109ad21a30ec0af5004cd3f65c337ac9775a29a3fe1d27c5dd8d0ef703"
+  end
 end

--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -3,7 +3,7 @@ cask "aws-vault" do
 
   appcast "https://github.com/99designs/aws-vault/releases.atom"
   name "aws-vault"
-  desc "Vault for securely storing and accessing AWS credentials in development environments"
+  desc "Securely stores and accesses AWS credentials in a development environment"
   homepage "https://github.com/99designs/aws-vault"
 
   binary "aws-vault"

--- a/Casks/aws-vault.rb
+++ b/Casks/aws-vault.rb
@@ -2,13 +2,13 @@ cask "aws-vault" do
   version "6.3.0"
 
   if Hardware::CPU.intel?
-    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
-
     sha256 "7af98c76d3afcffd60829716d06986224239d2583108fd7669cb660e215ff98e"
-  else
-    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-arm64.dmg"
 
+    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-amd64.dmg"
+  else
     sha256 "1e99a2109ad21a30ec0af5004cd3f65c337ac9775a29a3fe1d27c5dd8d0ef703"
+
+    url "https://github.com/99designs/aws-vault/releases/download/v#{version}/aws-vault-darwin-arm64.dmg"
   end
 
   appcast "https://github.com/99designs/aws-vault/releases.atom"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
