### PR TITLE
aldente: skip livecheck on Catalina or older

### DIFF
--- a/Casks/aldente.rb
+++ b/Casks/aldente.rb
@@ -3,13 +3,16 @@ cask "aldente" do
     version "1.2"
     sha256 "a588dc29faca894b7321e23420ca17d6a944b9b3b46412435f519b96e4ebee7b"
     url "https://github.com/davidwernhart/AlDente/releases/download/#{version}/AlDente.app.zip"
+
+    livecheck do
+      skip
+    end
   else
     version "2.1.2"
     sha256 "39cebc2db5b75c4217abd42470ecfee8280a35178b0d2581df3857cd8b742880"
     url "https://github.com/davidwernhart/AlDente/releases/download/#{version}/AlDente_#{version}_Notarized.app.zip"
   end
 
-  appcast "https://github.com/davidwernhart/AlDente/releases.atom"
   name "AlDente"
   desc "Menu bar tool to limit maximum charging percentage"
   homepage "https://github.com/davidwernhart/AlDente"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Current proposal:

```rb
  if MacOS.version <= :catalina
    # ...

    livecheck do
      skip
    end
  else
    # ...
  end
```

Alternative proposal:

```rb
  livecheck do
    skip if MacOS.version <= :catalina
  end
```