### PR TITLE
update wechat from 2.6.1,16853 to 3.0.0,17801

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,5 +1,5 @@
 cask "wechat" do
-  version "2.6.1,16853"
+  version "3.0.0,17801"
   sha256 :no_check
 
   url "https://dldir1.qq.com/weixin/mac/WeChatMac.dmg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.