### PR TITLE
Don't skip livecheck unless absolutely necessary.

### DIFF
--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -8,11 +8,11 @@ cask "wechat" do
   desc "Free messaging and calling application"
   homepage "https://mac.weixin.qq.com/"
 
-  # There is an appcast at https://dldir1.qq.com/weixin/mac/mac-release.xml,
-  # but it's slower to update than the submissions we get. See:
+  # This appcast is slower to update than the submissions we get. See:
   #   https://github.com/Homebrew/homebrew-cask/pull/90907#issuecomment-710107547
   livecheck do
-    skip
+    url "https://dldir1.qq.com/weixin/mac/mac-release.xml"
+    strategy :sparkle
   end
 
   auto_updates true

--- a/Casks/wechat.rb
+++ b/Casks/wechat.rb
@@ -1,5 +1,5 @@
 cask "wechat" do
-  version "3.0.0,17801"
+  version "3.0.0.17,17801"
   sha256 :no_check
 
   url "https://dldir1.qq.com/weixin/mac/WeChatMac.dmg"


### PR DESCRIPTION
I think we should still have the correct appcast in the livecheck rather than blindly skipping the check.