### PR TITLE
Update emacs from 27.1-1 to 27.2-2

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -4,7 +4,7 @@ cask "emacs" do
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   name "Emacs"
-  desc "Extensible, customizable, free/libre text editor - and more"
+  desc "Text editor"
   homepage "https://emacsformacosx.com/"
 
   livecheck do

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,9 +1,10 @@
 cask "emacs" do
-  version "27.1-1"
-  sha256 "67688cfa124544a2d41d62ad33dcd12843679a1bd48e870836044d9a0bb9b062"
+  version "27.2"
+  sha256 "fad00b2329cc2a375ca280f703991541325125e731c2057c69316d773517fcbc"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   name "Emacs"
+  desc "Extensible, customizable, free/libre text editor - and more"
   homepage "https://emacsformacosx.com/"
 
   livecheck do

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,6 +1,6 @@
 cask "emacs" do
-  version "27.2-1"
-  sha256 "28a252020ae7236115689f029170f2af42b4b2195eac49e277bdc81853074349"
+  version "27.2-2"
+  sha256 "a5f5efe3ce8e3c2ef1c0e1aaf6ab9197ee93ad22e80c2742710338fad27bad8b"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   name "Emacs"
@@ -17,6 +17,9 @@ cask "emacs" do
 
   app "Emacs.app"
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: "emacs"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
 
   zap trash: [
     "~/Library/Caches/org.gnu.Emacs",

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -17,9 +17,6 @@ cask "emacs" do
 
   app "Emacs.app"
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: "emacs"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
-  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
 
   zap trash: [
     "~/Library/Caches/org.gnu.Emacs",

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -10,7 +10,7 @@ cask "emacs" do
   livecheck do
     url "https://emacsformacosx.com/atom/release"
     strategy :page_match
-    regex(%r{href=.*?/Emacs-(\d+(?:\.\d+)*-\d+)-universal\.dmg}i)
+    regex(%r{href=.*?/Emacs-(\d+(?:\.\d+)*(?:-\d+)?)-universal\.dmg}i)
   end
 
   conflicts_with formula: "emacs"

--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,6 +1,6 @@
 cask "emacs" do
-  version "27.2"
-  sha256 "fad00b2329cc2a375ca280f703991541325125e731c2057c69316d773517fcbc"
+  version "27.2-1"
+  sha256 "28a252020ae7236115689f029170f2af42b4b2195eac49e277bdc81853074349"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   name "Emacs"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

