### PR TITLE
Update Tipp10 to only install on macOS before Catalina

### DIFF
--- a/Casks/tipp10.rb
+++ b/Casks/tipp10.rb
@@ -8,6 +8,7 @@ cask "tipp10" do
   name "TIPP10"
   desc "Free touch typing tutor"
   homepage "https://www.tipp10.com/"
+  depends_on macos: "<= :mojave"
 
   app "TIPP10.app"
 end

--- a/Casks/tipp10.rb
+++ b/Casks/tipp10.rb
@@ -8,6 +8,7 @@ cask "tipp10" do
   name "TIPP10"
   desc "Free touch typing tutor"
   homepage "https://www.tipp10.com/"
+
   depends_on macos: "<= :mojave"
 
   app "TIPP10.app"

--- a/Casks/tipp10.rb
+++ b/Casks/tipp10.rb
@@ -12,4 +12,8 @@ cask "tipp10" do
   depends_on macos: "<= :mojave"
 
   app "TIPP10.app"
+  
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/tipp10.rb
+++ b/Casks/tipp10.rb
@@ -12,7 +12,7 @@ cask "tipp10" do
   depends_on macos: "<= :mojave"
 
   app "TIPP10.app"
-  
+
   caveats do
     discontinued
   end


### PR DESCRIPTION
Tipp10 is not supported on newer versions of MacOS and this adds the requirements for it.
From the website:
> Attention: No longer works since macOS 10.15 Catalina!
> Please use the online version instead.
(https://www.tipp10.com/en/download/)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
