### PR TITLE
Update Raspberry Pi Imager from 1.6 to 1.6.1, updating its livecheck strategy

### DIFF
--- a/Casks/raspberry-pi-imager.rb
+++ b/Casks/raspberry-pi-imager.rb
@@ -1,6 +1,6 @@
 cask "raspberry-pi-imager" do
-  version "1.6"
-  sha256 "800c48d49eca9199f275a73821686381e23dc5a22d0b87b77b57322afafbe5f2"
+  version "1.6.1"
+  sha256 "7c84ec9d458b43cb8174b4463a80607d59615521150e0003c04affa9be7282d0"
 
   url "https://downloads.raspberrypi.org/imager/imager_#{version}.dmg"
   name "Raspberry Pi Imager"

--- a/Casks/raspberry-pi-imager.rb
+++ b/Casks/raspberry-pi-imager.rb
@@ -8,9 +8,8 @@ cask "raspberry-pi-imager" do
   homepage "https://www.raspberrypi.org/downloads/"
 
   livecheck do
-    url "https://www.raspberrypi.org/software/"
-    strategy :page_match
-    regex(%r{href=.*?/imager_(\d+(?:\.\d+)*)\.dmg}i)
+    url "https://downloads.raspberrypi.org/imager/imager_latest.dmg"
+    strategy :header_match
   end
 
   app "Raspberry Pi Imager.app"


### PR DESCRIPTION
Now that Raspberry Pi provide a redirect to the latest version of Raspberry Pi Imager at https://downloads.raspberrypi.org/imager/imager_latest.dmg, use that instead of scraping the Software page and bump from version 1.6 to 1.6.1.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
