### PR TITLE
Add chatterino 2.2.3-fix cask

### DIFF
--- a/Casks/chatterino.rb
+++ b/Casks/chatterino.rb
@@ -7,6 +7,12 @@ cask "chatterino" do
   desc "Chat client for https://twitch.tv"
   homepage "https://chatterino.com/"
 
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(%r{span>macOS \((.*)\)</span}i)
+  end
+
   app "chatterino.app"
 
   zap trash: "~/Library/Application Support/chatterino"

--- a/Casks/chatterino.rb
+++ b/Casks/chatterino.rb
@@ -5,7 +5,7 @@ cask "chatterino" do
   url "https://chatterino.com/download/#{version}/Chatterino.dmg"
   name "Chatterino"
   desc "Chat client for https://twitch.tv"
-  homepage "https://chatterino.com"
+  homepage "https://chatterino.com/"
 
   app "chatterino.app"
 

--- a/Casks/chatterino.rb
+++ b/Casks/chatterino.rb
@@ -1,0 +1,13 @@
+cask "chatterino" do
+  version "2.2.3-beta2"
+  sha256 "ce5a10067ee9d04f348349fca2bd039094d4cc6ae27747d80deaac1286942f29"
+
+  url "https://chatterino.com/download/#{version}/Chatterino.dmg"
+  name "Chatterino"
+  desc "Chat client for https://twitch.tv"
+  homepage "https://chatterino.com"
+
+  app "chatterino.app"
+
+  zap trash: "~/Library/Application Support/chatterino"
+end

--- a/Casks/chatterino.rb
+++ b/Casks/chatterino.rb
@@ -10,7 +10,7 @@ cask "chatterino" do
   livecheck do
     url :homepage
     strategy :page_match
-    regex(%r{span>macOS \((.*)\)</span}i)
+    regex(%r{span>macOS \(v(.*)\)</span}i)
   end
 
   app "chatterino.app"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.


The currently recommended version of chatterino for macOS is `2.2.3-beta2` whereas other operating systems is 2.2.2-fix. Since it's the recommended version it should be put into the stable repo as most - if not all - macOS users are on it.