### PR TITLE
Update Unite cask to use new Appcast URL and bump version to 4.1.0.1

### DIFF
--- a/Casks/unite.rb
+++ b/Casks/unite.rb
@@ -4,10 +4,14 @@ cask "unite" do
 
   url "https://bzgdownloads.s3.amazonaws.com/Unite/Unite+#{version}.zip",
       verified: "bzgdownloads.s3.amazonaws.com/Unite/"
-  appcast "https://bzgdownloads.s3.amazonaws.com/Unite/App+Cast/Unite+4+appcast.xml"
   name "Unite"
   desc "Turn websites into apps"
   homepage "https://bzgapps.com/unite"
+
+  livecheck do
+    url "https://bzgdownloads.s3.amazonaws.com/Unite/App+Cast/Unite+#{version.major}+appcast.xml"
+    strategy :sparkle
+  end
 
   auto_updates true
   depends_on macos: ">= :high_sierra"

--- a/Casks/unite.rb
+++ b/Casks/unite.rb
@@ -1,10 +1,10 @@
 cask "unite" do
-  version "4.0,sWbXL0HYRsWzxwrH8Zw1"
-  sha256 "80bef525cdbeee5d35da93d0aa71a42dd268b039ce4f61f242ee18f103538ff9"
+  version "4.1.0.1"
+  sha256 "554b2353dd28db494739a4c1dade75da1733f5329f68ef377bb3a42169219c13"
 
-  url "https://paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/#{version.after_comma}_Unite.zip",
-      verified: "paddle.s3.amazonaws.com/fulfillment_downloads/20398/638879/"
-  appcast "https://drive.google.com/uc?export=download&id=1gb_luG8qUL6XZu8tdI-9zrUE9I_oFBmo"
+  url "https://bzgdownloads.s3.amazonaws.com/Unite/Unite+#{version}.zip",
+      verified: "bzgdownloads.s3.amazonaws.com/Unite/"
+  appcast "https://bzgdownloads.s3.amazonaws.com/Unite/App+Cast/Unite+4+appcast.xml"
   name "Unite"
   desc "Turn websites into apps"
   homepage "https://bzgapps.com/unite"


### PR DESCRIPTION
Unite had an issue with its appcast URL and [it had to be replaced](https://bzgapps.substack.com/p/action-required-unite-4101-with-full). Please let me know if I made any mistakes.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
