### PR TITLE
vmware-fusion: add livecheck

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -3,10 +3,17 @@ cask "vmware-fusion" do
   sha256 "fbc94a432c00fb9e05dd648cc80dd58cfb052c3aa53f44dc996be02e25a7c270"
 
   url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
-  appcast "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml"
   name "VMware Fusion"
   desc "App to run other operating systems without rebooting"
   homepage "https://www.vmware.com/products/fusion.html"
+
+  livecheck do
+    url "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml"
+    strategy :page_match do |page|
+      scan = page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/core}i)
+      scan.map { |v| "#{v[0]}-#{v[1]}" }
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
```
ykursadkaya@YKKs-MacBook-Air: ~% brew livecheck --cask --debug vmware-fusion

Cask:             vmware-fusion
Livecheckable?:   Yes

URL:              https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml
Strategy:         PageMatch

Matched Versions:
10.1.4-10700604, 8.0.0-2985594, 11.0.0-10120384, 8.5.6-5234762, 11.0.3-12992109, 8.5.2-4635224, 8.5.3-4696910, 10.1.2-8502123, 11.0.2-10952296, 12.1.0-17195230, 8.0.1-3094680, 8.5.9-7098239, 11.5.1-15018442, 8.1.0-3272237, 11.0.1-10738065, 11.5.5-16269456, 11.1.0-13668589, 11.5.0-14634996, 11.5.2-15794494, 8.5.4-5115894, 11.5.7-17130923, 8.5.8-5824040, 8.5.0-4352717, 11.5.3-15870345, 10.0.0-6665085, 8.1.1-3771013, 12.1.1-17801503, 10.1.5-10950653, 10.0.1-6754183, 10.1.3-9472307, 11.5.6-16696540, 8.5.10-7527438, 10.1.0-7370838, 10.1.1-7520154, 8.5.7-5528452, 8.0.2-3164312, 8.5.5-5192483, 10.1.6-12989998, 8.5.1-4543325
vmware-fusion : 12.1.1-17801503 ==> 12.1.1-17801503
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
