### PR TITLE
Fix incorrect shasum for backblaze

### DIFF
--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,6 +1,6 @@
 cask "backblaze" do
   version "7.0.2.492"
-  sha256 "bec93cfedb5726aff1f1a67d85a1552428260f6ba2875a036600b18cc6a2dcfa"
+  sha256 "ca9ff4cd0670055df23555030819d8b12578d0f9859b187ba3600b32f0e62f03"
 
   url "https://secure.backblaze.com/api/install_backblaze?file=bzinstall-mac-#{version}.zip"
   name "Backblaze"


### PR DESCRIPTION
```
$ brew install --cask backblaze
==> Downloading https://secure.backblaze.com/api/install_backblaze?file=bzinstall-mac-7.0.2.492.zip
Already downloaded: /Users/strawb/Library/Caches/Homebrew/downloads/6ab430491e87bea263cffea153e3e98a69d50f9c45308e9a0c6165894bd70501--download_error.html
Error: SHA256 mismatch
Expected: bec93cfedb5726aff1f1a67d85a1552428260f6ba2875a036600b18cc6a2dcfa
  Actual: ca9ff4cd0670055df23555030819d8b12578d0f9859b187ba3600b32f0e62f03
    File: /Users/strawb/Library/Caches/Homebrew/downloads/6ab430491e87bea263cffea153e3e98a69d50f9c45308e9a0c6165894bd70501--download_error.html
To retry an incomplete download, remove the file above.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
