### PR TITLE
Modify url of zoom

### DIFF
--- a/Casks/zoom.rb
+++ b/Casks/zoom.rb
@@ -4,13 +4,11 @@ cask "zoom" do
   if Hardware::CPU.intel?
     sha256 "e0b01025388de07b292c7f14a13ea9041fa6333e308b115210c3fa3610a60521"
 
-    url "https://cdn.zoom.us/prod/#{version}/Zoom.pkg",
-        verified: "cdn.zoom.us/"
+    url "https://cdn.zoom.us/prod/#{version}/Zoom.pkg"
   else
     sha256 "3f860a6c37e99634b24747ec948f66cb2f466f4c2af542cd9517a5c25e8a6026"
 
-    url "https://cdn.zoom.us/prod/#{version}/arm64/Zoom.pkg",
-        verified: "cdn.zoom.us/"
+    url "https://cdn.zoom.us/prod/#{version}/arm64/Zoom.pkg"
   end
 
   name "Zoom.us"

--- a/Casks/zoom.rb
+++ b/Casks/zoom.rb
@@ -4,13 +4,13 @@ cask "zoom" do
   if Hardware::CPU.intel?
     sha256 "e0b01025388de07b292c7f14a13ea9041fa6333e308b115210c3fa3610a60521"
 
-    url "https://d11yldzmag5yn.cloudfront.net/prod/#{version}/Zoom.pkg",
-        verified: "d11yldzmag5yn.cloudfront.net/"
+    url "https://cdn.zoom.us/prod/#{version}/Zoom.pkg",
+        verified: "cdn.zoom.us/"
   else
     sha256 "3f860a6c37e99634b24747ec948f66cb2f466f4c2af542cd9517a5c25e8a6026"
 
-    url "https://d11yldzmag5yn.cloudfront.net/prod/#{version}/arm64/Zoom.pkg",
-        verified: "d11yldzmag5yn.cloudfront.net/"
+    url "https://cdn.zoom.us/prod/#{version}/arm64/Zoom.pkg",
+        verified: "cdn.zoom.us/"
   end
 
   name "Zoom.us"


### PR DESCRIPTION
The official site of Zoom (https://zoom.us/download#client_4meeting) currently downloads the package from `https://zoom.us/client/latest/Zoom.pkg`, which redirects to `https://cdn.zoom.us/prod/#{version}/Zoom.pkg`. The domain `cdn.zoom.us` is a CNAME pointing to `d11yldzmag5yn.cloudfront.net.` (the domain of the current `url` stanza).
I modified the `url` stanza of the `zoom` cask to `https://cdn.zoom.us/prod/#{version}/Zoom.pkg`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
