### PR TITLE
Update datadog-agent from 7.22.0-1 to 7.26.0-1 and add livecheck to cask

### DIFF
--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -10,7 +10,7 @@ cask "datadog-agent" do
 
   livecheck do
     url "https://s3.amazonaws.com/dd-agent/"
-    regex(%r{<Key>datadog-agent-([\d.-]+)\.dmg</Key>})
+    regex(%r{<Key>datadog-agent-([\d.-]+)\.dmg</Key>}i)
   end
 
   installer manual: "datadog-agent-#{version}.pkg"

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -4,10 +4,14 @@ cask "datadog-agent" do
 
   url "https://s3.amazonaws.com/dd-agent/datadog-agent-#{version}.dmg",
       verified: "s3.amazonaws.com/dd-agent/"
-  appcast "https://s3.amazonaws.com/dd-agent/"
   name "Datadog Agent"
   desc "Monitoring and security across systems, apps, and services"
   homepage "https://www.datadoghq.com/"
+
+  livecheck do
+    url "https://s3.amazonaws.com/dd-agent/"
+    regex(%r{<Key>datadog-agent-([\d.-]+)\.dmg</Key>})
+  end
 
   installer manual: "datadog-agent-#{version}.pkg"
 

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -1,6 +1,6 @@
 cask "datadog-agent" do
-  version "7.22.0-1"
-  sha256 "ceb52c36924959c6dc88c75f7f403361937ced94efaf9bbf70fbdd895bb81e21"
+  version "7.26.0-1"
+  sha256 "b6bfcbff5daeb4da7815aae774228b02a54d84d46ffd4124b93f1843675e79ec"
 
   url "https://s3.amazonaws.com/dd-agent/datadog-agent-#{version}.dmg",
       verified: "s3.amazonaws.com/dd-agent/"

--- a/Casks/datadog-agent.rb
+++ b/Casks/datadog-agent.rb
@@ -20,13 +20,13 @@ cask "datadog-agent" do
             pkgutil:   "com.datadoghq.agent",
             delete:    [
               "/Applications/Datadog Agent.app",
-              "/opt/datadog-agent",
               "/usr/local/bin/datadog-agent",
             ]
 
   zap trash: [
     "~/.datadog-agent",
     "~/Library/LaunchAgents/com.datadoghq.agent.plist",
+    "/opt/datadog-agent",
   ]
 
   caveats <<~EOS


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

## Caveat
While testing this, I realized that the agent stores its config files in its own little virtual environment in `/opt/datadog-agent/` and symlinks them into `~/.datadog-agent/`, rather than the reverse. Since `/opt/datadog-agent/` also contains the entire installation, it's in the `uninstall` stanza, meaning config files get deleted when upgrading/uninstalling. This isn't new, but it'll presumably be triggered every time the cask is updated. Does Homebrew have any tooling for dealing with something like this?
