### PR TITLE
Update edfbrowser from 1.77 to 1.83

### DIFF
--- a/Casks/edfbrowser.rb
+++ b/Casks/edfbrowser.rb
@@ -10,10 +10,10 @@ cask "edfbrowser" do
   homepage "https://www.teuniz.net/edfbrowser"
 
   app "EDFbrowser.app"
-  
+
   zap trash: [
-      "~/Library/Preferences/net.teuniz.EDFbrowser.plist",
-      "~/Library/Saved Application State/net.teuniz.EDFbrowser.savedState",
-      "~/.EDFbrowser",
+    "~/Library/Preferences/net.teuniz.EDFbrowser.plist",
+    "~/Library/Saved Application State/net.teuniz.EDFbrowser.savedState",
+    "~/.EDFbrowser",
   ]
 end

--- a/Casks/edfbrowser.rb
+++ b/Casks/edfbrowser.rb
@@ -1,12 +1,19 @@
 cask "edfbrowser" do
-  version "1.77,d46af4a00350581592aff8e210fe8295"
-  sha256 "d51f87e1d08fac2f6144219833a60e9fa59deab4d7bc0b260c29d57169784fe5"
+  version "1.83,0df0318a9d8d122320cb921bbab7be53"
+  sha256 "9be58f3fd9d8c46d85e0f6e6e89703d3eed956e953fef0c275b24054fe65a142"
 
   url "https://gitlab.com/whitone/EDFbrowser/uploads/#{version.after_comma}/EDFbrowser-#{version.before_comma}.dmg",
       verified: "gitlab.com/whitone/EDFbrowser/"
   appcast "https://gitlab.com/whitone/EDFbrowser/-/tags?format=atom"
   name "EDFbrowser"
+  desc "EDF+ and BDF+ viewer and toolbox"
   homepage "https://www.teuniz.net/edfbrowser"
 
   app "EDFbrowser.app"
+  
+  zap trash: [
+      "~/Library/Preferences/net.teuniz.EDFbrowser.plist",
+      "~/Library/Saved Application State/net.teuniz.EDFbrowser.savedState",
+      "~/.EDFbrowser",
+  ]
 end


### PR DESCRIPTION
Added missing `desc` and `zap` stanzas

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
