### PR TITLE
Bump flutter to 2.0.4

### DIFF
--- a/Casks/flutter.rb
+++ b/Casks/flutter.rb
@@ -1,5 +1,5 @@
 cask "flutter" do
-  version "2.0.3"
+  version "2.0.4"
   sha256 "f9f7ef2118945252961a738b0d245e41aac289b793ee872735ae546637758551"
 
   url "https://storage.googleapis.com/flutter_infra/releases/stable/macos/flutter_macos_#{version}-stable.zip",

--- a/Casks/flutter.rb
+++ b/Casks/flutter.rb
@@ -1,6 +1,6 @@
 cask "flutter" do
   version "2.0.4"
-  sha256 "f9f7ef2118945252961a738b0d245e41aac289b793ee872735ae546637758551"
+  sha256 "31e4a9f874e9d9743e7c3bb6bc69b3ba1bad122e71a4424e4240f204d0c9b34e"
 
   url "https://storage.googleapis.com/flutter_infra/releases/stable/macos/flutter_macos_#{version}-stable.zip",
       verified: "storage.googleapis.com/flutter_infra/"


### PR DESCRIPTION
This fixes the following issues:

https://github.com/flutter/flutter/issues/78589 - Cocoapod transitive dependencies with bitcode fail to link against debug Flutter framework
https://github.com/flutter/flutter/issues/76122 - Adding a WidgetSpan widget causes web HTML renderer painting issue
https://github.com/flutter/flutter/issues/75280 - Dragging the "draggable" widget causes widget to freeze in the overlay layer on Web