### PR TITLE
Add KaTrain 1.8.3

### DIFF
--- a/Casks/katrain.rb
+++ b/Casks/katrain.rb
@@ -1,0 +1,11 @@
+cask "katrain" do
+  version "1.8.3"
+  sha256 "c092602e5cadc311a119d7168186c6441e914ba53b9915ac534d9bd470c37e40"
+
+  url "https://github.com/sanderland/katrain/releases/download/#{version}/KaTrainOSX.zip"
+  name "KaTrain"
+  desc "Tool for analyzing games and playing go with AI feedback from KataGo"
+  homepage "https://github.com/sanderland/katrain"
+
+  app "KaTrain.app"
+end

--- a/Casks/katrain.rb
+++ b/Casks/katrain.rb
@@ -8,4 +8,6 @@ cask "katrain" do
   homepage "https://github.com/sanderland/katrain"
 
   app "KaTrain.app"
+
+  zap trash: "~/.katrain"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.


This is a premier frontend for Go players to analyze and train against the KataGo engine (which is already in Homebrew).