### PR TITLE
Update osxfuse postflight to not change the whole ownership

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -11,7 +11,10 @@ cask "osxfuse" do
   pkg "Extras/FUSE for macOS #{version}.pkg"
 
   postflight do
-    set_ownership ["/usr/local/include", "/usr/local/lib"]
+    set_ownership ["/usr/local/lib/libosxfuse.2.dylib", "/usr/local/lib/libosxfuse.dylib",
+                   "/usr/local/lib/libosxfuse.la", "/usr/local/lib/libosxfuse_i64.2.dylib",
+                   "/usr/local/lib/libosxfuse_i64.dylib", "/usr/local/lib/libosxfuse_i64.la",
+                   "/usr/local/include/osxfuse"]
   end
 
   uninstall pkgutil: [

--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -8,13 +8,24 @@ cask "osxfuse" do
   desc "File system integration"
   homepage "https://osxfuse.github.io/"
 
+  livecheck do
+    url "https://github.com/osxfuse/osxfuse/releases"
+    strategy :page_match
+    regex(/osxfuse-(\d+(?:\.\d+)*)\.dmg/i)
+  end
+
   pkg "Extras/FUSE for macOS #{version}.pkg"
 
   postflight do
-    set_ownership ["/usr/local/lib/libosxfuse.2.dylib", "/usr/local/lib/libosxfuse.dylib",
-                   "/usr/local/lib/libosxfuse.la", "/usr/local/lib/libosxfuse_i64.2.dylib",
-                   "/usr/local/lib/libosxfuse_i64.dylib", "/usr/local/lib/libosxfuse_i64.la",
-                   "/usr/local/include/osxfuse"]
+    set_ownership [
+      "/usr/local/include/osxfuse",
+      "/usr/local/lib/libosxfuse.2.dylib",
+      "/usr/local/lib/libosxfuse.dylib",
+      "/usr/local/lib/libosxfuse_i64.2.dylib",
+      "/usr/local/lib/libosxfuse_i64.dylib",
+      "/usr/local/lib/libosxfuse_i64.la",
+      "/usr/local/lib/libosxfuse.la",
+    ]
   end
 
   uninstall pkgutil: [


### PR DESCRIPTION
The osxfuse postflight is trying to change set_ownership of both directories, and it could fail the installation if a file or directory won't change the ownership. 

So this change instead whitelist the related files and directories that need to change the ownership

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

