### PR TITLE
Add dependency on Katago for M1 Macs

### DIFF
--- a/Casks/katrain.rb
+++ b/Casks/katrain.rb
@@ -7,6 +7,8 @@ cask "katrain" do
   desc "Tool for analyzing games and playing go with AI feedback from KataGo"
   homepage "https://github.com/sanderland/katrain"
 
+  depends_on formula: "katago" if Hardware::CPU.arm?
+
   app "KaTrain.app"
 
   zap trash: "~/.katrain"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.


## Explanation

It turns out that on M1 Macs, the embedded copy of KataGo that KaTrain ships with [does not run properly](https://github.com/sanderland/katrain/issues/331) under Rosetta2. The good news is that an M1-native version of KataGo already exists in `homebrew-core`, and the upstream maintainer of KaTrain has been kind enough to explicitly use the Homebrew-provided binary on M1 Macs instead, so both sides of the aisle are happy.

So this patch simply adds a dependency on `katago` on ARM-based Macs. Non-ARM Macs can and should continue to use the embedded one.

Tested manually on my M1 Mac Mini.