### PR TITLE
Add Battery Buddy v1.0.3

### DIFF
--- a/Casks/battery-buddy.rb
+++ b/Casks/battery-buddy.rb
@@ -1,5 +1,5 @@
 cask "battery-buddy" do
-  version "1.0.3"
+  version "1.0.3,11"
   sha256 :no_check
 
   url "https://batterybuddy.app/releases/Battery%20Buddy.zip"

--- a/Casks/battery-buddy.rb
+++ b/Casks/battery-buddy.rb
@@ -16,4 +16,10 @@ cask "battery-buddy" do
   depends_on macos: ">= :big_sur"
 
   app "Battery Buddy.app"
+
+  zap trash: [
+  "~/Library/Application Scripts/com.NeilSardesai.Battery-Buddy-Helper",
+  "~/Library/Containers/com.NeilSardesai.Battery-Buddy-Helper",
+  "~/Library/Preferences/com.NeilSardesai.Battery-Buddy.plist",
+  ]
 end

--- a/Casks/battery-buddy.rb
+++ b/Casks/battery-buddy.rb
@@ -4,8 +4,13 @@ cask "battery-buddy" do
 
   url "https://batterybuddy.app/releases/Battery%20Buddy.zip"
   name "Battery Buddy"
-  desc "Cute replacement of the default battery indicator in the menu bar"
+  desc "Replacement of the default battery indicator in the menu bar"
   homepage "https://batterybuddy.app/"
+
+  livecheck do
+    url "https://batterybuddy.app/releases/appcast.xml"
+    strategy :sparkle
+  end
 
   auto_updates true
   depends_on macos: ">= :big_sur"

--- a/Casks/battery-buddy.rb
+++ b/Casks/battery-buddy.rb
@@ -18,8 +18,8 @@ cask "battery-buddy" do
   app "Battery Buddy.app"
 
   zap trash: [
-  "~/Library/Application Scripts/com.NeilSardesai.Battery-Buddy-Helper",
-  "~/Library/Containers/com.NeilSardesai.Battery-Buddy-Helper",
-  "~/Library/Preferences/com.NeilSardesai.Battery-Buddy.plist",
+    "~/Library/Application Scripts/com.NeilSardesai.Battery-Buddy-Helper",
+    "~/Library/Containers/com.NeilSardesai.Battery-Buddy-Helper",
+    "~/Library/Preferences/com.NeilSardesai.Battery-Buddy.plist",
   ]
 end

--- a/Casks/battery-buddy.rb
+++ b/Casks/battery-buddy.rb
@@ -1,0 +1,14 @@
+cask "battery-buddy" do
+  version "1.0.3"
+  sha256 :no_check
+
+  url "https://batterybuddy.app/releases/Battery%20Buddy.zip"
+  name "Battery Buddy"
+  desc "Cute replacement of the default battery indicator in the menu bar"
+  homepage "https://batterybuddy.app/"
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Battery Buddy.app"
+end


### PR DESCRIPTION
Hello! This is a PR for adding [Battery Buddy](https://batterybuddy.app/).

I'm not really sure about versioning with this cask, because the URL is unversioned (https://batterybuddy.app/releases/Battery%20Buddy.zip), and the app auto-updates. Adding both in the ruby file gave a warning, so I stated the version with `auto_updates true` set, not sure if that was correct 😄

Also,, I can't find the code on GitHub, so the notability of this app can be gauged on [Product Hunt](https://www.producthunt.com/posts/battery-buddy) and [Twitter](https://twitter.com/search?q=%40neilsardesai%20battery%20buddy).

**EDIT: Yup, looks like livecheck grabbed no version, which is correct, and the tests failed. Is this a cask that can be created if it also automatically updates?**

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
