### PR TITLE
ltspice: Update formula for `.pkg`-style distribution in v17.0.22.0

### DIFF
--- a/Casks/ltspice.rb
+++ b/Casks/ltspice.rb
@@ -13,9 +13,7 @@ cask "ltspice" do
 
   pkg "LTspice.pkg"
 
-  uninstall pkgutil: [
-    "com.analog.LTspice.App",
-  ]
+  uninstall pkgutil: "com.analog.LTspice.App"
 
   zap trash: [
     "~/Documents/LTspice/examples",

--- a/Casks/ltspice.rb
+++ b/Casks/ltspice.rb
@@ -11,11 +11,16 @@ cask "ltspice" do
     skip "No version information available"
   end
 
-  app "LTspice.app"
+  pkg "LTspice.pkg"
+
+  uninstall pkgutil: [
+    "com.analog.LTspice.App",
+  ]
 
   zap trash: [
     "~/Documents/LTspice/examples",
     "~/Library/Application Support/LTspice",
+    "~/Library/Preferences/com.analog.LTspice.App.plist",
   ],
       rmdir: "~/Documents/LTspice"
 end


### PR DESCRIPTION
[LTspice.app](https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html) used to be distributed as a single **`.app` file within the distributed `.dmg`**.
Version 17.0.22.0 now comes with a single **`.pkg` file instead**, and so breaks the present install formula, which hunts for, and fails to find a `.app` file within the directory created in `Caskroom`.

This new formula was (besides being `brew audit`ed and `style`ed), also **tested for install, uninstall, and zap** performance on the author's machine.

### Modification to Zap Stanza
On preliminary filesystem inspection using `find -x / -iname '*ltspice*'`, as well as by manually running said `.pkg` installer, the present zap stanza *seems sufficient*.
However, this zap stanza does not remove the **`.plist` of preferences**, which is — the author assumes, and asks to be corrected if wrong — what a user might expect out of a zap.
Thus the addition of the `.plist` preferences file in the "trash" portion

---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:
_(irrelevant)_