### PR TITLE
Update cold-turkey-blocker from 4.2 to 4.2.1

### DIFF
--- a/Casks/cold-turkey-blocker.rb
+++ b/Casks/cold-turkey-blocker.rb
@@ -1,8 +1,8 @@
 cask "cold-turkey-blocker" do
   version "4.2.1"
-  sha256 "745408cc07c761f8ecc58243adb4fad28be9a1a43e5922403432ab2e82e644ce"
+  sha256 :no_check
 
-  url "https://getcoldturkey.com/files/Cold_Turkey_Mac_Installer.pkg?v=#{version}"
+  url "https://getcoldturkey.com/files/Cold_Turkey_Mac_Installer.pkg"
   name "Cold Turkey"
   desc "Block websites, games and applications"
   homepage "https://getcoldturkey.com/"
@@ -13,7 +13,7 @@ cask "cold-turkey-blocker" do
     regex(/Cold_Turkey_Mac_Installer\.pkg\?v=(\d+(?:\.\d+)*)/i)
   end
 
-  pkg "Cold_Turkey_Blocker.pkg"
+  pkg "Cold_Turkey_Mac_Installer.pkg"
 
   uninstall launchctl: [
     "launchkeep.cold-turkey",

--- a/Casks/cold-turkey-blocker.rb
+++ b/Casks/cold-turkey-blocker.rb
@@ -1,8 +1,8 @@
 cask "cold-turkey-blocker" do
-  version "4.2,0"
+  version "4.2.1"
   sha256 :no_check
 
-  url "https://getcoldturkey.com/files/Cold_Turkey_Mac_Installer.pkg"
+  url "https://getcoldturkey.com/files/Cold_Turkey_Mac_Installer.pkg?v=#{version}"
   name "Cold Turkey"
   homepage "https://getcoldturkey.com/"
 

--- a/Casks/cold-turkey-blocker.rb
+++ b/Casks/cold-turkey-blocker.rb
@@ -1,12 +1,19 @@
 cask "cold-turkey-blocker" do
   version "4.2.1"
-  sha256 :no_check
+  sha256 "745408cc07c761f8ecc58243adb4fad28be9a1a43e5922403432ab2e82e644ce"
 
   url "https://getcoldturkey.com/files/Cold_Turkey_Mac_Installer.pkg?v=#{version}"
   name "Cold Turkey"
+  desc "Block websites, games and applications"
   homepage "https://getcoldturkey.com/"
 
-  pkg "Cold_Turkey_Mac_Installer.pkg"
+  livecheck do
+    url "https://getcoldturkey.com/download/mac/"
+    strategy :page_match
+    regex(/Cold_Turkey_Mac_Installer\.pkg\?v=(\d+(?:\.\d+)*)/i)
+  end
+
+  pkg "Cold_Turkey_Blocker.pkg"
 
   uninstall launchctl: [
     "launchkeep.cold-turkey",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

NOTE: I wasn't able to get the `.pkg` file to install properly. I think the problem is coming from the fact that the creator of Cold Turkey Blocker uses a query string in the url to figure out which version of the file to download. As a result, the file in `~/Library/Homebrew/downloads` doesn't end in a `.pkg` but ends in `.pkg?v=4.2.1` so Homebrew can't install it. I'm not sure how to fix this, so I thought I would submit my pull request to see if someone else knows how to fix this. 
