### PR TITLE
Revert "Revert "Add Emacs man pages""

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -20,6 +20,10 @@ cask "emacs" do
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1.gz"
 
   zap trash: [
     "~/Library/Caches/org.gnu.Emacs",


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#103378

brew 3.1.0 has released which supports the .gz man pages. It would be safe to add this back.