### PR TITLE
Update Monal cask url

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,8 +1,8 @@
 cask "monal" do
-  version "5.0,712"
+  version "5.0,716"
   sha256 :no_check
 
-  url "https://monal.im/Monal-OSX/Monal-OSX.zip"
+  url "https://monal.im/macOS/Monal-macOS.tar.gz"
   name "Monal"
   desc "Tool to securely connect to chat servers"
   homepage "https://monal.im/"

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -8,7 +8,8 @@ cask "monal" do
   homepage "https://monal.im/"
 
   livecheck do
-    skip "unversioned URL"
+    url :url
+    strategy :extract_plist
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
Monal changed its download url, this PR updates the cask accordingly. [Blog entry for reference](https://monal.im/blog/monal-5-beta-1/).

> The Mac build address has been updated to a tar.gz file instead of zip. It should open the same. The link has been updated to use the new macOS name as well.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

