### PR TITLE
Update old sha256 value for adobe-digital-editions

### DIFF
--- a/Casks/adobe-digital-editions.rb
+++ b/Casks/adobe-digital-editions.rb
@@ -1,6 +1,6 @@
 cask "adobe-digital-editions" do
   version "4.5.11"
-  sha256 "4bfdb9fdefb7a65bc5227518531ffba2cd2d547a1293265709a526a153800e7e"
+  sha256 "9a797ad403180d94f180d2c265885cc6b506ec054cd8489578b431319466abe4"
 
   url "https://adedownload.adobe.com/pub/adobe/digitaleditions/ADE_#{version.major_minor}_Installer.dmg"
   name "Adobe Digital Editions"


### PR DESCRIPTION
I got a SHA256 mismatch error, but there was no version bump, so I changed the SHA256 value and it worked (I checked double-checked to make sure that the download wasn't corrupted, and tried twice)
![Screenshot of console](https://user-images.githubusercontent.com/18013689/114469930-3bcdfb80-9bab-11eb-8752-e944f002abb2.png)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
