### PR TITLE
update popo from 3.20.1 to 3.21.1

### DIFF
--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask "popo" do
-  version "3.20.1"
-  sha256 "ca11e5db6881fa5b789bc66f3fe876b725fdb9ba9737ed135f7c38cbf67757e3"
+  version "3.21.1"
+  sha256 "03077ae7118de4a942b486a45883f41add3e5168dc68cb82d3676550038d5cc2"
 
   url "https://popo.netease.com/file/popomac/POPO_Mac_V#{version.dots_to_underscores}.dmg"
   appcast "http://http.popo.netease.com:8080/api/open/jsonp/check_version?device=4",


### PR DESCRIPTION
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.