### PR TITLE
birdfont: update to 4.15.3, 4.15.2 (catalina), and 4.15.0 (older)

### DIFF
--- a/Casks/birdfont.rb
+++ b/Casks/birdfont.rb
@@ -1,13 +1,19 @@
 cask "birdfont" do
   if MacOS.version <= :mojave
-    version "4.8.9"
-    sha256 "0f2e4f5398e0c9ad90f13c3e18910686d34f29e6e49b12c771ddb3e2f03d8589"
+    version "4.15.0"
+    sha256 "5433ee7bdbe68192bf69a253ce9c248cff844032ece43a2bbc910431c62b1a3f"
   elsif MacOS.version <= :catalina
-    version "4.8.10"
-    sha256 "067755cd2e02a70997aac3cb29a49ab2ec1c304c30d89f58b96add0df7802c88"
+    version "4.15.2"
+    sha256 "f5a34569ed38f293fe4902930b722649f3f1914c3fc9077de20482634a65cf01"
+
+    livecheck do
+      url "https://birdfont.org/purchase.php"
+      strategy :page_match
+      regex(%r{Mac\s*OS\s*10\.15.*?/birdfont-(\d+(?:\.\d+)*)-free\.dmg}i)
+    end
   else
-    version "4.14.3"
-    sha256 "7928073acf20b2b199e48154f53bf188a8b6553480a65f3cc1a49c2337ed2efe"
+    version "4.15.3"
+    sha256 "f36042a339a851aca029d7afa6dcbfb6e56efec94db925bca952d556055a07f7"
 
     livecheck do
       url "https://birdfont.org/purchase.php"
@@ -21,7 +27,7 @@ cask "birdfont" do
   desc "Free font editor"
   homepage "https://birdfont.org/"
 
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :sierra"
 
   app "BirdFontNonCommercial.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://birdfont.org/purchase.php

> **Find the right version**
> ...
> 
> Mac OS 11.0 and later: birdfont-4.15.3-free.dmg
> Mac OS 10.15 and later: birdfont-4.15.2-free.dmg
> Mac OS 10.12 and later: birdfont-4.15.0-free.dmg
> 