### PR TITLE
chore(docker): move version outside the if

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -1,7 +1,8 @@
 cask "docker" do
+  version "3.3.1,63152"
+
   if Hardware::CPU.intel?
-    version "3.3.0,62916"
-    sha256 "d533aa7d4a4a00d49bb78f4488535e577d7674292538c59769daa61e9bff1109"
+    sha256 "360f8142b1e07dc9e232cbccfafda52a8e7e9b48ad8323f0ba389339b0501a60"
 
     url "https://desktop.docker.com/mac/stable/amd64/#{version.after_comma}/Docker.dmg"
 
@@ -10,7 +11,6 @@ cask "docker" do
       strategy :sparkle
     end
   else
-    version "3.3.1,63152"
     sha256 "68b5038b09292aa3b2acb62f9edc5d2fdc314f37cc020ce4cf282d7114248070"
 
     url "https://desktop.docker.com/mac/stable/arm64/#{version.after_comma}/Docker.dmg"


### PR DESCRIPTION
This caused an error when trying to use bump-cask-pr.  Also, this fixed the recent PR that only updated the arm64 version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
