### PR TITLE
Fix release url for Cutter 2.0.1

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -2,7 +2,7 @@ cask "cutter" do
   version "2.0.1"
   sha256 "f797ab73079e5f261a7137c8ac78989d9f45326255bdde0eb2bfab7e544c8b58"
 
-  url "https://github.com/rizinorg/cutter/releases/download/v#{version}/Cutter-v#{version}-Darwin.dmg",
+  url "https://github.com/rizinorg/cutter/releases/download/v#{version}/Cutter-v#{version}-x64.macOS.dmg",
       verified: "github.com/rizinorg/cutter/"
   name "Cutter"
   desc "Reverse engineering platform powered by radare2"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.