### PR TITLE
Update printrun from 1.6.0 to 2.0.0rc8

### DIFF
--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -9,10 +9,8 @@ cask "printrun" do
 
   livecheck do
     url "https://github.com/kliment/Printrun/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/printrun-(\d+(?:\.\d+)*)/pronterface-macos-(.*?)\.zip}i)
-      "#{match[1]},#{match[2]}"
-    end
+    strategy :page_match
+    regex(%r{href=.*?/pronterface-macos-app-(\d+(?:\.\d+)*(?:rc\d*)?)\.zip}i)
   end
 
   app "pronterface.app"

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -4,7 +4,7 @@ cask "printrun" do
 
   url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/pronterface-macos-app-#{version}.zip"
   name "Printrun"
-  desc "control your 3D printer from your PC"
+  desc "Control your 3D printer from your PC"
   homepage "https://github.com/kliment/Printrun"
 
   livecheck do

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -1,18 +1,18 @@
 cask "printrun" do
-  version "1.6.0,18Nov2017"
-  sha256 "426229043a2a33a6768dcca12135f0751c007595af078665eb854cf87e4e2999"
+  version "2.0.0rc8"
+  sha256 "45f2a288939b3cb2594c821a614fa21af37b17e2b46310d7b72f3be45e15f5af"
 
-  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version.before_comma}/Printrun-Mac-#{version.after_comma}.zip"
+  url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/pronterface-macos-app-#{version}.zip"
   name "Printrun"
   homepage "https://github.com/kliment/Printrun"
 
   livecheck do
     url "https://github.com/kliment/Printrun/releases/latest"
     strategy :page_match do |page|
-      match = page.match(%r{href=.*?/printrun-(\d+(?:\.\d+)*)/Printrun-Mac-(.*?)\.zip}i)
+      match = page.match(%r{href=.*?/printrun-(\d+(?:\.\d+)*)/pronterface-macos-(.*?)\.zip}i)
       "#{match[1]},#{match[2]}"
     end
   end
 
-  app "Printrun-Mac-#{version.after_comma}.app"
+  app "pronterface.app"
 end

--- a/Casks/printrun.rb
+++ b/Casks/printrun.rb
@@ -4,6 +4,7 @@ cask "printrun" do
 
   url "https://github.com/kliment/Printrun/releases/download/printrun-#{version}/pronterface-macos-app-#{version}.zip"
   name "Printrun"
+  desc "control your 3D printer from your PC"
   homepage "https://github.com/kliment/Printrun"
 
   livecheck do

--- a/Casks/pronterface.rb
+++ b/Casks/pronterface.rb
@@ -1,4 +1,4 @@
-cask "printrun" do
+cask "pronterface" do
   version "2.0.0rc8"
   sha256 "45f2a288939b3cb2594c821a614fa21af37b17e2b46310d7b72f3be45e15f5af"
 


### PR DESCRIPTION
Comments:
- the old version (1.6.0) doesn't run on 64bit computers -> update to 2.0.0rc8 is needed for the app to work!
- the name of the binary changed to pronterface -> maybe we could rename the cask?
- structure of releases changed -> I had to modify the URL
- cask successfully installed on my computer

---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
