### PR TITLE
Fix broken link for stable versions in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 After making all changes to a cask, verify:
 
-- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
+- [ ] The submission is for [a stable version](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
 - [ ] `brew audit --cask {{cask_file}}` is error-free.
 - [ ] `brew style --fix {{cask_file}}` reports no offenses.
 


### PR DESCRIPTION
The link to stable versions in the PR template is outdated. I replaced with a working link.