### PR TITLE
ltspice: use new PKG url from homepage and plist version 17.0.33

### DIFF
--- a/Casks/ltspice.rb
+++ b/Casks/ltspice.rb
@@ -1,14 +1,15 @@
 cask "ltspice" do
-  version "17.0.22.0"
+  version "17.0.33"
   sha256 :no_check
 
-  url "https://ltspice.analog.com/software/LTspice.dmg"
+  url "https://ltspice.analog.com/software/LTspice.pkg"
   name "LTspice"
   desc "SPICE simulation software, schematic capture and waveform viewer"
   homepage "https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html"
 
   livecheck do
-    skip "No version information available"
+    url :url
+    strategy :extract_plist
   end
 
   pkg "LTspice.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes:

Changes to try to fix #104201

DMG URL still works, but the structure was changed back to use APP rather than PKG.

However, official homepage (https://www.analog.com/en/design-center/design-tools-and-calculators/ltspice-simulator.html) now only links a new PKG URL: https://ltspice.analog.com/software/LTspice.pkg, so switched to that in case DMG is removed in future.

Also, there are some issues with version history.
It looks like different installation methods have different versions (e.g. v17.0.31, v17.0.32, and v17.0.33 appear to be same version).
For now, trying to track the PKG version.