### PR TITLE
Add `HOMEBREW_CASK_SYNC_TOKEN`.

### DIFF
--- a/.github/workflows/sync-templates-and-ci-config.yml
+++ b/.github/workflows/sync-templates-and-ci-config.yml
@@ -42,7 +42,7 @@ jobs:
         uses: peter-evans/create-pull-request@052fc72b4198ba9fbc81b818c6e1859f747d49a8
         with:
           path: vendor/${{ matrix.repo }}
-          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          token: ${{ secrets.HOMEBREW_CASK_SYNC_TOKEN }}
           branch: sync-templates-and-ci-config
           title: Synchronize templates and CI configuration.
           body: >


### PR DESCRIPTION
Separate token for syncing templates and CI configuration.