### PR TITLE
Add timeout to `audit` step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
         id: audit
         run: |
           brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}'${{ matrix.cask.path || matrix.tap }}'
+        timeout-minutes: 30
         if: >
           always() && steps.gems.outcome == 'success' &&
           (!matrix.cask || steps.fetch.outcome == 'success') &&


### PR DESCRIPTION
The `livecheck` may not time out by itself.