### PR TITLE
upgrade lens version to 4.2.2

### DIFF
--- a/Casks/lens.rb
+++ b/Casks/lens.rb
@@ -1,6 +1,6 @@
 cask "lens" do
-  version "4.2.1"
-  sha256 "edd299988416a471012618e70df1066bb2425fa3ea9e7ab3853e8f0186449b49"
+  version "4.2.2"
+  sha256 "d34753f6da17df2bfd89525ec6f5a521c00f8a512c7b245b3153ec7a302d5198"
 
   url "https://github.com/lensapp/lens/releases/download/v#{version}/Lens-#{version}.dmg",
       verified: "github.com/lensapp/lens/"


### PR DESCRIPTION
This PR bumps lens release to 4.2.2

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

