### PR TITLE
Update cryptomator from 1.5.14 to 1.5.15 to use github releases as it's done on the official site download page

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -8,11 +8,6 @@ cask "cryptomator" do
   desc "Multi-platform client-side cloud file encryption tool"
   homepage "https://cryptomator.org/"
 
-  livecheck do
-    url "https://github.com/cryptomator/cryptomator"
-    strategy :git
-  end
-
   depends_on macos: ">= :yosemite"
 
   app "Cryptomator.app"

--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,9 +1,9 @@
 cask "cryptomator" do
-  version "1.5.14"
-  sha256 "2c7edaa8beae6b0db06260910846b15a57f4950f68e5c4025513ead540809d4c"
+  version "1.5.15"
+  sha256 "f7a1d37424ad125e2bda525cb0c2771df9133e0c941eb190ef7fa3f7d1450ce6"
 
-  url "https://dl.bintray.com/cryptomator/cryptomator/#{version}/Cryptomator-#{version}.dmg",
-      verified: "dl.bintray.com/cryptomator/cryptomator/"
+  url "https://github.com/cryptomator/cryptomator/releases/download/#{version}/Cryptomator-#{version}.dmg",
+      verified: "github.com/cryptomator/cryptomator/"
   name "Cryptomator"
   desc "Multi-platform client-side cloud file encryption tool"
   homepage "https://cryptomator.org/"


### PR DESCRIPTION
Updated to the url on the official cryptomator website as seen here:
https://cryptomator.org/downloads/mac/thanks/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md#stable-versions) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
