### PR TITLE
update BetterTouchTool from 3.560-1700 to 3.561-1701

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -9,7 +9,7 @@ cask "bettertouchtool" do
 
   livecheck do
     url "https://folivora.ai/releases/"
-    strategy :page_match do
+    strategy :page_match do |page|
       page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
           .max_by { |(_, time)| Time.parse(time) }
           .first

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -9,8 +9,11 @@ cask "bettertouchtool" do
 
   livecheck do
     url "https://folivora.ai/releases/"
-    strategy :page_match
-    regex(/btt(\d+(?:.\d+)*)\.zip/i)
+    strategy :page_match do
+      page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d\d\d\d-\d\d-\d\d)\s+\d\d:\d\d)/i)
+          .max_by { |(_, time)| Time.parse(time) }
+          .first
+    end
   end
 
   auto_updates true

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -1,15 +1,16 @@
 cask "bettertouchtool" do
-  version "3.561,1701"
+  version "3.561-1701"
   sha256 "6f19467a71bec4ee992c61fe7fff762677c1d97856b6360f872aafc6f7c0a841"
 
-  url "https://folivora.ai/releases/btt#{version.before_comma}-#{version.after_comma}.zip"
+  url "https://folivora.ai/releases/btt#{version}.zip"
   name "BetterTouchTool"
   desc "Tool to customize input devices and automate computer systems"
   homepage "https://folivora.ai/"
 
   livecheck do
     url "https://updates.folivora.ai/appcast.xml?trial=1"
-    strategy :sparkle
+    strategy :page_match
+    regex(/btt(\d+(?:.\d+)*)\.zip/i)
   end
 
   auto_updates true

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -10,7 +10,7 @@ cask "bettertouchtool" do
   livecheck do
     url "https://folivora.ai/releases/"
     strategy :page_match do
-      page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d\d\d\d-\d\d-\d\d)\s+\d\d:\d\d)/i)
+      page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2})\s+\d{2}:\d{2})/i)
           .max_by { |(_, time)| Time.parse(time) }
           .first
     end

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -8,7 +8,7 @@ cask "bettertouchtool" do
   homepage "https://folivora.ai/"
 
   livecheck do
-    url "https://updates.folivora.ai/appcast.xml?trial=1"
+    url "https://folivora.ai/releases/"
     strategy :page_match
     regex(/btt(\d+(?:.\d+)*)\.zip/i)
   end

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -10,7 +10,7 @@ cask "bettertouchtool" do
   livecheck do
     url "https://folivora.ai/releases/"
     strategy :page_match do
-      page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2})\s+\d{2}:\d{2})/i)
+      page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
           .max_by { |(_, time)| Time.parse(time) }
           .first
     end

--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -1,6 +1,6 @@
 cask "bettertouchtool" do
-  version "3.560,1700"
-  sha256 "cec80de7977fc19cd54f5d4bb4abda1db28bb8a2ff2267b77317eca195e9b287"
+  version "3.561,1701"
+  sha256 "6f19467a71bec4ee992c61fe7fff762677c1d97856b6360f872aafc6f7c0a841"
 
   url "https://folivora.ai/releases/btt#{version.before_comma}-#{version.after_comma}.zip"
   name "BetterTouchTool"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.