### PR TITLE
update tencent-meeting from 2.9.4.401 to 2.10.5.408

### DIFF
--- a/Casks/tencent-meeting.rb
+++ b/Casks/tencent-meeting.rb
@@ -1,12 +1,12 @@
 cask "tencent-meeting" do
   if Hardware::CPU.intel?
-    version "2.9.4.401,b151cc342f235237a2702235d2220208"
-    sha256 "1e8f1123484e979944a3db9bef4ad1e78a82c82b0a602f4266b58b252b90e25c"
+    version "2.10.5.408,47e717cd17e9ac43e48cab9628defd50"
+    sha256 "f4102a85732e84c74f0792b2ebd2425bf55a6b00593cd8081591d03bafba511b"
     url "https://updatecdn.meeting.qq.com/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.x86_64.dmg",
         verified: "qq.com/"
   else
-    version "2.9.4.401,4a9e49af106a6edf8ff31e5e095fa5e1"
-    sha256 "e4c033d34176cfa963de9cfe0cd6d883f265e151a1ad479c25a93a7857b97e8e"
+    version "2.10.5.408,65a04e9daebb97fee0941fe1c1027153"
+    sha256 "dcf67054496e2df1dc2194c65971548e07e7d284c7699c45d74111fbc9edf086"
     url "https://updatecdn.meeting.qq.com/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.arm64.dmg",
         verified: "qq.com/"
   end


### PR DESCRIPTION
- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.