### PR TITLE
Update visual-studio masos dep to high_sierra

### DIFF
--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -11,7 +11,7 @@ cask "visual-studio" do
   homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
   depends_on cask: "homebrew/cask-versions/mono-mdk-for-visual-studio"
 
   app "Visual Studio.app"

--- a/Casks/visual-studio.rb
+++ b/Casks/visual-studio.rb
@@ -4,11 +4,19 @@ cask "visual-studio" do
 
   url "https://dl.xamarin.com/VsMac/VisualStudioForMac-#{version}.dmg",
       verified: "dl.xamarin.com/VsMac/"
-  appcast "https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2019-mac-relnotes",
-          must_contain: version.major_minor_patch
   name "Microsoft Visual Studio"
   desc "Integrated development environment"
   homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
+
+  livecheck do
+    url "https://docs.microsoft.com/en-us/visualstudio/releasenotes/vs2019-mac-relnotes"
+    strategy :page_match do |page|
+      match = page.match(
+        /Visual\sStudio\s(\d+(?:\.\d+)*)\sfor\sMac\sversion\s(\d+(?:\.\d+)*)\s\((\d+(?:\.\d+)*)\)/i,
+      )
+      (match[3]).to_s
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---
High Sierra is now [required](https://docs.microsoft.com/en-us/visualstudio/productinfo/vs2019-system-requirements-mac#visual-studio-2019-for-mac).