### PR TITLE
Update XQuartz 2.8.1 pkg file name

### DIFF
--- a/Casks/xquartz.rb
+++ b/Casks/xquartz.rb
@@ -17,7 +17,7 @@ cask "xquartz" do
 
   auto_updates true
 
-  pkg "Xquartz.pkg"
+  pkg "XQuartz.pkg"
 
   uninstall launchctl: "org.xquartz.privileged_startx",
             pkgutil:   "org.xquartz.X11"


### PR DESCRIPTION
XQuartz won't install on a case sensitive file system, because the file name differs in the actual DMG image: 

```➜  ~ brew install xquartz
==> Downloading https://github.com/XQuartz/XQuartz/releases/download/XQuartz-2.8.1/XQuartz-2.8.1.dmg
Already downloaded: /Users/user/Library/Caches/Homebrew/downloads/d919462a1157a8871a5564342d93589799c4e38d29e86059dd37b1b0b3ac4ee1--XQuartz-2.8.1.dmg
==> Installing Cask xquartz
==> Running installer for xquartz; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
==> Purging files for version 2.8.1 of Cask xquartz
Error: Could not find PKG source file 'Xquartz.pkg', found 'XQuartz.pkg' instead.
```

The file name for XQuartz 2.8.0 was actually changed in https://github.com/Homebrew/homebrew-cask/issues/102559, it seems like the developers changed it back to the original filename.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
