### PR TITLE
bump lens to 4.2.3

### DIFF
--- a/Casks/lens.rb
+++ b/Casks/lens.rb
@@ -1,6 +1,6 @@
 cask "lens" do
-  version "4.2.2"
-  sha256 "d34753f6da17df2bfd89525ec6f5a521c00f8a512c7b245b3153ec7a302d5198"
+  version "4.2.3"
+  sha256 "4a59e904518e92642f8a36dd0d4269bad6af8483d034e380b0757372d5ed0183"
 
   url "https://github.com/lensapp/lens/releases/download/v#{version}/Lens-#{version}.dmg",
       verified: "github.com/lensapp/lens/"


### PR DESCRIPTION
This PR updates lens Cask to 4.2.3

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.
