### PR TITLE
audio-hijack: add livecheck

### DIFF
--- a/Casks/audio-hijack.rb
+++ b/Casks/audio-hijack.rb
@@ -3,13 +3,18 @@ cask "audio-hijack" do
   sha256 :no_check
 
   url "https://rogueamoeba.com/audiohijack/download/AudioHijack.zip"
-  appcast "https://www.rogueamoeba.com/audiohijack/releasenotes.php"
   name "Audio Hijack"
   desc "Records audio from any application"
   homepage "https://www.rogueamoeba.com/audiohijack/"
 
+  livecheck do
+    url "https://www.rogueamoeba.com/audiohijack/releasenotes.php"
+    strategy :page_match
+    regex(/ra-version="(\d+(?:\.\d+)*)"/i)
+  end
+
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "Audio Hijack.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Minimum macOS version updated:
> Audio Hijack 3.8.4
> Released March 5, 2021 (Release Notes)
> For MacOS 10.13 to MacOS 11

Last supported version for macOS Sierra: **Audio Hijack 3.7.2**
https://rogueamoeba.com/legacy/#audiohijack