### PR TITLE
Update IINA from 1.1.2 to 1.2.0

### DIFF
--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -1,8 +1,8 @@
 cask "iina" do
-  version "1.1.2,128"
-  sha256 "783ff165c73839c87cf9fd5f4418b87131063c3be77abc94dfca0585aa992b98"
+  version "1.2.0"
+  sha256 "91b87e80055f097a1cb7a8c91979deb5303315f2067552cbe7387f48bfc42736"
 
-  url "https://dl.iina.io/IINA.v#{version.before_comma}.dmg"
+  url "https://github.com/iina/iina/releases/download/v#{version}/IINA.v#{version}.dmg"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"

--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -3,7 +3,7 @@ cask "iina" do
   sha256 "91b87e80055f097a1cb7a8c91979deb5303315f2067552cbe7387f48bfc42736"
 
   url "https://github.com/iina/iina/releases/download/v#{version}/IINA.v#{version}.dmg",
-     verified: "github.com/iina/iina"
+      verified: "github.com/iina/iina"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"
@@ -34,3 +34,4 @@ cask "iina" do
     "~/Library/Saved Application State/com.colliderli.iina.savedState",
   ]
 end
+

--- a/Casks/iina.rb
+++ b/Casks/iina.rb
@@ -2,7 +2,8 @@ cask "iina" do
   version "1.2.0"
   sha256 "91b87e80055f097a1cb7a8c91979deb5303315f2067552cbe7387f48bfc42736"
 
-  url "https://github.com/iina/iina/releases/download/v#{version}/IINA.v#{version}.dmg"
+  url "https://github.com/iina/iina/releases/download/v#{version}/IINA.v#{version}.dmg",
+     verified: "github.com/iina/iina"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"


### PR DESCRIPTION
Updates to the Universal binary.


- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.