### PR TITLE
exist-db: Move URL from Bintray to GitHub Releases

### DIFF
--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -3,16 +3,10 @@ cask "exist-db" do
   sha256 "16d20b665a68ba30090dbec1f47ad3ec26a73781af965039fb0790e9a5874142"
 
   url "https://github.com/eXist-db/exist/releases/download/eXist-#{version}/eXist-db-#{version}.dmg",
-      verified: "github.com/eXist-db/exist"
+      verified: "github.com/eXist-db/exist/"
   name "eXist-db"
   desc "Native XML database and application platform"
   homepage "https://exist-db.org/exist/apps/homepage/index.html"
-
-  livecheck do
-    url "https://github.com/eXist-db/exist"
-    strategy :git
-    regex(/^eXist-(\d+(?:\.\d+)*)$/i)
-  end
 
   app "eXist-db.app"
 

--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -2,8 +2,8 @@ cask "exist-db" do
   version "5.2.0"
   sha256 "16d20b665a68ba30090dbec1f47ad3ec26a73781af965039fb0790e9a5874142"
 
-  url "https://bintray.com/artifact/download/existdb/releases/eXist-db-#{version}.dmg",
-      verified: "bintray.com/artifact/download/existdb/"
+  url "https://github.com/eXist-db/exist/releases/download/eXist-#{version}/eXist-db-#{version}.dmg",
+      verified: "github.com/eXist-db/exist"
   name "eXist-db"
   desc "Native XML database and application platform"
   homepage "https://exist-db.org/exist/apps/homepage/index.html"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Previously eXist-db's releases were distributed via bintray. With bintray's impending closure, the eXist-db organization is moving its distribution facility to GitHub Releases.