### PR TITLE
chatology: update to final version 1.2.5 and mark discontinued

### DIFF
--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -1,13 +1,22 @@
 cask "chatology" do
-  version "1.2.4"
-  sha256 "e5ad4c9716afb2b5c1ac56f5b103ff8b8919de0cdda0627abd141c07368df7ad"
+  version "1.2.5"
+  sha256 "c47e8af749553e2c3b02b390b1d4d30fc2dec32cd7e01f85bc1699b770039a8a"
 
-  url "https://d60ism0l33mmr.cloudfront.net/Chatology_#{version}.zip",
-      verified: "d60ism0l33mmr.cloudfront.net/"
-  appcast "https://flexibits.com/chatology/appcast.php"
+  url "https://cdn.flexibits.com/Chatology_#{version}.zip"
   name "Chatology"
   desc "Chat manager and message search software"
   homepage "https://flexibits.com/chatology"
 
+  livecheck do
+    url "https://flexibits.com/chatology/appcast.php"
+    strategy :sparkle, &:short_version
+  end
+
+  depends_on macos: ">= :el_capitan"
+
   app "Chatology.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### From https://flexibits.com/chatology
> After more than 7 years, Chatology has been discontinued due to major changes with Messages in the upcoming release of macOS Big Sur.
> ...
> Supports macOS 10.11 El Capitan through macOS 10.15 Catalina

**EDIT:** Appcast mentions support for Apple silicon and Big Sur in final release, so removed upper bound on macOS version

---

Download URL https://flexibits.com/chatology/download -> https://cdn.flexibits.com/Chatology_1.2.5.zip