### PR TITLE
Update codelite from 14.0.0 to 15.0.0 and add livecheck

### DIFF
--- a/Casks/codelite.rb
+++ b/Casks/codelite.rb
@@ -1,13 +1,19 @@
 cask "codelite" do
-  version "14.0.0"
-  sha256 :no_check
+  version "15.0.0"
+  sha256 "4757fb3a16751ab541d53d07976d4ca59257bf77f94d7e96b86f64f415a7c199"
 
-  url "https://downloads.codelite.org/downloads.php?osx"
-  appcast "https://github.com/eranif/codelite/releases.atom",
-          must_contain: version.chomp(".0")
+  url "https://downloads.codelite.org/codelite/#{version}/codelite.app.tar.gz"
   name "CodeLite"
   desc "IDE for C, C++, PHP and Node.js"
   homepage "https://codelite.org/"
+
+  livecheck do
+    url "https://downloads.codelite.org/"
+    strategy :page_match do |page|
+      match = page.match(/CodeLite\s*(\d+\.\d+)((?:\.\d+)*)\s*-\s*Stable\s*Release/i)
+      "#{match[1]}#{match[2].presence || ".0"}"
+    end
+  end
 
   app "codelite.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Download URL
Try switching to versioned URL based on files at https://downloads.codelite.org/ReleaseArchive.php.

SHA256 appears to be the same between unversioned stable URL and versioned 15.0.0 URL
- https://downloads.codelite.org/downloads.php?osx
- https://downloads.codelite.org/codelite/15.0.0/codelite.app.tar.gz

### Livecheck
Livecheck based on stable release from https://downloads.codelite.org/

From archive.org, the version was sometimes shown with only major_minor version,
e.g. **13.0** https://web.archive.org/web/20190616061232/https://downloads.codelite.org/

The versioned URL requires the patch version too,
e.g. **13.0.0** https://downloads.codelite.org/codelite/13.0.0/codelite.app.tar.gz

Attempted workaround by providing default `.0` via `.presence || ".0"`

Alternative livecheck could be GitHub: https://github.com/eranif/codelite. Some notes:
- Tags created for both weekly and stable versions, so probably can't use `:git` strategy unless weekly is fine.
- Similar to above, for major version release, tag is missing patch (e.g. `15.0`) so would need similar workaround.