### PR TITLE
cryptomator: add livecheck

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -8,7 +8,13 @@ cask "cryptomator" do
   desc "Multi-platform client-side cloud file encryption tool"
   homepage "https://cryptomator.org/"
 
-  depends_on macos: ">= :yosemite"
+  livecheck do
+    url "https://cryptomator.org/downloads/mac/thanks/"
+    strategy :page_match
+    regex(%r{href=.*?/Cryptomator-(\d+(?:\.\d+)*)\.dmg}i)
+  end
+
+  depends_on macos: ">= :high_sierra"
 
   app "Cryptomator.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes:

Default GitHub `livecheck` shows Windows-only release: **1.5.16 (Hotfix Windows)**

To `livecheck` on GitHub repo, it would require detecting `dmg` inside available assets for release tag.

Instead, switched to official homepage macOS download page:
- All download page: https://cryptomator.org/downloads/
- Mac download page: https://cryptomator.org/downloads/mac/thanks/

---

Also, update min OS requirement:
> Minimum: macOS 10.13