### PR TITLE
Update trainerroad from 2020.50.0.118 to 2021.16.0.130 and add livecheck

### DIFF
--- a/Casks/trainerroad.rb
+++ b/Casks/trainerroad.rb
@@ -1,13 +1,20 @@
 cask "trainerroad" do
-  version "2020.50.0.118"
-  sha256 "cec74fc39756ff807fc838a1b20df8b8bfe2882fea30391af3e91fb6fc188699"
+  version "2021.16.0.130"
+  sha256 "d2ecc050422fa8f969771ff199615f38921bae5f8323149d9953fa0c9f7a5163"
 
   url "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/TrainerRoad-#{version}.dmg",
       verified: "trainrdtrcmn01un1softw01.blob.core.windows.net/"
-  appcast "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/latest-mac.yml"
   name "TrainerRoad"
   desc "Cycling training system"
   homepage "https://www.trainerroad.com/"
+
+  livecheck do
+    url "https://trainrdtrcmn01un1softw01.blob.core.windows.net/installers/mac/v001/Production/latest-mac.yml"
+    strategy :page_match
+    regex(/url:\s*TrainerRoad-(\d+(?:\.\d+)*)\.dmg/i)
+  end
+
+  depends_on macos: ">= :el_capitan"
 
   app "TrainerRoad.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Minimum OS version from https://support.trainerroad.com/hc/en-us/articles/201661500-Minimum-System-Requirements-
> Mac OS X v10.11 or greater. (Be aware: if you are on a Beta version of OS X, the TrainerRoad app may not function properly)

Although `livecheck` URL is in `:electron_builder` format, the version doesn't match with filename, so just regex matched page:
```yml
version: 2021.16.130
files:
  - url: TrainerRoad-2021.16.0.130.zip
    sha512: C5sD9UADNR6jASZ9GttcWXlrH3EHN0KvenR4oHTnIOWaiBaDx2zbf+CR0n4Xj4WSj3RsHAp4srWCv0VWl+j0Kg==
    size: 151841175
    blockMapSize: 160891
  - url: TrainerRoad-2021.16.0.130.dmg
    sha512: /v8G9Mb2Vvk4J7tPPCIj3HvfGYgeu2yTbM8vdfFsapYa2qxDuHsa13XcOTHmGZcaiSk8rRuLwsi50PtgkqSz4A==
    size: 156190178
path: TrainerRoad-2021.16.0.130.zip
sha512: C5sD9UADNR6jASZ9GttcWXlrH3EHN0KvenR4oHTnIOWaiBaDx2zbf+CR0n4Xj4WSj3RsHAp4srWCv0VWl+j0Kg==
releaseDate: '2021-04-26T22:43:36.603Z'
```