### PR TITLE
Update toinane-colorpicker from 2.0.3 to 2.0.5

### DIFF
--- a/Casks/toinane-colorpicker.rb
+++ b/Casks/toinane-colorpicker.rb
@@ -1,10 +1,11 @@
 cask "toinane-colorpicker" do
-  version "2.0.3"
-  sha256 "536a4bb6cae0f1fe029b3e316a12a5823e6682e60a5ecbfb7030087bbe5cac0a"
+  version "2.0.5"
+  sha256 "6459d542b4a0786cb9a81e3bec824fe42c3dbdcff48874e7a02a52e143d4a9e8"
 
-  url "https://github.com/toinane/colorpicker/releases/download/#{version}/Colorpicker_#{version}_darwin.zip",
+  url "https://github.com/toinane/colorpicker/releases/download/#{version}/Colorpicker-#{version}.dmg",
       verified: "github.com/toinane/colorpicker/"
   name "Colorpicker"
+  desc "Get and save color codes"
   homepage "https://colorpicker.fr/"
 
   app "Colorpicker.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Only **2.0.3** release had ZIP file.
**2.0.5** and other previous releases used DMG, so switched to that for update.