### PR TITLE
Update torguard from 4.3.0 to 4.6.0 and add livecheck

### DIFF
--- a/Casks/torguard.rb
+++ b/Casks/torguard.rb
@@ -1,12 +1,20 @@
 cask "torguard" do
-  version "4.3.0"
-  sha256 "3c14a3bca3b6fa258f0e10dc8af4a9642cd114015391f619d6fd6b03dbb65a73"
+  version "4.6.0"
+  sha256 "a74fe666aabc968c799a0cd03dfbb3879bbfa01eeaa98f2de27b847c92302131"
 
   url "https://updates.torguard.biz/Software/MacOSX/TorGuard-v#{version}.dmg",
       verified: "torguard.biz/"
-  appcast "https://updates.torguard.biz/Software/MacOSX/checksums.sha256"
   name "TorGuard"
+  desc "VPN client"
   homepage "https://torguard.net/"
+
+  livecheck do
+    url "https://updates.torguard.biz/Software/MacOSX/checksums.sha256"
+    strategy :page_match
+    regex(/TorGuard-v(\d+(?:\.\d+)*)\.dmg/i)
+  end
+
+  depends_on macos: ">= :sierra"
 
   pkg "Install TorGuard.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://torguard.net/downloads.php
> Supports macOS 10.12+ (64Bit only)