### PR TITLE
Update bootstrap-studio from 5.5.3 to 5.6.2 and add livecheck

### DIFF
--- a/Casks/bootstrap-studio.rb
+++ b/Casks/bootstrap-studio.rb
@@ -1,14 +1,20 @@
 cask "bootstrap-studio" do
-  version "5.5.3"
-  sha256 "b4d6f82e1da9ba92a9009386b34a0668a7823db6f499e092d5824ba9295ae745"
+  version "5.6.2"
+  sha256 "2940599008dbb8488594274848696d8c1a7106250ddf89bb99ebe55f31be1dc0"
 
   url "https://bootstrapstudio.io/releases/desktop/#{version}/Bootstrap%20Studio.dmg"
-  appcast "https://bootstrapstudio.io/pages/releases"
   name "Bootstrap Studio"
   desc "Design and prototype websites using the Bootstrap framework"
   homepage "https://bootstrapstudio.io/"
 
+  livecheck do
+    url "https://bootstrapstudio.io/pages/releases/"
+    strategy :page_match
+    regex(/Version\s*(\d+(?:\.\d+)*)/i)
+  end
+
   auto_updates true
+  depends_on macos: ">= :yosemite"
 
   app "Bootstrap Studio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://bootstrapstudio.io/contact-us#faq
> **Which operating systems are supported?**
> Bootstrap Studio works on Windows (7, 8 and 10), macOS (10.10 and up) and many Linux distributions (including Ubuntu, Debian and Fedora). Chrome OS is not supported.

https://bootstrapstudio.io/pages/releases/
> **Version 5.6.2**
> Apr 15, 2021
