### PR TITLE
Update camtasia from 2020.0.18 to 2021.0.0 and add livecheck

### DIFF
--- a/Casks/camtasia.rb
+++ b/Casks/camtasia.rb
@@ -1,14 +1,20 @@
 cask "camtasia" do
-  version "2020.0.18,114362"
-  sha256 :no_check
+  version "2021.0.0"
+  sha256 "1afed5fb6bef606eae88d116247bb8ba5d678b33716c342ea8a548d2a3f05240"
 
-  url "https://download.techsmith.com/camtasiamac/releases/Camtasia.dmg"
-  appcast "https://support.techsmith.com/hc/en-us/articles/115006624748-Camtasia-Mac-Version-History"
+  url "https://download.techsmith.com/camtasiamac/releases/#{version.major[-2..]}#{version.minor_patch.no_dots}/Camtasia.dmg"
   name "Camtasia"
+  desc "Screen recorder and video editor"
   homepage "https://www.techsmith.com/camtasia.html"
 
+  livecheck do
+    url "https://support.techsmith.com/hc/en-us/articles/115006624748-Camtasia-Mac-Version-History"
+    strategy :page_match
+    regex(/Camtasia\s*\(Mac\)\s*(\d+(?:\.\d+)*)/i)
+  end
+
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :mojave"
 
   app "Camtasia #{version.major}.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Versioned URL.
e.g. Version **2021.0.0** is shown as **21.0.0** in https://www.techsmith.com/download/oldversions
The following appear to be same DMG:
- https://download.techsmith.com/camtasiamac/releases/2100/Camtasia.dmg
- https://download.techsmith.com/camtasiamac/releases/Camtasia.dmg

### Compatibility
https://support.techsmith.com/hc/en-us/articles/219910027-Mac-OS-X-Support-Matrix
- High Sierra: 3.1.1 - 2020.x.x.
  - 20.0.18 released: 2021 Apr 07
- Mojave - Big Sur all work with latest
  -  21.0.0 released: 2021 Apr 27