### PR TITLE
Add arm64 version for clash-for-windows

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,8 +1,14 @@
 cask "clash-for-windows" do
   version "0.15.4"
-  sha256 "749729ed774af61aeac08f577f153d2ab0c351ba281fdf708f864a9617bce913"
 
-  url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
+  if Hardware::CPU.intel?
+    url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
+    sha256 "749729ed774af61aeac08f577f153d2ab0c351ba281fdf708f864a9617bce913"
+  else
+    url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}-arm64.dmg"
+    sha256 "c6e1766e6bf15cf80d37871401b840516c8896dcb418770f4e9faaaf316db0b3"
+  end
+
   name "Clash for Windows"
   desc "GUI based on Clash"
   homepage "https://github.com/Fndroid/clash_for_windows_pkg"


### PR DESCRIPTION
Currently home-brew will download intel version for arm64.To fix this bug, add arm64 url for downloading.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
