### PR TITLE
Improve melonDS 0.9.2 Cask

### DIFF
--- a/Casks/melonds.rb
+++ b/Casks/melonds.rb
@@ -3,10 +3,12 @@ cask "melonds" do
 
   if Hardware::CPU.intel?
     sha256 "253c3ce58c626d05c62444a347ccc6b3bd6e7698f685ffd404c9a51ac5c08a91"
-    url "http://melonds.kuribo64.net/downloads/melonDS_#{version}_mac64.dmg"
+    url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_mac64.dmg"
+        verified: "github.com/Arisotura/melonDS"
   else
     sha256 "5dc4f493aaabaac91bf8fdd79c5de1c5014daa2cce64718c43f461c2640c82ab"
-    url "http://melonds.kuribo64.net/downloads/melonDS_#{version}_macARM.dmg"
+    url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_macARM.dmg"
+        verified: "github.com/Arisotura/melonDS"
   end
 
   name "melonDS"
@@ -17,10 +19,6 @@ cask "melonds" do
     url "https://github.com/Arisotura/melonDS"
     strategy :github_latest
   end
-
-  depends_on formula: "libslirp"
-  depends_on formula: "qt@5"
-  depends_on formula: "sdl2"
 
   app "melonDS.app"
 

--- a/Casks/melonds.rb
+++ b/Casks/melonds.rb
@@ -3,11 +3,11 @@ cask "melonds" do
 
   if Hardware::CPU.intel?
     sha256 "253c3ce58c626d05c62444a347ccc6b3bd6e7698f685ffd404c9a51ac5c08a91"
-    url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_mac64.dmg"
+    url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_mac64.dmg",
         verified: "github.com/Arisotura/melonDS"
   else
     sha256 "5dc4f493aaabaac91bf8fdd79c5de1c5014daa2cce64718c43f461c2640c82ab"
-    url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_macARM.dmg"
+    url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_macARM.dmg",
         verified: "github.com/Arisotura/melonDS"
   end
 

--- a/Casks/melonds.rb
+++ b/Casks/melonds.rb
@@ -4,21 +4,16 @@ cask "melonds" do
   if Hardware::CPU.intel?
     sha256 "253c3ce58c626d05c62444a347ccc6b3bd6e7698f685ffd404c9a51ac5c08a91"
     url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_mac64.dmg",
-        verified: "github.com/Arisotura/melonDS"
+        verified: "github.com/Arisotura/melonDS/"
   else
     sha256 "5dc4f493aaabaac91bf8fdd79c5de1c5014daa2cce64718c43f461c2640c82ab"
     url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_macARM.dmg",
-        verified: "github.com/Arisotura/melonDS"
+        verified: "github.com/Arisotura/melonDS/"
   end
 
   name "melonDS"
   desc "Nintendo DS and DSi emulator"
   homepage "http://melonds.kuribo64.net/"
-
-  livecheck do
-    url "https://github.com/Arisotura/melonDS"
-    strategy :github_latest
-  end
 
   app "melonDS.app"
 


### PR DESCRIPTION
- melonDS does not require libs to be installed anymore
- Use GitHub releases (https) instead of melonDS site (http)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
