### PR TITLE
exist-db: Constrain to compatible versions

### DIFF
--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -13,6 +13,6 @@ cask "exist-db" do
   zap trash: "~/Library/Application Support/org.exist"
 
   caveats do
-    depends_on_java "8+"
+    depends_on_java ["8", "11"]
   end
 end


### PR DESCRIPTION
The eXist community is aware that [a bug in Java 12-15 could lead to data corruption in eXist](https://github.com/eXist-db/exist/pull/3545). This PR ensures that users are advised to stick to Java 8 or 11. 

Java 16 compatibility [has not yet been confirmed](https://github.com/eXist-db/exist/pull/3840). Once Java 16 compatibility has been established, I will remove the specific versions listed here so that users safely assume they can use the latest stable release of Java. 

But for now, this PR will help users avoid versions of Java that will cause data corruption with eXist.

I followed the usage of the depends_on_java caveat as described by @reitermarkus in https://github.com/Homebrew/homebrew-cask/issues/16383#issuecomment-726548725 and https://github.com/Homebrew/homebrew-cask/issues/16383#issuecomment-810828782

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

