### PR TITLE
Update neo4j from 1.3.11 to 1.4.3 and add livecheck

### DIFF
--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -1,12 +1,20 @@
 cask "neo4j" do
   # NOTE: "4" is not a version number, but an intrinsic part of the product name
-  version "1.3.11"
-  sha256 "5d60752d712f0e708cdf94d68c287508967ff79f8fd89bcca593d49a3982cc86"
+  version "1.4.3"
+  sha256 "2aa524605d529520495499e80334b6d8dc7f180217f37fa1dd90be2d86ee20e0"
 
   url "https://neo4j.com/artifact.php?name=neo4j-desktop-#{version}.dmg"
-  appcast "https://neo4j.com/download/"
   name "Neo4j Desktop"
+  desc "Developer IDE or Management Environment for Neo4j instances"
   homepage "https://neo4j.com/download/"
+
+  livecheck do
+    url "https://neo4j.com/download-center/#desktop"
+    strategy :page_match
+    regex(%r{href=.*?/neo4j-desktop/.*?flavour=osx.*?release=(\d+(?:\.\d+)*)}i)
+  end
+
+  depends_on macos: ">= :yosemite"
 
   app "Neo4j Desktop.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Min macOS: https://neo4j.com/download/
> MacOS 10.10 (Yosemite)+, Windows 7+, Ubuntu 12.04+, Fedora 21, Debian 8.

Description based on: https://neo4j.com/developer/neo4j-desktop/
> Neo4j Desktop is a Developer IDE or Management Environment for Neo4j instances similar to Enterprise Manager, but better. You can manage as many projects and database servers locally as you like and also connect to remote Neo4j servers. Neo4j Desktop comes with a free Developer License of Neo4j Enterprise Edition. The Java Runtime is also bundled.

Livecheck sample 
- Current `<a href="/download/neo4j-desktop/?edition=desktop&flavour=osx&release=1.4.3&offline=false">Neo4j Desktop (dmg)</a>`
- Archive.org `<a href="/web/20190415103434/https://neo4j.com/download/neo4j-desktop/?edition=desktop&amp;flavour=osx&amp;release=1.1.20&amp;offline=true">Neo4j Desktop (dmg)</a>`