### PR TITLE
Upgrade TradingView.app to 1.0.0-beta.3, new URL's and livecheck.

### DIFF
--- a/Casks/tradingview.rb
+++ b/Casks/tradingview.rb
@@ -8,7 +8,8 @@ cask "tradingview" do
   homepage "https://www.tradingview.com/desktop/"
 
   livecheck do
-    skip "No Version Information Available"
+    url "https://tvd-packages.tradingview.com/stable/latest/darwin/x64/stable-mac.yml"
+    strategy :electron_builder
   end
 
   app "TradingView.app"

--- a/Casks/tradingview.rb
+++ b/Casks/tradingview.rb
@@ -1,16 +1,14 @@
 cask "tradingview" do
-  version "1.0.0-beta.1"
-  sha256 "03b03d765ff7f8cb1f3059490b64344e38aa35bf44e161327b7b8baeac66aa2c"
+  version "1.0.0-beta.3"
+  sha256 "4223b41a138e2904383f9970d2a4289db933365183ffd30f901b83e1b7a659ed"
 
-  url "https://tvd-packages.tradingview.com/beta/#{version}/win32/x64/TradingView.dmg"
-  name "TradingView Desktop Beta"
-  desc "Desktop client for TradingView"
+  url "https://tvd-packages.tradingview.com/stable/#{version}/darwin/x64/TradingView.dmg"
+  name "TradingView Desktop"
+  desc "Experience with the power and flexibility of a desktop application"
   homepage "https://www.tradingview.com/desktop/"
 
   livecheck do
-    url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/(\d+(?:\.\d+)*-beta\.\d+)/win32/x64/TradingView\.dmg}i)
+    skip "No Version Information Available"
   end
 
   app "TradingView.app"


### PR DESCRIPTION
App upgrade to 1.0.0-beta.3 as new definitions to correct URL's addressing dmg's to {darwin/x64} hrefs, livechek also defined to 'skip' as main homepage do not have version validation other than :latest.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
