### PR TITLE
Update OS compatability for Tuple package

### DIFF
--- a/Casks/tuple.rb
+++ b/Casks/tuple.rb
@@ -14,7 +14,7 @@ cask "tuple" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :mojave"
 
   app "Tuple.app"
 


### PR DESCRIPTION
In a recent version of Tuple, we dropped support for High Sierra. This PR updates the `macos:` dependency to `mojave`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.