### PR TITLE
Add Recut v1.1.2

### DIFF
--- a/Casks/recut.rb
+++ b/Casks/recut.rb
@@ -1,8 +1,8 @@
 cask "recut" do
-  version "1.1.2"
+  version "1.1.2,364"
   sha256 "1f6d33a99a74422db9cb8fdee09b6ba8b3690a3661fdf6f284733278765e87ac"
 
-  url "https://updates.getrecut.com/Recut-#{version}.dmg"
+  url "https://updates.getrecut.com/Recut-#{version.before_comma}.dmg"
   name "Recut"
   desc "Remove silence from videos and automatically generate a cut list"
   homepage "https://getrecut.com/"

--- a/Casks/recut.rb
+++ b/Casks/recut.rb
@@ -1,0 +1,25 @@
+cask "recut" do
+  version "1.1.2"
+  sha256 "1f6d33a99a74422db9cb8fdee09b6ba8b3690a3661fdf6f284733278765e87ac"
+
+  url "https://updates.getrecut.com/Recut-#{version}.dmg"
+  name "Recut"
+  desc "Remove silence from videos and automatically generate a cut list"
+  homepage "https://getrecut.com/"
+
+  livecheck do
+    url "https://updates.getrecut.com/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Recut.app"
+
+  zap trash: [
+    "~/Library/Caches/co.tinywins.recut",
+    "~/Library/Preferences/co.tinywins.recut.plist",
+    "~/Library/Saved Application State/co.tinywins.recut.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

Recut fits under "Freemium" according to [Acceptable Casks](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Casks.md) - most of the app continues to work (including the screen recorder) after the trial parts expire.

The app got some buzz on Twitter when I [launched it](https://twitter.com/dceddia/status/1364235563126190084) a few months ago and some love on [Show HN](https://news.ycombinator.com/item?id=26317265) too. It's no blockbuster yet but it [crossed 100 sales](https://twitter.com/dceddia/status/1387859581469171721) yesterday and has seen around 200 downloads.
