### PR TITLE
detach chromium from shell script PID when using brew provided wrapper

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -1,6 +1,6 @@
 cask "chromium" do
-  version "875978"
-  sha256 "d9a58514abbd3eb6b48e58e47d0223771f77435892c2040ebca277075b5bb1f8"
+  version "878726"
+  sha256 "b3e8559bf657d48253570602e8894333684b862485e54c0b409a19c492857a18"
 
   url "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/#{version}/chrome-mac.zip",
       verified: "commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/"
@@ -26,7 +26,7 @@ cask "chromium" do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      'exec #{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
+      exec '#{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
     EOS
   end
 

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -26,7 +26,7 @@ cask "chromium" do
   preflight do
     IO.write shimscript, <<~EOS
       #!/bin/sh
-      '#{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
+      'exec #{appdir}/Chromium.app/Contents/MacOS/Chromium' "$@"
     EOS
   end
 


### PR DESCRIPTION
This simple shell wrapper is provided to execute chromium from command line.
The way it is defined, chromium will have the PID `/bin/sh` as PPID:

```
  501 77821  1088   0  6:24pm ttys028    0:01.53 -zsh
  501 78177 77821   0  6:24pm ttys028    0:00.01 /bin/sh /usr/local/bin/chromium
  501 78181 78177   0  6:24pm ttys028    0:01.83 /Applications/Chromium.app/Contents/MacOS/Chromium
```

I'm using chromedp to interact with `chromium/Chrome`, and this
behaviour triggers some issues. When the execution context is done in
the library, it triggers the termination of the shell process instead of the chromium process and
chromium is left as an orphan process on the system.

There is an open issue documenting this behaviour [here](https://github.com/chromedp/chromedp/issues/752)

Using `exec` will detach `chomium` process from the shell, and will provide
expected behaviour when called with such libraries; user
experience when calling `chromium` from the shell will not change.

```
  501 77821  1088   0  6:24pm ttys028    0:01.61 -zsh
  501 93092 77821   0  6:26pm ttys028    0:01.40 /Applications/Chromium.app/Contents/MacOS/Chromium
```

Thank you.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
