### PR TITLE
Update dropbox-passwords from 7.2.36 to 8.2.12 and add livecheck

### DIFF
--- a/Casks/dropbox-passwords.rb
+++ b/Casks/dropbox-passwords.rb
@@ -1,13 +1,19 @@
 cask "dropbox-passwords" do
-  version "7.2.36"
-  sha256 "51c57af430f2a90ae91c436096e3c09a141fcede5b06838733acd75f6c1b1655"
+  version "8.2.12"
+  sha256 "f891e724be047cc3fef0d6804ad3e979a28b9cebd6c37ba49920395522eeb419"
 
   url "https://clientupdates.dropboxstatic.com/dbx-releng/dropbox_passwords/mac/DropboxPasswords_#{version}.dmg",
       verified: "clientupdates.dropboxstatic.com/"
-  appcast "https://www.dropbox.com/dropbox-passwords-download/mac/stable"
   name "Dropbox Passwords"
   desc "Password manager that syncs across devices"
   homepage "https://www.dropbox.com/features/security/passwords"
+
+  livecheck do
+    url "https://www.dropbox.com/dropbox-passwords-download/mac/stable"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :sierra"
 
   app "Dropbox Passwords.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

```xml
<sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
```