### PR TITLE
logisim: development suspended indefinitely on 11 Oct 2014

### DIFF
--- a/Casks/logisim.rb
+++ b/Casks/logisim.rb
@@ -4,11 +4,15 @@ cask "logisim" do
 
   url "https://downloads.sourceforge.net/circuit/#{version.sub(/\d+$/, "x")}/#{version}/logisim-macosx-#{version}.tar.gz",
       verified: "sourceforge.net/circuit/"
-  appcast "https://sourceforge.net/projects/circuit/rss"
   name "Logisim"
+  desc "Tool for designing and simulating digital logic circuits"
   homepage "http://www.cburch.com/logisim/"
 
   app "Logisim.app"
 
   zap trash: "~/Library/Preferences/com.cburch.logisim.plist"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

http://www.cburch.com/logisim/
> Note: Further Logisim development is suspended indefinitely. [More information] (11 Oct 2014)

http://www.cburch.com/logisim/retire-note.html
> I am officially suspending development of Logisim. My prior employer supported work on Logisim; but the time came to move to another job. Working on Logisim is no longer compatible with my paid responsibilities.
> ...

Download version in Cask was from 21 Mar 2011.