### PR TITLE
pycharm-ce-with-anaconda-plugin: discontinue as JetBrains stopped building since 2020.3.3

### DIFF
--- a/Casks/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/pycharm-ce-with-anaconda-plugin.rb
@@ -32,4 +32,8 @@ cask "pycharm-ce-with-anaconda-plugin" do
     "~/Library/Preferences/PyCharmCE#{version.major_minor}",
     "~/Library/Saved Application State/com.jetbrains.pycharm.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/pycharm-ce-with-anaconda-plugin.rb
@@ -3,11 +3,14 @@ cask "pycharm-ce-with-anaconda-plugin" do
   sha256 "978819647422f10a58761f9fc93f2a302f497da3e966c8a6b9e4a113558daf32"
 
   url "https://download.jetbrains.com/python/pycharm-community-anaconda-#{version.before_comma}.dmg"
-  appcast "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release"
   name "Jetbrains PyCharm Community Edition with Anaconda plugin"
   name "PyCharm CE with Anaconda plugin"
   desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
+
+  livecheck do
+    skip "Discontinued"
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

As seen on https://www.jetbrains.com/pycharm/download/other.html, the last build for **macOS with Anaconda plugin (dmg)** was version 2020.3.2.

Further details on discontinued builds from JetBrains at https://youtrack.jetbrains.com/issue/PY-46717#focus=Comments-27-4659512.0-0 (emphasis mine):
> `Pavel Karateev` commented 30 Jan 2021 13:45
> Hi `@David Potts` We have **stopped building PyCharm for Anaconda since 2020.3.3**. Please use pure Community / Professional Edition. The differences are minimal so you should not notice any burdens.
>
> ...
> 
> `Pavel Karateev` commented 8 Feb 2021 12:12
> Hi `@Jeroen L`, valid point indeed. I am sorry for the bad updating experience. We were somewhat **"rushing" to drop Anaconda Edition** and didn't prepare it thoroughly. We will take a look on how this can be handled gracefully.