### PR TITLE
vienna: Move URL from Bintray to GitHub Releases

### DIFF
--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -19,9 +19,12 @@ cask "vienna" do
 
   zap trash: [
     "~/Library/Application Support/Vienna",
+    "~/Library/Application Scripts/uk.co.opencommunity.vienna2",
     "~/Library/Caches/uk.co.opencommunity.vienna2",
     "~/Library/Cookies/uk.co.opencommunity.vienna2.binarycookies",
+    "~/Library/HTTPStorages/uk.co.opencommunity.vienna2.binarycookies",
     "~/Library/Preferences/uk.co.opencommunity.vienna2.plist",
     "~/Library/Saved Application State/uk.co.opencommunity.vienna2.savedState",
+    "~/Library/Scripts/Vienna",
   ]
 end

--- a/Casks/vienna.rb
+++ b/Casks/vienna.rb
@@ -2,8 +2,8 @@ cask "vienna" do
   version "3.7.1,7437"
   sha256 "3b6879e55ccc95ba965e6868084f5f3dd1d8d937f20f7c95730f1b8aedc2ba9a"
 
-  url "https://dl.bintray.com/viennarss/vienna-rss/Vienna#{version.before_comma}.tar.gz",
-      verified: "bintray.com/viennarss/"
+  url "https://github.com/ViennaRSS/vienna-rss/releases/download/v%2F#{version.before_comma}/Vienna#{version.before_comma}.tar.gz",
+      verified: "github.com/ViennaRSS/vienna-rss/"
   name "Vienna"
   desc "RSS and Atom reader"
   homepage "https://www.vienna-rss.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.
---
- Updates the Bintray download URL to GitHub Releases (per Sparkle appcast).
- Adds a few more locations to the zap stanza.
