### PR TITLE
Update qt-creator from 4.14.1 to 4.15.0 and add livecheck

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,12 +1,21 @@
 cask "qt-creator" do
-  version "4.14.1"
-  sha256 "7fb68dff6ed1fd3b02bd82857e9394afa240fb89d2bdfe8a672335319d9906e6"
+  version "4.14.2"
+  sha256 "1a2b1c5a85f253c78085914094e6163e6b6630bdf0b3ad1b6ad6631466c57410"
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
-  appcast "https://download.qt.io/official_releases/qtcreator/",
-          must_contain: version.major_minor
   name "Qt Creator"
+  desc "IDE for application development"
   homepage "https://www.qt.io/developers/"
+
+  livecheck do
+    url "https://download.qt.io/official_releases/qtcreator/"
+    strategy :page_match do |page|
+      page.scan(%r{href="(\d+(?:\.\d+)*)/"}i).lazy.map do |match|
+        version_page = Net::HTTP.get(URI.parse("#{url}#{match[0]}/"))
+        version_page[%r{href="(\d+(?:\.\d+)*)/"}i, 1]
+      end.reject(&:nil?).first
+    end
+  end
 
   depends_on macos: ">= :sierra"
 

--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -1,6 +1,6 @@
 cask "qt-creator" do
-  version "4.14.2"
-  sha256 "1a2b1c5a85f253c78085914094e6163e6b6630bdf0b3ad1b6ad6631466c57410"
+  version "4.15.0"
+  sha256 "94d5e2a85d68beae77d3026b562fd30fff9a928b0b7889f58d0a31121e16c7c5"
 
   url "https://download.qt.io/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg"
   name "Qt Creator"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

For `livecheck`:
- Can't use `page.match` since https://download.qt.io/official_releases/qtcreator/ shows empty upcoming release number 4.15, so need to at least go through first 2 (4.15 and 4.14) to find latest version
- Using `lazy` with selecting first non-nil to try to avoid doing 9 extra HTTP GETs. The versions are ordered with newest first.