### PR TITLE
Update studiolinkstandalone from 20.05.5 to 21.03.2 and add livecheck

### DIFF
--- a/Casks/studiolinkstandalone.rb
+++ b/Casks/studiolinkstandalone.rb
@@ -1,12 +1,27 @@
 cask "studiolinkstandalone" do
-  version "20.05.5"
-  sha256 "33cde83fb612f2d0f152cd32e788a0da15d97c3c59dc7dea273f567130eb9c0b"
+  version "21.03.2"
 
-  url "https://download.studio.link/releases/v#{version}-stable/osx/signed/studio-link-standalone-v#{version}-stable.zip",
-      verified: "download.studio.link/"
-  appcast "https://gitlab.com/studio.link/app/-/tags?format=atom"
+  if MacOS.version <= :mojave
+    sha256 "d09e0b5a27c6a2dbdf206a6f44e966ddb58a8044f2d9ce8895084d5a26a51d88"
+
+    url "https://download.studio.link/releases/v#{version}-stable/macos_x86_64/studio-link-standalone-v#{version}-stable.zip",
+        verified: "download.studio.link/"
+  else
+    sha256 "feae3f82fd88af6b670d3d6ee2ab91300e86012a8470ff0b7d56a443d6cdc4c3"
+
+    url "https://download.studio.link/releases/v#{version}-stable/macos_x86_64/signed/studio-link-standalone-v#{version}-stable.zip",
+        verified: "download.studio.link/"
+  end
+
   name "Studio Link Standalone"
+  desc "SIP application to create high quality Audio over IP (AoIP) connections"
   homepage "https://studio-link.de/"
+
+  livecheck do
+    url "https://gitlab.com/studio.link/app.git"
+    strategy :git
+    regex(/^v?(\d+(?:\.\d+)*)[._-]stable$/i)
+  end
 
   app "StudioLinkStandalone.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes
- **Description** from https://gitlab.com/studio.link/app:
   > Studio Link is a SIP application to create high quality Audio over IP (AoIP) connections.
- **Version** confirmed at https://doku.studio-link.de/standalone/installation-standalone.html
   > Neue Version: v21.03.2-stable (20.03.2021) [Changelog]
- **URLs** from https://doku.studio-link.de/standalone/installation-standalone.html
   > macOS 10.9-10.14 Standalone App 64Bit
   - https://download.studio.link/releases/v21.03.2-stable/macos_x86_64/studio-link-standalone-v21.03.2-stable.zip
   > macOS 10.15+ Catalina/Big Sur Standalone Universal (Intel/ARM64) (Notarized)
   - https://download.studio.link/releases/v21.03.2-stable/macos_x86_64/signed/studio-link-standalone-v21.03.2-stable.zip