### PR TITLE
bootchamp: discontinued and not compatible with 10.11+

### DIFF
--- a/Casks/bootchamp.rb
+++ b/Casks/bootchamp.rb
@@ -4,6 +4,7 @@ cask "bootchamp" do
 
   url "https://kainjow.com/downloads/BootChamp.zip"
   name "BootChamp"
+  desc "Menu bar app to boot into your Boot Camp Windows partition"
   homepage "https://www.kainjow.com/"
 
   livecheck do
@@ -11,5 +12,11 @@ cask "bootchamp" do
     strategy :sparkle
   end
 
+  depends_on macos: "<= :yosemite"
+
   app "BootChamp.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Officially discontinued on Nov 27, 2015.
Last functioning release 10.10 Yosemite.
Not compatible with 10.11 El Capitan onward.

---

### Resources:

https://github.com/kainjow/BootChamp
> BootChamp is not compatible with El Capitan and has been discontinued.

https://kainjow.tumblr.com/post/128933657269/bootchamp-and-el-capitan
> Since El Capitan beta 7 BootChamp no longer is functioning. When clicking “Restart into Windows” a “Bless failed” error will show with “Could not set boot device property”.
> ...
> **Update 2 (Nov 27, 2015)**: I am officially shutting down BootChamp