### PR TITLE
Update script-debugger from 7.0.12-7A112 to 7.0.13,7A125 and add livecheck

### DIFF
--- a/Casks/script-debugger.rb
+++ b/Casks/script-debugger.rb
@@ -1,12 +1,19 @@
 cask "script-debugger" do
-  version "7.0.12-7A112"
-  sha256 "3be99ccffadebf5d876cfd0dddc5f81bd4ae36c93f1913a633c0bb36fbfa41c9"
+  version "7.0.13,7A125"
+  sha256 "ff39872c7a9bc3926abb2d4f476bd6ade1db094491889b40e433726461d030c0"
 
-  url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version}.dmg",
+  url "https://s3.amazonaws.com/latenightsw.com/ScriptDebugger#{version.before_comma}-#{version.after_comma}.dmg",
       verified: "s3.amazonaws.com/latenightsw.com/"
-  appcast "https://www.latenightsw.com/versions/com.latenightsw.ScriptDebugger#{version.major}.php"
   name "Script Debugger"
+  desc "Integrated development environment focused entirely on AppleScript"
   homepage "https://latenightsw.com/"
+
+  livecheck do
+    url "https://www.latenightsw.com/versions/com.latenightsw.ScriptDebugger#{version.major}.php"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :el_capitan"
 
   app "Script Debugger.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Confirm latest version at https://latenightsw.com/sd7/download/
> Version: 7.0.13, 44MB

Min macOS shown at https://latenightsw.com/sd7/download/
> Script Debugger 7 requires Mac OS X 10.11 (El Capitan) or later.

Description based on https://latenightsw.com/
> **WHAT IS SCRIPT DEBUGGER?**
> Script Debugger is an integrated development environment focused entirely on AppleScript. This focus allows it to deliver a suite of tools that make AppleScript development amazingly productive. You can use it to write and edit code, analyze target applications, debug scripts, and more.