### PR TITLE
Adjust exist-db depends_on_java caveat for Java 8 only

### DIFF
--- a/Casks/exist-db.rb
+++ b/Casks/exist-db.rb
@@ -13,6 +13,6 @@ cask "exist-db" do
   zap trash: "~/Library/Application Support/org.exist"
 
   caveats do
-    depends_on_java ["8", "11"]
+    depends_on_java "8"
   end
 end


### PR DESCRIPTION
As [discussed](https://github.com/Homebrew/brew/pull/11290#discussion_r625205931) with @MikeMcQuaid and @vitorgalvao, this cask's previous revision to include Java `"11"` in the `depends_on_java` caveat is problematic, since the Homebrew organization does not supply this version of Java. 

This PR switches to the most appropriate and user-friendly value at the moment—`"8"`—because eXist-db has long supported Java 8, and the eXist Community [is working to confirm Java 16 compatibility](https://github.com/eXist-db/exist/pull/3840) (the version you'd get if you install the current `adoptopenjdk` cask). 

Looking ahead, when a release confirmed to be compatible with Java 16 (or the then-current stable version of Java) is released, the eXist Community will update the caveat accordingly.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.