### PR TITLE
tigervnc-viewer: migrate bintray URL to SourceForge

### DIFF
--- a/Casks/tigervnc-viewer.rb
+++ b/Casks/tigervnc-viewer.rb
@@ -8,6 +8,11 @@ cask "tigervnc-viewer" do
   desc "Multi-platform VNC client and server"
   homepage "https://tigervnc.org/"
 
+  livecheck do
+    url "https://github.com/TigerVNC/tigervnc"
+    strategy :git
+  end
+
   app "TigerVNC Viewer #{version}.app"
 
   zap trash: "~/Library/Saved Application State/com.tigervnc.tigervnc.savedState"

--- a/Casks/tigervnc-viewer.rb
+++ b/Casks/tigervnc-viewer.rb
@@ -2,8 +2,8 @@ cask "tigervnc-viewer" do
   version "1.11.0"
   sha256 "851fa20a55e7144e2fe3210aee65e977ea7df5fde3f2287014db946dbaa9a37e"
 
-  url "https://bintray.com/tigervnc/stable/download_file?file_path=TigerVNC-#{version}.dmg",
-      verified: "bintray.com/tigervnc/"
+  url "https://downloads.sourceforge.net/tigervnc/TigerVNC-#{version}.dmg",
+      verified: "downloads.sourceforge.net/tigervnc/"
   name "TigerVNC"
   desc "Multi-platform VNC client and server"
   homepage "https://tigervnc.org/"

--- a/Casks/tigervnc-viewer.rb
+++ b/Casks/tigervnc-viewer.rb
@@ -8,11 +8,6 @@ cask "tigervnc-viewer" do
   desc "Multi-platform VNC client and server"
   homepage "https://tigervnc.org/"
 
-  livecheck do
-    url "https://github.com/TigerVNC/tigervnc"
-    strategy :git
-  end
-
   app "TigerVNC Viewer #{version}.app"
 
   zap trash: "~/Library/Saved Application State/com.tigervnc.tigervnc.savedState"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://github.com/TigerVNC/tigervnc/releases/tag/v1.11.0
> Binaries are available from SourceForge:
> https://sourceforge.net/projects/tigervnc/files/stable/1.11.0/