### PR TITLE
sonic-visualiser: change URL as bintray is no longer available

### DIFF
--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -1,13 +1,20 @@
 cask "sonic-visualiser" do
-  version "4.3"
+  version "4.3,2788"
   sha256 "eafd46decd7c00680ba95c2246fd34a9da64a280479bb3077d4487d656a6cdc2"
 
-  url "https://bintray.com/sonic-visualiser/sonic-visualiser/download_file?file_path=Sonic+Visualiser-#{version}.dmg",
-      verified: "bintray.com/sonic-visualiser/"
-  appcast "https://code.soundsoftware.ac.uk/projects/sonic-visualiser/repository/raw/CHANGELOG"
+  url "https://code.soundsoftware.ac.uk/attachments/download/#{version.after_comma}/Sonic%20Visualiser-#{version.before_comma}.dmg",
+      verified: "code.soundsoftware.ac.uk/"
   name "Sonic Visualiser"
   desc "Visualisation, analysis, and annotation of music audio recordings"
   homepage "https://www.sonicvisualiser.org/"
+
+  livecheck do
+    url "https://www.sonicvisualiser.org/download.html"
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/(\d+)/Sonic%20Visualiser-(\d+(?:\.\d+)*)\.dmg}i)
+      "#{match[2]},#{match[1]}"
+    end
+  end
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Bintray mirror no longer available.
Switch back to previous download URL: https://github.com/Homebrew/homebrew-cask/commit/0e83ede11ec742ca3c78a709ba17d8ed27da0936#diff-b6a53a90557568f1a7b93c7c4acc63f698857175edd0999d47f633fdbefffc3c

---

**Note:** Experiencing some SSL issues on personal system for download URL, so may happen to others.
Since Cask is currently broken right now and there is no other mirror, going ahead with migration PR as URL was previously working.