### PR TITLE
Update shotcut from 21.03.21 to 21.05.01 and add ARM DMG

### DIFF
--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -1,9 +1,18 @@
 cask "shotcut" do
-  version "21.03.21"
-  sha256 "c1321fb078a1edcb0412167dc989f0feb05130c591a66a84ebb4ff972e2f8e04"
+  version "21.05.01"
 
-  url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg",
-      verified: "github.com/mltframework/shotcut/"
+  if Hardware::CPU.intel?
+    sha256 "f58990467a4879de43a7c0a35c07c5aec07a8f7d0e5bdfc60a48338edaee4134"
+
+    url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-signed-#{version.no_dots}.dmg",
+        verified: "github.com/mltframework/shotcut/"
+  else
+    sha256 "261852a754ebd640bd35cff65958b4b4c038f54ed4277b85e82083bc872dc646"
+
+    url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-ARM64-#{version.no_dots}.dmg",
+        verified: "github.com/mltframework/shotcut/"
+  end
+
   name "Shotcut"
   desc "Video editor"
   homepage "https://www.shotcut.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Confirmed latest version from https://www.shotcut.org/download/

ARM build added. There is a missing feature based on https://github.com/mltframework/shotcut/releases/v21.05.01
> This build does not support JACK Audio.

Not sure if this is important or not for users.