### PR TITLE
Update lidarr from 0.7.2.1878 to 0.8.1.2135

### DIFF
--- a/Casks/lidarr.rb
+++ b/Casks/lidarr.rb
@@ -1,8 +1,8 @@
 cask "lidarr" do
-  version "0.7.2.1878"
-  sha256 "088c57c8c15b3fd5dd14e7aa4399b1497fc5cff53217b5705e339e7608e5555f"
+  version "0.8.1.2135"
+  sha256 "cb11dffaf2b4aa800adfb3540e10ea7723b3f5cc379cf2f4486a2836712f1991"
 
-  url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.master.#{version}.osx-app.zip",
+  url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.master.#{version}.osx-app-core-x64.zip",
       verified: "github.com/lidarr/Lidarr/"
   name "Lidarr"
   desc "Looks and smells like Sonarr but made for music"
@@ -12,6 +12,8 @@ cask "lidarr" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "Lidarr.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://lidarr.audio/#downloads-v1-macos
> Lidarr v0.8+ is not compatible with OSX versions < 10.13 due to netcore compatability.

