### PR TITLE
Update operator from 0.9.24 to 0.9.25 and use versioned URL

### DIFF
--- a/Casks/operator.rb
+++ b/Casks/operator.rb
@@ -1,8 +1,9 @@
 cask "operator" do
-  version "0.9.24"
-  sha256 :no_check
+  version "0.9.25"
+  sha256 "86452ae423c4b2b3c1ef74fb10fcb81a409c84beaae91ee09121b1a50493901f"
 
-  url "https://download.prelude.org/latest?platform=darwin&variant=zip"
+  url "https://s3.amazonaws.com/operator.versions/release-builds/#{version}/Operator-#{version}-mac.zip",
+      verified: "s3.amazonaws.com/operator.versions/"
   name "Operator"
   desc "Prelude Operator is a desktop adversary emulation platform"
   homepage "https://www.prelude.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Use versioned URL from `location` redirect of previous URL
```console
❯ curl -v "https://download.prelude.org/latest?platform=darwin&variant=zip" 2>&1 | grep location
< location: https://s3.amazonaws.com/operator.versions/release-builds/0.9.25/Operator-0.9.25-mac.zip
```