### PR TITLE
Update fing from 2.5.1 to 2.6.0 and add versioned URL

### DIFF
--- a/Casks/fing.rb
+++ b/Casks/fing.rb
@@ -1,8 +1,8 @@
 cask "fing" do
-  version "2.5.1"
-  sha256 :no_check
+  version "2.6.0"
+  sha256 "b380a04b226a1ae2740a6476406fc1877e5ca93b5872a2c2ac9400e92b4fffad"
 
-  url "https://get.fing.com/fing-desktop-releases/mac/Fing.dmg"
+  url "https://get.fing.com/fing-desktop-releases/mac/Fing-#{version}.dmg"
   name "Fing Desktop"
   desc "Network scanner"
   homepage "https://www.fing.com/products/fing-desktop"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Versioned URL from `livecheck` appcast https://get.fing.com/fing-desktop-releases/mac/latest-mac.yml:
```yml
version: 2.6.0
files:
  - url: Fing-2.6.0.zip
    sha512: EDNykdcAGhpXZP4QBEK1LqROBQPq01PBTf9x07tMMxwXIKGBj2adoZJ32OAolSINvG/ETEaqPMmpCTYxELKWiQ==
    size: 116230549
    blockMapSize: 120965
  - url: Fing-2.6.0.dmg
    sha512: 45wW7BTTtdArdQlKhkvN1zsHoZFBpL5fqSbeSLFfMvmeU3JoX6Rqu5uZnas5jVwsgctKrrfMrRfbEBmC6DcoPA==
    size: 122457081
path: Fing-2.6.0.zip
sha512: EDNykdcAGhpXZP4QBEK1LqROBQPq01PBTf9x07tMMxwXIKGBj2adoZJ32OAolSINvG/ETEaqPMmpCTYxELKWiQ==
releaseDate: '2021-04-26T08:09:36.145Z'
```

Versioned DMG are available is in same path as YAML file.