### PR TITLE
Fix Autodesk Sketchbook 8.7.1 url

### DIFF
--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -11,7 +11,7 @@ cask "sketchbook" do
   livecheck do
     url "https://www.autodesk.com/products/sketchbook/free-download"
     strategy :page_match do |page|
-      match = page.match(%r{sketchbook_(\d+)/sketchbook_v?(\d+(?:\.\d+)*)_mac\.dmg}/i)
+      match = page.match(%r{sketchbook_(\d+)/sketchbook_v?(\d+(?:\.\d+)*)_mac\.dmg}i)
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -1,18 +1,14 @@
 cask "sketchbook" do
-  version "8.7.1"
+  version "8.7.1,2019"
   sha256 "a96042dc95483cd6fac849a9f60a22980204ee4ee0a26b0804b0aa6ab23b842a"
 
-  url "https://update.sketchbook.com/mac/SketchBook_v#{version}_mac.dmg"
+  url "https://download.autodesk.com/us/support/files/sketchbook/sketchbook_#{version.after_comma}/sketchbook_v#{version.before_comma}_mac.dmg",
+      verified: "https://download.autodesk.com/us/support/files/sketchbook"
   name "Autodesk Sketchbook"
   desc "Draw, paint, & sketch application"
   homepage "https://www.sketchbook.com/"
 
-  livecheck do
-    url "https://update.sketchbook.com/mac/latest"
-    strategy :header_match
-  end
-
-  pkg "SketchBook_v#{version}_mac.pkg"
+  pkg "SketchBook_v#{version.before_comma}_mac.pkg"
 
   uninstall quit:    "com.autodesk.SketchBook",
             pkgutil: ".*SketchBook.*"

--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -8,6 +8,14 @@ cask "sketchbook" do
   desc "Draw, paint, & sketch application"
   homepage "https://www.sketchbook.com/"
 
+  livecheck do
+    url "https://www.autodesk.com/products/sketchbook/free-download"
+    strategy :page_match do |page|
+      match = page.match(%r{sketchbook_(\d+)/sketchbook_v?(\d+(?:\.\d+)*)_mac\.dmg}/i)
+      "#{match[2]},#{match[1]}"
+    end
+  end
+
   pkg "SketchBook_v#{version.before_comma}_mac.pkg"
 
   uninstall quit:    "com.autodesk.SketchBook",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Note I have removed the liveckeck stanzas because there's no more `https://update.sketchbook.com/mac/latest`. I'm not sure it's possible from this page : https://www.autodesk.com/products/sketchbook/free-download

It follows suggestions from https://github.com/Homebrew/homebrew-cask/issues/104962
