### PR TITLE
Update virtualhereserver from 4.2.9 to 4.3.0

### DIFF
--- a/Casks/virtualhereserver.rb
+++ b/Casks/virtualhereserver.rb
@@ -1,21 +1,23 @@
 cask "virtualhereserver" do
-  version "4.2.9"
+  version "4.3.0"
   sha256 :no_check
 
-  if Hardware::CPU.intel?
+  if MacOS.version <= :mojave
     url "https://www.virtualhere.com/sites/default/files/usbserver/VirtualHereServer.dmg"
+
+    app "VirtualHereServer.app"
   else
-    url "https://www.virtualhere.com/sites/default/files/usbserver/VirtualHereServerSilicon.dmg"
+    url "https://www.virtualhere.com/sites/default/files/usbserver/VirtualHereServerUniversal.dmg"
+
+    app "VirtualHereServerUniversal.app"
   end
 
   name "VirtualHereServer"
+  desc "Remotely access your connected USB devices over the network"
   homepage "https://www.virtualhere.com/osx_server_software"
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Version\s*(\d+(?:\.\d*)*)/i)
   end
-
-  app "VirtualHereServer.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://www.virtualhere.com/osx_server_software
> Download VirtualHereServer.dmg for Intel Macs to 10.14
> OR VirtualHereServerUniversal.dmg for Silicon or Intel Macs 10.15+ (including Big Sur) (audio/webcams/bluetooth usb devices cant be accessed due to Apple restrictions)