### PR TITLE
Update devbook from 0.1.16 to 0.1.18 and add ARM DMG

### DIFF
--- a/Casks/devbook.rb
+++ b/Casks/devbook.rb
@@ -1,6 +1,17 @@
 cask "devbook" do
-  version "0.1.16"
-  sha256 :no_check
+  version "0.1.18"
+
+  if Hardware::CPU.intel?
+    sha256 "1294edfd9ecd586ffb0d1d2cf0247dde8b274b128e7c22c773c8645c8cd8e233"
+
+    url "https://download.todesktop.com/2102273jsy18baz/Devbook%20#{version}.dmg",
+        verified: "download.todesktop.com/"
+  else
+    sha256 "a1e7a0f821bf30dc9bd3b6dd07da8c28af51b415faafb80cc96f4eaed06d37e5"
+
+    url "https://download.todesktop.com/2102273jsy18baz/Devbook%20#{version}-arm64.dmg",
+        verified: "download.todesktop.com/"
+  end
 
   name "Devbook"
   desc "Search engine for developers"
@@ -9,12 +20,6 @@ cask "devbook" do
   livecheck do
     url "https://download.todesktop.com/2102273jsy18baz/latest-mac.yml"
     strategy :electron_builder
-  end
-
-  if Hardware::CPU.intel?
-    url "https://download.usedevbook.com/mac/dmg/x64"
-  else
-    url "https://download.usedevbook.com/mac/dmg/arm64"
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Versioned URLs from `livecheck` URL: https://download.todesktop.com/2102273jsy18baz/latest-mac.yml
```yml
  - url: Devbook 0.1.18.dmg
    ...
  - url: Devbook 0.1.18-arm64.dmg
```

Also available of webpage: https://usedevbook.com/download?os=macos
- Intel Macs
   - URL: https://dl.todesktop.com/2102273jsy18baz/mac/dmg/x64
   - Redirect: https://download.todesktop.com/2102273jsy18baz/Devbook%200.1.18.dmg
- Apple Silicon
   - URL: https://dl.todesktop.com/2102273jsy18baz/mac/dmg/arm64
   - Redirect: https://download.todesktop.com/2102273jsy18baz/Devbook%200.1.18-arm64.dmg
