### PR TITLE
Update xmplify from 1.9.8 to 1.9.9

### DIFF
--- a/Casks/xmplify.rb
+++ b/Casks/xmplify.rb
@@ -1,15 +1,23 @@
 cask "xmplify" do
-  version "1.9.8"
-  sha256 "b742d5f039e119758ea2548a59a17aac5cb329c2102f835ca67e90e738f2cb7e"
+  if MacOS.version <= :mojave
+    version "1.9.8"
+    sha256 "b742d5f039e119758ea2548a59a17aac5cb329c2102f835ca67e90e738f2cb7e"
+  else
+    version "1.9.9"
+    sha256 "bab6ccb1fb1e727d4415a7b5b004e45091dc87add4377f2a524190ddf22cbfdf"
+  end
 
   url "http://xmplifyapp.com/releases/Xmplify-#{version}.dmg"
   name "Xmplify"
+  desc "XML editor"
   homepage "http://xmplifyapp.com/"
 
   livecheck do
     url "http://xmplifyapp.com/appcast.xml"
     strategy :sparkle
   end
+
+  depends_on macos: ">= :sierra"
 
   app "Xmplify.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

From http://xmplifyapp.com/download.html

Minimum macOS:
> requires macOS 10.12 Sierra or above

Download the Universal Release of MOSO Xmplify:
- Unversioned URL = http://xmplifyapp.com/releases/Xmplify.dmg 
  - SHA256`bab6ccb1fb1e727d4415a7b5b004e45091dc87add4377f2a524190ddf22cbfdf`
- New v1.9.9 URL = http://xmplifyapp.com/releases/Xmplify-1.9.9.dmg
  - SHA256 `bab6ccb1fb1e727d4415a7b5b004e45091dc87add4377f2a524190ddf22cbfdf`

Download the Universal Release of MOSO Xmplify:
- Unversioned URL = http://xmplifyapp.com/releases/Xmplify.Pre-Catalina.dmg
   - SHA256 `b742d5f039e119758ea2548a59a17aac5cb329c2102f835ca67e90e738f2cb7e`
- Prev v1.9.8 URL = http://xmplifyapp.com/releases/Xmplify-1.9.8.dmg
   - SHA256 `b742d5f039e119758ea2548a59a17aac5cb329c2102f835ca67e90e738f2cb7e`