### PR TITLE
Update feishu from 3.46.9,061e09 to 3.47.7,c99117 and fix URL/livecheck

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,8 +1,8 @@
 cask "feishu" do
-  version "3.46.9,061e09"
-  sha256 "c49a282d163f1ff7453819537551ef82cffca69c19bcefb41936a0524168b19a"
+  version "3.47.7,c99117"
+  sha256 "eb5e52ae3b421f74a121ac5191da76b7b101e894191bba527e00b829c8523553"
 
-  url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.after_comma}/feishu-mac-#{version.before_comma}.dmg",
+  url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.after_comma}/Feishu-darwin_x64-#{version.before_comma}-signed.dmg",
       verified: "sf3-cn.feishucdn.com/"
   name "feishu"
   desc "Project management software"
@@ -11,7 +11,7 @@ cask "feishu" do
   livecheck do
     url "https://www.feishu.cn/api/downloads"
     strategy :page_match do |page|
-      match = page.match(%r{sf3-cn\.feishucdn\.com/obj/ee-appcenter/(\w+)/feishu-mac-(\d+(?:\.\d+)*)\.dmg}i)
+      match = page.match(%r{/(\h+)/Feishu-darwin_x64-(\d+(?:\.\d+)*)-signed\.dmg}i)
       "#{match[2]},#{match[1]}"
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Livecheck issue due to new download URL format
```console
❯ brew livecheck --cask feishu
Error: feishu: undefined method `[]' for nil:NilClass
```