### PR TITLE
Update maciasl from 1.6.0 to 1.6.1

### DIFF
--- a/Casks/maciasl.rb
+++ b/Casks/maciasl.rb
@@ -4,6 +4,7 @@ cask "maciasl" do
 
   url "https://github.com/acidanthera/MaciASL/releases/download/#{version}/MaciASL-#{version}-RELEASE.dmg"
   name "MaciASL"
+  desc "ACPI Machine Language (AML) compiler and IDE"
   homepage "https://github.com/acidanthera/MaciASL"
 
   app "MaciASL.app"

--- a/Casks/maciasl.rb
+++ b/Casks/maciasl.rb
@@ -1,8 +1,8 @@
 cask "maciasl" do
-  version "1.6.0"
-  sha256 "afaf1ecfb8aab59172829e34a0f82cd5f32eb92203043b65e540412ca2368cec"
+  version "1.6.1"
+  sha256 "9ba67e2b2f66383ceea6ddf57d9408150e70a4cff58fa9c5806c80772370fdc8"
 
-  url "https://github.com/acidanthera/MaciASL/releases/download/#{version}/MaciASL-#{version}-RELEASE.zip"
+  url "https://github.com/acidanthera/MaciASL/releases/download/#{version}/MaciASL-#{version}-RELEASE.dmg"
   name "MaciASL"
   homepage "https://github.com/acidanthera/MaciASL"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.