### PR TITLE
feat(framer): add new desktop app url

### DIFF
--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,14 +1,10 @@
 cask "framer" do
   version "2021.16.5"
+  sha256 :no_check
   
   if Hardware::CPU.intel?
-    sha256 "008279eca248e6c7cad163223b1e7df2de330e62b918216f15aba469cd09d6da"
-
     url "https://updates.framer.com/electron/darwin/x64/Framer.zip"
-    end
   else
-    sha256 "296efac5623ce68a5832b9be20a6483ee2c7d9692778f403c69d489c75042f53"
-
     url "https://updates.framer.com/electron/darwin/arm64/Framer.zip"
   end
 

--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,8 +1,17 @@
 cask "framer" do
-  version "63096,1616509244"
-  sha256 "010dac8f36fa842171832d863c69d898445b700623a65b7425b484971ea242d9"
+  version "2021.16.5"
+  
+  if Hardware::CPU.intel?
+    sha256 "008279eca248e6c7cad163223b1e7df2de330e62b918216f15aba469cd09d6da"
 
-  url "https://dl.framer.com/com.framer.desktop/#{version.before_comma}/#{version.after_comma}/FramerDesktop-#{version.before_comma}.zip"
+    url "https://updates.framer.com/electron/darwin/x64/Framer.zip"
+    end
+  else
+    sha256 "296efac5623ce68a5832b9be20a6483ee2c7d9692778f403c69d489c75042f53"
+
+    url "https://updates.framer.com/electron/darwin/arm64/Framer.zip"
+  end
+
   name "Framer"
   desc "Tool that helps teams design every part of the product experience"
   homepage "https://www.framer.com/desktop/"

--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -1,7 +1,7 @@
 cask "framer" do
   version "2021.16.5"
   sha256 :no_check
-  
+
   if Hardware::CPU.intel?
     url "https://updates.framer.com/electron/darwin/x64/Framer.zip"
   else

--- a/Casks/framer.rb
+++ b/Casks/framer.rb
@@ -13,10 +13,8 @@ cask "framer" do
   homepage "https://www.framer.com/desktop/"
 
   livecheck do
-    url "https://updates.framer.com/sparkle/com.framer.desktop"
-    strategy :sparkle do |item|
-      "#{item.version},#{item.url[%r{/(\d+)/FramerDesktop-\d+.zip}i, 1]}"
-    end
+    url :url
+    strategy :extract_plist
   end
 
   auto_updates true


### PR DESCRIPTION
See [here](https://www.framer.com/support/using-framer/windows-mac/) for more info.

Also would be nice remove deprecated **Framer X** as they do not support it

**NOTE**: I do not know where is URL of **livecheck** of new Framer Desktop app, if could knew, i would be add

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
