### PR TITLE
chocolat: fix livecheck due to bad pubDate in sparkle

### DIFF
--- a/Casks/chocolat.rb
+++ b/Casks/chocolat.rb
@@ -8,8 +8,8 @@ cask "chocolat" do
   homepage "https://chocolatapp.com/"
 
   livecheck do
-    url "https://chocolatapp.com/userspace/appcast/appcast_alpha.php"
-    strategy :sparkle
+    url "https://chocolatapp.com/download/"
+    strategy :header_match
   end
 
   app "Chocolat.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` was broken due to Sparkle RSS using empty dates like: `<pubDate></pubDate>`.
Error from `brew livecheck`:
```console
❯ arch -x86_64 brew livecheck --debug --cask chocolat
git config --get homebrew.devcmdrun

Cask:             chocolat
Livecheckable?:   Yes

URL:              https://chocolatapp.com/userspace/appcast/appcast_alpha.php
Strategy:         Sparkle
Error: chocolat: no time information in ""
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/time.rb:194:in `make_time'
```