### PR TITLE
dashcam-viewer: fix livecheck

### DIFF
--- a/Casks/dashcam-viewer.rb
+++ b/Casks/dashcam-viewer.rb
@@ -6,11 +6,11 @@ cask "dashcam-viewer" do
       verified: "filedn.com/l2s8TAtm4VASBX72ds0zYD8/dcv/"
   name "Dashcam Viewer"
   name "Dashcam Viewer by Earthshine Software"
+  desc "View videos, GPS data, and G-force data recorded by dashcams and action cams"
   homepage "https://dashcamviewer.com/"
 
   livecheck do
-    url "https://dashcamviewer.com/"
-    strategy :page_match
+    url "https://dashcamviewer.com/free-trial/"
     regex(%r{href=.*?/Dashcam_Viewer_v?(\d+(?:\.\d+)*)\.dmg}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` wasn't working probably due to change in website HTML.
Switched to using trial page: https://dashcamviewer.com/free-trial/
Also removed unnecessary `strategy` as `:page_match` is default for URL.
```console
❯ brew livecheck --debug --cask dashcam-viewer
git config --get homebrew.devcmdrun

Cask:             dashcam-viewer
Livecheckable?:   Yes

URL:              https://dashcamviewer.com/
Strategy:         PageMatch
Regex:            /href=.*?\/Dashcam_Viewer_v?(\d+(?:\.\d+)*)\.dmg/i
Error: dashcam-viewer: Unable to get versions
```