### PR TITLE
Update file-juicer from 4.93 to 4.94

### DIFF
--- a/Casks/file-juicer.rb
+++ b/Casks/file-juicer.rb
@@ -1,5 +1,5 @@
 cask "file-juicer" do
-  version "4.93"
+  version "4.94"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://echoone.com/filejuicer/FileJuicer-#{version}.zip"
@@ -11,6 +11,8 @@ cask "file-juicer" do
     url "https://echoone.com/filejuicer/latestversion"
     strategy :header_match
   end
+
+  depends_on macos: ">= :el_capitan"
 
   app "File Juicer.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Minimum macOS from https://echoone.com/filejuicer/:

> Requirements
> Mac OS 10.11 See the read me for previous versions.