### PR TITLE
Update lightworks from 2021.1,126716 to 2021.2.1,128456

### DIFF
--- a/Casks/lightworks.rb
+++ b/Casks/lightworks.rb
@@ -1,8 +1,8 @@
 cask "lightworks" do
-  version "2021.1,126716"
-  sha256 "cde6525e031e84a241f3721284fc64b1f6425b17360395127717f7640271e4b6"
+  version "2021.2.1,128456"
+  sha256 "cb772b20bbbdc1234c2d1bcfc499dff61b19f5c7169099c1bb8f0834b19c353b"
 
-  url "https://cdn.lwks.com/releases/#{version.before_comma}/lightworks_#{version.before_comma}_r#{version.after_comma}.dmg"
+  url "https://cdn.lwks.com/releases/#{version.before_comma}/lightworks_#{version.before_comma.major_minor}_r#{version.after_comma}.dmg"
   name "Lightworks"
   desc "Complete video creation package"
   homepage "https://www.lwks.com/"
@@ -10,7 +10,7 @@ cask "lightworks" do
   livecheck do
     url "https://www.lwks.com/index.php?option=com_docman&task=doc_download&gid=210"
     strategy :header_match do |headers|
-      match = headers["location"].match(/lightworks_(\d+(?:\.\d+)*)_r(\d+)\.dmg/i)
+      match = headers["location"].match(%r{/(\d+(?:\.\d+)*)/lightworks_\d+(?:\.\d+)*_r(\d+)\.dmg}i)
       "#{match[1]},#{match[2]}"
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Needed to change `livecheck`/`version` format due to patch behavior.

Previous livecheck-constructed url: https://cdn.lwks.com/releases/2021.2/lightworks_2021.2_r128456.dmg

New livecheck-constructed url: https://cdn.lwks.com/releases/2021.2.1/lightworks_2021.2_r128456.dmg