### PR TITLE
Update macgamestore from 4.3.0,6080 to 4.3.1,6081

### DIFF
--- a/Casks/macgamestore.rb
+++ b/Casks/macgamestore.rb
@@ -1,9 +1,10 @@
 cask "macgamestore" do
-  version "4.3.0,6080"
-  sha256 "be51e1caa0a60a5efad126cab62f50a1913eb8103d3e63c91303aebf4cbd9598"
+  version "4.3.1,6081"
+  sha256 "ba659f4a537148e87c7b9a1241bf00d015bffc37709040550cd5d7ce71cd0430"
 
   url "https://www.macgamestore.com/api_clientapp/clientupdates/public/core6/MacGameStore_#{version.before_comma}_#{version.after_comma}.tgz"
   name "MacGameStore"
+  desc "Buy, download, and play your games"
   homepage "https://www.macgamestore.com/app/"
 
   livecheck do
@@ -13,6 +14,8 @@ cask "macgamestore" do
       "#{match[1]},#{match[2]}"
     end
   end
+
+  depends_on macos: ">= :sierra"
 
   app "MacGameStore.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

```xml
<title>MacGameStore App 4.3.1</title>
<sparkle:releaseNotesLink>https://www.macgamestore.com/api_clientapp/clientupdates/public/notes-basic.html</sparkle:releaseNotesLink>
<sparkle:minimumSystemVersion>10.12.0</sparkle:minimumSystemVersion>
```