### PR TITLE
Update unity-appletv-support-for-editor from 2020.1.16f1 to 2021.1.6f1

### DIFF
--- a/Casks/unity-appletv-support-for-editor.rb
+++ b/Casks/unity-appletv-support-for-editor.rb
@@ -1,13 +1,24 @@
 cask "unity-appletv-support-for-editor" do
-  version "2020.1.16f1,f483ad6465d6"
-  sha256 "e5004e0dda371aa52959bc704d7762cb016d9c1b0f7f8e9f54fe897ec5440ac6"
+  version "2021.1.6f1,c0fade0cc7e9"
+  sha256 "c2b86c911c09b2203d9c4062ced1b50b6b74fb48bdecaf4612d55f4bb0f45826"
 
   url "https://download.unity3d.com/download_unity/#{version.after_comma}/MacEditorTargetInstaller/UnitySetup-AppleTV-Support-for-Editor-#{version.before_comma}.pkg",
       verified: "download.unity3d.com/download_unity/"
-  appcast "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
   name "Unity AppleTV Build Support"
   desc "AppleTV target support for Unity"
   homepage "https://unity.com/products"
+
+  livecheck do
+    url "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
+    strategy :page_match do |page|
+      page.scan(%r{
+        /download_unity/(\h+)/MacEditorTargetInstaller
+        /UnitySetup-AppleTV-Support-for-Editor-(\d+(?:\.\d+)*[a-z]*\d*)\.pkg
+      }ix).map do |match|
+        "#{match[1]},#{match[0]}"
+      end
+    end
+  end
 
   depends_on cask: "unity"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
