### PR TITLE
obs: restrict livecheck to avoid pre-releases and non-macOS hotfixes

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -8,8 +8,8 @@ cask "obs" do
   homepage "https://obsproject.com/"
 
   livecheck do
-    url "https://github.com/obsproject/obs-studio"
-    strategy :git
+    url :homepage
+    regex(%r{href=.*?/obs-mac-(\d+(?:\.\d+)*)\.dmg}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` picking up pre-release:
```console
❯ brew livecheck obs
obs : 26.1.2 ==> 27.0.0-rc3
```

Based on some releases in https://github.com/obsproject/obs-studio/releases, sometimes `latest` release is a hotfix for only specific platforms.

So using `:homepage` for macOS latest version.