### PR TITLE
mullvadvpn: fix livecheck

### DIFF
--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -9,11 +9,12 @@ cask "mullvadvpn" do
   homepage "https://mullvad.net/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://mullvad.net/download/app/pkg/latest/"
+    strategy :header_match
   end
 
   conflicts_with cask: "homebrew/cask-versions/mullvadvpn-beta"
+  depends_on macos: ">= :high_sierra"
 
   pkg "MullvadVPN-#{version}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` failure:
```console
❯ brew livecheck --debug --cask mullvadvpn
git config --get homebrew.devcmdrun

Cask:             mullvadvpn
Livecheckable?:   Yes

URL (url):        https://github.com/mullvad/mullvadvpn-app/releases/download/2021.3/MullvadVPN-2021.3.pkg
Strategy:         GithubLatest
URL (strategy):   https://github.com/mullvad/mullvadvpn-app/releases/latest
URL (final):      https://github.com/mullvad/mullvadvpn-app/releases/tag/android/2021.1
Regex (strategy): /href=.*?\/tag\/v?(\d+(?:\.\d+)+)["' >]/i
Error: mullvadvpn: Unable to get versions
```

The issue is the current GitHub latest is Android release https://github.com/mullvad/mullvadvpn-app/releases/tag/android%2F2021.1

Switched to `:header_match` identified by:
- Homepage general download page: https://mullvad.net/en/download/macos/, contains the...
- **MacOS specific latest download URL: https://mullvad.net/download/app/pkg/latest/**
- Redirects to https://mullvad.net/en/download/app/pkg/latest/ then https://mullvad.net/media/app/MullvadVPN-2021.3.pkg

Minimum macOS from download page:
> Works on macOS High Sierra (10.13) or later (64 bit only)

