### PR TITLE
Update qdslrdashboard from 3.5.9 to 3.6.4 and add livecheck

### DIFF
--- a/Casks/qdslrdashboard.rb
+++ b/Casks/qdslrdashboard.rb
@@ -1,12 +1,21 @@
 cask "qdslrdashboard" do
-  version "3.5.9"
-  sha256 "349e0fb9532c92120b9d89790e984fc251d14c5373bfddef4d96f0ff05af26b7"
+  version "3.6.4"
+  sha256 "29df5858f8d3c5d8e8e6ab6b220f52a391fabd619f0d444094b07e9c36fd81f2"
 
-  url "https://files.lrtimelapse.com/dslrdashboard/V#{version}/qDslrDashboard_V#{version}_macOS.dmg",
+  url "https://files.lrtimelapse.com/dslrdashboard/V#{version}/qDslrDashboard_V#{version}_macOS_x64.dmg",
       verified: "files.lrtimelapse.com/dslrdashboard/"
-  appcast "https://dslrdashboard.info/downloads/"
   name "qDslrDashboard"
+  desc "Application for controlling Nikon, Canon and Sony cameras"
   homepage "https://dslrdashboard.info/"
+
+  livecheck do
+    url "https://dslrdashboard.info/downloads/"
+    strategy :page_match do |page|
+      page[%r{href=.*?/qdslrdashboard[._-]v?(\d+(?:-\d+)*)[._-]macos}i, 1].tr("-", ".")
+    end
+  end
+
+  depends_on macos: ">= :mojave"
 
   app "qDslrDashboard.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

From https://dslrdashboard.info/downloads/:


OSX x64 (10.14 and up) | qDslrDashboard V3.6.4 macOS x64Download 48.93 MB 665 downloads
-- | --




Livecheck set to detect following on page:
`href="https://dslrdashboard.info/download/qdslrdashboard-v3-6-4-macos-x64/"`