### PR TITLE
Update atomic-wallet from 2.28.1 to 2.28.2 and try using versioned ZIP

### DIFF
--- a/Casks/atomic-wallet.rb
+++ b/Casks/atomic-wallet.rb
@@ -1,8 +1,8 @@
 cask "atomic-wallet" do
-  version "2.28.1"
-  sha256 :no_check
+  version "2.28.2"
+  sha256 "6c8f8469d6f03c30aba751cd2c379cbc1b3689990573309dc43fc9b2da29aeb5"
 
-  url "https://get.atomicwallet.io/download/atomicwallet.dmg"
+  url "https://releases.atomicwallet.io/AtomicWallet-#{version}.zip"
   name "Atomic Wallet"
   desc "Manage Bitcoin, Ethereum, XRP, Litecoin, XLM and over 300 other coins and tokens"
   homepage "https://atomicwallet.io/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Trying to switch to versioned ZIP according to electron builder appcast:
https://releases.atomicwallet.io/latest-mac.yml
```yml
version: 2.28.2
files:
  - url: AtomicWallet-2.28.2.zip
    sha512: 0YnaUJITCs0Y3FZLgcfGwjYPL1z9JVYJhYgcIypcJCxtDPFGpIH4CRZaHyT5bqnKMM2mv26VgscTJQKMoR7kBg==
    size: 74485059
    blockMapSize: 77353
  - url: AtomicWallet-2.28.2.dmg
    sha512: EJbzUUhb0M6MFM5yywp/WFeCRp+MzjCvRUxpRTYNg9GxvfHoxzkYe/cx7vqF/2tKjGyz9Bom7YwgVkhPjaJu6A==
    size: 71413186
path: AtomicWallet-2.28.2.zip
sha512: 0YnaUJITCs0Y3FZLgcfGwjYPL1z9JVYJhYgcIypcJCxtDPFGpIH4CRZaHyT5bqnKMM2mv26VgscTJQKMoR7kBg==
releaseDate: '2021-05-03T13:19:44.308Z'
```

DMG doesn't actually exist, but ZIP does.
So, trying to switch to that for better versioning/updates/security(sha).

If users experience unexpected issues, we can revert back to unversioned DMG.