### PR TITLE
Update fuwari from 0.5.1 to 0.6.0

### DIFF
--- a/Casks/fuwari.rb
+++ b/Casks/fuwari.rb
@@ -1,8 +1,8 @@
 cask "fuwari" do
-  version "0.5.1"
-  sha256 "dd72adc918e9984548a20a513bd3d4319e63ee78ca688ee75546103a16d9f3c2"
+  version "0.6.0"
+  sha256 "b9094bfb586408dec8f2860fd462f6079d94c5b3bb735b6842d88ff90217577e"
 
-  url "https://github.com/kentya6/Fuwari/releases/download/v#{version}/Fuwari.zip",
+  url "https://github.com/kentya6/Fuwari/releases/download/v#{version}/Fuwari.v#{version}.zip",
       verified: "github.com/kentya6/Fuwari/"
   name "Fuwari"
   desc "Floating screenshot like a sticky"
@@ -13,9 +13,9 @@ cask "fuwari" do
     strategy :github_latest
   end
 
-  app "Fuwari/Fuwari.app"
+  app "Fuwari v#{version}/Fuwari.app"
 
-  uninstall quit:       "com.appknop.Fuwari"
+  uninstall quit: "com.appknop.Fuwari"
 
   zap trash: [
     "~/Library/Application Support/com.appknop.Fuwari",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.


Min macOS from app store page: https://apps.apple.com/app/fuwari/id1187652334

> Compatibility
> Mac
> Requires macOS 10.12 or later.