### PR TITLE
Update hype from 4.1.5,728 to 4.1.6,734 and use versioned URL

### DIFF
--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -1,8 +1,8 @@
 cask "hype" do
-  version "4.1.5,728"
-  sha256 :no_check
+  version "4.1.6,734"
+  sha256 "2e2895a5dd6627285a2bc8c6283ae03eb162d30944ce6058f392b372f5047a79"
 
-  url "https://tumult.com/hype/download/Hype.zip"
+  url "https://tumult.com/hype/download/Hype-#{version.after_comma}.dmg"
   name "Tumult Hype"
   desc "App to create animated and interactive web content"
   homepage "https://tumult.com/hype/"
@@ -11,6 +11,8 @@ cask "hype" do
     url "https://tumult.com/hype/appcast_hype#{version.major}.xml"
     strategy :sparkle
   end
+
+  depends_on macos: ">= :yosemite"
 
   # Renamed for consistency: app name is different in the Finder and in a shell
   app "Hype#{version.major}.app", target: "Hype #{version.major}.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Versioned download URL and min macOS from https://tumult.com/hype/download/all/#show