### PR TITLE
Update trinity from 1.6.1 to 1.6.2 and mark as final version

### DIFF
--- a/Casks/trinity.rb
+++ b/Casks/trinity.rb
@@ -1,15 +1,15 @@
 cask "trinity" do
-  version "1.6.1"
-  sha256 "1f4c7b31889899472b220a5e986d183efba04e129643ca9e75405fd1e241050e"
+  version "1.6.2"
+  sha256 "c37926a9612e8a8360490b6b924b1a2922a4374377e428f24b985f45de66ad68"
 
   url "https://github.com/iotaledger/trinity-wallet/releases/download/desktop-#{version}/trinity-desktop-#{version}.dmg",
       verified: "github.com/iotaledger/trinity-wallet/"
   name "IOTA Trinity Wallet"
+  desc "Cryptocurrency wallet"
   homepage "https://trinity.iota.org/"
 
   livecheck do
     url :url
-    strategy :git
     regex(/^desktop-(\d+(?:\.\d+)*)$/i)
   end
 
@@ -24,4 +24,8 @@ cask "trinity" do
     "~/Library/Preferences/org.iota.trinity.plist",
     "~/Library/Saved Application State/org.iota.trinity.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Not familiar with Trinity, but the GitHub release says
(https://github.com/iotaledger/trinity-wallet/releases/tag/desktop-1.6.2)

> ### Changelog
> The final version of Trinity Desktop. RIP 💔
> 
> - Add deprecation warning (#_3275, #_3341)