### PR TITLE
Update retrobatch from 1.4.3,946 to 1.4.4,963 and use versioned URL

### DIFF
--- a/Casks/retrobatch.rb
+++ b/Casks/retrobatch.rb
@@ -1,9 +1,10 @@
 cask "retrobatch" do
-  version "1.4.3,946"
-  sha256 :no_check
+  version "1.4.4,963"
+  sha256 "0307da1a3ea5cda76f616433370522c01fc3c1b5b794968f98892e0e22afc872"
 
-  url "https://flyingmeat.com/download/Retrobatch.zip"
+  url "https://flyingmeat.com/download/Retrobatch-#{version.before_comma}.zip"
   name "Retrobatch"
+  desc "Batch image processor"
   homepage "https://flyingmeat.com/retrobatch/"
 
   livecheck do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Seems to be undocumented versioned download URL.
Worth trying out instead of current unversioned URL.

SHA256 matches between two:
```console
❯ curl -sLO https://flyingmeat.com/download/Retrobatch-1.4.4.zip

❯ curl -sLO https://flyingmeat.com/download/Retrobatch.zip

❯ sha256sum Retrobatch-1.4.4.zip
0307da1a3ea5cda76f616433370522c01fc3c1b5b794968f98892e0e22afc872  Retrobatch-1.4.4.zip

❯ sha256sum Retrobatch.zip
0307da1a3ea5cda76f616433370522c01fc3c1b5b794968f98892e0e22afc872  Retrobatch.zip
```