### PR TITLE
xamarin-studio: mark as discontinued

### DIFF
--- a/Casks/xamarin-studio.rb
+++ b/Casks/xamarin-studio.rb
@@ -6,9 +6,14 @@ cask "xamarin-studio" do
       verified: "dl.xamarin.com/MonoDevelop/Mac/"
   appcast "https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml"
   name "Xamarin Studio"
+  desc "IDE for mobile app development"
   homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
 
   conflicts_with cask: "xamarin"
 
   app "Xamarin Studio.app"
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/xamarin-studio.rb
+++ b/Casks/xamarin-studio.rb
@@ -4,10 +4,13 @@ cask "xamarin-studio" do
 
   url "https://dl.xamarin.com/MonoDevelop/Mac/XamarinStudio-#{version}.dmg",
       verified: "dl.xamarin.com/MonoDevelop/Mac/"
-  appcast "https://xampubdl.blob.core.windows.net/static/installer_assets/v3/Mac/Universal/InstallationManifest.xml"
   name "Xamarin Studio"
   desc "IDE for mobile app development"
   homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
+
+  livecheck do
+    skip "Discontinued"
+  end
 
   conflicts_with cask: "xamarin"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

From https://github.com/xamarin/release-notes-archive/blob/master/release-notes/studio/xamarin.studio_6.3/xamarin.studio_6.3.md
> ℹ️ Update for May 10, 2017: **Xamarin Studio 6.3 is the final release of Xamarin Studio**. We recommend that developers now use Visual Studio on both Windows and Mac. Visual Studio for Mac has all the features of Xamarin Studio, adds cloud and web development, and contains improvements for cross-platform mobile development.

I think the `visual-studio` cask is the successor to `xamarin-studio` cask.