### PR TITLE
Update engine-prime from 1.6.0 to 1.6.1,5f4b42a70b and add livecheck

### DIFF
--- a/Casks/engine-prime.rb
+++ b/Casks/engine-prime.rb
@@ -1,14 +1,22 @@
 cask "engine-prime" do
-  version "1.6.0"
-  sha256 "49927e5500f7ebef12087d8cf38f4848925eeb1d949203307b8b9833a4a53c1f"
+  version "1.6.1,5f4b42a70b"
+  sha256 "978c1fdde817f855242502a833b9a7447501fdc2ba9af0d941509561059f90b3"
 
-  url "https://cdn.inmusicbrands.com/denondj/EnginePrime/Engine_Prime_#{version}_Setup.dmg",
+  url "https://cdn.inmusicbrands.com/denondj/EnginePrime/#{version.before_comma.no_dots}/Engine_Prime_#{version.before_comma}_#{version.after_comma}_Setup.dmg",
       verified: "inmusicbrands.com/"
   name "Engine Prime"
   desc "Music Management Software for Denon's Engine OS Hardware"
   homepage "https://www.denondj.com/engineprime"
 
-  pkg "Engine Prime_#{version}_Setup.pkg"
+  livecheck do
+    url "https://www.denondj.com/downloads"
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/Engine[._-]?Prime[._-]?v?(\d+(?:\.\d+)*)(?:[._-]([0-9a-z]+))?[._-]Setup\.dmg}i)
+      "#{match[1]}#{"," + match[2] if match[2]}"
+    end
+  end
+
+  pkg "Engine Prime_#{version.before_comma}_Setup.pkg"
 
   uninstall pkgutil: "com.airmusictechnology.engineprime.application"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

A bit complicated `livecheck` to try to still function even if download filename changes back.
- Previous: `Engine_Prime_1.6.0_Setup.dmg`
- Current: `Engine_Prime_1.6.1_5f4b42a70b_Setup.dmg`

Since this is 1st time the extra characters are used in filename, the `livecheck` uses an optional regex group:
- Optional grouping with 2nd capture pattern: `(?:[._-]([0-9a-z]+))?`
- Output string only shows comma & 2nd part if it exists: `#{"," + match[2] if match[2]}`

Tested by changing `livecheck` URL to archive.org version of site (https://web.archive.org/web/20200929030833/https://www.denondj.com/downloads):
```
engine-prime : 1.6.1,5f4b42a70b ==> 1.5.1
```