### PR TITLE
flip4mac: mark as discontinued

### DIFF
--- a/Casks/flip4mac.rb
+++ b/Casks/flip4mac.rb
@@ -4,9 +4,16 @@ cask "flip4mac" do
 
   url "https://www.telestream.net/download-files/flip4mac/#{version.sub(/^(\d+)\.(\d+).*$/, '\1-\2')}/Flip4Mac-#{version}.dmg"
   name "Flip4Mac"
+  desc "Play back and convert Windows Media"
   homepage "https://www.telestream.net/flip4mac/"
+
+  depends_on macos: "<= :el_capitan"
 
   pkg "Flip4Mac.pkg"
 
   uninstall pkgutil: "net.telestream.Flip4Mac"
+
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/flip4mac.rb
+++ b/Casks/flip4mac.rb
@@ -7,6 +7,10 @@ cask "flip4mac" do
   desc "Play back and convert Windows Media"
   homepage "https://www.telestream.net/flip4mac/"
 
+  livecheck do
+    skip "Discontinued"
+  end
+
   depends_on macos: "<= :el_capitan"
 
   pkg "Flip4Mac.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://www.telestream.net/flip4mac/
> Flip4Mac sales and support have ended

http://telestream.force.com/kb/articles/Knowledge_Article/Flip4Mac-El-Capitan-Support
> Flip4Mac 3.3.8 supports Mac OS X 10.6.8 through 10.11.6, at this time we are unable to support Mac OS X 10.12 (Sierra), 10.13 (High Sierra), 10.14 (Mojave) or 10.15 (Catalina)