### PR TITLE
Upgrade bdash from 1.9.5 to 1.10.2

### DIFF
--- a/Casks/bdash.rb
+++ b/Casks/bdash.rb
@@ -1,6 +1,6 @@
 cask "bdash" do
-  version "1.9.5"
-  sha256 "b25c363f86303be096845f8aa3bec03ca24d859dfb7b716ceb7dc78f29b03db6"
+  version "1.10.2"
+  sha256 "7e90357c2e81c809003fd999d613c976bc97aa3c199f2acbe7fa6a53d4e5b26c"
 
   url "https://github.com/bdash-app/bdash/releases/download/v#{version}/Bdash-#{version}-mac.zip"
   name "Bdash"


### PR DESCRIPTION
This PR updates `bdash` from 1.9.5 to 1.10.2.
The release note is available [here](https://github.com/bdash-app/bdash/releases/tag/v1.10.2).

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md). (document link is broken. I'd like to know what should I do)
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] (*) `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.

(*) `brew audit --new-cask {{cask_file}}` succeeded with the error

```bash
> brew audit --new-cask Casks/bdash.rb
Error: Failed to load formula: Casks/bdash.rb
bdash: undefined method `cask' for Formulary::FormulaNamespaceb3ec84e2bde266412f7ad4f536a127e5:Module
Warning: Treating Casks/bdash.rb as a cask.
audit for bdash: passed
```