### PR TITLE
change url of version-latest

### DIFF
--- a/doc/faq/app_not_upgrading.md
+++ b/doc/faq/app_not_upgrading.md
@@ -17,7 +17,7 @@ There are a few ideas to fix this problem:
 
 So we let software be. Installing it with Homebrew Cask should make it behave the same as if you had installed it manually. But we also want to support software that does not auto-upgrade, so we add [`auto_updates true`](https://github.com/Homebrew/homebrew-cask/blob/62c0495b254845a481dacac6ea7c8005e27a3fb0/Casks/alfred.rb#L10) to casks of software that can do it, which excludes them from `brew upgrade`.
 
-Casks which use [`version :latest`](https://docs.brew.sh/Cask-Cookbook.md#version-latest) are also excluded, because we have no way to track the version they’re in. It helps to ask the developers of such software to provide versioned releases (i.e. have the version in the path of the download `url`).
+Casks which use [`version :latest`](https://docs.brew.sh/Cask-Cookbook#version-latest) are also excluded, because we have no way to track the version they’re in. It helps to ask the developers of such software to provide versioned releases (i.e. have the version in the path of the download `url`).
 
 If you still want to force software to be upgraded via Homebrew Cask, you can:
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

change URL of `version :latest` document in `app_not_upgrading.md`, because the link is not document page but raw markdown data.
