### PR TITLE
deluge: add livecheck

### DIFF
--- a/Casks/deluge.rb
+++ b/Casks/deluge.rb
@@ -4,10 +4,14 @@ cask "deluge" do
 
   url "https://ftp.osuosl.org/pub/deluge/mac_osx/deluge-#{version}-macosx-x64.dmg",
       verified: "ftp.osuosl.org/"
-  appcast "https://ftp.osuosl.org/pub/deluge/mac_osx/?C=M;O=D"
   name "Deluge"
   desc "BitTorrent client"
   homepage "https://deluge-torrent.org/"
+
+  livecheck do
+    url "https://ftp.osuosl.org/pub/deluge/mac_osx/?C=M;O=D"
+    regex(/href=["']?deluge[._-]v?(\d+(?:\.\d+)*)[._-][a-z0-9._-]*\.dmg/i)
+  end
 
   app "Deluge.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

```console
❯ brew livecheck --debug --verbose --cask deluge
git config --get homebrew.devcmdrun
#<Homebrew::CLI::Args named=["deluge"], remaining=["deluge"], d?=true, debug?=true, Display any debugging information.?=false, q?=false, quiet?=false, Make some output more quiet.?=false, v?=true, verbose?=true, Make some output more verbose.?=false, h?=false, help?=false, Show this message.?=false, full_name?=false, Print formulae/casks with fully_qualified names.?=false, tap=nil, Check formulae/casks within the given tap, specified as <user>`/`<repo>.=nil, all?=false, Check all available formulae/casks.?=false, installed?=false, Check formulae/casks that are currently installed.?=false, newer_only?=false, Show the latest version only if it's newer than the formula/cask.?=false, json?=false, Output information in JSON format.?=false, Suppress warnings, don't print a progress bar for JSON output.?=false, formula?=false, formulae?=false, Only check formulae.?=false, cask?=true, casks?=true, Only check casks.?=false>

Cask:             deluge
Livecheckable?:   Yes

URL:              https://ftp.osuosl.org/pub/deluge/mac_osx/?C=M;O=D
Strategies:       PageMatch
Strategy:         PageMatch
Regex:            /href=["']?deluge[._-]v?(\d+(?:\.\d+)*)[._-][a-z0-9._-]*\.dmg/i

Matched Versions:
1.3.15.1 => #<Version:0x00000001489aec20 @version="1.3.15.1", @detected_from_url=false>
1.3.14 => #<Version:0x00000001489aeb80 @version="1.3.14", @detected_from_url=false>
1.3.13 => #<Version:0x00000001489aeae0 @version="1.3.13", @detected_from_url=false>
1.3.12 => #<Version:0x00000001489aea68 @version="1.3.12", @detected_from_url=false>
deluge : 1.3.15.1 ==> 1.3.15.1
```