### PR TITLE
Update coscreen from 1.7.49 to 2.1.12 and add livecheck

### DIFF
--- a/Casks/coscreen.rb
+++ b/Casks/coscreen.rb
@@ -1,15 +1,20 @@
 cask "coscreen" do
-  version "1.7.49-beta"
-  sha256 "052d8c34ad72f30f3aab512a6b35977fb9cd181e46ab83ddac0d5d2a0e0ef316"
+  version "2.1.12"
+  sha256 "dafd0dfefa7fdbe642198da2ca539ce050b2afce23c931803db291ffad811334"
 
-  url "https://update.coscreen.org/CoScreen-#{version}.dmg",
+  url "https://update.coscreen.org/CoScreen-#{version}-beta.dmg",
       verified: "https://update.coscreen.org/"
-  appcast "https://update.coscreen.org/beta-mac.yml"
   name "CoScreen"
   desc "Collaboration tool with multi-user screen sharing"
   homepage "https://coscreen.co/"
 
+  livecheck do
+    url "https://update.coscreen.org/beta-mac.yml"
+    strategy :electron_builder
+  end
+
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   app "CoScreen.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

### Notes
1. Move `appcast` to electron-builder `livecheck`
2. Set minimum macOS based on https://www.coscreen.co/download
   > CoScreen supports macOS 10.14 (2018 and later) and Windows 10 and above. for Linux support.
3. Based on Download Page, the beta is still part of main download URL:
   > https://update.coscreen.org/CoScreen-2.1.12-beta.dmg
4. Moved `-beta` part of version to `url` to work better with default electron-builder `livecheck`