### PR TITLE
Use File instead of IO for file operations

### DIFF
--- a/Casks/j.rb
+++ b/Casks/j.rb
@@ -4,11 +4,17 @@ cask "j" do
 
   url "https://www.jsoftware.com/download/j#{version}/install/j#{version}_mac64.zip"
   name "J"
+  desc "Programming language for mathematical, statistical and logical analysis of data"
   homepage "https://www.jsoftware.com/"
 
   apps = %w[jbrk jcon jhs jqt]
   apps.each do |a|
     app "j#{version}/#{a}.app"
+  end
+
+  livecheck do
+    url "https://code.jsoftware.com/wiki/System/Installation"
+    regex(%r{href=.*?/ReleaseNotes/J(\d+(?:\.\d+)*)/?["' >]}i)
   end
 
   installer script: "j#{version}/macos-fix.command"
@@ -30,13 +36,13 @@ cask "j" do
     # Use `readlink` to get full path of symlinked commands.
     commands.each do |c|
       command = "#{staged_path}/j#{version}/bin/#{c}.command"
-      IO.write command, IO.read(command).gsub("$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")')
+      File.write command, File.read(command).gsub("$0", '$(/usr/bin/readlink "$0" || /bin/echo "$0")')
     end
 
     # Fix relative paths inside App bundles.
     apps.each do |a|
       apprun = "#{appdir}/#{a}.app/Contents/MacOS/apprun"
-      IO.write apprun, IO.read(apprun).gsub(%r{`dirname "\$0"`.*?/bin}, "#{staged_path}/j#{version}/bin")
+      File.write apprun, File.read(apprun).gsub(%r{`dirname "\$0"`.*?/bin}, "#{staged_path}/j#{version}/bin")
     end
   end
 

--- a/Casks/minecraft-server.rb
+++ b/Casks/minecraft-server.rb
@@ -4,9 +4,17 @@ cask "minecraft-server" do
 
   url "https://launcher.mojang.com/v#{version.major}/objects/#{version.after_comma}/server.jar",
       verified: "launcher.mojang.com/"
-  appcast "https://minecraft.net/en-us/download/server/"
   name "Minecraft Server"
-  homepage "https://minecraft.net/"
+  desc "Run a Minecraft multiplayer server"
+  homepage "https://www.minecraft.net/en-us/"
+
+  livecheck do
+    url "https://www.minecraft.net/en-us/download/server/"
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/objects/(\h+)/server\.jar[^>]*>minecraft[_-]server[._-]v?(\d+(?:\.\d+)*)\.jar}i)
+          .map { |match| "#{match[1]},#{match[0]}" }
+    end
+  end
 
   container type: :naked
 
@@ -19,7 +27,7 @@ cask "minecraft-server" do
   preflight do
     FileUtils.mkdir_p config_dir
 
-    IO.write shimscript, <<~EOS
+    File.write shimscript, <<~EOS
       #!/bin/sh
       cd '#{config_dir}' && \
         exec /usr/bin/java ${@:--Xms1024M -Xmx1024M} -jar '#{staged_path}/server.jar' nogui

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -4,7 +4,17 @@ cask "openzfs" do
 
   url "https://openzfsonosx.org/w/images/#{version.after_comma[0]}/#{version.after_comma}/OpenZFS_on_OS_X_#{version.before_comma}.dmg"
   name "OpenZFS on OS X"
+  desc "Open source port of OpenZFS"
   homepage "https://openzfsonosx.org/"
+
+  livecheck do
+    url "https://openzfsonosx.org/wiki/Downloads"
+    strategy :page_match do |page|
+      page.scan(%r{href=['"]?/w/images/\d/(\h+)/openzfs[_-]on[_-]os[_-]x[._-](\d+(?:\.\d+)*)\.dmg}i).map do |match|
+        "#{match[1]},#{match[0]}"
+      end
+    end
+  end
 
   # Unusual case: The software will stop working, or is dangerous to run, on the next macOS release.
   depends_on macos: [
@@ -29,15 +39,15 @@ cask "openzfs" do
 
   uninstall_preflight do
     uninstall_zfs = "#{staged_path}/Docs & Scripts/uninstall-openzfsonosx.sh"
-    IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub("$(which zpool)", "/usr/local/bin/zpool"))
-    IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub("$(which zfs)", "/usr/local/bin/zfs"))
-    IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub("zpool status", "/usr/local/bin/zpool status"))
-    IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub("zfs get name", "/usr/local/bin/zfs get name"))
-    IO.write(uninstall_zfs, IO.read(uninstall_zfs).gsub(
-                              "sudo /sbin/kextunload -b net.lundman.zfs",
-                              "sudo /bin/launchctl unload /Library/LaunchDaemons/org.openzfsonosx.zed.plist && " \
-                              "sudo /sbin/kextunload -b net.lundman.zfs",
-                            ))
+    File.write(uninstall_zfs, File.read(uninstall_zfs).gsub("$(which zpool)", "/usr/local/bin/zpool"))
+    File.write(uninstall_zfs, File.read(uninstall_zfs).gsub("$(which zfs)", "/usr/local/bin/zfs"))
+    File.write(uninstall_zfs, File.read(uninstall_zfs).gsub("zpool status", "/usr/local/bin/zpool status"))
+    File.write(uninstall_zfs, File.read(uninstall_zfs).gsub("zfs get name", "/usr/local/bin/zfs get name"))
+    File.write(uninstall_zfs, File.read(uninstall_zfs).gsub(
+                                "sudo /sbin/kextunload -b net.lundman.zfs",
+                                "sudo /bin/launchctl unload /Library/LaunchDaemons/org.openzfsonosx.zed.plist && " \
+                                "sudo /sbin/kextunload -b net.lundman.zfs",
+                              ))
   end
 
   uninstall delete:    "~/zfsuninstaller.*",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

See https://github.com/Homebrew/brew/pull/11140

Replace `IO.write` and `IO.read` with `File.write` and `File.read`, respectively, in `j`, `minecraft-server`, and `openzfs`.

Note that I was unable to test this for `openzfs` because it depends on certain macOS versions that I don't have access to (i.e. doesn't work on Big Sur).
