### PR TITLE
openineditor-lite: livecheck only 'lite' versions

### DIFF
--- a/Casks/openineditor-lite.rb
+++ b/Casks/openineditor-lite.rb
@@ -7,5 +7,10 @@ cask "openineditor-lite" do
   desc "Finder Toolbar app to open the current directory in Editor"
   homepage "https://github.com/Ji4n1ng/OpenInTerminal"
 
+  livecheck do
+    url "https://raw.githubusercontent.com/Ji4n1ng/OpenInTerminal/master/Resources/README-Lite.md"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)*)}i)
+  end
+
   app "OpenInEditor-Lite.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous default `livecheck` detected 'full' versions (e.g. v2.3.3):
```console
❯ brew livecheck --debug openineditor-lite
git config --get homebrew.devcmdrun

Cask:             openineditor-lite
Livecheckable?:   No

URL:              https://github.com/Ji4n1ng/OpenInTerminal/releases/download/v1.2.3/OpenInEditor-Lite.app.zip
URL (processed):  https://github.com/Ji4n1ng/OpenInTerminal.git
Strategy:         Git

Matched Versions:
0.1.0, 0.1.1, 0.10.0, 0.10.1, 0.10.2, 0.10.3, 0.2.0, 0.3.0, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.9.0, 0.9.1, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.03, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.1.1, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 2.3.0, 2.3.1, 2.3.2, 2.3.3
openineditor-lite : 1.2.3 ==> 2.3.3
```

Changed to do `livecheck` on Markdown page for 'lite' version that directly links latest release for lite version (v1.2.3):
```console
❯ brew livecheck --debug openineditor-lite
git config --get homebrew.devcmdrun

Cask:             openineditor-lite
Livecheckable?:   Yes

URL:              https://raw.githubusercontent.com/Ji4n1ng/OpenInTerminal/master/Resources/README-Lite.md
Strategy:         PageMatch
Regex:            /href=.*?\/tag\/v?(\d+(?:\.\d+)*)/i

Matched Versions:
1.2.3
openineditor-lite : 1.2.3 ==> 1.2.3
```