### PR TITLE
Update clocker from 20.10.03 to 21.03.01

### DIFF
--- a/Casks/clocker.rb
+++ b/Casks/clocker.rb
@@ -1,21 +1,12 @@
 cask "clocker" do
-  version "20.10.03,5613815"
-  sha256 "27692bbfafb74d0c9f85a7e7bfae53708831900e59eb9ac35681dbebf4bce3c4"
+  version "21.03.01"
+  sha256 "0644d6f5873a332e43e67a1aa8ca84fe98d9e7975b08dd58b0e06b8017a85455"
 
-  url "https://github.com/n0shake/Clocker/files/#{version.after_comma}/Clocker.app.zip",
+  url "https://github.com/n0shake/Clocker/releases/download/v#{version}/Clocker.app.zip",
       verified: "github.com/n0shake/Clocker/"
   name "Clocker"
   desc "Track timezones from your menubar"
   homepage "https://abhishekbanthia.com/clocker"
-
-  livecheck do
-    url "https://github.com/n0shake/Clocker/releases/latest"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/tag/(\d+(?:\.\d+)*)}i, 1]
-      id = page[%r{href=.*?/(\d+)/Clocker\.app\.zip}i, 1]
-      "#{v},#{id}"
-    end
-  end
 
   app "Clocker.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Download file available as GitHub asset now and default `:git` strategy seems to work.