### PR TITLE
selfcontrol: fix livecheck issue due to non-standard pubDate

### DIFF
--- a/Casks/selfcontrol.rb
+++ b/Casks/selfcontrol.rb
@@ -4,11 +4,12 @@ cask "selfcontrol" do
 
   url "https://downloads.selfcontrolapp.com/SelfControl-#{version}.zip"
   name "SelfControl"
+  desc "Block your own access to distracting websites"
   homepage "https://selfcontrolapp.com/"
 
   livecheck do
-    url "https://selfcontrolapp.com/SelfControlAppcast.xml"
-    strategy :sparkle
+    url :homepage
+    regex(%r{href=.*?/SelfControl[._-](\d+(?:\.\d+)*)\.zip}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` picking up wrong version due to non-English `pubDate`:
`<pubDate>ven., 06 déc. 2019 11:27:04 PM -0800</pubDate>`
```console
❯ arch -x86_64 brew livecheck --debug selfcontrol
git config --get homebrew.devcmdrun

Cask:             selfcontrol
Livecheckable?:   Yes

URL:              https://selfcontrolapp.com/SelfControlAppcast.xml
Strategy:         Sparkle

Matched Versions:
2.3.2
selfcontrol : 3.0.3 ==> 2.3.2
```

Updated `livecheck` to just use homepage:
```console
❯ brew livecheck --debug selfcontrol
git config --get homebrew.devcmdrun

Cask:             selfcontrol
Livecheckable?:   Yes

URL (homepage):   https://selfcontrolapp.com/
Strategy:         PageMatch
Regex:            /href=.*?\/SelfControl[._-](\d+(?:\.\d+)*)\.zip/i

Matched Versions:
3.0.3, 1.5.1
selfcontrol : 3.0.3 ==> 3.0.3
```