### PR TITLE
celestia: fix livecheck

### DIFF
--- a/Casks/celestia.rb
+++ b/Casks/celestia.rb
@@ -8,6 +8,11 @@ cask "celestia" do
   desc "Space simulation for exploring the universe in three dimensions"
   homepage "https://celestia.space/"
 
+  livecheck do
+    url "https://celestia.space/download.html"
+    regex(%r{href=.*?/celestia[._-](\d+(?:\.\d+)*)[._-]macOS\.zip["' >]}i)
+  end
+
   app "Celestia.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous default `livecheck` on GitHub picking up other other version tags.
Both `:git` with regex and `:github_latest` won't work as it picks up `1.6.2.2`, which is Windows-only release

```console
❯ brew livecheck --debug celestia
git config --get homebrew.devcmdrun

Cask:             celestia
Livecheckable?:   No

URL:              https://github.com/CelestiaProject/Celestia/releases/download/1.6.2/celestia-1.6.2-macOS.zip
URL (processed):  https://github.com/CelestiaProject/Celestia.git
Strategy:         Git

Matched Versions:
1.5.1, 1.6.1, 1.6.2, 1.6.2.1, 1.6.2.2, 1010, 106, 107, 108, 110, 111, 112, 124, 1_4_0, 1_4_1, 1_5_0, 1_6_0, 1_3_0
celestia : 1.6.2 ==> 1010
```

Updated to use homepage versions:
```console
❯ brew livecheck --debug celestia
git config --get homebrew.devcmdrun

Cask:             celestia
Livecheckable?:   Yes

URL:              https://celestia.space/download.html
Strategy:         PageMatch
Regex:            /href=.*?\/celestia[._-](\d+(?:\.\d+)*)[._-]macOS\.zip["' >]/i

Matched Versions:
1.6.2
celestia : 1.6.2 ==> 1.6.2
```