### PR TITLE
darktable: fix livecheck

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -8,6 +8,12 @@ cask "darktable" do
   desc "Photography workflow application and raw developer"
   homepage "https://www.darktable.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(%r{href=.*?/tag/release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+
   conflicts_with cask: "homebrew/cask-versions/darktable-dev"
 
   app "darktable.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous:
```console
❯ brew livecheck --debug darktable
git config --get homebrew.devcmdrun

Cask:             darktable
Livecheckable?:   No

URL:              https://github.com/darktable-org/darktable/releases/download/release-3.4.1/darktable-3.4.1.dmg
URL (processed):  https://github.com/darktable-org/darktable.git
Strategy:         Git

Matched Versions:
0.3, 0.4, 0.9, 0.5, 0.6, 0.7, 0.7.1, 0.7.2, 0.8, 0.9, 0.9.1, 0.9.2, 0.9.3, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.1, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.2, 1.2.1, 1.2.2, 1.2.3, 1.3, 1.4, 1.4.1, 1.4.2, 1.5, 1.5.1, 1.5.2, 1.5.3, 1.6.0, 1.6.1, 1.6.2, 1.6.3, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8, 1.6.9, 1.7.0, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.1.0, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.3.0, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.5.0, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.7.0, 3.0.0, 3.0.1, 3.0.2, 3.1.0, 3.2.1, 3.3.0, 3.4.0, 3.4.1, 3.4.1.1, 3.5.0, 0.4
darktable : 3.4.1 ==> 3.5.0
```

Updated:
```console
❯ brew livecheck --debug darktable
git config --get homebrew.devcmdrun

Cask:             darktable
Livecheckable?:   Yes

URL (url):        https://github.com/darktable-org/darktable/releases/download/release-3.4.1/darktable-3.4.1.dmg
Strategy:         GithubLatest
Regex:            /href=.*?\/tag\/release[._-]v?(\d+(?:\.\d+)+)["' >]/i
URL (strategy):   https://github.com/darktable-org/darktable/releases/latest
URL (final):      https://github.com/darktable-org/darktable/releases/tag/release-3.4.1

Matched Versions:
3.4.1
darktable : 3.4.1 ==> 3.4.1
```