### PR TITLE
raze: fix livecheck

### DIFF
--- a/Casks/raze.rb
+++ b/Casks/raze.rb
@@ -9,8 +9,7 @@ cask "raze" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^(\d+(?:\.\d+)*)/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "Raze.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` seeing **1.1.0** (due to **1.1.0pre**):
```console
❯ brew livecheck --debug raze
git config --get homebrew.devcmdrun

Cask:             raze
Livecheckable?:   Yes

URL (url):        https://github.com/coelckers/Raze/releases/download/1.0.3/raze-macos-1.0.3.zip
URL (processed):  https://github.com/coelckers/Raze.git
Strategy:         Git
Regex:            /^(\d+(?:\.\d+)*)/

Matched Versions:
0.10.0, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.5.0, 0.5.1, 0.6.0, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.8.0, 0.8.1, 0.9.0, 0.9.1, 1.0.0, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.1.0
raze : 1.0.3 ==> 1.1.0
```

Updated `livecheck` to use end anchor `$` along with some homebrew-core preferences
```console
❯ brew livecheck --debug raze
git config --get homebrew.devcmdrun

Cask:             raze
Livecheckable?:   Yes

URL (url):        https://github.com/coelckers/Raze/releases/download/1.0.3/raze-macos-1.0.3.zip
URL (processed):  https://github.com/coelckers/Raze.git
Strategy:         Git
Regex:            /^v?(\d+(?:\.\d+)+)$/i

Matched Versions:
0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.4.0, 0.4.1, 0.4.2, 0.4.3, 0.4.4, 0.4.5, 0.5.0, 0.5.1, 0.6.0, 1.0.0, 1.0.1, 1.0.2, 1.0.3
raze : 1.0.3 ==> 1.0.3
```