### PR TITLE
mongodb-compass: fix livecheck

### DIFF
--- a/Casks/mongodb-compass.rb
+++ b/Casks/mongodb-compass.rb
@@ -9,8 +9,7 @@ cask "mongodb-compass" do
 
   livecheck do
     url "https://info-mongodb-com.s3.amazonaws.com/com-download-center/compass.json"
-    strategy :page_match
-    regex(/"version"\s*:\s*"(\d+(?:\.\d+)*)\s*/i)
+    regex(/"version"\s*:\s*"(\d+(?:\.\d+)+)\s*\(Stable/i)
   end
 
   app "MongoDB Compass.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous `livecheck` picking up 1.27.0 due to 1.27.0-beta.1
```console
❯ brew livecheck mongodb-compass
mongodb-compass : 1.26.1 ==> 1.27.0
```

Updated `livecheck` to only see `(Stable)` version:
```console
❯ brew livecheck mongodb-compass
mongodb-compass : 1.26.1 ==> 1.26.1
```