### PR TITLE
Update google-drive from 46.0.3.0 to 47.0.19 and add livecheck

### DIFF
--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -1,5 +1,5 @@
 cask "google-drive" do
-  version "46.0.3.0"
+  version "47.0.19"
   sha256 :no_check
 
   url "https://dl.google.com/drive-file-stream/GoogleDrive.dmg"
@@ -8,7 +8,8 @@ cask "google-drive" do
   homepage "https://www.google.com/drive/"
 
   livecheck do
-    skip "No version information available"
+    url :url
+    strategy :extract_plist
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Try using `:extract_plist` for version.
Major/Minor version (47.0) at least matches the release notes: https://support.google.com/a/answer/7577057

May want to get a user to check if auto-updates are supported since most Google Casks do have stanza set.
From support page:
- https://support.google.com/a/answer/7491144#zippy=%2Cmac
   > Drive for desktop comes packaged with Google Update (Windows) or Google Software Update (Mac) to auto-update Drive for desktop on your users’ computers. 
- https://support.google.com/a/answer/10514878
   > When auto-updates is on, users always have the latest version. Your users might install and set up Google Drive for desktop themselves. However, only admins can configure auto-update settings.
