### PR TITLE
geph: add livecheck based on GitHub repo

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -9,7 +9,7 @@ cask "geph" do
   homepage "https://geph.io/"
 
   livecheck do
-    skip
+    url "https://github.com/geph-official/geph4"
   end
 
   app "Geph.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Homepage (https://geph.io/en/) has links to GitHub repo (https://github.com/geph-official/geph4).
Looks like tags match released versions, so using default `:git` strategy on GitHub repo URL.

The other location for latest releases seems to be forum: https://community.geph.io/
However, not that easy to detect latest version here.

The homepage doesn't seem to be updated with newest releases.