### PR TITLE
focused: fix dead download URL

### DIFF
--- a/Casks/focused.rb
+++ b/Casks/focused.rb
@@ -1,18 +1,18 @@
 cask "focused" do
   version "3.2,1825:1544822315"
-  sha256 "e9da7b084243c73f78d2a441f1414b1e6d3a2b31c0391b8e9ae3631efa834f03"
+  sha256 :no_check
 
-  url "https://dl.devmate.com/com.71squared.focused/#{version.after_comma.before_colon}/#{version.after_colon}/Focused-#{version.after_comma.before_colon}.zip",
-      verified: "devmate.com/com.71squared.focused/"
+  url "https://www.codebots.co.uk/download/Focused"
   name "Focused"
+  desc "Markdown writing app"
   homepage "https://codebots.co.uk/"
 
   livecheck do
-    url "https://updates.devmate.com/com.71squared.focused.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version}:#{item.url[%r{/(\d+)/Focused-\d+\.zip}i, 1]}"
-    end
+    url :url
+    strategy :extract_plist
   end
+
+  depends_on macos: ">= :el_capitan"
 
   app "Focused.app"
 end

--- a/Casks/focused.rb
+++ b/Casks/focused.rb
@@ -1,5 +1,5 @@
 cask "focused" do
-  version "3.2,1825:1544822315"
+  version "3.2,1825"
   sha256 :no_check
 
   url "https://www.codebots.co.uk/download/Focused"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Download URL (https://dl.devmate.com/com.71squared.focused/1825/1544822315/Focused-1825.zip) is currently going to 404 Not Found.

From quick glance through homepage: https://www.codebots.co.uk/
- Listed Download URL: https://www.codebots.co.uk/download/Focused
- Redirect URL: https://dl.devant.io/v1/ffbdbfd0-ecfc-11e9-9897-1b1ad6ec37c4/Focused.zip
- Redirect URL:  https://cdn.devant.io/app-ffbdbfd0-ecfc-11e9-9897-1b1ad6ec37c4/releases/Focused.zip

Appears to be rehosted with unversioned URL.

---

Plan to run with `:extract_plist` livecheck via CI to see if it picks up any version number.
If nothing, may just use `:latest` tag.