### PR TITLE
Update alfaview from 8.17.0 to 8.18.1

### DIFF
--- a/Casks/alfaview.rb
+++ b/Casks/alfaview.rb
@@ -1,6 +1,6 @@
 cask "alfaview" do
-  version "8.17.0"
-  sha256 "4965126d5e235b37a62b4db58150c6aca88bca736cd3efcf57d710fa8110b52d"
+  version "8.18.1"
+  sha256 "0263c769a8c183b486a4eb1dbc16833a172abbfbb19b69ed9e34238d1ea05fa7"
 
   url "https://assets.alfaview.com/stable/mac/alfaview-mac-production-#{version}.dmg"
   name "Alfaview"
@@ -9,9 +9,10 @@ cask "alfaview" do
 
   livecheck do
     url "https://production-alfaview-assets.alfaview.com/stable/mac/version.info"
-    strategy :page_match
     regex(/alfaview-mac-production-(\d+(?:\.\d+)*)\.dmg/i)
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "alfaview.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Bump version and also:
- Remove extraneous `strategy` stanza as default for `url`
- Add min OS from https://alfaview.com/en/download/:
   > macOS 10.13 or newer
