### PR TITLE
Update navicat-premium from 15.0.26 to 15.0.28

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,5 +1,5 @@
 cask "navicat-premium" do
-  version "15.0.26"
+  version "15.0.28"
   sha256 :no_check
 
   language "zh-CN" do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Manually bumped version as `brew bump-cask-pr` isn't working with multiple languages right now.
It tries to replace `no_check`:
```
==> Downloading https://download.navicat.com.cn/download/navicat150_premium_cs.dmg
######################################################################## 100.0%
Warning: Cannot verify integrity of '712bdad67bd11a4eef72ec5e1264da307c5c2088460940b066e6eb38bbd3107a--navicat150_premium_cs.dmg'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "1988517222cba9e0ba311fd1738ff681d513facab735f7722df9db400b614325"
==> Downloading http://download.navicat.com/download/navicat150_premium_en.dmg
######################################################################## 100.0%
Warning: Cannot verify integrity of 'd5243947d4e0f6608f2eefe752e21091403860846f2ae91f573f97689532d5c9--navicat150_premium_en.dmg'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "54b0311561d670f8543cc09c65b06d05ef730da52b34a09a3330477234b04529"
==> replace /version\s+["']15\.0\.26["']/m with "version \"15.0.28\""
  1 cask "navicat-premium" do
==> replace "no_check" with "1988517222cba9e0ba311fd1738ff681d513facab735f7722df9db400b614325"
==> replace "no_check" with "54b0311561d670f8543cc09c65b06d05ef730da52b34a09a3330477234b04529"
Error: inreplace failed
/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/navicat-premium.rb:
  expected replacement of "no_check" with "54b0311561d670f8543cc09c65b06d05ef730da52b34a09a3330477234b04529"
```