### PR TITLE
Update vlc from 3.0.12 to 3.0.14

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -18,8 +18,8 @@ cask "vlc" do
   homepage "https://www.videolan.org/vlc/"
 
   livecheck do
-    url "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml"
-    strategy :sparkle
+    url "https://www.videolan.org/vlc/download-macosx.html"
+    regex(%r{href=.*?/vlc[._-]v?(\d+(?:\.\d+)+)(?:[._-][a-z]\w*)?\.dmg}i)
   end
 
   auto_updates true

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,13 +1,13 @@
 cask "vlc" do
-  version "3.0.13"
+  version "3.0.14"
 
   if Hardware::CPU.intel?
-    sha256 "46ff8614c9638768c3f7ffb5ebd6515a9014a6ea6d3066cdbc4825e554aee9bd"
+    sha256 "a5628b5f7e69ce18dd13ca724f67c7c4381c0ed22862fcb2064d00227f42f42f"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-intel64.dmg"
 
   else
-    sha256 "0f7034b12dc855d70dead31bf4937d7cc16478c61627ac250c8349285fdfe4de"
+    sha256 "8d0b897ba5a9366f1482d84fea4e67eec42c47711df18f80ae596872ac881365"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-arm64.dmg"
 

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,7 +1,7 @@
 cask "vlc" do
   if Hardware::CPU.intel?
-    version "3.0.12"
-    sha256 "9b8b5a78ee0d7448e840680df34c1417f7c8c87161127c2d150794b2449be5d1"
+    version "3.0.13"
+    sha256 "46ff8614c9638768c3f7ffb5ebd6515a9014a6ea6d3066cdbc4825e554aee9bd"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-intel64.dmg"
 
@@ -10,8 +10,8 @@ cask "vlc" do
       strategy :sparkle
     end
   else
-    version "3.0.12.1"
-    sha256 "5a5572c3a0bcf5c7a286dee0fbc027899a916a1c3fea919492894ae714789efa"
+    version "3.0.13"
+    sha256 "0f7034b12dc855d70dead31bf4937d7cc16478c61627ac250c8349285fdfe4de"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-arm64.dmg"
 

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -6,24 +6,25 @@ cask "vlc" do
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-intel64.dmg"
 
-    livecheck do
-      url "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml"
-      strategy :sparkle
-    end
   else
     sha256 "0f7034b12dc855d70dead31bf4937d7cc16478c61627ac250c8349285fdfe4de"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-arm64.dmg"
 
-    livecheck do
-      url "https://update.videolan.org/vlc/sparkle/vlc-arm64.xml"
-      strategy :sparkle
-    end
   end
 
   name "VLC media player"
   desc "Multimedia player"
   homepage "https://www.videolan.org/vlc/"
+
+  livecheck do
+    if Hardware::CPU.intel?
+      url "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml"
+    else
+      url "https://update.videolan.org/vlc/sparkle/vlc-arm64.xml"
+    end
+    strategy :sparkle
+  end
 
   auto_updates true
   conflicts_with cask: "homebrew/cask-versions/vlc-nightly"

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -1,6 +1,7 @@
 cask "vlc" do
+  version "3.0.13"
+
   if Hardware::CPU.intel?
-    version "3.0.13"
     sha256 "46ff8614c9638768c3f7ffb5ebd6515a9014a6ea6d3066cdbc4825e554aee9bd"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-intel64.dmg"
@@ -10,7 +11,6 @@ cask "vlc" do
       strategy :sparkle
     end
   else
-    version "3.0.13"
     sha256 "0f7034b12dc855d70dead31bf4937d7cc16478c61627ac250c8349285fdfe4de"
 
     url "https://get.videolan.org/vlc/#{version}/macosx/vlc-#{version}-arm64.dmg"

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -18,11 +18,7 @@ cask "vlc" do
   homepage "https://www.videolan.org/vlc/"
 
   livecheck do
-    if Hardware::CPU.intel?
-      url "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml"
-    else
-      url "https://update.videolan.org/vlc/sparkle/vlc-arm64.xml"
-    end
+    url "https://update.videolan.org/vlc/sparkle/vlc-intel64.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

`brew audit` complains because `livecheck` version mismatch. I confirmed this is a stable release from the [release page](https://www.videolan.org/vlc/releases/3.0.13.html) and [CHANGELOG](https://code.videolan.org/videolan/vlc/-/raw/master/NEWS). Looks like sparkle appcast just hasn't been updated.