### PR TITLE
changed deprecated `brew cask` command

### DIFF
--- a/doc/reporting_bugs/checksum_does_not_match_error.md
+++ b/doc/reporting_bugs/checksum_does_not_match_error.md
@@ -4,6 +4,6 @@ If the problem persists, the cask must be outdated. It’ll likely need a new ve
 
 1. Go to the vendor’s website (`brew home <cask_name>`).
 2. Find out what the latest version is. It may be expressed in the URL used to download it.
-3. Take a look at the cask’s version (`brew cask _stanza version <cask_name>`) and verify it is indeed outdated. If it is:
+3. Take a look at the cask’s version (`brew info <cask_name>`) and verify it is indeed outdated. If it is:
 
 Help us by [submitting a fix](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#updating-a-cask). If you get stumped, [open an issue](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.md) explaining your steps so far and where you’re having trouble.


### PR DESCRIPTION
Changed `brew cask _stanza version <cask_name>` to `brew info <cask_name>`
Issue: #105556