### PR TITLE
Update blocs from 4.0.3,403 to 4.2.1,421

### DIFF
--- a/Casks/blocs.rb
+++ b/Casks/blocs.rb
@@ -1,5 +1,5 @@
 cask "blocs" do
-  version "4.0.3,403"
+  version "4.2.1,421"
   sha256 :no_check
 
   url "https://blocsapp.com/download/Blocs.zip"
@@ -13,6 +13,7 @@ cask "blocs" do
   end
 
   auto_updates true
+  depends_on macos: ">= :sierra"
   container nested: "Blocs/Blocs-#{version.major}.dmg"
 
   app "Blocs.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

```xml
            <pubDate>Tuesday 10th May 2021 12:00:00 +0000</pubDate>
            <enclosure url="https://blocsapp.com/update/v4/Blocs.zip" sparkle:version="421" sparkle:shortVersionString="4.2.1" length="1472893" type="application/octet-stream" sparkle:dsaSignature="234818feCa1JyW30nbkBwainOzrN6EQuAh" />
            <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
```