### PR TITLE
dotnet: various updates

### DIFF
--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,5 +1,5 @@
 cask "dotnet" do
-  version "5.0.6,4e2e2c76-626f-4927-8753-55d47ab79e06:4417509d68777cab1ed5f927e86db82"
+  version "5.0.6,4e2e2c76-626f-4927-8753-55d47ab79e06:24417509d68777cab1ed5f927e86db82"
   sha256 "208eae389ea28d76b6b081f944cecca9ec7f0d59bba6711ade976a8c2bf18994"
 
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-x64.pkg"

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -1,11 +1,16 @@
 cask "dotnet" do
-  version "5.0.5,0e2acfdc-5dad-48a8-935d-6095a0ae2217:3ffa41859dbb1ca40a7e1ff704651178"
-  sha256 "f4f3b02899e48b7cb0f1ed8b99f38db630f2e957d47b96de1ee76444b9201dae"
+  version "5.0.6,4e2e2c76-626f-4927-8753-55d47ab79e06:4417509d68777cab1ed5f927e86db82"
+  sha256 "208eae389ea28d76b6b081f944cecca9ec7f0d59bba6711ade976a8c2bf18994"
 
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   appcast "https://dotnet.microsoft.com/download/dotnet-core"
-  name ".Net Core Runtime"
+  name ".Net Runtime"
+  desc "Developer platform"
   homepage "https://www.microsoft.com/net/core#macos"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   conflicts_with cask: [
     "dotnet-sdk",

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -16,7 +16,7 @@ cask "dotnet" do
     "homebrew/cask-versions/dotnet-preview",
     "homebrew/cask-versions/dotnet-sdk-preview",
   ]
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   pkg "dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
   binary "/usr/local/share/dotnet/dotnet"

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -8,7 +8,12 @@ cask "dotnet" do
   homepage "https://www.microsoft.com/net/core#macos"
 
   livecheck do
-    skip "No version information available"
+    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/#{version.major_minor}/releases.json"
+    strategy :page_match do |page|
+      page.scan(%r{/download/pr/([^/]+)/([^/]+)/dotnet-runtime-v?(\d+(?:\.\d+)+)-osx-x64\.pkg}i).map do |match|
+        "#{match[2]},#{match[0]}:#{match[1]}"
+      end
+    end
   end
 
   conflicts_with cask: [

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -3,7 +3,6 @@ cask "dotnet" do
   sha256 "208eae389ea28d76b6b081f944cecca9ec7f0d59bba6711ade976a8c2bf18994"
 
   url "https://download.visualstudio.microsoft.com/download/pr/#{version.after_comma.before_colon}/#{version.after_colon}/dotnet-runtime-#{version.before_comma}-osx-x64.pkg"
-  appcast "https://dotnet.microsoft.com/download/dotnet-core"
   name ".Net Runtime"
   desc "Developer platform"
   homepage "https://www.microsoft.com/net/core#macos"

--- a/Casks/dotnet.rb
+++ b/Casks/dotnet.rb
@@ -7,6 +7,9 @@ cask "dotnet" do
   desc "Developer platform"
   homepage "https://www.microsoft.com/net/core#macos"
 
+  # This identifies releases with the same major/minor version as the current
+  # cask version. New major/minor releases occur annually in November and the
+  # check will automatically update its behavior when the cask is updated.
   livecheck do
     url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/#{version.major_minor}/releases.json"
     strategy :page_match do |page|


### PR DESCRIPTION
Not sure how best to add a `livecheck` here -- the page:

https://dotnet.microsoft.com/download/dotnet

lists the versions, and opening the "recommended" one takes you to:

https://dotnet.microsoft.com/download/dotnet/5.0

and then clicking on either the "SDK" or "Runtime" pages take you to:

https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.203-macos-x64-installer

or:

https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-5.0.6-macos-x64-installer

which have the links with all the required `version` parts, but how to extract them?

There is also this page with the direct links:

https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.6/5.0.6.md