### PR TITLE
updated chromedriver deprecated links

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,12 +1,18 @@
 cask "chromedriver" do
   version "90.0.4430.24"
-  sha256 "1318b3717576154e36476c3253ee8e87a2e09eaf07631ee4948348a8f6a1545f"
 
-  url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip",
-      verified: "chromedriver.storage.googleapis.com/"
+  if Hardware::CPU.intel?
+    url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64.zip",
+        verified: "chromedriver.storage.googleapis.com/"
+    sha256 "1318b3717576154e36476c3253ee8e87a2e09eaf07631ee4948348a8f6a1545f"
+  else
+    url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_mac64_m1.zip",
+        verified: "chromedriver.storage.googleapis.com/"
+    sha256 "c1af4f3eb0efd4050dc502db5928f72b267ac2c6ea1e76614491662a3db0300d"
+  end
   name "ChromeDriver"
   desc "Automated testing of webapps for Google Chrome"
-  homepage "https://sites.google.com/a/chromium.org/chromedriver/home"
+  homepage "https://sites.google.com/chromium.org/driver/"
 
   livecheck do
     url "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"


### PR DESCRIPTION
Old homepage is now deprecated
Download links updated to  follow recommendations from [chrome driver website](https://sites.google.com/chromium.org/driver/downloads/version-selection)

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.