### PR TITLE
Fixed sha256 sum for xca v4.2.0

### DIFF
--- a/Casks/xca.rb
+++ b/Casks/xca.rb
@@ -1,6 +1,6 @@
 cask "xca" do
   version "2.4.0"
-  sha256 "3445524ef5e81d5f19c4d4ace1f849480fe982458e31cebe689b6fd8b11200bc"
+  sha256 "a5672fd46168b8d81c226dc47dd0022773382389291676c8aa17d6765e20b697"
 
   url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}.dmg",
       verified: "github.com/chris2511/xca/"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

The sha256 sum for the xca v2.4.0 isn't right. Regular installation using `brew install xca` failed on my machine (MBP 13" M1, 11.3.1).