### PR TITLE
update OverSight to 2.0.0

### DIFF
--- a/Casks/oversight.rb
+++ b/Casks/oversight.rb
@@ -1,37 +1,32 @@
 cask "oversight" do
-  version "1.2.0"
-  sha256 "786eea6de3da8a15919159b51a7753ef7ecb26a0ed638725f7925fd0392a6fa9"
+  version "2.0.0"
+  sha256 "89a87d114684778f55fa83080f1d0aafe4a4eee563b915b3fc55cc878ecc5a03"
 
-  url "https://bitbucket.org/objective-see/deploy/downloads/OverSight_#{version}.zip",
-      verified: "bitbucket.org/objective-see/deploy/downloads/"
+  url "https://github.com/objective-see/OverSight/releases/download/v#{version}/OverSight_#{version}.zip",
+      verified: "github.com/objective-see/OverSight"
   appcast "https://objective-see.com/products/changelogs/OverSight.txt"
   name "OverSight"
   desc "Monitors computer mic and webcam"
   homepage "https://objective-see.com/products/oversight.html"
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :catalina"
 
   installer script: {
-    executable: "#{staged_path}/OverSight_Installer.app/Contents/MacOS/OverSight_Installer",
+    executable: "#{staged_path}/OverSight Installer.app/Contents/MacOS/OverSight Installer",
     args:       ["-install"],
     sudo:       true,
   }
 
   uninstall script: {
-    executable: "#{staged_path}/OverSight_Installer.app/Contents/MacOS/OverSight_Installer",
+    executable: "#{staged_path}/OverSight Installer.app/Contents/MacOS/OverSight Installer",
     args:       ["-uninstall"],
     sudo:       true,
   }
 
   zap trash: [
-    "~/Library/Application Support/Objective-See/OverSight",
-    "~/Library/Caches/com.objective-see.OverSight",
+    "~/Library/Caches/com.objective-see.oversight",
     "~/Library/Caches/com.objective-see.OverSightHelper",
-    "~/Library/Preferences/com.objective-see.OverSight.plist",
+    "~/Library/Preferences/com.objective-see.oversight.plist",
     "~/Library/Preferences/com.objective-see.OverSightHelper.plist",
   ]
-
-  caveats "Due to an upstream bug, the installer hangs. To solve, manually close OverSight from the menu bar " \
-          "by clicking on the umbrella icon and then choosing “quit”. As soon as brew moves on, you may reopen " \
-          "OverSight."
 end

--- a/Casks/oversight.rb
+++ b/Casks/oversight.rb
@@ -4,7 +4,6 @@ cask "oversight" do
 
   url "https://github.com/objective-see/OverSight/releases/download/v#{version}/OverSight_#{version}.zip",
       verified: "github.com/objective-see/OverSight"
-  appcast "https://objective-see.com/products/changelogs/OverSight.txt"
   name "OverSight"
   desc "Monitors computer mic and webcam"
   homepage "https://objective-see.com/products/oversight.html"


### PR DESCRIPTION
- upstream source/binaries moved to GitHub
- bumped minimum macOS version
- removed outdated caveat that is no longer necessary with the new version
- fixed capitalization in zapped paths

I'm not entirely sure about the `~/Library/Application Support/Objective-See/OverSight` path, at least on my system (fresh install, after uninstalling the old cask) that doesn't get created.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.