### PR TITLE
Update porting-kit.rb

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -14,14 +14,4 @@ cask "porting-kit" do
   auto_updates true
 
   app "Porting Kit.app"
-
-  zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/edu.ufrj.vitormm.porting-kit.sfl*",
-    "~/Library/Application Support/Porting-Kit",
-    "~/Library/Caches/edu.ufrj.vitormm.Porting-Kit",
-    "~/Library/Cookies/edu.ufrj.vitormm.Porting-Kit.binarycookies",
-    "~/Library/Preferences/edu.ufrj.vitormm.Porting-Kit.plist",
-    "~/Library/Saved Application State/edu.ufrj.vitormm.Porting-Kit.savedState",
-    "~/Library/WebKit/edu.ufrj.vitormm.Porting-Kit",
-  ]
 end

--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,14 +1,14 @@
 cask "porting-kit" do
-  version "3.0.60"
-  sha256 "7c6fd060d90e76c2a8c2272d49f92ef99600c65ed9b7c71617f9e96256a76637"
+  version "4.1.31"
+  sha256 "7b1c65bafd41a621e5b10843f5eb27ad9f10b77dede13ad5219911cb94a2871f"
 
-  url "https://portingkit.com/kit/Porting%20Kit%20#{version}.zip"
+  url "https://portingkit.com/pub/portingkit/Porting%20Kit-#{version}-mac.zip"
   name "Porting Kit"
   homepage "https://portingkit.com/"
 
   livecheck do
-    url "https://portingkit.com/kit/updatecast.xml"
-    strategy :sparkle
+    url "https://portingkit.com/pub/portingkit/latest-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true

--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -4,6 +4,7 @@ cask "porting-kit" do
 
   url "https://portingkit.com/pub/portingkit/Porting%20Kit-#{version}-mac.zip"
   name "Porting Kit"
+  desc "Install games and apps compiled for Microsoft Windows"
   homepage "https://portingkit.com/"
 
   livecheck do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

---

This now an electron app and the bundle changed to `com.paulthetall.portingkit`. Which means there’s a good chance the zap items have changed.

All the people who recently updated this seem to be people who update a lot of casks, not necessarily people using this, so will remove the zap for now and lets wait for it to be readded (e.g. as part of https://github.com/Homebrew/homebrew-cask/issues/88469).