### PR TITLE
Change the name of the unofficial redis cask

### DIFF
--- a/Casks/jpadilla-redis.rb
+++ b/Casks/jpadilla-redis.rb
@@ -1,4 +1,4 @@
-cask "redis" do
+cask "jpadilla-redis" do
   version "4.0.2-build.1"
   sha256 "1a4c0c82739a2bddbd5fa78f598cd28dd2c348467a12cb8de6687114f2bad4da"
 

--- a/Casks/jpadilla-redis.rb
+++ b/Casks/jpadilla-redis.rb
@@ -4,7 +4,7 @@ cask "jpadilla-redis" do
 
   url "https://github.com/jpadilla/redisapp/releases/download/#{version}/Redis.zip",
       verified: "github.com/jpadilla/redisapp/"
-  name "Redis.app"
+  name "Redis"
   desc "App wrapper for Redis"
   homepage "https://jpadilla.github.io/redisapp/"
 

--- a/Casks/jpadilla-redis.rb
+++ b/Casks/jpadilla-redis.rb
@@ -5,6 +5,7 @@ cask "jpadilla-redis" do
   url "https://github.com/jpadilla/redisapp/releases/download/#{version}/Redis.zip",
       verified: "github.com/jpadilla/redisapp/"
   name "Redis"
+  desc "App wrapper for Redis"
   homepage "https://jpadilla.github.io/redisapp/"
 
   app "Redis.app"

--- a/Casks/jpadilla-redis.rb
+++ b/Casks/jpadilla-redis.rb
@@ -4,7 +4,7 @@ cask "jpadilla-redis" do
 
   url "https://github.com/jpadilla/redisapp/releases/download/#{version}/Redis.zip",
       verified: "github.com/jpadilla/redisapp/"
-  name "Redis"
+  name "Redis.app"
   desc "App wrapper for Redis"
   homepage "https://jpadilla.github.io/redisapp/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

`redis` is normally installed from homebrew-core via `brew install redis`. `brew install --cask redis` install some [unofficial `redis` app](https://github.com/jpadilla/redisapp) and can lead to confusion. The change is also driven by the [token name guidelines](https://docs.brew.sh/Cask-Cookbook#potentially-misleading-name).

It's a bit similar issue to [the one with `mongodb`](https://github.com/Homebrew/homebrew-cask/issues/71503), but `redis` is actually located in homebrew-core, not in a tap - however it can be misleading anyway, so that's why I suggest the change.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
