### PR TITLE
Change the name of the unofficial rabbitmq cask

### DIFF
--- a/Casks/jpadilla-rabbitmq.rb
+++ b/Casks/jpadilla-rabbitmq.rb
@@ -5,6 +5,7 @@ cask "jpadilla-rabbitmq" do
   url "https://github.com/jpadilla/rabbitmqapp/releases/download/#{version}/RabbitMQ.zip",
       verified: "github.com/jpadilla/rabbitmqapp/"
   name "RabbitMQ"
+  desc "App wrapper for RabbitMQ"
   homepage "https://jpadilla.github.io/rabbitmqapp/"
 
   app "RabbitMQ.app"

--- a/Casks/jpadilla-rabbitmq.rb
+++ b/Casks/jpadilla-rabbitmq.rb
@@ -1,4 +1,4 @@
-cask "rabbitmq" do
+cask "jpadilla-rabbitmq" do
   version "3.6.1-build.1"
   sha256 "1838afcece704ab1d23645d5d44953b809474f1f67ec4b18f3f98d440e5b5aad"
 

--- a/Casks/jpadilla-rabbitmq.rb
+++ b/Casks/jpadilla-rabbitmq.rb
@@ -4,7 +4,7 @@ cask "jpadilla-rabbitmq" do
 
   url "https://github.com/jpadilla/rabbitmqapp/releases/download/#{version}/RabbitMQ.zip",
       verified: "github.com/jpadilla/rabbitmqapp/"
-  name "RabbitMQ"
+  name "RabbitMQ.app"
   desc "App wrapper for RabbitMQ"
   homepage "https://jpadilla.github.io/rabbitmqapp/"
 

--- a/Casks/jpadilla-rabbitmq.rb
+++ b/Casks/jpadilla-rabbitmq.rb
@@ -4,7 +4,7 @@ cask "jpadilla-rabbitmq" do
 
   url "https://github.com/jpadilla/rabbitmqapp/releases/download/#{version}/RabbitMQ.zip",
       verified: "github.com/jpadilla/rabbitmqapp/"
-  name "RabbitMQ.app"
+  name "RabbitMQ"
   desc "App wrapper for RabbitMQ"
   homepage "https://jpadilla.github.io/rabbitmqapp/"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

`rabbitmq` is normally installed from homebrew-core via `brew install rabbitmq`. `brew install --cask rabbitmq` install some [unofficial `rabbitmq` app](https://github.com/jpadilla/rabbitmqapp) and can lead to confusion. The change is also driven by the [token name guidelines](https://docs.brew.sh/Cask-Cookbook#potentially-misleading-name).

It's a bit similar issue to [the one with `mongodb`](https://github.com/Homebrew/homebrew-cask/issues/71503), but `rabbitmq` is actually located in homebrew-core, not in a tap - however it can be misleading anyway, so that's why I suggest the change.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
