### PR TITLE
Update vscodium from 1.56.1 to 1.56.2

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask "vscodium" do
-  version "1.56.1"
-  sha256 "f1a0b414d0037d51f012905bfc00a08b11ba1b6cc98bcc9dd731171d483c34d8"
+  version "1.56.2"
+  sha256 "5dc85ef87f943142e1233eb1933d3fa235dedeed93ccc04e7a04afe220e01117"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.x64.#{version}.dmg"
   name "VSCodium"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
