### PR TITLE
Change the name of the unofficial postgres cask

### DIFF
--- a/Casks/postgres-unofficial.rb
+++ b/Casks/postgres-unofficial.rb
@@ -1,10 +1,11 @@
-cask "postgres" do
+cask "postgres-unofficial" do
   version "2.4.2"
   sha256 "4ea80659448cb98edd16a53e664672a558a1b64d5c960393dd72456da6772231"
 
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version}/Postgres-#{version}-9.5-9.6-10-11-12-13.dmg",
       verified: "github.com/PostgresApp/PostgresApp/"
   name "Postgres"
+  desc "App wrapper for Postgres"
   homepage "https://postgresapp.com/"
 
   livecheck do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

`postgresql` is normally installed from homebrew-core via `brew install postgres`. `brew install --cask postgres` install some [unofficial `postgres` app](https://github.com/PostgresApp/PostgresApp) and can lead to confusion. The change is also driven by the [token name guidelines](https://docs.brew.sh/Cask-Cookbook#potentially-misleading-name).

It's a bit similar issue to [the one with `mongodb`](https://github.com/Homebrew/homebrew-cask/issues/71503), but `postgres` is actually located in homebrew-core, not in a tap - however it can be misleading anyway, so that's why I suggest the change.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
