### PR TITLE
mumble: add livecheck

### DIFF
--- a/Casks/mumble.rb
+++ b/Casks/mumble.rb
@@ -8,5 +8,12 @@ cask "mumble" do
   desc "Open-source, low-latency, high quality voice chat software for gaming"
   homepage "https://wiki.mumble.info/wiki/Main_Page"
 
+  livecheck do
+    url "https://dl.mumble.info/latest/stable/client-macos-x64"
+    strategy :header_match
+  end
+
+  depends_on macos: ">= :high_sierra"
+
   app "Mumble.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Existing default livecheck picks up version that doesn't work with macOS:
```console
❯ brew livecheck mumble
mumble : 1.3.3 ==> 1.3.4
```

https://www.mumble.info/downloads/

> Version 1.3.4 is the latest stable version of Mumble and was released on February 10th, 2021.
> 
> Note: Due to problems with our macOS builder, we are **currently unable to provide 1.3.4 binaries for macOS.** We are working on it, but for the time being the macOS download will still refer to version 1.3.3.
> 
> Suggested Mumble Version
> 
> Mumble for macOS >= 10.13 (x64)