### PR TITLE
Update a-better-finder-rename from 11.31 to 11.32

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -1,5 +1,5 @@
 cask "a-better-finder-rename" do
-  version "11.31"
+  version "11.32"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.publicspace.net/download/ABFRX#{version.major}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

update `a-better-finder-rename` to version `11.32`
