### PR TITLE
Update 4k-stogram from 3.4.0 to 3.4.1

### DIFF
--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -9,7 +9,7 @@ cask "4k-stogram" do
 
   livecheck do
     url "https://www.4kdownload.com/downloads"
-    regex(%r{href=.*?/4kstogram[._-]?v?(\d+(?:\.\d+)*)\.dmg}i)
+    regex(%r{href=.*?/4kstogram[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   auto_updates true

--- a/Casks/4k-stogram.rb
+++ b/Casks/4k-stogram.rb
@@ -1,6 +1,6 @@
 cask "4k-stogram" do
-  version "3.4.0"
-  sha256 "c6339111f3dd6f81f1ea60b34d262b900fa47d80bc410f410fcf4b46e8fcbf8f"
+  version "3.4.1"
+  sha256 "ec7bc90606d156a4012c8f379a6737b075eee7a3856c063dd473b816343d81d4"
 
   url "https://dl.4kdownload.com/app/4kstogram_#{version}.dmg"
   name "4K Stogram"
@@ -8,9 +8,8 @@ cask "4k-stogram" do
   homepage "https://www.4kdownload.com/products/product-stogram"
 
   livecheck do
-    url "https://www.4kdownload.com/download"
-    strategy :page_match
-    regex(%r{href=.*?/4kstogram_(\d+(?:\.\d+)*)\.dmg}i)
+    url "https://www.4kdownload.com/downloads"
+    regex(%r{href=.*?/4kstogram[._-]?v?(\d+(?:\.\d+)*)\.dmg}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Modify `livecheck` to remove unnecessary `strategy`, add some extra regex patterns to improve maintainability, and skip URL redirect:
```console
❯ curl -I "https://www.4kdownload.com/download"
HTTP/2 301
date: Sat, 15 May 2021 05:44:05 GMT
content-type: text/html
content-length: 162
location: https://www.4kdownload.com/downloads
server: nginx
```

