### PR TITLE
Update valentina-studio from 11.2.6 to 11.2.7 and use versioned URL

### DIFF
--- a/Casks/valentina-studio.rb
+++ b/Casks/valentina-studio.rb
@@ -1,16 +1,15 @@
 cask "valentina-studio" do
-  version "11.2.6"
-  sha256 :no_check
+  version "11.2.7"
+  sha256 "fe5dbe3b93acb616726ba8e3d74e4137fa7f7f69fa1a22ece89c571bcfe7b2cb"
 
-  url "https://valentina-db.com/en/all-downloads/vstudio/current/vstudio_mac_x64-dmg?format=raw"
+  url "https://valentina-db.com/download/prev_releases/#{version}/mac_64/vstudio_x64_#{version.major}_mac.dmg"
   name "Valentina Studio"
   desc "Visual editors for data"
   homepage "https://valentina-db.com/en/valentina-studio-overview"
 
   livecheck do
     url "https://valentina-db.com/en/all-downloads/vstudio"
-    strategy :page_match
-    regex(%r{href=['"]?/en/all-downloads/vstudio/current['"]?>\s*(\d+(?:\.\d+)*)}i)
+    regex(%r{href=['"]?/en/all-downloads/vstudio/current['"]?>\s*(\d+(?:\.\d+)+)}i)
   end
 
   app "Valentina Studio.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Try using versioned URL.
It looks like `prev_releases` page has latest release DMG too (same SHA).
Can switch back if not updated in future releases.