### PR TITLE
dcp-o-matic-player: update to 2.14.51

### DIFF
--- a/Casks/dcp-o-matic-player.rb
+++ b/Casks/dcp-o-matic-player.rb
@@ -1,6 +1,6 @@
 cask "dcp-o-matic-player" do
-  version "2.14.50"
-  sha256 "adae4c833dca5032e77d0799c8f054b8fe16070f0190eba0b3fd40b580cd3ff2"
+  version "2.14.51"
+  sha256 "56622938191ceec784f85241bc9e6872ad2170286c3f21294706c902e36d4857"
 
   url "https://dcpomatic.com/dl.php?id=osx-10.9-player&version=#{version}"
   name "DCP-o-matic Player"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

update `dcp-o-matic-player` to version `2.14.51`
