### PR TITLE
Update virtualc64 from 4.0.1 to 4.1

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,9 +1,9 @@
 cask "virtualc64" do
   # NOTE: "64" is not a version number, but an intrinsic part of the product name
-  version "4.0.1"
-  sha256 "eb3467c08d66a5c80376bbe3dd1f63e99914cf9c9658d29548cfd130cc2058e4"
+  version "4.1"
+  sha256 "3e21194af9a6b1958e24fe04cd9c1a24b56866a4ee46cc346ddc5e537ce59a07"
 
-  url "https://github.com/dirkwhoffmann/virtualc64/releases/download/v#{version}/VirtualC64_#{version}.app.zip",
+  url "https://github.com/dirkwhoffmann/virtualc64/releases/download/v#{version}/VirtualC64.zip",
       verified: "github.com/dirkwhoffmann/virtualc64/"
   name "VirtualC64"
   desc "Cycle-accurate C64 emulator"
@@ -11,8 +11,8 @@ cask "virtualc64" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  app "VirtualC64_#{version}.app"
+  app "VirtualC64.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Also try using standard `:git` strategy over rate-limited `:github_latest`.

It looks like beta (pre-releases) use append a `b#` at end:
```console
❯ git ls-remote --tag https://github.com/dirkwhoffmann/virtualc64/ | awk '{print $2}'
refs/tags/V2.5
refs/tags/V2.5^{}
refs/tags/V3.3
refs/tags/V3.3^{}
refs/tags/v3.4
refs/tags/v3.4b1
refs/tags/v4.0
refs/tags/v4.0.1
refs/tags/v4.0b1
refs/tags/v4.0b2
refs/tags/v4.0b3
refs/tags/v4.0b4
refs/tags/v4.0b5
refs/tags/v4.1
```