### PR TITLE
Update insync from 3.3.9.40955 to 3.3.10.40961

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -1,6 +1,6 @@
 cask "insync" do
-  version "3.3.9.40955"
-  sha256 "24a169d1a1684b17915066de041bd6ba5d598b671f3293c34a219fdff4df6c68"
+  version "3.3.10.40961"
+  sha256 "283996ee8768c6275227d1e5047a49ece1e8d29cb0c587d1feca1b00334277f0"
 
   url "http://s.insynchq.com/builds/Insync-#{version}.dmg"
   name "Insync"
@@ -9,8 +9,7 @@ cask "insync" do
 
   livecheck do
     url :homepage
-    strategy :page_match
-    regex(/Version\s*(\d+(?:\.\d+)*)/i)
+    regex(%r{/Insync[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
