### PR TITLE
Update melodics from 2.1.6059 to 2.1.6079

### DIFF
--- a/Casks/melodics.rb
+++ b/Casks/melodics.rb
@@ -1,15 +1,17 @@
 cask "melodics" do
-  version "2.1.6059"
-  sha256 :no_check # required as upstream package is updated in-place
+  version "2.1.6079,A2A93732-8BA6-41EC-87BA-1C345A1C022B"
+  sha256 "6c9c3579742c271a7aeee3864fcd04cfd29f9ae18648fdf56bf2a426cb1ed562"
 
-  url "https://web-cdn.melodics.com/download/MelodicsV#{version.major}.dmg"
+  url "https://web-cdn.melodics.com/download/#{version.after_comma}.zip"
   name "Melodics"
   desc "Helps you learn to play your instrument"
   homepage "https://melodics.com/"
 
   livecheck do
     url "https://web-cdn.melodics.com/download/osxupdatescastv#{version.major}.xml"
-    strategy :sparkle
+    strategy :sparkle do |item|
+      "#{item.version},#{item.url[%r{/(\h+(?:-\h+)+)\.zip}i, 1]}"
+    end
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Trying out enclosure URL from sparkle appcast:
```xml
<title>Latest Version</title>
<description/>
<sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
<pubDate>Thu, 13 May 2021 11:57:35 +1200</pubDate>
<enclosure url="https://web-cdn.melodics.com/download/A2A93732-8BA6-41EC-87BA-1C345A1C022B.zip" sparkle:version="2.1.6079" type="application/octet-stream"/>
```