### PR TITLE
osxfuse: add caveat on switching to macfuse

### DIFF
--- a/Casks/osxfuse.rb
+++ b/Casks/osxfuse.rb
@@ -8,6 +8,11 @@ cask "osxfuse" do
   desc "File system integration"
   homepage "https://osxfuse.github.io/"
 
+  livecheck do
+    url :url
+    regex(/^osxfuse[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   pkg "Extras/FUSE for macOS #{version}.pkg"
 
   postflight do
@@ -25,5 +30,12 @@ cask "osxfuse" do
 
   caveats do
     reboot
+    <<~EOS
+      `#{token}` has been succeeded by `macfuse` as of version 4.0.0.
+
+      To update to a newer version, do:
+        brew uninstall #{token}
+        brew install macfuse
+    EOS
   end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://github.com/osxfuse/osxfuse/releases/tag/macfuse-4.0.0
> FUSE for macOS is now macFUSE.

```console
❯ brew info osxfuse
osxfuse: 3.11.2
https://osxfuse.github.io/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/osxfuse.rb
==> Name
OSXFUSE
==> Description
File system integration
==> Artifacts
Extras/FUSE for macOS 3.11.2.pkg (Pkg)
==> Caveats
`osxfuse` has been succeeded by `macfuse` as of version 4.0.0.

To update to a newer version, do:
  brew uninstall osxfuse
  brew install macfuse

osxfuse requires a kernel extension to work.
If the installation fails, retry after you enable it in:
  System Preferences → Security & Privacy → General

For more information, refer to vendor documentation or this Apple Technical Note:
  https://developer.apple.com/library/content/technotes/tn2459/_index.html

You must reboot for the installation of osxfuse to take effect.
```