### PR TITLE
vidcutter: add livecheck and desc

### DIFF
--- a/Casks/vidcutter.rb
+++ b/Casks/vidcutter.rb
@@ -2,10 +2,16 @@ cask "vidcutter" do
   version "6.0.2"
   sha256 "cebc95bd66d5df7fb46831bdd12993a9738ea1528850275e09a3ca69446851a7"
 
-  url "https://github.com/ozmartian/vidcutter/releases/download/#{version.major_minor}.0/VidCutter-#{version}-macOS.dmg",
-      verified: "github.com/ozmartian/vidcutter/"
+  url "https://github.com/ozmartian/vidcutter/releases/download/#{version.major_minor}.0/VidCutter-#{version}-macOS.dmg"
   name "VidCutter"
-  homepage "https://vidcutter.ozmartians.com/"
+  desc "Media cutter and joiner"
+  homepage "https://github.com/ozmartian/vidcutter"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(%r{href=.*?/VidCutter[._-]v?(\d+(?:\.\d+)+)[._-]macOS\.dmg}i)
+  end
 
   app "VidCutter.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Default `livecheck` showing source-code only release, so switch to `:github_latest`.

Updated `homepage` as it just redirects to GitHub repo

Also added `desc`.