### PR TITLE
Fix missing zap stanza in vAmiga.app Cask

### DIFF
--- a/Casks/vamiga.rb
+++ b/Casks/vamiga.rb
@@ -5,7 +5,7 @@ cask "vamiga" do
   url "https://github.com/dirkwhoffmann/vAmiga/releases/download/v#{version}/vAmiga.zip",
       verified: "github.com/dirkwhoffmann/vAmiga/"
   name "vAmiga"
-  desc "User-friendly Amiga 500, 1000, 2000 emulator"
+  desc "Amiga 500, 1000, 2000 emulator"
   homepage "https://dirkwhoffmann.github.io/vAmiga"
 
   livecheck do

--- a/Casks/vamiga.rb
+++ b/Casks/vamiga.rb
@@ -1,0 +1,22 @@
+cask "vamiga" do
+  version "1.0"
+  sha256 "c39f16935c7e1a4094a0fc23cdc2c4362d356056b7e9b03c95db47d9c65a852b"
+
+  url "https://github.com/dirkwhoffmann/vAmiga/releases/download/v#{version}/vAmiga.zip",
+      verified: "github.com/dirkwhoffmann/vAmiga/"
+  name "vAmiga"
+  desc "User-friendly Amiga 500, 1000, 2000 emulator"
+  homepage "https://dirkwhoffmann.github.io/vAmiga"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  app "vAmiga.app"
+
+  zap trash: [
+    "~/Library/Application Support/vAmiga",
+    "~/Library/Preferences/dirkwhoffmann.vAmiga.plist",
+  ]
+end


### PR DESCRIPTION
This adds the missing zap stanza in the vAmiga.app v1.0 Cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask {{cask_file}}` worked successfully.
- [X] `brew install --cask {{cask_file}}` worked successfully.
- [X] `brew uninstall --cask {{cask_file}}` worked successfully.
