### PR TITLE
Update lrtimelapse from 5.5.6 to 5.5.8 and add livecheck

### DIFF
--- a/Casks/lrtimelapse.rb
+++ b/Casks/lrtimelapse.rb
@@ -1,11 +1,16 @@
 cask "lrtimelapse" do
-  version "5.5.6"
-  sha256 "8c7431e9f4b217989dad4869577caf6b031abae027831410a575b3a6747b6b23"
+  version "5.5.8"
+  sha256 "e0a836f9b856817ef65430667be51377593c042143c5c5befb33af61b4472415"
 
-  url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/"
-  appcast "https://lrtimelapse.com/download/"
+  url "https://lrtimelapse.com/files/lrtimelapse-#{version.major}-mac/?version=#{version.dots_to_hyphens}"
   name "LRTimelapse"
+  desc "Time lapse editing, keyframing, grading and rendering"
   homepage "https://lrtimelapse.com/"
+
+  livecheck do
+    url "https://lrtimelapse.com/download/"
+    regex(/LRTimelapse[._-]?v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
+  end
 
   pkg "LRTimelapse #{version} Installer.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Previous URL changed in-place on same major release.

Try switching to URL based on older releases, e.g.:
- Older release download page: https://lrtimelapse.com/download/older-versions/
- Older release download link: https://lrtimelapse.com/files/lrtimelapse-5-mac/?version=5-4-0
- Current release download link: https://lrtimelapse.com/files/lrtimelapse-5-mac/