### PR TITLE
workflows: enable commit signing for BrewTestBot

### DIFF
--- a/.github/workflows/bump-unversioned-casks.yml
+++ b/.github/workflows/bump-unversioned-casks.yml
@@ -44,6 +44,12 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up commit signing
+        id: set-up-commit-signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       # Workaround until the `cache` action uses the changes from
       # https://github.com/actions/toolkit/pull/580.
       - name: Unlink workspace
@@ -91,6 +97,7 @@ jobs:
         env:
           HOMEBREW_DEBUG: 1
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         timeout-minutes: 20
 
       # Workaround until the `cache` action uses the changes from

--- a/.github/workflows/sync-templates-and-ci-config.yml
+++ b/.github/workflows/sync-templates-and-ci-config.yml
@@ -34,9 +34,17 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up GPG commit signing
+        id: set-up-commit-signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Detect changes
         id: detect_changes
         run: ./.github/actions/sync/templates.rb 'vendor/${{ matrix.repo }}' '${{ matrix.repo }}' 'sync-templates-and-ci-config'
+        env:
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@01f7dd1d28f5131231ba3ede0f1c8cb413584a1d


### PR DESCRIPTION
This PR adds the `setup-commit-signing` action to enable commit signing for BrewTestBot, wherever required. See Homebrew/brew#11403.

CC @nandahkrishna
