### PR TITLE
Link shell completion scripts with Docker.app

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -28,7 +28,7 @@ cask "docker" do
   homepage "https://www.docker.com/products/docker-desktop"
 
   auto_updates true
-  conflicts_with formula: "docker"
+  conflicts_with formula: ["docker", "docker-completion"]
 
   app "Docker.app"
   binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion",

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -28,7 +28,14 @@ cask "docker" do
   homepage "https://www.docker.com/products/docker-desktop"
 
   auto_updates true
-  conflicts_with formula: ["docker", "docker-completion"]
+  conflicts_with formula: %w[
+    docker
+    docker-completion
+    docker-compose
+    docker-compose-completion
+    hyperkit
+    kubernetes-cli
+  ]
 
   app "Docker.app"
   binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion",

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -28,6 +28,7 @@ cask "docker" do
   homepage "https://www.docker.com/products/docker-desktop"
 
   auto_updates true
+  conflicts_with formula: "docker"
 
   app "Docker.app"
 

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -31,6 +31,10 @@ cask "docker" do
   conflicts_with formula: "docker"
 
   app "Docker.app"
+  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion",
+         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker"
+  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
+         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
 
   uninstall delete:    [
     "/Library/PrivilegedHelperTools/com.docker.vmnetd",

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -35,6 +35,14 @@ cask "docker" do
          target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker"
   binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
          target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
+  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.zsh-completion",
+         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker"
+  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.zsh-completion",
+         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker_compose"
+  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.fish-completion",
+         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker.fish"
+  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
+         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
 
   uninstall delete:    [
     "/Library/PrivilegedHelperTools/com.docker.vmnetd",


### PR DESCRIPTION
- Docker.app conflicts_with docker formula (and [others](https://github.com/Homebrew/homebrew-cask/pull/105990/files#diff-69311afaafb577bb3a6618c5f2d0acf5cbd596db0236c994414a0491cccff721R31-R37))
- Docker.app installs bash shell completion

I added the `conflicts_with formula:` stanza, even though it's still a no-op stub, as it provides a bit of documentation to cask authors; but primarily so that if/when the stanza is implemented, this cask will be able to leverage it. (Note, the cask already conflicts with the binaries installed by other formulae; this is not newly-introduced by the linking of completions.)

I've noticed that there are very few completion scripts installed by casks. (Filebot being a [notable exception](https://github.com/Homebrew/homebrew-cask/blob/1212ae9879ed484487aeed96cb8d31ef497893ed/Casks/filebot.rb#L17-L18)) In general, that seems to make sense because casks are geared towards GUI apps and completion scripts are for CLIs, which are typically installed as formulae.

However, in docker's case (and perhaps others in a similar situation), I believe the completion should be installed. As noted, the Docker.app cask conflicts with the docker formula; which means only one of the two can be linked at a time. If one prefers the Docker.app cli binaries to be the ones linked, then it ought to be completion scripts that are bundled with said binaries that are installed.

Without the cask installing the completion scripts, then from the perspective of the Docker.app bundle, the app installation isn't "complete". But what's more,  if the cask is linked _over top_ of the formula installation, then it would be the formula's completion scripts being invoked for the cask binaries. That is a recipe for version conflicts and/or incompatibility.

https://github.com/Homebrew/homebrew-cask/issues/59696

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

