### PR TITLE
zerotier-one: update zap stanza, remove kext unload

### DIFF
--- a/Casks/zerotier-one.rb
+++ b/Casks/zerotier-one.rb
@@ -14,7 +14,9 @@ cask "zerotier-one" do
 
   pkg "ZeroTier One.pkg"
 
-  uninstall pkgutil:   "com.zerotier.pkg.ZeroTierOne",
-            launchctl: "com.zerotier.one",
-            kext:      "com.zerotier.tap"
+  uninstall quit:      "com.zerotier.ZeroTier-One",
+            pkgutil:   "com.zerotier.pkg.ZeroTierOne",
+            launchctl: "com.zerotier.one"
+
+  zap trash: "~/Library/Preferences/com.zerotier.ZeroTier-One.plist"
 end


### PR DESCRIPTION
ZeroTier has not used a kernel extension since 2019. This removes the caveat that says it still does. Additionally, this adds a zap option to remove ZeroTier's preferences that was missing before.
https://www.zerotier.com/2019/08/21/how-zerotier-eliminated-kernel-extensions-on-macos/

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.