### PR TITLE
Upgrade TradingView.app to 1.0.0-beta.4

### DIFF
--- a/Casks/tradingview.rb
+++ b/Casks/tradingview.rb
@@ -1,14 +1,14 @@
 cask "tradingview" do
-  version "1.0.0-beta.3"
-  sha256 "4223b41a138e2904383f9970d2a4289db933365183ffd30f901b83e1b7a659ed"
+  version "1.0.0-beta.4"
+  sha256 "dd4e666be5ef1051f5b90447690538e8e12857ed0a0fb48bd7f2b641dd289c8a"
 
-  url "https://tvd-packages.tradingview.com/stable/#{version}/darwin/x64/TradingView.dmg"
+  url "https://tvd-packages.tradingview.com/stable/#{version}/darwin/TradingView.dmg"
   name "TradingView Desktop"
   desc "Experience with the power and flexibility of a desktop application"
   homepage "https://www.tradingview.com/desktop/"
 
   livecheck do
-    url "https://tvd-packages.tradingview.com/stable/latest/darwin/x64/stable-mac.yml"
+    url "https://tvd-packages.tradingview.com/stable/latest/darwin/stable-mac.yml"
     strategy :electron_builder
   end
 


### PR DESCRIPTION
App upgrade to 1.0.0-beta.4 and all fetching paths was corrected as developers omitted 'x64' download paths as new dmg's are now universal for M1 'Aarch64' and 'x64'.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
