### PR TITLE
Add Mambaforge v4.10.1-1

### DIFF
--- a/Casks/mambaforge.rb
+++ b/Casks/mambaforge.rb
@@ -24,7 +24,10 @@ cask "mambaforge" do
   homepage "https://github.com/conda-forge/miniforge"
 
   auto_updates true
-  conflicts_with cask: ["miniconda", "miniforge"]
+  conflicts_with cask: [
+    "miniconda",
+    "miniforge",
+  ]
   container type: :naked
 
   binary "#{caskroom_path}/base/condabin/conda"

--- a/Casks/mambaforge.rb
+++ b/Casks/mambaforge.rb
@@ -1,0 +1,43 @@
+cask "mambaforge" do
+  version "4.10.1-1"
+
+  if Hardware::CPU.intel?
+    sha256 "c66af1181fdf4afd0d42ed749d2f05b78583eba3dad4fd7fd49b0a645556a771"
+    url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Mambaforge-#{version}-MacOSX-x86_64.sh"
+
+    installer script: {
+      executable: "Mambaforge-#{version}-MacOSX-x86_64.sh",
+      args:       ["-b", "-p", "#{caskroom_path}/base"],
+    }
+  else
+    sha256 "6ccf0e1de671df659f9146bd7c205e15b6287f6d761fefd07651c27baacd7110"
+    url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Mambaforge-#{version}-MacOSX-arm64.sh"
+
+    installer script: {
+      executable: "Mambaforge-#{version}-MacOSX-arm64.sh",
+      args:       ["-b", "-p", "#{caskroom_path}/base"],
+    }
+  end
+
+  name "mambaforge"
+  desc "Minimal installer for conda with preinstalled support for Mamba"
+  homepage "https://github.com/conda-forge/miniforge"
+
+  auto_updates true
+  conflicts_with cask: ["miniconda", "miniforge"]
+  container type: :naked
+
+  binary "#{caskroom_path}/base/condabin/conda"
+
+  uninstall delete: "#{caskroom_path}/base"
+
+  zap trash: [
+    "~/.condarc",
+    "~/.conda",
+  ]
+
+  caveats <<~EOS
+    Please run the following to setup your shell:
+      conda init "$(basename "${SHELL}")"
+  EOS
+end


### PR DESCRIPTION
Although there's already a Cask for `miniforge`, a
very similar project by the `conda-forge` authors, this
cask installs a version with built-in support for `mamba`,
a drop-in replacement for `conda`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
