### PR TITLE
Sublime-text: update to version 4 

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,12 +1,11 @@
 cask "sublime-text" do
   version "4.107"
-  sha256:no_check
+  sha256 :no_check
 
   url "https://download.sublimetext.com/sublime_text_build_#{version.no_dots}_mac.zip"
   name "Sublime Text"
   desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/"
-
 
   auto_updates true
   conflicts_with cask: "sublime-text-dev"

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -7,13 +7,6 @@ cask "sublime-text" do
   desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/"
 
-  livecheck do
-    url "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml"
-    strategy :sparkle do |item|
-      match = item.version.match(/(\d)(\d+)/)
-      "#{match[1]}.#{match[2]}"
-    end
-  end
 
   auto_updates true
   conflicts_with cask: "sublime-text-dev"

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,11 +1,11 @@
 cask "sublime-text" do
-  version "3.211"
-  sha256 "531c84e24983927c59dc0c5611f605776f917d1c516af80c69c09ea232d24e01"
+  version "4.107"
+  sha256:no_check
 
-  url "https://download.sublimetext.com/Sublime%20Text%20Build%20#{version.no_dots}.dmg"
+  url "https://download.sublimetext.com/sublime_text_build_#{version.no_dots}_mac.zip"
   name "Sublime Text"
   desc "Text editor for code, markup and prose"
-  homepage "https://www.sublimetext.com/#{version.major}"
+  homepage "https://www.sublimetext.com/"
 
   livecheck do
     url "https://www.sublimetext.com/updates/#{version.major}/stable/appcast_osx.xml"
@@ -24,7 +24,6 @@ cask "sublime-text" do
   uninstall quit: "com.sublimetext.#{version.major}"
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sublimetext.#{version.major}.sfl*",
     "~/Library/Application Support/Sublime Text #{version.major}",
     "~/Library/Caches/com.sublimetext.#{version.major}",
     "~/Library/Preferences/com.sublimetext.#{version.major}.plist",


### PR DESCRIPTION
Changes: 
* Updated version number and download URL 
* Remove livecheck due to new version having no livecheck URL
* Removed sha256, none supplied from developer

Loved homebrew for a long time, new to contributing. Apologies if things are out of order. 

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
