### PR TITLE
Update electerm from 1.12.24 to 1.13.1

### DIFF
--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,6 +1,6 @@
 cask "electerm" do
-  version "1.12.24"
-  sha256 "a40b236370f5e9e10db51bc4f5837a67609392e6f4ed2db824c273fe3bf252bc"
+  version "1.13.1"
+  sha256 "621a041f888dde3cab4a5c59a7a1150ac36149bde9321e39a4596f1a852f0739"
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac.dmg"
   name "electerm"


### PR DESCRIPTION
Created with `brew bump-cask-pr`.
