### PR TITLE
Updated vmpk 0.8.3 dependencies: VMPK cask could use fluid-synth #106124

### DIFF
--- a/Casks/vmpk.rb
+++ b/Casks/vmpk.rb
@@ -10,7 +10,6 @@ cask "vmpk" do
 
   depends_on formula: "fluid-synth"
   depends_on macos: ">= :sierra"
-  depends_on arch: :x86_64
 
   app "vmpk.app"
 end

--- a/Casks/vmpk.rb
+++ b/Casks/vmpk.rb
@@ -8,7 +8,9 @@ cask "vmpk" do
   desc "Virtual MIDI Piano Keyboard"
   homepage "https://vmpk.sourceforge.io/"
 
+  depends_on formula: "fluid-synth"
   depends_on macos: ">= :sierra"
+  depends_on arch: :x86_64
 
   app "vmpk.app"
 end


### PR DESCRIPTION
This merge request adds fluid-synth as dependency, because it is not fully included inside the dmg package, but the users may want to use the drumstick backend, like in Linux and Windows.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
