### PR TITLE
Add dmidiplayer.app v1.3.0

### DIFF
--- a/Casks/dmidiplayer.rb
+++ b/Casks/dmidiplayer.rb
@@ -1,0 +1,16 @@
+cask "dmidiplayer" do
+  version "1.3.0"
+  sha256 "61d1cc6842ba61b704cf45c98220c38fb5ccd506fb72fe10c434a476edd3f53d"
+
+  url "https://downloads.sourceforge.net/dmidiplayer/#{version}/dmidiplayer-#{version}-mac-x64.dmg",
+      verified: "downloads.sourceforge.net/dmidiplayer/"
+  name "dmidiplayer"
+  desc "Multiplatform MIDI File Player"
+  homepage "https://dmidiplayer.sourceforge.io/"
+
+  depends_on formula: "fluid-synth"
+  depends_on macos: ">= :sierra"
+  depends_on arch: :x86_64
+
+  app "dmidiplayer.app"
+end

--- a/Casks/dmidiplayer.rb
+++ b/Casks/dmidiplayer.rb
@@ -13,4 +13,10 @@ cask "dmidiplayer" do
   depends_on arch: :x86_64
 
   app "dmidiplayer.app"
+
+  zap trash: [
+    "~/Library/Preferences/net.sourceforge.dmidiplayer.plist",
+    "~/Library/Preferences/net.sourceforge.drumstick.Drumstick MIDI File Multiplatform Player.plist",
+    "~/Library/Saved Application State/net.sourceforge.dmidiplayer.savedState"
+  ]
 end

--- a/Casks/dmidiplayer.rb
+++ b/Casks/dmidiplayer.rb
@@ -17,6 +17,6 @@ cask "dmidiplayer" do
   zap trash: [
     "~/Library/Preferences/net.sourceforge.dmidiplayer.plist",
     "~/Library/Preferences/net.sourceforge.drumstick.Drumstick MIDI File Multiplatform Player.plist",
-    "~/Library/Saved Application State/net.sourceforge.dmidiplayer.savedState"
+    "~/Library/Saved Application State/net.sourceforge.dmidiplayer.savedState",
   ]
 end


### PR DESCRIPTION
dmidiplayer is a multilplatform MIDI file player, with the following main features:
* MIDI Output to hardware MIDI ports, or soft synths (macOS DLS Synth and Fluidsynth included)
* Transpose song tonality between -12 and +12 semitones
* Change MIDI volume level (using MIDI CC7)
* Scale song speed between half and double tempo
* Lyrics (karaoke), Piano Player and MIDI Channels views

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
