### PR TITLE
Add IPATool v1.0.1

### DIFF
--- a/Casks/ipatool.rb
+++ b/Casks/ipatool.rb
@@ -1,0 +1,17 @@
+cask "ipatool" do
+  version "1.0.1"
+  sha256 "3f32a497d7cc8115ff2a7e05c49ce62334b88e9dacfa979f290b941d4de27200"
+
+  url "https://github.com/majd/ipatool/releases/download/v#{version}/ipatool"
+  name "IPATool"
+  desc "CLI tool for searching and downloading iOS app packages from the App Store"
+  homepage "https://github.com/majd/ipatool"
+
+  depends_on macos: ">= :el_capitan"
+
+  binary "ipatool"
+
+  postflight do
+    system "xattr", "-d", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/ipatool"
+  end
+end


### PR DESCRIPTION
IPATool is a command-line tool that allows users to search and download app packages (known as ipa files) from the iOS App Store.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
