### PR TITLE
Bump fsnotes to 4.10.1

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,8 +1,8 @@
 cask "fsnotes" do
-  version "4.10.0"
-  sha256 "f28f42e9241825d017c88f84cdf7227a330550f0d917b2051a9088516a294161"
+  version "4.10.1"
+  sha256 "e5661f113bb3669e771e4293638cc9cb5ded2f970693c2e55cf18391dc26541b"
 
-  url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes.zip",
+  url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip",
       verified: "github.com/glushchenko/fsnotes/"
   name "FSNotes"
   desc "Notes manager"

--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 cask "fsnotes" do
   version "4.10.1"
   sha256 "e5661f113bb3669e771e4293638cc9cb5ded2f970693c2e55cf18391dc26541b"

--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,3 @@
-# typed: false
-# frozen_string_literal: true
-
 cask "fsnotes" do
   version "4.10.1"
   sha256 "e5661f113bb3669e771e4293638cc9cb5ded2f970693c2e55cf18391dc26541b"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.