### PR TITLE
Update xpra from 4.1.3 to 4.2,0

### DIFF
--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -1,15 +1,18 @@
 cask "xpra" do
-  version "4.1.3"
-  sha256 :no_check
+  version "4.2,0"
+  sha256 "af44d9943b1cfd08f40d2cc4ab4d9a14d231a0a46e0df95fb24ee79a1df1498d"
 
-  url "https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg"
+  url "https://www.xpra.org/dists/osx/x86_64/Xpra-Python3-x86_64-#{version.before_comma}-r#{version.after_comma}.pkg"
   name "Xpra"
   desc "Screen and application forwarding system"
   homepage "https://www.xpra.org/"
 
   livecheck do
-    url "https://github.com/Xpra-org/xpra/releases"
-    strategy :git
+    url "https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg.sha1"
+    strategy :page_match do |page|
+      match = page.match(/x86_64[._-]v?(\d+(?:\.\d+)+)[._-]r(\d+)\.pkg/i)
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   pkg "Xpra-x86_64.pkg"

--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -15,7 +15,7 @@ cask "xpra" do
     end
   end
 
-  pkg "Xpra-x86_64.pkg"
+  pkg "Xpra-Python3-x86_64-#{version.before_comma}-r#{version.after_comma}.pkg"
 
   uninstall pkgutil:  "org.xpra.pkg"
 

--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -17,7 +17,7 @@ cask "xpra" do
 
   pkg "Xpra-Python3-x86_64-#{version.before_comma}-r#{version.after_comma}.pkg"
 
-  uninstall pkgutil:  "org.xpra.pkg"
+  uninstall pkgutil: "org.xpra.pkg"
 
   zap trash: "/Library/Application Support/Xpra"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Also try using versioned URL and updated livecheck.

The original unversioned URL https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg has checksum files:
- https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg.sha1
- https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg.md5

These show the versioned filename: `Xpra-Python3-x86_64-4.2-r0.pkg`

Both appear to be the same file:
```console
❯ sha256sum *pkg
af44d9943b1cfd08f40d2cc4ab4d9a14d231a0a46e0df95fb24ee79a1df1498d  Xpra-Python3-x86_64-4.2-r0.pkg
af44d9943b1cfd08f40d2cc4ab4d9a14d231a0a46e0df95fb24ee79a1df1498d  Xpra-x86_64.pkg
```