### PR TITLE
feat: Add `tizen-studio` aka Tizen SDK

### DIFF
--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -1,0 +1,20 @@
+cask "tizen-studio" do
+  version "4.1"
+  sha256 :no_check
+
+  url "https://download.tizen.org/sdk/Installer/tizen-studio_4.1/web-ide_Tizen_Studio_4.1_macos-64.dmg"
+
+  name "Framer"
+  desc "Tizen Studio is the official IDE for developing web and native applications for Tizen"
+  homepage "https://developer.tizen.org/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  auto_updates true
+  depends_on macos: ">= :mojave"
+
+  app "Tizen Studio.app"
+end

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -5,7 +5,7 @@ cask "tizen-studio" do
   url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
 
   name "Tizen Studio"
-  desc "The Official IDE for developing web and native applications for Tizen"
+  desc "Official IDE for developing web and native applications for Tizen"
   homepage "https://developer.tizen.org/"
 
   livecheck do
@@ -17,11 +17,11 @@ cask "tizen-studio" do
   depends_on macos: ">= :catalina"
 
   app "Tizen Studio.app"
-  
+
   zap trash: [
     "~/tizen-studio",
     "~/Applications/tizen-studio",
     "~/Library/Preferences/org.tizen.sdk.ide.plist",
-    "~/Library/Saved Application State/org.tizen.sdk.ide.savedState"
+    "~/Library/Saved Application State/org.tizen.sdk.ide.savedState",
   ]
 end

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -1,7 +1,6 @@
 cask "tizen-studio" do
   version "4.1"
   sha256 "c538328806b14cec190591213465d813a180bcbd"
-
   url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
 
   name "Tizen Studio"

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -1,6 +1,6 @@
 cask "tizen-studio" do
   version "4.1"
-  sha256 "c538328806b14cec190591213465d813a180bcbd"
+  sha256 "e49893861fd9b0871e9decf9fd5ad963f6398957c32c5b604a18cce96c8a539f"
 
   url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
   name "Tizen Studio"

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -14,7 +14,7 @@ cask "tizen-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "Tizen Studio.app"
 end

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -9,7 +9,7 @@ cask "tizen-studio" do
 
   livecheck do
     url "https://download.tizen.org/sdk/Installer/"
-    regex(/tizen-studio_(\d+(?:\.\d+)*)/}i)
+    regex(/tizen-studio_(\d+(?:\.\d+)*)/i)
   end
 
   auto_updates true

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -3,7 +3,6 @@ cask "tizen-studio" do
   sha256 "c538328806b14cec190591213465d813a180bcbd"
 
   url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
-
   name "Tizen Studio"
   desc "Official IDE for developing web and native applications for Tizen"
   homepage "https://developer.tizen.org/"

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -4,7 +4,7 @@ cask "tizen-studio" do
 
   url "https://download.tizen.org/sdk/Installer/tizen-studio_4.1/web-ide_Tizen_Studio_4.1_macos-64.dmg"
 
-  name "Framer"
+  name "Tizen Studio"
   desc "Tizen Studio is the official IDE for developing web and native applications for Tizen"
   homepage "https://developer.tizen.org/"
 

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -2,14 +2,14 @@ cask "tizen-studio" do
   version "4.1"
   sha256 "e49893861fd9b0871e9decf9fd5ad963f6398957c32c5b604a18cce96c8a539f"
 
-  url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
+  url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version}/web-ide_Tizen_Studio_#{version}_macos-64.dmg"
   name "Tizen Studio"
   desc "Official IDE for developing web and native applications for Tizen"
   homepage "https://developer.tizen.org/"
 
   livecheck do
-    url "https://download.tizen.org/sdk/Installer"
-    regex(%r{href=.*?/tizen-studio[._-]?(\d+(?:\.\d+)+)/web-ide_Tizen_Studio[._-]?(\d+(?:\.\d+)+)_macos-64\.dmg}i)
+    url "https://download.tizen.org/sdk/Installer/"
+    regex(/tizen-studio_(\d+(?:\.\d+)*)/}i)
   end
 
   auto_updates true

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -1,20 +1,27 @@
 cask "tizen-studio" do
   version "4.1"
-  sha256 :no_check
+  sha256 "c538328806b14cec190591213465d813a180bcbd"
 
-  url "https://download.tizen.org/sdk/Installer/tizen-studio_4.1/web-ide_Tizen_Studio_4.1_macos-64.dmg"
+  url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
 
   name "Tizen Studio"
-  desc "Tizen Studio is the official IDE for developing web and native applications for Tizen"
+  desc "The Official IDE for developing web and native applications for Tizen"
   homepage "https://developer.tizen.org/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://download.tizen.org/sdk/Installer"
+    regex(%r{href=.*?/tizen-studio[._-]?(\d+(?:\.\d+)+)/web-ide_Tizen_Studio[._-]?(\d+(?:\.\d+)+)_macos-64\.dmg}i)
   end
 
   auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Tizen Studio.app"
+  
+  zap trash: [
+    "~/tizen-studio",
+    "~/Applications/tizen-studio",
+    "~/Library/Preferences/org.tizen.sdk.ide.plist",
+    "~/Library/Saved Application State/org.tizen.sdk.ide.savedState"
+  ]
 end

--- a/Casks/tizen-studio.rb
+++ b/Casks/tizen-studio.rb
@@ -1,6 +1,7 @@
 cask "tizen-studio" do
   version "4.1"
   sha256 "c538328806b14cec190591213465d813a180bcbd"
+
   url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version.major_minor}/web-ide_Tizen_Studio_#{version.major_minor}_macos-64.dmg"
 
   name "Tizen Studio"


### PR DESCRIPTION
This commit adds new application called **Tizen SDK**.

Download url is https://developer.tizen.org/development/tizen-studio/download

There no support for **Apple Silicon**, so this app is only for **Intel x64**, see https://docs.tizen.org/application/tizen-studio/setup/prerequisites/

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
