### PR TITLE
Add WordCounter v1.6.5

### DIFF
--- a/Casks/wordcounter.rb
+++ b/Casks/wordcounter.rb
@@ -1,0 +1,21 @@
+cask "wordcounter" do
+  version "1.6.5"
+  sha256 "8b7e2df1170382362bf83bb199dcd8daab64c9824ddaffda9182d5cbd39554d6"
+
+  url "https://d1dncsspr585u3.cloudfront.net/WordCounter-v#{version}.dmg", verified: "d1dncsspr585u3.cloudfront.net"
+  name "wordcounter"
+  desc "Count words written across apps and display in the menu bar"
+  homepage "https://wordcounterapp.com/"
+
+  depends_on macos: ">= :sierra"
+
+  app "WordCounter.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/de.christiantietze.WordCounter-LaunchAtLoginHelper",
+    "~/Library/Application Support/WordCounter",
+    "~/Library/Containers/de.christiantietze.WordCounter-LaunchAtLoginHelper",
+    "~/Library/Logs/WordCounter",
+    "~/Library/Preferences/de.christiantietze.WordCounter.plist",
+  ]
+end

--- a/Casks/wordcounter.rb
+++ b/Casks/wordcounter.rb
@@ -3,7 +3,7 @@ cask "wordcounter" do
   sha256 "8b7e2df1170382362bf83bb199dcd8daab64c9824ddaffda9182d5cbd39554d6"
 
   url "https://d1dncsspr585u3.cloudfront.net/WordCounter-v#{version}.dmg", verified: "d1dncsspr585u3.cloudfront.net"
-  name "wordcounter"
+  name "WordCounter"
   desc "Count words written across apps and display in the menu bar"
   homepage "https://wordcounterapp.com/"
 


### PR DESCRIPTION
(Re?)creating a cask for WordCounter.

WordCounter had already a cask until 2019 (the last PR I found refers to v1.4.3: Homebrew#61722), but I haven't found any issue explaining why it was removed/deleted at some point. The only possible explanation I see is that the previous URL wasn't working anymore. A new distribution URL from Cloudfront is used here.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask {{cask_file}}` worked successfully.
- [x] `brew install --cask {{cask_file}}` worked successfully.
- [x] `brew uninstall --cask {{cask_file}}` worked successfully.
