### PR TITLE
Update VirtualC64 from 4.1 to 4.2

### DIFF
--- a/Casks/virtualc64.rb
+++ b/Casks/virtualc64.rb
@@ -1,9 +1,9 @@
 cask "virtualc64" do
   # NOTE: "64" is not a version number, but an intrinsic part of the product name
-  version "4.1"
-  sha256 "3e21194af9a6b1958e24fe04cd9c1a24b56866a4ee46cc346ddc5e537ce59a07"
+  version "4.2"
+  sha256 "625dedcd37c8c22fa6935578f3751d7b78fd07d4bf1982c27a3686487d04823d"
 
-  url "https://github.com/dirkwhoffmann/virtualc64/releases/download/v#{version}/VirtualC64.zip",
+  url "https://github.com/dirkwhoffmann/virtualc64/releases/download/v#{version}/VirtualC64.app.zip",
       verified: "github.com/dirkwhoffmann/virtualc64/"
   name "VirtualC64"
   desc "Cycle-accurate C64 emulator"
@@ -15,4 +15,10 @@ cask "virtualc64" do
   end
 
   app "VirtualC64.app"
+
+  zap trash: [
+    "~/Library/Application Support/VirtualC64",
+    "~/Library/Caches/de.dirkwhoffmann.VirtualC64",
+    "~/Library/Preferences/de.dirkwhoffmann.VirtualC64.plist",
+  ]
 end


### PR DESCRIPTION
The filename has slightly changed. This also adds a zap stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask {{cask_file}}` is error-free.
- [X] `brew style --fix {{cask_file}}` reports no offenses.
