### PR TITLE
Update electron from 12.0.9 to 13.0.0

### DIFF
--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,12 +1,12 @@
 cask "electron" do
-  version "12.0.9"
+  version "13.0.0"
 
   if Hardware::CPU.intel?
-    sha256 "b3f1e378f58e7c36b54451c5a3485adc370277827974e1eb0790b6965737c872"
+    sha256 "f3b9e45a442f82f06da8dd6cbdccd8031a191f3ba73e2886572f6472160d1f2d"
     url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-x64.zip",
         verified: "github.com/electron/electron/"
   else
-    sha256 "cb8aa8153005ea0d801182eb714d56af0217345b1152d867317291670731daeb"
+    sha256 "9c26405efd126d4e076fa8068e9003463be62b449182632babd5445f633712b6"
     url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-arm64.zip",
         verified: "github.com/electron/electron/"
   end


### PR DESCRIPTION
 Created with `brew bump-cask-pr`.
