### PR TITLE
Removed reference from README.md to deleted file hacking.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ And there we have it. An application installed with one quick command: no clicki
 
 * Find basic documentation on using Homebrew Cask in [USAGE.md](USAGE.md)
 * Want to contribute a Cask? Awesome! See [CONTRIBUTING.md](CONTRIBUTING.md)
-* Want to hack on our code? Also awesome! See [hacking.md](doc/development/hacking.md)
 * More project-related details and discussion are available in the [documentation](doc)
 
 ## Reporting bugs


### PR DESCRIPTION
In Feb this year @vitorgalvao removed file "hacking.md" from this reop in #100401.
However there is still a link to this file from the main README.md page.
The most practical solution seems to be to delete the sentence with this link in it too - as per this PR(??)

Problem found using a GitHub deadlink finder tool that I created and can be re-used to validate this repo one PR approved: https://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3A%2F%2Fgithub.com%2FHomebrew%2Fhomebrew-cask&User=&NumberOfReposToSearchFor=&MinStar=5000&UpdatedAfter=&SearchSort=2&SortAscDsc=1




**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [N/A doc issue] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [N/A doc issue] `brew audit --cask {{cask_file}}` is error-free.
- [N/A doc issue] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**: N/A doc issue

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
