### PR TITLE
.github/workflows/dispatch-command.yml:  Don't Re-Run on User Forks

### DIFF
--- a/.github/workflows/dispatch-command.yml
+++ b/.github/workflows/dispatch-command.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   dispatch-command:
+    if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch /rebase Command


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Don't run the 'dispatch-command' workflow outside the Homebrew organization and thus on user forks; it fails if your fork doesn't supply a '`token`' as input, anyway.  (I thought GitHub's Actions documentation said workflows aren't supposed to run on forks by default, last I looked, but I keep seeing it happen regardless.)  