### PR TITLE
bitcoin-core: fix livecheck

### DIFF
--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -9,7 +9,7 @@ cask "bitcoin-core" do
 
   livecheck do
     url "https://github.com/bitcoin/bitcoin"
-    strategy :git
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   # Renamed for consistency: app name is different in the Finder and in a shell.


### PR DESCRIPTION
Edits to `livecheck`
- remove `strategy` as `:git` is default
- add regex to filter out bad tags like `v21.99-guixtest1` and `v0.21.1rc1`

Before
```
❯ brew livecheck bitcoin-core
bitcoin-core : 0.21.1 ==> 21.99-guixtest1
```

After
```
❯ brew livecheck bitcoin-core
bitcoin-core : 0.21.1 ==> 0.21.1
```