### PR TITLE
Update eloston-chromium from 90.0.4430.212-1.1_x86-64 to 91.0.4472.77-1.1_x86-64

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,7 +1,7 @@
 cask "eloston-chromium" do
   if Hardware::CPU.intel?
-    version "90.0.4430.212-1.1_x86-64"
-    sha256 "fb1c992747f1667283f0820d92315a195d7a91c4135226e7cd424e93de2675c4"
+    version "91.0.4472.77-1.1_x86-64"
+    sha256 "6147710a275c1233ad88e6575bff7fcd4c95d1caf709048d8d154d6bf458e72d"
   else
     version "90.0.4430.93-1.1_arm64"
     sha256 "efecba9e8c1ffdfb457448cc3b139c9c5d86135b4a73af373a0a4f6bb27fa17b"


### PR DESCRIPTION

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask {{cask_file}}` is error-free.
- [ ] `brew style --fix {{cask_file}}` reports no offenses.