### PR TITLE
Add depends on Big Sur to Carbon Copy Cloner

### DIFF
--- a/Casks/carbon-copy-cloner.rb
+++ b/Casks/carbon-copy-cloner.rb
@@ -14,6 +14,7 @@ cask "carbon-copy-cloner" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Carbon Copy Cloner.app"
 


### PR DESCRIPTION
Carbon Copy Cloner now requires Big Sur to run as of version 6

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.