### PR TITLE
Upgrade Linear.app (linear-linear) to 1.3.4

### DIFF
--- a/Casks/linear-linear.rb
+++ b/Casks/linear-linear.rb
@@ -13,7 +13,7 @@ cask "linear-linear" do
   homepage "https://linear.app/"
 
   livecheck do
-    url "https://desktop.linear.app/mac/dmg/x64"
+    url :url
     strategy :header_match
   end
 

--- a/Casks/linear-linear.rb
+++ b/Casks/linear-linear.rb
@@ -1,11 +1,12 @@
 cask "linear-linear" do
   version "1.3.4"
+  sha256 :no_check
+
   if Hardware::CPU.intel?
     url "https://desktop.linear.app/mac/dmg/x64"
   else
     url "https://desktop.linear.app/mac/dmg/arm64"
   end
-  sha256 :no_check
 
   name "Linear"
   desc "App to manage software development and track bugs"

--- a/Casks/linear-linear.rb
+++ b/Casks/linear-linear.rb
@@ -1,16 +1,19 @@
 cask "linear-linear" do
-  version "1.2.15"
-  sha256 "437910bced988d023f5ab9e45adefb5c38212b4a88d5f456c864a904686e61ef"
+  version "1.3.4"
+  if Hardware::CPU.intel?
+    url "https://desktop.linear.app/mac/dmg/x64"
+  else
+    url "https://desktop.linear.app/mac/dmg/arm64"
+  end
+  sha256 :no_check
 
-  url "https://download.linear.app/darwin/Linear-darwin-x64-#{version}.zip"
   name "Linear"
   desc "App to manage software development and track bugs"
   homepage "https://linear.app/"
 
   livecheck do
-    url "https://api.linear.app/update/darwin/0.0.0"
-    strategy :page_match
-    regex(%r{/Linear-darwin-x64-(\d+(?:\.\d+)*)\.zip}i)
+    url "https://desktop.linear.app/mac/dmg/x64"
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/linear-linear.rb
+++ b/Casks/linear-linear.rb
@@ -13,7 +13,7 @@ cask "linear-linear" do
   homepage "https://linear.app/"
 
   livecheck do
-    url :url
+    url "https://desktop.linear.app/mac/dmg/x64"
     strategy :header_match
   end
 


### PR DESCRIPTION
Updates the download url, adds m1 url, fixes livecheck

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask {{cask_file}}` worked successfully.
- [ ] `brew install --cask {{cask_file}}` worked successfully.
- [ ] `brew uninstall --cask {{cask_file}}` worked successfully.
