### PR TITLE
Update amazon-workspaces from 3.1.7.1881 to 3.1.8.1929

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,16 +1,19 @@
 cask "amazon-workspaces" do
-  version "3.1.7.1881"
-  sha256 :no_check
+  version "3.1.8.1929"
+  sha256 "53dde99e45e55f0cfa51048cb7d8b9f2b88583a34d94c349122d929b95c3b570"
 
-  url "https://workspaces-client-updates.s3.amazonaws.com/prod/iad/osx/WorkSpaces.pkg",
-      verified: "workspaces-client-updates.s3.amazonaws.com/"
+  url "https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpaces_AllProducts_#{version.split(".")[-1]}.zip",
+      verified: "d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/"
   name "Amazon Workspaces"
+  desc "Cloud native persistent desktop virtualization"
   homepage "https://clients.amazonworkspaces.com/"
 
   livecheck do
     url "https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpacesAppCast_macOS_20171023.xml"
     strategy :sparkle
   end
+
+  depends_on macos: ">= :sierra"
 
   pkg "WorkSpaces.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

From livecheck URL:
https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpacesAppCast_macOS_20171023.xml

There is a download URL for ZIP:
https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpaces_AllProducts_1929.zip

Looks to be versioned based on last part of version (probably build number): 1929

SHA256 matches between unversioned PKG file and versioned PKG inside ZIP.