### PR TITLE
Update clip-studio-paint from 1.10.6 to 1.10.10

### DIFF
--- a/Casks/clip-studio-paint.rb
+++ b/Casks/clip-studio-paint.rb
@@ -1,6 +1,6 @@
 cask "clip-studio-paint" do
-  version "1.10.6"
-  sha256 "956b22c1c00f79361e372e3a7078ff26d591bdf4306af523b622d96ba16b36b1"
+  version "1.10.10"
+  sha256 "1c545581b1411de0b5347f0262cc86deeb1f8846abcf4830628d65d3aad8f98b"
 
   url "https://vd.clipstudio.net/clipcontent/paint/app/#{version.no_dots}/CSP_#{version.no_dots}m_app.pkg"
   name "Clip Studio Paint"
@@ -8,12 +8,11 @@ cask "clip-studio-paint" do
   homepage "https://www.clipstudio.net/en"
 
   livecheck do
-    url "https://www.clipstudio.net/en/dl"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/CSP_(\d+?)(\d+)(\d+?)m_app\.pkg}i)
-      "#{match[1]}.#{match[2]}.#{match[3]}"
-    end
+    url "https://www.clipstudio.net/en/dl/release_note/"
+    regex(/Clip\s+Studio\s+Paint\s+(?:v|Ver\.?|Version)?\s*(\d+(?:\.\d+)+)/i)
   end
+
+  depends_on macos: ">= :high_sierra"
 
   installer manual: "CSP_#{version.no_dots}m_app.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Updated livecheck since it wasn't showing correct version
```
clip-studio-paint : 1.10.6 ==> 1.101.0
```

Minimum OS from https://www.clipstudio.net/en/dl/system_popup/#mac