### PR TITLE
miniconda: add desc and livecheck

### DIFF
--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -5,7 +5,13 @@ cask "miniconda" do
   url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-x86_64.sh",
       verified: "repo.anaconda.com/miniconda/"
   name "Continuum Analytics Miniconda"
+  desc "Minimal installer for conda"
   homepage "https://conda.io/miniconda.html"
+
+  livecheck do
+    url "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    regex(/^#\s*VER:\s*((?:py\d*[._-])?v?(\d+(?:\.\d+)+))/i)
+  end
 
   auto_updates true
   conflicts_with cask: "miniforge"

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -8,9 +8,12 @@ cask "miniconda" do
   desc "Minimal installer for conda"
   homepage "https://conda.io/miniconda.html"
 
+  # This regex restricts matching to a specific Python version. This will need
+  # to be updated when the prefix changes in the latest version at the top of:
+  # https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
   livecheck do
-    url "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-    regex(/^#\s*VER:\s*((?:py\d*[._-])?v?(\d+(?:\.\d+)+))/i)
+    url "https://repo.anaconda.com/miniconda/"
+    regex(/>\s*Miniconda3-(py38[._-]\d+(?:\.\d+)+)-MacOSX-x86_64\.sh\s*</i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

For livecheck, trying to grab version info from latest shell script
https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
```sh
#!/bin/sh
#
# NAME:  Miniconda3
# VER:   py38_4.9.2
# PLAT:  osx-64
# LINES: 577
# MD5:   6e21e31f666558d485dfdab74c1bc1c8
```

Seems the easiest way, though it will require curl'ing a ~55M file.

A more complicated option would be to regex matching the MD5 checksum for latest shell script inside https://repo.anaconda.com/miniconda/ and then using that to find the versioned shell script that has same MD5 checksum.