### PR TITLE
google-backup-and-sync: add livecheck and desc

### DIFF
--- a/Casks/google-backup-and-sync.rb
+++ b/Casks/google-backup-and-sync.rb
@@ -4,7 +4,13 @@ cask "google-backup-and-sync" do
 
   url "https://dl.google.com/drive/InstallBackupAndSync.dmg"
   name "Google Backup and Sync"
+  desc "Back up and sync files with Google Drive"
   homepage "https://www.google.com/drive/download/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   auto_updates true
   conflicts_with cask: "google-photos-backup-and-sync"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

I wasn't able to find full version number online.

Closest was the major/minor version in https://support.google.com/a/answer/7573023?hl=en
(up through 3.43, they listed the full version, but from 3.44 to 3.54, only partial version is listed).

Not too sure how the app is using patch numbers as our past updates have some odd oscillation until the next minor release:
- #95871 `3.53.3404.7585 to 3.53.3471.0626`
- #96037 `3.53.3471.0626 to 3.53.3404.7585`
- #97045 `3.53.3404.7585 to 3.53.3471.0626`
- #98556 `3.53.3471.0626 to 3.54.3529.0458`

For now, I guess we can livecheck the full version until there is sufficient data to tell if it is actually correct.