### PR TITLE
Update adobe-creative-cloud from 5.4.1.534 to 5.4.5.550 and add livecheck

### DIFF
--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -1,12 +1,12 @@
 cask "adobe-creative-cloud" do
-  version "5.4.1.534"
+  version "5.4.5.550"
 
   if Hardware::CPU.intel?
-    sha256 "dd71684c8189532356e10c3347edbb62c95cd5d76cf75ad8bcc1c871308f62e2"
+    sha256 "2efca959497b9f2fe3278a64341aa8a817e3855b1db9a9768f99259ef56e5227"
 
     url "https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/#{version.major_minor_patch.dots_to_underscores}/osx10/ACCCx#{version.dots_to_underscores}.dmg"
   else
-    sha256 "cd8a62869e68c90885fca738e8184c6091a20bb55b56a1d93cc123aa69994417"
+    sha256 "fe77eb37c4cbebe57750834063d8c01233887585252400dd8cfa2fb77b2a8fb3"
 
     url "https://ccmdl.adobe.com/AdobeProducts/KCCC/CCD/#{version.major_minor_patch.dots_to_underscores}/macarm64/ACCCx#{version.dots_to_underscores}.dmg"
   end
@@ -14,6 +14,11 @@ cask "adobe-creative-cloud" do
   name "Adobe Creative Cloud"
   desc "Collection of apps and services for photography, design, video, web, and UX"
   homepage "https://www.adobe.com/creativecloud.html"
+
+  livecheck do
+    url "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html"
+    regex(/Version\s*(\d+(?:\.\d+)+),?\s+(?:(?:was\s+)?released|for\s+macOS)/i)
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Livecheck on https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html
Regex to try to match the various patterns used in previous releases:
- Common pattern: `Version 5.4.5.550 released on 05/10/2021(mandatory release)`
- OS-specific pattern: `Version 5.4.2.540 for macOS (Intel and ARM) and version 5.4.2.541 for Windows (Intel) released on 03/12/2021(web release)`
- Added extra "was": `Version 2.0.0.74 was released on 4/21/2015`
- Added extra comma: `Version 1.0.0.183, released on 6/24/2013`
