### PR TITLE
Update jetbrains-space from 2021.1.1.65998 to 2021.1.2.68492

### DIFF
--- a/Casks/jetbrains-space.rb
+++ b/Casks/jetbrains-space.rb
@@ -1,11 +1,16 @@
 cask "jetbrains-space" do
-  version "2021.1.1.65998"
+  version "2021.1.2.68492"
   sha256 :no_check
 
   url "https://download.jetbrains.com/space/jetbrains-space.dmg"
   name "JetBrains Space"
   desc "Team communication and collaboration software"
   homepage "https://www.jetbrains.com/space/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   app "JetBrains Space.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

For livecheck, currently no standard JetBrains release page, so using plist.
