### PR TITLE
phpstorm: add 10.13+ requirement and align livecheck

### DIFF
--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -3,9 +3,11 @@ cask "phpstorm" do
 
   if Hardware::CPU.intel?
     sha256 "f6371a659691c1ff58f6c81946207b1acd99539b89be3147c777130b4153c2df"
+
     url "https://download.jetbrains.com/webide/PhpStorm-#{version.before_comma}.dmg"
   else
     sha256 "b245a58612c0917235c108172a4e55c29ab89907a00522d696c32d3b81177201"
+
     url "https://download.jetbrains.com/webide/PhpStorm-#{version.before_comma}-aarch64.dmg"
   end
 
@@ -16,13 +18,14 @@ cask "phpstorm" do
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release"
     strategy :page_match do |page|
-      version = page.match(/"version":"(\d+(?:\.\d+)*)/i)
-      build = page.match(/"build":"(\d+(?:\.\d+)*)/i)
-      "#{version[1]},#{build[1]}"
+      JSON.parse(page)["PS"].map do |release|
+        "#{release["version"]},#{release["build"]}"
+      end
     end
   end
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "PhpStorm.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

https://www.jetbrains.com/phpstorm/download/#section=mac
> macOS 10.13 or higher

Also match livecheck from #106589.