### PR TITLE
youtrack-workflow: discontinued

### DIFF
--- a/Casks/youtrack-workflow.rb
+++ b/Casks/youtrack-workflow.rb
@@ -3,13 +3,18 @@ cask "youtrack-workflow" do
   sha256 "113749a54abd6c537bf1838a91cf35a70b2fdf04cfc4880eb906448b3156053e"
 
   url "https://download.jetbrains.com/charisma/youtrack-workflow-editor-#{version}-macos.zip"
-  appcast "https://data.services.jetbrains.com/products/releases?code=YTWE&latest=true&type=release"
   name "JetBrains Youtrack Workflow Editor"
+  desc "Create and edit workflows for YouTrack"
   homepage "https://www.jetbrains.com/youtrack/download/get_youtrack.html#materials=workflow-editor"
+
+  livecheck do
+    skip "Discontinued"
+  end
 
   app "youtrack-workflow.app"
 
   caveats do
+    discontinued
     depends_on_java
   end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

As far as I can tell, this app is discontinued.

Last release was 2017-03-09.

Homepage link no longer has any mention of this particular app.
It only has cloud/server/docker variants of YouTrack.

Other sources:
- https://www.jetbrains.com/help/youtrack/standalone/converting-old-workflows.html#convert-workflows-manually
  > Prior to YouTrack 2017.2, workflows were written in a domain-specific language in an external YouTrack Workflow Editor. YouTrack 2018.3 requires that all new workflows are written in JavaScript.
  >
  > Later this year, we plan to remove the logic that supports legacy workflows completely. As a result, any legacy workflow that is still attached to a project in YouTrack will stop working.
- https://blog.jetbrains.com/youtrack/2020/11/youtrack-workflows-from-2018-and-earlier-are-now-discontinued/#:~:text=YouTrack%202020.5%20officially%20discontinues%20support,workflows%20as%20smooth%20as%20possible.
  > **What are legacy workflows?**
  > Legacy workflows are those that were written in the old Workflow Editor, which was an external application in YouTrack versions 2018.3 and earlier.
  >
  > We officially deprecated support for legacy workflows in 2019. In YouTrack 2020.5, we have completely removed the logic that supports them.