### PR TITLE
sketchup: discontinued

### DIFF
--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -5,7 +5,13 @@ cask "sketchup" do
   # downloads can be found at https://www.sketchup.com/download/all
   url "https://www.sketchup.com/sketchup/#{version.before_comma}/en/sketchupmake-#{version.before_comma}-#{version.after_comma}-en-dmg"
   name "SketchUp"
+  name "SketchUp Make"
+  desc "3D design software"
   homepage "https://www.sketchup.com/"
+
+  livecheck do
+    skip "discontinued"
+  end
 
   suite "SketchUp #{version.before_comma}"
 
@@ -20,4 +26,8 @@ cask "sketchup" do
     "~/Library/Preferences/com.sketchup.SketchUp.#{version.before_comma}.plist",
     "~/Library/Preferences/Trimble.SketchUp-Helper.plist",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

2017 version of Sketchup (Make) was the final release.

https://blog.sketchup.com/article/new-in-sketchup-2018
> We released a maintenance update for SketchUp Make this past October and in fact that will be the **last update** for our free desktop version. Because so many people use it, we’ll continue to offer SketchUp Make for download on our website. But we **won’t continue developing it**.