### PR TITLE
Update perforce from 20.1,1991450 to 2021.1,2126753 and add livecheck

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,10 +1,26 @@
 cask "perforce" do
-  version "20.1,1991450"
-  sha256 "e93b556b4824afa3b9c1b7e328a53c605c8953cc9facd6c12d7a3b3451434ea6"
+  version "2021.1,2126753"
+  sha256 "9a1f528f92568531785b1f125e60a48e84b1a958f9e1d74dfc6e61c060e08721"
 
-  url "https://cdist2.perforce.com/perforce/r#{version.before_comma}/bin.macosx1010x86_64/helix-core-server.tgz"
-  name "Perforce Helix Versioning Engine"
+  url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
+  name "Perforce Helix Core Server"
+  name "Perforce Helix Command-Line Client (P4)"
+  name "Perforce Helix Broker (P4Broker)"
+  name "Perforce Helix Versioning Engine (P4D)"
+  name "Perforce Helix Proxy (P4P)"
+  desc "Version control"
   homepage "https://www.perforce.com/"
+
+  livecheck do
+    url "https://www.perforce.com/perforce/doc.current/user/relnotes.txt"
+    strategy :page_match do |page|
+      page.scan(%r{\((\d+(?:\.\d+)+)/(\d+)\)}i).map do |match|
+        "#{match[0]},#{match[1]}"
+      end
+    end
+  end
+
+  depends_on macos: ">= :sierra"
 
   binary "p4"
   binary "p4broker"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask {{cask_file}}` is error-free.
- [x] `brew style --fix {{cask_file}}` reports no offenses.

---

Matched upstream version format of: `2021.1/2126753` ==> `2021.1,2126753`