### PR TITLE
Update mochi from 1.11.4 to 1.11.5

### DIFF
--- a/Casks/mochi.rb
+++ b/Casks/mochi.rb
@@ -1,6 +1,6 @@
 cask "mochi" do
-  version "1.11.4"
-  sha256 "a719a80759302d62668703a84a547cd0da2383b265f26dd400aa5c2614b46f13"
+  version "1.11.5"
+  sha256 "09b5b029eb996ceb13996e4fa9f649bdd2b5168d6122f4926a763005366b9ebd"
 
   url "https://mochi.cards/releases/Mochi-#{version}.dmg"
   name "Mochi"


### PR DESCRIPTION
Created with `brew bump-cask-pr`.
