### PR TITLE
netnewswire: update homepage and url.

### DIFF
--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -2,11 +2,11 @@ cask "netnewswire" do
   version "6.0.2"
   sha256 "bf3f78a2d4552a022a17a4117ad819508a025b51c79e1905bcd44233331d1eed"
 
-  url "https://github.com/brentsimmons/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip",
-      verified: "github.com/brentsimmons/NetNewsWire/"
+  url "https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip",
+      verified: "github.com/Ranchero-Software/NetNewsWire/"
   name "NetNewsWire"
   desc "Free and open-source RSS reader"
-  homepage "https://ranchero.com/netnewswire/"
+  homepage "https://netnewswire.com/"
 
   livecheck do
     url :url


### PR DESCRIPTION
Updates the homepage and download URL for NetNewsWire to their new canonical locations.



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

