### PR TITLE
chromium: point livecheck to the stable branch

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -9,8 +9,10 @@ cask "chromium" do
   homepage "https://www.chromium.org/Home"
 
   livecheck do
-    url "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac%2FLAST_CHANGE?alt=media"
-    regex(/v?(\d+(?:\.\d+)*)/i)
+    # Obtain the base position for the stable branch on macOS
+    # See https://www.chromium.org/getting-involved/download-chromium
+    url "https://omahaproxy.appspot.com/all.json?os=mac&channel=stable"
+    regex(/"branch_base_position": "(\d{6})",/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
Currently, livecheck points to the development branch.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
