### PR TITLE
Update checksum on debeaver-community

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -1,6 +1,6 @@
 cask "dbeaver-community" do
   version "21.1.0"
-  sha256 "d8500c45917480c2532db584e0470b9c015abd25a09ce68beafd7a70dba3c3ff"
+  sha256 "dec806a96ea9609e45357ca31685e39495973d22ee1612099b73756cfe740573"
 
   url "https://dbeaver.io/files/#{version}/dbeaver-ce-#{version}-macos.dmg"
   name "DBeaver Community Edition"


### PR DESCRIPTION
### Problem

`brew upgrade` is currently failing for `dbeaver-community` version `21.1.0` because the checksums don't match.

### Checksum source:

https://download.dbeaver.com/community/21.1.0/checksum/dbeaver-ce-21.1.0-macos.dmg.sha256.

### Checked before opening PR

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
