### PR TITLE
Update isyncr from 6.0.3 to 6.0.9 and fix livecheck

### DIFF
--- a/Casks/isyncr.rb
+++ b/Casks/isyncr.rb
@@ -1,10 +1,10 @@
 cask "isyncr" do
   if MacOS.version <= :mojave
-    version "5.14.11"
-    sha256 "b234a1de565854fc9cdfefba9b2f05887e150ec01612bbfadaa0a0d95566034e"
+    version "5.14.12"
+    sha256 "b4f0ddd19ba49924e00226ff09d543928e13a4e8ec10d2b9cb53e227aeaf2953"
   else
-    version "6.0.3"
-    sha256 "c7033eb946a6a6104a75cc5c182506f47a0399b54f3b4ce486e82a1c7d040154"
+    version "6.0.9"
+    sha256 "870bee027f598410175e95af74e1e4cf9a8740d0ece6eb52cf839db89dde5855"
   end
 
   url "https://www.jrtstudio.com/files/iSyncr%20Desktop%20#{version}.pkg"
@@ -12,10 +12,17 @@ cask "isyncr" do
   desc "Syncs iTunes to Android over a USB or WiFi connection"
   homepage "https://www.jrtstudio.com/iSyncr-iTunes-for-Android"
 
+  # The download page is rendered using JavaScript with the download links
+  # obtained from https://www.jrtstudio.com/files/SlashiSyncr<number>.js
+  # Since the <number> is not fixed in the filename, the current JavaScript
+  # file needs to be extracted from the download page.
   livecheck do
-    url "https://www.jrtstudio.com/files/SlashiSyncr38.js"
-    strategy :page_match
-    regex(/iSyncr\s*Desktop\s*(\d+(?:\.\d+)*)\.pkg/i)
+    url "https://www.jrtstudio.com/iSyncr-Desktop-Download"
+    strategy :page_match do |page|
+      js_file = page[%r{src=["']?/(files/SlashiSyncr\d+\.js)\??["' >]}i, 1]
+      version_page = Homebrew::Livecheck::Strategy.page_content("https://www.jrtstudio.com/#{js_file}")
+      version_page[:content].scan(/iSyncr\s*Desktop\s*(\d+(?:\.\d+)+)\.pkg/i).flatten
+    end
   end
 
   pkg "iSyncr Desktop #{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Fixes #106710 for 10.15+.

Doesn't `livecheck` the 10.14 and older release
