### PR TITLE
`figma`: split livecheck for intel & arm version + intel version bump

### DIFF
--- a/Casks/figma.rb
+++ b/Casks/figma.rb
@@ -1,7 +1,7 @@
 cask "figma" do
   if Hardware::CPU.intel?
     version "98.13.0"
-    sha256 "e9899d8dafdb752414c8fe0e070d6f81b32bc713f220618b4fc90b380e345a72"
+    sha256 "213753d01235bc39925553bb78d8d079553885516cadf2e18702ccc6da46a8a8"
 
     url "https://desktop.figma.com/mac/Figma-#{version}.zip"
   else

--- a/Casks/figma.rb
+++ b/Casks/figma.rb
@@ -1,11 +1,11 @@
 cask "figma" do
-  version "98.11.0"
-
   if Hardware::CPU.intel?
+    version "98.13.0"
     sha256 "e9899d8dafdb752414c8fe0e070d6f81b32bc713f220618b4fc90b380e345a72"
 
     url "https://desktop.figma.com/mac/Figma-#{version}.zip"
   else
+    version "98.11.0"
     sha256 "85bf1fc63a799b46c0d8e2e041033b54537cca5ee5dcb27af3b6016f080ca7c0"
 
     url "https://desktop.figma.com/mac-arm/Figma-#{version}.zip"
@@ -16,7 +16,11 @@ cask "figma" do
   homepage "https://www.figma.com/"
 
   livecheck do
-    url "https://desktop.figma.com/mac/RELEASE.json"
+    if Hardware::CPU.intel?
+      url "https://desktop.figma.com/mac/RELEASE.json"
+    else
+      url "https://desktop.figma.com/mac-arm/RELEASE.json"
+    end
     regex(%r{/Figma[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 

--- a/Casks/figma.rb
+++ b/Casks/figma.rb
@@ -4,25 +4,26 @@ cask "figma" do
     sha256 "213753d01235bc39925553bb78d8d079553885516cadf2e18702ccc6da46a8a8"
 
     url "https://desktop.figma.com/mac/Figma-#{version}.zip"
+
+    livecheck do
+      url "https://desktop.figma.com/mac/RELEASE.json"
+      regex(%r{/Figma[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    end
   else
     version "98.11.0"
     sha256 "85bf1fc63a799b46c0d8e2e041033b54537cca5ee5dcb27af3b6016f080ca7c0"
 
     url "https://desktop.figma.com/mac-arm/Figma-#{version}.zip"
+
+    livecheck do
+      url "https://desktop.figma.com/mac-arm/RELEASE.json"
+      regex(%r{/Figma[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    end
   end
 
   name "Figma"
   desc "Collaborative team software"
   homepage "https://www.figma.com/"
-
-  livecheck do
-    if Hardware::CPU.intel?
-      url "https://desktop.figma.com/mac/RELEASE.json"
-    else
-      url "https://desktop.figma.com/mac-arm/RELEASE.json"
-    end
-    regex(%r{/Figma[._-]v?(\d+(?:\.\d+)+)\.zip}i)
-  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


PS: The ARM version has not yet been updated, therefore I needed to split those. See the https://github.com/Homebrew/brew/issues/11485.