### PR TITLE
Add p4

### DIFF
--- a/Casks/p4.rb
+++ b/Casks/p4.rb
@@ -1,0 +1,28 @@
+cask "p4" do
+  version "2021.1,2126753"
+  sha256 "85c0d2f92b59564ea36a56a8f07b87aecf0b2806637e8b7d69d6edd0d79d6c40"
+
+  url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/p4"
+  name "Perforce Helix Command-Line Client (P4)"
+  desc "Use it to gain instant access to operations and complete control over the system"
+  homepage "https://www.perforce.com/products/helix-core-apps/command-line-client"
+
+  livecheck do
+    url "https://www.perforce.com/perforce/doc.current/user/relnotes.txt"
+    strategy :page_match do |page|
+      page.scan(%r{\((\d+(?:\.\d+)+)/(\d+)\)}i).map do |match|
+        "#{match[0]},#{match[1]}"
+      end
+    end
+  end
+
+  conflicts_with cask: "perforce"
+  depends_on macos: ">= :catalina"
+  container type: :naked
+
+  binary "bin.macosx1015x86_64", target: "p4"
+
+  postflight do
+    set_permissions "#{staged_path}/bin.macosx1015x86_64", "0755"
+  end
+end

--- a/Casks/p4.rb
+++ b/Casks/p4.rb
@@ -20,12 +20,5 @@ cask "p4" do
   depends_on macos: ">= :catalina"
   container type: :naked
 
-  binary "p4"
-
-  preflight do
-    # brew 3.1.9 saves the downloaded binary under the name of the directory
-    if File.file?("#{staged_path}/bin.macosx1015x86_64")
-      File.rename "#{staged_path}/bin.macosx1015x86_64", "#{staged_path}/p4"
-    end
-  end
+  binary "bin.macosx1015x86_64", target: "p4"
 end

--- a/Casks/p4.rb
+++ b/Casks/p4.rb
@@ -20,9 +20,12 @@ cask "p4" do
   depends_on macos: ">= :catalina"
   container type: :naked
 
-  binary "bin.macosx1015x86_64", target: "p4"
+  binary "p4"
 
-  postflight do
-    set_permissions "#{staged_path}/bin.macosx1015x86_64", "0755"
+  preflight do
+    # brew 3.1.9 saves the downloaded binary under the name of the directory
+    if File.file?("#{staged_path}/bin.macosx1015x86_64")
+      File.rename "#{staged_path}/bin.macosx1015x86_64", "#{staged_path}/p4"
+    end
   end
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions).
- [x] `brew audit --cask homebrew/cask/p4` is error-free.
- [x] `brew style --fix homebrew/cask/p4` reports no offenses.

Additionally, because adding a new cask:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues). See below, this is not clear.
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask homebrew/cask/p4` worked successfully.
- [x] `brew install --cask homebrew/cask/p4` worked successfully.
- [x] `brew uninstall --cask homebrew/cask/p4` worked successfully.

Added version 2021.1.2126753.

After having the `p4v` cask available for the visual client, the `p4` cask will allow installing the command-line client too, without all the server tools from the `perforce` cask.

It appears that the `p4` cask was added by #22995, but later removed and replaced with `perforce` by #29180. However, there is no comment there about why. While the server is needed only on one machine, all developers need just the client. It is not necessary installing the server package everywhere. The `p4v` cask does not include the server either.