### PR TITLE
Add Yippy.app v2.5.0

### DIFF
--- a/Casks/yippy.rb
+++ b/Casks/yippy.rb
@@ -1,0 +1,17 @@
+cask "yippy" do
+  version "2.5.0"
+  sha256 :no_check
+
+  url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip",
+      verified: "github.com/mattDavo/Yippy/"
+  appcast "https://github.com/mattDavo/Yippy/releases.atom"
+  name "Yippy"
+  desc "Open source clipboard manager"
+  homepage "https://yippy.mattdavo.com/"
+
+  app "Yippy.app"
+
+  zap trash: [
+    "~/Library/Application Support/MatthewDavidson.Yippy",
+  ]
+end

--- a/Casks/yippy.rb
+++ b/Casks/yippy.rb
@@ -1,17 +1,14 @@
 cask "yippy" do
   version "2.5.0"
-  sha256 :no_check
+  sha256 "58e8a5ff11d9c9a2b3cfae91e36ba74250670210b58977ebc0e02d46dc8ddb36"
 
   url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip",
       verified: "github.com/mattDavo/Yippy/"
-  appcast "https://github.com/mattDavo/Yippy/releases.atom"
   name "Yippy"
   desc "Open source clipboard manager"
   homepage "https://yippy.mattdavo.com/"
 
   app "Yippy.app"
 
-  zap trash: [
-    "~/Library/Application Support/MatthewDavidson.Yippy",
-  ]
+  zap trash: "~/Library/Application Support/MatthewDavidson.Yippy"
 end

--- a/Casks/yippy.rb
+++ b/Casks/yippy.rb
@@ -1,6 +1,6 @@
 cask "yippy" do
   version "2.5.0"
-  sha256 "58e8a5ff11d9c9a2b3cfae91e36ba74250670210b58977ebc0e02d46dc8ddb36"
+  sha256 "39b59894324e9e4a986dc076d925a9449cf35edcf0e84fc7d57557d0c5e87318"
 
   url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip",
       verified: "github.com/mattDavo/Yippy/"


### PR DESCRIPTION
# Add Yippy.app

Adding Yippy.app under the token `yippy` at its current version of 2.5.0.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
