### PR TITLE
Update caramba-switcher from 2021.04.26 to 2021.06.08

### DIFF
--- a/Casks/caramba-switcher.rb
+++ b/Casks/caramba-switcher.rb
@@ -1,5 +1,5 @@
 cask "caramba-switcher" do
-  version "2021.04.26"
+  version "2021.06.08"
   sha256 :no_check
 
   url "https://cdn.caramba-switcher.com/files/CarambaSwitcherBeta.pkg"


### PR DESCRIPTION
Simple bump as not versioned URL