### PR TITLE
Update atlauncher from 3.4.3.3 to 3.4.4.3 and use versioned GitHub URL

### DIFF
--- a/Casks/atlauncher.rb
+++ b/Casks/atlauncher.rb
@@ -1,17 +1,12 @@
 cask "atlauncher" do
-  version "3.4.3.3"
-  sha256 :no_check
+  version "3.4.4.3"
+  sha256 "650bf251d212e392eeec44712265976bd855f6b87795b14ed76e0490c31c56fc"
 
-  url "https://www.atlauncher.com/download/zip"
+  url "https://github.com/ATLauncher/ATLauncher/releases/download/v#{version}/ATLauncher-#{version}.zip",
+      verified: "github.com/ATLauncher/ATLauncher/"
   name "ATLauncher"
   desc "Minecraft launcher"
-  homepage "https://www.atlauncher.com/"
-
-  livecheck do
-    url "https://atlauncher.com/downloads"
-    strategy :page_match
-    regex(/{\s*active:\s*['"](\d+(?:\.\d+)*)['"]\s*}/i)
-  end
+  homepage "https://atlauncher.com/"
 
   app "ATLauncher.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Download page https://atlauncher.com/downloads has changelog fixes that link to GitHub https://github.com/ATLauncher/ATLauncher

SHA256 appears to match homepage download
```
650bf251d212e392eeec44712265976bd855f6b87795b14ed76e0490c31c56fc  ATLauncher.zip
```

---

Change homepage URL https://www.atlauncher.com/ to redirect
```
❯ curl https://www.atlauncher.com/
<html>
<head><title>301 Moved Permanently</title></head>
```

---

Remove `livecheck` to use default for GitHub URL.