### PR TITLE
Update dosbox-x from 0.83.13 to 0.83.14

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,7 +1,7 @@
 cask "dosbox-x" do
   if Hardware::CPU.intel?
-    version "0.83.13,20210430230655"
-    sha256 "0854427a1fec933d886a65285d0fe5dc54e5cb842d2a614efd40176ffdd931d5"
+    version "0.83.14,20210531184050"
+    sha256 "9f06f82ef733ba5fa237edebfa3a64fc0ca7d5a717a7b9e6ec66ef77e80486b3"
 
     url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x86_64-#{version.after_comma}.zip",
         verified: "github.com/joncampbell123/dosbox-x/"
@@ -14,8 +14,8 @@ cask "dosbox-x" do
       end
     end
   else
-    version "0.83.13,20210430230543"
-    sha256 "205695b80c2976998f0e637b6515c3b4c6d4364bb1489564e9ec57aa32682a9b"
+    version "0.83.14,20210531191420"
+    sha256 "9f08db1cd9228129dfc3570cd8a4ec6258c494fd72535aa6cac53f96f370fec0"
 
     url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-arm64-#{version.after_comma}.zip",
         verified: "github.com/joncampbell123/dosbox-x/"
@@ -34,4 +34,9 @@ cask "dosbox-x" do
   homepage "https://dosbox-x.com/"
 
   app "dosbox-x/dosbox-x.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.dosbox-x.plist",
+    "~/Library/Preferences/mapper-dosbox-x.map",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

- version bump
- zap added