### PR TITLE
Update joplin from 1.8.5 to 2.0.8

### DIFF
--- a/Casks/joplin.rb
+++ b/Casks/joplin.rb
@@ -1,6 +1,6 @@
 cask "joplin" do
-  version "1.8.5"
-  sha256 "a224dafb4679fa33ea4cadb53939948d4ee0cce3c5b235d05329d1dae38816d8"
+  version "2.0.8"
+  sha256 "b1f53662c8919366bb001d1fd181a92714d9e14cd0d0bacfd01f54dd3946c7db"
 
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg",
       verified: "github.com/laurent22/joplin/"


### PR DESCRIPTION
Created with `brew bump-cask-pr`.
