### PR TITLE
colorsnapper: fix livecheck and add minimum OS

### DIFF
--- a/Casks/colorsnapper.rb
+++ b/Casks/colorsnapper.rb
@@ -8,10 +8,15 @@ cask "colorsnapper" do
   desc "Color picking application"
   homepage "https://colorsnapper.com/"
 
+  # The Sparkle feed has incorrect pubDates for newer items, which causes the
+  # `:sparkle` strategy to choose an older version as latest. As a workaround,
+  # we find the latest version using the value of `sparkle:version`.
   livecheck do
     url "https://cs2-appcast.s3.amazonaws.com/appcast.xml"
-    strategy :sparkle
+    regex(/sparkle:version=["']?(\d+(?:\.\d+)+)["' >]/i)
   end
+
+  depends_on macos: ">= :sierra"
 
   app "ColorSnapper2.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Previous livecheck using default `:sparkle` shows downgrade:
```console
❯ arch -x86_64 brew livecheck colorsnapper
colorsnapper : 1.6.4 ==> 1.6.2
```

The `livecheck` ended up picking older version since 1.6.3/1.6.4 have wrong `pubDate` where 2010 is used instead of 2020.