### PR TITLE
exfalso: restrict livecheck to macOS Ex Falso releases

### DIFF
--- a/Casks/exfalso.rb
+++ b/Casks/exfalso.rb
@@ -9,9 +9,8 @@ cask "exfalso" do
   homepage "https://quodlibet.readthedocs.io/"
 
   livecheck do
-    url :url
-    strategy :git
-    regex(/^release-(\d+(?:\.\d+)*)$/i)
+    url "https://quodlibet.readthedocs.io/en/latest/downloads.html"
+    regex(%r{href=.*?/ExFalso[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   app "ExFalso.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Previous livecheck:
```console
❯ brew livecheck exfalso
exfalso : 4.3.0 ==> 4.4.0
```

However, 4.4.0 is not available for macOS.