### PR TITLE
macfuse fixes

### DIFF
--- a/Casks/macfuse.rb
+++ b/Casks/macfuse.rb
@@ -22,6 +22,6 @@ cask "macfuse" do
   ]
 
   caveats do
-    reboot
+    kext
   end
 end

--- a/Casks/macfuse.rb
+++ b/Casks/macfuse.rb
@@ -8,6 +8,12 @@ cask "macfuse" do
   desc "File system integration"
   homepage "https://osxfuse.github.io/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(%r{href=.*?/macfuse-(\d+(?:\.\d+)*)\.dmg}i)
+  end
+
   depends_on macos: ">= :sierra"
 
   pkg "Extras/macFUSE #{version}.pkg"

--- a/Casks/macfuse.rb
+++ b/Casks/macfuse.rb
@@ -14,7 +14,6 @@ cask "macfuse" do
     regex(%r{href=.*?/macfuse-(\d+(?:\.\d+)*)\.dmg}i)
   end
 
-  conflicts_with cask: "macfuse-dev"
   depends_on macos: ">= :sierra"
 
   pkg "Extras/macFUSE #{version}.pkg"

--- a/Casks/macfuse.rb
+++ b/Casks/macfuse.rb
@@ -14,6 +14,7 @@ cask "macfuse" do
     regex(%r{href=.*?/macfuse-(\d+(?:\.\d+)*)\.dmg}i)
   end
 
+  conflicts_with cask: "macfuse-dev"
   depends_on macos: ">= :sierra"
 
   pkg "Extras/macFUSE #{version}.pkg"


### PR DESCRIPTION
- use `kext` caveat instead of `reboot`
- fix livechek
- add conflict with macfuse-dev

See https://github.com/Homebrew/homebrew-cask-versions/pull/11173

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
