### PR TITLE
Update time-out to 2.8.1 (June 2021)

### DIFF
--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -3,10 +3,14 @@ cask "time-out" do
   sha256 "e72d1f57e5e60f133e27b03543c2ebf5c7bef7317cbfe869c4783952840f4d1d"
 
   url "https://www.dejal.com/download/timeout-#{version}.zip"
-  appcast "https://dejal.net/appcast/?prod=timeout&aed=direct&from=2037&rel=gen"
   name "Time Out"
   desc "Customizable timing of breaks"
   homepage "https://www.dejal.com/timeout/"
+
+  livecheck do
+    url "https://dejal.net/appcast/?prod=timeout"
+    strategy :sparkle, &:short_version
+  end
 
   app "Time Out.app"
 end

--- a/Casks/time-out.rb
+++ b/Casks/time-out.rb
@@ -1,6 +1,6 @@
 cask "time-out" do
-  version "2.7.1"
-  sha256 "40fe0c87b0c9007c372bf3297f878b3f60537852dfc921078ce00656ef9c7a17"
+  version "2.8.1"
+  sha256 "e72d1f57e5e60f133e27b03543c2ebf5c7bef7317cbfe869c4783952840f4d1d"
 
   url "https://www.dejal.com/download/timeout-#{version}.zip"
   appcast "https://dejal.net/appcast/?prod=timeout&aed=direct&from=2037&rel=gen"


### PR DESCRIPTION
Update time-out from 2.7.1 (30 Nov 2020) to 2.8.1 (2 June 2021)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

- [ x] `brew audit --cask <cask>` is error-free.
- [ x] `brew style --fix <cask>` reports no offenses.