### PR TITLE
Update yippy from 2.5.0 to 2.7.0

### DIFF
--- a/Casks/yippy.rb
+++ b/Casks/yippy.rb
@@ -1,12 +1,17 @@
 cask "yippy" do
-  version "2.5.0"
-  sha256 "39b59894324e9e4a986dc076d925a9449cf35edcf0e84fc7d57557d0c5e87318"
+  version "2.6.0"
+  sha256 "6beb1020993074114941732b8c0db911776d1f66752ddbfb33118eb26a74672b"
 
   url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip",
       verified: "github.com/mattDavo/Yippy/"
   name "Yippy"
   desc "Open source clipboard manager"
   homepage "https://yippy.mattdavo.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "Yippy.app"
 

--- a/Casks/yippy.rb
+++ b/Casks/yippy.rb
@@ -1,6 +1,6 @@
 cask "yippy" do
-  version "2.6.0"
-  sha256 "6beb1020993074114941732b8c0db911776d1f66752ddbfb33118eb26a74672b"
+  version "2.7.0"
+  sha256 "3d00f116ceedf3ceb0fd6b6b490f83e6399333d0b8cd546fd564897916ce07bf"
 
   url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip",
       verified: "github.com/mattDavo/Yippy/"

--- a/Casks/yippy.rb
+++ b/Casks/yippy.rb
@@ -8,11 +8,6 @@ cask "yippy" do
   desc "Open source clipboard manager"
   homepage "https://yippy.mattdavo.com/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   app "Yippy.app"
 
   zap trash: "~/Library/Application Support/MatthewDavidson.Yippy"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.