### PR TITLE
Add Polkadot-JS Apps v0.92.3

### DIFF
--- a/Casks/polkadot-js.rb
+++ b/Casks/polkadot-js.rb
@@ -1,4 +1,4 @@
-cask "polkadotjs" do
+cask "polkadot-js" do
   version "0.92.3"
   sha256 "9053695edd6bb29dcd36871db06487cdd8e76e964cadc192f989f9763c726b83"
 

--- a/Casks/polkadotjs.rb
+++ b/Casks/polkadotjs.rb
@@ -1,0 +1,12 @@
+cask "polkadotjs" do
+  version "0.92.3"
+  sha256 "9053695edd6bb29dcd36871db06487cdd8e76e964cadc192f989f9763c726b83"
+
+  url "https://github.com/polkadot-js/apps/releases/download/v#{version}/Polkadot-JS-Apps-mac-#{version}.dmg",
+      verified: "github.com/polkadot-js/apps/"
+  name "polkadot{.js}"
+  desc "Portal into the Polkadot and Substrate networks"
+  homepage "https://polkadot.js.org/"
+
+  app "Polkadot-JS Apps.app"
+end

--- a/Casks/polkadotjs.rb
+++ b/Casks/polkadotjs.rb
@@ -9,4 +9,9 @@ cask "polkadotjs" do
   homepage "https://polkadot.js.org/"
 
   app "Polkadot-JS Apps.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.polkadotjs.polkadotjs-apps.plist",
+    "~/Library/Saved Application State/com.polkadotjs.polkadotjs-apps.savedState",
+  ]
 end


### PR DESCRIPTION
This is the official Electron app for the [Polkadot-JS Apps](https://polkadot.js.org/apps/), which allows people to interact with the [Polkadot](https://polkadot.network/), [Kusama](https://kusama.network/), and other [Substrate](http://substrate.dev/) based blockchains.