### PR TITLE
Adding Artiphon's Orba.app Latest

### DIFF
--- a/Casks/orba.rb
+++ b/Casks/orba.rb
@@ -1,0 +1,18 @@
+cask "orba" do
+  version "0.15.18"
+  sha256 "591fc3ca8d87ba57ac6e9aa1c0eaff24a0d2abbaeb5b8de0363d9cab6e15dbe7"
+
+  url "https://storage.googleapis.com/artiphon-web-content/Orba%20App/Orba-#{version}.dmg",
+      verified: "https://storage.googleapis.com/artiphon-web-content/"
+  name "Orba"
+  desc "Companion to the Orba handheld MIDI-Controller"
+  homepage "https://artiphon.com/"
+
+  app "Orba.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.artiphon.orba.plist",
+    "~/Library/Saved Application State/com.artiphon.orba.savedState/",
+    "~/Library/Artiphon/Orba/",
+  ]
+end


### PR DESCRIPTION
Orba.app (v0.15.18) is a companion app to the handled MIDI-Controller
device of the same name. Allows loading samples to the device, controlling
the device, as well as configuring the device.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
