### PR TITLE
Adding Artiphon's INSTRUMENT 1 Editor - Latest

### DIFF
--- a/Casks/instrument1.rb
+++ b/Casks/instrument1.rb
@@ -1,0 +1,19 @@
+cask "instrument1" do
+  version "1.0.20"
+  sha256 "fe1304b08c174783d49622fe000a2d2728deb653ce104aefbfc4115681c5fb54"
+
+  url "https://storage.googleapis.com/artiphon-preset-editor/Artiphon%20INSTRUMENT%201%20Editor-#{version}.dmg",
+      verified: "https://storage.googleapis.com/artiphon-preset-editor/"
+  name "INSTRUMENT 1 Editor"
+  desc "Companion to the INSTRUMENT 1 handheld MIDI-Controller"
+  homepage "https://artiphon.com/"
+
+  app "Artiphon INSTRUMENT 1 Editor.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.artiphon.preseteditor.helper.plist",
+    "~/Library/Preferences/com.artiphon.preseteditor.plist",
+    "~/Library/Saved Application State/com.artiphon.preseteditor.savedState",
+    "~/Library/Application Support/Artiphon INSTRUMENT 1 Editor",
+  ]
+end


### PR DESCRIPTION
Artiphon's INSTRUMENT 1 Editor is a companion app to the MIDI-Controller
device of the name INSTRUMENT 1. It allows you to control the device,
configure the device, and add samples, sounds, tempos, etc.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
