### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/bootchamp.rb
+++ b/Casks/bootchamp.rb
@@ -5,12 +5,7 @@ cask "bootchamp" do
   url "https://kainjow.com/downloads/BootChamp.zip"
   name "BootChamp"
   desc "Menu bar app to boot into your Boot Camp Windows partition"
-  homepage "https://www.kainjow.com/"
-
-  livecheck do
-    url "https://kainjow.com/updates/bootchamp.xml"
-    strategy :sparkle
-  end
+  homepage "https://kainjow.com/"
 
   depends_on macos: "<= :yosemite"
 

--- a/Casks/candybar.rb
+++ b/Casks/candybar.rb
@@ -7,12 +7,6 @@ cask "candybar" do
   desc "Tool to modify file icons"
   homepage "https://panic.com/blog/candybar-mountain-lion-and-beyond/"
 
-  livecheck do
-    url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/CandyBar%20(\d+(?:\.\d+)*)\.zip}i)
-  end
-
   app "CandyBar.app"
 
   caveats do

--- a/Casks/chatology.rb
+++ b/Casks/chatology.rb
@@ -7,11 +7,6 @@ cask "chatology" do
   desc "Chat manager and message search software"
   homepage "https://flexibits.com/chatology"
 
-  livecheck do
-    url "https://flexibits.com/chatology/appcast.php"
-    strategy :sparkle, &:short_version
-  end
-
   depends_on macos: ">= :el_capitan"
 
   app "Chatology.app"

--- a/Casks/eclipse-javascript.rb
+++ b/Casks/eclipse-javascript.rb
@@ -7,10 +7,6 @@ cask "eclipse-javascript" do
   desc "Eclipse IDE for JavaScript and web developers"
   homepage "https://eclipse.org/"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse JavaScript.app"
 

--- a/Casks/eclipse-testing.rb
+++ b/Casks/eclipse-testing.rb
@@ -7,10 +7,6 @@ cask "eclipse-testing" do
   desc "Eclipse IDE for testing purposes"
   homepage "https://eclipse.org/"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Testing.app"
 

--- a/Casks/flip4mac.rb
+++ b/Casks/flip4mac.rb
@@ -7,10 +7,6 @@ cask "flip4mac" do
   desc "Play back and convert Windows Media"
   homepage "https://www.telestream.net/flip4mac/"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   depends_on macos: "<= :el_capitan"
 
   pkg "Flip4Mac.pkg"

--- a/Casks/framer-x.rb
+++ b/Casks/framer-x.rb
@@ -7,14 +7,6 @@ cask "framer-x" do
   desc "Tool that helps teams design every part of the product experience"
   homepage "https://framer.com/"
 
-  livecheck do
-    url "https://updates.framer.com/sparkle/com.framer.x"
-    strategy :page_match do |page|
-      match = page.match(%r{/(\d+)/FramerX-(\d+).zip}i)
-      "#{match[2]},#{match[1]}"
-    end
-  end
-
   auto_updates true
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/handbrakebatch.rb
+++ b/Casks/handbrakebatch.rb
@@ -6,13 +6,6 @@ cask "handbrakebatch" do
   name "HandBrakeBatch"
   homepage "https://osomac.com/apps/osx/handbrake-batch/"
 
-  livecheck do
-    url "https://osomac.com/appcasts/handbrakebatch/HandBrakeBatch.xml"
-    strategy :sparkle do |item|
-      item.url[%r{/HandBrakeBatch_(\d+(?:\.\d+)*)\.zip}i, 1]
-    end
-  end
-
   app "HandBrakeBatch.app"
 
   caveats do

--- a/Casks/hwsensors.rb
+++ b/Casks/hwsensors.rb
@@ -7,12 +7,6 @@ cask "hwsensors" do
   desc "Tool to access information from available hardware sensors"
   homepage "https://github.com/kozlekek/HWSensors/"
 
-  livecheck do
-    url "https://github.com/kozlekek/HWSensors/releases/latest"
-    strategy :page_match
-    regex(%r{href=.*?/HWSensors\.(\d+(?:\.\d+)*)\.pkg\.zip}i)
-  end
-
   pkg "HWSensors.#{version}.pkg"
 
   uninstall login_item: "HWMonitor",

--- a/Casks/linein.rb
+++ b/Casks/linein.rb
@@ -7,11 +7,6 @@ cask "linein" do
   desc "Audio play-thru of input devices"
   homepage "https://www.rogueamoeba.com/freebies/"
 
-  livecheck do
-    url "https://rogueamoeba.com/freebies/version-linein.rss"
-    strategy :sparkle
-  end
-
   depends_on macos: "<= :mojave"
 
   app "LineIn.app"

--- a/Casks/mplayer-osx-extended.rb
+++ b/Casks/mplayer-osx-extended.rb
@@ -8,12 +8,6 @@ cask "mplayer-osx-extended" do
   desc "Video player thats uses MPlayer as backend"
   homepage "https://mplayerosx.ch/"
 
-  livecheck do
-    url :url
-    strategy :git
-    regex(/^rev(\d+(?:\.\d+)*)$/i)
-  end
-
   app "MPlayer OSX Extended.app"
 
   zap trash: "~/.mplayer"

--- a/Casks/obs-virtualcam.rb
+++ b/Casks/obs-virtualcam.rb
@@ -6,14 +6,6 @@ cask "obs-virtualcam" do
   name "OBS Virtual Camera"
   homepage "https://github.com/johnboiles/obs-mac-virtualcam"
 
-  livecheck do
-    url "https://github.com/johnboiles/obs-mac-virtualcam/releases"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/obs-mac-virtualcam-([a-f0-9]+)-v?(\d+(?:\.\d+)*)\.pkg}i)
-      "#{match[2]},#{match[1]}"
-    end
-  end
-
   depends_on macos: ">= :high_sierra"
 
   pkg "obs-mac-virtualcam-#{version.after_comma}-v#{version.before_comma}.pkg"

--- a/Casks/omnidazzle.rb
+++ b/Casks/omnidazzle.rb
@@ -7,11 +7,6 @@ cask "omnidazzle" do
   desc "Set of plug-ins to highlight areas of your screen and your mouse pointer"
   homepage "https://support.omnigroup.com/omnidazzle-troubleshooting/"
 
-  livecheck do
-    url "https://update.omnigroup.com/appcast/com.omnigroup.OmniDazzle"
-    strategy :sparkle
-  end
-
   app "OmniDazzle.app"
 
   caveats do

--- a/Casks/panic-unison.rb
+++ b/Casks/panic-unison.rb
@@ -7,12 +7,6 @@ cask "panic-unison" do
   desc "App to access Usenet Newsgroups"
   homepage "https://panic.com/blog/the-future-of-unison/"
 
-  livecheck do
-    url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/Unison%20(\d+(?:\.\d+)*)\.zip}i)
-  end
-
   app "Unison.app"
 
   caveats do

--- a/Casks/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/pycharm-ce-with-anaconda-plugin.rb
@@ -8,10 +8,6 @@ cask "pycharm-ce-with-anaconda-plugin" do
   desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   auto_updates true
 
   app "PyCharm CE with Anaconda plugin.app"

--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -7,10 +7,6 @@ cask "pycharm-with-anaconda-plugin" do
   desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   auto_updates true
 
   app "PyCharm with Anaconda plugin .app"

--- a/Casks/qcma.rb
+++ b/Casks/qcma.rb
@@ -7,14 +7,6 @@ cask "qcma" do
   name "Qcma"
   homepage "https://codestation.github.io/qcma/"
 
-  livecheck do
-    url "https://github.com/codestation/qcma/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/Qcma_(\d+(?:\.\d+)*)-(\d+)\.dmg}i)
-      "#{match[1]},#{match[2]}"
-    end
-  end
-
   app "Qcma.app"
 
   caveats do

--- a/Casks/sketchup.rb
+++ b/Casks/sketchup.rb
@@ -9,10 +9,6 @@ cask "sketchup" do
   desc "3D design software"
   homepage "https://www.sketchup.com/"
 
-  livecheck do
-    skip "discontinued"
-  end
-
   suite "SketchUp #{version.before_comma}"
 
   zap trash: [

--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -8,11 +8,6 @@ cask "spectacle" do
   desc "Move and resize windows with ease"
   homepage "https://www.spectacleapp.com/"
 
-  livecheck do
-    url "https://www.spectacleapp.com/updates/appcast.xml"
-    strategy :sparkle
-  end
-
   auto_updates true
 
   app "Spectacle.app"

--- a/Casks/tagger.rb
+++ b/Casks/tagger.rb
@@ -8,12 +8,6 @@ cask "tagger" do
   desc "Music metadata editor supporting batch edits and importing VGMdb data"
   homepage "https://bilalh.github.io/projects/tagger/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{/Tagger_(\d+(?:\.\d+)*)\.zip}i)
-  end
-
   app "Tagger.app"
 
   caveats do

--- a/Casks/trinity.rb
+++ b/Casks/trinity.rb
@@ -8,11 +8,6 @@ cask "trinity" do
   desc "Cryptocurrency wallet"
   homepage "https://trinity.iota.org/"
 
-  livecheck do
-    url :url
-    regex(/^desktop-(\d+(?:\.\d+)*)$/i)
-  end
-
   app "Trinity.app"
 
   uninstall quit: "org.iota.trinity"

--- a/Casks/wanna.rb
+++ b/Casks/wanna.rb
@@ -7,14 +7,6 @@ cask "wanna" do
   name "Wanna"
   homepage "https://wanna.js.org/"
 
-  livecheck do
-    url "https://github.com/mkermani144/wanna/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*[^/]*)%2B([^/]+)/[^/]*?\.dmg}i)
-      "#{match[1]}+#{match[2]}"
-    end
-  end
-
   app "wanna.app"
 
   caveats do

--- a/Casks/xamarin-studio.rb
+++ b/Casks/xamarin-studio.rb
@@ -8,10 +8,6 @@ cask "xamarin-studio" do
   desc "IDE for mobile app development"
   homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   conflicts_with cask: "xamarin"
 
   app "Xamarin Studio.app"

--- a/Casks/youtrack-workflow.rb
+++ b/Casks/youtrack-workflow.rb
@@ -7,10 +7,6 @@ cask "youtrack-workflow" do
   desc "Create and edit workflows for YouTrack"
   homepage "https://www.jetbrains.com/youtrack/download/get_youtrack.html#materials=workflow-editor"
 
-  livecheck do
-    skip "Discontinued"
-  end
-
   app "youtrack-workflow.app"
 
   caveats do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes `livecheck` blocks for discontinued casks. `brew livecheck` will automatically skip a cask if it's discontinued and a `livecheck` block isn't present in the cask (i.e., having a `livecheck` block in a discontinued cask overrides the automatic skip).

Some of the casks in this PR use `skip "Discontinued"`, which unnecessarily duplicates the automatic skip for discontinued casks. Without these `livecheck` blocks, these casks will continue to be correctly skipped (e.g., `eclipse-javascript : discontinued`).

The other casks in this PR contain working `livecheck` blocks. If a discontinued cask won't be updated to a new version in the future, the `livecheck` block should be removed when the cask is discontinued. This is similar to how we remove `livecheck` blocks from deprecated/disabled formulae in homebrew/core (as livecheck skips them in the same manner when a `livecheck` block isn't present).