### PR TITLE
ddnet: add zap and auto_updates true

### DIFF
--- a/Casks/ddnet.rb
+++ b/Casks/ddnet.rb
@@ -12,6 +12,14 @@ cask "ddnet" do
     strategy :github_latest
   end
 
+  auto_updates true
+
   app "DDNet.app"
   app "DDNet-Server.app"
+
+  zap trash: [
+    "~/Library/Preferences/DDNet-Server-Launcher.plist",
+    "~/Library/Saved Application State/org.DDNetClient.app.savedState",
+    # "~/Library/Application Support/Teeworlds/" is left out on purpose because teeworlds uses it as well.
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Note that we leave out `~/Library/Application Support/Teeworlds/` on purpose. Imagine having both teeworlds and ddnet and you want to uninstall only ddnet. It would delete all user data of teeworlds as well as they share it.