### PR TITLE
sage: Update URLs to avoid 404.

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -9,7 +9,7 @@ cask "sage" do
 
   url "https://mirrors.mit.edu/sage/osx/intel/old/sage-#{version.before_comma}-OSX_#{version.after_comma}-x86_64.app.dmg",
       verified: "mirrors.mit.edu/sage/osx/intel/"
-  appcast "https://mirrors.mit.edu/sage/osx/intel/index.html"
+  appcast "https://mirrors.mit.edu/sage/osx/intel/old/index.html"
   name "Sage"
   homepage "https://www.sagemath.org/"
 

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -7,7 +7,7 @@ cask "sage" do
     sha256 "fa6eb93368d4f7c220cbdd7a1483c1ef9d9b718b0f179c17c2acf14fb74f10c1"
   end
 
-  url "https://mirrors.mit.edu/sage/osx/intel/sage-#{version.before_comma}-OSX_#{version.after_comma}-x86_64.app.dmg",
+  url "https://mirrors.mit.edu/sage/osx/intel/old/sage-#{version.before_comma}-OSX_#{version.after_comma}-x86_64.app.dmg",
       verified: "mirrors.mit.edu/sage/osx/intel/"
   appcast "https://mirrors.mit.edu/sage/osx/intel/index.html"
   name "Sage"


### PR DESCRIPTION
The download URLs for in the current sage cask are 404s. This commit simply changes the URLs to their new location. Although the URL now contains `old`, these are the latest releases. Sage 9.2 is the latest stable release for Mac; the 9.3 releases are in beta.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.