### PR TITLE
thingsmacsandboxhelper: fix download url

### DIFF
--- a/Casks/thingsmacsandboxhelper.rb
+++ b/Casks/thingsmacsandboxhelper.rb
@@ -2,16 +2,14 @@ cask "thingsmacsandboxhelper" do
   version "3.26"
   sha256 "29e74de692f15e2c1da63c425e3f91637ced39a361457bcb96d1457ea5083b25"
 
-  url "https://culturedcode.cachefly.net/things/thingssandboxhelper/#{version}/ThingsHelper.zip",
-      verified: "culturedcode.cachefly.net/"
+  url "https://static.culturedcode.com/things/thingssandboxhelper/#{version}/ThingsHelper.zip"
   name "Things Helper"
   desc "Helper application for Things"
   homepage "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things#{version.major}/"
 
   livecheck do
-    url "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things3/"
-    strategy :page_match
-    regex(%r{href=.*?/(\d+(?:\.\d+)*)/ThingsHelper\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+(?:\.\d+)+)/ThingsHelper\.zip}i)
   end
 
   app "ThingsMacSandboxHelper.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Previous URL:
```console
❯ brew fetch --cask thingsmacsandboxhelper
==> Downloading https://culturedcode.cachefly.net/things/thingssandboxhelper/3.26/ThingsHelper.zip

curl: (22) The requested URL returned error: 404
Error: Download failed on Cask 'thingsmacsandboxhelper' with message: Download failed: https://culturedcode.cachefly.net/things/thingssandboxhelper/3.26/ThingsHelper.zip
```