### PR TITLE
twonkyserver: update sha256, add desc, touch-up livecheck

### DIFF
--- a/Casks/twonkyserver.rb
+++ b/Casks/twonkyserver.rb
@@ -1,15 +1,15 @@
 cask "twonkyserver" do
   version "8.5.2"
-  sha256 "6cf6cdc36069342211bdcb75a160045c494bd8825a3d73dc0e0520f720e28ed5"
+  sha256 "e010897ffab5fff125ba1e3b2b249cc62bfcae7613de858061d0b496464883be"
 
   url "https://download.twonky.com/#{version}/TwonkyServerInstaller-#{version}.pkg"
   name "Twonky Server"
+  desc "DLNA/UPnP media server"
   homepage "https://twonky.com/"
 
   livecheck do
     url "https://twonky.com/downloads/index.html"
-    strategy :page_match
-    regex(%r{href=.*?/TwonkyServerInstaller-(\d+(?:\.\d+)*)\.pkg}i)
+    regex(%r{href=.*?/TwonkyServerInstaller[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
   end
 
   pkg "TwonkyServerInstaller-#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Previous SHA fetch test result:
```console
❯ brew fetch --cask twonkyserver
==> Downloading https://download.twonky.com/8.5.2/TwonkyServerInstaller-8.5.2.pkg
######################################################################## 100.0%
Downloaded to: /Users/cho-m/Library/Caches/Homebrew/downloads/d46a511a287beb6e1f724d518c2f5fd993b7622b122a2d51ac71ecae1a7b6ba3--TwonkyServerInstaller-8.5.2.pkg
SHA256: e010897ffab5fff125ba1e3b2b249cc62bfcae7613de858061d0b496464883be
Warning: Cask reports different sha256: 6cf6cdc36069342211bdcb75a160045c494bd8825a3d73dc0e0520f720e28ed5
```