### PR TITLE
jad: mark discontinued and restrict OS as 32-bit

### DIFF
--- a/Casks/jad.rb
+++ b/Casks/jad.rb
@@ -7,18 +7,18 @@ cask "jad" do
   desc "Java decompiler"
   homepage "https://varaneckas.com/jad/"
 
-  livecheck do
-    url "https://varaneckas.com/jad/"
-    strategy :page_match
-    regex(/Jad\s*(\d+(?:\.\d+)*\w?)\s*for/i)
-  end
+  depends_on macos: "<= :mojave"
 
   binary "jad"
   manpage "jad.1"
 
-  caveats <<~EOS
-    Instructions on using jad are available in
+  caveats do
+    discontinued
 
-      #{staged_path}/Readme.txt
-  EOS
+    <<~EOS
+      Instructions on using jad are available in
+
+        #{staged_path}/Readme.txt
+    EOS
+  end
 end


### PR DESCRIPTION
Fixes #107277

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Software is 32-bit, which means it is no longer compatible with macOS 10.15+.

Also, closed source (so no option to rebuild for 64-bit)

> Q1: Is the source code of Jad available?
> 
> A1: Currently I have no plans to release the Jad source code for any purposes including porting to other computer platforms.

---

Marking as `discontinued` is based on a few factors.

First, the current Cask homepage and download link had been switched to mirrors as official webpage was gone for some time. From https://varaneckas.com/jad/:
> As http://www.kpdus.com is no longer accessible, JAD Java Decompiler download is extremely hard to find. Here is a mirror where you can get JAD for various platforms.

Although original site is restored, there is no real updates and 1.5.8g release was from 2006.

Various books, websites, etc have labeled this software as discontinued/unmaintained/etc.