### PR TITLE
Update sound-siphon from 3.2.4 to 3.3.2 and add livecheck

### DIFF
--- a/Casks/sound-siphon.rb
+++ b/Casks/sound-siphon.rb
@@ -1,11 +1,18 @@
 cask "sound-siphon" do
-  version "3.2.4,5876"
-  sha256 "c05ce45e0eb4950926ffdfdca6a49540e562f756475df68aed2d39db53156e3f"
+  version "3.3.2"
+  sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://staticz.com/download/#{version.after_comma}/"
-  appcast "http://staticz.net/updates/soundsiphon#{version.major}.rss"
+  url "https://staticz.com/download/5876/"
   name "SoundSiphon"
+  desc "App audio capture"
   homepage "https://staticz.com/soundsiphon/"
+
+  livecheck do
+    url "http://staticz.net/updates/soundsiphon#{version.major}.rss"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :mojave"
 
   app "Sound Siphon.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The URL has remained the same since Nov 1, 2019 (#71869) with `version.after_comma` remaining unchanged.
