### PR TITLE
Update widelands from 21 to 1.0

### DIFF
--- a/Casks/widelands.rb
+++ b/Casks/widelands.rb
@@ -1,16 +1,16 @@
 cask "widelands" do
-  version "21"
-  sha256 "d296642fc9b48e50e087f18b2c7f5697b6a4faf6c6289ab82b31edc0553b4526"
+  version "1.0"
+  sha256 "1b690a7b001b16aab5bf5685b89714e2c02c6866914aba8ad5bde103f2ead789"
 
-  url "https://launchpad.net/widelands/build#{version}/build#{version}/+download/widelands_10.9_build-#{version}.dmg",
+  url "https://launchpad.net/widelands/#{version.major}.x/#{version}/+download/widelands_10.9_#{version}.dmg",
       verified: "launchpad.net/widelands/"
   name "Widelands"
+  desc "Free real-time strategy game like Settlers II"
   homepage "https://www.widelands.org/"
 
   livecheck do
-    url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/widelands_10\.9_build-(\d+)\.dmg}i)
+    url "https://www.widelands.org/wiki/Download/"
+    regex(/href=.*?widelands[._-]10\.9[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "Widelands.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This updates `widelands` to version 1.0, the first stable release. The previous version format (e.g., `21`) corresponds to beta versions (e.g., `build21`).

This also updates the existing `livecheck` block, as it gives an `Unable to get versions` error now that the version format has changed. Notable changes are as follows:

* Check the first-party download page, as this may be more reliable than the news on the homepage.
* Update the regex to match stable versions like `1.2`/`1.2.3`/etc. instead of beta versions like `build21`.