### PR TITLE
platypus: update livecheck URL to fix certificate issue

### DIFF
--- a/Casks/platypus.rb
+++ b/Casks/platypus.rb
@@ -8,7 +8,7 @@ cask "platypus" do
   homepage "https://sveinbjorn.org/platypus"
 
   livecheck do
-    url "https://www.sveinbjorn.org/files/appcasts/PlatypusAppcast.xml"
+    url "https://sveinbjorn.org/files/appcasts/PlatypusAppcast.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
Minor change removing `www.` from livecheck URL

Before:
```console
❯ arch -x86_64 brew livecheck --cask platypus
curl: (60) SSL: no alternative certificate subject name matches target host name 'www.sveinbjorn.org'
Error: platypus: Unable to get versions
```

After:
```console
❯ arch -x86_64 brew livecheck --cask platypus
platypus : 5.3,1113 ==> 5.3,1113
```