### PR TITLE
Change logisim-evolution to use v3.5.0 .dmg file

### DIFF
--- a/Casks/logisim-evolution.rb
+++ b/Casks/logisim-evolution.rb
@@ -1,8 +1,8 @@
 cask "logisim-evolution" do
   version "3.5.0"
-  sha256 "3cabd296b78457a7a9727ef66b1ba706ec4e4beccbbc28519fcc2e591fa9d1e4"
+  sha256 "feea8b0c11c03e08a2bd4cb5def08bb0fb5e3bc494ac178b3e210559b63848d5"
 
-  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/logisim-evolution-#{version}-all.jar"
+  url "https://github.com/reds-heig/logisim-evolution/releases/download/v#{version}/Logisim-evolution-#{version}.dmg"
   name "Logisim Evolution"
   desc "Digital logic designer and simulator"
   homepage "https://github.com/reds-heig/logisim-evolution"
@@ -12,13 +12,7 @@ cask "logisim-evolution" do
     strategy :github_latest
   end
 
-  container type: :naked
-
-  app "logisim-evolution-#{version}-all.jar", target: "logisim-evolution.jar"
+  app "Logisim-evolution.app"
 
   zap trash: "~/Library/Preferences/com.cburch.logisim.plist"
-
-  caveats do
-    depends_on_java "9+"
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

This is a follow-up to #99944. After the discussion here, the developer of `logisim-evolution` had fixed the code-signing issue in [#505](https://github.com/reds-heig/logisim-evolution/issues/505) and version v3.4.2 (pre-release). Recently, the fix here is merged into a stable release [v3.5.0](https://github.com/logisim-evolution/logisim-evolution/releases/tag/v3.5.0), thus can be used directly. Use `dmg` have several advantages over original approach of `jar` wrapper, like no Java 9+ requirement anymore. Thus this PR again proposed to change `logisim-evolution` to use `dmg` as it is working now.
