### PR TITLE
Update spotify from 1.1.60.672.g6ad9c215,1.1.60.672.g6ad9c215-15 to 1…

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,5 +1,5 @@
 cask "spotify" do
-  version "1.1.60.672.g6ad9c215,1.1.60.672.g6ad9c215-15"
+  version "1.1.61.583.gad060c66,1.1.61.583.gad060c66-7"
   sha256 :no_check
 
   url "https://download.scdn.co/Spotify.dmg",


### PR DESCRIPTION
Updated cask spotify from 1.1.60.672.g6ad9c215,1.1.60.672.g6ad9c215-15 to 1.1.61.583.gad060c66,1.1.61.583.gad060c66-7

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions)
- [X] `brew audit --cask spotify` is error-free.
- [X] `brew style --fix spotify` reports no offenses.
