### PR TITLE
Update eloston-chromium from 91.0.4472.101-1.1_arm64 to 91.0.4472.106-1.1_arm64

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -3,8 +3,8 @@ cask "eloston-chromium" do
     version "91.0.4472.106-1.1_x86-64"
     sha256 "cd77265b9dfef1139eca091181cb834778244d46871232e4dbb3a0588a6c657a"
   else
-    version "91.0.4472.101-1.1_arm64"
-    sha256 "1d10477d4a90bf42461453fd4e9893d3bf1c7726aad008bdd62d343546db6b35"
+    version "91.0.4472.106-1.1_arm64"
+    sha256 "d0e32f361bfa9661c3e80898388edd93fdba6fcf06bd53e8087022cb657963b1"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}-macos.dmg",


### PR DESCRIPTION


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.