### PR TITLE
appdelete: use HTTP urls since certificate expired

### DIFF
--- a/Casks/appdelete.rb
+++ b/Casks/appdelete.rb
@@ -2,13 +2,13 @@ cask "appdelete" do
   version "4.3.3"
   sha256 :no_check
 
-  url "https://www.reggieashworth.com/downloads/AppDelete.dmg"
+  url "http://www.reggieashworth.com/downloads/AppDelete.dmg"
   name "AppDelete"
   desc "App uninstaller"
-  homepage "https://www.reggieashworth.com/appdelete.html"
+  homepage "http://www.reggieashworth.com/appdelete.html"
 
   livecheck do
-    url "https://www.reggieashworth.com/AD#{version.major}Appcast.xml"
+    url "http://www.reggieashworth.com/AD#{version.major}Appcast.xml"
     strategy :sparkle
   end
 

--- a/Casks/appdelete.rb
+++ b/Casks/appdelete.rb
@@ -23,4 +23,8 @@ cask "appdelete" do
     "~/Library/Saved Application State/com.apps4macs.AppDelete.savedState",
     "~/Library/Services/AppDelete.workflow",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

<img width="439" alt="appdelete" src="https://user-images.githubusercontent.com/20700669/122502453-830da980-cfab-11eb-9d3d-0c7edb97a160.png">
