### PR TITLE
Update drivedx from 1.10.1 to 1.11.0

### DIFF
--- a/Casks/drivedx.rb
+++ b/Casks/drivedx.rb
@@ -1,8 +1,8 @@
 cask "drivedx" do
-  version "1.10.1,701"
-  sha256 "9720750128a0f5489ca1a09b9fd56a29c534566866b860d7992067aaefd8f9f5"
+  version "1.11.0,730"
+  sha256 "e72c18695916cc99ce10dd08b91d7c5d6d799ca471fef8cbabf79fb3a3d93bef"
 
-  url "https://binaryfruit.com/download/drivedx/mac/#{version.major}/bin/DriveDx.#{version.before_comma}.zip"
+  url "https://download.binaryfruit.com/drivedx/mac/#{version.major}/DriveDx.#{version.before_comma}.zip"
   name "DriveDX"
   desc "Drive health diagnostic & monitoring tool"
   homepage "https://binaryfruit.com/drivedx"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
