### PR TITLE
Update vidcutter from 6.0.2 to 6.0.5.1

### DIFF
--- a/Casks/vidcutter.rb
+++ b/Casks/vidcutter.rb
@@ -1,6 +1,6 @@
 cask "vidcutter" do
-  version '6.0.5.1'
-  sha256 '8d1556887f0b203ebcb7b6e13a33389afad173a2c73dbc906b69ece034218f02'
+  version "6.0.5.1"
+  sha256 "8d1556887f0b203ebcb7b6e13a33389afad173a2c73dbc906b69ece034218f02"
 
   url "https://github.com/ozmartian/vidcutter/releases/download/#{version}/VidCutter-#{version}-macOS.dmg"
   name "VidCutter"

--- a/Casks/vidcutter.rb
+++ b/Casks/vidcutter.rb
@@ -1,8 +1,8 @@
 cask "vidcutter" do
-  version "6.0.2"
-  sha256 "cebc95bd66d5df7fb46831bdd12993a9738ea1528850275e09a3ca69446851a7"
+  version '6.0.5.1'
+  sha256 '8d1556887f0b203ebcb7b6e13a33389afad173a2c73dbc906b69ece034218f02'
 
-  url "https://github.com/ozmartian/vidcutter/releases/download/#{version.major_minor}.0/VidCutter-#{version}-macOS.dmg"
+  url "https://github.com/ozmartian/vidcutter/releases/download/#{version}/VidCutter-#{version}-macOS.dmg"
   name "VidCutter"
   desc "Media cutter and joiner"
   homepage "https://github.com/ozmartian/vidcutter"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
