### PR TITLE
Firecamp upgraded t0 v2.0.3

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.0.1"
-  sha256 "f2567ee4184187473519fb8502a4d01b6cc265646247ffd4dfc80fa9347e917d"
+  version "2.0.3"
+  sha256 "06464b36008e00fc4e95e7132b0e25bad317982c826883d1022b12ba86b8f809"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
