### PR TITLE
Firecamp upgraded to v2.0.5

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.0.3"
-  sha256 "06464b36008e00fc4e95e7132b0e25bad317982c826883d1022b12ba86b8f809"
+  version "2.0.5"
+  sha256 "1c79a2d65aa42e19ec72ad052fd6b92e84b57d248115545f44f62c32eaec4a44"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"

--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -14,4 +14,10 @@ cask "firecamp" do
   end
 
   app "Firecamp.app"
+
+  zap trash: [
+    "~/Library/Application Support/firecamp",
+    "~/Library/Preferences/com.firecamp.app.plist",
+    "~/.firecamp",
+  ]
 end


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses