### PR TITLE
Update Monal from 5.0,716 to 5.0,747

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,8 +1,8 @@
 cask "monal" do
-  version "5.0,716"
+  version "5.0,747"
   sha256 :no_check
 
-  url "https://monal.im/macOS/Monal-macOS.tar.gz"
+  url "https://monal.im/macOS/Monal-macOS.zip"
   name "Monal"
   desc "Tool to securely connect to chat servers"
   homepage "https://monal.im/"


### PR DESCRIPTION
Monal changed its download url, this PR updates the cask accordingly. See download link on https://monal.im for reference.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.