### PR TITLE
vitalsource-bookshelf: update to 9.4.3.1330, update URL, add livecheck

### DIFF
--- a/Casks/vitalsource-bookshelf.rb
+++ b/Casks/vitalsource-bookshelf.rb
@@ -1,12 +1,17 @@
 cask "vitalsource-bookshelf" do
-  version "9.4.0.1304"
-  sha256 "47f996046bd898afbc0c6ac3cc30403869fcfc3feefc03bdc0bae09af057e387"
+  version "9.4.3.1330"
+  sha256 "fe183fc2796906e15bdfa2902e195c83390321692ab5fa621a505f3e9fc1fc91"
 
-  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor}/mac/bookshelf/VitalSource-Bookshelf_#{version}.dmg",
+  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor_patch}/mac/bookshelf/VitalSource-Bookshelf_#{version}.dmg",
       verified: "downloads.vitalbook.com/"
-  appcast "https://support.vitalsource.com/hc/en-us/articles/360014107913-Mac"
   name "VitalSource Bookshelf"
+  desc "Access eTextbooks"
   homepage "https://www.vitalsource.com/bookshelf-features"
+
+  livecheck do
+    url "https://support.vitalsource.com/hc/en-us/articles/360014107913-Mac"
+    regex(/href=.*?VitalSource-Bookshelf[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
`url` now includes major_minor_patch

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.