### PR TITLE
sage: various updates

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -18,8 +18,8 @@ cask "sage" do
 
   depends_on macos: ">= :high_sierra"
 
-  app "SageMath-#{version.before_comma}.app"
-  binary "#{appdir}/SageMath-#{version.before_comma}.app/Contents/Resources/sage/sage"
+  app "SageMath-#{version.before_comma.dots_to_hyphens}.app"
+  binary "#{appdir}/SageMath-#{version.before_comma.dots_to_hyphens}.app/Contents/Resources/sage/sage"
 
   uninstall quit: "org.sagemath.Sage"
 

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -21,7 +21,12 @@ cask "sage" do
   app "SageMath-#{version.before_comma.dots_to_hyphens}.app"
   pkg "Recommended_#{version.before_comma.dots_to_underscores}.pkg"
 
-  uninstall quit:    "org.sagemath.Sage",
+  uninstall quit:    [
+    "org.computop.sage",
+    "org.computop.SageMath",
+    "com.tcltk.tcllibrary",
+    "com.tcltk.tklibrary",
+  ],
             pkgutil: [
               "org.computop.SageMath.bin",
               "org.computop.SageMath.share",
@@ -29,8 +34,7 @@ cask "sage" do
 
   zap trash: [
     "~/.sage",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.sagemath.sage.sfl*",
-    "~/Library/Logs/sage.log",
-    "~/Library/Preferences/org.sagemath.Sage.plist",
+    "~/Library/Application Support/SageMath",
+    "~/Library/Preferences/SageMath.plist",
   ]
 end

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -19,7 +19,7 @@ cask "sage" do
   depends_on macos: ">= :high_sierra"
 
   app "SageMath-#{version.before_comma.dots_to_hyphens}.app"
-  binary "#{appdir}/SageMath-#{version.before_comma.dots_to_hyphens}.app/Contents/Resources/sage/sage"
+  binary "#{appdir}/SageMath-#{version.before_comma.dots_to_hyphens}.app/Contents/MacOS/SageMath", target: "sage"
 
   uninstall quit: "org.sagemath.Sage"
 

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,19 +1,22 @@
 cask "sage" do
-  if MacOS.version <= :mojave
-    version "9.1,10.11.6"
-    sha256 "23c13690b8a72deca1628dd0e66a0f7b83557f98c13c3db1dc7eb15d80cf3a8d"
-  else
-    version "9.2,10.15.7"
-    sha256 "fa6eb93368d4f7c220cbdd7a1483c1ef9d9b718b0f179c17c2acf14fb74f10c1"
-  end
+  version "9.3,1.1"
+  sha256 "23c13690b8a72deca1628dd0e66a0f7b83557f98c13c3db1dc7eb15d80cf3a8d"
 
-  url "https://mirrors.mit.edu/sage/osx/intel/sage-#{version.before_comma}-OSX_#{version.after_comma}-x86_64.app.dmg",
-      verified: "mirrors.mit.edu/sage/osx/intel/"
-  appcast "https://mirrors.mit.edu/sage/osx/intel/index.html"
+  url "https://github.com/3-manifolds/Sage_macOS/releases/download/v#{version.after_comma}/SageMath-#{version.before_comma}.dmg",
+      verified: "github.com/3-manifolds/Sage_macOS/"
   name "Sage"
+  desc "Mathematics software system"
   homepage "https://www.sagemath.org/"
 
-  depends_on macos: ">= :el_capitan"
+  livecheck do
+    url "https://github.com/3-manifolds/Sage_macOS/releases/latest"
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/SageMath-(\d+(?:\.\d+)*)\.dmg}i)
+      "#{match[2]},#{match[1]}"
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
 
   app "SageMath-#{version.before_comma}.app"
   binary "#{appdir}/SageMath-#{version.before_comma}.app/Contents/Resources/sage/sage"

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -19,7 +19,7 @@ cask "sage" do
   depends_on macos: ">= :high_sierra"
 
   app "SageMath-#{version.before_comma.dots_to_hyphens}.app"
-  binary "#{appdir}/SageMath-#{version.before_comma.dots_to_hyphens}.app/Contents/MacOS/SageMath", target: "sage"
+  pkg "Recommended_#{version.before_comma.dots_to_underscores}.pkg"
 
   uninstall quit: "org.sagemath.Sage"
 

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -21,7 +21,9 @@ cask "sage" do
   app "SageMath-#{version.before_comma.dots_to_hyphens}.app"
   pkg "Recommended_#{version.before_comma.dots_to_underscores}.pkg"
 
-  uninstall quit: "org.sagemath.Sage"
+  uninstall quit:    "org.sagemath.Sage",
+            pkgutil: "org.computop.SageMath.bin",
+                     "org.computop.SageMath.share"
 
   zap trash: [
     "~/.sage",

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -22,8 +22,10 @@ cask "sage" do
   pkg "Recommended_#{version.before_comma.dots_to_underscores}.pkg"
 
   uninstall quit:    "org.sagemath.Sage",
-            pkgutil: "org.computop.SageMath.bin",
-                     "org.computop.SageMath.share"
+            pkgutil: [
+              "org.computop.SageMath.bin",
+              "org.computop.SageMath.share",
+            ]
 
   zap trash: [
     "~/.sage",

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -1,6 +1,6 @@
 cask "sage" do
   version "9.3,1.1"
-  sha256 "23c13690b8a72deca1628dd0e66a0f7b83557f98c13c3db1dc7eb15d80cf3a8d"
+  sha256 "3504a4e47264ab935a93853473c8cee9fa82e43ab0c5f546c1fc95143fd9e1e1"
 
   url "https://github.com/3-manifolds/Sage_macOS/releases/download/v#{version.after_comma}/SageMath-#{version.before_comma}.dmg",
       verified: "github.com/3-manifolds/Sage_macOS/"


### PR DESCRIPTION
The [downloads page](https://www.sagemath.org/download.html) from the [homepage](https://www.sagemath.org/index.html) seems to point to this [Github releases page](https://github.com/3-manifolds/Sage_macOS/releases) as the recommended way to install Sage.