### PR TITLE
Update swiftformat-for-xcode from 0.48.5 to 0.48.6

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "swiftformat-for-xcode" do
-  version "0.48.5"
-  sha256 "7e190d6707d9120d76efd4ded64b3f2f7bf89f547ee8f298a2b5231511ce93fe"
+  version "0.48.6"
+  sha256 "fa23ff3d459c153c5e93931333dbd48355b85942544fa95eaa9ba51213ba21eb"
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   name "SwiftFormat for Xcode"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.