### PR TITLE
[CI] Respect `depends_on macos:`

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -29,7 +29,7 @@ module CiMatrix
       [*Regexp.last_match(1)]
     end
     return RUNNERS if args.nil?
-  
+
     # Preform same checks as `brew install` would
     required_macos = if args.count > 1
       { versions: args, comparator: "==" }

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -36,11 +36,14 @@ module CiMatrix
     end
 
     # Filter
-    RUNNERS.select do |runner, _|
+    filtered_runners = RUNNERS.select do |runner, _|
       required_macos[:versions].any? do |v|
         MacOS::Version.from_symbol(runner[:symbol]).public_send(required_macos[:comparator], v)
       end
     end
+    return filtered_runners unless filtered_runners.empty?
+
+    RUNNERS
   end
 
   def self.random_runner(avalible_runners = RUNNERS)


### PR DESCRIPTION
Accounts for `depends_on macOS:` when determining runners for CI.

Fixes #107570

When reviewing, just double check I haven't made any obvious mistakes and if any changes are needed for style or a regex.
