### PR TITLE
eaccess: add livecheck and add download ID to version

### DIFF
--- a/Casks/eaccess.rb
+++ b/Casks/eaccess.rb
@@ -1,12 +1,23 @@
 cask "eaccess" do
-  version "1.13.3"
-  sha256 :no_check
+  version "1.13.3,97899"
+  sha256 "b496682ccaa4b90bdb7a9ae81b631e714235f81481d985c3c752c313dc7d7058"
 
-  url "https://glutz.com/service/downloads/?dwnldid=97899"
-  appcast "https://glutz.com/service/downloads/soft-und-firmware/"
+  url "https://glutz.com/service/downloads/?dwnldid=#{version.after_comma}"
   name "eAccess Desktop"
   desc "Software for eAccess devices"
   homepage "https://glutz.com/service/download/software-and-firmware/"
+
+  livecheck do
+    url "https://glutz.com/download-center/category-assets/26303"
+    strategy :page_match do |page|
+      JSON.parse(page)["assets"].map do |asset|
+        v = asset["title"][/Desktop\s+MacOS\s+v?(\d+(?:\.\d+)+)/i, 1]
+        "#{v},#{asset["external_id"]}" if v
+      end.compact
+    end
+  end
+
+  depends_on macos: ">= :el_capitan"
 
   app "eAccess Desktop.app"
   binary "#{appdir}/eAccess Desktop.app/Contents/MacOS/eAccessServer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The ID appears to be unique per version, so tracking it in `version` should allow for properly versioning download URL and tracking SHA256.
```console
❯ brew livecheck --debug --verbose eaccess
...
Matched Versions:
1.13.2,97676 => #<Version:0x000000014ee66f50 @version="1.13.2,97676", @detected_from_url=false>
1.13.3,97899 => #<Version:0x000000014ee66f00 @version="1.13.3,97899", @detected_from_url=false>
1.13.1,97482 => #<Version:0x000000014ee66ed8 @version="1.13.1,97482", @detected_from_url=false>
eaccess : 1.13.3,97899 ==> 1.13.3,97899
```