### PR TITLE
ealeksandrov-cd-to: add desc and fix livecheck to dotted version

### DIFF
--- a/Casks/ealeksandrov-cd-to.rb
+++ b/Casks/ealeksandrov-cd-to.rb
@@ -4,7 +4,16 @@ cask "ealeksandrov-cd-to" do
 
   url "https://github.com/ealeksandrov/cdto/releases/download/#{version.dots_to_underscores}/cd_to_#{version.major_minor.dots_to_underscores}.zip"
   name "cd_to"
+  desc "Finder Toolbar app to open the current directory in the Terminal"
   homepage "https://github.com/ealeksandrov/cdto"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.gsub("_", ".") }.compact
+    end
+  end
 
   app "cd_to_#{version.major_minor.dots_to_underscores}/terminal/cd_to.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Before, uses underscores:
```console
❯ brew livecheck --debug ealeksandrov-cd-to

Cask:             ealeksandrov-cd-to
Livecheckable?:   No

URL:              https://github.com/ealeksandrov/cdto/releases/download/2_8_0/cd_to_2_8.zip
URL (processed):  https://github.com/ealeksandrov/cdto.git
Strategy:         Git

Matched Versions:
2_0_0, 2_1_0, 2_1_1, 2_2_0, 2_3_0, 2_5_0, 2_6_0, 2_7_0, 2_8_0
ealeksandrov-cd-to : 2.8.0 ==> 2_8_0
```

After, uses dots:
```console
❯ brew livecheck --debug ealeksandrov-cd-to

Cask:             ealeksandrov-cd-to
Livecheckable?:   Yes

URL (url):        https://github.com/ealeksandrov/cdto/releases/download/2_8_0/cd_to_2_8.zip
URL (processed):  https://github.com/ealeksandrov/cdto.git
Strategy:         Git
Regex:            /^v?(\d+(?:[._]\d+)+)$/i

Matched Versions:
2.0.0, 2.1.0, 2.1.1, 2.2.0, 2.3.0, 2.5.0, 2.6.0, 2.7.0, 2.8.0
ealeksandrov-cd-to : 2.8.0 ==> 2.8.0
```