### PR TITLE
teamviewer: add livecheck

### DIFF
--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -3,10 +3,14 @@ cask "teamviewer" do
   sha256 :no_check
 
   url "https://download.teamviewer.com/download/TeamViewer.dmg"
-  appcast "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=14.7.1965&os=macos&osversion=10.15.1&type=1&channel=1"
   name "TeamViewer"
   desc "Remote access and connectivity software focused on security"
   homepage "https://www.teamviewer.com/"
+
+  livecheck do
+    url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=15.9.4&os=macos&osversion=10.15.1&type=1&channel=1"
+    strategy :sparkle
+  end
 
   auto_updates true
   conflicts_with cask: "teamviewer-host"

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -8,7 +8,7 @@ cask "teamviewer" do
   homepage "https://www.teamviewer.com/"
 
   livecheck do
-    url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=15.9.4&os=macos&osversion=10.15.1&type=1&channel=1"
+    url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"
     strategy :sparkle
   end
 


### PR DESCRIPTION
Adds livecheck stanza for Teamviewer.
Any thoughts on the reliability of the appcast URL? It seems to have remained stable in the past.

#107289 

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.