### PR TITLE
vagrant-vmware-utility: add description, livecheck

### DIFF
--- a/Casks/vagrant-vmware-utility.rb
+++ b/Casks/vagrant-vmware-utility.rb
@@ -4,9 +4,14 @@ cask "vagrant-vmware-utility" do
 
   url "https://releases.hashicorp.com/vagrant-vmware-utility/#{version}/vagrant-vmware-utility_#{version}_x86_64.dmg",
       verified: "releases.hashicorp.com/vagrant-vmware-utility/"
-  appcast "https://releases.hashicorp.com/vagrant-vmware-utility/"
   name "Vagrant VMware Utility"
+  desc "Gives Vagrant VMware plugin access to various VMware functionalities"
   homepage "https://www.vagrantup.com/vmware/downloads.html"
+
+  livecheck do
+    url "https://releases.hashicorp.com/vagrant-vmware-utility/"
+    regex(%r{href=["']?/?vagrant-vmware-utility/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
 
   pkg "VagrantVMwareUtility.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck gives an `Unable to get versions` error for `vagrant-vmware-utility`. This PR adds a `livecheck` block that checks the directory listing page previously used as the `appcast`. This check identifies versions from the version directories on this page, as the related disk image files are kept inside of these directories.

Besides that, this also adds a description to the cask by adapting some language found in the [related docs](https://www.vagrantup.com/docs/providers/vmware/vagrant-vmware-utility#usage).