### PR TITLE
fork: use latest stable version

### DIFF
--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,6 +1,6 @@
 cask "fork" do
-  version "2.9.3"
-  sha256 "240462647bf50fd041478e5e033159d7c7de179f8d6877d4ac0caa501f84fbb2"
+  version "2.9.2"
+  sha256 "4db0cb4c26b60b59957e7f752fcfde05f132cc727345451a8c7f7cec80267743"
 
   url "https://forkapp.ams3.cdn.digitaloceanspaces.com/mac/Fork-#{version}.dmg",
       verified: "forkapp.ams3.cdn.digitaloceanspaces.com/mac/"

--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -1,6 +1,6 @@
 cask "fork" do
-  version "2.9.2"
-  sha256 "4db0cb4c26b60b59957e7f752fcfde05f132cc727345451a8c7f7cec80267743"
+  version "2.8"
+  sha256 "9c582da29b089ebdbc2543032261239a97f183582b745549bf4436ef1f24dea0"
 
   url "https://forkapp.ams3.cdn.digitaloceanspaces.com/mac/Fork-#{version}.dmg",
       verified: "forkapp.ams3.cdn.digitaloceanspaces.com/mac/"

--- a/Casks/fork.rb
+++ b/Casks/fork.rb
@@ -9,13 +9,14 @@ cask "fork" do
   homepage "https://git-fork.com/"
 
   livecheck do
-    url "https://git-fork.com/update/feed.xml"
+    url "https://git-fork.com/update/feed-stable.xml"
     strategy :sparkle do |item|
       item.url[%r{/Fork-(\d+(?:\.\d+)*)\.dmg}i, 1]
     end
   end
 
   auto_updates true
+  conflicts_with cask: "fork-dev"
 
   app "Fork.app"
   binary "#{appdir}/Fork.app/Contents/Resources/fork_cli", target: "fork"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

HBC should advertise a stable Fork version so downgrading it back to 2.8 and ensuring that the correct feed is used.
