### PR TITLE
dosbox: update livecheck

### DIFF
--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -5,7 +5,7 @@ cask "dosbox" do
   url "https://downloads.sourceforge.net/dosbox/dosbox/#{version.before_comma}/DOSBox-#{version.before_comma}-#{version.after_comma}.dmg",
       verified: "sourceforge.net/dosbox/"
   name "DOSBox"
-  desc "An x86 emulator with DOS"
+  desc "x86 emulator with DOS"
   homepage "https://www.dosbox.com/"
 
   livecheck do

--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -5,7 +5,7 @@ cask "dosbox" do
   url "https://downloads.sourceforge.net/dosbox/dosbox/#{version.before_comma}/DOSBox-#{version.before_comma}-#{version.after_comma}.dmg",
       verified: "sourceforge.net/dosbox/"
   name "DOSBox"
-  desc "x86 emulator with DOS"
+  desc "Emulator for x86 with DOS"
   homepage "https://www.dosbox.com/"
 
   livecheck do

--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -5,6 +5,7 @@ cask "dosbox" do
   url "https://downloads.sourceforge.net/dosbox/dosbox/#{version.before_comma}/DOSBox-#{version.before_comma}-#{version.after_comma}.dmg",
       verified: "sourceforge.net/dosbox/"
   name "DOSBox"
+  desc "An x86 emulator with DOS"
   homepage "https://www.dosbox.com/"
 
   livecheck do

--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -4,9 +4,20 @@ cask "dosbox" do
 
   url "https://downloads.sourceforge.net/dosbox/dosbox/#{version.before_comma}/DOSBox-#{version.before_comma}-#{version.after_comma}.dmg",
       verified: "sourceforge.net/dosbox/"
-  appcast "https://sourceforge.net/projects/dosbox/rss?path=/dosbox"
   name "DOSBox"
   homepage "https://www.dosbox.com/"
+
+  livecheck do
+    url "https://sourceforge.net/projects/dosbox/rss?path=/dosbox"
+    strategy :page_match do |page|
+      page.scan(%r{<link>.*/DOSBox-(\d+(?:[.-]\d+)*).dmg}i).map do |matches|
+        versions = matches[0].split("-")
+        version = "#{versions[0]}-#{versions[1]},#{versions[2]}" if versions.length == 3
+        version = "#{versions[0]}-#{versions[1]}" if versions.length == 2
+        version
+      end
+    end
+  end
 
   app "dosbox.app"
 


### PR DESCRIPTION
This assumes that the version formatting remains the same, and there may be a more eloquent way to handle the version splitting.

Perhaps a better options would be to change the version formatting to match the filename (0.74-3-3 - instead of 0.74-3,3)