### PR TITLE
Updated amazon-music from 8.4.0.2249 to 8.6.0.2271

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -14,6 +14,8 @@ cask "amazon-music" do
 
   auto_updates true
 
+  container nested: "Amazon+Music+Installer.dmg"
+
   installer script: {
     executable: "Amazon Music Installer.app/Contents/MacOS/installbuilder.sh",
   }

--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,20 +1,16 @@
 cask "amazon-music" do
-  version "8.6.0.2271"
-  sha256 :no_check
+  version "8.6.0.2271,22710610_e91247c784977e6c258edc2ea5d1a151"
+  sha256 "85d69d9a46296c43936344c1dccb009cbba90ca85c3d7b60620540aff3155ef8"
 
-  url "https://www.amazon.com/gp/dmusic/desktop/downloadPlayer"
+  url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.after_comma}/Amazon+Music+Installer.dmg",
+      verified: "morpho-releases.s3-us-west-2.amazonaws.com/mac/"
+  appcast "https://www.amazon.com/gp/dmusic/desktop/downloadPlayer",
+          must_contain: version.after_comma
   name "Amazon Music"
   desc "Desktop client for Amazon Music"
   homepage "https://www.amazon.com/musicapps"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
-
   auto_updates true
-
-  container nested: "Amazon+Music+Installer.dmg"
 
   installer script: {
     executable: "Amazon Music Installer.app/Contents/MacOS/installbuilder.sh",

--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask "amazon-music" do
-  version "8.4.0.2249,224949_d5c94ee480b0c856a9257863319df96e"
-  sha256 "c7d001f1be8a37bd14bca1eee3851c3235327fb43d45700726ddbb5eb322c783"
+  version "8.6.0.2271,22710610_e91247c784977e6c258edc2ea5d1a151"
+  sha256 "85d69d9a46296c43936344c1dccb009cbba90ca85c3d7b60620540aff3155ef8"
 
   url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.after_comma}/Amazon+Music+Installer.dmg",
       verified: "morpho-releases.s3-us-west-2.amazonaws.com/mac/"

--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,14 +1,16 @@
 cask "amazon-music" do
-  version "8.6.0.2271,22710610_e91247c784977e6c258edc2ea5d1a151"
-  sha256 "85d69d9a46296c43936344c1dccb009cbba90ca85c3d7b60620540aff3155ef8"
+  version "8.6.0.2271"
+  sha256 :no_check
 
-  url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.after_comma}/Amazon+Music+Installer.dmg",
-      verified: "morpho-releases.s3-us-west-2.amazonaws.com/mac/"
-  appcast "https://www.amazon.com/gp/dmusic/desktop/downloadPlayer",
-          must_contain: version.after_comma
+  url "https://www.amazon.com/gp/dmusic/desktop/downloadPlayer"
   name "Amazon Music"
   desc "Desktop client for Amazon Music"
   homepage "https://www.amazon.com/musicapps"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   auto_updates true
 


### PR DESCRIPTION
Updated amazon-music from 8.4.0.2249 to 8.6.0.2271 and updated the SHA256. The newer version 8.6.0.2271 is compatible with Big Sur on M1.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
