### PR TITLE
Include SwiftDefaultApps' binary and add description

### DIFF
--- a/Casks/swiftdefaultappsprefpane.rb
+++ b/Casks/swiftdefaultappsprefpane.rb
@@ -4,7 +4,9 @@ cask "swiftdefaultappsprefpane" do
 
   url "https://github.com/Lord-Kamina/SwiftDefaultApps/releases/download/v#{version}/SwiftDefaultApps-v#{version}.zip"
   name "SwiftDefaultApps"
+  desc "Replacement for RCDefaultApps, written in Swift"
   homepage "https://github.com/Lord-Kamina/SwiftDefaultApps"
 
+  binary "swda"
   prefpane "SwiftDefaultApps.prefPane"
 end


### PR DESCRIPTION
SwiftDefaultApps provides a CLI version located inside the bundle, but for some reason the cask didn't include it. Now it should correctly install the binary in addition to the prefpane. Tested it and the CLI version works.

Also, I added the short description from SwiftDefaultApps' [GitHub page](https://github.com/Lord-Kamina/SwiftDefaultApps) to the cask as `brew audit` prompted me to add the `desc` field...

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.