### PR TITLE
boom-3d: add livecheck, change version formatting

### DIFF
--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -1,5 +1,5 @@
 cask "boom-3d" do
-  version "1.3.11,029"
+  version "1.3.11,101.3.11029"
   sha256 :no_check
 
   url "https://dfvk972795zr9.cloudfront.net/Boom3Dmac/webstore/Boom3D.dmg",
@@ -9,11 +9,8 @@ cask "boom-3d" do
   homepage "https://www.globaldelight.com/boom/"
 
   livecheck do
-    url "https://www.macupdater.net/cgi-bin/extract_text/send_post_request_data.cgi?url=https://apiboom3.globaldelight.net/v1/native/queryupdate/&data={%22AppIdentifier%22:%22com.globaldelight.Boom3D%22,%22ApplicationId%22:%22com.globaldelight.Boom3D%22,%22RequestType%22:0,%22AppName%22:%22Boom%203D%22}"
-    strategy :page_match do |page|
-      page.scan(/AppVersionAvailable":"(\d+(?:[._-]\d+)+)\((\d+)\)"/i)
-          .map { |match| "#{match[0]},#{match[1]}" }
-    end
+    url :url
+    strategy :extract_plist
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -1,13 +1,20 @@
 cask "boom-3d" do
-  version "1.3.11,101.3.11029"
+  version "1.3.11,029"
   sha256 :no_check
 
   url "https://dfvk972795zr9.cloudfront.net/Boom3Dmac/webstore/Boom3D.dmg",
       verified: "https://dfvk972795zr9.cloudfront.net/"
-  appcast "https://www.macupdater.net/cgi-bin/extract_text/send_post_request_data.cgi?url=https://apiboom3.globaldelight.net/v1/native/queryupdate/&data={%22AppIdentifier%22:%22com.globaldelight.Boom3D%22,%22ApplicationVersion%22:%221.3.3%22,%22AppVersion%22:%22101.3.3018%22,%22ApplicationId%22:%22com.globaldelight.Boom3D%22,%22RequestType%22:0,%22AppName%22:%22Boom%203D%22}"
   name "Boom 3D"
   desc "Volume booster and equalizer software"
   homepage "https://www.globaldelight.com/boom/"
+
+  livecheck do
+    url "https://www.macupdater.net/cgi-bin/extract_text/send_post_request_data.cgi?url=https://apiboom3.globaldelight.net/v1/native/queryupdate/&data={%22AppIdentifier%22:%22com.globaldelight.Boom3D%22,%22ApplicationId%22:%22com.globaldelight.Boom3D%22,%22RequestType%22:0,%22AppName%22:%22Boom%203D%22}"
+    strategy :page_match do |page|
+      page.scan(/AppVersionAvailable":"(\d+(?:[._-]\d+)+)\((\d+)\)"/i)
+          .map { |match| "#{match[0]},#{match[1]}" }
+    end
+  end
 
   depends_on macos: ">= :yosemite"
 


### PR DESCRIPTION
BrewTestBot changed the version formatting of this cask recently based on an unversioned cask bump. The formatting in this PR seems more suitable.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses