### PR TITLE
Tweetbot livecheck

### DIFF
--- a/Casks/lynx.rb
+++ b/Casks/lynx.rb
@@ -1,11 +1,16 @@
 cask "lynx" do
-  version "6.6.6"
+  version "6.6.6.0"
   sha256 :no_check
 
   url "https://download.saharasupport.com/lynx/production/macx/Lynx-install.dmg"
-  appcast "https://downloads.saharasupport.com/lynx/production/macx/version.txt"
   name "Lynx by Clevertouch"
+  desc "Clevertouch software installer"
   homepage "https://download.saharasupport.com/"
+
+  livecheck do
+    url "https://downloads.saharasupport.com/lynx/production/macx/version.txt"
+    regex(/(\d+(?:[._-]\d+)+)/)
+  end
 
   auto_updates true
 

--- a/Casks/tweetbot.rb
+++ b/Casks/tweetbot.rb
@@ -1,14 +1,19 @@
 cask "tweetbot" do
-  version "3.5.300,4"
+  version "3.5.3,35300"
   sha256 "d7501211b6d8dce67a9061b0a33b66c57b5fcda9ae171b1858a40e31df71afc7"
 
-  url "https://tapbots.net/tweetbot#{version.after_comma}/Tweetbot.#{version.before_comma.no_dots}.zip",
+  url "https://tapbots.net/tweetbot4/Tweetbot.#{version.after_comma}.zip",
       verified: "tapbots.net/"
-  appcast "https://tapbots.net/tweetbot#{version.after_comma}/update.plist",
-          must_contain: version.before_comma.no_dots
   name "Tweetbot"
   desc "Twitter client"
   homepage "https://tapbots.com/tweetbot/mac/"
+
+  livecheck do
+    url "https://tapbots.net/tweetbot4/update.plist"
+    strategy :extract_plist do |version|
+      "#{version.values.map(&:short_version).compact.first},#{version.values.map(&:version).compact.first}"
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
Proposed versioning change included.

Previously `4` was used as the version after comma, however this has no bearing within livecheck, so would have to be hardcoded in the livecheck. I have opted to hardcode this into the URLs, it may require updating when there is a major release, but this allows for livecheck to be used.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.