### PR TITLE
audacity: update livecheck to ignore RCs

### DIFF
--- a/Casks/audacity.rb
+++ b/Casks/audacity.rb
@@ -8,6 +8,11 @@ cask "audacity" do
   desc "Multi-track audio editor and recorder"
   homepage "https://www.audacityteam.org/"
 
+  livecheck do
+    url :url
+    regex(/^Audacity[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
   app "Audacity.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Before:
```console
❯ brew livecheck --cask audacity
audacity : 3.0.2 ==> 3.0.3-RC2
```

After:
```console
❯ brew livecheck --cask audacity
audacity : 3.0.2 ==> 3.0.2
```