### PR TITLE
Firecamp upgraded to v2.0.8

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.0.5"
-  sha256 "1c79a2d65aa42e19ec72ad052fd6b92e84b57d248115545f44f62c32eaec4a44"
+  version "2.0.8"
+  sha256 "5369e599f366daac100ec5d8a2e87a5fe95647b809a23137cdc8b6bfb6ba1d45"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
