### PR TITLE
google-chrome: alternative download for Intel chips

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -2,7 +2,12 @@ cask "google-chrome" do
   version "91.0.4472.114"
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
+  if Hardware::CPU.intel?
+    url "https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"
+  else
+    url "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
+  end
+
   name "Google Chrome"
   desc "Web browser"
   homepage "https://www.google.com/chrome/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This cask was altered to use universal download https://github.com/Homebrew/homebrew-cask/pull/93326 but in the meantime, `Hardware::CPU` check got implemented. This is done specifically to reduce download and install size as @i0ntempest mentioned https://github.com/Homebrew/homebrew-cask/pull/93326#issuecomment-731753577