### PR TITLE
Update clash-for-windows from 0.16.0 to 0.16.1

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,12 +1,12 @@
 cask "clash-for-windows" do
-  version "0.16.0"
+  version "0.16.1"
 
   if Hardware::CPU.intel?
     url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
-    sha256 "1549c16b094442447de5fe345e2b472321581591c9a1b0bf3125f7bfd01f5c08"
+    sha256 "4275fc5bffd76105e7fe2b462c5ffa5a8912275282a5bba37ff3932414bd6185"
   else
     url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}-arm64.dmg"
-    sha256 "c9b2f06b2c59b41867cb29016fa0ce07b0da3ac88d72f5a9411082150d4c6e75"
+    sha256 "9c78dfb1abc07036b810450b8af255883e4864383f8adb0aea8224935b55fba9"
   end
 
   name "Clash for Windows"


### PR DESCRIPTION
Created with brew `bump-cask-pr`.