### PR TITLE
Add Physics 101.app

### DIFF
--- a/Casks/physics-101.rb
+++ b/Casks/physics-101.rb
@@ -1,4 +1,4 @@
-cask "physics" do
+cask "physics-101" do
   version "9.1,9.9.9.3.9"
   sha256 :no_check
 

--- a/Casks/physics.rb
+++ b/Casks/physics.rb
@@ -1,11 +1,16 @@
 cask "physics" do
-  version :latest
+  version "9.1,9.9.9.3.9"
   sha256 :no_check
 
-  url "http://praetersoftware.com/download/physics101/Physics101.dmg"
+  url "https://praetersoftware.com/download/physics101/Physics101.dmg"
   name "Physics 101"
-  desc "Physics tools and simulations"
+  desc "Collection of simulations, tools, and equations across the field of physics"
   homepage "http://www.praetersoftware.com/new/physics101/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   app "Physics 101.app"
 

--- a/Casks/physics.rb
+++ b/Casks/physics.rb
@@ -1,0 +1,16 @@
+cask "physics" do
+  version :latest
+  sha256 :no_check
+
+  url "http://praetersoftware.com/download/physics101/Physics101.dmg"
+  name "Physics 101"
+  desc "Physics tools and simulations"
+  homepage "http://www.praetersoftware.com/new/physics101/"
+
+  app "Physics 101.app"
+
+  zap trash: [
+    "~/Library/Application Support/Physics 101",
+    "~/Library/Saved Application State/com.praetersoftware.physics101se.savedState",
+  ]
+end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


This cask is for a trial app but the author offers (for free) a serial key on its website to unlock all the features of the paid/full version.

The command `brew style --fix` reports `Description shouldn't start with the cask name.`, but to be honest this seems more like a false positive.