### PR TITLE
Bumping renpy to 7.4.6

### DIFF
--- a/Casks/renpy.rb
+++ b/Casks/renpy.rb
@@ -1,6 +1,6 @@
 cask "renpy" do
-  version "7.4.4"
-  sha256 "b06491573cb59d2fd0c511c550ddb82b22a78a0ef34680370f280d47ff9683a6"
+  version "7.4.6"
+  sha256 "3a3b8608f8150be8e50ab5f27d371fc0f828554874c96c31b1cf77e300953cb3"
 
   url "https://www.renpy.org/dl/#{version}/renpy-#{version}-sdk.zip"
   name "Ren'Py"

--- a/Casks/renpy.rb
+++ b/Casks/renpy.rb
@@ -7,5 +7,10 @@ cask "renpy" do
   desc "Visual novel engine in Python"
   homepage "https://www.renpy.org/"
 
+  livecheck do
+    url "https://www.renpy.org/latest.html"
+    regex(/href=.*?renpy[._-]v?(\d+(?:\.\d+)+)[._-]sdk\.dmg/i)
+  end
+
   suite "renpy-#{version}-sdk"
 end


### PR DESCRIPTION
Bumps renpy to 7.4.6.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
