### PR TITLE
sip: update livecheck, versions

### DIFF
--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -2,23 +2,26 @@ cask "sip" do
   if MacOS.version <= :sierra
     version "1.2"
     sha256 "93569421eef761ccdd2784d73e5f201d29e5e22ad6814a7a169f459f460bf4ff"
+  elsif MacOS.version <= :high_sierra
+    version "2.4.1"
+    sha256 "9e8e69b8874891fab4fcc44edfb9b6ff2e510a1f41c87e9faea6060fc3f33073"
   else
-    version "2.5.3,253"
-    sha256 "4b66da32237ce195ea6b57e22942bf3508bca7fb5958f78df46b00e233bba484"
+    version "2.5.4"
+    sha256 "a7f025c82088b4fef10997c68d2b1c9fb076b5519a493acd834d13c1cacbeb70"
   end
 
-  url "https://sipapp.io/updates/v#{version.major}/sip-#{version.before_comma}.zip"
+  url "https://sipapp.io/updates/v#{version.major}/sip-#{version}.zip"
   name "Sip"
   desc "Collect, organize & share colors"
   homepage "https://sipapp.io/"
 
   livecheck do
-    url "https://sipapp.io/updates/v#{version.major}/sip.xml"
-    strategy :sparkle
+    url "https://sipapp.io/updates/"
+    regex(/href=.*?sip[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   app "Sip.app"
 

--- a/Casks/sip.rb
+++ b/Casks/sip.rb
@@ -21,7 +21,7 @@ cask "sip" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :sierra"
 
   app "Sip.app"
 


### PR DESCRIPTION

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.