### PR TITLE
Add config.yml to `ISSUE_TEMPLATE`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Get help in GitHub Discussions
+    url: https://github.com/Homebrew/discussions/discussions
+    about: Have a question? Not sure if your issue affects everyone reproducibly? The quickest way to get help is on Homebrew's GitHub Discussions!
+  - name: New issue on Homebrew/brew
+    url: https://github.com/Homebrew/brew/issues/new/choose
+    about: Having a `brew` problem that's not from a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/brew (the Homebrew package manager).
+  - name: New issue on Homebrew/homebrew-core
+    url: https://github.com/Homebrew/homebrew-core/issues/new/choose
+    about: Having a Homebrew formula problem? Report it to Homebrew/homebrew-core (the formula tap/repository)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     about: Have a question? Not sure if your issue affects everyone reproducibly? The quickest way to get help is on Homebrew's GitHub Discussions!
   - name: New issue on Homebrew/brew
     url: https://github.com/Homebrew/brew/issues/new/choose
-    about: Having a `brew` problem that's not from a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/brew (the Homebrew package manager).
+    about: Having a `brew` problem that's not from a `brew install` or `brew upgrade` of a single cask? Report it to Homebrew/brew (the Homebrew package manager).
   - name: New issue on Homebrew/homebrew-core
     url: https://github.com/Homebrew/homebrew-core/issues/new/choose
     about: Having a Homebrew formula problem? Report it to Homebrew/homebrew-core (the formula tap/repository)


### PR DESCRIPTION
This mirrors the equivalent file in Homebrew/core.

In particular, this disables blank issues, so that users must answer the prompts requesting debug information (i.e. `brew doctor`) when opening issues.