### PR TITLE
remote-wake-up: style fixes for RuboCop 1.18.3

### DIFF
--- a/Casks/remote-wake-up.rb
+++ b/Casks/remote-wake-up.rb
@@ -16,18 +16,18 @@ cask "remote-wake-up" do
 
   zap trash: [
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/" \
-      "Library/Preferences/com.mac-attender.Remote-Wake-Up.plist",
+    "Library/Preferences/com.mac-attender.Remote-Wake-Up.plist",
     "~/Library/Preferences/com.mac-attender.Remote-Wake-Up.plist",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/Library/Application Support/Remote Wake Up",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/Library/Cookies/Cookies.binarycookies",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/Library/Caches/com.plausiblelabs.crashreporter.data",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/" \
-      "Library/Saved Application State/com.mac-attender.Remote-Wake-Up.savedState",
+    "Library/Saved Application State/com.mac-attender.Remote-Wake-Up.savedState",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/Library/Caches/com.mac-attender.Remote-Wake-Up",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/" \
-      "Library/Application Support/com.mac-attender.Remote-Wake-Up",
+    "Library/Application Support/com.mac-attender.Remote-Wake-Up",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/" \
-      "Library/Application Support/com.mac-attender.Remote_Wake_Up",
+    "Library/Application Support/com.mac-attender.Remote_Wake_Up",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/tmp",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/SystemData",
     "~/Library/Containers/com.mac-attender.Remote-Wake-Up/Data/default.profraw",


### PR DESCRIPTION
Required for Homebrew/brew#11664, done entirely by `brew style --fix`.

I wasn't too happy with this particular autocorrect, so if there are alternatives I'd be happy to update the PR.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
