### PR TITLE
webviewscreensaver: codesign when installing on Apple Silicon

### DIFF
--- a/Casks/webviewscreensaver.rb
+++ b/Casks/webviewscreensaver.rb
@@ -13,4 +13,12 @@ cask "webviewscreensaver" do
   end
 
   screen_saver "WebViewScreenSaver.saver"
+
+  postflight do
+    if (MacOS.version >= :big_sur) && Hardware::CPU.arm?
+      binary = "#{ENV["HOME"]}/Library/Screen Savers/WebViewScreenSaver.saver"
+      odebug "Codesigning #{binary}"
+      quiet_system("codesign", "--sign", "-", "--force", binary)
+    end
+  end
 end


### PR DESCRIPTION
This change codesigns `webviewscreensaver` when installing on Apple Silicon.
The cask is distributed as an **unsigned** binary built from an OSS project, and running it on Apple Sillicon requires a code signature.
The proposal is inspired by https://github.com/Homebrew/brew/pull/9102 but it doesn't use `apply_ad_hoc_signature` as I would consider that private in the current form. (a future stanza could enable that though)


This may be controversial as I haven't seen other example casks doing this.
I also started a [discussion](https://github.com/Homebrew/discussions/discussions/1790) around this topic that didn't yield other suggestions so far.

---
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `brew install --cask <cask>` and `brew reinstall` worked successfully on **x86**
- [x] `brew install --cask <cask>` and `brew reinstsall` worked successfully on **arm**

