### PR TITLE
routebuddy: update homepage, livecheck

### DIFF
--- a/Casks/routebuddy.rb
+++ b/Casks/routebuddy.rb
@@ -5,10 +5,11 @@ cask "routebuddy" do
   url "https://objects-us-east-1.dream.io/routebuddy/download/apps2/RouteBuddy_#{version}.dmg",
       verified: "objects-us-east-1.dream.io/routebuddy/"
   name "RouteBuddy"
-  homepage "https://routebuddy.com/"
+  desc "GPS-enabled mapping software"
+  homepage "http://routebuddy.com/"
 
   livecheck do
-    url "https://routebuddy.com/routebuddy-topo-map-software-for-windows-and-mac-os-x/"
+    url "http://routebuddy.com/routebuddy-topo-map-software-for-windows-and-mac-os-x/"
     strategy :page_match
     regex(%r{href=.*?/RouteBuddy_(\d+(?:\.\d+)*)\.dmg}i)
   end


### PR DESCRIPTION
Removed https links, as the SSL certificate isn't working

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.