### PR TITLE
chessx: add livecheck

### DIFF
--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -4,9 +4,13 @@ cask "chessx" do
 
   url "https://downloads.sourceforge.net/chessx/chessx/#{version}/chessx-#{version}.dmg",
       verified: "downloads.sourceforge.net/chessx/"
-  appcast "https://sourceforge.net/projects/chessx/rss?path=/chessx"
   name "ChessX"
   homepage "https://chessx.sourceforge.io/"
+
+  livecheck do
+    url "https://sourceforge.net/projects/chessx/files/latest/download"
+    strategy :header_match
+  end
 
   pkg "chessx-installer.mpkg"
 

--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -5,6 +5,7 @@ cask "chessx" do
   url "https://downloads.sourceforge.net/chessx/chessx/#{version}/chessx-#{version}.dmg",
       verified: "downloads.sourceforge.net/chessx/"
   name "ChessX"
+  desc "Chess database"
   homepage "https://chessx.sourceforge.io/"
 
   livecheck do


### PR DESCRIPTION
Uses a strategy because the default Sourceforge strategy is returning a beta release