### PR TITLE
Flag Google Drive as auto updates

### DIFF
--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -12,6 +12,7 @@ cask "google-drive" do
     strategy :extract_plist
   end
 
+  auto_updates true
   depends_on macos: ">= :el_capitan"
 
   pkg "GoogleDrive.pkg"


### PR DESCRIPTION
"Drive for desktop comes packaged with ... Google Software Update (Mac) to auto-update Drive for desktop on your users’ computers". I have flagged Google Drive as auto updates and have verified the cask as below.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
