### PR TITLE
Update swiftformat-for-xcode from 0.48.7 to 0.48.8

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "swiftformat-for-xcode" do
-  version "0.48.7"
-  sha256 "bd62918fa047c58deddf68604a0865644f25a1bfec008588d0ae4a2a2208e5e5"
+  version "0.48.8"
+  sha256 "25339528460dcb8cc1d77fd4fbd2b3c3caa164a5a6b210bd7cc6556b87a20212"
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   name "SwiftFormat for Xcode"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
