### PR TITLE
Update zeplin from 3.23,1230 to 3.23.1,1238

### DIFF
--- a/Casks/zeplin.rb
+++ b/Casks/zeplin.rb
@@ -1,5 +1,5 @@
 cask "zeplin" do
-  version "3.23,1230"
+  version "3.23.1,1238"
   sha256 :no_check
 
   url "https://api.zeplin.io/urls/download-mac"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.