### PR TITLE
Update clash-for-windows from 0.16.1 to 0.16.2

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,12 +1,12 @@
 cask "clash-for-windows" do
-  version "0.16.1"
+  version "0.16.2"
 
   if Hardware::CPU.intel?
     url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
-    sha256 "4275fc5bffd76105e7fe2b462c5ffa5a8912275282a5bba37ff3932414bd6185"
+    sha256 "fb950201d3198e1a67228262faadc3a72ba63e39f386a207f87a31bf0917c1bb"
   else
     url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}-arm64.dmg"
-    sha256 "9c78dfb1abc07036b810450b8af255883e4864383f8adb0aea8224935b55fba9"
+    sha256 "7e530177e4a0ce5f739371a471484f1692649f61d6571c154f8608147cd9bb20"
   end
 
   name "Clash for Windows"


### PR DESCRIPTION
Created with brew `bump-cask-pr`.