### PR TITLE
Firecamp upgraded to v2.0.10

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.0.9"
-  sha256 "5be2c0b42342eafc839dc8ffb3af52b460116a85f45a69f4ddd1465395b1aeb7"
+  version "2.0.10"
+  sha256 "149b9855c97b0ab72cb4ed70742e44c44e2cba4a3206f3f0f022cf6fd16c9149"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"

--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.0.8"
-  sha256 "5369e599f366daac100ec5d8a2e87a5fe95647b809a23137cdc8b6bfb6ba1d45"
+  version "2.0.9"
+  sha256 "5be2c0b42342eafc839dc8ffb3af52b460116a85f45a69f4ddd1465395b1aeb7"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"

--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,5 +1,4 @@
 cask "firecamp" do
-
   version "2.0.10"
   sha256 "149b9855c97b0ab72cb4ed70742e44c44e2cba4a3206f3f0f022cf6fd16c9149"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
