### PR TITLE
microsoft-office: update livecheck for individual apps

### DIFF
--- a/Casks/microsoft-auto-update.rb
+++ b/Casks/microsoft-auto-update.rb
@@ -9,8 +9,8 @@ cask "microsoft-auto-update" do
   homepage "https://docs.microsoft.com/officeupdates/release-history-microsoft-autoupdate"
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/?linkid=830196"
-    strategy :header_match
+    url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409MSau04-chk.xml"
+    regex(%r{Version</key>\s*<string>(\d+(?:\.\d+)*)</}i)
   end
 
   auto_updates true

--- a/Casks/microsoft-excel.rb
+++ b/Casks/microsoft-excel.rb
@@ -9,8 +9,8 @@ cask "microsoft-excel" do
   homepage "https://products.office.com/en-US/excel"
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/p/?linkid=525135"
-    strategy :header_match
+    url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409XCEL2019-chk.xml"
+    regex(%r{Version</key>\s*<string>(\d+(?:\.\d+)*)</}i)
   end
 
   auto_updates true

--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -9,8 +9,8 @@ cask "microsoft-outlook" do
   homepage "https://products.office.com/en-us/outlook/email-and-calendar-software-microsoft-outlook"
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/p/?linkid=525137"
-    strategy :header_match
+    url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409OPIM2019-chk.xml"
+    regex(%r{Version</key>\s*<string>(\d+(?:\.\d+)*)</}i)
   end
 
   auto_updates true

--- a/Casks/microsoft-powerpoint.rb
+++ b/Casks/microsoft-powerpoint.rb
@@ -9,8 +9,8 @@ cask "microsoft-powerpoint" do
   homepage "https://products.office.com/en-US/powerpoint"
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/p/?linkid=525136"
-    strategy :header_match
+    url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409PPT32019-chk.xml"
+    regex(%r{Version</key>\s*<string>(\d+(?:\.\d+)*)</}i)
   end
 
   auto_updates true

--- a/Casks/microsoft-word.rb
+++ b/Casks/microsoft-word.rb
@@ -9,8 +9,8 @@ cask "microsoft-word" do
   homepage "https://products.office.com/en-US/word"
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/p/?linkid=525134"
-    strategy :header_match
+    url "https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409MSWD2019-chk.xml"
+    regex(%r{Version</key>\s*<string>(\d+(?:\.\d+)*)</}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Microsoft AutoUpdate uses following feed format:
https://officecdn-microsoft-com.akamaized.net/pr/{{channel-id}}/MacAutoupdate/{{app-id}}-chk.xml
(e.g. https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409XCEL2019-chk.xml)

App IDs were extracted by intercepting MAU network traffic and there is also a separate opensource update checker listing exact same IDs used for verification: https://github.com/pbowden-msft/OfficeCDNCheck/blob/9c33167778d276859b299a0ddec63ded46d12ef4/OfficeCDNCheck#L17-L46

Additional data about particular update is available through following URL format:
https://officecdn-microsoft-com.akamaized.net/pr/{{channel-id}}/MacAutoupdate/{{app-id}}.xml
(e.g. https://officecdn-microsoft-com.akamaized.net/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409XCEL2019.xml)

I'm fully aware that existing livechecks work but using a stable update feed is better IMO than checking redirects on shortlinks that could change in the future.