### PR TITLE
Update clash-for-windows from 0.16.2 to 0.16.3

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,12 +1,12 @@
 cask "clash-for-windows" do
-  version "0.16.2"
+  version "0.16.3"
 
   if Hardware::CPU.intel?
     url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}.dmg"
-    sha256 "fb950201d3198e1a67228262faadc3a72ba63e39f386a207f87a31bf0917c1bb"
+    sha256 "322c4b9d390a3ed14e8384f9692f91898fe4feb3aec4fffe027f6a028b0d6a92"
   else
     url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}-arm64.dmg"
-    sha256 "7e530177e4a0ce5f739371a471484f1692649f61d6571c154f8608147cd9bb20"
+    sha256 "04e0209971c9adad4b553eb2d6590dee9c5968c765a64fe7909d59579b2dd355"
   end
 
   name "Clash for Windows"


### PR DESCRIPTION
Created with brew `bump-cask-pr`.