### PR TITLE
Fix Maestral 1.4.6 hash

### DIFF
--- a/Casks/maestral.rb
+++ b/Casks/maestral.rb
@@ -1,6 +1,6 @@
 cask "maestral" do
   version "1.4.6"
-  sha256 "b37235199aade10baa8a7b6163c1f607be424ef7333ad402c925b4425bb07642"
+  sha256 "8a84bb54d63ef02728c03d0ce2c51116417b2a54d57dec61d9b560f29ebb6b67"
 
   url "https://github.com/SamSchott/maestral/releases/download/v#{version}/Maestral-#{version}.dmg",
       verified: "github.com/SamSchott/maestral"


### PR DESCRIPTION
The current SHA does not match the file it is pointing to. https://github.com/SamSchott/maestral/releases/download/v1.4.6/Maestral-1.4.6.dmg has a SHA 8a84bb54d63ef02728c03d0ce2c51116417b2a54d57dec61d9b560f29ebb6b67 which causes an error when attempting to install via brew.
```
brew install --cask maestral
==> Downloading https://github.com/SamSchott/maestral/releases/download/v1.4.6/Maestral-1.4.6.dmg
==> Downloading from https://github-releases.githubusercontent.com/159194638/1431f500-e100-11eb-8618-ef071879484a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credent
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: b37235199aade10baa8a7b6163c1f607be424ef7333ad402c925b4425bb07642
  Actual: 8a84bb54d63ef02728c03d0ce2c51116417b2a54d57dec61d9b560f29ebb6b67
    File: /Users/dc/Library/Caches/Homebrew/downloads/4b5b6749beb25b47182f89932fc64f9524490237d5b6426dfae90fa7ab66c54e--Maestral-1.4.6.dmg
To retry an incomplete download, remove the file above.
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I just changed the hash so assuming it passed `brew audit` and `brew style` before, it will still do so.
