### PR TITLE
Update hyper from 3.0.2 to 3.1.0

### DIFF
--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -1,9 +1,9 @@
 cask "hyper" do
-  version "3.0.2"
-  sha256 "56ac31f2f8aa99edf03f277b25203eca9d8b6c4d6535f673a996fddca0d21bb5"
+  version "3.1.0"
+  sha256 "8a0da3bd3b5d067b88a42bf5375c0f46af47bc7f92f5fa6e680ed69f343a6316"
 
-  url "https://github.com/zeit/hyper/releases/download/#{version}/hyper-#{version}-mac.zip",
-      verified: "github.com/zeit/hyper/"
+  url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac-x64.zip",
+      verified: "github.com/vercel/hyper/"
   name "Hyper"
   desc "Terminal built on web technologies"
   homepage "https://hyper.is/"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.