### PR TITLE
Update subler 1.6.11 to 1.6.12

### DIFF
--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -1,6 +1,6 @@
 cask "subler" do
-  version "1.6.11"
-  sha256 "0e258bd02433c2ad8bca165229804ba9565c328eda0a54d89c6f237f35a3678e"
+  version "1.6.12"
+  sha256 "709C7AECCCB2A42A715037EE41CDC235DF629BFC3B28EEA6DBCF391BB325704D"
 
   url "https://bitbucket.org/galad87/subler/downloads/Subler-#{version}.zip",
       verified: "bitbucket.org/galad87/subler/"

--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -8,11 +8,6 @@ cask "subler" do
   desc "Mux and tag mp4 files"
   homepage "https://subler.org/"
 
-  #livecheck do
-    #url "https://subler.org/appcast/appcast.xml"
-    #strategy :sparkle
-  #end
-
   auto_updates true
 
   app "Subler.app"

--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -8,10 +8,10 @@ cask "subler" do
   desc "Mux and tag mp4 files"
   homepage "https://subler.org/"
 
-  livecheck do
-    url "https://subler.org/appcast/appcast.xml"
-    strategy :sparkle
-  end
+  #livecheck do
+    #url "https://subler.org/appcast/appcast.xml"
+    #strategy :sparkle
+  #end
 
   auto_updates true
 

--- a/Casks/subler.rb
+++ b/Casks/subler.rb
@@ -8,6 +8,11 @@ cask "subler" do
   desc "Mux and tag mp4 files"
   homepage "https://subler.org/"
 
+  livecheck do
+    url "https://subler.org/appcast/appcast.xml"
+    regex(/url=.*?Subler[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   auto_updates true
 
   app "Subler.app"


### PR DESCRIPTION
Subler 1.6.11 to 1.6.12

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.