### PR TITLE
Altserver: Change download link according to the official one

### DIFF
--- a/Casks/altserver.rb
+++ b/Casks/altserver.rb
@@ -2,8 +2,7 @@ cask "altserver" do
   version "1.4.6,55"
   sha256 "983fba5a785e753f9bc020b39e84b41516c1181cb5b9ffc492f9f54274be1f74"
 
-  url "https://f000.backblazeb2.com/file/altstore/altserver/#{version.before_comma.dots_to_underscores}.zip",
-      verified: "f000.backblazeb2.com/file/"
+  url "https://cdn.altstore.io/file/altstore/altserver/#{version.before_comma.dots_to_underscores}.zip"
   name "AltServer"
   desc "iOS App Store alternative"
   homepage "https://altstore.io/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven&rsquo;t performed its action.* Honesty is indispensable for a smooth review process.

*In the following questions `<cask>` is the token of the cask you&rsquo;re submitting.*

After making all changes to a cask, verify:

-   [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
-   [X] `brew audit --cask <cask>` is error-free.
-   [X] `brew style --fix <cask>` reports no offenses.


# Explanation

Current link is a backup link from blazeb2 cloud server, and it is [a known issue among a handful of users](https://www.reddit.com/r/AltStore/comments/m101cr/cant_download_altserveraltstorealtinstallerzip/). And, seems like network routing service providers, or [malware blockers, mistook it as a malware site](https://forums.malwarebytes.com/topic/270156-f000backblazeb2com/). Indeed, you can say this is due to local network setting issue, it isn&rsquo;t obvious how to manage this kind of malfunction to the end user.

Plus, official download link is <https://cdn.altstore.io/file/> not <https://f000.backblazeb2.com/file/>. Hence, it seems reasonable to change `brew`&rsquo;s download link accordingly.