### PR TITLE
fix: SHA256 mismatch for mactracker

### DIFF
--- a/Casks/mactracker.rb
+++ b/Casks/mactracker.rb
@@ -1,6 +1,6 @@
 cask "mactracker" do
   version "7.10.6"
-  sha256 "a96c75e9ac404440d3edfc81e79e11a7394881d290c82ccf47f95e055e30b943"
+  sha256 "c17b735410c9769126e54eb0180a8f1d4ef6bb3ebd7f48485c63c5906fa6fc67"
 
   url "https://www.mactracker.ca/downloads/Mactracker_#{version}.zip"
   name "Mactracker"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for **a stable version**
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I'm sorry I'm not familiar with the debugging process of brew. I only changed the `shasum256` to the correct one.