### PR TITLE
loopback: add script to install ace component

### DIFF
--- a/Casks/loopback.rb
+++ b/Casks/loopback.rb
@@ -16,6 +16,17 @@ cask "loopback" do
   depends_on macos: ">= :sierra"
 
   app "Loopback.app"
+  installer script: {
+    executable: "Loopback.app/Contents/Resources/aceinstaller",
+    args:       ["install", "--silent"],
+    sudo:       true,
+  }
+
+  uninstall script: {
+    executable: "Loopback.app/Contents/Resources/aceinstaller",
+    args:       ["uninstall", "--silent"],
+    sudo:       true,
+  }
 
   zap trash: [
     "~/Library/Application Support/Loopback",


### PR DESCRIPTION
I wrote this for use in my own tap, so I thought I would open the PR here for discussion.

When first opened Loopback asks to install/update it's ACE component. This script installs and uninstalls the package as a part of the process. I had noticed some minor issues with the drivers not updating, potentially when using `brew upgrade`, so I am hoping this fixes the issue.

------

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.