### PR TITLE
Fixed mmex cask, updated url scheme and version

### DIFF
--- a/Casks/mmex.rb
+++ b/Casks/mmex.rb
@@ -11,7 +11,7 @@ cask "mmex" do
   livecheck do
     url "https://sourceforge.net/projects/moneymanagerex/rss"
     strategy :page_match do |page|
-      match = page.match(%r{/mmex[._-](\d+(?:\.\d+)*)[._-]Darwin[._-](\d+(?:\-\d+)*)\.dmg}i)
+      match = page.match(%r{/mmex[._-](\d+(?:\.\d+)*)[._-]Darwin[._-](\d+(?:-\d+)*)\.dmg}i)
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/mmex.rb
+++ b/Casks/mmex.rb
@@ -1,8 +1,8 @@
 cask "mmex" do
-  version "1.5.1,2021.04.24"
-  sha256 "36dda3d0177dddc71fd3ed29fc43a64783f2e2d2637dc473ebfc2f89d4351a1d"
+  version "1.5.4,2021-07-18"
+  sha256 "66af898086ce6a89dfc03961ffadfa8309c8f3563600216362523a4c04a6a047"
 
-  url "https://downloads.sourceforge.net/moneymanagerex/mmex%20v#{version.before_comma}-macOS.#{version.after_comma}.dmg",
+  url "https://downloads.sourceforge.net/moneymanagerex/mmex-#{version.before_comma}-Darwin-#{version.after_comma}.dmg",
       verified: "downloads.sourceforge.net/moneymanagerex/"
   name "Money Manager Ex"
   desc "Money management application"

--- a/Casks/mmex.rb
+++ b/Casks/mmex.rb
@@ -11,7 +11,7 @@ cask "mmex" do
   livecheck do
     url "https://sourceforge.net/projects/moneymanagerex/rss"
     strategy :page_match do |page|
-      match = page.match(%r{/mmex\s*v?(\d+(?:\.\d+)*)[._-]macOS[._-](\d+(?:\.\d+)*)\.dmg}i)
+      match = page.match(%r{/mmex[._-](\d+(?:\.\d+)*)[._-]Darwin[._-](\d+(?:\-\d+)*)\.dmg}i)
       "#{match[1]},#{match[2]}"
     end
   end


### PR DESCRIPTION
_In the following questions `mmex` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.