### PR TITLE
Add Hush.app v1.0

### DIFF
--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -1,0 +1,14 @@
+# typed: false
+# frozen_string_literal: true
+
+cask "hush" do
+  version "1.0"
+  sha256 "ed5050e0806d633a717807f90e28acf4b6c2ebcd789b68d3b1c4d461aba0dfc7"
+
+  url "https://github.com/oblador/hush/releases/download/v#{version}/Hush.dmg"
+  name "Hush"
+  desc "Block nags to accept cookies and privacy invasive tracking in Safari"
+  homepage "https://github.com/oblador/hush"
+
+  app "Hush.app"
+end

--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -1,6 +1,3 @@
-# typed: false
-# frozen_string_literal: true
-
 cask "hush" do
   version "1.0"
   sha256 "ed5050e0806d633a717807f90e28acf4b6c2ebcd789b68d3b1c4d461aba0dfc7"
@@ -9,6 +6,8 @@ cask "hush" do
   name "Hush"
   desc "Block nags to accept cookies and privacy invasive tracking in Safari"
   homepage "https://github.com/oblador/hush"
+
+  depends_on macos: ">= :big_sur"
 
   app "Hush.app"
 

--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -11,4 +11,11 @@ cask "hush" do
   homepage "https://github.com/oblador/hush"
 
   app "Hush.app"
+
+  zap trash: [
+  "~/Library/Application Scripts/se.oblador.Hush",
+  "~/Library/Application Scripts/se.oblador.Hush.ContentBlocker",
+  "~/Library/Containers/se.oblador.Hush",
+  "~/Library/Containers/se.oblador.Hush.ContentBlocker",
+]
 end

--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -2,10 +2,11 @@ cask "hush" do
   version "1.0"
   sha256 "ed5050e0806d633a717807f90e28acf4b6c2ebcd789b68d3b1c4d461aba0dfc7"
 
-  url "https://github.com/oblador/hush/releases/download/v#{version}/Hush.dmg"
+  url "https://github.com/oblador/hush/releases/download/v#{version}/Hush.dmg",
+      verified: "github.com/oblador/hush/"
   name "Hush"
   desc "Block nags to accept cookies and privacy invasive tracking in Safari"
-  homepage "https://github.com/oblador/hush"
+  homepage "https://oblador.github.io/hush/"
 
   depends_on macos: ">= :big_sur"
 

--- a/Casks/hush.rb
+++ b/Casks/hush.rb
@@ -13,9 +13,9 @@ cask "hush" do
   app "Hush.app"
 
   zap trash: [
-  "~/Library/Application Scripts/se.oblador.Hush",
-  "~/Library/Application Scripts/se.oblador.Hush.ContentBlocker",
-  "~/Library/Containers/se.oblador.Hush",
-  "~/Library/Containers/se.oblador.Hush.ContentBlocker",
-]
+    "~/Library/Application Scripts/se.oblador.Hush",
+    "~/Library/Application Scripts/se.oblador.Hush.ContentBlocker",
+    "~/Library/Containers/se.oblador.Hush",
+    "~/Library/Containers/se.oblador.Hush.ContentBlocker",
+  ]
 end


### PR DESCRIPTION
Hush - Block nags to accept cookies and privacy invasive tracking in Safari

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
