### PR TITLE
Update react-native-debugger (v0.12.0)

### DIFF
--- a/Casks/react-native-debugger.rb
+++ b/Casks/react-native-debugger.rb
@@ -1,6 +1,6 @@
 cask "react-native-debugger" do
-  version "0.11.9"
-  sha256 "6aaabe96215f99e282db56e008b69142204625a4598dd3df393a250c994fba46"
+  version "0.12.0"
+  sha256 "370bd7d511b15362c544051e5e3e04c86201182ded22c51a082437db9e92d024"
 
   url "https://github.com/jhen0409/react-native-debugger/releases/download/v#{version}/rn-debugger-macos-x64.zip"
   name "React Native Debugger"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
