### PR TITLE
robo-3t: update livecheck

### DIFF
--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -9,8 +9,8 @@ cask "robo-3t" do
   homepage "https://robomongo.org/"
 
   livecheck do
-    url "https://github.com/Studio3T/robomongo/releases/latest"
-    strategy :page_match do |page|
+    url "https://github.com/Studio3T/robomongo"
+    strategy :github_latest do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/robo3t-\1-darwin-x86_64-([0-9a-f]+)\.dmg}i)
       "#{match[1]},#{match[2]}"
     end

--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -8,9 +8,8 @@ cask "robo-3t" do
   desc "MongoDB management tool"
   homepage "https://robomongo.org/"
 
-  # We need to check all releases since the current latest release is a beta version.
   livecheck do
-    url "https://github.com/Studio3T/robomongo/releases"
+    url "https://github.com/Studio3T/robomongo/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/robo3t-\1-darwin-x86_64-([0-9a-f]+)\.dmg}i)
       "#{match[1]},#{match[2]}"


### PR DESCRIPTION
Updates livecheck to only check for stable releases. Cask was previously changed to allow beta-releases, however the in-app update is now only returning the latest stable release.

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.