### PR TITLE
Update p4 from 2021.1,2126753 to 2021.1,2156517

### DIFF
--- a/Casks/p4.rb
+++ b/Casks/p4.rb
@@ -1,6 +1,6 @@
 cask "p4" do
-  version "2021.1,2126753"
-  sha256 "85c0d2f92b59564ea36a56a8f07b87aecf0b2806637e8b7d69d6edd0d79d6c40"
+  version "2021.1,2156517"
+  sha256 "6ce7ba5241a35979a439bf344b46d3f5d5b0ae8d0916c88a4fb4a092be0b4dcb"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/p4"
   name "Perforce Helix Command-Line Client (P4)"


### PR DESCRIPTION
Update version and expected SHA per latest 14-July release.

Perforce release their patch versions for a `major.minor` over the top of the old versions; so the current cask won't install due to sha256sum mismatch.

* **Version number** taken from:
  ```
  $ p4 -V
  Perforce - The Fast Software Configuration Management System.
  Copyright 1995-2021 Perforce Software.  All rights reserved.
  This product includes software developed by the OpenSSL Project
  for use in the OpenSSL Toolkit (http://www.openssl.org/)
  Version of OpenSSL Libraries: OpenSSL 1.1.1k  25 Mar 2021
  See 'p4 help [ -l ] legal' for additional license information on
  these licenses and others.
  Extensions/scripting support built-in.
  Parallel sync threading built-in.
  Rev. P4/MACOSX1015X86_64/2021.1/2156517 (2021/07/14).
  ```
* **SHA256SUM** taken from: https://cdist2.perforce.com/perforce/r21.1/bin.macosx1015x86_64/SHA256SUMS


**Checklist**
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

