### PR TITLE
Add etlegacy v2.77.1 (2nd try)

### DIFF
--- a/Casks/etlegacy.rb
+++ b/Casks/etlegacy.rb
@@ -1,0 +1,23 @@
+cask "etlegacy" do
+  version "2.77.1"
+  sha256 :no_check
+
+  url "https://www.etlegacy.com/download/file/258"
+  name "ET: Legacy"
+  desc "Open source project based on the code of Wolfenstein: Enemy Territory"
+  homepage "https://www.etlegacy.com/"
+
+  depends_on macos: ">= :big_sur"
+  depends_on formula: "wget"
+
+  suite "ETLegacy"
+  installer script: {
+    executable: "wget",
+    args:       ["https://mirror.etlegacy.com/etmain/pak0.pk3", "-P", "#{caskroom_path}/#{version}/ETLegacy/etmain", "https://mirror.etlegacy.com/etmain/pak1.pk3", "-P", "#{caskroom_path}/#{version}/ETLegacy/etmain", "https://mirror.etlegacy.com/etmain/pak2.pk3", "-P", "#{caskroom_path}/#{version}/ETLegacy/etmain"],
+  }
+
+  uninstall delete: [
+    "~/Library/Application Support/etlegacy",
+    "~/Library/Saved Application State/com.etlegacy.etl.savedState",
+  ]
+end

--- a/Casks/etlegacy.rb
+++ b/Casks/etlegacy.rb
@@ -7,6 +7,11 @@ cask "etlegacy" do
   desc "Open source project based on the code of Wolfenstein: Enemy Territory"
   homepage "https://www.etlegacy.com/"
 
+  livecheck do
+    url :url
+    strategy :header_match
+  end
+
   depends_on macos: ">= :big_sur"
   depends_on formula: "wget"
 

--- a/Casks/etlegacy.rb
+++ b/Casks/etlegacy.rb
@@ -13,12 +13,11 @@ cask "etlegacy" do
   end
 
   depends_on macos: ">= :big_sur"
-  depends_on formula: "wget"
 
   suite "ETLegacy"
   installer script: {
-    executable: "wget",
-    args:       ["https://mirror.etlegacy.com/etmain/pak0.pk3", "-P", "#{caskroom_path}/#{version}/ETLegacy/etmain", "https://mirror.etlegacy.com/etmain/pak1.pk3", "-P", "#{caskroom_path}/#{version}/ETLegacy/etmain", "https://mirror.etlegacy.com/etmain/pak2.pk3", "-P", "#{caskroom_path}/#{version}/ETLegacy/etmain"],
+    executable: "curl", # change below to curl command instead
+    args:       ["https://mirror.etlegacy.com/etmain/pak0.pk3", "-o", "#{caskroom_path}/#{version}/ETLegacy/etmain/pak0.pk3"],
   }
 
   uninstall delete: [

--- a/Casks/etlegacy.rb
+++ b/Casks/etlegacy.rb
@@ -16,7 +16,7 @@ cask "etlegacy" do
 
   suite "ETLegacy"
   installer script: {
-    executable: "curl", # change below to curl command instead
+    executable: "curl",
     args:       ["https://mirror.etlegacy.com/etmain/pak0.pk3", "-o", "#{caskroom_path}/#{version}/ETLegacy/etmain/pak0.pk3"],
   }
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

Next try ;) Apparently you only need pak0.pk3. Is this solution acceptable or do I need to reach out upstream and ask them for a download script that I can run without curl?