### PR TITLE
Update bricklink-studio from 2.1.10_7 to 2.2.7_1

### DIFF
--- a/Casks/bricklink-studio.rb
+++ b/Casks/bricklink-studio.rb
@@ -1,13 +1,17 @@
 cask "bricklink-studio" do
-  version "2.1.10_7"
-  sha256 "b24f645ef5a6f16150fdd98735cd315beaf605b53d64920563abfb6938d1bc3b"
+  version "2.2.7_1"
+  sha256 "cf19b4eed6a715e041c56786297c0d5c6b6fa0dd836f853da551025ca4d9b129"
 
   url "https://blstudio.s3.amazonaws.com/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg",
       verified: "blstudio.s3.amazonaws.com/"
-  appcast "https://www.bricklink.com/v3/studio/download.page"
   name "Studio"
   desc "Build, render, and create LEGO instructions"
   homepage "https://www.bricklink.com/v3/studio/download.page"
+
+  livecheck do
+    url "https://www.bricklink.com/v2/build/studio.page"
+    regex(/"version"\s*:\s*"(\d+(?:[._-]\d+)*)"/i)
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

I tried using https://www.bricklink.com/v3/studio/download.page for livecheck, but it also includes version numbers for early access releases. Instead, I used https://www.bricklink.com/v2/build/studio.page