### PR TITLE
set tutanota.rb to auto_updates

### DIFF
--- a/Casks/tutanota.rb
+++ b/Casks/tutanota.rb
@@ -11,6 +11,8 @@ cask "tutanota" do
     url "https://mail.tutanota.com/desktop/latest-mac.yml"
     strategy :electron_builder
   end
+  
+  auto_updates true
 
   app "Tutanota Desktop.app"
 

--- a/Casks/tutanota.rb
+++ b/Casks/tutanota.rb
@@ -11,7 +11,7 @@ cask "tutanota" do
     url "https://mail.tutanota.com/desktop/latest-mac.yml"
     strategy :electron_builder
   end
-  
+
   auto_updates true
 
   app "Tutanota Desktop.app"


### PR DESCRIPTION
Tutanota client and homebrew are always competing for updates. Oftentimes the client will update first then later homebrew will apply the update again. Just let the client do it.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
