### PR TITLE
Update eloston-chromium from 92.0.4515.107-1.1 to 92.0.4515.107-1.2

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,10 +1,10 @@
 cask "eloston-chromium" do
   if Hardware::CPU.intel?
-    version "92.0.4515.107-1.1_x86-64"
-    sha256 "699afd22616e76f9f148dad547728d40800006d3795646e1e56ee4be9c64325e"
+    version "92.0.4515.107-1.2_x86-64"
+    sha256 "c8dc0ba40f3110c070883df408999d72676dc1c8f982095de71e218186e18db2"
   else
-    version "92.0.4515.107-1.1_arm64"
-    sha256 "3d78dba300a6b5e06a15ded820512d8cd54e7705234b92dfd450085f0d6a7c01"
+    version "92.0.4515.107-1.2_arm64"
+    sha256 "b6a6db46f03f88af649af7b601aca3b1bab9fd67688678f87753bf781616b80f"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}-macos.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
