### PR TITLE
Update monitorcontrol URL

### DIFF
--- a/Casks/monitorcontrol.rb
+++ b/Casks/monitorcontrol.rb
@@ -2,10 +2,10 @@ cask "monitorcontrol" do
   version "2.2.0"
   sha256 "02e029ad8e799fb3b1a1fe036fd309058bcaabddb94c5fb6859714cdbf78d868"
 
-  url "https://github.com/the0neyouseek/MonitorControl/releases/download/v#{version}/MonitorControl.#{version}.dmg"
+  url "https://github.com/MonitorControl/MonitorControl/releases/download/v#{version}/MonitorControl.#{version}.dmg"
   name "MonitorControl"
   desc "Tool to control external monitor brightness & volume"
-  homepage "https://github.com/the0neyouseek/MonitorControl"
+  homepage "https://github.com/MonitorControl/MonitorControl"
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
Repository is now under the "MonitorControl" org, so URL and homepage should be updated (old ones work, they just redirect to there). The previous behavior is confusing if you follow the instructions from MonitorControl's README but see a different URL used for the download.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.