### PR TITLE
cave-story: allow install on Mojave and below

### DIFF
--- a/Casks/cave-story.rb
+++ b/Casks/cave-story.rb
@@ -45,8 +45,6 @@ cask "cave-story" do
   desc "Action-adventure game reminiscent of classic 8- and 16-bit games"
   homepage "https://www.cavestory.org/"
 
-  depends_on macos: ">= :catalina"
-
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "Doukutsu.app", target: "Cave Story.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

From https://www.nakiwo.com/software.html

> - 動作環境:macOS 10.15 (Catalina) 以上
> - download > 『洞窟物語』for macOS (0.2.0)
> 
> (古い版)
> 
> - 一つ前 (10.15 以上) -> v0.1.0
> - macOS 10.14 以前用 -> v0.0.9
> - OS X 10.9 以前用 -> v0.0.7

This roughly translates to:

> - Operating system: macOS 10.15 (Catalina) or above
> - download > "Cave Story" for macOS (0.2.0)
> 
> (Old version)
> 
> - Previous (10.15 or higher) -> v0.1.0
> - For macOS 10.14 and earlier -> v0.0.9
> - For OS X 10.9 and earlier -> v0.0.7

Output of `rg LSMinimumSystemVersion -A1 'Cave Story.app/Contents/Info.plist'` for version 0.0.9:

```
49:	<key>LSMinimumSystemVersion</key>
50-	<string>10.10</string>
```

(0.0.9 is already included in the `cave-story` cask in `if MacOS.version <= :mojave`)