### PR TITLE
Update spitfire-audio from 3.2.20,1615300200 to 3.3.10,1626771600

### DIFF
--- a/Casks/spitfire-audio.rb
+++ b/Casks/spitfire-audio.rb
@@ -1,6 +1,6 @@
 cask "spitfire-audio" do
-  version "3.2.20,1615300200"
-  sha256 "7036dfe458d0e543b261cc2490c67df1911aff463fc4d023269606fe52e5b0a4"
+  version "3.3.10,1626771600"
+  sha256 "1b9972d0711dfb5c4779e8801dc0b96e8ae2415e806c4e657efe9caeee040e5d"
 
   url "https://d1t3zg51rvnesz.cloudfront.net/p/files/lm/#{version.after_comma}/mac/SpitfireAudio-Mac-#{version.before_comma}.dmg",
       verified: "d1t3zg51rvnesz.cloudfront.net/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I'm currently reinstalling macOS, so I cannot test these changes on my machine. I've verified that the new download link and shasum are correct, but that's all I can test at the moment. If anyone is willing to make sure the `audit` and `style` commands run cleanly, I'd really appreciate it!