### PR TITLE
duplicati: livecheck only stable and beta versions

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -9,10 +9,12 @@ cask "duplicati" do
   homepage "https://www.duplicati.com/"
 
   livecheck do
-    url "https://github.com/duplicati/duplicati/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/duplicati-(\d+(?:\.\d+)*)_([^/]*?)_(\d+(?:-\d+)*)\.dmg}i)
-      "#{match[1]},#{match[2]}:#{match[3]}"
+    url :url
+    strategy :git do |tags|
+      tags.map do |tag|
+        match = tag.match(/^v(\d+(?:\.\d+)*)-(?:\d+(?:\.\d+)*)_(stable|beta)_(\d+(?:-\d+)*)$/i)
+        "#{match[1]},#{match[2]}:#{match[3]}" if match
+      end.compact
     end
   end
 


### PR DESCRIPTION
Livecheck edits:
- use a git strategy
- only look for stable and beta versions as already discussed with @reitermarkus in #97381

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.