### PR TITLE
Use Sparkle strategy in livecheck of cloudflare warp

### DIFF
--- a/Casks/cloudflare-warp.rb
+++ b/Casks/cloudflare-warp.rb
@@ -1,5 +1,5 @@
 cask "cloudflare-warp" do
-  version "1.5.207.0,20210616.5"
+  version "1.5.463.0,20210722.12"
   sha256 :no_check
 
   url "https://cloudflarewarp.com/Cloudflare_WARP.zip"

--- a/Casks/cloudflare-warp.rb
+++ b/Casks/cloudflare-warp.rb
@@ -8,8 +8,8 @@ cask "cloudflare-warp" do
   homepage "https://cloudflarewarp.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://api.appcenter.ms/v0.1/public/sparkle/apps/87d9992a-351c-44a9-849b-3f9a89d63d18"
+    strategy :sparkle
   end
 
   auto_updates true


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

This PR changes the livecheck strategy of `cloudflare-warp` from `extract_plist` to `sparkle`, because that's what Cloudflare WARP uses behind the scenes. It also updates the version to the most recent one.

Not using `sparkle` has the disadvantage that the latest version is not detected properly: According to `extract_plist` `1.5.207.0,20210616.5` is the most recent one (because the binary says so), but immediately after install, a update window pops up, because `1.5.463.0,20210722.12` is actually the most recent one. Also, the check is much faster with `sparkle`.
FYI: I've extracted the livecheck url from the WARP binary itself, so it's the exact same source as the integrated updater uses :)