### PR TITLE
TextMate: link `mate_wait` binary

### DIFF
--- a/Casks/textmate.rb
+++ b/Casks/textmate.rb
@@ -18,6 +18,7 @@ cask "textmate" do
 
   app "TextMate.app"
   binary "#{appdir}/TextMate.app/Contents/Resources/mate"
+  binary "#{appdir}/TextMate.app/Contents/Resources/mate", target: "mate_wait"
 
   uninstall quit: "com.macromates.TextMate"
 


### PR DESCRIPTION
If the `mate` CLI tool is invoked with name `mate_wait`, then it automatically acts as though `-w` was passed on the command line. This is helpful when something is invoking it via `$EDITOR` but doesn't interpret properly when `EDITOR="mate -w"`. Reference: https://macromates.com/manual/en/using_textmate_from_terminal#the_general_editor_variable

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
