### PR TITLE
Update dosbox-x from 0.83.15 to 0.83.16

### DIFF
--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,7 +1,8 @@
 cask "dosbox-x" do
+  version "0.83.16,20210801002330"
+
   if Hardware::CPU.intel?
-    version "0.83.15,20210703020047"
-    sha256 "CAE937A4F75DBB6209A61251658344B3233A62D34DD27CE67B6D7E0BE1F73272"
+    sha256 "1b4c5690a798d9a40578cbad281b0ee03110cdbb2c97898a53f9838ad8cee588"
 
     url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-x86_64-#{version.after_comma}.zip",
         verified: "github.com/joncampbell123/dosbox-x/"
@@ -14,8 +15,7 @@ cask "dosbox-x" do
       end
     end
   else
-    version "0.83.15,20210703020142"
-    sha256 "2915CEED8A25105A918486BB13FA9DAFCD702B3AE1E6C0E6F87CEBF733C3063C"
+    sha256 "b4c3b328e110d6d79a37f90fc12aef9f0105bc792f307adc9cc81827f05830b0"
 
     url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-arm64-#{version.after_comma}.zip",
         verified: "github.com/joncampbell123/dosbox-x/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
