### PR TITLE
Update mattermost to support apple silicon build.

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -1,8 +1,14 @@
 cask "mattermost" do
   version "4.7.1"
-  sha256 "e4c580ebb9b6c55da2569cf0ee6dbcbed413310213a9bf86e6cdf7b716226a93"
 
-  url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
+  if Hardware::CPU.intel?
+    sha256 "e4c580ebb9b6c55da2569cf0ee6dbcbed413310213a9bf86e6cdf7b716226a93"
+    url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac.zip"
+  else
+    sha256 "241dcc2e8840958415a827cdc25f8306615265f23927ec34573d597f1348928b"
+    url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac-m1.zip"
+  end
+
   name "Mattermost"
   desc "Open-source, self-hosted Slack-alternative"
   homepage "https://about.mattermost.com/"


### PR DESCRIPTION
Since v4.7.0 mattermost desktop is also shipping with native apple silicon (m1) build. Those builds are marked as beta though, i am not sure if this will get accepted because of that. But anyway i have been running those builds since RC releases with no issues.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
