### PR TITLE
Typo in binary name (cask nextcloud)

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -20,7 +20,7 @@ cask "nextcloud" do
   depends_on macos: ">= :yosemite"
 
   pkg "Nextcloud-#{version}.pkg"
-  binary "#{appdir}/nextcloud.app/Contents/MacOS/nextcloudcmd"
+  binary "#{appdir}/Nextcloud.app/Contents/MacOS/nextcloudcmd"
 
   uninstall pkgutil: "com.nextcloud.desktopclient"
 


### PR DESCRIPTION
If a case sensitive filesystem is present, the following error occur:

```
...
installer: The upgrade was successful.
==> Purging files for version 3.3.0 of Cask nextcloud
Error: It seems the symlink source '/Applications/nextcloud.app/Contents/MacOS/nextcloudcmd' is not there.
```


- [x] The submission is for [a stable version
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
