### PR TITLE
fix github URL

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -3,11 +3,11 @@ cask "github" do
 
   if Hardware::CPU.intel?
     sha256 "2f799a2ee4d9d9e359dbea2ed9759dd412021bf2c03f2c54740e5a6e95c947ea"
-    url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop-x64.zip",
+    url "https://desktop.githubusercontent.com/github-desktop/releases/#{version}/GitHubDesktop-x64.zip",
         verified: "githubusercontent.com/"
   else
     sha256 "6739b2477a747761caa89fda1e68b8a362fec693accf8f2173b2f6954698d537"
-    url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop-arm64.zip",
+    url "https://desktop.githubusercontent.com/github-desktop/releases/#{version}/GitHubDesktop-arm64.zip",
         verified: "githubusercontent.com/"
   end
 


### PR DESCRIPTION
https://desktop.githubusercontent.com/releases/2.9.0-4806a6dc/GitHubDesktop-x64.zip returns `404`, https://central.github.com/deployments/desktop/desktop/latest/darwin points to https://desktop.githubusercontent.com/github-desktop/releases/2.9.0-4806a6dc/GitHubDesktop-x64.zip which works. Same for the ARM version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
