### PR TITLE
Upgrade lark and install arm64 version for Apple Silicon

### DIFF
--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -1,9 +1,18 @@
 cask "lark" do
-  version "4.5.4,66e254"
-  sha256 "638c8a006f2af40f4d791de54c555f5dbd707fe01e0bce25153e3df7198878fb"
+  if Hardware::CPU.intel?
+    version "4.5.6,f9ffce"
+    sha256 "e239a9e6eb956a1040f64bca3855523302f19dd171630e8cc75bf4cb3bfae01a"
 
-  url "https://sf16-va.larksuitecdn.com/obj/lark-artifact-storage/#{version.after_comma}/Lark-darwin_x64-#{version.before_comma}-signed.dmg",
+    url "https://sf16-va.larksuitecdn.com/obj/lark-artifact-storage/#{version.after_comma}/Lark-darwin_x64-#{version.before_comma}-signed.dmg",
       verified: "sf16-va.larksuitecdn.com/obj/lark-artifact-storage/"
+  else
+    version "4.4.10,3eac8c"
+    sha256 "29fb4f611a03f3ba54ae1e96a8503039515ac5af3ed5d05edad637acde4ab25b"
+
+    url "https://sf16-va.larksuitecdn.com/obj/lark-artifact-storage/#{version.after_comma}/Lark-darwin_arm64-#{version.before_comma}-signed.dmg",
+      verified: "sf16-va.larksuitecdn.com/obj/lark-artifact-storage/"
+  end
+
   name "Lark"
   desc "Project management software"
   homepage "https://www.larksuite.com/"
@@ -11,7 +20,7 @@ cask "lark" do
   livecheck do
     url "https://www.larksuite.com/api/downloads"
     strategy :page_match do |page|
-      match = page.match(%r{/lark-artifact-storage/(\w+)/Lark-darwin_x64-(\d+(?:\.\d+)*)-signed\.dmg}i)
+      match = page.match(%r{/lark-artifact-storage/(\w+)/Lark-darwin_(arm64|x64)-(\d+(?:\.\d+)*)-signed\.dmg}i)
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -4,26 +4,34 @@ cask "lark" do
     sha256 "e239a9e6eb956a1040f64bca3855523302f19dd171630e8cc75bf4cb3bfae01a"
 
     url "https://sf16-va.larksuitecdn.com/obj/lark-artifact-storage/#{version.after_comma}/Lark-darwin_x64-#{version.before_comma}-signed.dmg",
-      verified: "sf16-va.larksuitecdn.com/obj/lark-artifact-storage/"
+        verified: "sf16-va.larksuitecdn.com/obj/lark-artifact-storage/"
+
+    livecheck do
+      url "https://www.larksuite.com/api/downloads"
+      strategy :page_match do |page|
+        match = page.match(%r{/lark-artifact-storage/(\w+)/Lark-darwin_x64-(\d+(?:\.\d+)*)-signed\.dmg}i)
+        "#{match[2]},#{match[1]}"
+      end
+    end
   else
     version "4.4.10,3eac8c"
     sha256 "29fb4f611a03f3ba54ae1e96a8503039515ac5af3ed5d05edad637acde4ab25b"
 
     url "https://sf16-va.larksuitecdn.com/obj/lark-artifact-storage/#{version.after_comma}/Lark-darwin_arm64-#{version.before_comma}-signed.dmg",
-      verified: "sf16-va.larksuitecdn.com/obj/lark-artifact-storage/"
+        verified: "sf16-va.larksuitecdn.com/obj/lark-artifact-storage/"
+
+    livecheck do
+      url "https://www.larksuite.com/api/downloads"
+      strategy :page_match do |page|
+        match = page.match(%r{/lark-artifact-storage/(\w+)/Lark-darwin_arm64-(\d+(?:\.\d+)*)-signed\.dmg}i)
+        "#{match[2]},#{match[1]}"
+      end
+    end
   end
 
   name "Lark"
   desc "Project management software"
   homepage "https://www.larksuite.com/"
-
-  livecheck do
-    url "https://www.larksuite.com/api/downloads"
-    strategy :page_match do |page|
-      match = page.match(%r{/lark-artifact-storage/(\w+)/Lark-darwin_(arm64|x64)-(\d+(?:\.\d+)*)-signed\.dmg}i)
-      "#{match[2]},#{match[1]}"
-    end
-  end
 
   auto_updates true
 


### PR DESCRIPTION
Upgrade lark to latest version and support installing arm64 version for Apple Silicon powered Mac.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask lark` is error-free.
- [x] `brew style --fix lark` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
