### PR TITLE
updated gns3 version from 2.2.22 to 2.2.23

### DIFF
--- a/Casks/gns3.rb
+++ b/Casks/gns3.rb
@@ -1,6 +1,6 @@
 cask "gns3" do
   # NOTE: "3" is not a version number, but an intrinsic part of the product name
-  version "2.2.22"
+  version "2.2.23"
   sha256 "6f8027bc27b365b336c65fa573fcf1593405cf03fca3d0c66db057281f80f06e"
 
   url "https://github.com/GNS3/gns3-gui/releases/download/v#{version}/GNS3-#{version}.dmg",


### PR DESCRIPTION
- [ x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ x ] `brew audit --cask <cask>` is error-free.
- [ x ] `brew style --fix <cask>` reports no offenses.