### PR TITLE
Upgrade feishu and install arm64 version for Apple Silicon

### DIFF
--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,20 +1,37 @@
 cask "feishu" do
-  version "4.5.4,16c57d"
-  sha256 "bb32610cbbb4ec31ee7954984bbd99293f3fbd74bec1b9e90cc5170c826a1002"
+  if Hardware::CPU.intel?
+    version "4.6.4,ad7f42"
+    sha256 "4757c1c562c3444f7116ef4cbb76085d130affd039394b7d440cecec67d62207"
 
-  url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.after_comma}/Feishu-darwin_x64-#{version.before_comma}-signed.dmg",
-      verified: "sf3-cn.feishucdn.com/"
+    url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.after_comma}/Feishu-darwin_x64-#{version.before_comma}-signed.dmg",
+        verified: "sf3-cn.feishucdn.com/"
+
+    livecheck do
+      url "https://www.feishu.cn/api/downloads"
+      strategy :page_match do |page|
+        match = page.match(%r{/(\h+)/Feishu-darwin_x64-(\d+(?:\.\d+)*)-signed\.dmg}i)
+        "#{match[2]},#{match[1]}"
+      end
+    end
+  else
+    version "4.6.4,09dbe9"
+    sha256 "715116886e220a8c2be4034f85a027a6ce24eb1f36efeaa16fdc29cac87aa7c4"
+
+    url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.after_comma}/Feishu-darwin_arm64-#{version.before_comma}-signed.dmg",
+        verified: "sf3-cn.feishucdn.com/"
+
+    livecheck do
+      url "https://www.feishu.cn/api/downloads"
+      strategy :page_match do |page|
+        match = page.match(%r{/(\h+)/Feishu-darwin_arm64-(\d+(?:\.\d+)*)-signed\.dmg}i)
+        "#{match[2]},#{match[1]}"
+      end
+    end
+  end
+
   name "feishu"
   desc "Project management software"
   homepage "https://www.feishu.cn/"
-
-  livecheck do
-    url "https://www.feishu.cn/api/downloads"
-    strategy :page_match do |page|
-      match = page.match(%r{/(\h+)/Feishu-darwin_x64-(\d+(?:\.\d+)*)-signed\.dmg}i)
-      "#{match[2]},#{match[1]}"
-    end
-  end
 
   auto_updates true
 


### PR DESCRIPTION
Upgrade feishu to latest version and support installing arm64 version for Apple Silicon powered Mac.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask feishu` is error-free.
- [x] `brew style --fix feishu` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
