### PR TITLE
Update u-he TripleCheese to v1.3.0

### DIFF
--- a/Casks/triplecheese.rb
+++ b/Casks/triplecheese.rb
@@ -4,12 +4,19 @@ cask "triplecheese" do
 
   url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/TripleCheese_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip",
       verified: "uhedownloads-heckmannaudiogmb.netdna-ssl.com/"
-  appcast "https://u-he.com/products/triplecheese/releasenotes.html"
   name "Triple Cheese"
   desc "Luscious and cheesy synthesizer"
   homepage "https://u-he.com/products/triplecheese/"
 
-  pkg "TripleCheese_#{version.after_comma}_Mac/TripleCheese 1.3.0 Installer.pkg"
+  livecheck do
+    url "https://u-he.com/products/triplecheese/releasenotes.html"
+    strategy :page_match do |page|
+      match = page.match(/Triple\s*Cheese\s*(\d+(?:\.\d+)*)\s*\(revision\s*(\d+(?:\.\d+)*)\)/i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  pkg "TripleCheese_#{version.after_comma}_Mac/TripleCheese #{version.before_comma}.0 Installer.pkg"
 
   uninstall pkgutil: [
     "com.u-he.TripleCheese.aax.pkg",

--- a/Casks/triplecheese.rb
+++ b/Casks/triplecheese.rb
@@ -19,6 +19,7 @@ cask "triplecheese" do
     "com.u-he.TripleCheese.presets.pkg",
     "com.u-he.TripleCheese.tuningFiles.pkg",
     "com.u-he.TripleCheese.vst.pkg",
+    "com.u-he.TripleCheese.vst3.pkg",
   ]
 
   caveats do

--- a/Casks/triplecheese.rb
+++ b/Casks/triplecheese.rb
@@ -1,6 +1,6 @@
 cask "triplecheese" do
-  version "1.2.1,3899"
-  sha256 "8a73cc611d6065ff11a43e237ff074c9b6eff591a46997362219fe6ac4bcd663"
+  version "1.3,12092"
+  sha256 "d2ed37186ddffe360fb564f357193ac66d09c370fecebbca71e619268ecfb0a7"
 
   url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/TripleCheese_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip",
       verified: "uhedownloads-heckmannaudiogmb.netdna-ssl.com/"
@@ -9,7 +9,7 @@ cask "triplecheese" do
   desc "Luscious and cheesy synthesizer"
   homepage "https://u-he.com/products/triplecheese/"
 
-  pkg "TripleCheese_#{version.after_comma}_Mac/TripleCheese #{version.before_comma} Installer.pkg"
+  pkg "TripleCheese_#{version.after_comma}_Mac/TripleCheese 1.3.0 Installer.pkg"
 
   uninstall pkgutil: [
     "com.u-he.TripleCheese.aax.pkg",


### PR DESCRIPTION
This PR updates the TripleCheese cask to the current version 1.3.0. Note: the developers move outdated versions to another place, which basically invalidates any previous version from that point on.  

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
