### PR TITLE
Update mweb from 3.4.4 to 4.13

### DIFF
--- a/Casks/mweb.rb
+++ b/Casks/mweb.rb
@@ -1,9 +1,16 @@
 cask "mweb" do
-  version "3.4.4,1607678309"
-  sha256 "8ee686c3a54301a8809afbf6f38ea97cecdd805e8dd00a5e67d55f314304b942"
+  version "4.1.3"
 
-  url "https://dl.devmate.com/com.coderforart.MWeb#{version.major}/#{version.before_comma}/#{version.after_comma}/MWeb#{version.major}-ProMarkdownwriting,notetakingandstaticbloggeneratorApp-#{version.before_comma}.dmg",
-      verified: "dl.devmate.com/com.coderforart.MWeb#{version.major}/"
+  if MacOS.version <= :catalina
+    url "https://cdn.mwebapp.cn/MWeb#{version.delete(".")}_catalina.dmg",
+        verified: "cdn.mwebapp.cn/MWeb#{version.delete(".")}"
+    sha256 "c0c71e3ab96a30a20b6ac9f4e21bc24fb8a6b5489fb5ec1bfb95d02b18ff2b81"
+  else
+    url "https://cdn.mwebapp.cn/MWeb#{version.delete(".")}.dmg",
+        verified: "cdn.mwebapp.cn/MWeb#{version.delete(".")}"
+    sha256 "f3da899d19bd6abb93c1e365feb4c964062124d118967170c0c1b34c413798b4"
+  end
+
   name "MWeb"
   desc "Markdown writing, note taking, and static blog generator app"
   homepage "https://www.mweb.im/"
@@ -15,7 +22,7 @@ cask "mweb" do
     end
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "MWeb.app"
 end

--- a/Casks/mweb.rb
+++ b/Casks/mweb.rb
@@ -2,12 +2,12 @@ cask "mweb" do
   version "4.1.3"
 
   if MacOS.version <= :catalina
-    url "https://cdn.mwebapp.cn/MWeb#{version.delete(".")}_catalina.dmg",
-        verified: "cdn.mwebapp.cn/MWeb#{version.delete(".")}"
+    url "https://cdn.mwebapp.cn/MWeb#{version.no_dots}_catalina.dmg",
+        verified: "cdn.mwebapp.cn/MWeb#{version.no_dots}"
     sha256 "c0c71e3ab96a30a20b6ac9f4e21bc24fb8a6b5489fb5ec1bfb95d02b18ff2b81"
   else
-    url "https://cdn.mwebapp.cn/MWeb#{version.delete(".")}.dmg",
-        verified: "cdn.mwebapp.cn/MWeb#{version.delete(".")}"
+    url "https://cdn.mwebapp.cn/MWeb#{version.no_dots}.dmg",
+        verified: "cdn.mwebapp.cn/MWeb#{version.no_dots}"
     sha256 "f3da899d19bd6abb93c1e365feb4c964062124d118967170c0c1b34c413798b4"
   end
 
@@ -16,10 +16,8 @@ cask "mweb" do
   homepage "https://www.mweb.im/"
 
   livecheck do
-    url "https://updates.devmate.com/com.coderforart.MWeb#{version.major}.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.url[%r{/(\d+)/MWeb}i, 1]}"
-    end
+    url "https://www.mweb.im/download.html"
+    regex(/>Download MWeb (\d+(?:\.\d+)+)</i)
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/mweb.rb
+++ b/Casks/mweb.rb
@@ -3,11 +3,11 @@ cask "mweb" do
 
   if MacOS.version <= :catalina
     url "https://cdn.mwebapp.cn/MWeb#{version.no_dots}_catalina.dmg",
-        verified: "cdn.mwebapp.cn/MWeb#{version.no_dots}"
+        verified: "cdn.mwebapp.cn/"
     sha256 "c0c71e3ab96a30a20b6ac9f4e21bc24fb8a6b5489fb5ec1bfb95d02b18ff2b81"
   else
     url "https://cdn.mwebapp.cn/MWeb#{version.no_dots}.dmg",
-        verified: "cdn.mwebapp.cn/MWeb#{version.no_dots}"
+        verified: "cdn.mwebapp.cn/"
     sha256 "f3da899d19bd6abb93c1e365feb4c964062124d118967170c0c1b34c413798b4"
   end
 
@@ -17,7 +17,7 @@ cask "mweb" do
 
   livecheck do
     url "https://www.mweb.im/download.html"
-    regex(/>Download MWeb (\d+(?:\.\d+)+)</i)
+    regex(/>Download\s*MWeb\s*(\d+(?:\.\d+)+)</i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
I've bumped the version, but I'd appreciate any help getting the livecheck stanza updated.
It seems they're no longer using sparkle (or the sparkle url is hidden somewhere I can't see).


- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
