### PR TITLE
Add u-he Zebra2 cask

### DIFF
--- a/Casks/zebra2.rb
+++ b/Casks/zebra2.rb
@@ -33,6 +33,18 @@ cask "zebra2" do
     "com.u-he.Zebra#{version.major}.support.pkg",
     "com.u-he.Zebra#{version.major}.themes.pkg",
   ]
+  
+  zap trash: [
+    '~/Library/Application Support/u-he/Zebra2',
+    '~/Library/Application Support/u-he/com.u-he.Zebra2.midiassign.txt',
+    '~/Library/Application Support/u-he/com.u-he.Zebra2.Preferences.txt',
+    '~/Library/Application Support/u-he/com.u-he.Zebralette.midiassign.txt',
+    '~/Library/Application Support/u-he/com.u-he.Zebralette.Preferences.txt',
+    '~/Library/Application Support/u-he/com.u-he.Zebrify.midiassign.txt',
+    '~/Library/Application Support/u-he/com.u-he.Zebrify.Preferences.txt',
+    '~/Library/Application Support/u-he/com.u-he.ZRev.midiassign.txt',
+    '~/Library/Application Support/u-he/com.u-he.ZRev.Preferences.txt',
+  ]
 
   caveats do
     reboot

--- a/Casks/zebra2.rb
+++ b/Casks/zebra2.rb
@@ -1,36 +1,37 @@
 cask "zebra2" do
+  # NOTE: "2" is not a version number, but an intrinsic part of the product name
   version "2.9.3,12092"
   sha256 "d088d17fc42eca3ffede5f7ee8586dceb19ddc9a29b1829f7d84b15221eb5fb2"
 
-  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/Zebra2_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip",
+  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/Zebra#{version.major}_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip",
       verified: "uhedownloads-heckmannaudiogmb.netdna-ssl.com/"
   name "Zebra2"
   desc "Wireless modular synthesizer"
   homepage "https://u-he.com/products/zebra2/"
 
   livecheck do
-    url "https://u-he.com/products/zebra2/releasenotes.html"
+    url "https://u-he.com/products/zebra#{version.major}/releasenotes.html"
     strategy :page_match do |page|
       match = page.match(/Zebra\s*(\d+(?:\.\d+)*)\s*\(revision\s*(\d+(?:\.\d+)*)\)/i)
       "#{match[1]},#{match[2]}"
     end
   end
 
-  pkg "Zebra2_#{version.after_comma}_Mac/Zebra2 #{version.before_comma} Installer.pkg"
+  pkg "Zebra#{version.major}_#{version.after_comma}_Mac/Zebra#{version.major} #{version.before_comma} Installer.pkg"
 
   uninstall pkgutil: [
-    "com.u-he.Zebra2.aax.pkg",
-    "com.u-he.Zebra2.au.pkg",
-    "com.u-he.Zebra2.data.pkg",
-    "com.u-he.Zebra2.documentation.pkg",
-    "com.u-he.Zebra2.presets.pkg",
-    "com.u-he.Zebra2.tuningFiles.pkg",
-    "com.u-he.Zebra2.vst.pkg",
-    "com.u-he.Zebra2.vst3.pkg",
-    "com.u-he.Zebra2.modules.pkg",
-    "com.u-he.Zebra2.nks.pkg",
-    "com.u-he.Zebra2.support.pkg",
-    "com.u-he.Zebra2.themes.pkg",
+    "com.u-he.Zebra#{version.major}.aax.pkg",
+    "com.u-he.Zebra#{version.major}.au.pkg",
+    "com.u-he.Zebra#{version.major}.data.pkg",
+    "com.u-he.Zebra#{version.major}.documentation.pkg",
+    "com.u-he.Zebra#{version.major}.presets.pkg",
+    "com.u-he.Zebra#{version.major}.tuningFiles.pkg",
+    "com.u-he.Zebra#{version.major}.vst.pkg",
+    "com.u-he.Zebra#{version.major}.vst3.pkg",
+    "com.u-he.Zebra#{version.major}.modules.pkg",
+    "com.u-he.Zebra#{version.major}.nks.pkg",
+    "com.u-he.Zebra#{version.major}.support.pkg",
+    "com.u-he.Zebra#{version.major}.themes.pkg",
   ]
 
   caveats do

--- a/Casks/zebra2.rb
+++ b/Casks/zebra2.rb
@@ -1,0 +1,35 @@
+cask "zebra2" do
+  version "2.9.3,12092"
+  sha256 "d088d17fc42eca3ffede5f7ee8586dceb19ddc9a29b1829f7d84b15221eb5fb2"
+
+  url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/Zebra2_#{version.before_comma.no_dots}_#{version.after_comma}_Mac.zip",
+      verified: "uhedownloads-heckmannaudiogmb.netdna-ssl.com/"
+  name "Zebra2"
+  desc "Wireless modular synthesizer"
+  homepage "https://u-he.com/products/zebra2/"
+
+  livecheck do
+    url "https://u-he.com/products/zebra2/releasenotes.html"
+    strategy :page_match do |page|
+      match = page.match(/Zebra\s*(\d+(?:\.\d+)*)\s*\(revision\s*(\d+(?:\.\d+)*)\)/i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  pkg "Zebra2_#{version.after_comma}_Mac/Zebra2 #{version.before_comma} Installer.pkg"
+
+  uninstall pkgutil: [
+    "com.u-he.Zebra2.aax.pkg",
+    "com.u-he.Zebra2.au.pkg",
+    "com.u-he.Zebra2.data.pkg",
+    "com.u-he.Zebra2.documentation.pkg",
+    "com.u-he.Zebra2.presets.pkg",
+    "com.u-he.Zebra2.tuningFiles.pkg",
+    "com.u-he.Zebra2.vst.pkg",
+    "com.u-he.Zebra2.vst3.pkg",
+  ]
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/zebra2.rb
+++ b/Casks/zebra2.rb
@@ -33,17 +33,17 @@ cask "zebra2" do
     "com.u-he.Zebra#{version.major}.support.pkg",
     "com.u-he.Zebra#{version.major}.themes.pkg",
   ]
-  
+
   zap trash: [
-    '~/Library/Application Support/u-he/Zebra2',
-    '~/Library/Application Support/u-he/com.u-he.Zebra2.midiassign.txt',
-    '~/Library/Application Support/u-he/com.u-he.Zebra2.Preferences.txt',
-    '~/Library/Application Support/u-he/com.u-he.Zebralette.midiassign.txt',
-    '~/Library/Application Support/u-he/com.u-he.Zebralette.Preferences.txt',
-    '~/Library/Application Support/u-he/com.u-he.Zebrify.midiassign.txt',
-    '~/Library/Application Support/u-he/com.u-he.Zebrify.Preferences.txt',
-    '~/Library/Application Support/u-he/com.u-he.ZRev.midiassign.txt',
-    '~/Library/Application Support/u-he/com.u-he.ZRev.Preferences.txt',
+    "~/Library/Application Support/u-he/Zebra2",
+    "~/Library/Application Support/u-he/com.u-he.Zebra2.midiassign.txt",
+    "~/Library/Application Support/u-he/com.u-he.Zebra2.Preferences.txt",
+    "~/Library/Application Support/u-he/com.u-he.Zebralette.midiassign.txt",
+    "~/Library/Application Support/u-he/com.u-he.Zebralette.Preferences.txt",
+    "~/Library/Application Support/u-he/com.u-he.Zebrify.midiassign.txt",
+    "~/Library/Application Support/u-he/com.u-he.Zebrify.Preferences.txt",
+    "~/Library/Application Support/u-he/com.u-he.ZRev.midiassign.txt",
+    "~/Library/Application Support/u-he/com.u-he.ZRev.Preferences.txt",
   ]
 
   caveats do

--- a/Casks/zebra2.rb
+++ b/Casks/zebra2.rb
@@ -27,6 +27,10 @@ cask "zebra2" do
     "com.u-he.Zebra2.tuningFiles.pkg",
     "com.u-he.Zebra2.vst.pkg",
     "com.u-he.Zebra2.vst3.pkg",
+    "com.u-he.Zebra2.modules.pkg",
+    "com.u-he.Zebra2.nks.pkg",
+    "com.u-he.Zebra2.support.pkg",
+    "com.u-he.Zebra2.themes.pkg",
   ]
 
   caveats do


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free. 
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully. 
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Regarding the name of this cask: it's likely that users will be confused by the already existing "zebra" package, which is a completely different software. Also, additional software from the company of this new cask has names that will likely cause confusion in the future. Maybe it would be appropriate to prefix this and future u-he packages with the company's name `u-he`? Something like `u-he-zebra2` or `uhe-zebra2` would seem fine to me.