### PR TITLE
Upgrade stack and fix pkg and appcast

### DIFF
--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -13,12 +13,14 @@ cask "stack" do
     regex(/href=.*?stack[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
   end
 
+  app "stack.app"
+
   uninstall login_item: "stack",
             signal:     ["TERM", "nl.transip.stack"],
             pkgutil:    "nl.transip.stack"
 
   zap trash: [
-    "~/Library/Caches/nl.transip.stack",
     "~/Library/Application Support/STACK/",
+    "~/Library/Caches/nl.transip.stack",
   ]
 end

--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -8,6 +8,11 @@ cask "stack" do
   desc "Personal online hard drive to store, view and share files"
   homepage "https://www.transip.nl/stack"
 
+  livecheck do
+    url "https://mirror.transip.net/stack/software/osx/"
+    regex(/href=.*?stack[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+  end
+
   uninstall login_item: "stack",
             signal:     ["TERM", "nl.transip.stack"],
             pkgutil:    "nl.transip.stack"

--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -1,15 +1,12 @@
 cask "stack" do
-  version "2.6.4-20200908"
-  sha256 "53f2e2fee658ba23105961771a1ab1b37e67a169b0f578fe4723900b730a7472"
+  version "2.8.2-20210809"
+  sha256 "2c684b4acf039556ab1103834a806b066fbc93fe5fc74a4b7a6286f665aed6a2"
 
-  url "https://mirror.transip.net/stack/software/osx/stack-#{version}.pkg",
+  url "https://mirror.transip.net/stack/software/osx/stack-#{version}.dmg",
       verified: "transip.net/stack/"
-  appcast "https://mirror.transip.net/stack/update/?version=0.0.0&platform=macos&oem=stack&versionsuffix=&updatesegment=18&sparkle=true"
   name "STACK"
   desc "Personal online hard drive to store, view and share files"
   homepage "https://www.transip.nl/stack"
-
-  pkg "stack-#{version}.pkg"
 
   uninstall login_item: "stack",
             signal:     ["TERM", "nl.transip.stack"],


### PR DESCRIPTION
Upgrading stack was broken, because transip uses dmg files now. Appcast didn't go through the audit.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
