### PR TITLE
Switch to supported download URL for Backblaze

### DIFF
--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -8,8 +8,9 @@ cask "backblaze" do
   homepage "https://backblaze.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://secure.backblaze.com/api/clientversion.xml"
+    strategy :page_match
+    regex(/mac_version=.*?(\d+(?:\.\d+)*)/i)
   end
 
   auto_updates true

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -1,8 +1,8 @@
 cask "backblaze" do
   version "8.0.1.534"
-  sha256 "1a32fe6a090054a4954acc88b598c4ea2550a85468547dae323044f1038de452"
+  sha256 :no_check
 
-  url "https://secure.backblaze.com/api/install_backblaze?file=bzinstall-mac-#{version}.zip"
+  url "https://secure.backblaze.com/mac/install_backblaze.dmg"
   name "Backblaze"
   desc "Data backup and storage service"
   homepage "https://backblaze.com/"
@@ -15,7 +15,7 @@ cask "backblaze" do
 
   auto_updates true
 
-  installer manual: "bzdoinstall.app"
+  installer manual: "Backblaze Installer.app"
 
   uninstall launchctl: [
     "com.backblaze.bzserv",

--- a/Casks/backblaze.rb
+++ b/Casks/backblaze.rb
@@ -8,9 +8,8 @@ cask "backblaze" do
   homepage "https://backblaze.com/"
 
   livecheck do
-    url "https://secure.backblaze.com/api/clientversion.xml"
-    strategy :page_match
-    regex(/mac_version=.*?(\d+(?:\.\d+)*)/i)
+    url :url
+    strategy :extract_plist
   end
 
   auto_updates true
@@ -23,14 +22,14 @@ cask "backblaze" do
   ],
             delete:    [
               "#{appdir}/Backblaze.app",
+              "/Library/Backblaze.bzpkg",
+              "/Library/Logs/DiagnosticReports/bzbmenu_*.*_resource.diag",
               "/Library/PreferencePanes/BackblazeBackup.prefPane",
             ]
 
   zap trash: [
-    "/Library/Backblaze.bzpkg",
-    "~/Library/Preferences/com.backblaze.bzbmenu.plist",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.backblaze.*.sfl*",
-    "/Library/Logs/DiagnosticReports/bzbmenu_*.*_resource.diag",
+    "~/Library/Preferences/com.backblaze.bzbmenu.plist",
     "~/Library/Logs/BackblazeGUIInstaller",
   ]
 end


### PR DESCRIPTION
With the release of Backblaze 8.0.1.534, the versioned download URL for Backblaze (via https://secure.backblaze.com/api/install_backblaze) no longer works, instead redirecting users to https://www.backblaze.com/download_error.html

Having contacted their support team, they confirmed the following:

> We do not support [using https://secure.backblaze.com/api/install_backblaze for] installing the
> Backblaze program.
>
> It may have worked previously, but we are not able to support this currently.
>
> We don't have a way to specify a version for download, unfortunately.
>
> That said, you're always welcome to use this Update page to get the newest version of the Backblaze installer: https://secure.backblaze.com/update.htm
>
> This page will contain the following download links, which you can use directly if you prefer:
>
> * https://secure.backblaze.com/win32/install_backblaze.exe
> * https://secure.backblaze.com/mac/install_backblaze.dmg

Therefore switch to using the unversioned download URL and suppress the checksum as per the example from https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#examples as the checksum will change on the same URL when a new version is released.

We keep the livecheck stanza as the official download page uses that same method to load the current application version number.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
