### PR TITLE
Reverts OpenSC to v 0.21

### DIFF
--- a/Casks/opensc.rb
+++ b/Casks/opensc.rb
@@ -1,6 +1,6 @@
 cask "opensc" do
-  version "0.22.0"
-  sha256 "3f3fa6e0378af84c2d57ea245ac0352a9ff840973bed010e6c1d4c506aaf6f07"
+  version "0.21.0"
+  sha256 "7d28313031d151a04e55158ed692bf0743380d9db0dbc1ab2f4e28320d16b52a"
 
   url "https://github.com/OpenSC/OpenSC/releases/download/#{version}/OpenSC-#{version}.dmg"
   name "OpenSC"


### PR DESCRIPTION
OpenSC 0.22 for macOS has been temporarily withdrawn due to incomplete dmg file - https://github.com/OpenSC/OpenSC/issues/2389#issuecomment-901148614

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
