### PR TITLE
telegram-desktop: add macos version dependency

### DIFF
--- a/Casks/telegram-desktop.rb
+++ b/Casks/telegram-desktop.rb
@@ -15,6 +15,7 @@ cask "telegram-desktop" do
 
   auto_updates true
   conflicts_with cask: "homebrew/cask-versions/telegram-desktop-beta"
+  depends_on macos: ">= :sierra"
 
   # Renamed to avoid conflict with telegram
   app "Telegram.app", target: "Telegram Desktop.app"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask telegram-desktop` is error-free.
- [X] `brew style --fix telegram-desktop` reports no offenses.

Telegram Desktop does not work on Mac OS X El Capitan (10.11) and the error message upon start states that it requires OS X version 10.12 or later. This PR introduces a check to prevent installation on older versions of Mac OS X.