### PR TITLE
AlDente: now has a built-in updater, no need for Homebrew to handle this

### DIFF
--- a/Casks/aldente.rb
+++ b/Casks/aldente.rb
@@ -12,6 +12,8 @@ cask "aldente" do
     strategy :github_latest
   end
 
+  auto_updates true
+
   depends_on macos: ">= :big_sur"
 
   app "AlDente.app"

--- a/Casks/aldente.rb
+++ b/Casks/aldente.rb
@@ -13,7 +13,6 @@ cask "aldente" do
   end
 
   auto_updates true
-
   depends_on macos: ">= :big_sur"
 
   app "AlDente.app"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.