### PR TITLE
tv-browser: bump version, set livecheck regex

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -1,13 +1,16 @@
 cask "tv-browser" do
-  version "4.2.1"
-  sha256 "bc7ce87e1d27d1d40964bdcb5b9b5779a518567d1cd36a71d62deb8da73d4f7c"
+  version "4.2.3"
+  sha256 "f5542146d514b44fbb3dddb0c36bc64af0436820db47bda4334d4b2e2b869f77"
 
   url "https://downloads.sourceforge.net/tvbrowser/tvbrowser_#{version}_macjava.dmg",
       verified: "sourceforge.net/tvbrowser/"
-  appcast "https://sourceforge.net/projects/tvbrowser/rss"
   name "TV-Browser"
   desc "Electronic TV guide"
   homepage "https://www.tvbrowser.org/"
+
+  livecheck do
+    regex(%r{url=.*?/tvbrowser/files/.*?[-_/](\d+(?:[-.]\d+)+)[._-]macjava.dmg}i)
+  end
 
   app "TV-Browser.app"
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.