### PR TITLE
Steam: revert versioning and update livecheck

### DIFF
--- a/Casks/steam.rb
+++ b/Casks/steam.rb
@@ -1,5 +1,5 @@
 cask "steam" do
-  version "2021-07-22"
+  version "2.0"
   sha256 :no_check
 
   url "https://steamcdn-a.akamaihd.net/client/installer/steam.dmg",
@@ -9,11 +9,8 @@ cask "steam" do
   homepage "https://store.steampowered.com/about/"
 
   livecheck do
-    url "https://store.steampowered.com/oldnews/?feed=steam_client"
-    strategy :page_match do |page|
-      date = Time.parse(page[/class=["']?date["']?[^>]*>([^<]+)/i, 1])
-      date.strftime("%Y-%m-%d")
-    end
+    url :url
+    strategy :extract_plist
   end
 
   auto_updates true


### PR DESCRIPTION
The internal app doesn't look like it has been updated since earlier 2020.
Using the update feed probably isn't the best option here because Steam handles the updating processing internally and the app is more of a wrapper.