### PR TITLE
fix sha256 for ishowu-instant 1.4.8

### DIFF
--- a/Casks/ishowu-instant.rb
+++ b/Casks/ishowu-instant.rb
@@ -1,5 +1,5 @@
 cask "ishowu-instant" do
-  version "1.4.8,1379"
+  version "1.4.8,1383"
   sha256 "897899b9691495d9c945d63d11ba6d7988a297c8913528e5ce5663eac0d18cee"
 
   url "https://www.shinywhitebox.com/downloads/instant/iShowU_Instant_#{version.before_comma}.dmg"

--- a/Casks/ishowu-instant.rb
+++ b/Casks/ishowu-instant.rb
@@ -1,6 +1,6 @@
 cask "ishowu-instant" do
   version "1.4.8,1379"
-  sha256 "653a5d0a16715f86bbe74e29d37b6a77d3cd0f5d2945eb6d94cb20349bb00128"
+  sha256 "897899b9691495d9c945d63d11ba6d7988a297c8913528e5ce5663eac0d18cee"
 
   url "https://www.shinywhitebox.com/downloads/instant/iShowU_Instant_#{version.before_comma}.dmg"
   name "iShowU Instant"


### PR DESCRIPTION
Looks like they changed binary so new hash is now `897899b9691495d9c945d63d11ba6d7988a297c8913528e5ce5663eac0d18cee`

```
Error: ishowu-instant: SHA256 mismatch
Expected: 653a5d0a16715f86bbe74e29d37b6a77d3cd0f5d2945eb6d94cb20349bb00128
  Actual: 897899b9691495d9c945d63d11ba6d7988a297c8913528e5ce5663eac0d18cee
    File: Homebrew/downloads/6f31dbf06cfcc085f90a89c81854ff1bc2ee1de8334f682a53b77b3ae010b846--iShowU_Instant_1.4.8.dmg
```