### PR TITLE
Update securid from 4.2.1 to 4.2.2

### DIFF
--- a/Casks/securid.rb
+++ b/Casks/securid.rb
@@ -4,7 +4,13 @@ cask "securid" do
 
   url "https://community.rsa.com/yfcdo34327/attachments/yfcdo34327/securid-software-token-macos/5/1/RSASecurIDMac#{version.no_dots}.dmg.zip"
   name "RSA SecurID"
+  desc "Authentication software"
   homepage "https://community.rsa.com/t5/rsa-securid-software-token-for/tkb-p/securid-software-token-macos"
+
+  livecheck do
+    url :homepage
+    regex(/SecurID\s*Software\s*Token\s*(\d+(?:\.\d+)*)\s*for\s*macOS/i)
+  end
 
   container nested: "RSASecurIDMac#{version.no_dots}.dmg"
 

--- a/Casks/securid.rb
+++ b/Casks/securid.rb
@@ -1,10 +1,12 @@
 cask "securid" do
-  version "4.2.1"
-  sha256 "e3d796f263cbdbc4a6c870931e469c64e8c8ffb14aa8ae68b4036cee0eeb0c04"
+  version "4.2.2"
+  sha256 "178109b820c97dd7ad1f8be907ae0338d2e4ae91cc6ddc4cd0484d9ad6c21198"
 
-  url "https://community.rsa.com/yfcdo34327/attachments/yfcdo34327/securid-software-token-macos/4/1/RSASecurIDMac#{version.no_dots}.dmg.zip"
+  url "https://community.rsa.com/yfcdo34327/attachments/yfcdo34327/securid-software-token-macos/5/1/RSASecurIDMac#{version.no_dots}.dmg.zip"
   name "RSA SecurID"
   homepage "https://community.rsa.com/t5/rsa-securid-software-token-for/tkb-p/securid-software-token-macos"
+
+  container nested: "RSASecurIDMac#{version.no_dots}.dmg"
 
   pkg "RSASecurIDTokenAutoMac#{version.no_dots}x64.pkg"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

