### PR TITLE
upgrade cyberghost-vpn from 7.1.0.92 to 8.2.0,137

### DIFF
--- a/Casks/cyberghost-vpn.rb
+++ b/Casks/cyberghost-vpn.rb
@@ -1,14 +1,14 @@
 cask "cyberghost-vpn" do
-  version "7.1.0.92"
-  sha256 "70cd118a860cd0504a29dfb3f45245c4c62777063f0c7280b22c7727cd205799"
+  version "8.2.0,137"
+  sha256 "5670e68423c74eaba74041eaa2fba5709b213f5a5d1ba424ca398a7fc9d918d9"
 
-  url "https://download.cyberghostvpn.com/mac/updates/v#{version.major}/cg#{version.major}mac_#{version}.dmg"
+  url "https://download.cyberghostvpn.com/mac/updates/v7/CyberGhost-#{version.before_comma}.#{version.after_comma}.dmg"
   name "CyberGhost"
   desc "VPN client"
   homepage "https://www.cyberghostvpn.com/"
 
   livecheck do
-    url "https://download.cyberghostvpn.com/mac/updates/v#{version.major}/cyberghost_mac_update.inf"
+    url "https://download.cyberghostvpn.com/mac/updates/v7/cyberghost_mac_update_v3.inf"
     strategy :sparkle
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.