### PR TITLE
Update edrawmax language and app name

### DIFF
--- a/Casks/edrawmax.rb
+++ b/Casks/edrawmax.rb
@@ -2,18 +2,18 @@ cask "edrawmax" do
   version :latest
   sha256 :no_check
 
-  language "CN" do
+  language "zh", "CN" do
     url "https://cc-download.edrawsoft.cn/edraw-max_cn_full5381.dmg"
     homepage "https://www.edrawsoft.cn/"
+    app "亿图图示.app"
   end
   language "en", default: true do
     url "https://download.edrawsoft.com/edraw-max_full5380.dmg"
     homepage "https://www.edrawsoft.com/"
+    app "Wondershare EdrawMax.app"
   end
 
   name "EdrawMax"
-
-  app "EdrawMax.app"
 
   zap trash: [
     "~/Library/Edraw",

--- a/Casks/wondershare-edrawmax.rb
+++ b/Casks/wondershare-edrawmax.rb
@@ -1,5 +1,5 @@
-cask "edrawmax" do
-  version :latest
+cask "wondershare-edrawmax" do
+  version "11.1.0"
   sha256 :no_check
 
   language "zh", "CN" do
@@ -14,6 +14,12 @@ cask "edrawmax" do
   end
 
   name "EdrawMax"
+  desc "Diagram software"
+
+  livecheck do
+    url "https://www.edrawsoft.com/whats-new/edrawmax.html"
+    regex(/EdrawMax\s*V?(\d+(?:\.\d+)*)/i)
+  end
 
   zap trash: [
     "~/Library/Edraw",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The old cask reports "It seems the App source is not there." error because the app name in dmg file is not "EdrawMax.app", it should be "亿图图示.app" in Chinese and "Wondershare EdrawMax.app" in English.

Another bug is that the cask didn't correctly detect the region when the language is zh_CN, so I added "zh", it works.