### PR TITLE
Remove the quarantine attribute Chromium to bypass GateKeeper

### DIFF
--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -44,6 +44,10 @@ cask "chromium" do
     EOS
   end
 
+  postflight do
+    exec("xattr -d com.apple.quarantine '#{appdir}/Chromium.app'")
+  end
+
   zap trash: [
     "~/Library/Application Support/Chromium",
     "~/Library/Caches/Chromium",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

Chromium builds are shipped without code signing and notarization, and macOS warns it being damaged when launching.
By explicitly removing `com.apple.quarantine` extended attribute key, this helps consumers to launching it immediately after installation without being confused.
