### PR TITLE
Update Spotify from 1.1.66.580.gbd43cbc9 to 1.1.67.586.gbb5ef64e

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,12 +1,12 @@
 cask "spotify" do
   if Hardware::CPU.intel?
-    version "1.1.66.580.gbd43cbc9,1.1.66.580.gbd43cbc9-18"
+    version "1.1.67.586.gbb5ef64e,1.1.67.586.gbb5ef64e-22"
     sha256 :no_check
 
     url "https://download.scdn.co/Spotify.dmg",
         verified: "scdn.co/"
   else
-    version "1.1.66.580.gbd43cbc9"
+    version "1.1.67.586.gbb5ef64e"
     sha256 :no_check
 
     url "https://download.scdn.co/SpotifyBetaARM64.dmg",


### PR DESCRIPTION
Signed-off-by: Andreas Eitel <github-aneitel@online.de>

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
