### PR TITLE
Update JOSM cask url: project move to 'JOSM' org at GitHub + bump version to 18193

### DIFF
--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -11,7 +11,7 @@ cask "josm" do
   livecheck do
     url :url
     strategy :github_latest
-    regex(%r{href=.*?/(\d+(?:\.\d+)*)(?:[._-]tested)?/JOSM-macOS-java\d+\.zip}i)
+    regex(%r{href=.*?/(\d+(?:\.\d+)*)(?:[._-]tested)?/JOSM-macOS-java\d+-\d+\.zip}i)
   end
 
   app "JOSM.app"

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -2,7 +2,7 @@ cask "josm" do
   version "18118"
   sha256 "278d087f601438d76a6835e732fcc81b12c945a20178bb041fcd25f2307d3b44"
 
-  url "https://github.com/openstreetmap/josm/releases/download/#{version}-tested/JOSM-macOS-java16.zip",
+  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java16.zip",
       verified: "github.com/openstreetmap/josm/"
   name "JOSM"
   desc "Extensible editor for OpenStreetMap"

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -3,7 +3,7 @@ cask "josm" do
   sha256 "278d087f601438d76a6835e732fcc81b12c945a20178bb041fcd25f2307d3b44"
 
   url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java16.zip",
-      verified: "github.com/openstreetmap/josm/"
+      verified: "github.com/JOSM/josm/"
   name "JOSM"
   desc "Extensible editor for OpenStreetMap"
   homepage "https://josm.openstreetmap.de/"

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask "josm" do
-  version "18118"
-  sha256 "278d087f601438d76a6835e732fcc81b12c945a20178bb041fcd25f2307d3b44"
+  version "18191"
+  sha256 "221c4c0a5c2c1b58d7282f9300b87342a30bd693c45f7ef1173d76b74a340b7d"
 
   url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java16-#{version}.zip",
       verified: "github.com/JOSM/josm/"

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -1,6 +1,6 @@
 cask "josm" do
-  version "18191"
-  sha256 "221c4c0a5c2c1b58d7282f9300b87342a30bd693c45f7ef1173d76b74a340b7d"
+  version "18193"
+  sha256 "3a80d7e6d3d32eb52019f05ad757455727ae5d26a2f1024d7902d6c28b7692c9"
 
   url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java16-#{version}.zip",
       verified: "github.com/JOSM/josm/"

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -17,8 +17,8 @@ cask "josm" do
   app "JOSM.app"
 
   zap trash: [
-    "~/Library/Preferences/JOSM",
-    "~/Library/Caches/JOSM",
     "~/Library/JOSM",
+    "~/Library/Caches/JOSM",
+    "~/Library/Preferences/JOSM",
   ]
 end

--- a/Casks/josm.rb
+++ b/Casks/josm.rb
@@ -2,7 +2,7 @@ cask "josm" do
   version "18118"
   sha256 "278d087f601438d76a6835e732fcc81b12c945a20178bb041fcd25f2307d3b44"
 
-  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java16.zip",
+  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java16-#{version}.zip",
       verified: "github.com/JOSM/josm/"
   name "JOSM"
   desc "Extensible editor for OpenStreetMap"


### PR DESCRIPTION
Recently the JOSM project moved from 'openstreetmap' GitHub organization to the dedicated 'JOSM'. This PR is to prepare upgrade to current tested-18191 release.

New JOSM Downloads: https://github.com/JOSM/josm/releases/

PR is resulted by:
```
% brew bump-cask-pr --version 18119 josm
==> Downloading https://github.com/openstreetmap/josm/releases/download/18119-tested/JOSM-macOS-java16.zip
==> Downloading from https://github.com/JOSM/josm/releases/download/18119-tested/JOSM-macOS-java16.zip
#=#=#                                                                         
curl: (22) The requested URL returned error: 404 
Error: Failed to download resource "josm"
Download failed: https://github.com/openstreetmap/josm/releases/download/18119-tested/JOSM-macOS-java16.zip
```

Finally included a version bump as well to allow successful test.

----

**Important:** _Do not tick a checkbox if you haven’t performed its action._ Honesty is indispensable for a smooth review process.
 
_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

* [x]  The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
* [x]  `brew audit --cask <cask>` is error-free.
* [x]  `brew style --fix <cask>` reports no offenses.