### PR TITLE
Upgrade tencent-meeting.app to v2.18.3.404

### DIFF
--- a/Casks/tencent-meeting.rb
+++ b/Casks/tencent-meeting.rb
@@ -1,13 +1,13 @@
 cask "tencent-meeting" do
   if Hardware::CPU.intel?
-    version "2.16.2.420,b4acf9b3b84361f9c0e51937f23bbde5"
-    sha256 "c97533d1cff73ec29977c682ad2708b34319f21c5595f27e9b0db12d967bebcf"
-    url "https://updatecdn.meeting.qq.com/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.x86_64.dmg",
+    version "2.18.3.404,637145a82cf1f9e7e23afada46b8ef98"
+    sha256 "0cfaddc50d4d50846ff88b2fd2577bedb932bafc0e3b6a935e13c0e526932d6b"
+    url "https://updatecdn.meeting.qq.com/cos/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.x86_64.dmg",
         verified: "qq.com/"
   else
-    version "2.15.3.400,6511c21f2ffa0b6c3c6521ca681a2f38"
-    sha256 "aa648bcc734deef2e6699e565439a6c3529574ac8e5f76c0d4113b91581d99ee"
-    url "https://updatecdn.meeting.qq.com/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.arm64.dmg",
+    version "2.18.3.404,452afb351949d9d831e860320aa2eeef"
+    sha256 "93b66146e14d7cba7896c8a49b1d1470f30e36220dbae1cdad6d892be8e82c61"
+    url "https://updatecdn.meeting.qq.com/cos/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.arm64.dmg",
         verified: "qq.com/"
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.