### PR TITLE
Update airdroid sha

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,6 +1,6 @@
 cask "airdroid" do
   version "3.6.9.2"
-  sha256 "5ed0cb9c480be4fc18ddfc184f92481d4b7c1871446f1ebab36c1dcb84614921"
+  sha256 "7fa7bca24d69e9f9951fe6887a8c73ea3db97ad17d7a9003ed67e4070e7371fe"
 
   url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg",
       verified: "s3.amazonaws.com/dl.airdroid.com/"


### PR DESCRIPTION
```
brew install --cask airdroid
==> Downloading https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_3.6.9.2.dmg
Already downloaded: /Users/gpalumbo/Library/Caches/Homebrew/downloads/0a7aa66924ea4b896fb3c2d0981aad67e8e45d3a475ae194c9039c09cffa1bed--AirDroid_Desktop_Client_3.6.9.2.dmg
Error: SHA256 mismatch
Expected: 5ed0cb9c480be4fc18ddfc184f92481d4b7c1871446f1ebab36c1dcb84614921
  Actual: 7fa7bca24d69e9f9951fe6887a8c73ea3db97ad17d7a9003ed67e4070e7371fe
    File: /Users/gpalumbo/Library/Caches/Homebrew/downloads/0a7aa66924ea4b896fb3c2d0981aad67e8e45d3a475ae194c9039c09cffa1bed--AirDroid_Desktop_Client_3.6.9.2.dmg
To retry an incomplete download, remove the file above.
```

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.