### PR TITLE
Add `allow_untrusted: true` to wine-stable

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -19,7 +19,7 @@ cask "wine-stable" do
   ]
   depends_on cask: "xquartz"
 
-  pkg "winehq-stable-#{version}.pkg",
+  pkg "winehq-stable-#{version}.pkg", allow_untrusted: true,
       choices: [
         {
           "choiceIdentifier" => "choice3",


### PR DESCRIPTION
There was no way for me to install wine without this fix because the package wasn't signed.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
