### PR TITLE
fix(adguard-vpn): m1 support fixed

### DIFF
--- a/Casks/adguard-vpn.rb
+++ b/Casks/adguard-vpn.rb
@@ -1,6 +1,6 @@
 cask "adguard-vpn" do
-  version "1.0.0.134"
-  sha256 "655e165b35498da72ba23aef3decafa34ef040f042c6f042c0d047caa1ed12c8"
+  version "1.0.0.135"
+  sha256 "3934f82a13077a78dd29086afc291454213c732ea1d6ba22451188e40a64e17f"
 
   url "https://static.adguard-vpn.com/mac/release/AdGuardVPN-#{version}.dmg"
   name "Adguard VPN"


### PR DESCRIPTION
Update AdGuard VPN to use native version of AdGuard VPN

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
