### PR TITLE
notion: Fix livecheck for arm64

### DIFF
--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -20,6 +20,7 @@ cask "notion" do
     livecheck do
       url "https://www.notion.so/desktop/apple-silicon/download"
       strategy :header_match
+      regex(%r{https://desktop-release.notion-static.com/Notion-(\d+(?:\.\d+)*?)(?:-arm64)?.dmg})
     end
   end
 

--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -20,7 +20,7 @@ cask "notion" do
     livecheck do
       url "https://www.notion.so/desktop/apple-silicon/download"
       strategy :header_match
-      regex(%r{https://desktop-release.notion-static.com/Notion-(\d+(?:\.\d+)*?)(?:-arm64)?.dmg})
+      regex(/Notion-(\d+(?:\.\d+)*?)(?:-arm64)?\.dmg/i)
     end
   end
 


### PR DESCRIPTION
Default livecheck strategy HeaderMatch fails on arm64 for notion cask:
Got from HTTP: location: https://desktop-release.notion-static.com/Notion-2.0.16-arm64.dmg
Version matched by livecheck: 64 (wrong)
Fix: add regex in livecheck block

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.