### PR TITLE
Update OwnCloud from 2.8.2.4246 to 2.9.0.5150

### DIFF
--- a/Casks/owncloud.rb
+++ b/Casks/owncloud.rb
@@ -1,6 +1,6 @@
 cask "owncloud" do
-  version "2.8.2.4246"
-  sha256 "50131244a9ab16ae49bf0633d56ecfe5b858b9c5cd3718645b9c77d869f875d0"
+  version "2.9.0.5150"
+  sha256 "b64def850cd901f23f93385e71fef491bad6ba405f87b974852b63ca98e2a9b2"
 
   url "https://download.owncloud.com/desktop/ownCloud/stable/#{version}/mac/ownCloud-#{version}.pkg"
   name "ownCloud"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

