### PR TITLE
qbittorrent: use 4.3.2 for High Sierra and below

### DIFF
--- a/Casks/qbittorrent.rb
+++ b/Casks/qbittorrent.rb
@@ -1,6 +1,11 @@
 cask "qbittorrent" do
-  version "4.3.8"
-  sha256 "51b2aebe38bff58d01b39214a006b53e8aece39444b57aef118c92f3232de0ac"
+  if MacOS.version <= :high_sierra
+    version "4.3.2"
+    sha256 "dd38e80710978430694c430276a6b7749ef3533cbd0271075bc9eada484ea36b"
+  else
+    version "4.3.8"
+    sha256 "51b2aebe38bff58d01b39214a006b53e8aece39444b57aef118c92f3232de0ac"
+  end
 
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg",
       verified: "sourceforge.net/qbittorrent/"


### PR DESCRIPTION
Version 4.3.3 and onwards require Mojave as per the changelog here:
https://www.qbittorrent.org/news.php

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.