### PR TITLE
bump kui from 10.5.2 to 10.5.4

### DIFF
--- a/Casks/kui.rb
+++ b/Casks/kui.rb
@@ -15,11 +15,6 @@ cask "kui" do
   desc "Hybrid command-line/UI development experience for cloud-native development"
   homepage "https://github.com/kubernetes-sigs/kui"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   binary "#{appdir}/Kui.app/Contents/Resources/kubectl-kui"
 
   zap trash: "~/Library/Application Support/Kui"

--- a/Casks/kui.rb
+++ b/Casks/kui.rb
@@ -1,21 +1,19 @@
 cask "kui" do
-  version "10.5.2"
+  version "10.5.4"
 
   if Hardware::CPU.intel?
-    url "https://github.com/kubernetes-sigs/kui/releases/download/v#{version}/Kui-darwin-x64.tar.bz2",
-        verified: "github.com/kubernetes-sigs/kui/"
-    sha256 "3e55829a1cd1deed292c3129fc29f536a961f41353a638faf2f72b365854d2ec"
+    url "https://github.com/kubernetes-sigs/kui/releases/download/v#{version}/Kui-darwin-x64.tar.bz2"
+    sha256 "4e3d43945fac6c25cc3c51fafdf8eed4b1c6454226907ddf5ebe0d96077acf4f"
     app "Kui-darwin-x64/Kui.app"
   else
-    url "https://github.com/kubernetes-sigs/kui/releases/download/v#{version}/Kui-darwin-arm64.tar.bz2",
-        verified: "github.com/kubernetes-sigs/kui/"
-    sha256 "a21bc0685e7c18f428afaca4b6c03ff50abe240d5fdc06272b3642525a85665b"
+    url "https://github.com/kubernetes-sigs/kui/releases/download/v#{version}/Kui-darwin-arm64.tar.bz2"
+    sha256 "9542ea0585b299be2505de1b7a690ab8b4800f7a433df5e0226c7e8a5dc61607"
     app "Kui-darwin-arm64/Kui.app"
   end
 
   name "Kui"
   desc "Hybrid command-line/UI development experience for cloud-native development"
-  homepage "https://kui.tools/"
+  homepage "https://github.com/kubernetes-sigs/kui"
 
   livecheck do
     url :url


### PR DESCRIPTION
This PR also updates the homepage, and removes the now-superfluous verified bit

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
