### PR TITLE
Add aarch64 support to Corretto and bump version to 17.0.0.35.2

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,20 +1,31 @@
 cask "corretto" do
-  version "16.0.2.7.1"
-  sha256 "2ca385d00a8de342130ff7b2465914fff62e1bc0ba713d9f8f097f90086dddbc"
+  version "17.0.0.35.2"
 
-  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-x64.pkg"
+  if Hardware::CPU.intel?
+    sha256 "9363489f7fef6e109a977225e72dd5063d5e5dc5b1466f17f875eca4db8f4bae"
+  else
+    sha256 "64083bd91f60bb9481c61c9484aacbd59d6776bb5fb3229d3ea2c6a2236d0a8b"
+  end
+
+  arch_string = if Hardware::CPU.intel?
+    "x64"
+  else
+    "aarch64"
+  end
+
+  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
   name "AWS Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
   livecheck do
-    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-x64-macos-jdk.pkg"
+    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch_string}-macos-jdk.pkg"
     strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-x64\.pkg}i, 1]
+      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-#{arch_string}\.pkg}i, 1]
     end
   end
 
-  pkg "amazon-corretto-#{version}-macosx-x64.pkg"
+  pkg "amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end

--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -3,29 +3,37 @@ cask "corretto" do
 
   if Hardware::CPU.intel?
     sha256 "9363489f7fef6e109a977225e72dd5063d5e5dc5b1466f17f875eca4db8f4bae"
+
+    url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-x64.pkg"
+
+    livecheck do
+      url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-x64-macos-jdk.pkg"
+      strategy :header_match do |headers|
+        headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-x64\.pkg}i, 1]
+      end
+    end
   else
     sha256 "64083bd91f60bb9481c61c9484aacbd59d6776bb5fb3229d3ea2c6a2236d0a8b"
+
+    url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-aarch64.pkg"
+
+    livecheck do
+      url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-aarch64-macos-jdk.pkg"
+      strategy :header_match do |headers|
+        headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-aarch64\.pkg}i, 1]
+      end
+    end
   end
 
-  arch_string = if Hardware::CPU.intel?
-    "x64"
-  else
-    "aarch64"
-  end
-
-  url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
   name "AWS Corretto JDK"
   desc "OpenJDK distribution from Amazon"
   homepage "https://corretto.aws/"
 
-  livecheck do
-    url "https://corretto.aws/downloads/latest/amazon-corretto-#{version.major}-#{arch_string}-macos-jdk.pkg"
-    strategy :header_match do |headers|
-      headers["location"][%r{/amazon-corretto-(\d+(?:\.\d+)*)-macosx-#{arch_string}\.pkg}i, 1]
-    end
+  if Hardware::CPU.intel?
+    pkg "amazon-corretto-#{version}-macosx-x64.pkg"
+  else
+    pkg "amazon-corretto-#{version}-macosx-aarch64.pkg"
   end
-
-  pkg "amazon-corretto-#{version}-macosx-#{arch_string}.pkg"
 
   uninstall pkgutil: "com.amazon.corretto.#{version.major}"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
- Not adding a new cask

Installation was tested on x64 and aarch64 and output of `java -version` was verified after installing.