### PR TITLE
Update spotify from 1.1.67.586.gbb5ef64e,1.1.67.586.gbb5ef64e-22 to 1.1.68.628.geb44bd66,1.1.68.628.geb44bd66-13

### DIFF
--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask "rocket-chat" do
-  version "3.5.1"
-  sha256 "cd409262a03e081a1bc4bd85bc58449fb9a4919eb42a142efa24da27949e65fc"
+  version "3.5.3"
+  sha256 "4e9d969ada69a67c499828abf44cc08fb48eac0686b1603807f60c0c4fe36902"
 
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg",
       verified: "github.com/RocketChat/Rocket.Chat.Electron/"

--- a/Casks/rocket-chat.rb
+++ b/Casks/rocket-chat.rb
@@ -1,6 +1,6 @@
 cask "rocket-chat" do
-  version "3.5.3"
-  sha256 "4e9d969ada69a67c499828abf44cc08fb48eac0686b1603807f60c0c4fe36902"
+  version "3.5.1"
+  sha256 "cd409262a03e081a1bc4bd85bc58449fb9a4919eb42a142efa24da27949e65fc"
 
   url "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/#{version}/rocketchat-#{version}.dmg",
       verified: "github.com/RocketChat/Rocket.Chat.Electron/"

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,12 +1,12 @@
 cask "spotify" do
   if Hardware::CPU.intel?
-    version "1.1.67.586.gbb5ef64e,1.1.67.586.gbb5ef64e-22"
+    version "1.1.68.628.geb44bd66,1.1.68.628.geb44bd66-13"
     sha256 :no_check
 
     url "https://download.scdn.co/Spotify.dmg",
         verified: "scdn.co/"
   else
-    version "1.1.66.580.gbd43cbc9"
+    version "1.1.66.578.gc54d0f69"
     sha256 :no_check
 
     url "https://download.scdn.co/SpotifyBetaARM64.dmg",

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -6,7 +6,7 @@ cask "spotify" do
     url "https://download.scdn.co/Spotify.dmg",
         verified: "scdn.co/"
   else
-    version "1.1.66.578.gc54d0f69"
+    version "1.1.66.578.gc54d0f69,1.1.66.578.gc54d0f69-13"
     sha256 :no_check
 
     url "https://download.scdn.co/SpotifyBetaARM64.dmg",


### PR DESCRIPTION
- [X] The submission is for a stable version
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.