### PR TITLE
Update mediainfo from 21.03 to 21.09

### DIFF
--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -1,6 +1,6 @@
 cask "mediainfo" do
-  version "21.03"
-  sha256 "568313eca4e016ae61102e0ab15ce3c1aa7b1decdd2d683effc794bb2f21ec77"
+  version "21.09"
+  sha256 "283afcd04ab4428f857f4495451c06ff38ef0a47dfede923d070952b5965e98a"
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   name "MediaInfo"

--- a/Casks/mediainfo.rb
+++ b/Casks/mediainfo.rb
@@ -4,6 +4,7 @@ cask "mediainfo" do
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   name "MediaInfo"
+  desc "Display technical and tag data for video and audio files"
   homepage "https://mediaarea.net/en/MediaInfo"
 
   livecheck do


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.