### PR TITLE
Add FirmaEC.app v2.10.0

### DIFF
--- a/Casks/firmaec.rb
+++ b/Casks/firmaec.rb
@@ -5,7 +5,7 @@ cask "firmaec" do
   url "https://www.firmadigital.gob.ec/firmaec/FirmaEC.zip"
   name "FirmaEC"
   desc "Firma electrónica en Ecuador"
-  homepage "https://www.firmadigital.gob.ec"
+  homepage "https://www.firmadigital.gob.ec/"
 
   livecheck do
     url "https://www.firmadigital.gob.ec/registro-de-cambios-de-firmaecchangelog/"
@@ -19,6 +19,6 @@ cask "firmaec" do
   zap trash: [
     "~/firmadigital.log",
     "~/firmadigital.log.lck",
-    "~/firmadigital.properties"
+    "~/firmadigital.properties",
   ]
 end

--- a/Casks/firmaec.rb
+++ b/Casks/firmaec.rb
@@ -1,0 +1,24 @@
+cask "firmaec" do
+  version "2.10.0"
+  sha256 :no_check
+
+  url "https://www.firmadigital.gob.ec/firmaec/FirmaEC.zip"
+  name "FirmaEC"
+  desc "Firma electrónica en Ecuador"
+  homepage "https://www.firmadigital.gob.ec"
+
+  livecheck do
+    url "https://www.firmadigital.gob.ec/registro-de-cambios-de-firmaecchangelog/"
+    regex(/Versión (\d+(?:\.\d+)+) \(/i)
+  end
+
+  container type: :zip
+
+  app "FirmaEC/FirmaEC.app"
+
+  zap trash: [
+    "~/firmadigital.log",
+    "~/firmadigital.log.lck",
+    "~/firmadigital.properties"
+  ]
+end

--- a/Casks/firmaec.rb
+++ b/Casks/firmaec.rb
@@ -4,15 +4,13 @@ cask "firmaec" do
 
   url "https://www.firmadigital.gob.ec/firmaec/FirmaEC.zip"
   name "FirmaEC"
-  desc "Firma electrónica en Ecuador"
+  desc "Sign documents through digital certificates"
   homepage "https://www.firmadigital.gob.ec/"
 
   livecheck do
     url "https://www.firmadigital.gob.ec/registro-de-cambios-de-firmaecchangelog/"
-    regex(/Versión (\d+(?:\.\d+)+) \(/i)
+    regex(/Versión\s*(\d+(?:\.\d+)+)/i)
   end
-
-  container type: :zip
 
   app "FirmaEC/FirmaEC.app"
 

--- a/Casks/firmaec.rb
+++ b/Casks/firmaec.rb
@@ -13,6 +13,7 @@ cask "firmaec" do
   end
 
   app "FirmaEC/FirmaEC.app"
+  app "FirmaEC/FirmaECTransversal.app"
 
   zap trash: [
     "~/firmadigital.log",


### PR DESCRIPTION
FirmaEC.app is the official digital signature (_firma electrónica_) recognized by Ecuadorian authorities.

The URL is sadly unversioned, but I added a `livecheck` for checking new versions on the official website.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
