### PR TITLE
Update JASP to version 0.15.0.0

### DIFF
--- a/Casks/jasp.rb
+++ b/Casks/jasp.rb
@@ -1,15 +1,10 @@
 cask "jasp" do
-  version "0.14.1.0"
-
-  if MacOS.version <= :mojave
-    sha256 "8fe3cf08058576e54c78e1d87a2cfe159dead894c26aca37fd6fa610a5fb3cf7"
-
-    url "https://static.jasp-stats.org/JASP-#{version}-preCatalina.dmg"
-  else
-    sha256 "ea682a95e51f9f0cd3d92b49eac18831c38de1e03f90020321cfce3eba5a0ee6"
-
-    url "https://static.jasp-stats.org/JASP-#{version}-postMojave.dmg"
-  end
+  version "0.15.0.0"
+  
+  sha256 "df1b186c23c739654d4af67ab225aa09a446e165efb2a70a9fee474506efadf9"
+  
+  url "https://static.jasp-stats.org/JASP-#{version}.dmg"
+  
   appcast "https://jasp-stats.org/download/",
           must_contain: version.sub(/(.0)+$/, "")
   name "JASP"

--- a/Casks/jasp.rb
+++ b/Casks/jasp.rb
@@ -1,10 +1,8 @@
 cask "jasp" do
   version "0.15.0.0"
-  
   sha256 "df1b186c23c739654d4af67ab225aa09a446e165efb2a70a9fee474506efadf9"
-  
+
   url "https://static.jasp-stats.org/JASP-#{version}.dmg"
-  
   appcast "https://jasp-stats.org/download/",
           must_contain: version.sub(/(.0)+$/, "")
   name "JASP"


### PR DESCRIPTION
Note: beginning with version 0.15.0.0, JASP no longer has separate download for pre-Catalina

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask <cask>` is error-free.
- [x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
