### PR TITLE
Update amazon-music from 8.6.0.2271 to 8.7.0.2277 and fix url

### DIFF
--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,9 +1,9 @@
 cask "amazon-music" do
-  version "8.6.0.2271,22710610_e91247c784977e6c258edc2ea5d1a151"
-  sha256 "85d69d9a46296c43936344c1dccb009cbba90ca85c3d7b60620540aff3155ef8"
+  version "8.7.1.2286,2286920_c59e08a0c650d2facfc92e4bb1e4dba8"
+  sha256 "49a5ecb3d3e18e8b7e8c245aa045f308c03d77f5d6c5a08393d24f0d9910d18c"
 
-  url "https://morpho-releases.s3-us-west-2.amazonaws.com/mac/#{version.after_comma}/Amazon+Music+Installer.dmg",
-      verified: "morpho-releases.s3-us-west-2.amazonaws.com/mac/"
+  url "https://d2j9xt6n9dg5d3.cloudfront.net/mac/#{version.after_comma}/Amazon+Music+Installer.dmg",
+      verified: "d2j9xt6n9dg5d3.cloudfront.net/mac/"
   appcast "https://www.amazon.com/gp/dmusic/desktop/downloadPlayer",
           must_contain: version.after_comma
   name "Amazon Music"

--- a/Casks/amazon-music.rb
+++ b/Casks/amazon-music.rb
@@ -1,6 +1,6 @@
 cask "amazon-music" do
-  version "8.7.1.2286,2286920_c59e08a0c650d2facfc92e4bb1e4dba8"
-  sha256 "49a5ecb3d3e18e8b7e8c245aa045f308c03d77f5d6c5a08393d24f0d9910d18c"
+  version "8.7.0.2277,2277722_956ebb4b9962d984cd83152141e48b98"
+  sha256 "3d75f4a427648236217b72d37a52900098775cebdcedd9638b2ae6126ae3c0bf"
 
   url "https://d2j9xt6n9dg5d3.cloudfront.net/mac/#{version.after_comma}/Amazon+Music+Installer.dmg",
       verified: "d2j9xt6n9dg5d3.cloudfront.net/mac/"


### PR DESCRIPTION
Update amazon-music from 8.6.0.2271 to 8.7.0.2277 and fix url.
Old url is not available.
```
==> Downloading https://morpho-releases.s3-us-west-2.amazonaws.com/mac/22710610_e91247c784977e6c258edc2ea5d1a151/Amazon+Music+Installer.dmg
#=#=-#  #
curl: (22) The requested URL returned error: 403 Forbidden
Error: Download failed on Cask 'amazon-music' with message: Download failed: https://morpho-releases.s3-us-west-2.amazonaws.com/mac/22710610_e91247c784977e6c258edc2ea5d1a151/Amazon+Music+Installer.dmg
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.