### PR TITLE
free-download-manager: zap folders from 6th series

### DIFF
--- a/Casks/free-download-manager.rb
+++ b/Casks/free-download-manager.rb
@@ -28,8 +28,15 @@ cask "free-download-manager" do
 
   zap trash: [
     "~/Library/Application Support/Free Download Manager",
+    "~/Library/Application Support/Softdeluxe/Free Download Manager",
     "~/Library/Caches/org.freedownloadmanager.fdm#{version.major}",
+    "~/Library/Caches/Softdeluxe/Free Download Manager",
     "~/Library/Preferences/org.freedownloadmanager.fdm#{version.major}.plist",
+    "~/Library/Preferences/com.softdeluxe.Free Download Manager.plist",
     "~/Library/Saved Application State/org.freedownloadmanager.fdm#{version.major}.savedState",
-  ]
+  ],
+      rmdir: [
+        "~/Library/Application Support/Softdeluxe",
+        "~/Library/Caches/Softdeluxe/",
+      ]
 end


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

I intentionaly left folders from 5th series.