### PR TITLE
firecamp upgraded to v2.2.0

### DIFF
--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.1.2"
-  sha256 "4932fde45878593ae96a4255b0267322637fc7369a0251567d5f93e9c15a7ff0"
+  version "2.2.0"
+  sha256 "9ac0412d0fa7cf18c7168838db7c442dc72fbb3af2c5c760ad1e34d57342f0f0"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.