### PR TITLE
Update eloston-chromium from 94.0.4606.54-1.1 to 94.0.4606.61-1.1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,10 +1,10 @@
 cask "eloston-chromium" do
   if Hardware::CPU.intel?
-    version "94.0.4606.54-1.1_x86-64"
-    sha256 "107b6f84558912ccd2012fe49aec880ae9bc0f613c4fd8190c86a26e414251a0"
+    version "94.0.4606.61-1.1_x86-64"
+    sha256 "57482a0fab55b632dddf2fb568c5b77e989c46b0700ee7d45cd5a75379a2478c"
   else
-    version "94.0.4606.54-1.1_arm64"
-    sha256 "6a3e33b01dc7f5c435621875f3fa4cb4ebf01d9059cc9fcc72bcc11b78351e22"
+    version "94.0.4606.61-1.1_arm64"
+    sha256 "0fb942f644372116085642811c5c81addd50caee2d5ab2a287b3b4dc86eec53e"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}-macos.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

