### PR TITLE
Revert "Update bitwarden to use the universal binary on Apple silicon"

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,8 +1,8 @@
 cask "bitwarden" do
   version "1.28.3"
-  sha256 "04fdf5f15a046d00f47bdf40483abf73626cb50728256c18ae1397012ceb22b7"
+  sha256 "19d4845b817b8b5098ac4927446c07adf8461b985e6b18ac3102a0313949f15f"
 
-  url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-universal.pkg",
+  url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-mac.zip",
       verified: "github.com/bitwarden/desktop/"
   name "Bitwarden"
   desc "Desktop password and login vault"
@@ -15,21 +15,21 @@ cask "bitwarden" do
 
   auto_updates true
 
-  pkg "Bitwarden-#{version}-universal.pkg"
+  app "Bitwarden.app"
 
-  uninstall pkgutil: [
+  uninstall quit: [
     "com.bitwarden.desktop",
     "com.bitwarden.desktop.helper",
   ]
 
   zap trash: [
+    "~/Library/Logs/Bitwarden",
     "~/Library/Application Support/Bitwarden",
     "~/Library/Caches/com.bitwarden.desktop",
     "~/Library/Caches/com.bitwarden.desktop.ShipIt",
-    "~/Library/Logs/Bitwarden",
     "~/Library/Preferences/ByHost/com.bitwarden.desktop.ShipIt.*.plist",
-    "~/Library/Preferences/com.bitwarden.desktop.helper.plist",
     "~/Library/Preferences/com.bitwarden.desktop.plist",
+    "~/Library/Preferences/com.bitwarden.desktop.helper.plist",
     "~/Library/Saved Application State/com.bitwarden.desktop.savedState",
   ]
 end


### PR DESCRIPTION
… (#111732)"

This reverts commit 54d619c2cbf3a55db51bc0589b1394b57fbc8bb9.

**This is due to the application not being able to be opened once installed, with the message, "You do not have permission to open the application 'Bitwarden'", being displayed.**

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
