### PR TITLE
fontstand: update livecheck strategy, add zap

### DIFF
--- a/Casks/fontstand.rb
+++ b/Casks/fontstand.rb
@@ -1,5 +1,5 @@
 cask "fontstand" do
-  version "2.4.0,105"
+  version "2.4.0"
   sha256 :no_check
 
   url "https://fontstand.com/apps/download/69"
@@ -9,7 +9,13 @@ cask "fontstand" do
 
   livecheck do
     url :url
-    strategy :extract_plist
+    regex(/Fontstand[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
+    strategy :header_match do |headers, regex|
+      match = headers["content-disposition"].match(regex)[1]
+      next if match.blank?
+
+      match.tr("-",".")
+    end
   end
 
   app "Fontstand.app"

--- a/Casks/fontstand.rb
+++ b/Casks/fontstand.rb
@@ -19,4 +19,13 @@ cask "fontstand" do
   end
 
   app "Fontstand.app"
+
+  zap trash: [
+    "~/Library/Application Support/Fontstand",
+    "~/Library/Application Support/Fontstand Agent",
+    "~/Library/Application Support/com.fontstand-bv.mac.Fontstand",
+    "~/Library/Caches/com.fontstand-bv.mac.Fontstand",
+    "~/Library/LaunchAgents/com.fontstand-bv.mac.Fontstand-Agent.plist",
+    "~/Library/Preferences/com.fontstand-bv.mac.Fontstand.plist",
+  ]
 end

--- a/Casks/fontstand.rb
+++ b/Casks/fontstand.rb
@@ -14,7 +14,7 @@ cask "fontstand" do
       match = headers["content-disposition"].match(regex)[1]
       next if match.blank?
 
-      match.tr("-",".")
+      match.tr("-", ".")
     end
   end
 


### PR DESCRIPTION
Updated to not use the `:extract_plist` strategy