### PR TITLE
Update for Multipass 1.7.2

### DIFF
--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -1,6 +1,6 @@
 cask "multipass" do
-  version "1.7.0"
-  sha256 "a576100b495acbde4fcf7d4943af8d57c4fb9ee30fe8852daa0d4f7ce3a7ec7b"
+  version "1.7.2"
+  sha256 "767f6e600e9dfc218a2f5f8fe0693e0cfefa539d21ef8f8851f7b611b1b7b275"
 
   url "https://github.com/canonical/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   name "Multipass"

--- a/Casks/multipass.rb
+++ b/Casks/multipass.rb
@@ -21,18 +21,15 @@ cask "multipass" do
             pkgutil:   "com.canonical.multipass.*",
             delete:    [
               "/Applications/Multipass.app",
+              "/Library/Application Support/com.canonical.multipass",
+              "/Library/Logs/Multipass",
               "/usr/local/bin/multipass",
               "/usr/local/etc/bash_completion.d/multipass",
-              "/var/root/Library/Caches/multipassd",
-              "/Library/Application Support/com.canonical.multipass",
             ]
 
   zap trash: [
     "~/Library/Application Support/multipass",
     "~/Library/Application Support/multipass-gui",
     "~/Library/Preferences/multipass",
-    "/var/root/Library/Application Support/multipassd",
-    "/var/root/Library/Preferences/multipassd",
-    "/Library/Logs/Multipass",
   ]
 end


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

NB: CI will fail, as this is a VM manager and the CI machines have no CPU support for them.