### PR TITLE
apache-directory-studio: add java vm caveat

### DIFF
--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -17,10 +17,11 @@ cask "apache-directory-studio" do
   zap trash: "~/.ApacheDirectoryStudio"
 
   caveats do
-    depends_on_java "8+"
+    depends_on_java "11+"
     <<~EOS
-      You might need to configure Java version by editing the following file:
-        #{appdir}/ApacheDirectoryStudio.app/Contents/Eclipse/ApacheDirectoryStudio.ini
+      To set the Java VM to use:
+
+        https://directory.apache.org/studio/faqs.html#how-to-set-the-java-vm-to-use
     EOS
   end
 end

--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -18,5 +18,9 @@ cask "apache-directory-studio" do
 
   caveats do
     depends_on_java "8+"
+    <<~EOS
+      You might need to configure Java version by editing the following file:
+        #{appdir}/ApacheDirectoryStudio.app/Contents/Eclipse/ApacheDirectoryStudio.ini
+    EOS
   end
 end


### PR DESCRIPTION
Apache Directory Studio might not start with a default java vm setting. Adding a caveat to let the user know where to configure the path.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
