### PR TITLE
fix mweb-pro 4.1.9 sha256 errors

### DIFF
--- a/Casks/mweb-pro.rb
+++ b/Casks/mweb-pro.rb
@@ -4,11 +4,11 @@ cask "mweb-pro" do
   if MacOS.version <= :catalina
     url "https://cdn.mwebapp.cn/MWebPro#{version.no_dots}_catalina.dmg",
         verified: "cdn.mwebapp.cn/"
-    sha256 "2e7595eef4acc0553adf8ea2ed1ba537f8f2862f84b027f26714b4486a75af85"
+    sha256 "c08a98550039e54ca504f22c213055d3c9982f9a3cbcddda00f1feecdfa8b28f"
   else
     url "https://cdn.mwebapp.cn/MWebPro#{version.no_dots}.dmg",
         verified: "cdn.mwebapp.cn/"
-    sha256 "b7b49b7684bdadeaa5cddc7228043076ff297b88cc17ffc845d5c9abea964baf"
+    sha256 "fea37f64ecd3dfe85bcde7b3293f40cdb3faacfa469a646cc1dfcb30696b32f3"
   end
 
   name "MWeb Pro"


### PR DESCRIPTION
Fix sha256 errors, make it consistent with original files downloaded from official download page: <https://www.mweb.im/download.html>. 

The **DIRECT** download URLs are as below:
**MWebPro419.dmg**: <https://cdn.mwebapp.cn/MWebPro419.dmg>
**MWebPro419_catalina.dmg**: <https://cdn.mwebapp.cn/MWebPro419_catalina.dmg>

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
