### PR TITLE
Rename rancher to rancher-desktop

### DIFF
--- a/Casks/rancher-desktop.rb
+++ b/Casks/rancher-desktop.rb
@@ -1,4 +1,4 @@
-cask "rancher" do
+cask "rancher-desktop" do
   version "0.5.0"
   sha256 "0ebdfb3e070e1c525a08730ccea761a040d366fa800c735870ff328080f8fa55"
 

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -26,7 +26,7 @@
   "ql-ansilove": "all",
   "profilecreator": "all",
   "qdesktop": "all",
-  "rancher": "all",
+  "rancher-desktop": "all",
   "seaglass": "all",
   "servpane": "all",
   "shadowsocksx-ng-r": "all",


### PR DESCRIPTION
The application is called "Rancher Desktop" not "Rancher", see https://rancherdesktop.io/.

"Rancher" is a different product, multi-cluster Kubernetes Management Solution and not a desktop app (https://rancher.com/products/rancher/).

The cask was just added a few days ago. Are any other steps necessary apart from renaming the file and the token?

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


