### PR TITLE
Add "Ricochet Refresh.app" v3.0.10

### DIFF
--- a/Casks/ricochet-refresh.rb
+++ b/Casks/ricochet-refresh.rb
@@ -6,7 +6,7 @@ cask "ricochet-refresh" do
       verified: "github.com/blueprint-freespeech/ricochet-refresh/"
   name "ricochet-refresh"
   desc "Private and anonymous instant messaging over tor"
-  homepage "https://www.ricochetrefresh.net"
+  homepage "https://www.ricochetrefresh.net/"
 
   app "Ricochet Refresh.app"
 

--- a/Casks/ricochet-refresh.rb
+++ b/Casks/ricochet-refresh.rb
@@ -4,9 +4,15 @@ cask "ricochet-refresh" do
 
   url "https://github.com/blueprint-freespeech/ricochet-refresh/releases/download/v#{version}-release/ricochet-refresh-#{version}-macos-x86_64.dmg",
       verified: "github.com/blueprint-freespeech/ricochet-refresh/"
-  name "ricochet-refresh"
+  name "Ricochet Refresh"
   desc "Private and anonymous instant messaging over tor"
   homepage "https://www.ricochetrefresh.net/"
+
+  livecheck do
+    url "https://github.com/blueprint-freespeech/ricochet-refresh/releases"
+    strategy :page_match
+    regex(/ricochet[._-]refresh[._-]v?(\d+(?:\.\d+)*)[._-]macos[._-]x86[._-]64\.dmg/i)
+  end
 
   app "Ricochet Refresh.app"
 

--- a/Casks/ricochet-refresh.rb
+++ b/Casks/ricochet-refresh.rb
@@ -1,0 +1,12 @@
+cask "ricochet-refresh" do
+  version "3.0.10"
+  sha256 "c9751b6f78365777f083d619aa36947bc83ae9043b4b74f099f884b70d8398ef"
+
+  url "https://github.com/blueprint-freespeech/ricochet-refresh/releases/download/v#{version}-release/ricochet-refresh-#{version}-macos-x86_64.dmg",
+      verified: "github.com/blueprint-freespeech/ricochet-refresh/"
+  name "ricochet-refresh"
+  desc "Private and anonymous instant messaging over tor"
+  homepage "ricochetrefresh.net"
+
+  app "Ricochet Refresh.app"
+end

--- a/Casks/ricochet-refresh.rb
+++ b/Casks/ricochet-refresh.rb
@@ -6,7 +6,7 @@ cask "ricochet-refresh" do
       verified: "github.com/blueprint-freespeech/ricochet-refresh/"
   name "ricochet-refresh"
   desc "Private and anonymous instant messaging over tor"
-  homepage "ricochetrefresh.net"
+  homepage "https://www.ricochetrefresh.net"
 
   app "Ricochet Refresh.app"
 

--- a/Casks/ricochet-refresh.rb
+++ b/Casks/ricochet-refresh.rb
@@ -9,4 +9,6 @@ cask "ricochet-refresh" do
   homepage "ricochetrefresh.net"
 
   app "Ricochet Refresh.app"
+
+  zap trash: "~/Library/Application Support/Ricochet-Refresh"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Hi
We're looking to get [Ricochet Refresh](ricochetrefresh.net) integrated into homebrew.
Fixed, see comment. ~~One issue was encountered when running `brew audit --cask ricochet-refresh`, see output:~~
```
noone@noone homebrew-cask % brew audit --new-cask ricochet-refresh
audit for ricochet-refresh: failed
 - exception while auditing ricochet-refresh: undefined method `downcase' for nil:NilClass
Error: 1 problem in 1 cask detected
noone@noone homebrew-cask % uname -a
Darwin noone.modem 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101 x86_64
noone@noone homebrew-cask %
```
~~Not sure if this is an error on my part or if it's a bug in `brew audit` (I tried to follow the docs and keep it fairly simple, but granted this is my first time packaging for homebrew).~~

Cheers,
M