### PR TITLE
au-lab: Update URLs

### DIFF
--- a/Casks/au-lab.rb
+++ b/Casks/au-lab.rb
@@ -2,10 +2,10 @@ cask "au-lab" do
   version "2.3"
   sha256 :no_check
 
-  url "https://images.apple.com/itunes/mastered-for-itunes/docs/au_lab.zip"
+  url "https://www.apple.com/apple-music/apple-digital-masters/docs/au_lab.zip"
   name "AU Lab"
   desc "Digital audio mixing application"
-  homepage "https://www.apple.com/itunes/mastered-for-itunes/"
+  homepage "https://www.apple.com/apple-music/apple-digital-masters/"
 
   app "AU Lab.app"
 end


### PR DESCRIPTION
Apple have moved the AU Lab download. The old homepage redirects, however the old download URL does not.

The version has not changed.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.