### PR TITLE
Update lagrange from 1.7.0 to 1.7.1

### DIFF
--- a/Casks/lagrange.rb
+++ b/Casks/lagrange.rb
@@ -4,7 +4,7 @@ cask "lagrange" do
   if Hardware::CPU.intel?
     sha256 "a67bda7454ed6060a09d938deed006c4b4078af28559191f792e19a6904554d8"
 
-    url "https://github.com/skyjake/lagrange/releases/download/v#{version}/lagrange_v#{version}-macos10.13-x86_64.tbz",
+    url "https://github.com/skyjake/lagrange/releases/download/v#{version}/lagrange_v#{version}_macos10.13-x86_64.tbz",
         verified: "github.com/skyjake/lagrange/"
   else
     sha256 "5acb33653df9d7803ae1147fd1243ea80f22593412dd06385087cf6ac9258716"

--- a/Casks/lagrange.rb
+++ b/Casks/lagrange.rb
@@ -1,13 +1,13 @@
 cask "lagrange" do
-  version "1.7.0"
+  version "1.7.1"
 
   if Hardware::CPU.intel?
-    sha256 "7f0891fa145703409157835c9b0379971f7c49de1ea745b6270da9d66b4d6eab"
+    sha256 "a67bda7454ed6060a09d938deed006c4b4078af28559191f792e19a6904554d8"
 
-    url "https://github.com/skyjake/lagrange/releases/download/v#{version}/lagrange_v#{version}-1_macos10.13-x86_64.tbz",
+    url "https://github.com/skyjake/lagrange/releases/download/v#{version}/lagrange_v#{version}-macos10.13-x86_64.tbz",
         verified: "github.com/skyjake/lagrange/"
   else
-    sha256 "f47559f5563db44c4020ff0f6e7fc48056a1ac3c1d503d028f87b30ab2143b7c"
+    sha256 "5acb33653df9d7803ae1147fd1243ea80f22593412dd06385087cf6ac9258716"
 
     url "https://github.com/skyjake/lagrange/releases/download/v#{version}/lagrange_v#{version}_macos11.0-arm64.tbz",
         verified: "github.com/skyjake/lagrange/"


### PR DESCRIPTION
Bumping the version manually because `bump-cask-pr` tries to use the wrong URL for the macOS 10.13 version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.