### PR TITLE
gqrx: Update to 2.14.5 and use the new GitHub URL

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,9 +1,9 @@
 cask "gqrx" do
-  version "2.14.4"
-  sha256 "4ceafde17ccb4a8e5780b3df490f7b9346fb60f2338ec6b7856e9f04a44b806c"
+  version "2.14.5"
+  sha256 "d72db2a8aec6c8005ff27ca0d51703ed574a57552bfda438dd472a08d1e1e285"
 
-  url "https://github.com/csete/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg",
-      verified: "github.com/csete/gqrx/"
+  url "https://github.com/gqrx-sdr/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg",
+      verified: "github.com/gqrx-sdr/gqrx/"
   name "Gqrx"
   desc "Software-defined radio receiver powered by GNU Radio and Qt"
   homepage "https://gqrx.dk/"


### PR DESCRIPTION
Gqrx recently moved from the original author's personal GitHub account to a dedicated GitHub organization (https://github.com/gqrx-sdr/). Also, I released version 2.14.5 yesterday: https://github.com/gqrx-sdr/gqrx/releases/tag/v2.14.5

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.