### PR TITLE
TeamViewer: fix path to installer package

### DIFF
--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -53,6 +53,7 @@ cask "teamviewer" do
     "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
     "~/Library/Application Support/TeamViewer",
     "~/Library/Caches/com.teamviewer.TeamViewer",
+    "~/Library/Caches/TeamViewer",
     "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
     "~/Library/Logs/TeamViewer",
     "~/Library/Preferences/com.teamviewer.TeamViewer.plist",

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -3,7 +3,7 @@ cask "teamviewer" do
     version "15.2.2756"
   else
     version "15.22.3"
-    
+
     livecheck do
       url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"
       strategy :sparkle

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -3,6 +3,11 @@ cask "teamviewer" do
     version "15.2.2756"
   else
     version "15.22.3"
+    
+    livecheck do
+      url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"
+      strategy :sparkle
+    end
   end
   sha256 :no_check
 
@@ -10,11 +15,6 @@ cask "teamviewer" do
   name "TeamViewer"
   desc "Remote access and connectivity software focused on security"
   homepage "https://www.teamviewer.com/"
-
-  livecheck do
-    url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"
-    strategy :sparkle
-  end
 
   auto_updates true
   conflicts_with cask: "teamviewer-host"

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -15,7 +15,7 @@ cask "teamviewer" do
   auto_updates true
   conflicts_with cask: "teamviewer-host"
 
-  pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+  pkg "Install TeamViewer.pkg"
 
   uninstall delete:    [
     "#{staged_path}/#{token}", # This Cask should be uninstalled manually.

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,5 +1,9 @@
 cask "teamviewer" do
-  version "15.22.3"
+  if MacOS.version <= :high_sierra
+    version "15.2.2756"
+  else
+    version "15.22.3"
+  end
   sha256 :no_check
 
   url "https://download.teamviewer.com/download/TeamViewer.dmg"
@@ -14,8 +18,13 @@ cask "teamviewer" do
 
   auto_updates true
   conflicts_with cask: "teamviewer-host"
+  depends_on macos: ">= :el_capitan"
 
-  pkg "Install TeamViewer.pkg"
+  if MacOS.version <= :high_sierra
+    pkg "Install TeamViewer.pkg"
+  else
+    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+  end
 
   uninstall delete:    [
     "#{staged_path}/#{token}", # This Cask should be uninstalled manually.

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,6 +1,11 @@
 cask "teamviewer" do
   if MacOS.version <= :high_sierra
     version "15.2.2756"
+
+    livecheck do
+      url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.11.1&type=1&channel=1"
+      strategy :sparkle
+    end
   else
     version "15.22.3"
 


### PR DESCRIPTION
Fixes this error I got with the latest TeamViewer version in master:

==> Downloading https://download.teamviewer.com/download/TeamViewer.dmg
==> Downloading from https://dl.teamviewer.com/download/version_15x/15.2.2756/TeamViewer.dmg
Warning: No checksum defined for cask 'teamviewer', skipping verification.
==> Installing Cask teamviewer
==> Running installer for teamviewer; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
==> Purging files for version 15.22.3 of Cask teamviewer
Error: Could not find PKG source file 'Install Install TeamViewer.pkg', found 'Install TeamViewer.pkg' instead.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.