### PR TITLE
Add `cert_error_allowlist` to `audit_exceptions`

### DIFF
--- a/audit_exceptions/cert_error_allowlist.json
+++ b/audit_exceptions/cert_error_allowlist.json
@@ -1,0 +1,4 @@
+{
+  "accurics": "https://www.accurics.com/",
+  "canva": "https://www.canva.com/"
+}


### PR DESCRIPTION
This PR corresponds with https://github.com/Homebrew/brew/pull/12185. It adds a list to the `audit_exceptions` directory to contain names and homepages for casks with homepages that are unreachable due to the Cloudflare issue.

@Homebrew/cask once this is merged, please add casks (and their homepages) to this list _instead of_ merging a PR with a failed audit. All you need to do is add a new line to the `audit_exceptions/cert_error_allowlist.json` file with the cask token and the homepage that is failing. Pushing that change (whether in a separate commit or ammending an existing one) should fix the failure and CI should be green.

As always, feel free to ping me once this is merged if it doesn't seem to be working right.
