### PR TITLE
Add `secure_connection_audit_skiplist` to `audit_exceptions`

### DIFF
--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -1,0 +1,3 @@
+{
+  "jaxx-liberty": "https://jaxx.io/"
+}


### PR DESCRIPTION
This PR corresponds with https://github.com/Homebrew/brew/pull/12185 (they can be merged in either order). It adds a list to the `audit_exceptions` directory to contain names and homepages for casks with homepages that are unreachable due to the Cloudflare issue.

@Homebrew/cask once this is merged, please add casks (and their homepages) to this list _instead of_ merging a PR with a failed audit. All you need to do is add a new line to the `audit_exceptions/cert_error_allowlist.json` file with the cask token and the homepage that is failing. Pushing that change (whether in a separate commit or ammending an existing one) should fix the failure and CI should be green.

As always, feel free to ping me once this is merged if it doesn't seem to be working right.

Currently, the list contains `accurics`, `badlion-client`, `canva`, and `ilok-license-manager` because those are the casks that I know are failing. If there are other casks that are known to have this issue, let me know so I can add them now. Otherwise, I figure this list will just be built up over time.

(Sorry for the double ping. I messed up my branches for some reason and needed to remake the PR)
