### PR TITLE
Update swiftformat-for-xcode from 0.48.12 to 0.48.13

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "swiftformat-for-xcode" do
-  version "0.48.12"
-  sha256 "0252f0bb95e191f644146576583248cb2647a27f5905b50151f39d07be502643"
+  version "0.48.13"
+  sha256 "c679e8d8709349f5ae93d7832ec357ab48e866d0f5b25b0cf06a9ca852008360"
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   name "SwiftFormat for Xcode"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.