### PR TITLE
Add IBM Semeru Cask

### DIFF
--- a/Casks/semeru-jdk-open.rb
+++ b/Casks/semeru-jdk-open.rb
@@ -16,7 +16,7 @@ cask "semeru-jdk-open" do
     end
   end
 
-  pkg "ibm-semeru-open-jdk_x64_mac_#{version.before_comma}_#{version.after_comma}.pkg"
+  pkg "ibm-semeru-open-jdk_x64_mac_#{version.before_comma.tr("+", "_")}_#{version.after_comma}.pkg"
 
   uninstall pkgutil: "net.ibm-semeru-open.#{version.major}.jdk"
 end

--- a/Casks/semeru-jdk-open.rb
+++ b/Casks/semeru-jdk-open.rb
@@ -2,35 +2,22 @@ cask "semeru-jdk-open" do
   version "16.0.2+7,openj9-0.27.0"
   sha256 "151dfbf918682663e28187ed3b59b06e8c5c8ad39f57dada42612aa8290e8977"
 
-  version_before_plus = version.before_comma.sub(/\+\d+/, "")
-  version_after_plus = version.before_comma.sub(/^[^+]+\+/, "")
-
-  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version_before_plus}%2B#{version_after_plus}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version_before_plus}_#{version_after_plus}_#{version.after_comma}.pkg",
+  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version.before_comma}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version.before_comma}_#{version.after_comma}.pkg",
       verified: "github.com/ibmruntimes/semeru#{version.major}-binaries/"
   name "IBM Semeru Runtime (JDK) Open Edition"
   desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"
   homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
 
-  # The download page is rendered using JavaScript. The source json data is embedded
-  # in a <script> at the bottom of the page. We match against this json data.
   livecheck do
     url "https://developer.ibm.com/languages/java/semeru-runtimes/downloads"
-    regex(%r{
-      downloadLink\s*:\s*'.*?/ibm-semeru-open-jdk_x64_mac_ # blurb
-      (\d+(?:\.\d+)*)                                      # version_before_plus
-      [._-]                                                # separator
-      (\d+)                                                # version_after_plus
-      [._-]                                                # separator
-      (openj9[._-]\d+(?:\.\d+)*)\.pkg                      # version.after_comma
-    }xi)
-    strategy :page_match do |page|
-      page.scan(regex).map do |match|
-        (match[0] && match[1] && match[2]) ? "#{match[0]}+#{match[1]},#{match[2]}" : ""
-      end
+    regex(/ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)
+        .map { |match| "#{match[0].gsub("_","+")},#{match[1]}"}
     end
   end
 
-  pkg "ibm-semeru-open-jdk_x64_mac_#{version_before_plus}_#{version_after_plus}_#{version.after_comma}.pkg"
+  pkg "ibm-semeru-open-jdk_x64_mac_#{version.before_comma}_#{version.after_comma}.pkg"
 
   uninstall pkgutil: "net.ibm-semeru-open.#{version.major}.jdk"
 end

--- a/Casks/semeru-jdk-open.rb
+++ b/Casks/semeru-jdk-open.rb
@@ -10,10 +10,9 @@ cask "semeru-jdk-open" do
 
   livecheck do
     url "https://developer.ibm.com/languages/java/semeru-runtimes/downloads"
-    regex(/ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg/i)
+    regex(%r{["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg["']}i)
     strategy :page_match do |page, regex|
-      page.scan(regex)
-        .map { |match| "#{match[0].gsub("_","+")},#{match[1]}"}
+      page.scan(regex).map { |match| "#{match[0].tr("_", "+")},#{match[1]}" }
     end
   end
 

--- a/Casks/semeru-jdk-open.rb
+++ b/Casks/semeru-jdk-open.rb
@@ -10,7 +10,7 @@ cask "semeru-jdk-open" do
 
   livecheck do
     url "https://developer.ibm.com/languages/java/semeru-runtimes/downloads"
-    regex(%r{["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg["']}i)
+    regex(/["'][^"']*ibm-semeru-open-jdk_x64_mac[._-](\d+(?:[._]\d+)+)[._-](.+)\.pkg["']/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0].tr("_", "+")},#{match[1]}" }
     end

--- a/Casks/semeru-jdk-open.rb
+++ b/Casks/semeru-jdk-open.rb
@@ -1,0 +1,36 @@
+cask "semeru-jdk-open" do
+  version "16.0.2+7,openj9-0.27.0"
+  sha256 "151dfbf918682663e28187ed3b59b06e8c5c8ad39f57dada42612aa8290e8977"
+
+  version_before_plus = version.before_comma.sub(/\+\d+/, "")
+  version_after_plus = version.before_comma.sub(/^[^+]+\+/, "")
+
+  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version_before_plus}%2B#{version_after_plus}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version_before_plus}_#{version_after_plus}_#{version.after_comma}.pkg",
+      verified: "github.com/ibmruntimes/semeru#{version.major}-binaries/"
+  name "IBM Semeru Runtime (JDK) Open Edition"
+  desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"
+  homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
+
+  # The download page is rendered using JavaScript. The source json data is embedded
+  # in a <script> at the bottom of the page. We match against this json data.
+  livecheck do
+    url "https://developer.ibm.com/languages/java/semeru-runtimes/downloads"
+    regex(%r{
+      downloadLink\s*:\s*'.*?/ibm-semeru-open-jdk_x64_mac_ # blurb
+      (\d+(?:\.\d+)*)                                      # version_before_plus
+      [._-]                                                # separator
+      (\d+)                                                # version_after_plus
+      [._-]                                                # separator
+      (openj9[._-]\d+(?:\.\d+)*)\.pkg                      # version.after_comma
+    }xi)
+    strategy :page_match do |page|
+      page.scan(regex).map do |match|
+        (match[0] && match[1] && match[2]) ? "#{match[0]}+#{match[1]},#{match[2]}" : ""
+      end
+    end
+  end
+
+  pkg "ibm-semeru-open-jdk_x64_mac_#{version_before_plus}_#{version_after_plus}_#{version.after_comma}.pkg"
+
+  uninstall pkgutil: "net.ibm-semeru-open.#{version.major}.jdk"
+end

--- a/Casks/semeru-jdk-open.rb
+++ b/Casks/semeru-jdk-open.rb
@@ -2,7 +2,7 @@ cask "semeru-jdk-open" do
   version "16.0.2+7,openj9-0.27.0"
   sha256 "151dfbf918682663e28187ed3b59b06e8c5c8ad39f57dada42612aa8290e8977"
 
-  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version.before_comma}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version.before_comma}_#{version.after_comma}.pkg",
+  url "https://github.com/ibmruntimes/semeru#{version.major}-binaries/releases/download/jdk-#{version.before_comma}_#{version.after_comma}/ibm-semeru-open-jdk_x64_mac_#{version.before_comma.tr("+", "_")}_#{version.after_comma}.pkg",
       verified: "github.com/ibmruntimes/semeru#{version.major}-binaries/"
   name "IBM Semeru Runtime (JDK) Open Edition"
   desc "Production-ready JDK with the OpenJDK class libraries and the Eclipse OpenJ9 JVM"


### PR DESCRIPTION
I've verified that:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask semeru-jdk-open` is error-free.
- [x] `brew style --fix semeru-jdk-open` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask semeru-jdk-open` worked successfully.
- [x] `brew install --cask semeru-jdk-open` worked successfully.
- [x] `brew uninstall --cask semeru-jdk-open` worked successfully.
