### PR TITLE
kryoflux: Add caveat

### DIFF
--- a/Casks/kryoflux.rb
+++ b/Casks/kryoflux.rb
@@ -23,4 +23,8 @@ cask "kryoflux" do
     "~/Library/Preferences/com.kryoflux.kryoflux-ui.plist",
     "~/.kryoflux",
   ]
+
+  caveats do
+    files_in_usr_local
+  end
 end


### PR DESCRIPTION
This cask installs `/usr/local/lib/libCAPSImage.dylib`, which gets picked up by `brew doctor` as a warning.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
