### PR TITLE
docker: conflicts `docker-credential-helper-ecr`

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -33,6 +33,7 @@ cask "docker" do
     docker-completion
     docker-compose
     docker-compose-completion
+    docker-credential-helper-ecr
     hyperkit
     kubernetes-cli
   ]


### PR DESCRIPTION
When the Homebrew prefix is `/usr/local`, I've gotten a couple different conflict behaviors when installing the `docker` cask and `docker-credential-helper-ecr` formula. 

The `docker` cask already installs the `docker-credential-ecr-login` binary, and uninstalls explicitly [here](https://github.com/Homebrew/homebrew-cask/blob/360007a52f3ca49ff566c6a78fd29d494651ac2f/Casks/docker.rb#L60).

Anecdotal experience: `docker-credential-helper` warns when gets a link warning or succeeds, but the `/usr/local/bin/docker-credential-ecr-login` is still linked to `/Applications/Docker.app/Contents/Resources/bin/docker-credential-ecr-login`

However, I'm having trouble reproducing now. A fresh install of `docker` (cask) doesn't seem to add `docker-credential-ecr-login` to the `/usr/local/bin`. 
But this does lead to the issue where

```
brew install --cask docker && brew install docker-credential-helper-ecr && brew uninstall --cask docker
```

Will removes the `docker-credential-ecr-login` created by `docker-credential-helper-ecr`.

So, I figured adding a conflict would be the most explicit option(?). But not sure if that's the best path.

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
