### PR TITLE
Updated 'PlistEDPlus.app' to '1.0.66'. Added varient for sierra and older.

### DIFF
--- a/Casks/plistedplus.rb
+++ b/Casks/plistedplus.rb
@@ -1,8 +1,14 @@
 cask "plistedplus" do
-  version "1.0.65"
-  sha256 "8752c338159b7e48e4d2fafe37e9f58ce299a5eef764d38267af26384ad3c083"
+  version "1.0.66"
 
-  url "https://github.com/ic005k/PlistEDPlus/releases/download/#{version}/PlistEDPlus_Mac.dmg"
+  if MacOS.version <= :sierra
+    sha256 "8c65897f3177f43992949693f00fee1847f6780f701b08ae969546455814a7c2"
+    url "https://github.com/ic005k/PlistEDPlus/releases/download/#{version}/PlistEDPlus_Mac10.12.and.below.dmg"
+  else
+    sha256 "b758ecfc1fb4b80e5c6aada3b9f7b8bbcd8d4d8c866cf0a005999d77c9a9b96d"
+    url "https://github.com/ic005k/PlistEDPlus/releases/download/#{version}/PlistEDPlus_Mac.dmg"
+  end
+
   name "PlistEDPlus"
   desc "Plist file editor"
   homepage "https://github.com/ic005k/PlistEDPlus"
@@ -12,14 +18,24 @@ cask "plistedplus" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "PlistEDPlus.app"
 
-  uninstall quit: "z.PlistEDPlus"
+  if MacOS.version <= :sierra
+    uninstall quit: "com.yourcompany.PlistEDPlus"
+  else
+    uninstall quit: "z.PlistEDPlus"
+  end
 
-  zap trash: [
-    "~/Library/Preferences/z.PlistEDPlus.plist",
-    "~/Library/Saved Application State/z.PlistEDPlus.savedState",
-  ]
+  if MacOS.version <= :sierra
+    zap trash: [
+      "~/Library/Preferences/com.github-com-ic005k.PlistEdPlus.plist",
+      "~/Library/Preferences/com.yourcompany.PlistEDPlus.plist",
+      "~/Library/Saved Application State/com.yourcompany.PlistEDPlus.savedState",
+    ]
+  else
+    zap trash: [
+      "~/Library/Preferences/z.PlistEDPlus.plist",
+      "~/Library/Saved Application State/z.PlistEDPlus.savedState",
+    ]
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

