### PR TITLE
gqrx: Update to 2.14.6

### DIFF
--- a/Casks/gqrx.rb
+++ b/Casks/gqrx.rb
@@ -1,6 +1,6 @@
 cask "gqrx" do
-  version "2.14.5"
-  sha256 "d72db2a8aec6c8005ff27ca0d51703ed574a57552bfda438dd472a08d1e1e285"
+  version "2.14.6"
+  sha256 "825364e34579d491d641844e3885821ea59839bff836d9c3ce778dbce216aaae"
 
   url "https://github.com/gqrx-sdr/gqrx/releases/download/v#{version.major_minor_patch}/Gqrx-#{version}.dmg",
       verified: "github.com/gqrx-sdr/gqrx/"


### PR DESCRIPTION
This picks up the latest [2.14.6 release](https://github.com/gqrx-sdr/gqrx/releases/tag/v2.14.6) of Gqrx.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.