### PR TITLE
wine-stable: update to 6.0.1

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -1,32 +1,22 @@
 cask "wine-stable" do
-  version "5.0"
-  sha256 "de2b23342edfa29a1518d8940992e855d30b3416084964311f184c9fdfb146a5"
+  version "6.0.1"
+  sha256 "33cd52c616b963d054313b5fd3ec7b855623087e3e6da1e340d702ff31f0b0ed"
 
-  url "https://dl.winehq.org/wine-builds/macosx/pool/winehq-stable-#{version}.pkg"
+  # Current winehq packages are depreciated these are WIP packages from the new maintainers
+  # packages will eventually be pushed to Winehq
+  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-stable-#{version}-osx64.tar.xz",
+      verified: "https://github.com/Gcenx/macOS_Wine_builds/"
   name "WineHQ-stable"
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
-
-  livecheck do
-    url "https://dl.winehq.org/wine-builds/macosx/download.html"
-    strategy :page_match
-    regex(%r{href=.*?/winehq-stable-(\d+(?:\.\d+)*)\.pkg}i)
-  end
 
   conflicts_with cask: [
     "wine-devel",
     "wine-staging",
   ]
-  depends_on cask: "xquartz"
+  depends_on formula: "xz"
 
-  pkg "winehq-stable-#{version}.pkg",
-      choices: [
-        {
-          "choiceIdentifier" => "choice3",
-          "choiceAttribute"  => "selected",
-          "attributeSetting" => 1,
-        },
-      ]
+  app "Wine Stable.app"
   binary "#{appdir}/Wine Stable.app/Contents/Resources/start/bin/appdb"
   binary "#{appdir}/Wine Stable.app/Contents/Resources/start/bin/winehelp"
   binary "#{appdir}/Wine Stable.app/Contents/Resources/wine/bin/msiexec"
@@ -44,17 +34,15 @@ cask "wine-stable" do
   binary "#{appdir}/Wine Stable.app/Contents/Resources/wine/bin/winepath"
   binary "#{appdir}/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
 
-  uninstall pkgutil: [
-    "org.winehq.wine-stable",
-    "org.winehq.wine-stable-deps",
-    "org.winehq.wine-stable-deps64",
-    "org.winehq.wine-stable32",
-    "org.winehq.wine-stable64",
-  ],
-            delete:  "/Applications/Wine stable.app"
-
   caveats <<~EOS
-    #{token} installs support for running 64 bit applications in Wine, which is considered experimental.
-    If you do not want 64 bit support, you should download and install the #{token} package manually.
+    #{token} supports both 32-bit and 64-bit now. It is compatible with your
+    existing 32-bit wine prefix, but it will now default to 64-bit when you
+    create a new wine prefix. The architecture can be selected using the
+      WINEARCH environment variable which can be set to either win32 or
+    win64.
+
+    To create a new pure 32-bit prefix, you can run:
+        $ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+    See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
   EOS
 end

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -2,13 +2,20 @@ cask "wine-stable" do
   version "6.0.1"
   sha256 "33cd52c616b963d054313b5fd3ec7b855623087e3e6da1e340d702ff31f0b0ed"
 
-  # Current winehq packages are depreciated these are WIP packages from the new maintainers
-  # packages will eventually be pushed to Winehq
+  # Current winehq packages are deprecated and these are packages from
+  # the new maintainers that will eventually be pushed to Winehq.
+  # See https://www.winehq.org/pipermail/wine-devel/2021-July/191504.html
   url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-stable-#{version}-osx64.tar.xz",
       verified: "https://github.com/Gcenx/macOS_Wine_builds/"
   name "WineHQ-stable"
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
+
+  livecheck do
+    url "https://github.com/Gcenx/macOS_Wine_builds/releases"
+    strategt :page_match
+    regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)*)[._-]osx64\.tar\.xz/i)
+  end
 
   conflicts_with cask: [
     "wine-devel",
@@ -35,14 +42,14 @@ cask "wine-stable" do
   binary "#{appdir}/Wine Stable.app/Contents/Resources/wine/bin/wineserver"
 
   caveats <<~EOS
-    #{token} supports both 32-bit and 64-bit now. It is compatible with your
-    existing 32-bit wine prefix, but it will now default to 64-bit when you
-    create a new wine prefix. The architecture can be selected using the
-      WINEARCH environment variable which can be set to either win32 or
-    win64.
+    #{token} supports both 32-bit and 64-bit. It is compatible with an existing
+    32-bit wine prefix, but it will now default to 64-bit when you create a new
+    wine prefix. The architecture can be selected using the WINEARCH environment
+    variable which can be set to either win32 or win64.
 
     To create a new pure 32-bit prefix, you can run:
-        $ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+      $ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+
     See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
   EOS
 end

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -13,7 +13,7 @@ cask "wine-stable" do
 
   livecheck do
     url "https://github.com/Gcenx/macOS_Wine_builds/releases"
-    strategt :page_match
+    strategy :page_match
     regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)*)[._-]osx64\.tar\.xz/i)
   end
 


### PR DESCRIPTION
Per https://github.com/Homebrew/discussions/discussions/2246, @gverm and myself are now the official Winehq package maintainers, the plan is to push packages directly to WineHQ around wine-7.0 but instead of leaving the depreciated packages on brew it makes more sense to provided the current _WIP_ packages.

Having the most recent wine-* casks directly from brew is preferable to requiring the need to add a tap.

**Please note** *I'd prefer `wine-devel` & `wine-staging` casks on https://github.com/Homebrew/homebrew-cask-versions not be updated until wine-6.19 when I'll open a PR for each.*

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
