### PR TITLE
Add Immersed (15.7)

### DIFF
--- a/Casks/immersed.rb
+++ b/Casks/immersed.rb
@@ -2,7 +2,8 @@ cask "immersed" do
   version "15.7,129"
   sha256 :no_check
 
-  url "https://immersedvr.com/dl/Immersed.dmg"
+  url "https://immersed.com/dl/Immersed.dmg",
+      verified: "immersed.com/dl/"
   name "Immersed"
   desc "Desktop Agent for VR Office"
   homepage "https://immersedvr.com/"

--- a/Casks/immersed.rb
+++ b/Casks/immersed.rb
@@ -1,0 +1,42 @@
+cask "immersed" do
+  version "15.7"
+  sha256 :no_check
+
+  url "https://immersedvr.com/dl/Immersed.dmg"
+  name "Immersed"
+  desc "Desktop Agent for VR Office"
+  homepage "https://immersedvr.com/"
+
+  livecheck do
+    url "https://immersedvr.com/dl/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Immersed.app"
+
+  uninstall_postflight do
+    system_command "/bin/launchctl",
+                   args:         [
+                     "kickstart",
+                     "-kp",
+                     "system/com.apple.audio.coreaudiod",
+                   ],
+                   sudo:         true,
+                   must_succeed: true
+  end
+
+  uninstall delete: [
+    "/Library/Audio/Plug-Ins/HAL/ImmersedAudio.driver",
+    "/Library/CoreMediaIO/Plug-Ins/DAL/ImmersedCamera.plugin",
+  ],
+            quit:   "team.Immersed"
+
+  zap trash: [
+    "~/Library/Application Support/Immersed",
+    "~/Library/Caches/team.Immersed",
+    "~/Library/Preferences/team.Immersed.plist",
+  ]
+end

--- a/Casks/immersed.rb
+++ b/Casks/immersed.rb
@@ -1,5 +1,5 @@
 cask "immersed" do
-  version "15.7"
+  version "15.7,129"
   sha256 :no_check
 
   url "https://immersedvr.com/dl/Immersed.dmg"


### PR DESCRIPTION
Immersed is desktop counterpart for the VR "office"/productivity app which allows to bring virtual screens into VR.


- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
