### PR TITLE
Fix and update versions for R, inlcuding ARM support

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,8 +1,22 @@
 cask "r" do
-  version "4.1.1"
-  sha256 "c239e97c3659169447c50474827d9af79176fff67a34249fcd413d8da6ef2414"
+  if MacOS.version <= :yosemite
+    version "3.3.3"
+    sha245 "77d7a145d1f7d5c3f5bd7310ae2beb7349118528d938e519845ce7d205b4c864"
+    url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
+  elsif MacOS.version <= :sierra
+    version "3.6.3.nn"
+    sha256 "f2b771e94915af0fe0a6f042bc7a04ebc84fb80cb01aad5b7b0341c4636336dd"
+    url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
+  elsif Hardware::CPU.intel?
+    version "4.1.1"
+    sha256 "c239e97c3659169447c50474827d9af79176fff67a34249fcd413d8da6ef2414"
+    url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
+  else
+    version "4.1.1"
+    sha256 "cc078658708fdc7ae807f927cf5b3a96d17d287717679b3327540030f625d47b"
+    url "https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-#{version}-arm64.pkg"
+  end
 
-  url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
   name "R"
   desc "Environment for statistical computing and graphics"
   homepage "https://www.r-project.org/"


### PR DESCRIPTION
The current version is dependent on macOS >= 10.13, so this has been slightly wrong for about 18 months since #81315.  Furthermore, there is now a separate ARM build for the latest.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

----

I'm not 100% on whether this is the ideal structure; is it okay to mix `MacOS.version` and `Hardware::CPU.intel?` so explicitly, or would it be preferable to nest the latter within an `else`?