### PR TITLE
Update swiftformat-for-xcode from 0.48.14 to 0.48.15

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "swiftformat-for-xcode" do
-  version "0.48.14"
-  sha256 "6fe70ef2b3de63a1ae28fd346c40eaf90ba1cc1836a7426304e80727a14217bf"
+  version "0.48.15"
+  sha256 "455987089eb93a4804d27b11a077c4de406ff69ca64e4450b5731c3a391e3369"
 
   url "https://github.com/nicklockwood/SwiftFormat/archive/#{version}.zip"
   name "SwiftFormat for Xcode"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
