### PR TITLE
Update audiobook-builder.rb

### DIFF
--- a/Casks/audiobook-builder.rb
+++ b/Casks/audiobook-builder.rb
@@ -1,6 +1,6 @@
 cask "audiobook-builder" do
   version "2.1.4"
-  sha256 "f69018b3016e775fce34f445109982b27ef7b7d999b358eb3610a76309b31bc1"
+  sha256 "beb51287843d9960171f64c5ed983c370c616f84b83b0c48a7e398bf6a0b25e8"
 
   url "https://www.splasm.com/downloads/audiobookbuilder/Audiobook%20Builder%20#{version}.dmg"
   name "Audiobook Builder"


### PR DESCRIPTION
Updates sha256 after 2.1.4 disk image was revised in place with new end user license agreements in ReadMe.pdf.

I'm sorry to create a pull request manually like this but I put in a fair amount of time trying to get "brew bump-cask-pr --version 2.1.4 audiobook-builder --sha256 beb51287843d9960171f64c5ed983c370c616f84b83b0c48a7e398bf6a0b25e8" to work first.  It kept saying my credentials were no good, even after I created a personal access token, added it to my shell profile(s), tried to delete my credentials with the "printf "protocol=https\nhost=github.com\n" | git credential-osxkeychain erase" in the error message (which didn't work), then deleted my credentials by hand in Keychain Access.

We didn't even know there was a cask for Audiobook Builder.  Thank you for giving users another way to get to our application!

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.  Actually, it reports 8 offenses, but only added the following at the top of the cask and a newline at the end that I don't see in other casks so my guess is these changes aren't really needed:
•••••  Begin changes •••••
# typed: false
# frozen_string_literal: true

••••• End changes •••••