### PR TITLE
Fix zap: robo-3t

### DIFF
--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -22,6 +22,10 @@ cask "robo-3t" do
 
   zap trash: [
     "~/.3T/robo-3t/",
+    "~/Library/Application Support/Robo 3T",
+    "~/Library/Caches/Robo 3T",
+    "~/Library/Preferences/com.3tsoftwarelabs.robo3t.plist",
+    "~/Library/Saved Application State/com.3tsoftwarelabs.robo3t.savedState",
     "~/Library/Saved Application State/Robo 3T.savedState",
   ]
 end


### PR DESCRIPTION
Fix zap: robo-3t

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
