### PR TITLE
Added zap for qgis

### DIFF
--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -16,4 +16,10 @@ cask "qgis" do
   end
 
   app "QGIS.app"
+
+  zap trash: [
+    "~/Library/Application Support/QGIS",
+    "~/Library/Caches/QGIS",
+    "~/Library/Saved Application State/org.qgis.qgis*.savedState",
+  ]
 end


### PR DESCRIPTION
Added zap for qgis #88469
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.