### PR TITLE
Added zap for switchhosts

### DIFF
--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -22,4 +22,11 @@ cask "switchhosts" do
   end
 
   app "SwitchHosts.app"
+
+  zap trash: [
+    "~/Library/Application Support/SwitchHosts",
+    "~/Library/Preferences/SwitchHosts.plist",
+    "~/Library/Saved Application State/SwitchHosts.savedState",
+    "~/.SwitchHosts",
+  ]
 end


### PR DESCRIPTION
Added zap for switchhosts #88469 

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.