### PR TITLE
New cask sdm v15.27.0

### DIFF
--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -8,4 +8,13 @@ cask "sdm" do
   homepage "https://www.strongdm.com/"
 
   app "SDM.app"
+
+  zap trash: [
+    "~/Library/Application Support/SDM",
+    "~/Library/Caches/com.electron.sdm",
+    "~/Library/Caches/com.electron.sdm.ShipIt",
+    "~/Library/Preferences/com.electron.sdm.plist",
+    "~/Library/Saved Application State/com.electron.sdm.savedState",
+    "~/.sdm",
+  ]
 end

--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -7,6 +7,11 @@ cask "sdm" do
   desc "Strongdm client"
   homepage "https://www.strongdm.com/"
 
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
   app "SDM.app"
 
   zap trash: [

--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -1,0 +1,11 @@
+cask "sdm" do
+  version "15.27.0"
+  sha256 :no_check
+
+  url "https://app.strongdm.com/downloads/client/darwin"
+  name "sdm"
+  desc "Strongdm client"
+  homepage "https://www.strongdm.com/docs/user-guide/client-installation/mac-installation"
+
+  app "SDM.app"
+end

--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -5,7 +5,7 @@ cask "sdm" do
   url "https://app.strongdm.com/downloads/client/darwin"
   name "sdm"
   desc "Strongdm client"
-  homepage "https://www.strongdm.com/docs/user-guide/client-installation/mac-installation"
+  homepage "https://www.strongdm.com/"
 
   app "SDM.app"
 end


### PR DESCRIPTION
**Note:** This cask was previously refused however circumstances have changed; the `dmg` is no longer behind any sort of login and can be easily installed using the documented cask process.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
