### PR TITLE
Update tenor domain

### DIFF
--- a/Casks/tenor.rb
+++ b/Casks/tenor.rb
@@ -2,14 +2,14 @@ cask "tenor" do
   version "2.0.5,21"
   sha256 :no_check
 
-  url "https://media.tenor.co/mac/bin/GIFforMac.dmg",
-      verified: "media.tenor.co/mac/bin/"
+  url "https://media.tenor.com/mac/bin/GIFforMac.dmg",
+      verified: "media.tenor.com/mac/bin/"
   name "Tenor"
   desc "Send, share and save gifs from the menu bar"
   homepage "https://tenor.com/mac"
 
   livecheck do
-    url "https://media.tenor.co/mac/gif_for_mac_appcast.xml"
+    url "https://media.tenor.com/mac/gif_for_mac_appcast.xml"
     strategy :sparkle
   end
 

--- a/Casks/tenor.rb
+++ b/Casks/tenor.rb
@@ -2,8 +2,7 @@ cask "tenor" do
   version "2.0.5,21"
   sha256 :no_check
 
-  url "https://media.tenor.com/mac/bin/GIFforMac.dmg",
-      verified: "media.tenor.com/mac/bin/"
+  url "https://media.tenor.com/mac/bin/GIFforMac.dmg"
   name "Tenor"
   desc "Send, share and save gifs from the menu bar"
   homepage "https://tenor.com/mac"


### PR DESCRIPTION
This updates the url domain from tenor.co to tenor.com. This is verifiable by the redirect from tenor.co to tenor.com's main site.

Current error:

```bash
$ brew install --cask tenor
==> Downloading https://media.tenor.co/mac/bin/GIFforMac.dmg

curl: (22) The requested URL returned error: 404 Not Found
Error: Download failed on Cask 'tenor' with message: Download failed: https://media.tenor.co/mac/bin/GIFforMac.dmg
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
