### PR TITLE
krisp: Update minimum OS version

### DIFF
--- a/Casks/krisp.rb
+++ b/Casks/krisp.rb
@@ -13,7 +13,7 @@ cask "krisp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   pkg "krisp_#{version}.pkg"
 


### PR DESCRIPTION
Mojave now, per: https://help.krisp.ai/hc/en-us/articles/360011979299#h_01EZ79QW6ME0NH2RXXWJC7MZ75

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.