### PR TITLE
notion: update arm 2.0.18 + clean code conditions

### DIFF
--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -1,12 +1,12 @@
 cask "notion" do
+  livecheck_folder = Hardware::CPU.intel? ? "mac" : "apple-silicon"
+
   if Hardware::CPU.intel?
     version "2.0.19"
     sha256 "0d13678367144d93f4243d2228e1cf40d1bb577592823ef4b9aff81659d64f22"
-    livecheck_folder = "mac"
   else
     version "2.0.18-arm64"
     sha256 "fa9e299d206dbc68950c44806871c500afe6703532da8d768502f062646954f6"
-    livecheck_folder = "apple-silicon"
   end
 
   url "https://desktop-release.notion-static.com/Notion-#{version}.dmg",

--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -2,31 +2,24 @@ cask "notion" do
   if Hardware::CPU.intel?
     version "2.0.19"
     sha256 "0d13678367144d93f4243d2228e1cf40d1bb577592823ef4b9aff81659d64f22"
-
-    url "https://desktop-release.notion-static.com/Notion-#{version}.dmg",
-        verified: "desktop-release.notion-static.com/"
-
-    livecheck do
-      url "https://www.notion.so/desktop/mac/download"
-      strategy :header_match
-    end
+    livecheck_folder = "mac"
   else
-    version "2.0.17"
-    sha256 "7411f5b5c2de8865cf47b112b26bd04cc70182ddd19b2f99ff6f33ffc5577ed9"
-
-    url "https://desktop-release.notion-static.com/Notion-#{version}-arm64.dmg",
-        verified: "desktop-release.notion-static.com/"
-
-    livecheck do
-      url "https://www.notion.so/desktop/apple-silicon/download"
-      strategy :header_match
-      regex(/Notion-(\d+(?:\.\d+)*?)(?:-arm64)?\.dmg/i)
-    end
+    version "2.0.18-arm64"
+    sha256 "fa9e299d206dbc68950c44806871c500afe6703532da8d768502f062646954f6"
+    livecheck_folder = "apple-silicon"
   end
 
+  url "https://desktop-release.notion-static.com/Notion-#{version}.dmg",
+      verified: "desktop-release.notion-static.com/"
   name "Notion"
   desc "App to write, plan, collaborate, and get organized"
   homepage "https://www.notion.so/"
+
+  livecheck do
+    url "https://www.notion.so/desktop/#{livecheck_folder}/download"
+    strategy :header_match
+    regex(/Notion-(\d+(?:\.\d+)*?[^.]*?)\.dmg/i)
+  end
 
   auto_updates true
 

--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -1,15 +1,16 @@
 cask "notion" do
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
   livecheck_folder = Hardware::CPU.intel? ? "mac" : "apple-silicon"
 
   if Hardware::CPU.intel?
     version "2.0.19"
     sha256 "0d13678367144d93f4243d2228e1cf40d1bb577592823ef4b9aff81659d64f22"
   else
-    version "2.0.18-arm64"
+    version "2.0.18"
     sha256 "fa9e299d206dbc68950c44806871c500afe6703532da8d768502f062646954f6"
   end
 
-  url "https://desktop-release.notion-static.com/Notion-#{version}.dmg",
+  url "https://desktop-release.notion-static.com/Notion-#{version}#{arch}.dmg",
       verified: "desktop-release.notion-static.com/"
   name "Notion"
   desc "App to write, plan, collaborate, and get organized"
@@ -18,7 +19,7 @@ cask "notion" do
   livecheck do
     url "https://www.notion.so/desktop/#{livecheck_folder}/download"
     strategy :header_match
-    regex(/Notion-(\d+(?:\.\d+)*?[^.]*?)\.dmg/i)
+    regex(/Notion-(\d+(?:\.\d+)*?)[^.]*?\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
