### PR TITLE
Update version to :latest

### DIFF
--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -1,5 +1,5 @@
 cask "sdm" do
-  version "15.27.0"
+  version ":latest"
   sha256 :no_check
 
   url "https://app.strongdm.com/downloads/client/darwin"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

We already commented about this change in the [original PR](https://github.com/Homebrew/homebrew-cask/pull/112468) submitted by @nwhobart 

The reasoning behind the change is:

> I wonder if we should specify `version ":latest"`. Since the used URL gives you the latest stable version. Now it's `15.27.0`, but that can change tomorrow and the URL would be exactly the same.
> 
> I changed the version and the commands for audit and style passed:
> ```
> $ brew audit --new-cask  sdm
> audit for sdm: passed
> $ brew style --fix sdm
> 1 file inspected, no offenses detected
> ```