### PR TITLE
github: fix livecheck (arm url is different)

### DIFF
--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -16,7 +16,8 @@ cask "github" do
   homepage "https://desktop.github.com/"
 
   livecheck do
-    url "https://central.github.com/deployments/desktop/desktop/latest/darwin"
+    platform = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
+    url "https://central.github.com/deployments/desktop/desktop/latest/#{platform}"
     strategy :header_match
     regex(%r{(\d+(?:\.\d+)[^/]*)/GitHubDesktop[._-]#{arch}\.zip}i)
   end

--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -1,5 +1,6 @@
 cask "github" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  platform = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
 
   version "2.9.4-24101633"
 
@@ -16,7 +17,6 @@ cask "github" do
   homepage "https://desktop.github.com/"
 
   livecheck do
-    platform = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
     url "https://central.github.com/deployments/desktop/desktop/latest/#{platform}"
     strategy :header_match
     regex(%r{(\d+(?:\.\d+)[^/]*)/GitHubDesktop[._-]#{arch}\.zip}i)


### PR DESCRIPTION
Resolve livecheck bug on arm:
```
livecheck URL: https://central.github.com/deployments/desktop/desktop/latest/darwin # x64 url
regex: /(\d+(?:\.\d+)[^\/]*)\/GitHubDesktop[._-]arm64\.zip/i # arm64 regex
result: Error: github: Unable to get versions
```

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.