### PR TITLE
feat: Add new cask `inso`

### DIFF
--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -1,8 +1,8 @@
 cask "inso" do
-  version "2.3.3-alpha.2"
-  sha256 "d2ee9b7e50f5e9c7ce75fd68405525f0155bc26efcd7aba2a43d9480b6134e56"
+  version "2.3.3-alpha.4"
+  sha256 "620f39604216f2519ed16d48e411823ff1f19589156c7c2a1e1adc3198f517ce"
 
-  url "https://github.com/Kong/insomnia/releases/download/lib%40#{version}/inso-macos-latest-#{version}.pkg",
+  url "https://github.com/Kong/insomnia/releases/download/lib%40#{version}/inso-macos-#{version}.zip",
       verified: "github.com/Kong/insomnia/"
   name "inso"
   desc "CLI HTTP and GraphQL Client"
@@ -11,14 +11,10 @@ cask "inso" do
   livecheck do
     url "https://github.com/Kong/insomnia/releases"
     strategy :page_match
-    regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+).*?)\.pkg/i)
+    regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+).*?)\.zip/i)
   end
 
   auto_updates true
 
-  pkg "inso-macos-latest-#{version}.pkg"
-
-  uninstall pkgutil: [
-    "com.insomnia.inso",
-  ]
+  binary "inso"
 end

--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -1,0 +1,24 @@
+cask "inso" do
+  version "2.3.3-alpha.2"
+  sha256 "d2ee9b7e50f5e9c7ce75fd68405525f0155bc26efcd7aba2a43d9480b6134e56"
+
+  url "https://github.com/Kong/insomnia/releases/download/lib%40#{version}/inso-macos-latest-#{version}.pkg",
+      verified: "github.com/Kong/insomnia/"
+  name "inso"
+  desc "CLI HTTP and GraphQL Client"
+  homepage "https://insomnia.rest/products/inso"
+
+  livecheck do
+    url "https://github.com/Kong/insomnia/releases"
+    strategy :page_match
+    regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+).*?)\.pkg/i)
+  end
+
+  auto_updates true
+
+  pkg "inso-macos-latest-#{version}.pkg"
+
+  uninstall pkgutil: [
+    "com.insomnia.inso",
+  ]
+end

--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -17,4 +17,8 @@ cask "inso" do
   auto_updates true
 
   binary "inso"
+
+  conflicts_with cask: [
+    "homebrew/cask-versions/inso-unstable",
+  ]
 end

--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -9,8 +9,8 @@ cask "inso" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases"
-    strategy :page_match
+    url :url
+    strategy :github_latest
     regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+).*?)\.zip/i)
   end
 

--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -18,6 +18,10 @@ cask "insomnia" do
 
   app "Insomnia.app"
 
+  conflicts_with cask: [
+    "homebrew/cask-versions/insomnia-unstable",
+  ]
+
   zap trash: [
     "~/Library/Application Support/Insomnia",
     "~/Library/Caches/com.insomnia.app",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

> When software is only available as a beta, development, or unstable version, its cask can go in the main repo.

~ [But There Is No Stable Version!](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version)

An official version of this self-sufficient binary is forthcoming and should be caught by this cask's `livecheck` stanza.

- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).

While working on https://github.com/Homebrew/homebrew-core/pull/86456 my colleagues were busy working on a self-sufficient binary distribution that circumvents the problems faced in the node/npm-based formula.
This cask uses that new binary.

- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
