### PR TITLE
insomnia: preemptively fix livecheck

### DIFF
--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -8,6 +8,8 @@ cask "insomnia" do
   desc "HTTP and GraphQL Client"
   homepage "https://insomnia.rest/"
 
+  # both Insomnia (GUI) and "inso" (CLI) are released from this repo
+  # thus regex for the GUI's filename is required
   livecheck do
     url "https://github.com/Kong/insomnia/releases"
     strategy :page_match

--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -9,8 +9,8 @@ cask "insomnia" do
   homepage "https://insomnia.rest/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://github.com/Kong/insomnia/releases"
+    strategy :page_match
     regex(/href=.*?Insomnia[._-]Core[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
Currently, Insomnia (the GUI app), shares a repo with at least the `inso` CLI client.

You can see what I'm talking about on the https://github.com/Kong/insomnia/tags page, there are 2 "flavors" of releases:
- `core@*` and
- `lib@*`

Currently this is unintentionally circumvented by the "latest" release being the GUI/"core" flavor:
https://github.com/Kong/insomnia/releases/latest -> https://github.com/Kong/insomnia/releases/tag/core@2021.5.3

But that's subject to change when the CLI gets released next, as "latest" will be the other, `lib@` flavor.

The changes in this PR make use of the `:page_match` strategy such that the github "latest" redirect can optionally be to a `lib@` release; and pave the way for [a forthcoming formula/cask for the CLI tool](https://github.com/Homebrew/homebrew-core/pull/86456).

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.