### PR TITLE
figma: update to 104.1.0 + various fixes

### DIFF
--- a/Casks/figma.rb
+++ b/Casks/figma.rb
@@ -1,12 +1,12 @@
 cask "figma" do
   arch = Hardware::CPU.intel? ? "mac" : "mac-arm"
 
-  version "102.9.0"
+  version "104.1.0"
 
   if Hardware::CPU.intel?
-    sha256 "88d30dc1fd870d32ae705828cafe77ace5120dab28a157824ba58405910cffbc"
+    sha256 "442b2649e388eeae644131c5cb4344c63166a147386ece179c42413ae6cc71f4"
   else
-    sha256 "b1c1b23b1f31e98f11383582c32a84c1a2ea16a93cd09f1da91b2326328d30c1"
+    sha256 "e5479dc1455daca530d99b67de8344c64ae5f1542f93dbcc96a8d44302f481ed"
   end
 
   url "https://desktop.figma.com/#{arch}/Figma-#{version}.zip"
@@ -16,7 +16,9 @@ cask "figma" do
 
   livecheck do
     url "https://desktop.figma.com/#{arch}/RELEASE.json"
-    regex(%r{/Figma[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    strategy :page_match do |page|
+      JSON.parse(page)["version"]
+    end
   end
 
   auto_updates true
@@ -25,6 +27,9 @@ cask "figma" do
 
   zap trash: [
     "~/Library/Application Support/Figma",
+    "~/Library/Application Support/figma-desktop",
+    "~/Library/Caches/com.figma.Desktop",
+    "~/Library/Caches/com.figma.agent",
     "~/Library/Preferences/com.figma.Desktop.plist",
     "~/Library/Saved Application State/com.figma.Desktop.savedState",
   ]


### PR DESCRIPTION
* Update figma from 102.9.0 to 104.1.0
* Extract livecheck version from JSON
* Add extra zap stanza

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
