### PR TITLE
xbar: depends_on catalina

### DIFF
--- a/Casks/xbar.rb
+++ b/Casks/xbar.rb
@@ -13,7 +13,7 @@ cask "xbar" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :high_sierra"
 
   app "xbar.app"
 

--- a/Casks/xbar.rb
+++ b/Casks/xbar.rb
@@ -13,6 +13,8 @@ cask "xbar" do
     strategy :header_match
   end
 
+  depends_on macos: ">= :catalina"
+
   app "xbar.app"
 
   uninstall quit: "xbar.v#{version}"


### PR DESCRIPTION
Per [README.md](https://github.com/matryer/xbar/tree/1410be750e94d29f1a10079ad2d47c28dd625b20#welcome-to-xbar)

----

FWIW, opening the application bundle says 10.13, but this is per the readme.