### PR TITLE
Oracle sqlcl

### DIFF
--- a/Casks/sqlcl.rb
+++ b/Casks/sqlcl.rb
@@ -4,7 +4,7 @@ cask "sqlcl" do
 
   url "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-#{version}.zip"
   name "sqlcl"
-  desc "Oracle SQLcl is the modern command line interface for the Oracle Database"
+  desc "Oracle SQLcl is the modern command-line interface for the Oracle Database"
   homepage "https://www.oracle.com/sqlcl"
 
   binary "sqlcl/bin/sql"

--- a/Casks/sqlcl.rb
+++ b/Casks/sqlcl.rb
@@ -6,7 +6,7 @@ cask "sqlcl" do
   name "sqlcl"
   desc "Oracle SQLcl is the modern command-line interface for the Oracle Database"
   homepage "https://www.oracle.com/sqlcl"
-  
+
   stage_only true
 
   caveats do

--- a/Casks/sqlcl.rb
+++ b/Casks/sqlcl.rb
@@ -1,0 +1,11 @@
+cask "sqlcl" do
+  version "21.3.1.281.1748"
+  sha256 "03774d2725d5649411e36cd23b055c5b935dd17054964934d6d2a054c029018b"
+
+  url "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-#{version}.zip"
+  name "sqlcl"
+  desc "Oracle SQLcl is the modern command line interface for the Oracle Database"
+  homepage "https://www.oracle.com/sqlcl"
+
+  binary "sqlcl/bin/sql"
+end

--- a/Casks/sqlcl.rb
+++ b/Casks/sqlcl.rb
@@ -7,5 +7,8 @@ cask "sqlcl" do
   desc "Oracle SQLcl is the modern command-line interface for the Oracle Database"
   homepage "https://www.oracle.com/sqlcl"
 
-  binary "sqlcl/bin/sql"
+  caveats do
+    depends_on_java "1.8"
+    path_environment_variable "/usr/local/Caskroom/sqlcl/#{version}/sqlcl/bin"
+  end
 end

--- a/Casks/sqlcl.rb
+++ b/Casks/sqlcl.rb
@@ -6,6 +6,8 @@ cask "sqlcl" do
   name "sqlcl"
   desc "Oracle SQLcl is the modern command-line interface for the Oracle Database"
   homepage "https://www.oracle.com/sqlcl"
+  
+  stage_only true
 
   caveats do
     depends_on_java "1.8"

--- a/Casks/sqlcl.rb
+++ b/Casks/sqlcl.rb
@@ -9,6 +9,10 @@ cask "sqlcl" do
 
   stage_only true
 
+  livecheck do
+     skip "No version information available"
+  end
+
   caveats do
     depends_on_java "1.8"
     path_environment_variable "/usr/local/Caskroom/sqlcl/#{version}/sqlcl/bin"


### PR DESCRIPTION
Oracle SQLcl is the modern command-line interface to the Oracle database.

Initial addition of this cask will be updated quarterly with new releases.



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `sqlcl` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask sqlcl` is error-free.
- [x] `brew style --fix sqlcl` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask sqlcl` worked successfully.
- [x] `brew install --cask sqlcl` worked successfully.
- [x] `brew uninstall --cask sqlcl` worked successfully.
