### PR TITLE
Transmit: update minimum OS version

### DIFF
--- a/Casks/transmit.rb
+++ b/Casks/transmit.rb
@@ -13,7 +13,7 @@ cask "transmit" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "Transmit.app"
 


### PR DESCRIPTION
Transmit requires macos 10.15 since version 5.8.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
