### PR TITLE
Upgrade Phoenix to 2.6.8

### DIFF
--- a/Casks/phoenix.rb
+++ b/Casks/phoenix.rb
@@ -4,6 +4,7 @@ cask "phoenix" do
 
   url "https://github.com/kasper/phoenix/releases/download/#{version}/phoenix-#{version}.tar.gz"
   name "Phoenix"
+  desc "Window and app manager scriptable with JavaScript"
   homepage "https://github.com/kasper/phoenix/"
 
   depends_on macos: ">= :yosemite"

--- a/Casks/phoenix.rb
+++ b/Casks/phoenix.rb
@@ -1,6 +1,6 @@
 cask "phoenix" do
-  version "2.6.7"
-  sha256 "27cd2fe78f6d898fda09288808e2559bcafc8b3069bdc6740fad050cb423cced"
+  version "2.6.8"
+  sha256 "b779791ae673d676d9084d88d2c075d6a8cdd5b11e97d6ac8287dfa6df5c7f55"
 
   url "https://github.com/kasper/phoenix/releases/download/#{version}/phoenix-#{version}.tar.gz"
   name "Phoenix"


### PR DESCRIPTION
Upgrade Phoenix to 2.6.8. Thanks!

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.