### PR TITLE
Fix `arch` string in Tandem.app Cask

### DIFF
--- a/Casks/tandem.rb
+++ b/Casks/tandem.rb
@@ -1,5 +1,5 @@
 cask "tandem" do
-  arch = Hardware::CPU.intel? ? "x64" : "amr64"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
   version "2.0.1001"
 


### PR DESCRIPTION
Fix download error:

```
Error: Download failed on Cask 'tandem' with message: Download failed: https://download.todesktop.com/200527auaqaacsy/Tandem%202.0.1001-amr64.dmg
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
