### PR TITLE
Fix `arch` string in Listen1.app Cask

### DIFF
--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -1,6 +1,6 @@
 cask "listen1" do
   # NOTE: "1" is not a version number, but an intrinsic part of the product name
-  arch = Hardware::CPU.intel? ? "x64" : "amr64"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
   version "2.21.6"
 


### PR DESCRIPTION
Fix download error:

```
Error: Download failed on Cask 'listen1' with message: Download failed: https://github.com/listen1/listen1_desktop/releases/download/v2.21.6/Listen1_2.21.6_mac_amr64.dmg
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
