### PR TITLE
livecheck update: graceful exit when regex fails page.match

### DIFF
--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -11,6 +11,8 @@ cask "aether" do
     url "https://static.getaether.net/WebsiteReleaseLinks/Latest/LatestReleaseLinks.json"
     strategy :page_match do |page|
       match = page.match(%r{/Aether-(\d+(?:\.\d+)*-dev\.\d+)%2B(\d+\.[0-9a-f]+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/aliworkbench.rb
+++ b/Casks/aliworkbench.rb
@@ -14,6 +14,7 @@ cask "aliworkbench" do
     strategy :header_match do |headers|
       id = headers["location"][%r{/([^/]+)\.dmg}i, 1]
       version = headers["content-disposition"][/-(\d+(?:\.\d+)*)\.dmg/i, 1]
+      next if version.blank? || id.blank?
 
       "#{version},#{id}"
     end

--- a/Casks/amazon-workdocs.rb
+++ b/Casks/amazon-workdocs.rb
@@ -11,6 +11,8 @@ cask "amazon-workdocs" do
     url "https://d28gdqadgmua23.cloudfront.net/mac/appcast/appcast-workdocs-prod.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/(\d+(?:\.\d+)*)/(\d+)/Amazon WorkDocs\.app\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/android-platform-tools.rb
+++ b/Casks/android-platform-tools.rb
@@ -12,6 +12,8 @@ cask "android-platform-tools" do
     url "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/([0-9a-f]{40,}).platform-tools_r([.0-9]+)-darwin})
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/ansible-dk.rb
+++ b/Casks/ansible-dk.rb
@@ -11,6 +11,8 @@ cask "ansible-dk" do
     url "https://github.com/omniti-labs/ansible-dk/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ansible-dk-(\d+(?:\.\d+)*)-(\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -11,6 +11,8 @@ cask "appzapper" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/appzapper(\d+)(\d+)(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/armitage.rb
+++ b/Casks/armitage.rb
@@ -11,6 +11,8 @@ cask "armitage" do
     url "http://www.fastandeasyhacking.com/download/"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/armitage(\d\d+)(\d\d+)(\d\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/atok.rb
+++ b/Casks/atok.rb
@@ -12,6 +12,8 @@ cask "atok" do
     url "https://mypassport.atok.com/install/install_mac.html"
     strategy :page_match do |page|
       match = page.match(%r{href="https:.*/mac/at(\d+)(try\d*)\.dmg"}im)
+      next if match.blank?
+
       "#{version.before_comma},#{match[1]}.#{version.after_comma.minor}.#{version.after_comma.patch}:#{match[2]}"
     end
   end

--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -12,6 +12,8 @@ cask "basictex" do
     url "https://ctan.org/texarchive/systems/mac/mactex/"
     strategy :page_match do |page|
       match = page.match(/href=.*?mactex-basictex-(\d{4})(\d{2})(\d{2})\.pkg/)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}#{match[3]}"
     end
   end

--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -11,6 +11,8 @@ cask "battery-report" do
     url "https://www.dssw.co.uk/batteryreport/dsswbatteryreport.dmg"
     strategy :header_match do |headers|
       match = headers["location"].match(/dsswbatteryreport-(\d+)(\d+)(\d+)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/bingpaper.rb
+++ b/Casks/bingpaper.rb
@@ -11,6 +11,8 @@ cask "bingpaper" do
     url "https://github.com/pengsrc/BingPaper/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/BingPaper\.v?(\d+(?:\.\d+)*)\.build\.(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/blu-ray-player-pro.rb
+++ b/Casks/blu-ray-player-pro.rb
@@ -11,6 +11,8 @@ cask "blu-ray-player-pro" do
     url "https://cdn.macblurayplayer.com/mac-bluray-player-pro3/appcast/Appcast.xml"
     strategy :sparkle do |item|
       match = item.url.match(/_(\d(?:\.\d+)*)_(.*?)\.dmg/)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -11,6 +11,8 @@ cask "bluej" do
     url "https://www.bluej.org"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/BlueJ-mac-(\d+)(\d+)(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/bluestacks.rb
+++ b/Casks/bluestacks.rb
@@ -11,6 +11,8 @@ cask "bluestacks" do
     url "https://cloud.bluestacks.com/api/getdownloadnow?platform=mac&mac_version=#{MacOS.full_version}"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/(\d(?:\.\d+)*)/([^/]+)/})
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -12,6 +12,8 @@ cask "bria" do
     url "https://www.counterpath.com/Bria#{version.major}forMac"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/Bria[._-]v?(\d+(?:\.\d+)+)[_-](\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/busycal.rb
+++ b/Casks/busycal.rb
@@ -12,6 +12,8 @@ cask "busycal" do
     url "https://www.busymac.com/download/BusyCal.zip"
     strategy :header_match do |headers|
       match = headers["location"].match(/bcl-(\d+(?:\.\d+)*)-(.*?)\.zip/)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/busycontacts.rb
+++ b/Casks/busycontacts.rb
@@ -12,6 +12,8 @@ cask "busycontacts" do
     url "https://www.busymac.com/download/BusyContacts.zip"
     strategy :header_match do |headers|
       match = headers["location"].match(/bct-(\d+(?:\.\d+)*)-(.*?)\.zip/)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/cirrus.rb
+++ b/Casks/cirrus.rb
@@ -12,6 +12,8 @@ cask "cirrus" do
     url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
     strategy :page_match do |page|
       match = page.match(%r{/(\d+)/(\d+)/cirrus(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/codelite.rb
+++ b/Casks/codelite.rb
@@ -11,6 +11,8 @@ cask "codelite" do
     url "https://downloads.codelite.org/"
     strategy :page_match do |page|
       match = page.match(/CodeLite\s*(\d+\.\d+)((?:\.\d+)*)\s*-\s*Stable\s*Release/i)
+      next if match.blank?
+
       "#{match[1]}#{match[2].presence || ".0"}"
     end
   end

--- a/Casks/comparemerge.rb
+++ b/Casks/comparemerge.rb
@@ -11,6 +11,8 @@ cask "comparemerge" do
     url "https://sourceforge.net/projects/comparemergenosandbox/rss"
     strategy :page_match do |page|
       match = page.match(%r{/CompareMerge(\d+(?:\.\d+)*\w)(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/cr.rb
+++ b/Casks/cr.rb
@@ -10,6 +10,8 @@ cask "cr" do
     url "https://sourceforge.net/projects/crengine/rss?path=/CoolReader#{version.major}/cr#{version.major}-#{version.before_comma}"
     strategy :page_match do |page|
       match = page.match(%r{url=.*?/cr(\d+(?:\.\d+)*)-(\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/cutesdr.rb
+++ b/Casks/cutesdr.rb
@@ -11,6 +11,8 @@ cask "cutesdr" do
     url "https://sourceforge.net/projects/cutesdr/rss"
     strategy :page_match do |page|
       match = page.match(/CuteSdr(\d+?)(\d+)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -14,6 +14,8 @@ cask "cycling74-max" do
     strategy :page_match do |page|
       json = JSON.parse(page)
       match = json["release_date"].match(/^\d{2}(\d{2})[._-](\d{2})[._-](\d{2})/)
+      next if match.blank?
+
       "#{json["_id"]}_#{match[1]}#{match[2]}#{match[3]}"
     end
   end

--- a/Casks/daedalus-mainnet.rb
+++ b/Casks/daedalus-mainnet.rb
@@ -12,6 +12,8 @@ cask "daedalus-mainnet" do
     url "https://update-cardano-mainnet.iohk.io/daedalus-latest-version.json"
     strategy :page_match do |page|
       match = page.match(%r{/daedalus[._-](\d+(?:\.\d+)*)[._-]mainnet[._-](\d+)\.pkg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/diskcatalogmaker.rb
+++ b/Casks/diskcatalogmaker.rb
@@ -11,6 +11,8 @@ cask "diskcatalogmaker" do
     url "https://download.diskcatalogmaker.com/zip/DiskCatalogMaker.zip"
     strategy :header_match do |headers|
       match = headers["location"].match(/DiskCatalogMaker(\d+)f?(\d+)\.zip/i)
+      next if match.blank?
+
       "#{match[1].split("", 3).reject(&:empty?).join(".")}.#{match[2]}"
     end
   end

--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -19,6 +19,8 @@ cask "dosbox-x" do
     url "https://github.com/joncampbell123/dosbox-x/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/dosbox-x-v?(\d+(?:\.\d+)*)/dosbox-x-macosx-#{arch}-([^/]+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/droplr.rb
+++ b/Casks/droplr.rb
@@ -11,6 +11,8 @@ cask "droplr" do
     url "https://files.droplr.com/apps/mac-current"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/Droplr(\d)(\d)(\d+)-(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]},#{match[4]}"
     end
   end

--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -13,6 +13,8 @@ cask "duplicati" do
     strategy :git do |tags|
       tags.map do |tag|
         match = tag.match(/^v(\d+(?:\.\d+)*)-(?:\d+(?:\.\d+)*)_(stable|beta)_(\d+(?:-\d+)*)$/i)
+        next if match.blank?
+
         "#{match[1]},#{match[2]}:#{match[3]}" if match
       end.compact
     end

--- a/Casks/dupscanub.rb
+++ b/Casks/dupscanub.rb
@@ -11,6 +11,8 @@ cask "dupscanub" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/DupScanUB_(\d+)(\d+)(\d+).dmg\.zip}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/engine-prime.rb
+++ b/Casks/engine-prime.rb
@@ -12,6 +12,8 @@ cask "engine-prime" do
     url "https://www.denondj.com/downloads"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Engine[._-]?Prime[._-]?v?(\d+(?:\.\d+)*)(?:[._-]([0-9a-z]+))?[._-]Setup\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}#{"," + match[2] if match[2]}"
     end
   end

--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -30,6 +30,8 @@ cask "evernote" do
 
     strategy :electron_builder do |yml|
       match = yml["files"][0]["url"].match(/Evernote-(\d+(?:\.\d+)*)-mac-ddl-ga-(\d+(?:\.\d+)*)/)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -11,6 +11,8 @@ cask "exifrenamer" do
     url "https://www.qdev.de/versions/ExifRenamer.txt"
     strategy :page_match do |page|
       version = page.split
+      next if version.blank?
+
       "#{version[0]},#{version[1].tr("()", "")}"
     end
   end

--- a/Casks/fabfilter-micro.rb
+++ b/Casks/fabfilter-micro.rb
@@ -11,6 +11,8 @@ cask "fabfilter-micro" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffmicro(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-one.rb
+++ b/Casks/fabfilter-one.rb
@@ -11,6 +11,8 @@ cask "fabfilter-one" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffone(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-c.rb
+++ b/Casks/fabfilter-pro-c.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-c" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffproc(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-ds.rb
+++ b/Casks/fabfilter-pro-ds.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-ds" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffprods(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-g.rb
+++ b/Casks/fabfilter-pro-g.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-g" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffprog(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-l.rb
+++ b/Casks/fabfilter-pro-l.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-l" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffprol(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-mb.rb
+++ b/Casks/fabfilter-pro-mb.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-mb" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=".*?/ffpromb(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-q.rb
+++ b/Casks/fabfilter-pro-q.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-q" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=".*?/ffproq(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-pro-r.rb
+++ b/Casks/fabfilter-pro-r.rb
@@ -11,6 +11,8 @@ cask "fabfilter-pro-r" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=".*?/ffpror(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-saturn.rb
+++ b/Casks/fabfilter-saturn.rb
@@ -11,6 +11,8 @@ cask "fabfilter-saturn" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=".*?/ffsaturn(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-simplon.rb
+++ b/Casks/fabfilter-simplon.rb
@@ -11,6 +11,8 @@ cask "fabfilter-simplon" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffsimplon(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-timeless.rb
+++ b/Casks/fabfilter-timeless.rb
@@ -11,6 +11,8 @@ cask "fabfilter-timeless" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=".*?/fftimeless(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-twin.rb
+++ b/Casks/fabfilter-twin.rb
@@ -11,6 +11,8 @@ cask "fabfilter-twin" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/fftwin(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fabfilter-volcano.rb
+++ b/Casks/fabfilter-volcano.rb
@@ -11,6 +11,8 @@ cask "fabfilter-volcano" do
     url "https://www.fabfilter.com/download"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ffvolcano(\d)(\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/fme.rb
+++ b/Casks/fme.rb
@@ -11,6 +11,8 @@ cask "fme" do
     url "https://www.safe.com/api/downloads/"
     strategy :page_match do |page|
       match = page.match(%r{/fme-desktop-(\d+(?:\.\d+)*)-b(\d+)-macosx\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -12,6 +12,8 @@ cask "fontforge" do
     url "https://github.com/fontforge/fontforge/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/FontForge-(\d+(?:-\d+)*)-([0-9a-f]+)\.app\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/foxitreader.rb
+++ b/Casks/foxitreader.rb
@@ -12,6 +12,8 @@ cask "foxitreader" do
     url "https://www.foxit.com/downloads/latest.html?product=Foxit-Reader&platform=Mac-OS-X"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/(\d+(?:\.\d+)*)/ML/FoxitPDFReader(\d+)\.L10N\.Setup\.pkg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2].delete_prefix(match[1].delete("."))}"
     end
   end

--- a/Casks/fpc-laz.rb
+++ b/Casks/fpc-laz.rb
@@ -12,6 +12,8 @@ cask "fpc-laz" do
     url "https://sourceforge.net/projects/lazarus/rss"
     strategy :page_match do |page|
       match = page.match(%r{Lazarus%20(\d+(?:.\d+)*)/fpc-(\d+(?:.\d+)*)\.intel-macosx\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/fpc-src-laz.rb
+++ b/Casks/fpc-src-laz.rb
@@ -12,6 +12,8 @@ cask "fpc-src-laz" do
     url "https://sourceforge.net/projects/lazarus/rss"
     strategy :page_match do |page|
       match = page.match(%r{Lazarus%20(\d+(?:.\d+)*)/fpc-src-(\d+(?:.\d+)*)-laz\.pkg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/fvim.rb
+++ b/Casks/fvim.rb
@@ -11,6 +11,8 @@ cask "fvim" do
     url :url
     strategy :github_latest do |page|
       match = page.match(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)%2B(g?\h+)["' >]}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/get-iplayer-automator.rb
+++ b/Casks/get-iplayer-automator.rb
@@ -11,6 +11,8 @@ cask "get-iplayer-automator" do
     url "https://github.com/Ascoware/get-iplayer-automator/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Get\.?iPlayer\.?Automator\.?v?(\d+(?:.\d+)*).b(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/gifox.rb
+++ b/Casks/gifox.rb
@@ -12,6 +12,8 @@ cask "gifox" do
     url "https://gifox.io/download/latest"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/(\d(\d)\d(\d)\d(\d).\d\d)\.dmg}i)
+      next if match.blank?
+
       "#{match[2]}.#{match[3]}.#{match[4]},#{match[1]}"
     end
   end

--- a/Casks/gramps.rb
+++ b/Casks/gramps.rb
@@ -12,6 +12,8 @@ cask "gramps" do
     url "https://github.com/gramps-project/gramps/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Gramps-Intel-(\d+(?:.\d+)*)-(\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/gyazmail.rb
+++ b/Casks/gyazmail.rb
@@ -11,6 +11,8 @@ cask "gyazmail" do
     url "http://gyazsquare.com/gyazmail/download.php"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/GyazMail-(\d+)(\d+)(\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/home-assistant.rb
+++ b/Casks/home-assistant.rb
@@ -15,6 +15,8 @@ cask "home-assistant" do
     url :url
     strategy :github_latest do |page|
       version = page.match(%r{href=".+/tree/(?:mac|release)/([\d.]+)/([\d.]+)"}i)
+      next if version.blank?
+
       "#{version[1]},#{version[2]}"
     end
   end

--- a/Casks/hook.rb
+++ b/Casks/hook.rb
@@ -12,6 +12,8 @@ cask "hook" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/(\d+)/(\d+)/Hook-productivity-app-(\d+(?:\.\d+)*(?:-\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{match[3]},#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/icc.rb
+++ b/Casks/icc.rb
@@ -12,6 +12,8 @@ cask "icc" do
     url "https://www.chessclub.com/software-download/icc-for-mac"
     strategy :page_match do |page|
       match = page.match(/>\s*(\d+(?:\.\d+)*)\s*r(\d+)\s*/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/iina-plus.rb
+++ b/Casks/iina-plus.rb
@@ -11,6 +11,8 @@ cask "iina-plus" do
     url "https://github.com/xjbeta/iina-plus/releases/latest"
     strategy :page_match do |page|
       match = page.match(/(\d+(?:\.\d+)*)\((\d+)\)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/iridient-developer.rb
+++ b/Casks/iridient-developer.rb
@@ -11,6 +11,8 @@ cask "iridient-developer" do
     url "https://www.iridientdigital.com/products/iridientdeveloper_download.html"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/IridientDeveloper_(\d+)(\d+)(\d+)_Universal\.dmg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/itk-snap.rb
+++ b/Casks/itk-snap.rb
@@ -12,6 +12,8 @@ cask "itk-snap" do
     url "http://www.nitrc.org/frs/downloadlink.php/11444"
     strategy :header_match do |headers|
       match = headers["location"].match(/itksnap[._-]?(\d+(?:\.\d+)*)[._-]?(\d+(?:\.\d+)*)[._-]?MacOS-x86_64\.dmg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/jdk-mission-control.rb
+++ b/Casks/jdk-mission-control.rb
@@ -11,6 +11,8 @@ cask "jdk-mission-control" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/(\d+)/binaries/jmc-(\d+(?:\.\d+)*)_osx-x64.tar\.gz}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/jietu.rb
+++ b/Casks/jietu.rb
@@ -12,6 +12,8 @@ cask "jietu" do
     url "https://jietu.qq.com/"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Jietu_(\d+(?:\.\d+)*)\((\d+)\)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/kapitainsky-rclone-browser.rb
+++ b/Casks/kapitainsky-rclone-browser.rb
@@ -10,6 +10,8 @@ cask "kapitainsky-rclone-browser" do
     url "https://github.com/kapitainsky/RcloneBrowser/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/rclone-browser-(\d+(?:.\d+)*)-([0-9a-f]+)-macos\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/kdocs.rb
+++ b/Casks/kdocs.rb
@@ -12,6 +12,8 @@ cask "kdocs" do
     url "https://www.kdocs.cn/kd/api/configure/list?idList=appOfficial"
     strategy :page_match do |page|
       match = page.match(/kdocs[._-](\d+(?:\.\d+)*)[._-]v?(\d+(?:\.\d+)*)\.dmg/i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/kekaexternalhelper.rb
+++ b/Casks/kekaexternalhelper.rb
@@ -12,6 +12,8 @@ cask "kekaexternalhelper" do
     url "https://github.com/aonez/Keka/releases"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/KekaExternalHelper-v?(\d+(?:\.\d+)*)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/keybase.rb
+++ b/Casks/keybase.rb
@@ -11,6 +11,8 @@ cask "keybase" do
     url "https://prerelease.keybase.io/update-darwin-prod-v2.json"
     strategy :page_match do |page|
       match = page.match(/Keybase-(\d+(?:\.\d+)*)-(\d+)%2B([0-9a-f]+)\.zip/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/komodo-edit.rb
+++ b/Casks/komodo-edit.rb
@@ -11,6 +11,8 @@ cask "komodo-edit" do
     url "https://www.activestate.com/komodo-ide/downloads/edit"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Komodo-Edit-(\d+(?:\.\d+)*)-(\d+)-macosx-x86_64\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/komodo-ide.rb
+++ b/Casks/komodo-ide.rb
@@ -11,6 +11,8 @@ cask "komodo-ide" do
     url "https://www.activestate.com/komodo-ide/downloads/ide"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Komodo-IDE-(\d+(?:\.\d+)*)-(\d+)-macosx-x86_64\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/lark.rb
+++ b/Casks/lark.rb
@@ -19,6 +19,8 @@ cask "lark" do
     url "https://www.larksuite.com/api/downloads"
     strategy :page_match do |page|
       match = page.match(%r{/lark-artifact-storage/(\w+)/Lark-darwin_#{arch}-(\d+(?:\.\d+)*)-signed\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/liclipse.rb
+++ b/Casks/liclipse.rb
@@ -12,6 +12,8 @@ cask "liclipse" do
     url "https://www.liclipse.com/download.html"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/([0-9a-z]+)/liclipse_(\d+(?:\.\d+)*)_macosx\.cocoa\.x86_64\.tar\.gz}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/lockrattler.rb
+++ b/Casks/lockrattler.rb
@@ -12,6 +12,8 @@ cask "lockrattler" do
     url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
     strategy :page_match do |page|
       match = page.match(%r{/(\d+)/(\d+)/lockrattler(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/lyricsx.rb
+++ b/Casks/lyricsx.rb
@@ -11,6 +11,8 @@ cask "lyricsx" do
     url "https://github.com/ddddxxx/LyricsX/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/LyricsX_(\d+(?:\.\d+)*)\+(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/macgamestore.rb
+++ b/Casks/macgamestore.rb
@@ -11,6 +11,8 @@ cask "macgamestore" do
     url "https://www.macgamestore.com/api_clientapp/clientupdates/public/update.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/MacGameStore_(\d+(?:\.\d+)*)_(\d+)\.tgz}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -12,6 +12,8 @@ cask "mactex-no-gui" do
     url "https://ctan.org/texarchive/systems/mac/mactex/"
     strategy :page_match do |page|
       match = page.match(/href=.*?mactex-(\d{4})(\d{2})(\d{2})\.pkg/)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}#{match[3]}"
     end
   end

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -12,6 +12,8 @@ cask "mactex" do
     url "https://ctan.org/texarchive/systems/mac/mactex/"
     strategy :page_match do |page|
       match = page.match(/href=.*?mactex-(\d{4})(\d{2})(\d{2})\.pkg/)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}#{match[3]}"
     end
   end

--- a/Casks/maria.rb
+++ b/Casks/maria.rb
@@ -11,6 +11,8 @@ cask "maria" do
     url "https://github.com/shincurry/Maria/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Maria_v?(\d+(?:\.\d+)*)_build(.*?)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/mars.rb
+++ b/Casks/mars.rb
@@ -11,6 +11,8 @@ cask "mars" do
     url "https://courses.missouristate.edu/KenVollmar/mars/download.htm"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?MARS_(\d+(?:_\d+)*)_(\w+\d+)/Mars(?:\d+(?:_\d+)*)\.jar}i)
+      next if match.blank?
+
       "#{match[1].tr("_", ".")},#{match[2]}"
     end
   end

--- a/Casks/mdrp.rb
+++ b/Casks/mdrp.rb
@@ -11,6 +11,8 @@ cask "mdrp" do
     url "https://www.macdvdripperpro.com/mdrp_sparkle#{version.major}.xml"
     strategy :page_match do |page|
       match = page.match(/MDRP_v(\d)(\d)(\d)\.zip/i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/media-center.rb
+++ b/Casks/media-center.rb
@@ -11,6 +11,8 @@ cask "media-center" do
     url "https://www.jriver.com/download.html"
     strategy :page_match do |page|
       match = page.match(/MediaCenter(\d\d+)(\d\d+)(\d\d+)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end

--- a/Casks/metasploit.rb
+++ b/Casks/metasploit.rb
@@ -11,6 +11,8 @@ cask "metasploit" do
     url "https://osx.metasploit.com/LATEST"
     strategy :page_match do |page|
       match = page.match(/metasploit-framework-(\d+(?:\.\d+)*)\+(\d+)-1rapid7-1\.pkg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/mumu.rb
+++ b/Casks/mumu.rb
@@ -11,6 +11,8 @@ cask "mumu" do
     url "https://vendors.paddle.com/download/product/597910"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/([^/]+)_Mumu%20(\d+(?:\.\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/nightingale.rb
+++ b/Casks/nightingale.rb
@@ -12,6 +12,8 @@ cask "nightingale" do
     url "https://github.com/nightingale-media-player/nightingale-hacking/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Nightingale_(\d+(?:\.\d+)*)-(\d+)_macosx-i686\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/noxappplayer.rb
+++ b/Casks/noxappplayer.rb
@@ -11,6 +11,8 @@ cask "noxappplayer" do
     url "https://www.bignox.com/en/download/fullPackage/mac_fullzip"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/(\d+)/([^/]+)\.dmg\?filename=NoxInstaller_(\d+(?:\.\d+)*)_en\.dmg}i)
+      next if match.blank?
+
       "#{match[3]},#{match[1]}:#{match[2]}"
     end
   end

--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -12,6 +12,8 @@ cask "opencpn" do
     url "https://github.com/OpenCPN/OpenCPN/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/OpenCPN_(\d+(?:\.\d+)*)\+(.*?)\.pkg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/openvpn-connect.rb
+++ b/Casks/openvpn-connect.rb
@@ -11,6 +11,8 @@ cask "openvpn-connect" do
     url "https://openvpn.net/downloads/openvpn-connect-v#{version.major}-macos.dmg"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/openvpn-connect-(\d+(?:\.\d+)*)\.(\d+)_signed\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/oracle-jdk-javadoc.rb
+++ b/Casks/oracle-jdk-javadoc.rb
@@ -14,6 +14,8 @@ cask "oracle-jdk-javadoc" do
     url "https://www.oracle.com/java/technologies/javase-jdk#{version.major}-doc-downloads.html"
     strategy :page_match do |page|
       match = page.match(%r{(\d+(?:\.\d+)*)\+(\d+(?:\.\d+)*)/(.+)/jdk-(\d+(?:\.\d+)*)_doc-all\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/packetsender.rb
+++ b/Casks/packetsender.rb
@@ -12,6 +12,8 @@ cask "packetsender" do
     url "https://github.com/dannagle/PacketSender/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/PacketSender_v?(\d+(?:\.\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/papyrus.rb
+++ b/Casks/papyrus.rb
@@ -11,6 +11,8 @@ cask "papyrus" do
     url "https://www.eclipse.org/papyrus/download.html"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/papyrus-(\d+(?:-\d+)*)-(\d+(?:\.\d+)*)-macosx64\.tar\.gz}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/parallels-client.rb
+++ b/Casks/parallels-client.rb
@@ -11,6 +11,8 @@ cask "parallels-client" do
     url "https://download.parallels.com/ras/v18/RAS%20Client%20for%20Mac%20Changelog.txt"
     strategy :page_match do |page|
       match = page.match(/Version\s*(\d+(?:\.\d+)*)\s*\((\d+)\)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/pitch.rb
+++ b/Casks/pitch.rb
@@ -11,6 +11,8 @@ cask "pitch" do
     url "https://desktop-app-builds.pitch.com/latest-mac.yml"
     strategy :page_match do |page|
       match = page.match(/Pitch[._-]v?(\d+(?:\.\d+)+)[._-]ci(\d+)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/playmemories-home.rb
+++ b/Casks/playmemories-home.rb
@@ -12,6 +12,8 @@ cask "playmemories-home" do
     url "https://support.d-imaging.sony.co.jp/disoft_DL/PMHMAC_DL/mac?fm=ttl&fm=ja"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/([^/]+)/PMHOME_(\d+)DL\.dmg}i)
+      next if match.blank?
+
       "#{match[2].split("", 3).join(".")},#{match[1]}"
     end
   end

--- a/Casks/pomotodo.rb
+++ b/Casks/pomotodo.rb
@@ -12,6 +12,8 @@ cask "pomotodo" do
     url "https://air.pomotodo.com/v1/p/com.pomotodo.PomotodoMac#{version.major}/latest.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/(\d+)/Pomotodo\.(\d+(?:\.\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/post-haste.rb
+++ b/Casks/post-haste.rb
@@ -10,6 +10,8 @@ cask "post-haste" do
     url "https://www.digitalrebellion.com/download/posthaste"
     strategy :header_match do |headers|
       match = headers["location"].match(/_((\d+)(\d+)(\d+)\d+)\.dmg/)
+      next if match.blank?
+
       "#{match[2]}.#{match[3]}.#{match[4]},#{match[1]}"
     end
   end

--- a/Casks/profilecreator.rb
+++ b/Casks/profilecreator.rb
@@ -11,6 +11,8 @@ cask "profilecreator" do
     url :url
     strategy :github_latest do |page|
       match = page.match(%r{href=.*?/ProfileCreator_v(\d+(?:\.\d+)*)-(.*?)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/pym-player.rb
+++ b/Casks/pym-player.rb
@@ -11,6 +11,8 @@ cask "pym-player" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(/Wersja:\s*(\d+(?:\.\d+)*)\s*\((\d+B\d+)\)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/qdesktop.rb
+++ b/Casks/qdesktop.rb
@@ -12,6 +12,8 @@ cask "qdesktop" do
     strategy :git do |tags|
       tags.map do |tag|
         match = tag.match(/^v?(\d+(?:\.\d+)*)-(\d+)$/i)
+        next if match.blank?
+
         "#{match[1]},#{match[2]}"
       end
     end

--- a/Casks/qgis.rb
+++ b/Casks/qgis.rb
@@ -11,6 +11,8 @@ cask "qgis" do
     url "https://qgis.org/downloads/macos/qgis-macos-pr.sha256sum"
     strategy :page_match do |page|
       match = page.match(/qgis_pr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
+      next if match.blank?
+
       "#{match[1].tr("_", ".")},#{match[2]}"
     end
   end

--- a/Casks/qiyimedia.rb
+++ b/Casks/qiyimedia.rb
@@ -13,6 +13,8 @@ cask "qiyimedia" do
     url "https://mbdapp.iqiyi.com/j/ot/iQIYIMedia_271.dmg"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/(\d+)/(\d+)/(\d+)/iQIYIMedia_\d+\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -10,6 +10,8 @@ cask "qlvideo" do
     url "https://github.com/Marginal/QLVideo/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/QLVideo_(\d+?)(\d+)\.pkg}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/querypie.rb
+++ b/Casks/querypie.rb
@@ -12,6 +12,8 @@ cask "querypie" do
     url "https://d2f8621kw7pn7s.cloudfront.net/latest/latest-mac.yml"
     strategy :page_match do |page|
       match = page.match(/version:\s*(\d+(?:\.\d+)*)-latest\.(\d+)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/quickhash.rb
+++ b/Casks/quickhash.rb
@@ -11,6 +11,8 @@ cask "quickhash" do
     url "https://www.quickhash-gui.org/downloads/"
     strategy :page_match do |page|
       match = page.match(%r{/quickhash[._-](?:gui[._-])?v?(\d+(?:-\d+)+)[._-]apple[._-]osx/\?wpdmdl=(\d+)}i)
+      next if match.blank?
+
       "#{match[1].tr("-", ".")},#{match[2]}"
     end
   end

--- a/Casks/retro-virtual-machine.rb
+++ b/Casks/retro-virtual-machine.rb
@@ -12,6 +12,8 @@ cask "retro-virtual-machine" do
     url "https://www.retrovirtualmachine.org/en/downloads"
     strategy :page_match do |page|
       match = page.match(/RetroVirtualMachine\.(\d+(?:\.\d+)*)\.beta-(\d+(?:\..\d+)*)\.macos\.dmg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/reunion.rb
+++ b/Casks/reunion.rb
@@ -11,6 +11,8 @@ cask "reunion" do
     url "https://store.leisterpro.com/updates/reunion#{version.major}/appcast.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/Reunion-(\d+(?:-\d+)*)-(\d+.*?)\.zip}i)
+      next if match.blank?
+
       "#{match[1].tr("-", ".")},#{match[2]}"
     end
   end

--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -12,6 +12,8 @@ cask "robo-3t" do
     url "https://github.com/Studio3T/robomongo"
     strategy :github_latest do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/robo3t-\1-darwin-x86_64-([0-9a-f]+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/robofont.rb
+++ b/Casks/robofont.rb
@@ -11,6 +11,8 @@ cask "robofont" do
     url "https://doc.robofont.com/appcast.xml"
     strategy :page_match do |page|
       match = page.match(/Version\s(\d+(?:\.\d+)*)\s\(build\s(\d+(?:\.\d+)*)\)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/rowanj-gitx.rb
+++ b/Casks/rowanj-gitx.rb
@@ -12,6 +12,8 @@ cask "rowanj-gitx" do
     url "https://github.com/rowanj/gitx/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?%2F(\d+(?:\.\d+)*)%2F(\d+)/GitX-dev-\d+\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -12,6 +12,8 @@ cask "sage" do
     url "https://github.com/3-manifolds/Sage_macOS/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/SageMath-(\d+(?:\.\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/sauerbraten.rb
+++ b/Casks/sauerbraten.rb
@@ -12,6 +12,8 @@ cask "sauerbraten" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{(\d+(?:_\d+)*)/sauerbraten[._-]?(\d+(?:_\d+)*)[._-]?macos.dmg}i)
+      next if match.blank?
+
       "#{match[1].tr("_", ".")},#{match[2].tr("_", ".")}"
     end
   end

--- a/Casks/shupapan.rb
+++ b/Casks/shupapan.rb
@@ -10,6 +10,8 @@ cask "shupapan" do
     url "http://sunsky3s.s41.xrea.com/shupapan/download/index.html"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Shupapan_v(\d+)(\d+)(\d+)(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]}.#{match[2]}.#{match[3]}.#{match[4]}"
     end
   end

--- a/Casks/silentknight.rb
+++ b/Casks/silentknight.rb
@@ -12,6 +12,8 @@ cask "silentknight" do
     url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
     strategy :page_match do |page|
       match = page.match(%r{/(\d+)/(\d+)/silentknight(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"
     end
   end

--- a/Casks/simpholders.rb
+++ b/Casks/simpholders.rb
@@ -10,6 +10,8 @@ cask "simpholders" do
     url "https://simpholders.com/latest/"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/(\d+)/simpholders_(\d+(?:_\d+)*).dmg}i)
+      next if match.blank?
+
       "#{match[2].tr("_", ".")},#{match[1]}"
     end
   end

--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -12,6 +12,8 @@ cask "sketchbook" do
     url "https://www.autodesk.com/products/sketchbook/free-download"
     strategy :page_match do |page|
       match = page.match(%r{sketchbook_(\d+)/sketchbook_v?(\d+(?:\.\d+)*)_mac\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/slicer.rb
+++ b/Casks/slicer.rb
@@ -12,6 +12,8 @@ cask "slicer" do
     url "http://download.slicer.org"
     strategy :page_match do |page|
       match = page.scan(%r{href=.*?/bitstream/(\d+).*?version\s*(\d+(?:\.\d+)*)}im)
+      next if match.blank?
+
       "#{match[1][1]},#{match[1][0]}"
     end
   end

--- a/Casks/snip.rb
+++ b/Casks/snip.rb
@@ -10,6 +10,8 @@ cask "snip" do
     url "https://snip.qq.com/download"
     strategy :header_match do |headers|
       match = headers["location"].match(/_V(\d+(?:\.\d+)*)_(\d+).dmg/)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/sogouinput.rb
+++ b/Casks/sogouinput.rb
@@ -12,6 +12,8 @@ cask "sogouinput" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{/(\d+(?:\.\d+)*)/sogou_mac_(\d+(?:.\d+).*)\.zip}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -12,6 +12,8 @@ cask "sonic-visualiser" do
     url "https://www.sonicvisualiser.org/download.html"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/(\d+)/Sonic%20Visualiser-(\d+(?:\.\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/squeak.rb
+++ b/Casks/squeak.rb
@@ -10,6 +10,8 @@ cask "squeak" do
     url "https://squeak.org/downloads/"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Squeak(\d+(?:\.\d+)*)-(\d+)-64bit-All-in-One\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/startupizer.rb
+++ b/Casks/startupizer.rb
@@ -12,6 +12,8 @@ cask "startupizer" do
     url "https://updates.devmate.com/com.gentlebytes.Startupizer#{version.major}.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/(\d+)/Startupizer(\d+)-\d+\.zip}i)
+      next if match.blank?
+
       "#{match[2]},#{item.version}:#{match[1]}"
     end
   end

--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -19,6 +19,8 @@ cask "stoplight-studio" do
     url "https://github.com/stoplightio/studio/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)+)[._-]stable[._-]([^/]+)/stoplight[._-]studio[._-]#{arch}\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -12,6 +12,8 @@ cask "sublime-text" do
     regex(/href=.*?v?(\d+)_mac\.zip/i)
     strategy :page_match do |page, regex|
       match = page.match(regex)[1]
+      next if match.blank?
+
       "#{match[0]}.#{match[1..]}"
     end
   end

--- a/Casks/superslicer.rb
+++ b/Casks/superslicer.rb
@@ -11,6 +11,8 @@ cask "superslicer" do
     url "https://github.com/supermerill/SuperSlicer/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/SuperSlicer_(\d+(?:\.\d+)*)_macos_(\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/tap-forms.rb
+++ b/Casks/tap-forms.rb
@@ -12,6 +12,8 @@ cask "tap-forms" do
     url "https://vendors.paddle.com/download/product/503174"
     strategy :header_match do |headers|
       version = headers["location"].match(/([A-z0-9]+)[._-]Tap%20Forms%20Install%20(\d+(?:\.\d+)+)\.dmg/)
+      next if version.blank?
+
       "#{version[2]},#{version[1]}"
     end
   end

--- a/Casks/tenable-nessus-agent.rb
+++ b/Casks/tenable-nessus-agent.rb
@@ -11,6 +11,8 @@ cask "tenable-nessus-agent" do
     url "https://www.tenable.com/downloads/nessus-agents?loginAttempted=true"
     strategy :page_match do |page|
       match = page.match(/"id"\s*:\s*(\d+)\s*,\s*"file"\s*:\s*"NessusAgent-(\d+(?:\.\d+)*).dmg"/)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/texworks.rb
+++ b/Casks/texworks.rb
@@ -12,6 +12,8 @@ cask "texworks" do
     url "https://github.com/TeXworks/texworks/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/TeXworks-macos-(\d+(?:\.\d+)*)-(\d+)-git_(.*?)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}:#{match[3]}"
     end
   end

--- a/Casks/ticktick.rb
+++ b/Casks/ticktick.rb
@@ -12,6 +12,8 @@ cask "ticktick" do
     url "https://www.ticktick.com/static/getApp/download?type=mac"
     strategy :header_match do |headers|
       match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-](\d+)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/toolreleases.rb
+++ b/Casks/toolreleases.rb
@@ -11,6 +11,8 @@ cask "toolreleases" do
     url "https://github.com/DeveloperMaris/ToolReleases/releases/latest"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/ToolReleases_v?(\d+(?:\.\d+)*)\.b(\d+)\.zip}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/tower.rb
+++ b/Casks/tower.rb
@@ -12,6 +12,8 @@ cask "tower" do
     url "https://updates.fournova.com/tower3-mac/stable/releases/latest/download"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{(\d+(?:\.\d+)*)-([a-z0-9]+)/Tower-(\d+(?:\.\d+)*)-(\d+(?:\.\d+)*)\.zip}i)
+      next if match.blank?
+
       "#{match[3]},#{match[1]}:#{match[2]}"
     end
   end

--- a/Casks/triplecheese.rb
+++ b/Casks/triplecheese.rb
@@ -12,6 +12,8 @@ cask "triplecheese" do
     url "https://u-he.com/products/triplecheese/releasenotes.html"
     strategy :page_match do |page|
       match = page.match(/Triple\s*Cheese\s*(\d+(?:\.\d+)*)\s*\(revision\s*(\d+(?:\.\d+)*)\)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -13,6 +13,8 @@ cask "tunnelblick" do
     url "https://github.com/Tunnelblick/Tunnelblick/releases"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/Tunnelblick_(\d+(?:\.\d+)*[a-z]?)_build_(\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -11,6 +11,8 @@ cask "upwork" do
     url "https://upwork-usw2-desktopapp.upwork.com/binaries/versions-mac.json"
     strategy :page_match do |page|
       match = page.match(%r{/v(\d+(?:_\d+)*)_([^/]+)/Upwork\.dmg}i)
+      next if match.blank?
+
       "#{match[1].tr("_", ".")},#{match[2]}"
     end
   end

--- a/Casks/visual-paradigm-ce.rb
+++ b/Casks/visual-paradigm-ce.rb
@@ -11,6 +11,8 @@ cask "visual-paradigm-ce" do
     url "https://www.visual-paradigm.com/downloads/vpce/checksum.html"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/vpce(\d+(?:\.\d+)*)/(\d+)/checksum\.html}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -11,6 +11,8 @@ cask "visual-paradigm" do
     url "https://www.visual-paradigm.com/downloads/vp/checksum.html"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/vp(\d+(?:\.\d+)*)/(\d+)/checksum\.html}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/volanta.rb
+++ b/Casks/volanta.rb
@@ -11,6 +11,8 @@ cask "volanta" do
     url "https://api.volanta.app/api/v1/ClientUpdate/latest-mac.yml"
     strategy :page_match do |page|
       match = page.match(%r{volanta-app/(\d+(?:\.\d+)+)-(.+)/}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/voov-meeting.rb
+++ b/Casks/voov-meeting.rb
@@ -13,6 +13,8 @@ cask "voov-meeting" do
     url "https://voovmeeting.com/download/darwin"
     strategy :header_match do |headers|
       match = headers["location"].match(/_(\d+)_(\d+(?:\.\d+)*)\.publish\.dmg/)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/vu.rb
+++ b/Casks/vu.rb
@@ -11,6 +11,8 @@ cask "vu" do
     url "https://updates.devmate.com/com.boriskarulin.vu.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/(\d+)/vu-(\d+(?:\.\d+)*)\.dmg}i)
+      next if match.blank?
+
       "#{item.short_version},#{item.version}:#{match[1]}"
     end
   end

--- a/Casks/wezterm.rb
+++ b/Casks/wezterm.rb
@@ -13,6 +13,8 @@ cask "wezterm" do
     regex(%r{href=.*?/WezTerm-macos-(\d{8}-\d{6})-([0-9a-f]+)\.zip}i)
     strategy :github_latest do |page, regex|
       match = page.match(regex)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/wwdc.rb
+++ b/Casks/wwdc.rb
@@ -12,6 +12,8 @@ cask "wwdc" do
     url :url
     strategy :github_latest do |page|
       match = page.match(/WWDC_v?(\d+(?:\.\d+)*)-(\d+(?:\.\d+)*)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/xiami.rb
+++ b/Casks/xiami.rb
@@ -11,6 +11,8 @@ cask "xiami" do
     url "https://g.alicdn.com/music/desktop-app/XiamiMac.xml"
     strategy :sparkle do |item|
       match = item.url.match(%r{/([^/]+)/([^/]+)\.zip}i)
+      next if match.blank?
+
       "#{item.short_version},#{item.version},#{match[1]}:#{match[2]}"
     end
   end

--- a/Casks/ximalaya.rb
+++ b/Casks/ximalaya.rb
@@ -13,6 +13,8 @@ cask "ximalaya" do
     url "https://www.ximalaya.com/down/lite?client=mac"
     strategy :header_match do |headers|
       match = headers["location"].match(%r{/Ximalaya[_-](\d+(?:\.\d+)*)[_-](\d+)\.dmg}i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/xpra.rb
+++ b/Casks/xpra.rb
@@ -11,6 +11,8 @@ cask "xpra" do
     url "https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg.sha1"
     strategy :page_match do |page|
       match = page.match(/x86_64[._-]v?(\d+(?:\.\d+)+)[._-]r(\d+)\.pkg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/xtorrent.rb
+++ b/Casks/xtorrent.rb
@@ -11,6 +11,8 @@ cask "xtorrent" do
     url "http://www.xtorrent.com/download.php"
     strategy :page_match do |page|
       match = page.match(/Xtorrent(\d+(?:\.\d+)*)\(v?(\d+(?:\.\d+)*)\)\.dmg/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/yu-writer.rb
+++ b/Casks/yu-writer.rb
@@ -11,6 +11,8 @@ cask "yu-writer" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/yu-writer-(?:([a-z]+)-)?(\d+(?:\.\d+)*)-macos\.dmg}i)
+      next if match.blank?
+
       "#{match[2]},#{match[1]}"
     end
   end

--- a/Casks/zebra2.rb
+++ b/Casks/zebra2.rb
@@ -13,6 +13,8 @@ cask "zebra2" do
     url "https://u-he.com/products/zebra#{version.major}/releasenotes.html"
     strategy :page_match do |page|
       match = page.match(/Zebra\s*(\d+(?:\.\d+)*)\s*\(revision\s*(\d+(?:\.\d+)*)\)/i)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end


### PR DESCRIPTION
This update causes livecheck to fail gracefully when `page.match` fails inside of the `do` block.
The documentation needs to be updated to match this pattern also.