### PR TITLE
Update gemini.rb version to "2.8.11,384:1635423816"

### DIFF
--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -2,7 +2,7 @@ cask "gemini" do
   version "2.8.11,384:1635423816"
   sha256 "63f8e4cac87830b5fa10d36deda4407087a4c0ede511cb9de0c891e7a343cd9c"
 
-  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_colon}/#{version.after_comma.before_colon}/Gemini#{version.major}-#{version.after_colon}.zip",
+  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_comma.before_colon}/#{version.after_colon}/Gemini#{version.major}-#{version.after_comma.before_colon}.zip",
       verified: "dl.devmate.com/com.macpaw.site.Gemini"
   name "Gemini"
   desc "Disk space cleaner that finds and deletes duplicated and similar files"

--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,5 +1,5 @@
 cask "gemini" do
-  version "2.8.11:384,1635423816"
+  version "2.8.11,384:1635423816"
   sha256 "63f8e4cac87830b5fa10d36deda4407087a4c0ede511cb9de0c891e7a343cd9c"
 
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_colon}/#{version.after_comma.before_colon}/Gemini#{version.major}-#{version.after_colon}.zip",

--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,8 +1,8 @@
 cask "gemini" do
-  version "2.8.10,383:1624958928"
+  version "2.8.11:384,1635423816"
   sha256 "63f8e4cac87830b5fa10d36deda4407087a4c0ede511cb9de0c891e7a343cd9c"
 
-  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_comma.before_colon}/#{version.after_colon}/Gemini#{version.major}-#{version.after_comma.before_colon}.zip",
+  url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_colon}/#{version.after_comma.before_colon}/Gemini#{version.major}-#{version.after_colon}.zip",
       verified: "dl.devmate.com/com.macpaw.site.Gemini"
   name "Gemini"
   desc "Disk space cleaner that finds and deletes duplicated and similar files"

--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -1,6 +1,6 @@
 cask "gemini" do
   version "2.8.11,384:1635423816"
-  sha256 "63f8e4cac87830b5fa10d36deda4407087a4c0ede511cb9de0c891e7a343cd9c"
+  sha256 "591874fc089bd6f3dcb95ec1a6ab14cdb72c06281790aeb29d59429d2f2f1da5"
 
   url "https://dl.devmate.com/com.macpaw.site.Gemini#{version.major}/#{version.after_comma.before_colon}/#{version.after_colon}/Gemini#{version.major}-#{version.after_comma.before_colon}.zip",
       verified: "dl.devmate.com/com.macpaw.site.Gemini"


### PR DESCRIPTION
It seems that they've changed the URL scheme in the feed at https://updates.devmate.com/com.macpaw.site.Gemini2.xml

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
