### PR TITLE
ppsspp: initial version

### DIFF
--- a/Casks/ppsspp.rb
+++ b/Casks/ppsspp.rb
@@ -3,7 +3,7 @@ cask "ppsspp" do
   sha256 "31059cb7c845622bcfb6686d7131d6a39f101c82d4274b0b16fe20efbf9050f3"
 
   url "https://github.com/hrydgard/ppsspp/releases/download/v#{version}/PPSSPPSDL-macOS-v#{version}.zip",
-    verified: "github.com/hrydgard/ppsspp/"
+      verified: "github.com/hrydgard/ppsspp/"
   name "PPSSPP"
   desc "PSP emulator"
   homepage "https://www.ppsspp.org/"

--- a/Casks/ppsspp.rb
+++ b/Casks/ppsspp.rb
@@ -2,7 +2,8 @@ cask "ppsspp" do
   version "1.12.3"
   sha256 "31059cb7c845622bcfb6686d7131d6a39f101c82d4274b0b16fe20efbf9050f3"
 
-  url "https://github.com/hrydgard/ppsspp/releases/download/v#{version}/PPSSPPSDL-macOS-v#{version}.zip"
+  url "https://github.com/hrydgard/ppsspp/releases/download/v#{version}/PPSSPPSDL-macOS-v#{version}.zip",
+    verified: "github.com/hrydgard/ppsspp/"
   name "PPSSPP"
   desc "PSP emulator"
   homepage "https://www.ppsspp.org/"

--- a/Casks/ppsspp.rb
+++ b/Casks/ppsspp.rb
@@ -1,0 +1,15 @@
+cask "ppsspp" do
+  version "1.12.3"
+  sha256 "31059cb7c845622bcfb6686d7131d6a39f101c82d4274b0b16fe20efbf9050f3"
+
+  url "https://github.com/hrydgard/ppsspp/releases/download/v#{version}/PPSSPPSDL-macOS-v#{version}.zip"
+  name "PPSSPP"
+  desc "PSP emulator"
+  homepage "https://www.ppsspp.org/"
+
+  auto_updates false
+
+  app "PPSSPPSDL.app"
+
+  uninstall quit: "org.ppsspp.ppsspp"
+end

--- a/Casks/ppsspp.rb
+++ b/Casks/ppsspp.rb
@@ -8,8 +8,6 @@ cask "ppsspp" do
   desc "PSP emulator"
   homepage "https://www.ppsspp.org/"
 
-  auto_updates false
-
   app "PPSSPPSDL.app"
 
   uninstall quit: "org.ppsspp.ppsspp"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

* This cask replaces PPSSPP formula as discussed in https://github.com/Homebrew/homebrew-core/issues/84737#issuecomment-922330856. I believe a separate PR will be needed to remove the formula.
* Uninstall will not be able to quit PPSSPP before 1.13 update due to a bug fixed in https://github.com/hrydgard/ppsspp/pull/15078, but this feels rather minor.
* PPSSPP stores its data in ~/.config/ppsspp, yet this folder contains game saves, texture packs, and so on. It may be very unintended to remove this directory when removing the app itself. For this reason I opted not to take it out.