### PR TITLE
xonotic: fix livecheck + add desc

### DIFF
--- a/Casks/xonotic.rb
+++ b/Casks/xonotic.rb
@@ -4,6 +4,7 @@ cask "xonotic" do
 
   url "https://dl.xonotic.org/xonotic-#{version}.zip"
   name "Xonotic"
+  desc "Arena-style first person shooter"
   homepage "https://www.xonotic.org/"
 
   livecheck do

--- a/Casks/xonotic.rb
+++ b/Casks/xonotic.rb
@@ -7,9 +7,8 @@ cask "xonotic" do
   homepage "https://www.xonotic.org/"
 
   livecheck do
-    url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/xonotic-(\d+(?:\.\d+)*)\.zip}i)
+    url "https://www.xonotic.org/download/"
+    regex(%r{href=.*?/xonotic[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 
   suite "Xonotic"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.