### PR TITLE
Install AWS session-manager-plugin from notarized pkg instead of zip

### DIFF
--- a/Casks/session-manager-plugin.rb
+++ b/Casks/session-manager-plugin.rb
@@ -1,9 +1,9 @@
 cask "session-manager-plugin" do
   version "1.2.279.0"
-  sha256 "15b8b932a09f05d723db27e13a928c42b048802e6fb638f8ba69a82aa8f33a9d"
+  sha256 "8f14d12aa528d27ba787b20e7ea8492e07cc80321de51843ecd44436dcd64dc1"
 
-  url "https://session-manager-downloads.s3.amazonaws.com/plugin/#{version}/mac/sessionmanager-bundle.zip",
-      verified: "session-manager-downloads.s3.amazonaws.com/"
+  url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/session-manager-plugin.pkg",
+      verified: "s3.amazonaws.com/session-manager-downloads/"
   name "Session Manager Plugin for the AWS CLI"
   desc "Plugin for AWS CLI to start and end sessions that connect to managed instances"
   homepage "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
@@ -13,5 +13,8 @@ cask "session-manager-plugin" do
     regex(%r{<td>\s*v?(\d+(?:\.\d+)+)\s*</td>}i)
   end
 
-  binary "sessionmanager-bundle/bin/session-manager-plugin"
+  pkg "session-manager-plugin.pkg"
+  binary "/usr/local/sessionmanagerplugin/bin/session-manager-plugin"
+
+  uninstall pkgutil: "session-manager-plugin"
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

This PR proposes installing AWS `session-manager-plugin` from notarized pkg instead of zip. It resolves issues
- https://github.com/Homebrew/homebrew-cask/issues/109290
- https://github.com/Homebrew/homebrew-cask/issues/90637

More about the problem can be read at https://github.com/aws/aws-cli/issues/5758.

To sum up since version `1.2.205.0` (June 10, 2021) AWS added support for signed macOS installer, hence brew should install cask from it. It's not a breaking change. People who have the current version already installed will be switched seamlessly during the next update (when a new version will be released). When somebody wants can force switch by running
```
brew reinstall session-manager-plugin 
```
New users will install the `session-manager-plugin` from pkg by default and avoid any mentioned above issues.


