### PR TITLE
Upgrade Disk Drill.app to 4.5.369

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,8 +1,8 @@
 cask "disk-drill" do
-  version "4.4.356"
-  sha256 "2f6c8be2c7803746723fbabf4fcd2b2976fea4db1cbd6405efa7ba24e32fbff1"
+  version "4.5.369"
+  sha256 :no_check
 
-  url "https://www.cleverfiles.com/releases/DiskDrill_#{version}.dmg"
+  url "https://dl.cleverfiles.com/diskdrill.dmg"
   name "Disk Drill"
   desc "Data recovery software"
   homepage "https://www.cleverfiles.com/"


### PR DESCRIPTION
bump-cask-pr was not working, because Clever Files changed versioned download path to unversioned download path.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
