### PR TITLE
acquia-dev: discontinued

### DIFF
--- a/Casks/acquia-dev.rb
+++ b/Casks/acquia-dev.rb
@@ -7,14 +7,6 @@ cask "acquia-dev" do
   desc "Install, test, and build Drupal sites locally"
   homepage "https://www.acquia.com/drupal/acquia-dev-desktop"
 
-  livecheck do
-    url "https://dev.acquia.com/downloads"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/AcquiaDevDesktop-(\d+(?:-\d+)*)-osx-installer_0\.zip}, 1]
-      v.tr("-", ".")
-    end
-  end
-
   installer manual: "Acquia Dev Desktop Installer.app"
 
   uninstall script: {
@@ -28,4 +20,8 @@ cask "acquia-dev" do
     "~/Library/Caches/com.acquia.acquia-dev-desktop#{version.major}",
     "~/Library/Saved Application State/com.acquia.acquia-dev-desktop#{version.major}.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
----
According to the [vendor](https://docs.acquia.com/resource/archive/dev-desktop/), this app has been discontinued. Because the download link has been removed from the website as well, the livecheck is broken too.
