### PR TITLE
Fix zap stanza for Porting Kit.app Cask

### DIFF
--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -12,4 +12,9 @@ cask "porting-kit" do
   depends_on macos: ">= :high_sierra"
 
   app "Porting Kit.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.paulthetall.portingkit.plist",
+    "~/Library/Saved Application State/com.paulthetall.portingkit.savedState",
+  ]
 end


### PR DESCRIPTION
Added zap stanza for Porting Kit.app, see https://github.com/Homebrew/homebrew-cask/issues/88469

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
