### PR TITLE
Add zap stanza to Synology Note Station Client.app

### DIFF
--- a/Casks/synology-note-station-client.rb
+++ b/Casks/synology-note-station-client.rb
@@ -14,4 +14,11 @@ cask "synology-note-station-client" do
   end
 
   app "Synology Note Station Client.app"
+
+  zap trash: [
+    "~/Library/Application Support/synology-note-station-client",
+    "~/Library/Caches/synology-note-station-client",
+    "~/Library/Saved Application State/synology.note.station.savedState",
+    "~/Library/Preferences/synology.note.station.plist",
+  ]
 end


### PR DESCRIPTION
Added missing zap Stanza to Synology Note Station Client, see https://github.com/Homebrew/homebrew-cask/issues/88469

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

