### PR TITLE
electrum: fix livecheck

### DIFF
--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -8,8 +8,9 @@ cask "electrum" do
   homepage "https://electrum.org/"
 
   livecheck do
-    url "https://github.com/spesmilo/electrum"
-    strategy :github_latest
+    url "https://github.com/spesmilo/electrum/tags"
+    strategy :page_match
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -8,9 +8,8 @@ cask "electrum" do
   homepage "https://electrum.org/"
 
   livecheck do
-    url "https://github.com/spesmilo/electrum/tags"
-    strategy :page_match
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "https://electrum.org/panel-download.html"
+    regex(/href=.*?electrum[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
The livecheck of `electrum` is broken, because there're only tags, but not releases any more (see [Wayback Machine](https://web.archive.org/web/20201111162205/https://github.com/spesmilo/electrum/releases)).