### PR TITLE
fvim: fix livecheck

### DIFF
--- a/Casks/fvim.rb
+++ b/Casks/fvim.rb
@@ -10,7 +10,7 @@ cask "fvim" do
   livecheck do
     url :url
     strategy :github_latest do |page|
-      match = page.match(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)%2B(g?\h+)["' >]}i)
+      match = page.match(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)\+(g?\h+)["' >]}i)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
The livecheck for `fvim` is broken, because GitHub seems to no longer urlencode the version in redirects any more.

I've noticed that GitHub reflects, if the version in the request is urlencoded (see `curl "https://github.com/yatli/fvim/releases/tag/v0.3.489+g98c4036" | grep "/yatli/fvim/releases/tag/` vs. `curl "https://github.com/yatli/fvim/releases/tag/v0.3.489%2Bg98c4036" | grep "/yatli/fvim/releases/tag/"`). Since the URL used for livecheck redirects to the non-urlencoded variant (see `curl https://github.com/yatli/fvim/releases/latest -I | grep "location:"`) the response contains the non-urlencoded version, hence the RegEx fails.