### PR TITLE
Update ankama from 3.5.1.12738 to 3.5.4.12908

### DIFF
--- a/Casks/ankama.rb
+++ b/Casks/ankama.rb
@@ -1,5 +1,5 @@
 cask "ankama" do
-  version "3.5.1.12738"
+  version "3.5.4.12908"
   sha256 :no_check
 
   url "https://launcher.cdn.ankama.com/installers/production/Ankama%20Launcher-Setup.dmg"
@@ -12,7 +12,7 @@ cask "ankama" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :yosemite"
 
   app "Ankama Launcher.app"
 


### PR DESCRIPTION
Both Info.plist and [this webpage](https://support.ankama.com/hc/en-us/articles/360017472154-Install-the-Ankama-Launcher#other-games) say 10.10 regarding minimum OS requirement.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.