### PR TITLE
Add uninstall script for Disk Drill.app

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -14,7 +14,10 @@ cask "disk-drill" do
 
   app "Disk Drill.app"
 
-  uninstall delete: "/Library/Application Support/CleverFiles"
+  uninstall script: {
+    executable: "#{staged_path}/Disk Drill.app/Contents/Resources/uninstall",
+    sudo:       true,
+  }
 
   zap trash: [
     "~/Library/Application Support/DiskDrill",


### PR DESCRIPTION
Disk Drill comes with it's own uninstall script. Running this script instead of removing anything via Cask stanzas is much easier, more future proof and more reliable.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
