### PR TITLE
Update beeper from 2.9.3 to 2.9.12

### DIFF
--- a/Casks/beeper.rb
+++ b/Casks/beeper.rb
@@ -1,7 +1,7 @@
 cask "beeper" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "2.9.3"
+  version "2.9.12"
   sha256 :no_check
 
   url "https://download.beeper.com/mac/dmg/#{arch}"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.