### PR TITLE
prezi-classic: fix livecheck + add desc and zap

### DIFF
--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -11,9 +11,9 @@ cask "prezi-classic" do
     url "https://prezidesktop.s3.amazonaws.com/assets/mac/pd6/updates/prezi-classic.xml"
     strategy :page_match do |page|
       match = page.match(/<enclosure.*?sparkle:version="(\d+).*?sparkle:shortVersionString="(\d+(?:\.\d+)*)"/im)
-        next if match.blank?
+      next if match.blank?
 
-        "#{match[2]},#{match[1]}"
+      "#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -10,7 +10,7 @@ cask "prezi-classic" do
   livecheck do
     url "https://prezidesktop.s3.amazonaws.com/assets/mac/pd6/updates/prezi-classic.xml"
     strategy :page_match do |page|
-      match = page.match(/<enclosure.*?sparkle:version="(\d+).*?sparkle:shortVersionString="(\d+(?:\.\d+)*)"/im)
+      match = page.match(/<enclosure.*?sparkle:version="(\d+).*?sparkle:shortVersionString="(\d+(?:\.\d+)+)"/im)
       next if match.blank?
 
       "#{match[2]},#{match[1]}"

--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -8,7 +8,12 @@ cask "prezi-classic" do
 
   livecheck do
     url "https://prezidesktop.s3.amazonaws.com/assets/mac/pd6/updates/prezi-classic.xml"
-    strategy :sparkle
+    strategy :page_match do |page|
+      match = page.match(/<enclosure.*?sparkle:version="(\d+).*?sparkle:shortVersionString="(\d+(?:\.\d+)*)"/im)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+    end
   end
 
   app "Prezi Classic.app"

--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -4,6 +4,7 @@ cask "prezi-classic" do
 
   url "https://desktopassets.prezi.com/mac/pd6/releases/Prezi_Classic_#{version.before_comma}.dmg"
   name "Prezi Classic"
+  desc "Desktop client for the Prezi presentation SaaS"
   homepage "https://prezi.com/desktop"
 
   livecheck do

--- a/Casks/prezi-classic.rb
+++ b/Casks/prezi-classic.rb
@@ -18,4 +18,13 @@ cask "prezi-classic" do
   end
 
   app "Prezi Classic.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.prezi.desktop",
+    "~/Library/Caches/com.prezi.desktop",
+    "~/Library/Logs/Prezi Classic",
+    "~/Library/Logs/Prezi Classic_debug.log",
+    "~/Library/Preferences/com.prezi.desktop.plist",
+    "~/Library/Saved Application State/com.prezi.desktop.savedState",
+  ]
 end


### PR DESCRIPTION
Livecheck with `strategy :sparkle` resulted in "prezi-classic : 6.14.0,24153 ==> 6.4.0,7037" because `pubDate` is empty.

https://github.com/Homebrew/homebrew-cask/issues/107289

