### PR TITLE
Updated zap for Disk Drill.app

### DIFF
--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -1,5 +1,5 @@
 cask "disk-drill" do
-  version "4.5.369"
+  version "4.6.370"
   sha256 :no_check
 
   url "https://dl.cleverfiles.com/diskdrill.dmg"

--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -19,9 +19,39 @@ cask "disk-drill" do
     sudo:       true,
   }
 
-  zap trash: [
-    "~/Library/Application Support/DiskDrill",
-    "~/Library/Caches/com.cleverfiles.Disk_Drill",
-    "~/Library/Logs/DiskDrill.log",
-  ]
+  zap script:    {
+    executable: "defaults",
+    args:       [
+      "delete com.cleverfiles.Disk_Drill",
+      "delete com.cleverfiles.DiskDrill",
+      "delete com.cleverfiles.DiskDrill-setapp",
+    ],
+  },
+      launchctl: "com.cleverfiles.cfbackd",
+      kext:      [
+        "com.cleverfiles.SecureDisk",
+        "com.cleverfiles.SecureDisk-11",
+      ],
+      quit:      [
+        "com.cleverfiles.DiskDrill",
+        "com.cleverfiles.DiskDrill.SmartDaemon",
+        "com.cleverfiles.cfbackd",
+      ],
+      signal:    [
+        ["KILL", "com.cleverfiles.DiskDrill"],
+      ],
+      trash:     [
+        "~/Library/Application Support/DiskDrill",
+        "~/Library/Caches/com.cleverfiles.Disk_Drill",
+        "~/Library/Logs/DiskDrill.log",
+        "~/Library/Preferences/com.cleverfiles.Disk_Drill.plist",
+        "~/Library/Preferences/com.cleverfiles.DiskDrill.plist",
+        "~/Library/Preferences/com.cleverfiles.DiskDrill-setapp.plist",
+        "~/Library/Containers/com.cleverfiles.DiskDrill.Media/Data/cfbackd.chief",
+        "/Library/Logs/CleverFiles",
+        "/Library/Application Support/CleverFiles",
+        "/Library/Preferences/com.cleverfiles.cfbackd.plist",
+        "/Library/Caches/CleverFiles",
+        "/Library/LaunchDaemons/com.cleverfiles.cfbackd.plist",
+      ]
 end

--- a/Casks/disk-drill.rb
+++ b/Casks/disk-drill.rb
@@ -19,39 +19,13 @@ cask "disk-drill" do
     sudo:       true,
   }
 
-  zap script:    {
-    executable: "defaults",
-    args:       [
-      "delete com.cleverfiles.Disk_Drill",
-      "delete com.cleverfiles.DiskDrill",
-      "delete com.cleverfiles.DiskDrill-setapp",
-    ],
-  },
-      launchctl: "com.cleverfiles.cfbackd",
-      kext:      [
-        "com.cleverfiles.SecureDisk",
-        "com.cleverfiles.SecureDisk-11",
-      ],
-      quit:      [
-        "com.cleverfiles.DiskDrill",
-        "com.cleverfiles.DiskDrill.SmartDaemon",
-        "com.cleverfiles.cfbackd",
-      ],
-      signal:    [
-        ["KILL", "com.cleverfiles.DiskDrill"],
-      ],
-      trash:     [
-        "~/Library/Application Support/DiskDrill",
-        "~/Library/Caches/com.cleverfiles.Disk_Drill",
-        "~/Library/Logs/DiskDrill.log",
-        "~/Library/Preferences/com.cleverfiles.Disk_Drill.plist",
-        "~/Library/Preferences/com.cleverfiles.DiskDrill.plist",
-        "~/Library/Preferences/com.cleverfiles.DiskDrill-setapp.plist",
-        "~/Library/Containers/com.cleverfiles.DiskDrill.Media/Data/cfbackd.chief",
-        "/Library/Logs/CleverFiles",
-        "/Library/Application Support/CleverFiles",
-        "/Library/Preferences/com.cleverfiles.cfbackd.plist",
-        "/Library/Caches/CleverFiles",
-        "/Library/LaunchDaemons/com.cleverfiles.cfbackd.plist",
-      ]
+  zap trash: [
+    "~/Library/Application Support/DiskDrill",
+    "~/Library/Caches/com.cleverfiles.Disk_Drill",
+    "~/Library/Containers/com.cleverfiles.DiskDrill.Media/Data/cfbackd.chief",
+    "~/Library/Logs/DiskDrill.log",
+    "~/Library/Preferences/com.cleverfiles.Disk_Drill.plist",
+    "~/Library/Preferences/com.cleverfiles.DiskDrill.plist",
+    "~/Library/Preferences/com.cleverfiles.DiskDrill-setapp.plist",
+  ]
 end


### PR DESCRIPTION
Transfered official uninstaller script for zap command. If Disk Drill
was uninstalled outside of Homebrew, a forced zap will still remove
everything that was installed by Disk Drill.

This pull request is a follow up to #113824.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.