### PR TITLE
Update origin from 10.5.104.48966 to 10.5.106.49298

### DIFF
--- a/Casks/origin.rb
+++ b/Casks/origin.rb
@@ -1,5 +1,5 @@
 cask "origin" do
-  version "10.5.104.48966"
+  version "10.5.106.49298"
   sha256 :no_check
 
   url "https://origin-a.akamaihd.net/Origin-Client-Download/origin/mac/live/Origin.dmg",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.