### PR TITLE
Update naver-whale from 2.10.123.42 to 2.11.126.23

### DIFF
--- a/Casks/naver-whale.rb
+++ b/Casks/naver-whale.rb
@@ -1,5 +1,5 @@
 cask "naver-whale" do
-  version "2.10.123.42"
+  version "2.11.126.23"
   sha256 :no_check
 
   url "http://update.whale.naver.net/downloads/installers/NaverWhale.dmg",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.