### PR TITLE
Update integrity from 10.4.3 to 10.4.5

### DIFF
--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -4,7 +4,7 @@ cask "integrity" do
 
   url "https://peacockmedia.software/mac/integrity/integrity.dmg"
   name "Integrity"
-  desc "Tool to scans a website checking for broken links"
+  desc "Tool to scan a website checking for broken links"
   homepage "https://peacockmedia.software/mac/integrity/"
 
   livecheck do

--- a/Casks/integrity.rb
+++ b/Casks/integrity.rb
@@ -1,5 +1,5 @@
 cask "integrity" do
-  version "10.4.3"
+  version "10.4.5"
   sha256 :no_check
 
   url "https://peacockmedia.software/mac/integrity/integrity.dmg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.