### PR TITLE
Update deltawalker from 2.5.6 to 2.6.0

### DIFF
--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -15,6 +15,11 @@ cask "deltawalker" do
 
   app "DeltaWalker.app"
 
+  installer script: {
+    executable: "#{staged_path}/run-me-first",
+    sudo:       false,
+  }
+
   zap trash: [
     "~/Library/Caches/com.deltopia.DeltaWalker",
     "~/Library/Containers/com.deltopia.DeltaWalker",

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -1,6 +1,6 @@
 cask "deltawalker" do
-  version "2.5.6"
-  sha256 "d823244f7262351b7bc3ffa39c3a01eede50f9d079f81f32435d3642e8b9a9d3"
+  version "2.6.0"
+  sha256 "445f24ae130c2743fb99951615c4ae77be8f58260a07236871d98fdcbfa434b1"
 
   url "https://deltawalker.s3.amazonaws.com/DeltaWalker-#{version}.dmg",
       verified: "deltawalker.s3.amazonaws.com/"
@@ -9,8 +9,8 @@ cask "deltawalker" do
   homepage "https://www.deltawalker.com/"
 
   livecheck do
-    url "https://www.deltawalker.com/assets/js/main.js"
-    regex(/DeltaWalker[._-]?v?(\d+(?:\.\d+)*)\.dmg/)
+    url "https://www.deltawalker.com/download"
+    regex(/href=.*?DeltaWalker[._-]?v?(\d+(?:\.\d+)+)\.dmg/)
   end
 
   app "DeltaWalker.app"

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -6,10 +6,10 @@ cask "deltawalker" do
       verified: "deltawalker.s3.amazonaws.com/"
   name "DeltaWalker"
   desc "Tool to compare and synchronize files and folders"
-  homepage "https://www.deltawalker.com/"
+  homepage "http://www.deltawalker.com/"
 
   livecheck do
-    url "https://www.deltawalker.com/download"
+    url "http://www.deltawalker.com/download"
     regex(/href=.*?DeltaWalker[._-]?v?(\d+(?:\.\d+)+)\.dmg/)
   end
 

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -16,8 +16,9 @@ cask "deltawalker" do
   app "DeltaWalker.app"
 
   installer script: {
-    executable: "#{staged_path}/run-me-first",
-    sudo:       false,
+    executable:   "#{staged_path}/run-me-first",
+    sudo:         false,
+    must_succeed: false,
   }
 
   zap trash: [

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -15,7 +15,7 @@ cask "deltawalker" do
 
   app "DeltaWalker.app"
 
-  installer script: {
+  uninstall script: {
     executable:   "#{staged_path}/run-me-first",
     sudo:         false,
     must_succeed: false,


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

> If installing over an existing copy, run the 'run-me-first' shell script from the DMG package, or the following in Terminal:
> rm -fr ~/Library/Containers/com.deltopia.DeltaWalker/Data/Library/Application\ Support

@miccal The shell script is a bit more granular than `rm -rf`. How would I invoke it? And is there a risk to be considered when automatically executing shell scripts provided by upstream which might make `rm -rf` preferable?