### PR TITLE
Adjust the build's macOS version requirement

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -15,7 +15,7 @@ cask "mpv" do
   end
 
   conflicts_with formula: "mpv"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   app "mpv.app"
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"


### PR DESCRIPTION
This build of 0.34.0 requires macOS Mojave or newer
