### PR TITLE
Update copyclip from 2.9.98.8 to 2.9.98.9, trim zap

### DIFF
--- a/Casks/copyclip.rb
+++ b/Casks/copyclip.rb
@@ -1,5 +1,5 @@
 cask "copyclip" do
-  version "2.9.98.8"
+  version "2.9.98.9"
   sha256 :no_check
 
   url "https://fiplab.com/app-download/CopyClip_#{version.major}.zip"
@@ -19,9 +19,7 @@ cask "copyclip" do
   uninstall quit: "com.fiplab.copyclip#{version.major}"
 
   zap delete: [
-    "~/Library/Application Scripts/com.fiplab.copyclip*helper",
     "~/Library/Application Scripts/com.fiplab.copyclip*",
-    "~/Library/Containers/com.fiplab.copyclip*helper",
     "~/Library/Containers/com.fiplab.copyclip*",
   ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.