### PR TITLE
Use archive URL instead of latest URL for oracle-jdk

### DIFF
--- a/Casks/oracle-jdk.rb
+++ b/Casks/oracle-jdk.rb
@@ -2,7 +2,12 @@ cask "oracle-jdk" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
   version "17.0.1"
-  sha256 "1cddd0c4b505bc78459e4353d6dadb81c4a9c1f15934d87531bef7d4c52d8e51"
+
+  if Hardware::CPU.intel?
+    sha256 "1cddd0c4b505bc78459e4353d6dadb81c4a9c1f15934d87531bef7d4c52d8e51"
+  else
+    sha256 "5d88b9c8e51650b46545bcb95842025a58d80c068f9d8f8062a8b6276620d8d3"
+  end
 
   url "https://download.oracle.com/java/#{version.major}/archive/jdk-#{version}_macos-#{arch}_bin.dmg"
   name "Oracle Java Standard Edition Development Kit"

--- a/Casks/oracle-jdk.rb
+++ b/Casks/oracle-jdk.rb
@@ -2,9 +2,9 @@ cask "oracle-jdk" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
   version "17.0.1"
-  sha256 :no_check   # required as upstream package is updated in place
+  sha256 "1cddd0c4b505bc78459e4353d6dadb81c4a9c1f15934d87531bef7d4c52d8e51"
 
-  url "https://download.oracle.com/java/#{version.major}/latest/jdk-#{version.major}_macos-#{arch}_bin.dmg"
+  url "https://download.oracle.com/java/#{version.major}/archive/jdk-#{version}_macos-#{arch}_bin.dmg"
   name "Oracle Java Standard Edition Development Kit"
   desc "JDK from Oracle"
   homepage "https://www.oracle.com/java/technologies/downloads/"


### PR DESCRIPTION
As per discussed [here](https://github.com/Homebrew/homebrew-cask/pull/112973#issuecomment-962542550).

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.