### PR TITLE
Revert "Update texstudio `depends_on` to Big Sur"

### DIFF
--- a/Casks/texstudio.rb
+++ b/Casks/texstudio.rb
@@ -8,7 +8,7 @@ cask "texstudio" do
   desc "LaTeX editor"
   homepage "https://texstudio.org/"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :catalina"
 
   app "texstudio.app"
 


### PR DESCRIPTION
Sorry to bother you. According to its maintainer (see [comment](https://github.com/texstudio-org/texstudio/issues/1911#issuecomment-962545393)), now texstudio works with macOS 10.15 again.

Reverts Homebrew/homebrew-cask#113658