### PR TITLE
Revert "Update virtualbox from 6.1.26,145957 to 6.1.28,147628 (#112954)"

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -1,6 +1,6 @@
 cask "virtualbox" do
-  version "6.1.28,147628"
-  sha256 "2a92fce1c93dd5eb1b3f82446b8a7e16c79fa487a72dabbd2f5b6ed30f40b319"
+  version "6.1.26,145957"
+  sha256 "c544b8500e7e0cc397a38c6210f4a1cf3f0cc30c9463bc61fb10c713a9c36ecc"
 
   url "https://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
   name "Oracle VirtualBox"
@@ -11,8 +11,6 @@ cask "virtualbox" do
     url "https://www.virtualbox.org/wiki/Downloads"
     strategy :page_match do |page|
       match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)*)-(\d+)-OSX.dmg/)
-      next if match.blank?
-
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -10,7 +10,9 @@ cask "virtualbox" do
   livecheck do
     url "https://www.virtualbox.org/wiki/Downloads"
     strategy :page_match do |page|
-      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)*)-(\d+)-OSX.dmg/)
+      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)+)-(\d+)-OSX.dmg/)
+      next if match.blank?
+
       "#{match[1]},#{match[2]}"
     end
   end


### PR DESCRIPTION
This reverts commit c878cf916ce63a8bb642326c4aaae91a535f0541.
Due to the new version of VirtualBox having several major issues one of which is [not correctly working on Monterey](https://www.virtualbox.org/ticket/20640), I suggest reverting to the older version.
The [changelog](https://www.virtualbox.org/wiki/Changelog) also shows no specific MacOS bugfixes and not much major fixes or improvements.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
