### PR TITLE
update Dogecoin Core from 1.14.4 to 1.14.5

### DIFF
--- a/Casks/dogecoin.rb
+++ b/Casks/dogecoin.rb
@@ -1,6 +1,6 @@
 cask "dogecoin" do
-  version "1.14.4"
-  sha256 "e4c88893f853e72ec5bc0682e35d0db0c5605883cf0490faac28feab14fca277"
+  version "1.14.5"
+  sha256 "0d158b236e0b07526fd70547a95bb60ac1c3840f214e910399b0c322902c65c1"
 
   url "https://github.com/dogecoin/dogecoin/releases/download/v#{version}/dogecoin-#{version}-osx.dmg",
       verified: "github.com/dogecoin/dogecoin/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.