### PR TITLE
crosspack-avr: add livecheck+desc

### DIFF
--- a/Casks/crosspack-avr.rb
+++ b/Casks/crosspack-avr.rb
@@ -9,7 +9,7 @@ cask "crosspack-avr" do
 
   livecheck do
     url "https://www.obdev.at/products/crosspack/download.html"
-    regex(/>Crosspack\s*([\d-]+)/i)
+    regex(/>Crosspack\s*(\d+(?:[.-]\d+)+)/i)
   end
 
   pkg "CrossPack-AVR.pkg"

--- a/Casks/crosspack-avr.rb
+++ b/Casks/crosspack-avr.rb
@@ -4,6 +4,7 @@ cask "crosspack-avr" do
 
   url "https://www.obdev.at/downloads/crosspack/CrossPack-AVR-#{version.no_hyphens}.dmg"
   name "CrossPack"
+  desc "Development environment for Atmel’s AVR® microcontrollers"
   homepage "https://www.obdev.at/products/crosspack/index.html"
 
   livecheck do

--- a/Casks/crosspack-avr.rb
+++ b/Casks/crosspack-avr.rb
@@ -6,6 +6,11 @@ cask "crosspack-avr" do
   name "CrossPack"
   homepage "https://www.obdev.at/products/crosspack/index.html"
 
+  livecheck do
+    url "https://www.obdev.at/products/crosspack/download.html"
+    regex(/>Crosspack\s*([\d-]+)/i)
+  end
+
   pkg "CrossPack-AVR.pkg"
 
   uninstall script:  {


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.