### PR TITLE
Update vscodium from 1.62.0 to 1.62.1

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask "vscodium" do
-  version "1.62.0"
-  sha256 "678b4fdf443a0c289d1e28ffd5e0317affd14301464d4e995b403b2f4ffce715"
+  version "1.62.1"
+  sha256 "69695b5fab5ad078a9c51974db91ba802959a5bee1942afe25dcc2316601cd8f"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.x64.#{version}.dmg"
   name "VSCodium"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
