### PR TITLE
Update 8x8-work from 7.11.4-3 to 7.12.2-6

### DIFF
--- a/Casks/8x8-work.rb
+++ b/Casks/8x8-work.rb
@@ -1,5 +1,5 @@
 cask "8x8-work" do
-  version "7.11.4-3"
+  version "7.12.2-6"
   sha256 "bc8b391879dac9dc6e3093c459d76aa56b30d0ca5929552bf86e8ab4f02aca7a"
 
   url "https://vod-updates.8x8.com/ga/work-dmg-v#{version}.dmg"

--- a/Casks/8x8-work.rb
+++ b/Casks/8x8-work.rb
@@ -1,6 +1,6 @@
 cask "8x8-work" do
   version "7.12.2-6"
-  sha256 "bc8b391879dac9dc6e3093c459d76aa56b30d0ca5929552bf86e8ab4f02aca7a"
+  sha256 "33a78184f1c4c26ddc1e691084b4f4b1eda9b5b9ecce2216034a378f25cc653f"
 
   url "https://vod-updates.8x8.com/ga/work-dmg-v#{version}.dmg"
   name "8x8_work"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
