### PR TITLE
Update deeper from 2.7.0 to 2.7.5

### DIFF
--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -17,7 +17,7 @@ cask "deeper" do
   elsif MacOS.version <= :catalina
     version "2.6.0"
     sha256 "302c91c7995364bd02b71613ed440c1480d905637ba02da661cc4e53402643b3"
-  else MacOS.version <= :big_sur
+  elsif MacOS.version <= :big_sur
     version "2.7.0"
     sha256 "695a1572294fb535bbf266f11cc1d3e1838995d762b4d841f2f7d77801e7a546"
   else

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -17,9 +17,12 @@ cask "deeper" do
   elsif MacOS.version <= :catalina
     version "2.6.0"
     sha256 "302c91c7995364bd02b71613ed440c1480d905637ba02da661cc4e53402643b3"
-  else
+  else MacOS.version <= :big_sur
     version "2.7.0"
     sha256 "695a1572294fb535bbf266f11cc1d3e1838995d762b4d841f2f7d77801e7a546"
+  else
+    version "2.7.5"
+    sha256 "e850ec58afab0b161e773a0947849d3b71ac5cb34396aebe9fa9f5badc83822a"
   end
 
   url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Deeper.dmg"
@@ -33,7 +36,7 @@ cask "deeper" do
   end
 
   # Unusual case: The software may stop working, or may be dangerous to run, on the latest macOS release.
-  depends_on macos: "<= :big_sur"
+  depends_on macos: "<= :monterey"
 
   app "Deeper.app"
 end

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -39,4 +39,11 @@ cask "deeper" do
   depends_on macos: "<= :monterey"
 
   app "Deeper.app"
+
+  zap trash: [
+    "~/Library/Caches/com.apple.helpd/Generated/Deeper Help*",
+    "~/Library/Logs/Deeper.log",
+    "~/Library/Preferences/com.titanium.Deeper.plist",
+    "~/Library/Saved Application State/com.titanium.Deeper.savedState",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.