### PR TITLE
lens: replace version substring '-latest.' with comma

### DIFF
--- a/Casks/lens.rb
+++ b/Casks/lens.rb
@@ -1,7 +1,7 @@
 cask "lens" do
   arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  version "5.2.7-latest.20211110.1"
+  version "5.2.7,20211110.1"
 
   if Hardware::CPU.intel?
     sha256 "51312def38e7c00030a285204ac47f6822ad1b31b93b0d8369947e4ab05cb07f"
@@ -9,7 +9,7 @@ cask "lens" do
     sha256 "8f220e3541c6e5a6d1524532e3a9cafe7e9c33fa9ae0a27c7646500df6af63fe"
   end
 
-  url "https://api.k8slens.dev/binaries/Lens-#{version}#{arch}.dmg"
+  url "https://api.k8slens.dev/binaries/Lens-#{version.before_comma}-latest.#{version.after_comma}#{arch}.dmg"
   name "Lens"
   desc "Kubernetes IDE"
   homepage "https://k8slens.dev/"

--- a/Casks/lens.rb
+++ b/Casks/lens.rb
@@ -16,7 +16,9 @@ cask "lens" do
 
   livecheck do
     url "https://lens-binaries.s3.amazonaws.com/ide/latest-mac.yml"
-    strategy :electron_builder
+    strategy :electron_builder do |data|
+      data["version"].sub("-latest.", ",")
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The download url always contains the substring '-latest.' starting with version 5.0.0 #107871