### PR TITLE
plex-media-server: replace dash in version string with comma

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -9,8 +9,10 @@ cask "plex-media-server" do
 
   livecheck do
     url "https://plex.tv/api/downloads/5.json"
-    strategy :page_match
-    regex(%r{href=.*?/PlexMediaServer-(\d+(?:\.\d+)*-[\da-f]+)-x86_64\.zip}i)
+    regex(%r{href=.*?/PlexMediaServer-(\d+(?:\.\d+)*)-([\da-f]+)-x86_64\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
   auto_updates true

--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,8 +1,8 @@
 cask "plex-media-server" do
-  version "1.24.5.5173-8dcc73a59"
+  version "1.24.5.5173,8dcc73a59"
   sha256 "2eff6614f4ac9397988bd368855e98226e75c20c09a583ff18fedcd4fe3ce752"
 
-  url "https://downloads.plex.tv/plex-media-server-new/#{version}/macos/PlexMediaServer-#{version}-x86_64.zip"
+  url "https://downloads.plex.tv/plex-media-server-new/#{version.before_comma}-#{version.after_comma}/macos/PlexMediaServer-#{version.before_comma}-#{version.after_comma}-x86_64.zip"
   name "Plex Media Server"
   desc "Home media server"
   homepage "https://www.plex.tv/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Same as #114152 but for `plex-media-server`

Here's a ripgrep command to find additional casks that this could maybe also apply to:

```
rg  --sort-files --pcre2 'version "(?![0-9]{4}-[0-9]{2}-[0-9]{2})[^,]*-(?!alpha|beta|rc|RC)(?![0-9]")[^,]*"'
```