### PR TITLE
SomeLivecheckUpgrades (1)

### DIFF
--- a/Casks/4k-slideshow-maker.rb
+++ b/Casks/4k-slideshow-maker.rb
@@ -1,6 +1,6 @@
 cask "4k-slideshow-maker" do
-  version "2.0.0"
-  sha256 "70653289082098b9d39844f42f8b843e8b545afa93da2a3f36ea3fa263bbb389"
+  version "2.0.1"
+  sha256 "4761cf9ebfde489f5aef14a2f6f28064111f0729d15246a97fb06fcde8666e67"
 
   url "https://dl.4kdownload.com/app/4kslideshowmaker_#{version}.dmg"
   name "4K Slideshow Maker"

--- a/Casks/4k-video-to-mp3.rb
+++ b/Casks/4k-video-to-mp3.rb
@@ -1,6 +1,6 @@
 cask "4k-video-to-mp3" do
-  version "3.0.0"
-  sha256 "591e27aeecf0adab9f9787d0d6da96a0945cd9679c38cd58a7c61dbc9333c4f7"
+  version "3.0.1"
+  sha256 "3a9b4b9920a712e3e356ea09ca770b8d59c88926ae7a63bd530a2d9682a24a8b"
 
   url "https://dl.4kdownload.com/app/4kvideotomp3_#{version}.dmg"
   name "4K Video to MP3"

--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask "4k-youtube-to-mp3" do
   # NOTE: "3" is not a version number, but an intrinsic part of the product name
-  version "4.3.4"
-  sha256 "7a77e5346c494390f474713bc97618215ffec898be7f0c2365652576a47e2480"
+  version "4.3.5"
+  sha256 "8d3a7f99d1110b0dcdf1bc1707fa0bf9cba91b9bcc817b3d15762b74cb95b92f"
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version}.dmg"
   name "4K YouTube to MP3"

--- a/Casks/4k-youtube-to-mp3.rb
+++ b/Casks/4k-youtube-to-mp3.rb
@@ -1,7 +1,7 @@
 cask "4k-youtube-to-mp3" do
   # NOTE: "3" is not a version number, but an intrinsic part of the product name
-  version "4.3.3"
-  sha256 "88085b4233c7ca661ba46cc5859552c36862a55aa47e1500ac840b3bd87b7bd2"
+  version "4.3.4"
+  sha256 "7a77e5346c494390f474713bc97618215ffec898be7f0c2365652576a47e2480"
 
   url "https://dl.4kdownload.com/app/4kyoutubetomp3_#{version}.dmg"
   name "4K YouTube to MP3"

--- a/Casks/5kplayer.rb
+++ b/Casks/5kplayer.rb
@@ -1,9 +1,10 @@
 cask "5kplayer" do
-  version "6.8.0,5000"
+  version "6.9.0,5000"
   sha256 :no_check
 
   url "https://www.5kplayer.com/download/5kplayer.dmg"
   name "5KPlayer"
+  desc "Play 4K/1080p/360° video, MP3 AAC APE FLAC music without quality loss"
   homepage "https://www.5kplayer.com/"
 
   livecheck do

--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-intro" do
-  version "11.0.11"
-  sha256 "2215d3ca75a30bdde361776da4e8291523fced319e9bd4ddacc404f83123a73e"
+  version "11.0.12"
+  sha256 "0847be19873fcb7d5f40f706b365b90b7a2e3c09df31cfff4b5a8416c8dd1cc8"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
   name "Ableton Live Intro"

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-lite" do
-  version "11.0.11"
-  sha256 "75696b52f942f3024374a50bc782f7e8572e2b4b55d2f5606f94252bb842ff5b"
+  version "11.0.12"
+  sha256 "184aa95440aa154425e7c3f9e84a916ef34b44fdd67a9b5d408bcc2e908b84ab"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
   name "Ableton Live Lite"

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-standard" do
-  version "11.0.11"
-  sha256 "cf9b13181652ea34da7c5a2c552ea1092c7e5011fac180a72c9c9ea0f7095d2f"
+  version "11.0.12"
+  sha256 "5195d68cbc0fc926bfd8c293d1bee7566eac4ae5b4af1fbb195e84945dcea838"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
   name "Ableton Live Standard"

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-suite" do
-  version "11.0.11"
-  sha256 "3519175c1fad3c29daca22af9464deb02790cd142e59fcd36a1cd7e64658f99e"
+  version "11.0.12"
+  sha256 "291b277b42485d5b4ce959883b0600d7dbb7743056eac5007e3c73237672c9ea"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
   name "Ableton Live Suite"


### PR DESCRIPTION
List of casks :
- 4k-slideshow-maker 2.0.0 ==> 2.0.1
- 4k-video-to-mp3 3.0.0 ==> 3.0.1
- 4k-youtube-to-mp3 4.3.3 ==> 4.3.5
- 5kplayer 6.8.0,5000 ==> 6.9.0,5000 (didn't changed the downloaded file) + added description
- ableton-live-* 11.0.11 ==> 11.0.12 (every file is 2-3 Gb, OOF)

Checks done for every cask
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.