### PR TITLE
Update dropbox-capture from 51.0.0 to 55.0.0, add depends_on

### DIFF
--- a/Casks/dropbox-capture.rb
+++ b/Casks/dropbox-capture.rb
@@ -1,5 +1,5 @@
 cask "dropbox-capture" do
-  version "51.0.0"
+  version "55.0.0"
   sha256 :no_check
 
   url "https://clientupdates.dropboxstatic.com/dbx-releng/dropbox_capture/mac/Dropbox_Capture.dmg",
@@ -12,6 +12,8 @@ cask "dropbox-capture" do
     url :url
     strategy :extract_plist
   end
+
+  depends_on macos: ">= :el_capitan"
 
   app "Dropbox Capture.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.