### PR TITLE
duckietv: fix livecheck

### DIFF
--- a/Casks/duckietv.rb
+++ b/Casks/duckietv.rb
@@ -9,8 +9,9 @@ cask "duckietv" do
   homepage "https://schizoduckie.github.io/DuckieTV/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://github.com/SchizoDuckie/DuckieTV/releases"
+    strategy :page_match
+    regex(/href=.*?DuckieTV[._-]?v?(\d+(?:\.\d+)+)[._-]OSX[._-]x64\.pkg/i)
   end
 
   pkg "DuckieTV-#{version}-OSX-x64.pkg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.