### PR TITLE
bettertouchtool: replace dash with comma in version string

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -1,8 +1,8 @@
 cask "bettertouchtool" do
-  version "3.622-1771"
+  version "3.622,1771"
   sha256 "5a032b0ab107741c0bf3f322892cce0d36f4e19f9ed4f44e98b61cad4502d037"
 
-  url "https://folivora.ai/releases/btt#{version}.zip"
+  url "https://folivora.ai/releases/btt#{version.before_comma}-#{version.after_comma}.zip"
   name "BetterTouchTool"
   desc "Tool to customize input devices and automate computer systems"
   homepage "https://folivora.ai/"
@@ -10,9 +10,10 @@ cask "bettertouchtool" do
   livecheck do
     url "https://folivora.ai/releases/"
     strategy :page_match do |page|
-      page.scan(/btt(\d+(?:.\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
+      page.scan(/btt(\d+(?:[._-]\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
           .max_by { |(_, time)| Time.parse(time) }
           .first
+          .tr("-", ",")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The four-digit number after the dash usually increases with the "version number", but there are cases where only the four-digit number changes:

- https://github.com/Homebrew/homebrew-cask/pull/113154
- https://github.com/Homebrew/homebrew-cask/pull/108272