### PR TITLE
Update enfusegui from 2.1.3 to 3.1.2

### DIFF
--- a/Casks/enfusegui.rb
+++ b/Casks/enfusegui.rb
@@ -7,5 +7,15 @@ cask "enfusegui" do
   desc "HDR image creator"
   homepage "https://swipeware.com/applications/enfusegui/"
 
+  livecheck do
+    url :homepage
+    strategy :page_match do |page|
+      match = page[/href=.*?enfusegui[._-]?v?(\d+(?:\_\d+)+)-mac/i, 1]
+      next if match.blank?
+
+      match.tr("_", ".")
+    end
+  end
+
   app "EnfuseGUI.app"
 end

--- a/Casks/enfusegui.rb
+++ b/Casks/enfusegui.rb
@@ -10,7 +10,7 @@ cask "enfusegui" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      match = page[/href=.*?enfusegui[._-]?v?(\d+(?:\_\d+)+)-mac/i, 1]
+      match = page[/href=.*?enfusegui[._-]?v?(\d+(?:_\d+)+)-mac/i, 1]
       next if match.blank?
 
       match.tr("_", ".")

--- a/Casks/enfusegui.rb
+++ b/Casks/enfusegui.rb
@@ -4,6 +4,7 @@ cask "enfusegui" do
 
   url "https://swipeware.com/apps/enfusegui/v#{version.major}/EnfuseGUI-#{version}.dmg"
   name "EnfuseGUI"
+  desc "HDR image creator"
   homepage "https://swipeware.com/applications/enfusegui/"
 
   app "EnfuseGUI.app"

--- a/Casks/enfusegui.rb
+++ b/Casks/enfusegui.rb
@@ -17,5 +17,7 @@ cask "enfusegui" do
     end
   end
 
+  depends_on macos: ">= :high_sierra"
+
   app "EnfuseGUI.app"
 end

--- a/Casks/enfusegui.rb
+++ b/Casks/enfusegui.rb
@@ -1,10 +1,10 @@
 cask "enfusegui" do
-  version "2.1.3"
-  sha256 "da762b7be32b9d264ffc121b43fae4b039dc797994be50e31f448bccf0d4b908"
+  version "3.1.2"
+  sha256 "4a96ab245d8fafaea90d5f3e86df4d7094928ec2d920ae25c9b86b317fc53f8d"
 
-  url "http://software.bergmark.com/enfusegui/files/2.1/EnfuseGUI-#{version}.dmg"
+  url "https://swipeware.com/apps/enfusegui/v#{version.major}/EnfuseGUI-#{version}.dmg"
   name "EnfuseGUI"
-  homepage "http://software.bergmark.com/enfusegui/Main.html"
+  homepage "https://swipeware.com/applications/enfusegui/"
 
   app "EnfuseGUI.app"
 end

--- a/Casks/enfusegui.rb
+++ b/Casks/enfusegui.rb
@@ -20,4 +20,9 @@ cask "enfusegui" do
   depends_on macos: ">= :high_sierra"
 
   app "EnfuseGUI.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.swipeware.enfusegui",
+    "~/Library/Containers/com.swipeware.enfusegui",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.