### PR TITLE
Update mweb-pro from 4.2.1 to 4.2.2

### DIFF
--- a/Casks/mweb-pro.rb
+++ b/Casks/mweb-pro.rb
@@ -1,5 +1,5 @@
 cask "mweb-pro" do
-  version "4.2.1"
+  version "4.2.2"
 
   if MacOS.version <= :catalina
     url "https://cdn.mwebapp.cn/MWebPro#{version.no_dots}_catalina.dmg",
@@ -8,7 +8,7 @@ cask "mweb-pro" do
   else
     url "https://cdn.mwebapp.cn/MWebPro#{version.no_dots}.dmg",
         verified: "cdn.mwebapp.cn/"
-    sha256 "836d890d2571e45ed3c69a4a9bf35dbb4ee03c08542b9e0be0eb40783bc953b1"
+    sha256 "28c39c263c00c791031718e3fc19945bafab4986fb83d11f3494bdd62cf517ef"
   end
 
   name "MWeb Pro"

--- a/Casks/mweb-pro.rb
+++ b/Casks/mweb-pro.rb
@@ -4,7 +4,7 @@ cask "mweb-pro" do
   if MacOS.version <= :catalina
     url "https://cdn.mwebapp.cn/MWebPro#{version.no_dots}_catalina.dmg",
         verified: "cdn.mwebapp.cn/"
-    sha256 "f9e349ad5e9c5a3bc3bd32271f04af4aa9a772027637507988dc993c1599e399"
+    sha256 "03c263aec90fdad780e68cdc00e81bc4a325ab8728607e82d13114bc8559c09b"
   else
     url "https://cdn.mwebapp.cn/MWebPro#{version.no_dots}.dmg",
         verified: "cdn.mwebapp.cn/"

--- a/Casks/mweb-pro.rb
+++ b/Casks/mweb-pro.rb
@@ -17,7 +17,7 @@ cask "mweb-pro" do
 
   livecheck do
     url "https://www.mweb.im/update_v4.json"
-    regex(/(?:"version":")(\d+(\.\d+)*)"/i)
+    regex(/"version":"(\d+(?:\.\d+)+)"/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.