### PR TITLE
geph: fix livecheck

### DIFF
--- a/Casks/geph.rb
+++ b/Casks/geph.rb
@@ -10,6 +10,7 @@ cask "geph" do
 
   livecheck do
     url "https://github.com/geph-official/geph4"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "Geph.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.