### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/adoptopenjdk.rb
+++ b/Casks/adoptopenjdk.rb
@@ -8,16 +8,6 @@ cask "adoptopenjdk" do
   desc "JDK from the Java User Group (JUG)"
   homepage "https://adoptopenjdk.net/"
 
-  livecheck do
-    url :url
-    strategy :git do |tags|
-      tags.map do |tag|
-        match = tag.match(/^jdk-(\d+(?:\.\d+)+)\+(\d+(?:\.\d+)*)$/i)
-        "#{match[1]},#{match[2]}" if match
-      end.compact
-    end
-  end
-
   pkg "OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.before_comma}_#{version.after_comma.major}.pkg"
 
   uninstall pkgutil: "net.adoptopenjdk.#{version.major}.jdk"

--- a/Casks/appdelete.rb
+++ b/Casks/appdelete.rb
@@ -7,11 +7,6 @@ cask "appdelete" do
   desc "App uninstaller"
   homepage "http://www.reggieashworth.com/appdelete.html"
 
-  livecheck do
-    url "http://www.reggieashworth.com/AD#{version.major}Appcast.xml"
-    strategy :sparkle
-  end
-
   auto_updates true
 
   app "AppDelete.app"

--- a/Casks/duplicacy.rb
+++ b/Casks/duplicacy.rb
@@ -8,11 +8,6 @@ cask "duplicacy" do
   desc "Cloud backup tool"
   homepage "https://duplicacy.com/"
 
-  livecheck do
-    url "https://duplicacy.com/download.html"
-    regex(/href=.*?duplicacy[._-]?gui[._-]?osx[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
-  end
-
   app "Duplicacy.app"
   binary "#{appdir}/Duplicacy.app/Contents/Resources/duplicacy_osx_x64_#{version}", target: "duplicacy"
 

--- a/Casks/jenkins-menu.rb
+++ b/Casks/jenkins-menu.rb
@@ -7,11 +7,6 @@ cask "jenkins-menu" do
   desc "Menu item which shows the status of a Jenkins CI server"
   homepage "https://github.com/qvacua/jenkins-menu/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   app "Jenkins Menu.app"
 
   zap trash: [

--- a/Casks/qv2ray.rb
+++ b/Casks/qv2ray.rb
@@ -8,11 +8,6 @@ cask "qv2ray" do
   desc "V2Ray GUI client with extensive protocol support"
   homepage "https://qv2ray.net/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   depends_on formula: "v2ray"
   depends_on macos: ">= :mojave"
 

--- a/Casks/tempo.rb
+++ b/Casks/tempo.rb
@@ -14,11 +14,6 @@ cask "tempo" do
   desc "Email client that delivers all email in batches"
   homepage "https://www.yourtempo.co/"
 
-  livecheck do
-    url "https://download.yourtempo.co/#{arch}/latest-mac.yml"
-    strategy :electron_builder
-  end
-
   auto_updates true
 
   app "Tempo.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes `livecheck` blocks from discontinued casks, so they will be automatically skipped as discontinued instead of continuing to be checked. This is necessary since we technically allow a `livecheck` block to override an automatic skip, as there are sometimes rare instances where we want to continue checking a formula/cask despite matching one of the built-in `SkipCondition`s. That isn't the case for these discontinued casks, so removing the `livecheck` block is appropriate.