### PR TITLE
Fix sonic-visualiser mirror

### DIFF
--- a/Casks/sonic-visualiser.rb
+++ b/Casks/sonic-visualiser.rb
@@ -2,8 +2,8 @@ cask "sonic-visualiser" do
   version "4.4,2813"
   sha256 "07550a124d503139837e809ff06701661749f0de77d43968a9e43494f4ff1bbf"
 
-  url "https://code.soundsoftware.ac.uk/attachments/download/#{version.after_comma}/Sonic%20Visualiser-#{version.before_comma}.dmg",
-      verified: "code.soundsoftware.ac.uk/"
+  url "https://github.com/sonic-visualiser/sonic-visualiser/releases/download/sv_v#{version.before_comma}/Sonic.Visualiser-#{version.before_comma}.dmg",
+      verified: "github.com/sonic-visualiser/sonic-visualiser/"
   name "Sonic Visualiser"
   desc "Visualisation, analysis, and annotation of music audio recordings"
   homepage "https://www.sonicvisualiser.org/"


### PR DESCRIPTION
‘brew install sonic-visualiser’ has been [broken for a few days because of an expired TLS key](https://github.com/sonic-visualiser/sonic-visualiser/issues/36). I believe it’s better to use the GitHub mirror, which is as of 2021-11-14 is listed on the official page at https://www.sonicvisualiser.org/download.html

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
