### PR TITLE
Update tencent-meeting from 2.20.2.413 to 3.1.2.424

### DIFF
--- a/Casks/tencent-meeting.rb
+++ b/Casks/tencent-meeting.rb
@@ -2,11 +2,11 @@ cask "tencent-meeting" do
   arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
   if Hardware::CPU.intel?
-    version "2.20.2.413,183b7606483d26619c88faab648e09e3"
-    sha256 "e3cbf89201e7397ee786a69dec4f3b028e6e796e949c1e43193dea98d694c5fa"
+    version "3.1.2.424,6f8c23ab8c6689027ec29fc164f677ab"
+    sha256 "124a13630b166e58a60e5d239ce4ac053ba69a15c62dfb21b10d3947474205ae"
   else
-    version "2.20.2.413,3d0373e8a5c07cfa3e7fc35b4aa09acf"
-    sha256 "56fcb79e2f9ef02139671265c584bcad1cc2a4d17ef9f75ee00ca1683e6014c8"
+    version "3.1.2.424,279d3942cd1a6d943f40d8c51b471573"
+    sha256 "708f0c34beb4f390ded1ce1d2332b6ae587fcdfdc10f659a8d06b9e3cc56a096"
   end
 
   url "https://updatecdn.meeting.qq.com/cos/#{version.after_comma}/TencentMeeting_0300000000_#{version.before_comma}.publish.#{arch}.dmg",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.