### PR TITLE
Update matterhorn.rb with latest release from 50200.14.0 to 50200.14.1

### DIFF
--- a/Casks/matterhorn.rb
+++ b/Casks/matterhorn.rb
@@ -1,6 +1,6 @@
 cask "matterhorn" do
-  version "50200.14.0"
-  sha256 "57391e71b0a9077c427b627d2fa3c26f88d58f525d5caa2e45c4841656563b24"
+  version "50200.14.1"
+  sha256 "25bb9010374b2b2320b46bc87ea16286930958f0740bdfe3e0c919522656e33f"
 
   url "https://github.com/matterhorn-chat/matterhorn/releases/download/#{version}/matterhorn-#{version}-Darwin-x86_64.tar.bz2"
   name "Matterhorn"


### PR DESCRIPTION
Updates matterhorn cask to use the latest release 50200.14.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
