### PR TITLE
Delete 03_cask_request.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_cask_request.yml
+++ b/.github/ISSUE_TEMPLATE/03_cask_request.yml
@@ -1,6 +1,0 @@
-name: Cask Request
-description: For requesting new casks
-body:
-    - type: markdown
-      attributes:
-        value: At the moment we don’t take cask requests. If you want a cask added, submit a [pull request](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md#adding-a-cask).


### PR DESCRIPTION
Has been broken for a while without anyone noticing. This doesn’t happen often; no need to add a field for users to write for something where we don’t want them to.