### PR TITLE
drivedx: add auto_updates + zap

### DIFF
--- a/Casks/drivedx.rb
+++ b/Casks/drivedx.rb
@@ -12,5 +12,15 @@ cask "drivedx" do
     strategy :sparkle
   end
 
+  auto_updates true
+
   app "DriveDx.app"
+
+  zap trash: [
+    "~/Library/Application Support/DriveDx",
+    "~/Library/Caches/DriveDx",
+    "~/Library/Caches/com.binaryfruit.DriveDx",
+    "~/Library/Logs/DriveDx",
+    "~/Library/Preferences/com.binaryfruit.DriveDx.plist",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.