### PR TITLE
Downgrade upwork to current livechek version

### DIFF
--- a/Casks/upwork.rb
+++ b/Casks/upwork.rb
@@ -1,6 +1,6 @@
 cask "upwork" do
-  version "5.6.9.3,10c2eb9781db4d7f"
-  sha256 "37ecf8703d99157ca09e9771ab5178e518d0440126ed9ddb89e10e7a8957968a"
+  version "5.6.8.0,836f43f6f6be4149"
+  sha256 "b7b7ac78f7c73b6c975b2c0ae5103406b53d6e526fcf0b670af9b65e8fccd992"
 
   url "https://upwork-usw2-desktopapp.upwork.com/binaries/v#{version.before_comma.dots_to_underscores}_#{version.after_comma}/Upwork.dmg"
   name "Upwork"


### PR DESCRIPTION
Revert "Update upwork from 5.6.8.0,836f43f6f6be4149 to 5.6.9.3,10c2eb9781db4d7f (#112201)"

This reverts commit 5f3026d261b7ea9155833d4c448bd00acb159481.

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
