### PR TITLE
sdm: rm socket on uninstall

### DIFF
--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -14,14 +14,13 @@ cask "sdm" do
 
   app "SDM.app"
 
-  uninstall delete:  "#{appdir}/SDM.app/Contents/Resources/sdm-socket"
+  uninstall delete: "#{appdir}/SDM.app/Contents/Resources/sdm-socket"
 
   zap trash: [
+    "~/.sdm",
     "~/Library/Application Support/SDM",
-    "~/Library/Caches/com.electron.sdm",
-    "~/Library/Caches/com.electron.sdm.ShipIt",
+    "~/Library/Caches/com.electron.sdm*",
     "~/Library/Preferences/com.electron.sdm.plist",
     "~/Library/Saved Application State/com.electron.sdm.savedState",
-    "~/.sdm",
   ]
 end

--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -14,6 +14,8 @@ cask "sdm" do
 
   app "SDM.app"
 
+  uninstall delete:  "#{appdir}/SDM.app/Contents/Resources/sdm-socket"
+
   zap trash: [
     "~/Library/Application Support/SDM",
     "~/Library/Caches/com.electron.sdm",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Fixes https://github.com/Homebrew/discussions/discussions/2472. Upstream gave their thumbs up on the fix and has elimination of said file on the roadmap.