### PR TITLE
Update unclack from 1.1.1,9 to 1.2.0 and various other updates

### DIFF
--- a/Casks/unclack.rb
+++ b/Casks/unclack.rb
@@ -1,8 +1,8 @@
 cask "unclack" do
-  version "1.1.1,9"
-  sha256 :no_check
+  version "1.2.0"
+  sha256 "3f260fea020f4f2ed7ce7b0c9f7a300dd2987aebf7e5b4ba022e3adea6c306a9"
 
-  url "https://unclack.app/app/Unclack.dmg"
+  url "https://unclack.app/app/#{version}/Unclack.dmg"
   name "Unclack"
   desc "Mutes your keyboard while you type"
   homepage "https://unclack.app/"

--- a/Casks/unclack.rb
+++ b/Casks/unclack.rb
@@ -8,7 +8,8 @@ cask "unclack" do
   homepage "https://unclack.app/"
 
   livecheck do
-    skip "unversioned URL"
+    url :homepage
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/Unclack\.dmg}i)
   end
 
   app "Unclack.app"

--- a/Casks/unclack.rb
+++ b/Casks/unclack.rb
@@ -12,6 +12,8 @@ cask "unclack" do
     regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/Unclack\.dmg}i)
   end
 
+  depends_on macos: ">= :catalina"
+
   app "Unclack.app"
 
   zap trash: [

--- a/Casks/unclack.rb
+++ b/Casks/unclack.rb
@@ -17,8 +17,7 @@ cask "unclack" do
   app "Unclack.app"
 
   zap trash: [
-    "~/Library/Application Scripts/dev.ajkueterman.unclack-LaunchAtLoginHelper",
-    "~/Library/Containers/dev.ajkueterman.unclack-LaunchAtLoginHelper",
-    "~/Library/Preferences/dev.ajkueterman.unclack.plist",
+    "~/Library/Application Scripts/dev.ajkueterman.unclack*",
+    "~/Library/Containers/dev.ajkueterman.unclack*",
   ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.