### PR TITLE
Update Android Studio zap paths

### DIFF
--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -26,10 +26,9 @@ cask "android-studio" do
 
   zap trash: [
     "~/Library/Android/sdk",
-    "~/Library/Application Support/AndroidStudio#{version.major_minor}",
-    "~/Library/Caches/AndroidStudio#{version.major_minor}",
-    "~/Library/Logs/AndroidStudio#{version.major_minor}",
-    "~/Library/Preferences/AndroidStudio#{version.major_minor}",
+    "~/Library/Application Support/Google/AndroidStudio#{version.major_minor}",
+    "~/Library/Caches/Google/AndroidStudio#{version.major_minor}",
+    "~/Library/Logs/Google/AndroidStudio#{version.major_minor}",
     "~/Library/Preferences/com.android.Emulator.plist",
     "~/Library/Preferences/com.google.android.studio.plist",
     "~/Library/Saved Application State/com.google.android.studio.savedState",

--- a/Casks/android-studio.rb
+++ b/Casks/android-studio.rb
@@ -3,14 +3,14 @@ cask "android-studio" do
 
   version "2020.3.1.25"
 
-  url "https://redirector.gvt1.com/edgedl/android/studio/install/#{version}/android-studio-#{version}-#{arch}.dmg",
-      verified: "redirector.gvt1.com/edgedl/android/studio/"
   if Hardware::CPU.intel?
     sha256 "caa2a4a6adbd5ff94e0fbb9ffec798d5b24319070d7d231684ea9a458b1420ee"
   else
     sha256 "156935cdc02d0525d1b1529492468194027d1f63eac71d89ebd9c1fc08ba7c60"
   end
 
+  url "https://redirector.gvt1.com/edgedl/android/studio/install/#{version}/android-studio-#{version}-#{arch}.dmg",
+      verified: "redirector.gvt1.com/edgedl/android/studio/"
   name "Android Studio"
   desc "Tools for building Android applications"
   homepage "https://developer.android.com/studio/"
@@ -25,6 +25,7 @@ cask "android-studio" do
   app "Android Studio.app"
 
   zap trash: [
+    "~/.android",
     "~/Library/Android/sdk",
     "~/Library/Application Support/Google/AndroidStudio#{version.major_minor}",
     "~/Library/Caches/Google/AndroidStudio#{version.major_minor}",
@@ -32,7 +33,6 @@ cask "android-studio" do
     "~/Library/Preferences/com.android.Emulator.plist",
     "~/Library/Preferences/com.google.android.studio.plist",
     "~/Library/Saved Application State/com.google.android.studio.savedState",
-    "~/.android",
   ],
       rmdir: [
         "~/AndroidStudioProjects",


### PR DESCRIPTION
This updates the zap paths for the Android Studio cask. These paths were changed when Android Studio moved to the 2020+ IntelliJ platform.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

