### PR TITLE
kekaexternalhelper: fix livecheck, add alt name, flip version parts

### DIFF
--- a/Casks/kekaexternalhelper.rb
+++ b/Casks/kekaexternalhelper.rb
@@ -4,6 +4,7 @@ cask "kekaexternalhelper" do
 
   url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}/KekaExternalHelper-v#{version.after_comma}.zip"
   name "Keka External Helper"
+  name "KekaDefaultApp"
   desc "Helper application for the Keka file archiver"
   homepage "https://github.com/aonez/Keka/wiki/Default-application"
 

--- a/Casks/kekaexternalhelper.rb
+++ b/Casks/kekaexternalhelper.rb
@@ -1,8 +1,8 @@
 cask "kekaexternalhelper" do
-  version "1.2.7,1.1.1"
+  version "1.1.1,1.2.7"
   sha256 "8f25d23df3941cda7af5b8e6c964c7c00d9b5a24af803cd241aa26f5a8a51e72"
 
-  url "https://github.com/aonez/Keka/releases/download/v#{version.before_comma}/KekaExternalHelper-v#{version.after_comma}.zip"
+  url "https://github.com/aonez/Keka/releases/download/v#{version.after_comma}/KekaExternalHelper-v#{version.before_comma}.zip"
   name "Keka External Helper"
   name "KekaDefaultApp"
   desc "Helper application for the Keka file archiver"
@@ -14,7 +14,7 @@ cask "kekaexternalhelper" do
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/KekaExternalHelper-v?(\d+(?:\.\d+)*)\.zip}i)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      "#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/kekaexternalhelper.rb
+++ b/Casks/kekaexternalhelper.rb
@@ -7,9 +7,8 @@ cask "kekaexternalhelper" do
   desc "Helper application for the Keka file archiver"
   homepage "https://github.com/aonez/Keka/wiki/Default-application"
 
-  # Not all releases contain the external helper, so we have to check all of them.
   livecheck do
-    url "https://github.com/aonez/Keka/releases"
+    url "https://www.keka.io/en/"
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/KekaExternalHelper-v?(\d+(?:\.\d+)*)\.zip}i)
       next if match.blank?


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
`version.before_comma` was not the app's version but the string needed to form `url`, so I flipped them.