### PR TITLE
Re-add TeamSpeak Client 3.5.6.

### DIFF
--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -1,0 +1,30 @@
+cask "teamspeak-client" do
+  desc "Voice communication client"
+
+  if MacOS.version <= :catalina
+    version "3.5.6"
+    sha256 "03c8e44256f2028917866924e496d4704de9e3298252f433fc53cfa37282770e"
+
+    url "https://files.teamspeak-services.com/releases/client/#{version}/TeamSpeak#{version.major}-Client-macosx-#{version}.dmg",
+        verified: "files.teamspeak-services.com/"
+  else
+    version "3.5.7-beta.1"
+    sha256 "993965f8c2a5f579de4ae17f6a6ac713557f7517d3ba5a9eb423cf95a33fbb90"
+
+    url "https://files.teamspeak-services.com/pre_releases/client/#{version}/TeamSpeak#{version.major}-Client-macosx-#{version.split("-").first}.dmg",
+        verified: "files.teamspeak-services.com/"
+  end
+
+  name "TeamSpeak Client"
+  homepage "https://www.teamspeak.com/"
+
+  livecheck do
+    url "https://versions.teamspeak.com/ts3-client-2"
+    regex(/stable.*?v?(\d+(?:\.\d+)+)/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sierra"
+
+  app "TeamSpeak #{version.major} Client.app"
+end

--- a/Casks/teamspeak-client.rb
+++ b/Casks/teamspeak-client.rb
@@ -1,27 +1,30 @@
 cask "teamspeak-client" do
-  desc "Voice communication client"
-
   if MacOS.version <= :catalina
     version "3.5.6"
     sha256 "03c8e44256f2028917866924e496d4704de9e3298252f433fc53cfa37282770e"
 
     url "https://files.teamspeak-services.com/releases/client/#{version}/TeamSpeak#{version.major}-Client-macosx-#{version}.dmg",
         verified: "files.teamspeak-services.com/"
+
+    livecheck do
+      url "https://versions.teamspeak.com/ts#{version.major}-client-2"
+      regex(/stable.*?v?(\d+(?:\.\d+)+)/i)
+    end
   else
     version "3.5.7-beta.1"
     sha256 "993965f8c2a5f579de4ae17f6a6ac713557f7517d3ba5a9eb423cf95a33fbb90"
 
     url "https://files.teamspeak-services.com/pre_releases/client/#{version}/TeamSpeak#{version.major}-Client-macosx-#{version.split("-").first}.dmg",
         verified: "files.teamspeak-services.com/"
+
+    livecheck do
+      skip "No version information available"
+    end
   end
 
   name "TeamSpeak Client"
+  desc "Voice communication client"
   homepage "https://www.teamspeak.com/"
-
-  livecheck do
-    url "https://versions.teamspeak.com/ts3-client-2"
-    regex(/stable.*?v?(\d+(?:\.\d+)+)/i)
-  end
 
   auto_updates true
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

3.5.6 does not work on Big Sure or Monterey, but there is a 3.5.7-beta.1 which does. The `livecheck` only covers the stable version, so it is currently failing.