### PR TITLE
Correct SHA256 hash for Retroarch 1.9.13

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask "retroarch" do
   version "1.9.13"
-  sha256 "672a3e4a57b68294eb381090c537792604b48fd88732c107efcda172fb62f16c"
+  sha256 "a8323e829791e3af9808ffa49e45d2045b81835f2f9a34ee61a7120d58cf035a"
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   name "RetroArch"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

I have deleted and redownloaded the dmg file multiple times and always arrive at the same hash, which is in conflict with the stored one here. Happy for someone to verify.

```
❯ wget https://buildbot.libretro.com/stable/1.9.13/apple/osx/x86_64/RetroArch.dmg
--2021-11-19 10:51:44--  https://buildbot.libretro.com/stable/1.9.13/apple/osx/x86_64/RetroArch.dmg
Resolving buildbot.libretro.com (buildbot.libretro.com)... 172.67.171.197, 104.21.55.171
Connecting to buildbot.libretro.com (buildbot.libretro.com)|172.67.171.197|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 157383237 (150M) [application/x-apple-diskimage]
Saving to: ‘RetroArch.dmg’

RetroArch.dmg          100%[===========================>] 150.09M  3.85MB/s    in 20s     

2021-11-19 10:52:04 (7.60 MB/s) - ‘RetroArch.dmg’ saved [157383237/157383237]


~ 
❯ sha256sum RetroArch.dmg                                                        
a8323e829791e3af9808ffa49e45d2045b81835f2f9a34ee61a7120d58cf035a  RetroArch.dmg
```