### PR TITLE
menubar-stats: raise depends_on + add zap

### DIFF
--- a/Casks/menubar-stats.rb
+++ b/Casks/menubar-stats.rb
@@ -15,5 +15,13 @@ cask "menubar-stats" do
   auto_updates true
   depends_on macos: ">= :mojave"
 
-  app "MenuBar Stats.app"
+  app "MenuBar Stats.app
+
+  zap trash: [
+    "~/Library/Application Scripts/3EYN7PPTPF.com.fabriceleyne.menubarstats",
+    "~/Library/Application Scripts/com.fabriceleyne.menubarstats*",
+    "~/Library/Containers/com.fabriceleyne.menubarstats*",
+    "~/Library/Group Containers/3EYN7PPTPF.com.fabriceleyne/com.fabriceleyne.menubarstats",
+    "~/Library/Group Containers/3EYN7PPTPF.com.fabriceleyne.menubarstats",
+  ]
 end

--- a/Casks/menubar-stats.rb
+++ b/Casks/menubar-stats.rb
@@ -15,7 +15,7 @@ cask "menubar-stats" do
   auto_updates true
   depends_on macos: ">= :mojave"
 
-  app "MenuBar Stats.app
+  app "MenuBar Stats.app"
 
   zap trash: [
     "~/Library/Application Scripts/3EYN7PPTPF.com.fabriceleyne.menubarstats",

--- a/Casks/menubar-stats.rb
+++ b/Casks/menubar-stats.rb
@@ -13,7 +13,7 @@ cask "menubar-stats" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   app "MenuBar Stats.app"
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.