### PR TITLE
Add Defold game engine

### DIFF
--- a/Casks/defold.rb
+++ b/Casks/defold.rb
@@ -12,6 +12,15 @@ cask "defold" do
   desc "Free to use game engine for development of desktop, mobile and web games"
   homepage "https://defold.com/"
 
+  livecheck do
+    url "http://d.defold.com/editor-alpha/info.json"
+    strategy :page_match do |json_content|
+      require "json"
+      info = JSON.parse(json_content)
+      "#{info["version"]},#{info["sha1"]}"
+    end
+  end
+
   depends_on macos: ">= :el_capitan"
 
   app "Defold.app"

--- a/Casks/defold.rb
+++ b/Casks/defold.rb
@@ -1,38 +1,21 @@
 cask "defold" do
-  version "1.2.189,229b4dbc78495615871b3a7679e79d75d018c27a"
-  sha256 :no_check
+  version "1.2.189"
+  sha256 "78a2d397b2c77e68bf8435fa5901b486ddb50fa043569ac9b763c59442c7168b"
 
-  # Yes, this is fine, editor-alpha is how their stable channel is called
-  release_channel = "editor-alpha"
-  release_info_url = "http://d.defold.com/#{release_channel}/info.json"
-
-  url release_info_url do |json_content|
-    require "json"
-    version_sha = JSON.parse(json_content)["sha1"]
-    "https://d.defold.com/archive/editor-alpha/#{version_sha}/editor-alpha/editor2/Defold-x86_64-darwin.dmg"
-  end
+  url "https://github.com/defold/defold/releases/download/#{version}/Defold-x86_64-darwin.dmg",
+      verified: "github.com/defold/defold/"
   name "Defold"
-  desc "Free to use game engine for development of desktop, mobile and web games"
+  desc "Game engine for development of desktop, mobile and web games"
   homepage "https://defold.com/"
 
-  livecheck do
-    url release_info_url
-    strategy :page_match do |json_content|
-      require "json"
-      info = JSON.parse(json_content)
-      "#{info["version"]},#{info["sha1"]}"
-    end
-  end
-
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Defold.app"
 
   zap trash: [
     "~/Library/Application Support/Defold",
-    "~/Library/Preferences/com.defold.editor.plist",
     "~/Library/Caches/com.defold.editor",
+    "~/Library/Preferences/com.defold.editor.plist",
     "~/Library/Saved Application State/com.defold.editor.savedState",
   ]
 end

--- a/Casks/defold.rb
+++ b/Casks/defold.rb
@@ -19,5 +19,7 @@ cask "defold" do
   zap trash: [
     "~/Library/Application Support/Defold",
     "~/Library/Preferences/com.defold.editor.plist",
+    "~/Library/Caches/com.defold.editor",
+    "~/Library/Saved Application State/com.defold.editor.savedState",
   ]
 end

--- a/Casks/defold.rb
+++ b/Casks/defold.rb
@@ -1,9 +1,12 @@
 cask "defold" do
-  version :latest
+  version "1.2.189,229b4dbc78495615871b3a7679e79d75d018c27a"
   sha256 :no_check
 
   # Yes, this is fine, editor-alpha is how their stable channel is called
-  url "http://d.defold.com/editor-alpha/info.json" do |json_content|
+  release_channel = "editor-alpha"
+  release_info_url = "http://d.defold.com/#{release_channel}/info.json"
+
+  url release_info_url do |json_content|
     require "json"
     version_sha = JSON.parse(json_content)["sha1"]
     "https://d.defold.com/archive/editor-alpha/#{version_sha}/editor-alpha/editor2/Defold-x86_64-darwin.dmg"
@@ -13,7 +16,7 @@ cask "defold" do
   homepage "https://defold.com/"
 
   livecheck do
-    url "http://d.defold.com/editor-alpha/info.json"
+    url release_info_url
     strategy :page_match do |json_content|
       require "json"
       info = JSON.parse(json_content)
@@ -21,6 +24,7 @@ cask "defold" do
     end
   end
 
+  auto_updates true
   depends_on macos: ">= :el_capitan"
 
   app "Defold.app"

--- a/Casks/defold.rb
+++ b/Casks/defold.rb
@@ -1,0 +1,23 @@
+cask "defold" do
+  version :latest
+  sha256 :no_check
+
+  # Yes, this is fine, editor-alpha is how their stable channel is called
+  url "http://d.defold.com/editor-alpha/info.json" do |json_content|
+    require "json"
+    version_sha = JSON.parse(json_content)["sha1"]
+    "https://d.defold.com/archive/editor-alpha/#{version_sha}/editor-alpha/editor2/Defold-x86_64-darwin.dmg"
+  end
+  name "Defold"
+  desc "Free to use game engine for development of desktop, mobile and web games"
+  homepage "https://defold.com/"
+
+  depends_on macos: ">= :el_capitan"
+
+  app "Defold.app"
+
+  zap trash: [
+    "~/Library/Application Support/Defold",
+    "~/Library/Preferences/com.defold.editor.plist",
+  ]
+end


### PR DESCRIPTION
This adds a cask for the Defold editor. Defold is a game engine for mobile and desktop game development: https://defold.com 

They release updates quite often (especially to the editor), so it made sense to take the `version :latest` approach. They also have an auto-update mechanism built into the app.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `defold` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask defold ` is error-free.
- [X] `brew style --fix defold ` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask defold` worked successfully.
- [X] `brew install --cask defold` worked successfully.
- [X] `brew uninstall --cask defold` worked successfully.
