### PR TITLE
mambaforge: fix livecheck

### DIFF
--- a/Casks/mambaforge.rb
+++ b/Casks/mambaforge.rb
@@ -17,7 +17,7 @@ cask "mambaforge" do
   livecheck do
     url :url
     strategy :github_latest
-    regex(/href=.*?\/tag\/v?(\d+(?:[._-]\d+)+)["' >]/i)
+    regex(%r{href=.*?/tag/v?(\d+(?:[._-]\d+)+)["' >]}i)
   end
 
   auto_updates true

--- a/Casks/mambaforge.rb
+++ b/Casks/mambaforge.rb
@@ -3,16 +3,22 @@ cask "mambaforge" do
 
   version "4.10.3-7"
 
-  url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Mambaforge-#{version}-MacOSX-#{arch}.sh"
   if Hardware::CPU.intel?
     sha256 "94ed8b8a647f48a815590958217aabebd4a3e3e10edaf2c5772d50a75727773a"
   else
     sha256 "49c7ba06fe663c634929d5d85b4c06840f4ab9844744be691aab90848c52444e"
   end
 
+  url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Mambaforge-#{version}-MacOSX-#{arch}.sh"
   name "mambaforge"
   desc "Minimal installer for conda with preinstalled support for Mamba"
   homepage "https://github.com/conda-forge/miniforge"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/href=.*?\/tag\/v?(\d+(?:[._-]\d+)+)["' >]/i)
+  end
 
   auto_updates true
   conflicts_with cask: [


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.