### PR TITLE
Re-rename `alttab` to `alt-tab`

### DIFF
--- a/Casks/alt-tab.rb
+++ b/Casks/alt-tab.rb
@@ -1,4 +1,4 @@
-cask "alttab" do
+cask "alt-tab" do
   version "6.28.0"
   sha256 "f86ecc32fe99e58a6dede0364ea3490caee878eac6788975bb4976944ab1e2f0"
 


### PR DESCRIPTION
We shouldn't break all the users of this cask by renaming it from
`alt-tab` to `alttab`, so let's change it back.
