### PR TITLE
Add macOS supported interface aliases to VLC

### DIFF
--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -23,11 +23,13 @@ cask "vlc" do
   conflicts_with cask: "homebrew/cask-versions/vlc-nightly"
 
   app "VLC.app"
+
   # shim scripts (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscripts = {
     cvlc: "-I dummy",
     nvlc: "-I ncurses",
-    vlc: "",
+    rvlc: "-I rc",
+    vlc:  "",
   }
 
   shimscripts.each_key do |shimscript|

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -23,15 +23,24 @@ cask "vlc" do
   conflicts_with cask: "homebrew/cask-versions/vlc-nightly"
 
   app "VLC.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/vlc.wrapper.sh"
-  binary shimscript, target: "vlc"
+  # shim scripts (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscripts = {
+    cvlc: "-I dummy",
+    nvlc: "-I ncurses",
+    vlc: "",
+  }
+
+  shimscripts.each_key do |shimscript|
+    binary "#{staged_path}/#{shimscript}.wrapper.sh", target: shimscript.to_s
+  end
 
   preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
-    EOS
+    shimscripts.each do |shimscript, args|
+      File.write "#{staged_path}/#{shimscript}.wrapper.sh", <<~EOS
+        #!/bin/sh
+        exec '#{appdir}/VLC.app/Contents/MacOS/VLC' #{args} "$@"
+      EOS
+    end
   end
 
   zap trash: [


### PR DESCRIPTION
### Context

VLC installations on many other platforms create a standard set of "interface aliases." These are small wrapper scripts (conceptually identical to a cask shimscript) that execute VLC with a particular [interface](https://wiki.videolan.org/Interfaces/). The default interface aliases are:

- `cvlc`: Non-interactive "dummy" interface.
- `rvlc`: Console rc-based interface.
- `svlc`: Skins interface.
- `qvlc`: Qt-based graphical interface.
- `nvlc`: Console ncurses-based interface.

Of all of these interfaces, only the "dummy", "rc", and "ncurses" interfaces are available on macOS.

### Changes

This PR adds aliases for `cvlc`, `nvlc`, and `rvlc` as shimscripts to the VLC cask. It leaves the existing `vlc` shimscript unchanged, allowing users to continue to pass their own interface arguments in the terminal.

### I've verified:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask vlc` is error-free.
- [x] `brew style --fix vlc` reports no offenses.
