### PR TITLE
Update tencent-docs from 2.2.24 to 2.2.25

### DIFF
--- a/Casks/tencent-docs.rb
+++ b/Casks/tencent-docs.rb
@@ -1,5 +1,5 @@
 cask "tencent-docs" do
-  version "2.2.24"
+  version "2.2.25"
   sha256 :no_check
 
   url "https://down.qq.com/qqweb/mac_docs/MacTencentDocs.dmg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.