### PR TITLE
Update firefox from 94.0.1 to 94.0.2

### DIFF
--- a/Casks/firefox.rb
+++ b/Casks/firefox.rb
@@ -1,108 +1,108 @@
 cask "firefox" do
-  version "94.0.1"
+  version "94.0.2"
 
   language "cs" do
-    sha256 "94cfd91c27228556885eade22d0785d50fc21b4d69ab7510b4f8d1a08a5ec9d2"
+    sha256 "923581c75b27f72673f05f03864a48197418bf62f0300b60589487d3b463eea4"
     "cs"
   end
   language "de" do
-    sha256 "5b8de30b760af0a26626f80f54623272bcae600f3e96892bc153542e69faec6f"
+    sha256 "0c5c8fd139824663b89bfdd5d85d8c0785d589eecc5356a931728b54a276ccf2"
     "de"
   end
   language "en-CA" do
-    sha256 "cbeff29537b94b86715e9394795cf40a41526f8cf9482905314e8ab8b8228298"
+    sha256 "d26e445830ab6c6dfa93fb9fa42561225b11514608af22cef90beb9c6e0b6e86"
     "en-CA"
   end
   language "en-GB" do
-    sha256 "35b5111185064dba50549431083aa44b4345aeb20351b48badc6ead1264e5ce4"
+    sha256 "ee73eadd5b822b1aa117523b2ef01c0e51447a3bbda6ae52528bde1c8f0f71ca"
     "en-GB"
   end
   language "en", default: true do
-    sha256 "e49efcf2295fc0ca3b912355c12cb2a2118c67cf654ad2f4527e67632aaa4ee7"
+    sha256 "51de64f078f31e064e1b70f129571b50b5f11e1ea91d7eb29b390792a3ab1959"
     "en-US"
   end
   language "eo" do
-    sha256 "4d16413b02c744645806a9b3a24cfd614bc6ddedbaf53771ce5584398470501a"
+    sha256 "8f99d1bc4cf7a792757ff071c0bc42d204f82723e2d22680c883f630fbae8d97"
     "eo"
   end
   language "es-AR" do
-    sha256 "6aea0a77d95fd2472816e8dd63e020f9e2a69cdc4abc79efe20913272498ebb1"
+    sha256 "f59c6385e27e29007e2155ff7caba9bf9535e46d16e5544271722f245e8f5f91"
     "es-AR"
   end
   language "es-CL" do
-    sha256 "0450b64ced4d5bb902ab77d3ec410651d9dfaaeea733653c09706bd8b38e3edc"
+    sha256 "e5b1ffa0a0631516d1b6086912ac9f5e2880180b77bb93258d127b7b55179bd2"
     "es-CL"
   end
   language "es-ES" do
-    sha256 "2de6c021f2c3c3e9b0f1d6d37c3ff6d51bd1d8a9f59ab4de6967a33df31ef41d"
+    sha256 "1960f863f57f588648244818606bb0fea8f6047ddc968662ab18ab98fe6f2f26"
     "es-ES"
   end
   language "fi" do
-    sha256 "dd40c5f3b0f0694801500c2c8a3624d1dee336030b38c33520ef49d6ade251b8"
+    sha256 "dd3026ece5dbd1229e1f7b6479d7940dcf63d48e454f71ebd841689cf4531e91"
     "fi"
   end
   language "fr" do
-    sha256 "ab8260fcb00bb6c5f37bd2326e7a75f97525789e9bd57cbec4dd18fcb7f09689"
+    sha256 "3085bb4bd30012fac35629d234fdb4a7538bcff98207420028d2eada3db64cc1"
     "fr"
   end
   language "gl" do
-    sha256 "00e91e87689c44a1f961428b71ffdca66a2f77ca396b8060715063826445238d"
+    sha256 "47aa1aeaaf16d28897f870ba38c00b2da92a2f009518588f24c4049c49354d1e"
     "gl"
   end
   language "in" do
-    sha256 "ddc512ed956b689921fe7113d77ec81132f4961beb07849c792f3615fbceee3f"
+    sha256 "ddb17a090c2ee30b3703cd2c7dd16b509c0fa92509e43abe8472b211de628836"
     "hi-IN"
   end
   language "it" do
-    sha256 "dad9df5f26bad17b405fa74cf0acf09efe0305723b3adafe314d922e69aad887"
+    sha256 "65ed47ae382d2e4b75688c3a1028a122962a70f5a00b4ff3666477f285b932b0"
     "it"
   end
   language "ja" do
-    sha256 "15b40c9cbfde967c5d89aa8d73c6744a786d35e64d7fa386784a6dd8503f6a33"
+    sha256 "f7ace9053149260e0fe69d26fbf9867672a92fad1b43d92fbee19b60baf07259"
     "ja-JP-mac"
   end
   language "ko" do
-    sha256 "41b0a5389ded86a1326c0be58c413e0104e4c73cb3032abc5c9f88b64a7a3b63"
+    sha256 "3932fde08563bddacfe544a2a7de61ed159e861adce53823d41623aabfa25aae"
     "ko"
   end
   language "nl" do
-    sha256 "8f50aa36a23a5d12d2cd61dbf9336f68ce1de3d2c7585ef88272e6eb9384b0fc"
+    sha256 "31cb07923ecdba9bcc5cb5b5d6e1ef6582a349f4e777e20403d49ba687990d2f"
     "nl"
   end
   language "pl" do
-    sha256 "098de0dfc2e20d7e03f42b8e27e8024980308e945063dbf87c5c1e086e57efae"
+    sha256 "33fe7212b9efaf1d7d1dc6b5add60458199f13fd475828b8a6e1714c54463978"
     "pl"
   end
   language "pt-BR" do
-    sha256 "1836034eb243b9bafa0df1a3859768f9b471a602827f7ffb3bda93e31dcde35e"
+    sha256 "4a0b97eaad5e36ba2af6619db36da0436f13b38fb240c5e48fb74f598eed4f0d"
     "pt-BR"
   end
   language "pt" do
-    sha256 "1aabe6dffedfd504ad58e6b4dc093b7e6687cffe4fad2d4133be6b4f2919216a"
+    sha256 "1e46d3dbb9fa5a541dc64a1628e7e85ff82225cdda5c7db0108d8a6d3a751d38"
     "pt-PT"
   end
   language "ru" do
-    sha256 "ca46a5e18a2d7023ecab75d86c15d43ce4e10547d6323d739cd5d727fb704c6c"
+    sha256 "3aceb71e7cc91364c61f75806a9f20fa1e0e27429a9a3a0c8394b7a89c1e8ec4"
     "ru"
   end
   language "sv" do
-    sha256 "6a3212ea4f44faa67caf48a80fe265bd3092d8a4ef90c0a483e0ee8bc123d5e3"
+    sha256 "7b6afd56b0ccfb892779ec70a62c0c6eac96cad3a66d7ec7b28ded8e38d79db1"
     "sv-SE"
   end
   language "tr" do
-    sha256 "ac810926ee39bb5e00748aa8513d8bcc85e397e62580e6ddfd3ff45728b197d5"
+    sha256 "67bcf02cf8e5bfc26960bceba69d914cf8870d42c60856a0634206f3ccdbe1fa"
     "tr"
   end
   language "uk" do
-    sha256 "27ca224a62a41965146b51e6f02fd48fd3efcfdb94d16bc6d8e88e481d6180bb"
+    sha256 "88003c901f5a3824b81691d1d6b82962142a849c10fb0f6fc0dd46ff584c15cb"
     "uk"
   end
   language "zh-TW" do
-    sha256 "bf141fc6d4b69267743eedf284ae2ea085933bc42a7128ae96f43d3620b1f7be"
+    sha256 "1905faa02fb1cd40243df66f161265ddb489997822f428c8c8f112aced855d62"
     "zh-TW"
   end
   language "zh" do
-    sha256 "6cbf9bf0c313c1ba7d78d2863ae9e7cd3eb95992b0fb8647260e0b527b4ff205"
+    sha256 "da6c4a21c6da104459ee640c939610dac4ea6b09060c0e37eed5ae00a0ac39ed"
     "zh-CN"
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.