### PR TITLE
virtualbox: intel only

### DIFF
--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -19,6 +19,7 @@ cask "virtualbox" do
 
   conflicts_with cask: "homebrew/cask-versions/virtualbox-beta"
   depends_on macos: ">= :high_sierra"
+  depends_on arch: :intel
 
   pkg "VirtualBox.pkg",
       choices: [

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -4,13 +4,13 @@ cask "virtualbox" do
 
   url "https://download.virtualbox.org/virtualbox/#{version.before_comma}/VirtualBox-#{version.before_comma}-#{version.after_comma}-OSX.dmg"
   name "Oracle VirtualBox"
-  desc "Free and open-source hosted hypervisor for x86 virtualization"
+  desc "Virtualizer for x86 hardware"
   homepage "https://www.virtualbox.org/"
 
   livecheck do
     url "https://www.virtualbox.org/wiki/Downloads"
     strategy :page_match do |page|
-      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)*)-(\d+)-OSX.dmg/)
+      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)+)-(\d+)-OSX.dmg/)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"
@@ -62,12 +62,9 @@ cask "virtualbox" do
 
   zap trash: [
     "/Library/Application Support/VirtualBox",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.virtualbox.app.virtualbox.sfl*",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.virtualbox.app.virtualboxvm.sfl*",
-    "~/Library/Preferences/org.virtualbox.app.VirtualBox.plist",
-    "~/Library/Preferences/org.virtualbox.app.VirtualBoxVM.plist",
-    "~/Library/Saved Application State/org.virtualbox.app.VirtualBox.savedState",
-    "~/Library/Saved Application State/org.virtualbox.app.VirtualBoxVM.savedState",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.virtualbox.app.virtualbox*",
+    "~/Library/Preferences/org.virtualbox.app.VirtualBox*",
+    "~/Library/Saved Application State/org.virtualbox.app.VirtualBox*",
     "~/Library/VirtualBox",
   ],
       rmdir: "~/VirtualBox VMs"

--- a/Casks/virtualbox.rb
+++ b/Casks/virtualbox.rb
@@ -19,7 +19,7 @@ cask "virtualbox" do
 
   conflicts_with cask: "homebrew/cask-versions/virtualbox-beta"
   depends_on macos: ">= :high_sierra"
-  depends_on arch: :intel
+  depends_on arch: :x86_64
 
   pkg "VirtualBox.pkg",
       choices: [


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

from [changelog](https://www.virtualbox.org/wiki/Changelog):

>macOS host: show message indicating the unsupported CPU on M1 based Macs and abort installation