### PR TITLE
netbeans: fix livecheck

### DIFF
--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -9,7 +9,7 @@ cask "netbeans" do
 
   livecheck do
     url "https://netbeans.apache.org/download/index.html"
-    regex(/NetBeans\s*v?(\d+(?:\.\d+)+)/i)
+    regex(/NetBeans\s*v?(\d+(?:\.\d+)+)</i)
   end
 
   pkg "Apache NetBeans #{version}.pkg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.