### PR TITLE
n1ghtshade: fix livecheck

### DIFF
--- a/Casks/n1ghtshade.rb
+++ b/Casks/n1ghtshade.rb
@@ -7,6 +7,12 @@ cask "n1ghtshade" do
   desc "Permits the downgrade/jailbreak of 32-bit iOS devices"
   homepage "https://github.com/synackuk/n1ghtshade"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(%r{href=.*?/tag/v?([\w._-]+)["' >]}i)
+  end
+
   depends_on formula: %w[
     libimobiledevice
     libirecovery


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.