### PR TITLE
Update surfshark from 3.9.0 to 3.10.1 + remove Hardware UUID from zap

### DIFF
--- a/Casks/surfshark.rb
+++ b/Casks/surfshark.rb
@@ -18,7 +18,7 @@ cask "surfshark" do
     "~/Library/Application Scripts/com.surfshark.vpnclient.macos",
     "~/Library/Application Scripts/com.surfshark.vpnclient.macos.PacktTunnel-OpenVPN",
     "~/Library/Application Scripts/com.surfshark.vpnclient.macos.launchAgent",
-    "~/Library/Application Support/CrashReporter/Surfshark.OpenVPN_DF2D8DF5-283D-5FFF-9DBF-511FBB24AE9D.plist",
+    "~/Library/Application Support/CrashReporter/Surfshark.OpenVPN_*.plist",
     "~/Library/Containers/com.surfshark.vpnclient.macos",
     "~/Library/Containers/com.surfshark.vpnclient.macos.PacktTunnel-OpenVPN",
     "~/Library/Containers/com.surfshark.vpnclient.macos.launchAgent",

--- a/Casks/surfshark.rb
+++ b/Casks/surfshark.rb
@@ -1,5 +1,5 @@
 cask "surfshark" do
-  version "3.10.0,1019"
+  version "3.10.1,1024"
   sha256 :no_check
 
   url "https://downloads.surfshark.com/macOS/latest/Surfshark.dmg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
The 5-group hex string after the underscore is machine dependent and thus renders the zap line useless to the overwhelming majority of users. Fixed. ;)