### PR TITLE
Update navicat-premium froom 15.0.30 to 15.0.32

### DIFF
--- a/Casks/navicat-premium.rb
+++ b/Casks/navicat-premium.rb
@@ -1,5 +1,5 @@
 cask "navicat-premium" do
-  version "15.0.30"
+  version "15.0.32"
   sha256 :no_check
 
   language "zh-CN" do


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.