### PR TITLE
Upgrade clash-for-windows to 0.18.10

### DIFF
--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -1,12 +1,12 @@
 cask "clash-for-windows" do
   arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  version "0.18.9"
+  version "0.18.10"
 
   if Hardware::CPU.intel?
-    sha256 "33ca1004ba19d425f1b1b82b1e29e42df2ac0fcce5a7ed159314b88d6faa11d1"
+    sha256 "d10c75861339fa35d7125021d4cfe0a1e78176d1bf85ec8b6acdb875235f249d"
   else
-    sha256 "0822306dec816772dc9fa0ed9ab317a4f8ca029e537edaaac2add7f1941a35cc"
+    sha256 "6b7b128a91e96b74f4a9050f5d63501a6af48f6f6d72ec2c151750f79603bb59"
   end
 
   url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}#{arch}.dmg"


### PR DESCRIPTION
Upgrade clash-for-windows to 0.18.10

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
