### PR TITLE
preferencecleaner: update livecheck + add zap

### DIFF
--- a/Casks/preferencecleaner.rb
+++ b/Casks/preferencecleaner.rb
@@ -4,6 +4,7 @@ cask "preferencecleaner" do
 
   url "https://echomist.co.uk/software/downloads/PreferenceCleaner_#{version}.dmg"
   name "PreferenceCleaner"
+  desc "Utility to simplify the task of deleting preference files"
   homepage "https://echomist.co.uk/software/PreferenceCleaner.php"
 
   livecheck do

--- a/Casks/preferencecleaner.rb
+++ b/Casks/preferencecleaner.rb
@@ -14,4 +14,6 @@ cask "preferencecleaner" do
   depends_on macos: ">= :catalina"
 
   app "PreferenceCleaner #{version.major}.app"
+
+  zap trash: "~/Library/Caches/uk.co.echomist.PreferenceCleaner#{version.major}"
 end

--- a/Casks/preferencecleaner.rb
+++ b/Casks/preferencecleaner.rb
@@ -2,9 +2,9 @@ cask "preferencecleaner" do
   version "2.0"
   sha256 "800f1df5ca2519eaf66e0efc383a7a3f76018f8f8760058c3cee08b5ec75bd8e"
 
-  url "https://www.echomist.co.uk/software/downloads/PreferenceCleaner_#{version}.dmg"
+  url "https://echomist.co.uk/software/downloads/PreferenceCleaner_#{version}.dmg"
   name "PreferenceCleaner"
-  homepage "https://www.echomist.co.uk/software/PreferenceCleaner.php"
+  homepage "https://echomist.co.uk/software/PreferenceCleaner.php"
 
   livecheck do
     url :homepage

--- a/Casks/preferencecleaner.rb
+++ b/Casks/preferencecleaner.rb
@@ -8,8 +8,7 @@ cask "preferencecleaner" do
 
   livecheck do
     url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/PreferenceCleaner_(\d+(?:\.\d+)*)\.dmg}i)
+    regex(%r{href=.*?/PreferenceCleaner[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.