### PR TITLE
Update eloston-chromium from 96.0.4664.45-1.1_x86-64 to 96.0.4664.55-1.1_x86-64

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -1,7 +1,7 @@
 cask "eloston-chromium" do
   if Hardware::CPU.intel?
-    version "96.0.4664.45-1.1_x86-64"
-    sha256 "42b48f75081e74e727e43baa35f1306210c86c0794a01af190aee659992c386f"
+    version "96.0.4664.55-1.1_x86-64"
+    sha256 "32620bcd432d33e68173e9ccb91d773b07722e19d7b1b153df1a389a68d68cce"
   else
     version "96.0.4664.45-1.1_arm64"
     sha256 "3fa8c683f4c9731d3b224c11bdd07ee16c257227a8f26408d48572b2e0cd961a"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
