### PR TITLE
Remove auto_updates flag

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -14,8 +14,6 @@ cask "gimp" do
     regex(%r{href=.*?/gimp-(\d+(?:\.\d+)*)-x86_64\.dmg}i)
   end
 
-  auto_updates true
-
   app "GIMP-#{version.major_minor}.app"
   binary "#{appdir}/GIMP-#{version.major_minor}.app/Contents/MacOS/gimp"
 

--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -11,7 +11,7 @@ cask "gimp" do
   livecheck do
     url "https://www.gimp.org/downloads/"
     strategy :page_match
-    regex(%r{href=.*?/gimp-(\d+(?:\.\d+)*)-x86_64\.dmg}i)
+    regex(%r{href=.*?/gimp-(\d+(?:\.\d+)+)-x86_64\.dmg}i)
   end
 
   app "GIMP-#{version.major_minor}.app"
@@ -22,8 +22,8 @@ cask "gimp" do
   end
 
   zap trash: [
-    "~/Library/Preferences/org.gimp.gimp-#{version.major_minor}:.plist",
     "~/Library/Application Support/Gimp",
+    "~/Library/Preferences/org.gimp.gimp-#{version.major_minor}:.plist",
     "~/Library/Saved Application State/org.gimp.gimp-#{version.major_minor}:.savedState",
   ]
 end


### PR DESCRIPTION
Auto update is not working for Gimp. See Gimp issue no [7325](https://gitlab.gnome.org/GNOME/gimp/-/issues/7325) for more info. This change reverts https://github.com/Homebrew/homebrew-cask/commit/3cc865bcd435aac4f1da800d651d79096bda5f00.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
