### PR TITLE
FME 2021.2

### DIFF
--- a/Casks/fme.rb
+++ b/Casks/fme.rb
@@ -20,8 +20,8 @@ cask "fme" do
   pkg "fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx.pkg"
 
   uninstall pkgutil: [
-    "com.safesoftware.pkg.engine.fme-desktop-2021.2-b21789-macosx",
-    "com.safesoftware.pkg.apps.fme-desktop-2021.2-b21789-macosx",
+    "com.safesoftware.pkg.engine.fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx",
+    "com.safesoftware.pkg.apps.fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx",
   ],
             delete:  [
               "/Applications/FME #{version.major_minor}",

--- a/Casks/fme.rb
+++ b/Casks/fme.rb
@@ -20,8 +20,8 @@ cask "fme" do
   pkg "fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx.pkg"
 
   uninstall pkgutil: [
-    "com.safesoftware.pkg.engine.fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx",
-    "com.safesoftware.pkg.apps.fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx",
+    "com.safesoftware.pkg.engine.fme-desktop-#{version.major_minor}-b#{version.after_comma}-macosx",
+    "com.safesoftware.pkg.apps.fme-desktop-#{version.major_minor}-b#{version.after_comma}-macosx",
   ],
             delete:  [
               "/Applications/FME #{version.major_minor}",

--- a/Casks/fme.rb
+++ b/Casks/fme.rb
@@ -19,11 +19,11 @@ cask "fme" do
 
   pkg "fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx.pkg"
 
-  uninstall pkgutil:   [
+  uninstall pkgutil: [
     "com.safesoftware.pkg.engine.fme-desktop-2021.2-b21789-macosx",
     "com.safesoftware.pkg.apps.fme-desktop-2021.2-b21789-macosx",
   ],
-            delete: [
+            delete:  [
               "/Applications/FME #{version.major_minor}",
               "/Library/FME/#{version.major_minor}",
             ]

--- a/Casks/fme.rb
+++ b/Casks/fme.rb
@@ -10,7 +10,7 @@ cask "fme" do
   livecheck do
     url "https://www.safe.com/api/downloads/"
     strategy :page_match do |page|
-      match = page.match(%r{/fme-desktop-(\d+(?:\.\d+)*)-b(\d+)-macosx\.pkg}i)
+      match = page.match(%r{/fme-desktop-(\d+(?:\.\d+)+)-b(\d+)-macosx\.pkg}i)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"

--- a/Casks/fme.rb
+++ b/Casks/fme.rb
@@ -1,8 +1,8 @@
 cask "fme" do
-  version "2021.0.3,21326"
-  sha256 "d0488a6db9a8b0c97d57f5ab99a5ba399038fe56b291b2526f3c7808a38bb95c"
+  version "2021.2.0.1,21789"
+  sha256 "5bd89c262999f554490f6fba7de49cdb1ec8b840b148a5cb5652dd922ee32072"
 
-  url "https://downloads.safe.com/fme/#{version.major}/fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx.dmg"
+  url "https://downloads.safe.com/fme/#{version.major}/fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx.pkg"
   name "FME Desktop"
   desc "Platform for integrating spatial data"
   homepage "https://www.safe.com/"
@@ -10,23 +10,18 @@ cask "fme" do
   livecheck do
     url "https://www.safe.com/api/downloads/"
     strategy :page_match do |page|
-      match = page.match(%r{/fme-desktop-(\d+(?:\.\d+)*)-b(\d+)-macosx\.dmg}i)
+      match = page.match(%r{/fme-desktop-(\d+(?:\.\d+)*)-b(\d+)-macosx\.pkg}i)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"
     end
   end
 
-  installer script: {
-    executable: "FME Desktop Installer.app/Contents/MacOS/applet",
-    sudo:       true,
-  }
+  pkg "fme-desktop-#{version.before_comma}-b#{version.after_comma}-macosx.pkg"
 
-  uninstall quit:   [
-    "com.safe.fmeworkbench",
-    "com.safe.datainspector",
-    "com.safe.fmequicktranslator",
-    "com.safe.fmehelp",
+  uninstall pkgutil:   [
+    "com.safesoftware.pkg.engine.fme-desktop-2021.2-b21789-macosx",
+    "com.safesoftware.pkg.apps.fme-desktop-2021.2-b21789-macosx",
   ],
             delete: [
               "/Applications/FME #{version.major_minor}",


### PR DESCRIPTION
Safe changed the installer packaging of FME from DMG to PKG; this in turn broke Homebrew's updated package detection. This formula updates both the version and the installation type.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
