### PR TITLE
Add Grammarly Desktop App 1.0.0.5

### DIFF
--- a/Casks/grammarly-desktop.rb
+++ b/Casks/grammarly-desktop.rb
@@ -1,0 +1,22 @@
+cask "grammarly-desktop" do
+  version "1.0.0.5"
+  sha256 :no_check
+
+  url "https://download-mac.grammarly.com/Grammarly.dmg"
+  name "Grammarly Desktop"
+  desc "Grammarly for desktop"
+  homepage "https://www.grammarly.com/desktop"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  app "Grammarly Installer.app", target: "Grammarly Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.grammarly.ProjectLlama",
+    "~/Library/Caches/com.grammarly.ProjectLlama",
+    "~/Library/Preferences/com.grammarly.ProjectLlama.plist",
+  ]
+end


### PR DESCRIPTION
We will need to discuss what to do with the `token` for this cask. There is currently a cask with token `grammarly` which the application that it provides has been renamed `Grammarly Editor` upstream. Generally, I would advise to rename the other cask, however, it is relatively popular. So I'd be interested in thoughts about the best way to proceed here. CC: @miccal 

```
grammarly
30 days: 658 (#233)
90 days: 1,413 (#272)
365 days: 4,703 (#296)
```

Contextually, there are now two apps from Grammarly. Our existing cask `grammarly` is for "Grammarly Editor" - which is a word-processor style application that provides grammar and style checking. This new cask is for "Grammarly Desktop" which provides system-wide grammar and style checking.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
