### PR TITLE
Add caveat for PowerShell setup

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -37,5 +37,4 @@ cask "powershell" do
           "the following command once within a PowerShell session:" \
           "" \
           "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"
-
 end

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -31,4 +31,11 @@ cask "powershell" do
     "~/.config/PowerShell",
     "~/.local/share/powershell",
   ]
+  
+  caveats "If PowerShell is used as a login shell, an entry must be added to the" \
+          "PowerShell profile file to use Homebrew. The easiest way to do this is to run" \
+          "the following command once within a PowerShell session:" \
+          "" \
+          "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"
+
 end

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -32,8 +32,8 @@ cask "powershell" do
     "~/.local/share/powershell",
   ]
   
-  caveats "If PowerShell is used as a login shell, an entry must be added to the" \
-          "PowerShell profile file to use Homebrew. The easiest way to do this is to run" \
+  caveats "If PowerShell is used as a login shell, an entry must be added to the " \
+          "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
           "the following command once within a PowerShell session:" \
           "" \
           "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -34,6 +34,6 @@ cask "powershell" do
 
   caveats <<~EOS
     To use Homebrew in PowerShell, set:
-      Add-Content -Path $PROFILE -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
+      Add-Content -Path $PROFILE.CurrentUserAllHosts -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
   EOS
 end

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -32,12 +32,8 @@ cask "powershell" do
     "~/.local/share/powershell",
   ]
   
-  caveats "If PowerShell is used as a login shell, an entry must be added to the " \
-          "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
-          "the following command once within a PowerShell session:" \
-          "\n\n" \
-          "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf " \
-          "/opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path " \
-          "-PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | " \
-          "Invoke-Expression -ErrorAction SilentlyContinue'"
+  caveats <<~EOS
+    To use Homebrew in PowerShell, set:
+      Add-Content -Path $PROFILE -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
+  EOS
 end

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -35,7 +35,7 @@ cask "powershell" do
   caveats "If PowerShell is used as a login shell, an entry must be added to the " \
           "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
           "the following command once within a PowerShell session:" \
-          "" \
+          "\n\n" \
           "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf " \
           "/opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path " \
           "-PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | " \

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -36,5 +36,8 @@ cask "powershell" do
           "PowerShell profile file to use Homebrew. The easiest way to do this is to run " \
           "the following command once within a PowerShell session:" \
           "" \
-          "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf /opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path -PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | Invoke-Expression -ErrorAction SilentlyContinue'"
+          "Add-Content -Path $PROFILE -Value '$(if (Test-Path -PathType Leaf " \
+          "/opt/homebrew/bin/brew) {/opt/homebrew/bin/brew shellenv} elseif (Test-Path " \
+          "-PathType Leaf /usr/local/bin/brew) {/usr/local/bin/brew shellenv}) | " \
+          "Invoke-Expression -ErrorAction SilentlyContinue'"
 end

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -31,7 +31,7 @@ cask "powershell" do
     "~/.config/PowerShell",
     "~/.local/share/powershell",
   ]
-  
+
   caveats <<~EOS
     To use Homebrew in PowerShell, set:
       Add-Content -Path $PROFILE -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'


### PR DESCRIPTION
Add caveat about enabling Homebrew for PowerShell sessions where environment variables are not inherited from zsh.

This requires pull request https://github.com/Homebrew/brew/pull/12494 to be approved and merged before the caveat becomes useful.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
