### PR TITLE
PowerShell: Add missing dependency and fix lowercase in cleanup

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -20,6 +20,7 @@ cask "powershell" do
     regex(/^v?(\d+(?:\.\d+)*)$/)
   end
 
+  depends_on formula: "openssl"
   depends_on macos: ">= :mojave"
 
   pkg "powershell-#{version}-osx-#{arch}.pkg"

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -29,7 +29,7 @@ cask "powershell" do
 
   zap trash: [
     "~/.cache/powershell",
-    "~/.config/PowerShell",
+    "~/.config/powershell",
     "~/.local/share/powershell",
   ]
 end


### PR DESCRIPTION
In comparison to the [PowerShell-preview formula](https://github.com/Homebrew/homebrew-cask-versions/blob/master/Casks/powershell-preview.rb), this one misses a dependency to `openssl`.

The dependency is actually quite high as remote activities rely on it and PS is used mostly for doing remote administration and configuration. It seems obvious to sync this dependency with the preview version.

Also taking the opportunity to change the `.config/powershell` cleanup part to lowercase as this is what's actually being used.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
