### PR TITLE
Update Semulov from 2.4.1 to 2.6

### DIFF
--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -1,11 +1,11 @@
 cask "semulov" do
-  version "2.4.1"
-  sha256 :no_check
+  version "2.6.0"
+  sha256 "fc25b015251562df79c89143b2fb123fc793d780e3f1eb9990d6d5723c870dc6"
 
-  url "https://kainjow.com/downloads/Semulov.zip"
+  url "https://github.com/kainjow/Semulov/releases/download/v2.6/Semulov.zip"
   name "Semulov"
   desc "Access mounted and unmounted volumes from the menubar"
-  homepage "https://kainjow.com/"
+  homepage "https://github.com/kainjow/Semulov"
 
   livecheck do
     url "https://kainjow.com/updates/semulov.xml"

--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -7,10 +7,5 @@ cask "semulov" do
   desc "Access mounted and unmounted volumes from the menubar"
   homepage "https://github.com/kainjow/Semulov"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   app "Semulov.app"
 end

--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -7,5 +7,10 @@ cask "semulov" do
   desc "Access mounted and unmounted volumes from the menubar"
   homepage "https://github.com/kainjow/Semulov"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Semulov.app"
 end

--- a/Casks/semulov.rb
+++ b/Casks/semulov.rb
@@ -1,16 +1,11 @@
 cask "semulov" do
-  version "2.6.0"
+  version "2.6"
   sha256 "fc25b015251562df79c89143b2fb123fc793d780e3f1eb9990d6d5723c870dc6"
 
-  url "https://github.com/kainjow/Semulov/releases/download/v2.6/Semulov.zip"
+  url "https://github.com/kainjow/Semulov/releases/download/v#{version}/Semulov.zip"
   name "Semulov"
   desc "Access mounted and unmounted volumes from the menubar"
   homepage "https://github.com/kainjow/Semulov"
-
-  livecheck do
-    url "https://kainjow.com/updates/semulov.xml"
-    strategy :sparkle
-  end
 
   app "Semulov.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Seems like author of this application stopped updating download page on their personal website, however releasing a stable version on the official [GitHub Releases](https://github.com/kainjow/Semulov/releases).

The Sparkle update feed may not be actively maintained anymore — it still says 2.4.1 as a latest version.

 I changed the website URL to point to GitHub (which is being updated) and changed livecheck strategy to `:github_latest`.
