### PR TITLE
id3-editor.rb: fix URL

### DIFF
--- a/Casks/id3-editor.rb
+++ b/Casks/id3-editor.rb
@@ -1,8 +1,8 @@
 cask "id3-editor" do
   version "1.28.50"
-  sha256 "c19eeb045d0a48862a9f66bbdc27b00f9077690a23491804b539d00d6b7ee352"
+  sha256 "43390edcb10183fae90e5f541bdf97c757e92f1c250bf1d3baaf7a52ef5a05b3"
 
-  url "http://www.pa-software.com/release/ID3Editor.ub.#{version}.dmg"
+  url "http://www.pa-software.com/release/ID3Editor.arm.#{version}.dmg"
   name "ID3 Editor"
   desc "MP3 and AIFF ID3 tag editor"
   homepage "http://www.pa-software.com/id3editor/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The “universal build” we have is PPC and Intel 32-bit. This one is the relevant universal build, despite the URL saying `arm`.