### PR TITLE
Add Soundtoys 5 Plugins v5.3.6

### DIFF
--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -15,7 +15,6 @@ cask "soundtoys" do
     end
   end
 
-  auto_updates false
   depends_on cask: "ilok-license-manager"
 
   pkg "Install Soundtoys #{version.major}.pkg"

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -1,0 +1,18 @@
+cask "soundtoys" do
+  version "5.3.6,16152"
+  sha256 "859676347419937c6d77c2eb47dca2b262574db056138b7028e2e3792080bb27"
+
+  url "https://storage.googleapis.com/soundtoys-download/versions/version_#{version.major}_#{version.minor}_#{version.patch}_#{version.after_comma}/Soundtoys#{version.major}_#{version.major}.#{version.minor}.#{version.patch}.#{version.after_comma}.dmg",
+      verified: "https://storage.googleapis.com/soundtoys-download/"
+  name "Soundtoys #{version.major}"
+  desc "Audio Effects Plugins"
+  homepage "https://www.soundtoys.com/product/soundtoys-#{version.major}/"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  pkg "Install Soundtoys #{version.major}.pkg"
+
+  uninstall pkgutil: "com.soundtoys.*"
+end

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -1,15 +1,18 @@
 cask "soundtoys" do
-  version "5.3.6,16152"
+  version "5.3.6.16152"
   sha256 "859676347419937c6d77c2eb47dca2b262574db056138b7028e2e3792080bb27"
 
-  url "https://storage.googleapis.com/soundtoys-download/versions/version_#{version.major}_#{version.minor}_#{version.patch}_#{version.after_comma}/Soundtoys#{version.major}_#{version.major}.#{version.minor}.#{version.patch}.#{version.after_comma}.dmg",
+  url "https://storage.googleapis.com/soundtoys-download/versions/version_#{version.dots_to_underscores}/Soundtoys#{version.major}_#{version}.dmg",
       verified: "https://storage.googleapis.com/soundtoys-download/"
-  name "Soundtoys #{version.major}"
+  name "Soundtoys"
   desc "Audio Effects Plugins"
-  homepage "https://www.soundtoys.com/product/soundtoys-#{version.major}/"
+  homepage "https://www.soundtoys.com/product/soundtoys/"
 
   livecheck do
-    skip "No version information available"
+    url "https://storage.googleapis.com/soundtoys-download/download.json"
+    strategy :page_match do |page|
+      JSON.parse(page)["Soundtoys5_Mac"]["fullversion"]
+    end
   end
 
   auto_updates false

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -15,5 +15,5 @@ cask "soundtoys" do
   pkg "Install Soundtoys #{version.major}.pkg"
 
   uninstall pkgutil:   ["com.soundtoys.*", "com.paceap.pkg.eden.*"],
-            launchctl: ["com.paceap.eden.*"]
+            launchctl: ["com.paceap.eden.licensed", "com.paceap.eden.licensed.agent"]
 end

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -15,4 +15,7 @@ cask "soundtoys" do
   pkg "Install Soundtoys #{version.major}.pkg"
 
   uninstall pkgutil: "com.soundtoys.*"
+
+  zap pkgutil: "com.paceap.pkg.eden.*",
+      launchctl: "com.paceap.eden.*"
 end

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -15,8 +15,6 @@ cask "soundtoys" do
     end
   end
 
-  depends_on cask: "ilok-license-manager"
-
   pkg "Install Soundtoys #{version.major}.pkg"
 
   uninstall pkgutil:   ["com.soundtoys.*", "com.paceap.pkg.eden.*"],

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -12,6 +12,9 @@ cask "soundtoys" do
     skip "No version information available"
   end
 
+  auto_updates false
+  depends_on cask: "ilok-license-manager"
+
   pkg "Install Soundtoys #{version.major}.pkg"
 
   uninstall pkgutil:   ["com.soundtoys.*", "com.paceap.pkg.eden.*"],

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -14,8 +14,6 @@ cask "soundtoys" do
 
   pkg "Install Soundtoys #{version.major}.pkg"
 
-  uninstall pkgutil: "com.soundtoys.*"
-
-  zap pkgutil: "com.paceap.pkg.eden.*",
-      launchctl: "com.paceap.eden.*"
+  uninstall pkgutil:   ["com.soundtoys.*", "com.paceap.pkg.eden.*"],
+            launchctl: ["com.paceap.eden.*"]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Soundtoys Cask was deleted (#49399) on July 2018. Since then the Soundtoys downloads are moved to Google Storage, which is not a walled page; anyone can access without have to logged in or registered to Soundtoys. (Can be checked from https://storage.googleapis.com/soundtoys-download/download.html and https://storage.googleapis.com/soundtoys-download/download.html?product=soundtoys-5 addresses)

I would like to reintroduce the Soundtoys Cask to Homebrew. One problem is there is no livecheck strategy currently, it could be possible to get the version name via the download link on the page https://storage.googleapis.com/soundtoys-download/download.html?product=soundtoys-5 or a manual update when a new version is released would be necessary.

Thank you for your time, I hope the cask code is in line with the guidelines.
