### PR TITLE
Update flipper from 0.122.0 to 0.123.0 (Manually)

### DIFF
--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -1,6 +1,6 @@
 cask "flipper" do
-  version "0.122.0"
-  sha256 "1c5216a503f14dd515d6da5bd19ac23764e9171e98aa871a7744e7f8cd025456"
+  version "0.123.0"
+  sha256 "f450830ddf4c2394758dde492ba07d43bcf1e32e836a0bee694f0e56edf80951"
 
   url "https://github.com/facebook/flipper/releases/download/v#{version}/Flipper-mac.dmg",
       verified: "github.com/facebook/flipper/"


### PR DESCRIPTION
`bump-cask-pr` doesn't seem to be working properly, so I manually verified and replaced the `sha256` with version `0.123.0`