### PR TITLE
Update softube-central from 1.5.1 to 1.5.9

### DIFF
--- a/Casks/softube-central.rb
+++ b/Casks/softube-central.rb
@@ -1,12 +1,16 @@
 cask "softube-central" do
-  version "1.5.1"
-  sha256 "ab5db2b2dedc2bc18757d0ed02cd07deada327f1ce6699a996975236c4c70077"
+  version "1.5.9"
+  sha256 "aba4d5ecd396fe00300e42be4d5a40b9ad0cc7690f43bdba71b6d5b54b68ace3"
 
   url "https://softubestorage.b-cdn.net/softubecentral/Softube%20Central-#{version}.pkg",
       verified: "softubestorage.b-cdn.net/"
   name "Softube Central"
   desc "Installer for installation and license activation of Softube products"
   homepage "https://www.softube.com/softube-central/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   auto_updates true
   depends_on cask: "ilok-license-manager"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.