### PR TITLE
Update far2l from 2.3.210921-716b329,2021-09-21_alpha to 2.3.211204-48654cc4,2021-12-04_alpha

### DIFF
--- a/Casks/far2l.rb
+++ b/Casks/far2l.rb
@@ -1,28 +1,34 @@
 cask "far2l" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  version "2.3.210921-716b329,2021-09-21_alpha"
-
   if MacOS.version <= :mojave
-    sha256 "efcf4b9cc19e1a0fce2e2526b0e1549f95a2ee1a1f532a0056daf575311f7935"
-
+    version "far2l-2.3.211204-48654cc,2021-12-04_alpha"
     url "https://github.com/elfmz/far2l/releases/download/v#{version.after_comma}/far2l-#{version.before_comma}-alpha-MacOS-10.11.dmg"
-  else
-    sha256 "b78ee531f31ad6174a6211ee3841eff929089fca215c26ffb47c5913ed66d19b"
+    sha256 "113c55b19e8427258bea955415ff9282d18a4669df5f459ca8340bb5ce1726f2"
 
+    livecheck do
+      url "https://github.com/elfmz/far2l/releases"
+      regex(%r{/v(.*)/far2l-(.*)-alpha-MacOS-10\.11\.dmg}i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+      end
+    end
+  else
+    version "2.3.211204-48654cc4,2021-12-04_alpha"
     url "https://github.com/elfmz/far2l/releases/download/v#{version.after_comma}/far2l-#{version.before_comma}-alpha-MacOS-10.15.dmg"
+    sha256 "b2e43058b9d77306670afe61d579cf2031827328706dab54e34d3f7597b7fa01"
+
+    livecheck do
+      url "https://github.com/elfmz/far2l/releases"
+      regex(%r{/v(.*)/far2l-(.*)-alpha-MacOS-10\.15\.dmg}i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+      end
+    end
   end
 
   name "far2l"
   desc "Unix fork of FAR Manager v2"
   homepage "https://github.com/elfmz/far2l"
-
-  livecheck do
-    url "https://github.com/elfmz/far2l/releases"
-    regex(%r{/v(.*)/far2l-(.*)-alpha-MacOS-10\.(11|15)\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
-    end
-  end
 
   depends_on macos: ">= :el_capitan"
 

--- a/Casks/far2l.rb
+++ b/Casks/far2l.rb
@@ -2,24 +2,24 @@ cask "far2l" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
   if MacOS.version <= :mojave
     version "far2l-2.3.211204-48654cc,2021-12-04_alpha"
-    url "https://github.com/elfmz/far2l/releases/download/v#{version.after_comma}/far2l-#{version.before_comma}-alpha-MacOS-10.11.dmg"
+    url "https://github.com/elfmz/far2l/releases/download/v#{version.csv.second}/far2l-#{version.csv.first}-alpha-MacOS-10.11.dmg"
     sha256 "113c55b19e8427258bea955415ff9282d18a4669df5f459ca8340bb5ce1726f2"
 
     livecheck do
       url "https://github.com/elfmz/far2l/releases"
-      regex(%r{/v(.*)/far2l-(.*)-alpha-MacOS-10\.11\.dmg}i)
+      regex(%r{/v([^/]+)/far2l-(.+)-alpha-MacOS-10\.11\.dmg}i)
       strategy :page_match do |page, regex|
         page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
       end
     end
   else
     version "2.3.211204-48654cc4,2021-12-04_alpha"
-    url "https://github.com/elfmz/far2l/releases/download/v#{version.after_comma}/far2l-#{version.before_comma}-alpha-MacOS-10.15.dmg"
+    url "https://github.com/elfmz/far2l/releases/download/v#{version.csv.second}/far2l-#{version.csv.first}-alpha-MacOS-10.15.dmg"
     sha256 "b2e43058b9d77306670afe61d579cf2031827328706dab54e34d3f7597b7fa01"
 
     livecheck do
       url "https://github.com/elfmz/far2l/releases"
-      regex(%r{/v(.*)/far2l-(.*)-alpha-MacOS-10\.15\.dmg}i)
+      regex(%r{/v([^/]+)/far2l-(.+)-alpha-MacOS-10\.15\.dmg}i)
       strategy :page_match do |page, regex|
         page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
       end


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
