### PR TITLE
Update gitdock to v0.1.14

### DIFF
--- a/Casks/gitdock.rb
+++ b/Casks/gitdock.rb
@@ -1,6 +1,6 @@
 cask "gitdock" do
   version "0.1.14"
-  sha256 "e57a1e0c5ac54a9cd6f94e54f2fb6c2250217b5fdd8f1f675b7772db85f7d507"
+  sha256 "fbd0e2b7f84f87767a0cf6bc431a685af3491c8dc274a15f1a1e9ea0c7b4821e"
 
   url "https://gitlab.com/mvanremmerden/gitdock/-/releases/v#{version}/downloads/GitDock-#{version}.dmg"
   name "GitDock"

--- a/Casks/gitdock.rb
+++ b/Casks/gitdock.rb
@@ -1,6 +1,6 @@
 cask "gitdock" do
-  version "0.1.12"
-  sha256 "8e80668391a8c836f82bccd073fca51196cd21fc50bcda134bad236ca0419702"
+  version "0.1.14"
+  sha256 "e57a1e0c5ac54a9cd6f94e54f2fb6c2250217b5fdd8f1f675b7772db85f7d507"
 
   url "https://gitlab.com/mvanremmerden/gitdock/-/releases/v#{version}/downloads/GitDock-#{version}.dmg"
   name "GitDock"


### PR DESCRIPTION
Updates GitDock to v0.1.14.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.