### PR TITLE
Update fastscripts.rb

### DIFF
--- a/Casks/fastscripts.rb
+++ b/Casks/fastscripts.rb
@@ -8,7 +8,7 @@ cask "fastscripts" do
   homepage "https://redsweater.com/fastscripts/"
 
   livecheck do
-    url "https://redsweater.com/fastscripts/appcast2.php"
+    url "https://redsweater.com/fastscripts/appcast3.php"
     strategy :sparkle
   end
 


### PR DESCRIPTION
I hope this is right way to submit this change. A homebrew user who depends on the FastScripts cask didn't notice that FastScripts 3.0 was released a while back, since the cask is stuck on the 2.x versions. The 3.0 is a paid upgrade, but should the same FastScripts cask still be updated to point to newer versions? If so, I think updating the Sparkle feed as indicated here should keep it up to date.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
