### PR TITLE
universal-media-server: remove unnecessary zap item

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -12,8 +12,5 @@ cask "universal-media-server" do
 
   app "Universal Media Server.app"
 
-  zap trash: [
-    "~/Library/Application Support/UMS",
-    "~/Library/Saved Application State/net.pms.PMS.savedState",
-  ]
+  zap trash: "~/Library/Application Support/UMS"
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.