### PR TITLE
Add arturia-midi-control-center v1.13.5.1

### DIFF
--- a/Casks/arturia-midi-control-center.rb
+++ b/Casks/arturia-midi-control-center.rb
@@ -1,0 +1,20 @@
+cask "arturia-midi-control-center" do
+  version "1.13.5.1"
+  sha256 "60e75c5aa52a1ce6909eb6ea8e18b0c1e51b3ee6209ce8ef9e3ceb8e4751ec3e"
+
+  url "https://downloads.arturia.net/extra/mcc/MIDI_Control_Center_#{version.dots_to_underscores}.pkg",
+      verified: "https://downloads.arturia.net"
+  name "Arturia MIDI Control Center"
+  desc "MIDI Controller Software"
+  homepage "https://www.arturia.com/support/downloads&manuals#mccu-784325106"
+
+  livecheck do
+    url "https://www.arturia.com/products/keystep/resources"
+    strategy :page_match
+    regex(/name="mccu-latest"/)
+  end
+
+  pkg "MIDI_Control_Center_#{version.dots_to_underscores}.pkg"
+
+  uninstall pkgutil: "com.Arturia.MIDIControlCenter.*"
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

I did try the `livecheck` with `brew livecheck --debug`command and the regex resulted with the correct version number, though I'm not 100% sure if this is the right way to do it. Feel free to correct if it's wrong, or please guide me on how should I do it. Another important thing is, I used a MIDI Controller page for the livecheck, because the main Downloads page took really long to load, this way (using a MIDI Controller page, Keystep in that case) the page can be loaded way quicker. Unfortunately the MIDI Control Center does not have a dedicated page, and the homepage link may not auto-scroll to the MIDI Control Center part because the page loads really slow, still I chose to put the most specific link I could find.

EDIT: Apparently the livecheck is not really working at all (regex finds the element but i have to work on it to select the right child element and do regex on it).