### PR TITLE
Switch depends_on to macFUSE

### DIFF
--- a/Casks/ntfstool.rb
+++ b/Casks/ntfstool.rb
@@ -7,7 +7,7 @@ cask "ntfstool" do
   homepage "https://github.com/ntfstool/ntfstool"
 
   auto_updates true
-  depends_on cask: "osxfuse"
+  depends_on cask: "macfuse"
 
   app "NTFSTool.app"
 

--- a/Casks/ntfstool.rb
+++ b/Casks/ntfstool.rb
@@ -4,6 +4,7 @@ cask "ntfstool" do
 
   url "https://github.com/ntfstool/ntfstool/releases/download/#{version}/NTFSTool-#{version}.dmg"
   name "NTFSTool"
+  desc "Utility that provides NTFS read and write support"
   homepage "https://github.com/ntfstool/ntfstool"
 
   auto_updates true


### PR DESCRIPTION
Use `macfuse` instead of `osxfuse` (deprecated).
Same as #99378.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
