### PR TITLE
softmaker-freeoffice: update livecheck regex

### DIFF
--- a/Casks/softmaker-freeoffice.rb
+++ b/Casks/softmaker-freeoffice.rb
@@ -11,10 +11,10 @@ cask "softmaker-freeoffice" do
   livecheck do
     url "https://www.freeoffice.com/en/download/servicepacks"
     strategy :page_match do |page|
-      match = page.match(/(\d+)-(\d+)-(\d+):\s*Revision\s*(\d+)/i)
+      match = page.match(/softmaker[._-]freeoffice[._-](\d+(?:\.\d+)*)\.pkg.*?Revision\s*(\d+)\s*</im)
       next if match.blank?
 
-      "#{match[1]},#{match[4]}"
+      "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
As noted in [#115128](https://github.com/Homebrew/homebrew-cask/pull/115128#discussion_r763769395), the current livecheck will likely produce a wrong version number come 2022. Before the release of the 2021 edition of FreeOffice earlier this year, the 2018 edition was current.