### PR TITLE
Update vscodium from 1.62.3 to 1.63.0

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -13,12 +13,12 @@ cask "vscodium" do
   binary "#{appdir}/VSCodium.app/Contents/Resources/app/bin/codium"
 
   zap trash: [
-    "~/Library/Application Support/VSCodium",
+    "~/.vscode-oss",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.visualstudio.code.oss.sfl*",
+    "~/Library/Application Support/VSCodium",
     "~/Library/Logs/VSCodium",
     "~/Library/Preferences/com.visualstudio.code.oss.helper.plist",
     "~/Library/Preferences/com.visualstudio.code.oss.plist",
     "~/Library/Saved Application State/com.visualstudio.code.oss.savedState",
-    "~/.vscode-oss",
   ]
 end

--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask "vscodium" do
-  version "1.62.3"
-  sha256 "357b08251a3434c053811e6e5cad58c33823295ef65e0c2f6e5cdc12be9806a6"
+  version "1.63.0"
+  sha256 "6ee5c6986c8249c6f6d2d9ac23a678158dc409b7fabcae9cfdb8d643a1ea9db5"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.x64.#{version}.dmg"
   name "VSCodium"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
