### PR TITLE
Add arm64 builds for Cryptomator

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,8 +1,15 @@
 cask "cryptomator" do
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
+  
   version "1.6.4"
-  sha256 "7c763610523dc6ced2d51d5e25fdb15ccd93366a107b8959460f7796eef83dc2"
+  
+  if Hardware::CPU.intel?
+    sha256 "7c763610523dc6ced2d51d5e25fdb15ccd93366a107b8959460f7796eef83dc2"
+  else
+    sha256 "1e7fc2bb09bbe914317c9b1459415a250d8f7baaa4cb51735c2f1a1e8d4605da"
+  end
 
-  url "https://github.com/cryptomator/cryptomator/releases/download/#{version}/Cryptomator-#{version}.dmg",
+  url "https://github.com/cryptomator/cryptomator/releases/download/#{version}/Cryptomator-#{version}#{arch}.dmg",
       verified: "github.com/cryptomator/cryptomator/"
   name "Cryptomator"
   desc "Multi-platform client-side cloud file encryption tool"
@@ -24,3 +31,4 @@ cask "cryptomator" do
     "~/Library/Preferences/org.cryptomator.plist",
   ]
 end
+


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Using suggestion from https://github.com/Homebrew/homebrew-cask/pull/115628#pullrequestreview-827203688 instead. - Had to refork and make a new PR 