### PR TITLE
Add arm64 builds to Cryptomator

### DIFF
--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -1,8 +1,15 @@
 cask "cryptomator" do
-  version "1.6.4"
-  sha256 "7c763610523dc6ced2d51d5e25fdb15ccd93366a107b8959460f7796eef83dc2"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  url "https://github.com/cryptomator/cryptomator/releases/download/#{version}/Cryptomator-#{version}.dmg",
+  version "1.6.4"
+
+  if Hardware::CPU.intel?
+    sha256 "7c763610523dc6ced2d51d5e25fdb15ccd93366a107b8959460f7796eef83dc2"
+  else
+    sha256 "1e7fc2bb09bbe914317c9b1459415a250d8f7baaa4cb51735c2f1a1e8d4605da"
+  end
+
+  url "https://github.com/cryptomator/cryptomator/releases/download/#{version}/Cryptomator-#{version}#{arch}.dmg",
       verified: "github.com/cryptomator/cryptomator/"
   name "Cryptomator"
   desc "Multi-platform client-side cloud file encryption tool"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

3rd time's a charm. 
Dang editor.
Using suggestion from #115628 (review) instead. - Had to refork and make a new PR