### PR TITLE
Update Spring Tools Suite to 4.13.0,4.22.0

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,6 +1,6 @@
 cask "springtoolsuite" do
-  version "4.12.1,4.21.0"
-  sha256 "e2fa67f147f41033604d4c5cd9b39e55fa6894a8af0483e0bfea816948b99a18"
+  version "4.13.0,4.22.0"
+  sha256 "ab25a0837de367605b3445fc358939bba1ba21408eb43cf8acccb8e7eb628be1"
 
   url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}.RELEASE/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}.RELEASE-e#{version.after_comma}-macosx.cocoa.x86_64.dmg",
       verified: "download.springsource.com/release/"

--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -2,7 +2,7 @@ cask "springtoolsuite" do
   version "4.13.0,4.22.0"
   sha256 "ab25a0837de367605b3445fc358939bba1ba21408eb43cf8acccb8e7eb628be1"
 
-  url "https://download.springsource.com/release/STS#{version.major}/#{version.before_comma}.RELEASE/dist/e#{version.after_comma.major_minor}/spring-tool-suite-#{version.major}-#{version.before_comma}.RELEASE-e#{version.after_comma}-macosx.cocoa.x86_64.dmg",
+  url "https://download.springsource.com/release/STS#{version.major}/#{version.csv.first}.RELEASE/dist/e#{version.csv.second.major_minor}/spring-tool-suite-#{version.major}-#{version.csv.first}.RELEASE-e#{version.csv.second}-macosx.cocoa.x86_64.dmg",
       verified: "download.springsource.com/release/"
   name "Spring Tool Suite"
   desc "Next generation tooling for Spring Boot"


### PR DESCRIPTION
Spring Tools Suite 4.13.0 was released on 2021-12-08. See [Changelog](https://github.com/spring-projects/sts4/wiki/Changelog#2021-12-08-4130-release-incl-language-servers-version-1290).

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.