### PR TITLE
Add Apple Silicon download URL for Rider

### DIFF
--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -3,13 +3,13 @@ cask "rider" do
 
   version "2021.3,213.5744.293"
 
-  url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}#{arch}.dmg"
   if Hardware::CPU.intel?
     sha256 "af5af5d7915e591a7a6a1dc1302db85745642882d8332d70867ab3f5310f20b9"
   else
     sha256 "f293dadaf584bf87cc969403e9d91ecd0e51f489e7c4f1d887b5b43f55c8f78a"
   end
 
+  url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}#{arch}.dmg"
   name "JetBrains Rider"
   desc ".NET IDE"
   homepage "https://www.jetbrains.com/rider/"

--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -1,8 +1,15 @@
 cask "rider" do
-  version "2021.3,213.5744.293"
-  sha256 "af5af5d7915e591a7a6a1dc1302db85745642882d8332d70867ab3f5310f20b9"
+  arch = Hardware::CPU.intel? ? "" : "-aarch64"
 
-  url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}.dmg"
+  version "2021.3,213.5744.293"
+
+  url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}#{arch}.dmg"
+  if Hardware::CPU.intel?
+    sha256 "af5af5d7915e591a7a6a1dc1302db85745642882d8332d70867ab3f5310f20b9"
+  else
+    sha256 "f293dadaf584bf87cc969403e9d91ecd0e51f489e7c4f1d887b5b43f55c8f78a"
+  end
+
   name "JetBrains Rider"
   desc ".NET IDE"
   homepage "https://www.jetbrains.com/rider/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Download URLs look like below:

- Intel: <https://download.jetbrains.com/rider/JetBrains.Rider-2021.3.dmg>
- Apple Silicon: <https://download.jetbrains.com/rider/JetBrains.Rider-2021.3-aarch64.dmg>

I followed the pattern already used by the cask for PyCharm CE:

<https://github.com/Homebrew/homebrew-cask/blob/333e07b17c26df732150a3d95778df2f8efc39a5/Casks/pycharm-ce.rb#L2-L11>