### PR TITLE
Fix sha256 of DDNet 15.7

### DIFF
--- a/Casks/ddnet.rb
+++ b/Casks/ddnet.rb
@@ -1,6 +1,6 @@
 cask "ddnet" do
   version "15.7"
-  sha256 "1ebce2c58bbb8329047e68da88da18b29a70ca3116d344271f05dfb2ad54956f"
+  sha256 "0ab7702ea25f27370a481bd5c8139accc700d9d960ec657acba0b9278fd340d2"
 
   url "https://ddnet.tw/downloads/DDNet-#{version}-osx.dmg"
   name "DDNet"


### PR DESCRIPTION
Accidentally released wrong version for macOS, fixed it a bit later, but was on homebrew already. (I'm the upstream maintainer of DDNet) @b3z 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
