### PR TITLE
thunderbird: depends_on sierra (10.12)

### DIFF
--- a/Casks/thunderbird.rb
+++ b/Casks/thunderbird.rb
@@ -79,6 +79,7 @@ cask "thunderbird" do
 
   auto_updates true
   conflicts_with cask: "homebrew/cask-versions/thunderbird-beta"
+  depends_on macos: ">= :sierra"
 
   app "Thunderbird.app"
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

----

FWIW, the [latest release notes](https://www.thunderbird.net/en-US/thunderbird/91.4.0/releasenotes/) erroneously list 10.9 as the minimum, but the [whole 91 branch](https://www.thunderbird.net/en-US/thunderbird/91.0/system-requirements/) is really dependent on 10.12.