### PR TITLE
Reverted changes which are blocking our bump automation + anka-build-cloud-controller-and-registry 1.20.0 -> 1.21.0

### DIFF
--- a/Casks/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/anka-build-cloud-controller-and-registry.rb
@@ -1,26 +1,21 @@
 cask "anka-build-cloud-controller-and-registry" do
-  version "1.20.0,035872f5"
-  sha256 "cf375336267ce1712995d26fad9a0aa690c95d6e98ee87b9bdb8caae814eb6c3"
+  version "1.21.0-bcc26b24"
+  sha256 "5ca9205da185f762564f8ae4c8d46be71c4ab57a42c5feef3ba2fa89c00a4ba4"
 
-  url "https://downloads.veertu.com/anka/AnkaControllerRegistry-#{version.before_comma}-#{version.after_comma}.pkg"
+  url "https://downloads.veertu.com/anka/AnkaControllerRegistry-#{version}.pkg"
   name "Anka Build Cloud Controller & Registry"
   desc "Virtual machine management GUI/API and registry"
   homepage "https://veertu.com/"
 
   livecheck do
     url "https://veertu.com/downloads/ankacontroller-registry-mac-latest"
-    regex(/AnkaControllerRegistry[._-]?v?(\d+(?:\.\d+)+)[._-](\h+)\.pkg/i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
+    strategy :header_match
+    regex(/AnkaControllerRegistry[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
   end
 
   depends_on macos: ">= :yosemite"
 
-  pkg "AnkaControllerRegistry-#{version.before_comma}-#{version.after_comma}.pkg"
+  pkg "AnkaControllerRegistry-#{version}.pkg"
 
   uninstall script: {
     executable: "/Library/Application Support/Veertu/Anka/tools/controller/uninstall.sh",


### PR DESCRIPTION
Problem:

```
❯ brew bump-cask-pr --version 1.21.0-bcc26b24 anka-build-cloud-controller-and-registry
Running `brew update --preinstall`...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 4 formulae.

==> Downloading https://downloads.veertu.com/anka/AnkaControllerRegistry-1.21.0-bcc26b24-.pkg
curl: (22) The requested URL returned error: 404                              

Error: Download failed on Cask 'anka-build-cloud-controller-and-registry' with message: Download failed: https://downloads.veertu.com/anka/AnkaControllerRegistry-1.21.0-bcc26b24-.pkg
```

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
