### PR TITLE
Update my-image-garden from 3.6.5 to 3.6.6,04

### DIFF
--- a/Casks/my-image-garden.rb
+++ b/Casks/my-image-garden.rb
@@ -1,13 +1,14 @@
 cask "my-image-garden" do
-  version "3.6.5"
-  sha256 "d40260bb5786738a40560b1a6834c4b284c7c9986ae7ce2d96c90e820d7f8f73"
+  version "3.6.6,04"
+  sha256 "1b83b4695cd8d84c7807a06a5ba4c7e46cc5cfd73bdaf606a327e7341f573bb2"
 
-  url "https://gdlp01.c-wss.com/gds/2/0200006062/02/mmig-mac-#{version.dots_to_underscores}-ea11.dmg",
+  url "https://gdlp01.c-wss.com/gds/2/0200006062/#{version.csv.second}/mmig-mac-#{version.csv.first.dots_to_underscores}-ea11.dmg",
       verified: "c-wss.com/"
   name "Canon My Image Garden"
+  desc "Photo editing and printing tool"
   homepage "https://support-asia.canon-asia.com/?personal"
 
-  pkg "My Image Garden V#{version.no_dots}.pkg"
+  pkg "My Image Garden V#{version.csv.first.no_dots}.pkg"
 
   uninstall pkgutil: "jp.co.canon.MyImageGarden",
             quit:    "jp.co.canon.MyImageGarden"

--- a/Casks/my-image-garden.rb
+++ b/Casks/my-image-garden.rb
@@ -8,6 +8,17 @@ cask "my-image-garden" do
   desc "Photo editing and printing tool"
   homepage "https://support-asia.canon-asia.com/?personal"
 
+  livecheck do
+    url "https://pdisp01.c-wss.com/gdl/WWUFORedirectTarget.do?id=MDIwMDAwNjA2MjA0"
+    regex(%r{/([^/]+)/mmig-mac[._-]v?(\d+(?:[._]\d+)+)-ea11\.dmg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"].match(regex)
+      next if match.blank?
+
+      "#{match[2].tr("_", ".")},#{match[1]}"
+    end
+  end
+
   pkg "My Image Garden V#{version.csv.first.no_dots}.pkg"
 
   uninstall pkgutil: "jp.co.canon.MyImageGarden",


### PR DESCRIPTION
Upgraded `my-image-garden` to version `3.6.6,04`.

Changed version to use comma to handle variable in url (was `02`, is now `04`, and might change in future) so we can easily use `brew bump-cask-pr` in the future.

Added `desc` stanza.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
