### PR TITLE
Julia 1.7 SHA change

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -4,7 +4,7 @@ cask "julia" do
   version "1.7.0"
 
   if Hardware::CPU.intel?
-    sha256 "9a7919448e13ba9cefb0f0fe8178ca089333c86e2722f1e482a1dc8c0e2f03b6"
+    sha256 "16768d5d40f7c0779da2d0c8ec0c3386f96193d32e91ff9997ba7136b91cfd15"
   else
     sha256 "6852aab9a40a3265551eb85ad19ff16c3ba5410c852f5e7949972cb9911d473a"
   end


### PR DESCRIPTION
I've confirmed on a couple devices that the Intel SHA seems to be wrong here.

⚠️ I'm not sure why it changed. ⚠️

Maybe the Julia maintainers updated it? (Can anyone confirm that this package install ever worked for them previously?)

**Update: see [comment below](https://github.com/Homebrew/homebrew-cask/pull/115998#issuecomment-996414708) -- can confirm that the official Julia download was swapped out in the last day or so** (Still unclear why.)

_Important: Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process._

In the following questions <cask> is the token of the cask you're submitting.

#### After making all changes to a cask, verify:

- [x] The submission is for a stable version or documented exception.
- [x] brew audit --cask <cask> is error-free.
- [x] brew style --fix <cask> reports no offenses.

#### Additionally, if adding a new cask: (not applicable)