### PR TITLE
vitalsigns: switch to new domain, raise minimum OS version

### DIFF
--- a/Casks/vitalsigns.rb
+++ b/Casks/vitalsigns.rb
@@ -2,10 +2,10 @@ cask "vitalsigns" do
   version "3.0.12,1"
   sha256 :no_check
 
-  url "https://www.disometric.com/downloads/VitalSigns#{version.major}/VitalSigns.dmg"
+  url "https://www.disometrics.com/downloads/VitalSigns#{version.major}/VitalSigns.dmg"
   name "Vitalsigns"
   desc "Temperature and memory monitor"
-  homepage "https://www.disometric.com/vitalsigns/"
+  homepage "https://www.disometrics.com/vitalsigns/"
 
   livecheck do
     url :url

--- a/Casks/vitalsigns.rb
+++ b/Casks/vitalsigns.rb
@@ -18,6 +18,8 @@ cask "vitalsigns" do
   app "VitalSigns.app"
 
   zap trash: [
+    "~/Library/Caches/com.creationalstate.VitalSigns",
+    "~/Library/HTTPStorages/com.creationalstate.VitalSigns",
     "~/Library/LaunchAgents/com.disometric.vitalsigns.launcher.plist",
     "~/Library/Preferences/com.creationalstate.VitalSigns.plist",
     "~/Library/Preferences/com.disometric.vitalsigns.plist",

--- a/Casks/vitalsigns.rb
+++ b/Casks/vitalsigns.rb
@@ -13,7 +13,7 @@ cask "vitalsigns" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "VitalSigns.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.