### PR TITLE
Update perforce from 2021.2,2201121 to 2021.2,2220431

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask "perforce" do
-  version "2021.2,2201121"
-  sha256 "7dd6dc41b4b86738926af6963ea86c34a8162e9616494f9c848a0d0267db923d"
+  version "2021.2,2220431"
+  sha256 "da19454f275ad6645591acd1adec12d6d813f5b1a92c1ea23b06a7ad60aa8ecc"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
   name "Perforce Helix Core Server"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This PR was generated by [a script](https://github.com/gitgitgadget/keep-homebrew-perforce-up-to-date/blob/master/run.sh) running in [an Azure Pipeline](https://dev.azure.com/gitgitgadget/git/_build?definitionId=11&_a=summary).
