### PR TITLE
generate_cask_token: make report adhere to brew style

### DIFF
--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -373,7 +373,7 @@ def report
   puts "Proposed Simplified App name: #{simplified_app_name}" if $debug
   puts "Proposed token:               #{cask_token}"
   puts "Proposed file name:           #{cask_file_name}"
-  puts "Cask Header Line:             cask '#{cask_token}' do"
+  puts "Cask Header Line:             cask \"#{cask_token}\" do"
   return if warnings.empty?
 
   $stderr.puts "\n"


### PR DESCRIPTION
The Cask Header Line generated by `generate_cask_token` displays a single-quoted string, which is not in accordance with current `brew style` rules, which prefer double-quoted strings:
```
% generate_cask_token /Volumes/Nicotine+/Nicotine+.app
Proposed token:               nicotine-plus
Proposed file name:           nicotine-plus.rb
Cask Header Line:             cask 'nicotine-plus' do

```
```
%  brew style --fix nicotine-plus.rb
nicotine-plus.rb:1:6: C: [Corrected] Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
cask 'nicotine-plus' do
     ^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense corrected
```
This patch seeks to fix that.