### PR TITLE
Update Librewolf to v95.0.2-1

### DIFF
--- a/Casks/librewolf.rb
+++ b/Casks/librewolf.rb
@@ -2,11 +2,11 @@ cask "librewolf" do
   arch = Hardware::CPU.intel? ? "" : "_aarch64_exp"
 
   if Hardware::CPU.intel?
-    version "95.0.1,1,5bb6190211fa0013084409c1ae2bffcd"
-    sha256 "fca05a020f8594ee9064819988daee64638192cf2ae0d0085944fe9a6233037c"
+    version "95.0.2,1,dd4be5c05d04d8fa4a9134ee13bc2e33"
+    sha256 "91bca5c96d725a70f9d73d622680064805bf3dbfcac0af36a44786d15437f0e6"
   else
-    version "95.0.1,1,a13300242c6e5b70f9e1d4eba54eadb2"
-    sha256 "b0fbb663823e8c2f6b4aa44341d1567b31d079ea59dcc1e00c2cdbb0ca0e6226"
+    version "95.0.2,1,199aedb468a551b3c1371f974487502f"
+    sha256 "70170da323506d6286008c13f781fb1de2f2332cec3f22406a1a61ee9b254a10"
   end
 
   url "https://gitlab.com/librewolf-community/browser/macos/uploads/#{version.csv.third}/librewolf-#{version.csv.first}-#{version.csv.second}#{arch}.dmg",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.