### PR TITLE
maestral: depends_on high sierra

### DIFF
--- a/Casks/maestral.rb
+++ b/Casks/maestral.rb
@@ -9,6 +9,7 @@ cask "maestral" do
   homepage "https://maestral.app/"
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Maestral.app"
   binary "#{appdir}/Maestral.app/Contents/MacOS/maestral-cli", target: "maestral"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.