### PR TITLE
sidequest: add arm version

### DIFF
--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -1,8 +1,15 @@
 cask "sidequest" do
-  version "0.10.26"
-  sha256 "92d7c4eaf165765c210035ce60bc0cfb1d75a93eb646e153ace68b2d52097ec4"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  url "https://github.com/SideQuestVR/SideQuest/releases/download/v#{version}/SideQuest-#{version}.dmg",
+  version "0.10.26"
+
+  if Hardware::CPU.intel?
+    sha256 "92d7c4eaf165765c210035ce60bc0cfb1d75a93eb646e153ace68b2d52097ec4"
+  else
+    sha256 "d3fcb61d32883cebd115c4108958e8b66e1e9759abb912902a44ad46a2bc6eaa"
+  end
+
+  url "https://github.com/SideQuestVR/SideQuest/releases/download/v#{version}/SideQuest-#{version}#{arch}.dmg",
       verified: "github.com/SideQuestVR/SideQuest/"
   name "SideQuest"
   desc "Virtual reality content platform"


### PR DESCRIPTION
Sidequest does not use Universal binaries, but has separate binaries for x86 and ARM. Configure it to download the appropriate version.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.