### PR TITLE
Fix URL for autofirma

### DIFF
--- a/Casks/autofirma.rb
+++ b/Casks/autofirma.rb
@@ -2,9 +2,10 @@ cask "autofirma" do
   version "1.6.5"
   sha256 "4564893f65a1566ea82c131a63bb56b44dbd2bcc218b5ba501ebb6dc22634c79"
 
-  url "https://estaticos.redsara.es/comunes/autofirma/#{major}/#{minor}/#{patch}/AutoFirma_Mac.zip",
+  url "https://estaticos.redsara.es/comunes/autofirma/#{version.major}/#{version.minor}/#{version.patch}/AutoFirma_Mac.zip",
       verified: "estaticos.redsara.es/comunes/autofirma/"
   name "AutoFirma"
+  desc "Add a digital signature to documents"
   homepage "https://firmaelectronica.gob.es/Home/Descargas.htm"
 
   pkg "AutoFirma_#{version.dots_to_underscores}.pkg"

--- a/Casks/autofirma.rb
+++ b/Casks/autofirma.rb
@@ -1,8 +1,8 @@
 cask "autofirma" do
   version "1.6.5"
-  sha256 :no_check
+  sha256 "4564893f65a1566ea82c131a63bb56b44dbd2bcc218b5ba501ebb6dc22634c79"
 
-  url "https://estaticos.redsara.es/comunes/autofirma/currentversion/AutoFirma_Mac.zip",
+  url "https://estaticos.redsara.es/comunes/autofirma/#{major}/#{minor}/#{patch}/AutoFirma_Mac.zip",
       verified: "estaticos.redsara.es/comunes/autofirma/"
   name "AutoFirma"
   homepage "https://firmaelectronica.gob.es/Home/Descargas.htm"

--- a/Casks/autofirma.rb
+++ b/Casks/autofirma.rb
@@ -5,7 +5,7 @@ cask "autofirma" do
   url "https://estaticos.redsara.es/comunes/autofirma/#{version.major}/#{version.minor}/#{version.patch}/AutoFirma_Mac.zip",
       verified: "estaticos.redsara.es/comunes/autofirma/"
   name "AutoFirma"
-  desc "Add a digital signature to documents"
+  desc "Digital signature editor and validator"
   homepage "https://firmaelectronica.gob.es/Home/Descargas.htm"
 
   livecheck do

--- a/Casks/autofirma.rb
+++ b/Casks/autofirma.rb
@@ -8,6 +8,17 @@ cask "autofirma" do
   desc "Add a digital signature to documents"
   homepage "https://firmaelectronica.gob.es/Home/Descargas.htm"
 
+  livecheck do
+    url :homepage
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/(\d+)/(\d+)/(\d+)/AutoFirma_Mac.zip}i)
+      next if match.blank?
+      
+	  "#{match[1]}.#{match[2]}.#{match[3]}"
+    end
+  end
+
+
   pkg "AutoFirma_#{version.dots_to_underscores}.pkg"
 
   # remove 'Autofirma ROOT' and '127.0.0.1' certificates from keychain (these were installed by pkg)

--- a/Casks/autofirma.rb
+++ b/Casks/autofirma.rb
@@ -13,11 +13,10 @@ cask "autofirma" do
     strategy :page_match do |page|
       match = page.match(%r{href=.*?/(\d+)/(\d+)/(\d+)/AutoFirma_Mac.zip}i)
       next if match.blank?
-      
-	  "#{match[1]}.#{match[2]}.#{match[3]}"
+
+      "#{match[1]}.#{match[2]}.#{match[3]}"
     end
   end
-
 
   pkg "AutoFirma_#{version.dots_to_underscores}.pkg"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The URL structure for this cask has changed and is now versioned. The previous URL, pointing to just "currentversion", now gives a 404 status code. I updated the URL according to the new download link provided at https://firmaelectronica.gob.es/Home/Descargas.html, which is the official place provided by the spanish government to download this application.

I also added the SHA256 and a description for the cask.