### PR TITLE
webots: fix livecheck

### DIFF
--- a/Casks/webots.rb
+++ b/Casks/webots.rb
@@ -11,8 +11,8 @@ cask "webots" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^(R\d+[a-z]+)$/i)
+    strategy :github_latest
+    regex(%r{href=.*?/tag/([\w._-]+)["' >]}i)
   end
 
   auto_updates true


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Before fix livecheck showed the pre-release R2022a.