### PR TITLE
Update tor-browser from 11.0.2 to 11.0.3

### DIFF
--- a/Casks/tor-browser.rb
+++ b/Casks/tor-browser.rb
@@ -1,144 +1,144 @@
 cask "tor-browser" do
-  version "11.0.2"
+  version "11.0.3"
 
   language "ar" do
-    sha256 "963996deca4c4f16d74cc1195411fe5124c87b50a724478a45750f843601f7fe"
+    sha256 "2bec67f5c943cc5fec741788bf54ac3b7a7c4ee8d7de9c1f02bd11bb9b844537"
     "ar"
   end
   language "ca" do
-    sha256 "eec3367865526242a79225aac89f0b1140f781189e0c2e8075ee7422500a33c9"
+    sha256 "37bcd045d513900565121c0309429518d495a85d66d7b457540109a923df8956"
     "ca"
   end
   language "cs" do
-    sha256 "1864f32ac49f303f59899dc66679c32fb7ed3662ba7fb2f05494a84d6471ac1c"
+    sha256 "337fef9e13203357e3527b6b10098edae24f13583851297077c79e9bb5a6c64b"
     "cs"
   end
   language "da" do
-    sha256 "631c2837ba2b91bd9b16437883934ae96267e8a98822b11ab3f51567f6645188"
+    sha256 "a78ef53f956f5c831113073278a369d48dce21a7476c9466220f11eefee01716"
     "da"
   end
   language "de" do
-    sha256 "061b21ba212f5dd23e6cfd44f7800b5ab690a7fb3ed9f619b890a08c2009102f"
+    sha256 "f6cc05bfd10b94ee2b690e13a8890cc308f15fa2891c90d9c2b0ada664c2f48d"
     "de"
   end
   language "el" do
-    sha256 "dbdec5bca45f47b895143b738516e715f192dd786071d01ff212770077a90529"
+    sha256 "8734e3c18640524bfede9a81bbf56ef1a241d14b62333f9817effa12926406ce"
     "el"
   end
   language "en", default: true do
-    sha256 "d560b510f747ed53117acd00f9ab18f2f65a7f6484e3e02ccda7bc13ca19521f"
+    sha256 "95936e04b51cd361726a4bd45871e3256fcc9e6e9a424c11898fb70e3cd070a7"
     "en-US"
   end
   language "es-AR" do
-    sha256 "2916f8b6692839e964a6e6a22ff73d9593a0986c3729b43579d32915fd2b3cb9"
+    sha256 "28a76d4d6784080213442d63c41392dd54dfa265a80ad2fd2bdd44a83eb0f08b"
     "es-AR"
   end
   language "es-ES" do
-    sha256 "4b9f94d1ccdd7fd7cf87bf8c756ee3f92d81abbfd33732176863a46152a9bedd"
+    sha256 "af6e7317eb2900788d4dce8a7abecbd8e870a0238eaf8e8a0b34c0b3682904c2"
     "es-ES"
   end
   language "fa" do
-    sha256 "be4525d9e4d488ba5e31c60bab9028f2d51e701cb0e41d8c586049d37c4c1eec"
+    sha256 "d4c5399861948b9d23ba0f9eb2bc64eaadf910fa5fc08a4c7c22272e910b1654"
     "fa"
   end
   language "fr" do
-    sha256 "73b4db77248120c511cd5ba0f567aca6f04697f70d8f09acfd5d5b441834e577"
+    sha256 "f205ecf341a95dcc6a4aecd9370013ed9378d18c3cf0f89584310a017af0224c"
     "fr"
   end
   language "ga" do
-    sha256 "b810940ab72e31a9a50580bef17c6aa339e2c05f22e1f7ee2a90698397269c57"
+    sha256 "7c4399f43d5363e82c48354a066d5f1052cbfe5a6801f1da69a22df66cdd89e4"
     "ga-IE"
   end
   language "he" do
-    sha256 "8d6b460757e19e9e0c9a5525592be4e084d483f124382255b7fbbdc09e933b4d"
+    sha256 "b1f447bc32f85e8b25ac9f22a1af35ecb2c98828f6233962dbdce011b35ce954"
     "he"
   end
   language "hu" do
-    sha256 "7f99b6981fbef13e6b0f90451aab85f6bdcd15fb044ef8ac5e2f9830fbdbd600"
+    sha256 "0eae2aefcea685556791d04e883d74b74b38ff79e6c6619b814d1d7089ebbef4"
     "hu"
   end
   language "id" do
-    sha256 "9f50ec5922298b206086cb040f1dfd513908dfede96bff05651542b46b6e9873"
+    sha256 "19b921ca7ce65715981778048b50f4ac35daabdba8c3c9a5aad596ae6c23f406"
     "id"
   end
   language "is" do
-    sha256 "97313362f0104c849f93066ace85079b4fcbb9a29607f2bcba671024c6994261"
+    sha256 "6071379f99a5ed801d47f38a8243c325543056ff8fa8b0c1300638d142856e46"
     "is"
   end
   language "it" do
-    sha256 "f029fc13e765cf9fc28955164928450ea7f8047e7d4cd0bf3d06a7b11b3046d3"
+    sha256 "a550e5942afa1abf089a146d959dc97b72dd40646fd53f75eea424a887ef888a"
     "it"
   end
   language "ja" do
-    sha256 "7d0869bd652a73f6382d7871447f46b2efb62f5124649082f98ef1cbbc15cc78"
+    sha256 "85301382ec2db23f83db6470b1f5a15ca9d2a4f4087f4b194d571e7dd986c24f"
     "ja"
   end
   language "ka" do
-    sha256 "0749c758e643a1eaccba998015e114a65b8dd96fb01fe182b1a252b2e16ad92d"
+    sha256 "98d5ea7d15d1ee9070621c73dd98e0736b1c9cc15a40e01dab19d1b7fdbde6d3"
     "ka"
   end
   language "ko" do
-    sha256 "ff0b0ea2a8a1115aa75e88345f5c6b3a2f0c680c49b3832dffa1e1dab56765fe"
+    sha256 "d363740ffe95dab469399935e8a9d9b5fb508c86db83536dc82119af69594997"
     "ko"
   end
   language "lt" do
-    sha256 "d77493734f09aca5ee04647aca74b7cef7003ad575edd18e5a955297ac2ade63"
+    sha256 "d6eb54a19556bb3b2e5d366b69ff1b08e06af59681d61e5f0c828b9ce916472c"
     "lt"
   end
   language "mk" do
-    sha256 "690960c7732bfea9f96dd3931b2ae32bc5644cbb8b5336eeb3c30477b9ed2033"
+    sha256 "68f924f5130d45d31aae575177476fe41c6eadb7c621933ff8eb6c4b2912bc38"
     "mk"
   end
   language "ms" do
-    sha256 "546713b27895f0c6504cab4103bf52ca2a6dc8fef911a867ef08b1ce5e501c0e"
+    sha256 "bb4ecbfc84cf305928ce2639855762a507d863aeb231cd0bedd1579a009695d5"
     "ms"
   end
   language "nb" do
-    sha256 "59453aafc805d8507150e413db2e7a418b2d0685fe27bed241604fe239372c6e"
+    sha256 "fe6a6a84110a52c40a21ea035a37a9bbd4935de3c31700a383656b2713a88ba5"
     "nb-NO"
   end
   language "nl" do
-    sha256 "975b144f520d7542263bd04920771ecb131f0b153e8d772650c63ac9525e8f8b"
+    sha256 "8f5d7396d79d8ad7178cb3af6f7d88f05999a42bd4bca6fcd047a9215b25fdfa"
     "nl"
   end
   language "pl" do
-    sha256 "f19b7266d94723d12f2330b638a1b5b62e141cd2cb9b16367dc8e1edc49968f9"
+    sha256 "fdbd93d5029316a687313e7f4ceeac1069c9dfa7ee0150ce1c3fada8312d6dc6"
     "pl"
   end
   language "pt" do
-    sha256 "134945e87ea1bc4d83257df3b1f5fbd3f748f3955afea92bb2325c725e27278f"
+    sha256 "0c0e501d63744cad8d435c27d2617470d45b39b8e7fc1c0b8478f1c03f7988e0"
     "pt-BR"
   end
   language "ro" do
-    sha256 "d509b653cf9d4e3c16ddf5728efe668389b0a0208870c3cee70594125743de83"
+    sha256 "80073f1f89f21b9b82e494d705dcb93cfa43099492e8e11f265fa7168b2b16aa"
     "ro"
   end
   language "ru" do
-    sha256 "2c72736615abe34a0e1f36171797d58895bc56ed555a2ecf98b07d99ed4f6421"
+    sha256 "b683b3020cf3582e0476544e2bfa324fb9f6f57f2a4f8504713ca39cd601eb50"
     "ru"
   end
   language "sv" do
-    sha256 "8d81f8875c067a17e1bc309d02850fc14d5825d70a6ba385b5f4c70bcbb1b05d"
+    sha256 "ee609a02f384a7e112298a988c76ff36f72b799c72a3e9fde2f5e24301ea5582"
     "sv-SE"
   end
   language "th" do
-    sha256 "298a2397d07502631ecb87afe2f13cf4b1253feec29d699d94a75f68339c6bca"
+    sha256 "e1c4b3110691e596f64e75587e904b1bca2ef4cc495f53585cdcf4c11db3c8fe"
     "th"
   end
   language "tr" do
-    sha256 "95c9b22db55129c584f27ccab835e1650fd7489a691464eb0ae0007545ec713c"
+    sha256 "f87c24681a6fa3ca06c7955d9e58327192f969f7282ac588f38a768e56e3204b"
     "tr"
   end
   language "vi" do
-    sha256 "5457666c2e33168f2328728f6fe74da66bc224ccd939e66d89c75a1d3a6cb769"
+    sha256 "eb3fb126c2f999bd296fc937432f01fc90d80e54f96c5f3741ddbcd19ae0283b"
     "vi"
   end
   language "zh-CN" do
-    sha256 "abdd589129354ce03c84853e22a617a9579cd318aab8db83cb7990af9b4e73b7"
+    sha256 "597b66bb5c8d07e8f4741f7eeb991b49482868f75c77245242bbd7c8846dfc47"
     "zh-CN"
   end
   language "zh-TW" do
-    sha256 "2e13e3cd04e53f3062fb6e65d9cf8848ee1c5f8249e69a054c6717ec32036d09"
+    sha256 "7041c8fb721bf61bcdfcf821426368bffdca64db92ae11b6deeb0cc20664bc1a"
     "zh-TW"
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Why `bump-cask-pr` failed on this cask with this error:

```
Error: inreplace failed
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/tor-browser.rb:
  expected replacement of /sha256\s+["']d560b510f747ed53117acd00f9ab18f2f65a7f6484e3e02ccda7bc13ca19521f["']/m with "sha256 \"95936e04b51cd361726a4bd45871e3256fcc9e6e9a424c11898fb70e3cd070a7\""
```