### PR TITLE
Fix screaming-frog-seo-spider checksum

### DIFF
--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -1,6 +1,6 @@
 cask "screaming-frog-seo-spider" do
   version "16.4"
-  sha256 "b6098e718c454dab1374bd03c6c489c73aaeffdac52cb093ae23879bf9a97a3d"
+  sha256 "58735cbff8911072f1e00fe3b105de90da32b8675a8efbe7b1e8e95bff1c2584"
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}.dmg"
   name "Screaming Frog SEO Spider"


### PR DESCRIPTION
There is an error on the checksum of the `screaming-frog-seo-spider` cask version `16.4`.
So I do a fix ;)

Checklist:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `brew install --cask <cask>` worked successfully (with this fix).
- [x] `brew uninstall --cask <cask>` worked successfully.
