### PR TITLE
Shell Completions and manpage for alacritty

### DIFF
--- a/Casks/alacritty.rb
+++ b/Casks/alacritty.rb
@@ -20,6 +20,7 @@ cask "alacritty" do
          target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/alacritty"
   binary "#{appdir}/Alacritty.app/Contents/Resources/completions/alacritty.fish",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/alacritty.fish"
+  manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty.1.gz"
 
   zap trash: [
     "~/Library/Preferences/io.alacritty.plist",

--- a/Casks/alacritty.rb
+++ b/Casks/alacritty.rb
@@ -14,6 +14,12 @@ cask "alacritty" do
 
   app "Alacritty.app"
   binary "#{appdir}/Alacritty.app/Contents/MacOS/alacritty"
+  binary "#{appdir}/Alacritty.app/Contents/Resources/completions/_alacritty",
+         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_alacritty"
+  binary "#{appdir}/Alacritty.app/Contents/Resources/completions/alacritty.bash",
+         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/alacritty"
+  binary "#{appdir}/Alacritty.app/Contents/Resources/completions/alacritty.fish",
+         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/alacritty.fish"
 
   zap trash: [
     "~/Library/Preferences/io.alacritty.plist",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

`Alacritty.app` bundles shell completions and a *gzipped* man page. 
- I symlinked the completions based on the `docker` cask.
  - Do casks not have access to `$SHELL_completion.install`? I tried and it didn't work
- How do I unzip the manpage? I know to install it with the `manpage` stanza.
