### PR TITLE
universal-media-server: switch livecheck strategy

### DIFF
--- a/Casks/universal-media-server.rb
+++ b/Casks/universal-media-server.rb
@@ -8,6 +8,11 @@ cask "universal-media-server" do
   desc "Media server supporting DLNA, UPnP and HTTP(S)"
   homepage "https://www.universalmediaserver.com/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :catalina"
 
   app "Universal Media Server.app"


### PR DESCRIPTION
Switching to `strategy :github_latest` since latest release (10.13.0) and latest tag (10.14.1) are not in sync.