### PR TITLE
qt-creator: use `compact_blank`

### DIFF
--- a/Casks/qt-creator.rb
+++ b/Casks/qt-creator.rb
@@ -22,7 +22,7 @@ cask "qt-creator" do
         next if versions.blank?
 
         versions
-      end.reject(&:nil?).first
+      end.compact_blank.first
     end
   end
 


### PR DESCRIPTION
Needed for https://github.com/Homebrew/brew/pull/12620

It looks like `#compact` doesn't exist on `Enumerator::Lazy` (which is what `#lazy` returns) until Ruby 3.1 but we can use `#compact_blank` instead (from ActiveSupport) which works just as well in this case.
