### PR TITLE
fix a bug that input method can not be installed

### DIFF
--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -2,8 +2,9 @@ cask "loginputmac" do
   version "2.5.3,24161"
   sha256 "9ad1e436283dbb6a60d040c205da3a31e5d97e999f53c6e6ed01682bb36e5857"
 
-  # The install source has to be a PKG file otherwise both install and update will be failed. 
-  # Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`, and needs privilege to write in, 
+  # The install source has to be a PKG file otherwise both install and update will be failed.
+  # Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`,
+  # and needs privilege to write in.
   # Pls DO NOT change the path into `.app` again, those files only for sparkle update framework tho.
   
   url "https://loginput-mac2.totest.top/loginputmac#{version.major}_latest.pkg",

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -2,7 +2,11 @@ cask "loginputmac" do
   version "2.5.3,24161"
   sha256 "9ad1e436283dbb6a60d040c205da3a31e5d97e999f53c6e6ed01682bb36e5857"
 
-  url "https://loginput-mac2.totest.top/LogInputMac#{version.major}.app#{version.csv.second}.zip",
+  # The install source has to be a PKG file otherwise both install and update will be failed. 
+  # Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`, and needs privilege to write in, 
+  # Pls DO NOT change the path into `.app` again, those files only for sparkle update framework tho.
+  
+  url "https://loginput-mac2.totest.top/loginputmac#{version.major}_latest.pkg",
       verified: "loginput-mac2.totest.top/"
   name "LoginputMac"
   desc "Chinese input method"
@@ -15,5 +19,8 @@ cask "loginputmac" do
 
   auto_updates true
 
-  app "LogInputMac#{version.major}.app"
+  pkg "loginputmac#{version.major}_latest.pkg"
+
+  uninstall pkgutil: "com.logcg.pkg.LoginputMac#{version.major}",
+            quit:    "com.logcg.inputmethod.LogInputMac#{version.major}"
 end

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -6,7 +6,7 @@ cask "loginputmac" do
   # Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`,
   # and needs privilege to write in.
   # Pls DO NOT change the path into `.app` again, those files only for sparkle update framework tho.
-  
+
   url "https://loginput-mac2.totest.top/loginputmac#{version.major}_latest.pkg",
       verified: "loginput-mac2.totest.top/"
   name "LoginputMac"

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -2,11 +2,6 @@ cask "loginputmac" do
   version "2.5.3,24161"
   sha256 "a6111d21be1f28e7a8ea748c7b98d5168432c20d47ad6abe93b05867429f58f5"
 
-  # The install source has to be a PKG file otherwise both install and update will be failed.
-  # Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`,
-  # and needs privilege to write in.
-  # Pls DO NOT change the path into `.app` again, those files only for sparkle update framework tho.
-
   url "https://loginput-mac2.totest.top/loginputmac#{version.major}_latest.pkg",
       verified: "loginput-mac2.totest.top/"
   name "LoginputMac"

--- a/Casks/loginputmac.rb
+++ b/Casks/loginputmac.rb
@@ -1,6 +1,6 @@
 cask "loginputmac" do
   version "2.5.3,24161"
-  sha256 "9ad1e436283dbb6a60d040c205da3a31e5d97e999f53c6e6ed01682bb36e5857"
+  sha256 "a6111d21be1f28e7a8ea748c7b98d5168432c20d47ad6abe93b05867429f58f5"
 
   # The install source has to be a PKG file otherwise both install and update will be failed.
   # Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`,


### PR DESCRIPTION
Since https://github.com/Homebrew/homebrew-cask/pull/112003, this cask been broken until now my user reported to me...
The install source has to be a PKG file otherwise both install and update will be failed. Inputmethod (IME) is a special application that lives in `/Library/Input\ Method` not `/Application`, and needs privilege to write in, pls DO not change the path into `.app` again, those file only for sparkle update frame tho.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
