### PR TITLE
jumpshare: fix typo

### DIFF
--- a/Casks/jumpshare.rb
+++ b/Casks/jumpshare.rb
@@ -2,7 +2,7 @@ cask "jumpshare" do
   version "2.7.3,103"
   sha256 "f9f1ddb4fdaafa64a817358805952836d8bc147f7a504a0a8417e7e17b3057a1"
 
-  url "https://d21hi1or3tbtjm.cloudfront.net//desktop/mac/updates/Jumpshare-#{version.before_comma}.tar.bz2",
+  url "https://d21hi1or3tbtjm.cloudfront.net/desktop/mac/updates/Jumpshare-#{version.csv.first}.tar.bz2",
       verified: "d21hi1or3tbtjm.cloudfront.net/"
   name "Jumpshare"
   desc "File sharing, screen recording, and screenshot capture app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.