### PR TITLE
inso: fix livecheck

### DIFF
--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -11,7 +11,7 @@ cask "inso" do
   livecheck do
     url "https://github.com/Kong/insomnia/releases"
     strategy :page_match
-    regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+).*?)\.zip/i)
+    regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+)+)\.zip/i)
   end
 
   conflicts_with cask: "homebrew/cask-versions/inso-beta"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Before: inso : 2.4.1 ==> 2.5.0-beta.0
After: inso : 2.4.1 ==> 2.4.1
