### PR TITLE
jellyfin-media-player: switch livecheck strategy

### DIFF
--- a/Casks/jellyfin-media-player.rb
+++ b/Casks/jellyfin-media-player.rb
@@ -8,6 +8,11 @@ cask "jellyfin-media-player" do
   desc "Jellyfin desktop client"
   homepage "https://jellyfin.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Jellyfin Media Player.app"
 
   zap trash: [


### PR DESCRIPTION
Before: `jellyfin-media-player : 1.6.1 ==> 1.7.0-pre2`
After: `jellyfin-media-player : 1.6.1 ==> 1.6.1`