### PR TITLE
samsung-dex: discontinued

### DIFF
--- a/Casks/samsung-dex.rb
+++ b/Casks/samsung-dex.rb
@@ -22,6 +22,7 @@ cask "samsung-dex" do
   ]
 
   caveats do
+    discontinued
     kext
     reboot
   end

--- a/Casks/samsung-dex.rb
+++ b/Casks/samsung-dex.rb
@@ -1,8 +1,8 @@
 cask "samsung-dex" do
-  version "20211108133743295"
-  sha256 "88279231aabd632dc196f6b1da191a830416ccd6498d59eb7f1d431f6fbebac6"
+  version "20211210154322368"
+  sha256 "6bf45739e81ad7970ae86147b64bc1df3392154b00672243fb666c62c983a9f6"
 
-  url "https://downloadcenter.samsung.com/content/SW/#{version[0..5]}/#{version}/SamsungDeXSetup.dmg"
+  url "https://downloadcenter.samsung.com/content/SW/#{version[0..5]}/#{version}/SamsungDeXSetupMac.dmg"
   name "Samsung DeX"
   desc "Extend some Samsung devices into a desktop-like experience"
   homepage "https://www.samsung.com/us/explore/dex/"

--- a/Casks/samsung-dex.rb
+++ b/Casks/samsung-dex.rb
@@ -8,9 +8,9 @@ cask "samsung-dex" do
   homepage "https://www.samsung.com/us/explore/dex/"
 
   livecheck do
-    url "https://www.samsung.com/global/download/SamsungDeXMac"
+    url "https://org.downloadcenter.samsung.com/downloadfile/ContentsFile.aspx?CDSite=COMMON&CttFileID=8385137"
     strategy :header_match
-    regex(%r{(\d+)/SamsungDeXSetup\.dmg}i)
+    regex(%r{(\d+)/SamsungDeXSetupMac\.dmg}i)
   end
 
   pkg "Install Samsung DeX.pkg"


### PR DESCRIPTION
> The DeX for PC service for Mac/Windows 7 OS will be terminated as of January 2022.

according to `homepage`.