### PR TITLE
epichrome: discontinued

### DIFF
--- a/Casks/epichrome.rb
+++ b/Casks/epichrome.rb
@@ -10,4 +10,8 @@ cask "epichrome" do
   pkg "epichrome-#{version}.pkg"
 
   uninstall pkgutil: "org.epichrome.Epichrome"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
> I'm ending development of Epichrome. [...] I will continue doing updates to stay current with the Brave browser engine until the end of 2021.

according to `homepage`.