### PR TITLE
macspice: update zap

### DIFF
--- a/Casks/macspice.rb
+++ b/Casks/macspice.rb
@@ -15,7 +15,9 @@ cask "macspice" do
   app "MacSpice.app"
 
   zap trash: [
+    "~/Documents/MacSpice",
     "~/Library/Application Support/MacSpice",
+    "~/Library/Caches/com.apple.helpd/Generated/uk.co.cdhw.MacSpice.help*#{version.csv.first}",
     "~/Library/Preferences/uk.co.cdhw.MacSpice.plist",
     "~/Library/Saved Application State/uk.co.cdhw.MacSpice.savedState",
   ]


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.