### PR TITLE
nomachine: add zap

### DIFF
--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -9,7 +9,7 @@ cask "nomachine" do
 
   livecheck do
     url "https://www.nomachine.com/download/download&id=7"
-    regex(/nomachine[._-]v?(\d+(?:\.\d+)*_\d+)\.dmg/i)
+    regex(/nomachine[._-]v?(\d+(?:\.\d+)+_\d+)\.dmg/i)
   end
 
   pkg "NoMachine.pkg"

--- a/Casks/nomachine.rb
+++ b/Casks/nomachine.rb
@@ -24,4 +24,10 @@ cask "nomachine" do
               "com.nomachine.server",
               "com.nomachine.uninstall",
             ]
+
+  zap trash: [
+    "/Library/Application Support/NoMachine",
+    "~/Documents/NoMachine",
+    "~/Library/Preferences/com.nomachine.nxdock.plist",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.