### PR TITLE
Add Paperpile citation plugin for MS Word v0.7.2

### DIFF
--- a/Casks/paperpile.rb
+++ b/Casks/paperpile.rb
@@ -1,14 +1,15 @@
 cask "paperpile" do
   version "0.7.2"
-  sha256 :no_check
+  sha256 "d512ad93042c580cdf6343f466dd3d83c1108b2badec400d0d9ad0dc49a14807"
 
-  url "https://paperpile.com/download/desktop/macos-latest"
+  url "https://cdn.paperpile.com/download/desktop/Paperpile-#{version}.dmg"
   name "Paperpile"
   desc "Citation plugin for Microsoft Word"
   homepage "https://paperpile.com/word-plugin/"
 
   livecheck do
-    skip "No version information available"
+    url "https://paperpile-desktop.s3.amazonaws.com/production/latest-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true

--- a/Casks/paperpile.rb
+++ b/Casks/paperpile.rb
@@ -1,0 +1,22 @@
+cask "paperpile" do
+  version "0.7.2"
+  sha256 :no_check
+
+  url "https://paperpile.com/download/desktop/macos-latest"
+  name "Paperpile"
+  desc "Citation plugin for Microsoft Word"
+  homepage "https://paperpile.com/word-plugin/"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  auto_updates true
+
+  app "Paperpile.app"
+
+  zap trash: [
+    "~/Library/Application Support/Paperpile",
+    "~/Library/Preferences/com.paperpile.paperpile.plist",
+  ]
+end

--- a/Casks/paperpile.rb
+++ b/Casks/paperpile.rb
@@ -18,6 +18,7 @@ cask "paperpile" do
 
   zap trash: [
     "~/Library/Application Support/Paperpile",
+    "~/Library/Group Containers/*.Office/User Content.localized/Startup.localized/Word/paperpile*",
     "~/Library/Preferences/com.paperpile.paperpile.plist",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

This is my first contributed cask. Here are a couple of things I am not entirely satisfied with:

## Unversioned URL
The URL is unversioned: `https://paperpile.com/download/desktop/macos-latest` and the website does not appear to provide any information about versions. Therefore I have used `skip` in livecheck. The URL redirects to a versioned URL, i.e. `https://cdn.paperpile.com/download/desktop/Paperpile-0.7.2.dmg`. Perhaps this could be used to do a proper livecheck like the following:
```
livecheck do
  url :url
  strategy :header
  regex(/Paperpile-(\d+(?:\.\d+)*)\.dmg/i)
end
```
However, the download is about 90 MB and curl timeouts when doing `brew livecheck --debug --verbose paperpile`.

## Word macro
As it is an application and Microsoft word plugin, it drops a Word macro in: `~/Library/Group Containers/UBF8T346G9.Office/User Content.localized/Startup.localized/Word/paperpile-0.7.2.dotm` where `UBF8T346G9` is a hash and will change with each user. I wasn't sure how to remove this with zap.
