### PR TITLE
Update adguard.rb

### DIFF
--- a/Casks/adguard.rb
+++ b/Casks/adguard.rb
@@ -15,6 +15,7 @@ cask "adguard" do
   end
 
   auto_updates true
+  depends_on macos: ">= :sierra"
 
   pkg "AdGuard.pkg"
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
