### PR TITLE
Update Signal from 5.26.1 to 5.27.0

### DIFF
--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,8 +1,15 @@
 cask "signal" do
-  version "5.27.0"
-  sha256 "dc3ce7042b68da70939d43fb348a8cda837d5e53153387b66bee44ffca85edf1"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  url "https://updates.signal.org/desktop/signal-desktop-mac-universal-#{version}.dmg"
+  version "5.27.0"
+
+  if Hardware::CPU.intel?
+    sha256 "5db47125c0ce53cf95b4a0919322cbea98674084ad87e0ecbf2761bdc06d1e73"
+  else
+    sha256 "c56392c0c02e3debf5625c12512be4b06b62bca50d2f4bd3c40ad4c50af12741"
+  end
+
+  url "https://updates.signal.org/desktop/signal-desktop-mac-#{arch}-#{version}.dmg"
   name "Signal"
   desc "Instant messaging application focusing on security"
   homepage "https://signal.org/"

--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -1,8 +1,8 @@
 cask "signal" do
-  version "5.26.1"
-  sha256 "8c7a54af394ecf8c598c4c17b5ad8cb32aea679b304a4c2592e8b9de972ed8fc"
+  version "5.27.0"
+  sha256 "dc3ce7042b68da70939d43fb348a8cda837d5e53153387b66bee44ffca85edf1"
 
-  url "https://updates.signal.org/desktop/signal-desktop-mac-#{version}.dmg"
+  url "https://updates.signal.org/desktop/signal-desktop-mac-universal-#{version}.dmg"
   name "Signal"
   desc "Instant messaging application focusing on security"
   homepage "https://signal.org/"


### PR DESCRIPTION
After making all changes to a cask, verify:
 
* [x]  The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
* [x]  `brew audit --cask <cask>` is error-free.
* [x]  `brew style --fix <cask>` reports no offenses.