### PR TITLE
sequel-ace: switch livecheck strategy to avoid RCs

### DIFF
--- a/Casks/sequel-ace.rb
+++ b/Casks/sequel-ace.rb
@@ -9,11 +9,11 @@ cask "sequel-ace" do
 
   livecheck do
     url :url
-    strategy :git do |tags|
-      tags.map do |tag|
-        match = tag.match(%r{^production/(\d+(?:\.\d+)+)-(\d+)$}i)
-        "#{match[1]},#{match[2]}" if match
-      end.compact
+    strategy :github_latest do |page|
+      match = page.match(%r{href=.*?/tag/production/v?(\d+(?:\.\d+)+)-(\d+)["' >]}i)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.