### PR TITLE
lazarus: fix livecheck

### DIFF
--- a/Casks/lazarus.rb
+++ b/Casks/lazarus.rb
@@ -9,9 +9,8 @@ cask "lazarus" do
   homepage "https://www.lazarus-ide.org/"
 
   livecheck do
-    url "https://sourceforge.net/projects/lazarus/rss"
-    strategy :page_match
-    regex(/Lazarus-(\d+(?:.\d+)*)-x86_64-macosx\.pkg/i)
+    url :homepage
+    regex(%r{href=.*?macOS%20x86-64/Lazarus%20v?(\d+(?:\.\d+)+)/}i)
   end
 
   depends_on cask: "fpc-laz"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.