### PR TITLE
Update adguard-vpn.rb

### DIFF
--- a/Casks/adguard-vpn.rb
+++ b/Casks/adguard-vpn.rb
@@ -3,13 +3,15 @@ cask "adguard-vpn" do
   sha256 "e36f532559a8283f0fe2bc4db1ccb0a9ac2187e55ce8a9560f0fabfe4ca9fb5c"
 
   url "https://static.adguard-vpn.com/mac/release/AdGuardVPN-#{version}.dmg"
-  name "Adguard VPN"
+  name "AdGuard VPN"
   desc "VPN for privacy and security"
   homepage "https://adguard-vpn.com/"
 
   livecheck do
     url "https://static.adguard-vpn.com/mac/adguard-release-appcast.xml"
-    regex(/AdGuardVPN[._-]?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :sparkle do |item|
+      item.short_version.sub(/ release.*/, "")
+    end
   end
 
   auto_updates true
@@ -19,7 +21,20 @@ cask "adguard-vpn" do
 
   uninstall quit:      "com.adguard.mac.vpn",
             launchctl: "com.adguard.mac.vpn.tun-helper",
-            pkgutil:   "com.adguard.mac.vpn-pkg"
+            pkgutil:   "com.adguard.mac.vpn-pkg",
+            delete:    [
+              "/Library/Application Support/AdGuard Software/com.adguard.mac.vpn",
+              "/Library/Application Support/com.adguard.mac.vpn",
+              "/Library/LaunchDaemons/com.adguard.mac.vpn.tun-helper.plist",
+            ],
+            rmdir:     "/Library/Application Support/AdGuard Software"
 
-  zap trash: "/Library/Application Support/com.adguard.mac.vpn"
+  zap trash: [
+    "/Library/Logs/com.adguard.mac.vpn",
+    "~/Library/Application Scripts/com.adguard.mac.vpn.launchatlogin",
+    "~/Library/Caches/com.adguard.mac.vpn",
+    "~/Library/Containers/com.adguard.mac.vpn.launchatlogin",
+    "~/Library/HTTPStorages/com.adguard.mac.vpn",
+    "~/Library/Preferences/com.adguard.mac.vpn.plist",
+  ]
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
