### PR TITLE
Upgrade standard-notes from 3.9.10 to 3.9.13

### DIFF
--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,13 +1,13 @@
 cask "standard-notes" do
-  version "3.9.12"
+  version "3.9.13"
 
   if Hardware::CPU.intel?
-    sha256 "63f808938e05aa0487fc3f89c5db40cf7c63141f3963af41fcb97aa29265b6ae"
+    sha256 "de625b569e3330a8b86e28e87dc4c800e250f2c555d16909396388228639feeb"
 
     url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-x64.zip",
         verified: "github.com/standardnotes/desktop/"
   else
-    sha256 "9584a1d2cce20979b24d0f8ff9df041fd636f281d2a9dca290a1ab524e9a85a6"
+    sha256 "aa29dda83dfc44e6a264dc2e9087307293b2b01d48ca9bb157955e2c27e92ae8"
 
     url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-arm64.zip",
         verified: "github.com/standardnotes/desktop/"

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,18 +1,16 @@
 cask "standard-notes" do
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+
   version "3.9.13"
 
   if Hardware::CPU.intel?
     sha256 "de625b569e3330a8b86e28e87dc4c800e250f2c555d16909396388228639feeb"
-
-    url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-x64.zip",
-        verified: "github.com/standardnotes/desktop/"
   else
     sha256 "aa29dda83dfc44e6a264dc2e9087307293b2b01d48ca9bb157955e2c27e92ae8"
-
-    url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-arm64.zip",
-        verified: "github.com/standardnotes/desktop/"
   end
 
+  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-#{arch}.zip",
+      verified: "github.com/standardnotes/desktop/"
   name "Standard Notes"
   desc "Free, open-source, and completely encrypted notes app"
   homepage "https://standardnotes.org/"
@@ -23,10 +21,10 @@ cask "standard-notes" do
 
   zap trash: [
     "~/Library/Application Support/Standard Notes",
-    "~/Library/Caches/org.standardnotes.standardnotes",
     "~/Library/Caches/org.standardnotes.standardnotes.ShipIt",
-    "~/Library/Preferences/org.standardnotes.standardnotes.plist",
+    "~/Library/Caches/org.standardnotes.standardnotes",
     "~/Library/Preferences/org.standardnotes.standardnotes.helper.plist",
+    "~/Library/Preferences/org.standardnotes.standardnotes.plist",
     "~/Library/Saved Application State/org.standardnotes.standardnotes.savedState",
   ]
 end

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,9 +1,18 @@
 cask "standard-notes" do
-  version "3.9.10"
-  sha256 "6a1af9b49a75429128d55c7d56e4c30fff2e14773c817dba416eb7d6898303f3"
+  version "3.9.12"
 
-  url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-x64.zip",
-      verified: "github.com/standardnotes/desktop/"
+  if Hardware::CPU.intel?
+    sha256 "63f808938e05aa0487fc3f89c5db40cf7c63141f3963af41fcb97aa29265b6ae"
+
+    url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-x64.zip",
+        verified: "github.com/standardnotes/desktop/"
+  else
+    sha256 "9584a1d2cce20979b24d0f8ff9df041fd636f281d2a9dca290a1ab524e9a85a6"
+
+    url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-arm64.zip",
+        verified: "github.com/standardnotes/desktop/"
+  end
+
   name "Standard Notes"
   desc "Free, open-source, and completely encrypted notes app"
   homepage "https://standardnotes.org/"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
