### PR TITLE
Add binary shim for `goneovim`

### DIFF
--- a/Casks/goneovim.rb
+++ b/Casks/goneovim.rb
@@ -15,6 +15,16 @@ cask "goneovim" do
   depends_on formula: "neovim"
 
   app "Goneovim-latest-macos/goneovim.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/goneovim.wrapper.sh"
+  binary shimscript, target: "goneovim"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/goneovim.app/Contents/MacOS/goneovim' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/Library/Saved Application State/com.ident.goneovim.savedState",


### PR DESCRIPTION
Add shim for `goneovim`, modelled after how it's done for `kitty`

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.