### PR TITLE
Update utools from 2.4.1 to 2.5.2

### DIFF
--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -1,6 +1,6 @@
 cask "utools" do
-  version "2.4.1"
-  sha256 "0f5a3e7cb8785f7143f2c71d0e4afe8eb370717204b593491e928d272820e49c"
+  version "2.5.2"
+  sha256 "40c68599367d6fe2fcb4d26085c748ce52ba3876e5968a085af566ddba49479d"
 
   url "https://publish.u-tools.cn/version2/uTools-#{version}.dmg",
       verified: "publish.u-tools.cn/"

--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -1,8 +1,15 @@
 cask "utools" do
-  version "2.5.2"
-  sha256 "40c68599367d6fe2fcb4d26085c748ce52ba3876e5968a085af566ddba49479d"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  url "https://publish.u-tools.cn/version2/uTools-#{version}.dmg",
+  version "2.5.2"
+
+  if Hardware::CPU.intel?
+    sha256 "40c68599367d6fe2fcb4d26085c748ce52ba3876e5968a085af566ddba49479d"
+  else
+    sha256 "020b09e550f7cf007f927b69d742cc51c883ba84ca2593176b36810e4c269cdf"
+  end
+
+  url "https://publish.u-tools.cn/version2/uTools-#{version}#{arch}.dmg",
       verified: "publish.u-tools.cn/"
   name "uTools"
   desc "Plug-in productivity tool set"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.