### PR TITLE
Revert eloston-chromium arm64 to 96.0.4664.110-1.1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -3,7 +3,7 @@ cask "eloston-chromium" do
     version "97.0.4692.71-1.2_x86-64"
     sha256 "324d339576b17029a692d20c80dbee4e81b72b92183b1196532dc4d72d7d51a5"
   else
-    version "97.0.4692.71-1.1_arm64"
+    version "96.0.4664.110-1.1_arm64"
     sha256 "875065219a9f3cbd88dc290b1a98c4780dc84228939fc37bfdaba675ead99b3c"
   end
 


### PR DESCRIPTION
[97.0.4692.71-1.1 release](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/97.0.4692.71-1.1_arm64__1641722599) introduced a non-deterministic URL for the `arm64` .dmg file.
This commit reverts to the previous release to avoid errors when trying to fetch the file until a convenient and repeatable way to assemble the download URL is figured out.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
