### PR TITLE
Update mana-security from 2.4.1 to 2.4.2; Add quit uninstall key in zap-stanza

### DIFF
--- a/Casks/mana-security.rb
+++ b/Casks/mana-security.rb
@@ -1,5 +1,5 @@
 cask "mana-security" do
-  version "2.4.1"
+  version "2.4.2"
   sha256 :no_check
 
   url "https://download.manasecurity.com/"
@@ -16,7 +16,8 @@ cask "mana-security" do
 
   app "Mana Security.app"
 
-  uninstall login_item: "Mana Security"
+  uninstall quit:       "com.manasecurity.mana",
+            login_item: "Mana Security"
 
   zap trash: [
     "~/Library/Application Support/Mana Security",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.