### PR TITLE
copyq: add legacy version

### DIFF
--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -1,6 +1,11 @@
 cask "copyq" do
-  version "6.0.1"
-  sha256 "b1fa44d9fc3db1c9f270e031e891201d0bbac36faffc3be6c994a7515328cec6"
+  if MacOS.version <= :catalina
+    version "5.0.0"
+    sha256 "7201ff51d1258c8eae03580262a96bbee7d65c6e2133b0d5d6f10f95f031edd4"
+  else
+    version "6.0.1"
+    sha256 "b1fa44d9fc3db1c9f270e031e891201d0bbac36faffc3be6c994a7515328cec6"
+  end
 
   url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ.dmg.zip",
       verified: "github.com/hluk/CopyQ/"

--- a/Casks/copyq.rb
+++ b/Casks/copyq.rb
@@ -2,6 +2,10 @@ cask "copyq" do
   if MacOS.version <= :catalina
     version "5.0.0"
     sha256 "7201ff51d1258c8eae03580262a96bbee7d65c6e2133b0d5d6f10f95f031edd4"
+
+    livecheck do
+      skip "Legacy version for Catalina and earlier"
+    end
   else
     version "6.0.1"
     sha256 "b1fa44d9fc3db1c9f270e031e891201d0bbac36faffc3be6c994a7515328cec6"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
Addresses #117183. This might only be needed temporarily as upstream hasn't documented a change of supported OS version. Upstream issue: https://github.com/hluk/CopyQ/issues/1866.