### PR TITLE
Fix MKVToolNix incorrect version in OS X 10.10

### DIFF
--- a/Casks/mkvtoolnix.rb
+++ b/Casks/mkvtoolnix.rb
@@ -1,5 +1,5 @@
 cask "mkvtoolnix" do
-  if MacOS.version <= "10.9"
+  if MacOS.version <= "10.10"
     version "24.0.0"
     sha256 "758da621d3a92358885333b767d64b024197a8147a339b1a0d14e938673452f9"
   elsif MacOS.version <= "10.11"


### PR DESCRIPTION
Fixed incorrect version identifying in OS X 10.10, as the macOS version <= 10.9, which is supported by 24.0.0, however, skipped by Homebrew when checking macOS version and JSON API state that on Yosemite should install 29.0.0, which isn't right. Probably because Homebrew now don't support Mavericks at all...

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

