### PR TITLE
Update Vale Server version and paths to suit new license

### DIFF
--- a/Casks/vale-server.rb
+++ b/Casks/vale-server.rb
@@ -2,19 +2,14 @@ cask "vale-server" do
   version "2.0.0"
   sha256 "3d8a84b268bc15a696df99739a96e1ed45b2b5b523f3ccf87fae117b4086f74e"
 
-  url "https://github.com/errata-ai/vale-server/releases/download/v#{version.major}.0.0/Vale-Server-#{version}-macos.dmg",
+  url "https://github.com/errata-ai/vale-server/releases/download/v#{version}/Vale-Server-#{version}-macos.dmg",
       verified: "github.com/errata-ai/vale-server/"
   name "Vale Server"
   desc "Cross-platform desktop application"
   homepage "https://errata.ai/vale-server/"
 
-  livecheck do
-    url "https://github.com/errata-ai/vale-server/releases/"
-    strategy :page_match
-    regex(/Vale[._-]Server[._-]v?(\d+(?:\.\d+)+)[._-]macos\.dmg/i)
-  end
-
-  depends_on macos: ">= :high_sierra"
+  depends_on formula: "vale"
+  depends_on macos: ">= :catalina"
 
   app "Vale Server.app"
 

--- a/Casks/vale-server.rb
+++ b/Casks/vale-server.rb
@@ -1,15 +1,15 @@
 cask "vale-server" do
-  version "1.13.0"
-  sha256 "a10067f4321386f49c5c79426cd078bc8cfea96684682a88809ad9f9c49d58a0"
+  version "2.0.0"
+  sha256 "3d8a84b268bc15a696df99739a96e1ed45b2b5b523f3ccf87fae117b4086f74e"
 
-  url "https://github.com/errata-ai/errata.ai/releases/download/v#{version.major}.0.0/Vale-Server-#{version}-macos.dmg",
-      verified: "github.com/errata-ai/errata.ai/"
+  url "https://github.com/errata-ai/vale-server/releases/download/v#{version.major}.0.0/Vale-Server-#{version}-macos.dmg",
+      verified: "github.com/errata-ai/vale-server/"
   name "Vale Server"
   desc "Cross-platform desktop application"
   homepage "https://errata.ai/vale-server/"
 
   livecheck do
-    url "https://github.com/errata-ai/errata.ai/releases/"
+    url "https://github.com/errata-ai/vale-server/releases/"
     strategy :page_match
     regex(/Vale[._-]Server[._-]v?(\d+(?:\.\d+)+)[._-]macos\.dmg/i)
   end


### PR DESCRIPTION
As mentioned in my original submission, Vale server was in the process of becoming open source and now it is, so this PR updates versions and paths to reflect that.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.