### PR TITLE
paraview: add Apple silicon support

### DIFF
--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -18,7 +18,7 @@ cask "paraview" do
 
   livecheck do
     url "https://www.paraview.org/files/listing.txt"
-    regex(/ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX10\.13[._-]Python3\.9[._-]x86[._-]64\.dmg/i)
+    regex(/ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX#{min_macos_version}[._-]Python3\.9[._-]#{arch}\.dmg/i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -1,8 +1,16 @@
 cask "paraview" do
-  version "5.10.0"
-  sha256 "346833f38ef82d9313fcb203396b901da41e968a8d7078e2f128a345d2d6bafc"
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
+  min_macos_version = Hardware::CPU.intel? ? "10.13" : "11.0"
 
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX10.13-Python3.9-x86_64.dmg",
+  version "5.10.0"
+
+  if Hardware::CPU.intel?
+    sha256 "346833f38ef82d9313fcb203396b901da41e968a8d7078e2f128a345d2d6bafc"
+  else
+    sha256 "701663d8bac7daa8f6e6ffb65a6f4dd73adbd9acf9c96e053b692220072f952c"
+  end
+
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX#{min_macos_version}-Python3.9-#{arch}.dmg",
       user_agent: :fake
   name "ParaView"
   desc "Data analysis and visualization application"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Add Apple silicon support for Paraview 5.10.0: an updated arm64 DMG is now available, which fixes the previously broken (as of #116404) arm64 DMG.