### PR TITLE
Update adguard-vpn.rb

### DIFF
--- a/Casks/adguard-vpn.rb
+++ b/Casks/adguard-vpn.rb
@@ -26,11 +26,11 @@ cask "adguard-vpn" do
             delete:    [
               "/Library/Application Support/AdGuard Software/com.adguard.mac.vpn",
               "/Library/Application Support/com.adguard.mac.vpn",
+              "/Library/Logs/com.adguard.mac.vpn",
             ],
             rmdir:     "/Library/Application Support/AdGuard Software"
 
   zap trash: [
-    "/Library/Logs/com.adguard.mac.vpn",
     "~/Library/Application Scripts/*.com.adguard.mac",
     "~/Library/Application Scripts/com.adguard.mac.vpn.launchatlogin",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.adguard.mac.vpn.launchatlogin.sfl*",

--- a/Casks/adguard-vpn.rb
+++ b/Casks/adguard-vpn.rb
@@ -15,6 +15,7 @@ cask "adguard-vpn" do
   end
 
   auto_updates true
+  conflicts_with cask: "homebrew/cask-versions/adguard-vpn-nightly"
   depends_on macos: ">= :sierra"
 
   pkg "AdGuard VPN.pkg"
@@ -26,10 +27,7 @@ cask "adguard-vpn" do
               "/Library/Application Support/AdGuard Software/com.adguard.mac.vpn",
               "/Library/Application Support/com.adguard.mac.vpn",
             ],
-            rmdir:     [
-              "/Library/Application Support/AdGuard Software",
-              "/Library/Application Support/AdGuard Software/com.adguard.mac",
-            ]
+            rmdir:     "/Library/Application Support/AdGuard Software"
 
   zap trash: [
     "/Library/Logs/com.adguard.mac.vpn",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
