### PR TITLE
windscribe: update zap

### DIFF
--- a/Casks/windscribe.rb
+++ b/Casks/windscribe.rb
@@ -9,8 +9,7 @@ cask "windscribe" do
 
   livecheck do
     url "https://windscribe.com/changelog/mac"
-    strategy :page_match
-    regex(/Windscribe\.dmg">\s*v(\d+(?:\.\d+)*)/i)
+    regex(/Windscribe\.dmg">\s*v(\d+(?:\.\d+)+)/i)
   end
 
   installer manual: "WindscribeInstaller.app"
@@ -28,15 +27,14 @@ cask "windscribe" do
               "/Applications/Windscribe.app",
               "/Library/PrivilegedHelperTools/com.windscribe.helper.macos",
               "/Library/LaunchDaemons/com.windscribe.helper.macos.plist",
-              "/private/var/run/windscribe_helper_socket2",
               "/usr/local/bin/windscribe-cli",
             ]
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.windscribe.launcher.macos.sfl*",
     "~/Library/Application Support/Windscribe",
-    "~/Library/Preferences/com.windscribe.Windscribe2.plist",
     "~/Library/Preferences/com.aaa.windscribe.windscribe.plist",
+    "~/Library/Preferences/com.windscribe.Windscribe2.plist",
     "~/Library/Saved Application State/com.windscribe.gui.macos.savedState",
   ]
 end

--- a/Casks/windscribe.rb
+++ b/Casks/windscribe.rb
@@ -33,6 +33,7 @@ cask "windscribe" do
             ]
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.windscribe.launcher.macos.sfl*",
     "~/Library/Application Support/Windscribe",
     "~/Library/Preferences/com.windscribe.Windscribe2.plist",
     "~/Library/Preferences/com.aaa.windscribe.windscribe.plist",


### PR DESCRIPTION
Added a file leftover from Windscribe after uninstalling it with --zap.
Similar to the first zap item [here](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/tunnelbear.rb).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.