### PR TITLE
Bump brackets 2.0.1

### DIFF
--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -2,7 +2,7 @@ cask "brackets" do
   version "2.0.1"
   sha256 "2aa93fc36011bea42554ec3c118f4e1c5d5518b92094b89b57c20f5ba1a1ec66"
 
-  url "https://github.com/brackets-cont/brackets/releases/download/v#{version}/Brackets.#{version}.signed.dmg
+  url "https://github.com/brackets-cont/brackets/releases/download/v#{version}/Brackets.#{version}.signed.dmg",
       verified: "github.com/brackets-cont/brackets/"
   name "Brackets"
   desc "Open-source code editor for web-developement"

--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -1,9 +1,9 @@
 cask "brackets" do
-  version "1.14.2"
-  sha256 "716be1a75099079aa1a22dedab403c9839155c4b99aab6677d8a24589f7f9a15"
+  version "2.0.1"
+  sha256 "2aa93fc36011bea42554ec3c118f4e1c5d5518b92094b89b57c20f5ba1a1ec66"
 
-  url "https://github.com/adobe/brackets/releases/download/release-#{version}/Brackets.Release.#{version}.dmg",
-      verified: "github.com/adobe/brackets/"
+  url "https://github.com/brackets-cont/brackets/releases/download/v#{version}/Brackets.#{version}.signed.dmg
+      verified: "github.com/brackets-cont/brackets/"
   name "Brackets"
   desc "Open-source code editor for web-developement"
   homepage "http://brackets.io/"
@@ -11,7 +11,7 @@ cask "brackets" do
   livecheck do
     url :url
     strategy :github_latest
-    regex(%r{href=.*?/Brackets\.Release\.(\d+(?:\.\d+)+)\.dmg}i)
+    regex(%r{href=.*?/Brackets\.(\d+(?:\.\d+)+)\.signed.dmg}i)
   end
 
   app "Brackets.app"

--- a/Casks/brackets.rb
+++ b/Casks/brackets.rb
@@ -6,7 +6,7 @@ cask "brackets" do
       verified: "github.com/brackets-cont/brackets/"
   name "Brackets"
   desc "Open-source code editor for web-developement"
-  homepage "http://brackets.io/"
+  homepage "https://brackets.io/"
 
   livecheck do
     url :url


### PR DESCRIPTION
Brackets got forked of a project previously maintained by Adobe. 

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.