### PR TITLE
docs: fix README.md links to error_examples.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ If your issue persists, [search for it](https://github.com/Homebrew/homebrew-cas
 If the issue is still not solved, see the guides for common problems:
 
 * [Examples of common errors and their solutions](doc/reporting_bugs/error_examples.md)
-* [`curl` error](doc/reporting_bugs/curl_error.md)
-* [`Permission denied` error](doc/reporting_bugs/permission_denied_error.md)
-* [`Checksum does not match` error](doc/reporting_bugs/checksum_does_not_match_error.md)
-* [`source is not there` error](doc/reporting_bugs/source_is_not_there_error.md)
-* [`wrong number of arguments` error](doc/reporting_bugs/wrong_number_of_arguments_error.md)
+* [`curl` error](doc/reporting_bugs/error_examples.md#curl-error)
+* [`Permission denied` error](doc/reporting_bugs/error_examples.md#permission-denied-error)
+* [`Checksum does not match` error](doc/reporting_bugs/error_examples.md#checksum-does-not-match-error)
+* [`source is not there` error](doc/reporting_bugs/error_examples.md#source-is-not-there-error)
+* [`wrong number of arguments` error](doc/reporting_bugs/error_examples.md#wrong-number-of-arguments-error)
 * [App isn’t included in `upgrade`](https://docs.brew.sh/FAQ#why-arent-some-apps-included-during-brew-upgrade)
 * [The app can’t be opened because it is from an unidentified developer](https://docs.brew.sh/FAQ#why-cant-i-open-a-mac-app-from-an-unidentified-developer)
 * [My problem isn’t listed](https://github.com/Homebrew/homebrew-cask/issues/new?template=01_bug_report.yml)


### PR DESCRIPTION
Fixes links in README.md that are currently broken.