### PR TITLE
wine-stable: update livecheck

### DIFF
--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -12,7 +12,7 @@ cask "wine-stable" do
   homepage "https://wiki.winehq.org/MacOS"
 
   livecheck do
-    url "https://github.com/Gcenx/macOS_Wine_builds/releases/latest"
+    url "https://github.com/Gcenx/macOS_Wine_builds/releases/"
     strategy :page_match
     regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)*)[._-]osx64\.tar\.xz/i)
   end

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -14,7 +14,7 @@ cask "wine-stable" do
   livecheck do
     url "https://github.com/Gcenx/macOS_Wine_builds/releases/"
     strategy :page_match
-    regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)*)[._-]osx64\.tar\.xz/i)
+    regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.tar\.xz/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
Before:
```
|-> brew livecheck wine-stable --debug

Cask:             wine-stable
Livecheckable?:   Yes

URL:              https://github.com/Gcenx/macOS_Wine_builds/releases/latest
Strategy:         PageMatch
Regex:            /wine[._-]stable[._-]v?(\d+(?:\.\d+)*)[._-]osx64\.tar\.xz/i
URL (final):      https://github.com/Gcenx/macOS_Wine_builds/releases/tag/6.23
Error: wine-stable: Unable to get versions
```
After:
```
|-> brew livecheck wine-stable --debug

Cask:             wine-stable
Livecheckable?:   Yes

URL:              https://github.com/Gcenx/macOS_Wine_builds/releases/
Strategy:         PageMatch
Regex:            /wine[._-]stable[._-]v?(\d+(?:\.\d+)*)[._-]osx64\.tar\.xz/i

Matched Versions:
6.0.2
wine-stable : 6.0.2 ==> 6.0.2
```