### PR TITLE
Update OnlyOffice to v7.0.0

### DIFF
--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,12 +1,12 @@
 cask "onlyoffice" do
   arch = Hardware::CPU.intel? ? "x86-64" : "arm"
 
-  version "6.4.2"
+  version "7.0.0"
 
   if Hardware::CPU.intel?
-    sha256 "ccd92a0a52805de903d7ff1fff6becc1c7814490f2d8feb63033d0930966e0b7"
+    sha256 "93703ef85b073e2eaedadfa3d721dae96b2564562953181c7b11ead3917ff95c"
   else
-    sha256 "828734f2dd15a0ee5bc59eb235080ec2dd9b7c1e9add71f4318a04b61f1e7cdb"
+    sha256 "996879beb0a3aee19a0bbd4d105a0a798164f479a01a4043d7e346e87331bf0b"
   end
 
   url "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v#{version}/ONLYOFFICE-#{arch}.dmg",

--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -1,5 +1,5 @@
 cask "onlyoffice" do
-  arch = Hardware::CPU.intel? ? "x86-64" : "arm"
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm"
 
   version "7.0.0"
 


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

