### PR TITLE
Update angry-ip-scanner.rb from 3.7.6 to 3.8.0

### DIFF
--- a/Casks/angry-ip-scanner.rb
+++ b/Casks/angry-ip-scanner.rb
@@ -1,12 +1,23 @@
 cask "angry-ip-scanner" do
-  version "3.7.6"
-  sha256 "16cee34ed7af7175f622197c764fd0c69399bc6dc8b7d891ac76266d077c5415"
+  arch = Hardware::CPU.intel? ? "X86" : "Arm64"
 
-  url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac-#{version}.zip",
+  version "3.8.0"
+
+  if Hardware::CPU.intel?
+    sha256 "6c514ecc4155806aef7eb0a913cf4a88214e20bdd69694ad9ac5c565d588dea9"
+  else
+    sha256 "eb91b66cced883e4445f8e26fbf33689c82d04f5c736866d08d00847bb46b1f8"
+  end
+
+  url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac#{arch}-#{version}.zip",
       verified: "github.com/angryip/ipscan/"
   name "Angry IP Scanner"
   desc "Network scanner"
   homepage "https://angryip.org/"
 
   app "Angry IP Scanner.app"
+
+  caveats do
+    depends_on_java "11"
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.