### PR TITLE
Add Surge XT version 1.0.0

### DIFF
--- a/Casks/surge-xt-synthesizer.rb
+++ b/Casks/surge-xt-synthesizer.rb
@@ -18,10 +18,12 @@ cask "surge-xt-synthesizer" do
     "com.surge-synth-team.surge-xt-fx.component.pkg",
     "com.surge-synth-team.surge-xt-fx.app.pkg",
     "com.surge-synth-team.surge-xt.resources.pkg",
-  ]
+  ],
+            delete:
+                     [
+                       "/Applications/Surge XT Effects.app",
+                       "/Applications/Surge XT.app",
+                     ]
 
-  zap trash: [
-    "/Applications/Surge XT Effects.app",
-    "/Applications/Surge XT.app",
-  ]
+  zap trash: []
 end

--- a/Casks/surge-xt-synthesizer.rb
+++ b/Casks/surge-xt-synthesizer.rb
@@ -14,11 +14,9 @@ cask "surge-xt-synthesizer" do
     "com.surge-synth-team.surge-xt.app.pkg",
     "com.surge-synth-team.surge-xt.component.pkg",
     "com.surge-synth-team.surge-xt.vst3.pkg",
-
     "com.surge-synth-team.surge-xt-fx.app.pkg",
     "com.surge-synth-team.surge-xt-fx.component.pkg",
     "com.surge-synth-team.surge-xt-fx.vst3.pkg",
-
     "com.surge-synth-team.surge-xt.resources.pkg",
   ],
             delete:

--- a/Casks/surge-xt-synthesizer.rb
+++ b/Casks/surge-xt-synthesizer.rb
@@ -19,4 +19,6 @@ cask "surge-xt-synthesizer" do
     "com.surge-synth-team.surge-xt-fx.app.pkg",
     "com.surge-synth-team.surge-xt.resources.pkg",
   ]
+
+  zap trash: []
 end

--- a/Casks/surge-xt-synthesizer.rb
+++ b/Casks/surge-xt-synthesizer.rb
@@ -20,5 +20,8 @@ cask "surge-xt-synthesizer" do
     "com.surge-synth-team.surge-xt.resources.pkg",
   ]
 
-  zap trash: []
+  zap trash: [
+    "/Applications/Surge XT Effects.app",
+    "/Applications/Surge XT.app",
+  ]
 end

--- a/Casks/surge-xt-synthesizer.rb
+++ b/Casks/surge-xt-synthesizer.rb
@@ -11,12 +11,14 @@ cask "surge-xt-synthesizer" do
   pkg "surge-xt-macOS-#{version}.pkg"
 
   uninstall pkgutil: [
-    "com.surge-synth-team.surge-xt.vst3.pkg",
-    "com.surge-synth-team.surge-xt.component.pkg",
     "com.surge-synth-team.surge-xt.app.pkg",
-    "com.surge-synth-team.surge-xt-fx.vst3.pkg",
-    "com.surge-synth-team.surge-xt-fx.component.pkg",
+    "com.surge-synth-team.surge-xt.component.pkg",
+    "com.surge-synth-team.surge-xt.vst3.pkg",
+
     "com.surge-synth-team.surge-xt-fx.app.pkg",
+    "com.surge-synth-team.surge-xt-fx.component.pkg",
+    "com.surge-synth-team.surge-xt-fx.vst3.pkg",
+
     "com.surge-synth-team.surge-xt.resources.pkg",
   ],
             delete:
@@ -25,5 +27,5 @@ cask "surge-xt-synthesizer" do
                        "/Applications/Surge XT.app",
                      ]
 
-  zap trash: []
+  # no zap stanza required
 end

--- a/Casks/surge-xt-synthesizer.rb
+++ b/Casks/surge-xt-synthesizer.rb
@@ -1,0 +1,22 @@
+cask "surge-xt-synthesizer" do
+  version "1.0.0"
+  sha256 "d0a481745e7526b02ba41267be9bf61a90377f0fed80ffcebc655777cd9c5a4f"
+
+  url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
+      verified: "github.com/surge-synthesizer/releases-xt/"
+  name "Surge XT"
+  desc "Hybrid synthesizer"
+  homepage "https://surge-synthesizer.github.io/"
+
+  pkg "surge-xt-macOS-#{version}.pkg"
+
+  uninstall pkgutil: [
+    "com.surge-synth-team.surge-xt.vst3.pkg",
+    "com.surge-synth-team.surge-xt.component.pkg",
+    "com.surge-synth-team.surge-xt.app.pkg",
+    "com.surge-synth-team.surge-xt-fx.vst3.pkg",
+    "com.surge-synth-team.surge-xt-fx.component.pkg",
+    "com.surge-synth-team.surge-xt-fx.app.pkg",
+    "com.surge-synth-team.surge-xt.resources.pkg",
+  ]
+end

--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -1,4 +1,4 @@
-cask "surge-xt-synthesizer" do
+cask "surge-xt" do
   version "1.0.0"
   sha256 "d0a481745e7526b02ba41267be9bf61a90377f0fed80ffcebc655777cd9c5a4f"
 
@@ -11,19 +11,18 @@ cask "surge-xt-synthesizer" do
   pkg "surge-xt-macOS-#{version}.pkg"
 
   uninstall pkgutil: [
-    "com.surge-synth-team.surge-xt.app.pkg",
-    "com.surge-synth-team.surge-xt.component.pkg",
-    "com.surge-synth-team.surge-xt.vst3.pkg",
     "com.surge-synth-team.surge-xt-fx.app.pkg",
     "com.surge-synth-team.surge-xt-fx.component.pkg",
     "com.surge-synth-team.surge-xt-fx.vst3.pkg",
+    "com.surge-synth-team.surge-xt.app.pkg",
+    "com.surge-synth-team.surge-xt.component.pkg",
     "com.surge-synth-team.surge-xt.resources.pkg",
+    "com.surge-synth-team.surge-xt.vst3.pkg",
   ],
-            delete:
-                     [
-                       "/Applications/Surge XT Effects.app",
-                       "/Applications/Surge XT.app",
-                     ]
+            delete:  [
+              "/Applications/Surge XT Effects.app",
+              "/Applications/Surge XT.app",
+            ]
 
-  # no zap stanza required
+  zap rmdir: "~/Documents/Surge XT"
 end


### PR DESCRIPTION
Surge XT is the next version of surge (already packagted as
surge-synthesizer). There are a variety of legitimate reasons to install
both bits of software simultaenously so we have split the version identity
and subsequently split the homebrew identities too.

The documentation for the synth is at https://surge-synthesizer.github.io/

Please note this version fails the 'git relevance' test because we
use a different repository for our binaries than our source. The source
repo https://github.com/surge-synthesizer/surge/issues has 279 forks
and 1.8k stars; and Surge 1.9 was downloaded more than 100k times from
our various distributions. I hope this technical split of source from
binary repo doesn't avoid inclusion of XT in HomeBrew.

Thank you as always for your consideration.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
