### PR TITLE
kmplayer: discontinued

### DIFF
--- a/Casks/kmplayer.rb
+++ b/Casks/kmplayer.rb
@@ -5,7 +5,7 @@ cask "kmplayer" do
   url "http://cdn.kmplayer.com/KMP/Download/KMPX/KMPlayer-#{version}.pkg"
   name "KMPlayer"
   desc "Video player"
-  homepage "http://www.kmplayer.com/"
+  homepage "https://www.kmplayer.com/"
 
   pkg "KMPlayer-#{version}.pkg"
 

--- a/Casks/kmplayer.rb
+++ b/Casks/kmplayer.rb
@@ -4,15 +4,14 @@ cask "kmplayer" do
 
   url "http://cdn.kmplayer.com/KMP/Download/KMPX/KMPlayer-#{version}.pkg"
   name "KMPlayer"
+  desc "Video player"
   homepage "http://www.kmplayer.com/"
-
-  livecheck do
-    url "http://www.kmplayer.com/mac"
-    strategy :page_match
-    regex(%r{href=.*?/KMPlayer-(\d+(?:\.\d+)*)\.pkg}i)
-  end
 
   pkg "KMPlayer-#{version}.pkg"
 
   uninstall pkgutil: "com.kmplayer.osx"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
macOS downloads are no longer available on their website, although the `url` still works.
```
|-> brew livecheck kmplayer --debug

Cask:             kmplayer
Livecheckable?:   Yes

URL:              http://www.kmplayer.com/mac
Strategy:         PageMatch
Regex:            /href=.*?\/KMPlayer-(\d+(?:\.\d+)*)\.pkg/i
URL (final):      https://www.kmplayer.com/home
Error: kmplayer: Unable to get versions
```
```
==> Analytics
install: 23 (30 days), 92 (90 days), 343 (365 days)
```