### PR TITLE
Add Apple Silicon download URL for Unity

### DIFF
--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -1,8 +1,15 @@
 cask "unity" do
-  version "2021.2.8f1,d0e5f0a7b06a"
-  sha256 "f0369662e6300ae209db5b259a3761598d5e7795011b3ba94c473f4ad1042e81"
+  arch = Hardware::CPU.intel? ? "" : "Arm64"
 
-  url "https://download.unity3d.com/download_unity/#{version.csv.second}/MacEditorInstaller/Unity-#{version.csv.first}.pkg",
+  version "2021.2.8f1,d0e5f0a7b06a"
+
+  if Hardware::CPU.intel?
+    sha256 "f0369662e6300ae209db5b259a3761598d5e7795011b3ba94c473f4ad1042e81"
+  else
+    sha256 "bd9eea59961a749273a586e958bb99ecc77562af5d700af4dc969c05b637c6cc"
+  end
+
+  url "https://download.unity3d.com/download_unity/#{version.csv.second}/MacEditorInstaller#{arch}/Unity-#{version.csv.first}.pkg",
       verified: "download.unity3d.com/download_unity/"
   name "Unity Editor"
   desc "Platform for 3D content"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Download URLs look like below:

- Intel: <https://download.unity3d.com/download_unity/d0e5f0a7b06a/MacEditorInstaller/Unity.pkg>
- Apple Silicon: <https://download.unity3d.com/download_unity/d0e5f0a7b06a/MacEditorInstallerArm64/Unity.pkg>

I followed the pattern already used by the cask for Rider:

<https://github.com/Homebrew/homebrew-cask/blob/b3983e96802f380143077db0491fbb5c0702c9a2/Casks/rider.rb#L2-L12>