### PR TITLE
vmpk: downgrade to 0.8.4 and fix livecheck

### DIFF
--- a/Casks/vmpk.rb
+++ b/Casks/vmpk.rb
@@ -8,6 +8,11 @@ cask "vmpk" do
   desc "Virtual MIDI Piano Keyboard"
   homepage "https://vmpk.sourceforge.io/"
 
+  livecheck do
+    url "https://sourceforge.net/projects/vmpk/rss?path=/vmpk"
+    regex(/url=.*?vmpk[._-]?v?(\d+(?:\.\d+)+)-mac-x64\.dmg/i)
+  end
+
   depends_on formula: "fluid-synth"
   depends_on macos: ">= :sierra"
 

--- a/Casks/vmpk.rb
+++ b/Casks/vmpk.rb
@@ -1,6 +1,6 @@
 cask "vmpk" do
-  version "0.8.5"
-  sha256 "00927344b06de2c9f42a4f1cda69d6495e767e5c68ff57e64ec5bc105995489b"
+  version "0.8.4"
+  sha256 "cbc0e4d821aa2277efe65b2caf6d8f631ac9289f802df24bbf44e4b0c153095e"
 
   url "https://downloads.sourceforge.net/vmpk/#{version.major_minor_patch}/vmpk-#{version}-mac-x64.dmg",
       verified: "downloads.sourceforge.net/vmpk/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

```
%  brew fetch vmpk
==> Downloading https://downloads.sourceforge.net/vmpk/0.8.5/vmpk-0.8.5-mac-x64.dmg
curl: (22) The requested URL returned error: 404

Error: Download failed on Cask 'vmpk' with message: Download failed: https://downloads.sourceforge.net/vmpk/0.8.5/vmpk-0.8.5-mac-x64.dmg
```