### PR TITLE
postman: make livecheck ignore disabled versions

### DIFF
--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -18,7 +18,7 @@ cask "postman" do
   livecheck do
     url "https://dl.pstmn.io/api/version/"
     strategy :page_match do |page|
-      stable_versions = JSON.parse(page).filter { |v| v["channel"] == "stable" }
+      stable_versions = JSON.parse(page).filter { |v| v["channel"] == "stable" && v["disabled"] == false }
       stable_versions.map { |v| v["name"] }
     end
   end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

`9.10.0` as currently suggested by `livecheck` fails to download. The `disabled` property being set to `true` for said version most likely explains it.