### PR TITLE
Update klayout from 0.26.8 to 0.27.7

### DIFF
--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -1,7 +1,7 @@
 cask "klayout" do
   version "0.27.7"
 
-if MacOS.version <= :catalina
+  if MacOS.version <= :catalina
     sha256 "7e7b515f2e0a735ce57f247a1a51e4f1b37b71d73dac5fb931c4e428ed38ff0b"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Catalina-1-qt5Brew-RsysPhb38.dmg",

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -5,22 +5,27 @@ cask "klayout" do
     sha256 "7e7b515f2e0a735ce57f247a1a51e4f1b37b71d73dac5fb931c4e428ed38ff0b"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Catalina-1-qt5Brew-RsysPhb38.dmg",
-        verified: "klayout.org/"
+        verified: "www.klayout.org/downloads/MacOS/"
   elsif MacOS.version <= :big_sur
     sha256 "398524660a4fab288190791f57d34262b120faf6bb19c024b438826edb0a7d28"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-BigSur-1-qt5Brew-RsysPhb38.dmg",
-        verified: "klayout.org/"
+        verified: "www.klayout.org/downloads/MacOS/"
   else
     sha256 "a5047a1058a8795f06ae7b26cce417ac093eee42b0fdd6d0bac86efaf5a003f4"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Monterey-1-qt5Brew-RsysPhb38.dmg",
-        verified: "klayout.org/"
+        verified: "www.klayout.org/downloads/MacOS/"
   end
 
-  appcast "https://www.klayout.de/development.html"
   name "KLayout"
+  desc "IC design layout viewer and editor"
   homepage "https://www.klayout.de/"
+
+  livecheck do
+    url "https://github.com/KLayout/klayout/"
+    strategy :github_latest
+  end
 
   depends_on macos: ">= :catalina"
   depends_on formula: "python@3.8"

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -24,7 +24,6 @@ cask "klayout" do
 
   livecheck do
     url "https://github.com/KLayout/klayout/"
-    strategy :github_latest
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -5,17 +5,17 @@ cask "klayout" do
     sha256 "7e7b515f2e0a735ce57f247a1a51e4f1b37b71d73dac5fb931c4e428ed38ff0b"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Catalina-1-qt5Brew-RsysPhb38.dmg",
-        verified: "www.klayout.org/downloads/MacOS/"
+        verified: "klayout.org/downloads/MacOS/"
   elsif MacOS.version <= :big_sur
     sha256 "398524660a4fab288190791f57d34262b120faf6bb19c024b438826edb0a7d28"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-BigSur-1-qt5Brew-RsysPhb38.dmg",
-        verified: "www.klayout.org/downloads/MacOS/"
+        verified: "klayout.org/downloads/MacOS/"
   else
     sha256 "a5047a1058a8795f06ae7b26cce417ac093eee42b0fdd6d0bac86efaf5a003f4"
 
     url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Monterey-1-qt5Brew-RsysPhb38.dmg",
-        verified: "www.klayout.org/downloads/MacOS/"
+        verified: "klayout.org/downloads/MacOS/"
   end
 
   name "KLayout"

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -27,8 +27,6 @@ cask "klayout" do
   end
 
   depends_on macos: ">= :catalina"
-  depends_on formula: "python@3.8"
-  depends_on formula: "qt@5"
 
   suite "KLayout"
 

--- a/Casks/klayout.rb
+++ b/Casks/klayout.rb
@@ -1,20 +1,20 @@
 cask "klayout" do
-  version "0.26.8"
+  version "0.27.7"
 
-  if MacOS.version <= :high_sierra
-    sha256 "b6ee7a8ee71e8cb218b6ecea4df6865cb1d0f49b646101246543bd7de1d6d5e7"
+if MacOS.version <= :catalina
+    sha256 "7e7b515f2e0a735ce57f247a1a51e4f1b37b71d73dac5fb931c4e428ed38ff0b"
 
-    url "https://www.klayout.org/downloads/MacOS/ST-klayout-#{version}-macOS-HighSierra-1-qt5MP-RsysPsys.dmg",
+    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Catalina-1-qt5Brew-RsysPhb38.dmg",
         verified: "klayout.org/"
-  elsif MacOS.version <= :mojave
-    sha256 "e3ade30ac217f312720d2157cd6e9afad566cbb239a08ecd55a6f9d8dc9af3e0"
+  elsif MacOS.version <= :big_sur
+    sha256 "398524660a4fab288190791f57d34262b120faf6bb19c024b438826edb0a7d28"
 
-    url "https://www.klayout.org/downloads/MacOS/ST-klayout-#{version}-macOS-Mojave-1-qt5MP-RsysPsys.dmg",
+    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-BigSur-1-qt5Brew-RsysPhb38.dmg",
         verified: "klayout.org/"
   else
-    sha256 "73641ce0c0f34bb21d43001f1f5924f60221a60458b131cb445fdf3f98c5dff5"
+    sha256 "a5047a1058a8795f06ae7b26cce417ac093eee42b0fdd6d0bac86efaf5a003f4"
 
-    url "https://www.klayout.org/downloads/MacOS/ST-klayout-#{version}-macOS-Catalina-1-qt5MP-RsysPsys.dmg",
+    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Monterey-1-qt5Brew-RsysPhb38.dmg",
         verified: "klayout.org/"
   end
 
@@ -22,7 +22,9 @@ cask "klayout" do
   name "KLayout"
   homepage "https://www.klayout.de/"
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
+  depends_on formula: "python@3.8"
+  depends_on formula: "qt@5"
 
   suite "KLayout"
 


### PR DESCRIPTION
Notes:
- This is a draft PR for a couple of reasons:
  - I have not tested anything other than Monterey even if I got the `sha256`s are correct for all 3 options.
  - This version `0.27.7` has removed support for older macOS versions and I am not sure how to deal with that.
  - The new `dmg`s available are not `qt5MP-RsysPsys` (system Ruby and system Python) but `qt5Bre-RsysPhb38` so I added some `depends_on` stanzas.
- ~~`brew audit` complains about the lack of `desc` that was already missing.~~

Formal part:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

