### PR TITLE
yu-writer: update urls and switch livecheck strategy

### DIFF
--- a/Casks/yu-writer.rb
+++ b/Casks/yu-writer.rb
@@ -1,21 +1,11 @@
 cask "yu-writer" do
-  version "0.5.3,beta"
+  version "0.5.3"
   sha256 "4fff4042c6ac7c047097c5e6d59a8a1c3f9dacfbdcadb3121904426413b38e06"
 
-  url "https://github.com/ivarptr/yu-writer.site/releases/download/v#{version.csv.first}/yu-writer-#{version.csv.second}-#{version.csv.first}-macos.dmg",
+  url "https://github.com/ivarptr/yu-writer.site/releases/download/v#{version}/yu-writer-beta-#{version}-macos.dmg",
       verified: "github.com/ivarptr/yu-writer.site"
   name "Yu Writer"
   homepage "https://ivarptr.github.io/yu-writer.site/"
-
-  livecheck do
-    url :homepage
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/yu-writer-(?:([a-z]+)-)?(\d+(?:\.\d+)*)-macos\.dmg}i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
-    end
-  end
 
   app "Yu Writer.app"
 

--- a/Casks/yu-writer.rb
+++ b/Casks/yu-writer.rb
@@ -2,10 +2,10 @@ cask "yu-writer" do
   version "0.5.3,beta"
   sha256 "4fff4042c6ac7c047097c5e6d59a8a1c3f9dacfbdcadb3121904426413b38e06"
 
-  url "https://github.com/hemashushu/yu-writer.site/releases/download/v#{version.csv.first}/yu-writer-#{version.csv.second}-#{version.csv.first}-macos.dmg",
-      verified: "github.com/hemashushu/yu-writer.site/"
+  url "https://github.com/ivarptr/yu-writer.site/releases/download/v#{version.csv.first}/yu-writer-#{version.csv.second}-#{version.csv.first}-macos.dmg",
+      verified: "github.com/ivarptr/yu-writer.site"
   name "Yu Writer"
-  homepage "https://hemashushu.github.io/yu-writer.site/"
+  homepage "https://ivarptr.github.io/yu-writer.site/"
 
   livecheck do
     url :homepage

--- a/Casks/yu-writer.rb
+++ b/Casks/yu-writer.rb
@@ -5,6 +5,7 @@ cask "yu-writer" do
   url "https://github.com/ivarptr/yu-writer.site/releases/download/v#{version}/yu-writer-beta-#{version}-macos.dmg",
       verified: "github.com/ivarptr/yu-writer.site"
   name "Yu Writer"
+  desc "Markdown editor"
   homepage "https://ivarptr.github.io/yu-writer.site/"
 
   app "Yu Writer.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

GitHub lists 0.5.3, which `homepage` links to, as pre-release, but they are all beta anyway, and it was merged like that previously, so I didn't change it.