### PR TITLE
Upgrade decrediton from 1.6.3 to 1.7.0

### DIFF
--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -1,11 +1,23 @@
 cask "decrediton" do
-  version "1.6.3"
-  sha256 "bca8e9fac99bded3cdc71bd1db1ac49c7c4a242750777189a48bd467baefbf97"
+  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
 
-  url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-v#{version}.dmg"
+  version "1.7.0"
+
+  if Hardware::CPU.intel?
+    sha256 "71600c35e284ae0c85b3b18de74977fbb241bb8c99346cd32987f167502d9037"
+  else
+    sha256 "28d2aedd3afe4781264acad2983ad12647b88d358d2238cc2ea2975c293397ce"
+  end
+
+  url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-#{arch}-v#{version}.dmg"
   name "Decrediton"
   desc "Wallet GUI for decred autonomous digital currency"
   homepage "https://github.com/decred/decrediton"
 
   app "decrediton.app"
+
+  zap trash: [
+    "~/Library/Application Support/decrediton",
+    "~/Library/Preferences/com.Electron.Decrediton.plist",
+  ]
 end


### PR DESCRIPTION
Upgraded Decrediton to 1.7.0, added arm64 support and zap trash

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
