### PR TITLE
coqide: switch livecheck strategy to avoid releases without binaries

### DIFF
--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -8,6 +8,12 @@ cask "coqide" do
   desc "Formal proof management system"
   homepage "https://coq.inria.fr/"
 
+  livecheck do
+    url "https://github.com/coq/coq/releases"
+    strategy :page_match
+    regex(/href=.*?coq[._-]?v?(\d+(?:\.\d+)+)-installer-macos\.dmg/i)
+  end
+
   depends_on macos: ">= :sierra"
 
   app "CoqIDE_#{version.major_minor_patch}.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.