### PR TITLE
Update vscode to load old version on 10.10

### DIFF
--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,7 +1,22 @@
 cask "visual-studio-code" do
   arch = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
 
-  version "1.63.2"
+  
+  if MacOS.version <= :yosemite
+    version "1.55.2"
+    if Hardware::CPU.intel?
+      sha256 "be3a1ebfac2c6c5e882714304adc518aff8bac6b663e194a9e73524c62065b94"
+    else
+      sha256 "c3621a13c9a927e99563513f95593d4d605f70a123e538681fba6d3ef6ec9dee"
+    end
+  else
+    version "1.63.2"
+    if Hardware::CPU.intel?
+      sha256 "1ef5957499ecbf92cc14fd9f49eef6251f3fc77c83babc8185c6f564a2886633"
+    else
+      sha256 "be22b8fcea0af2d2416f47fbe0cae7f8199f21ad0c3ba28402027752d4f93630"
+    end
+  end
 
   if Hardware::CPU.intel?
     sha256 "1ef5957499ecbf92cc14fd9f49eef6251f3fc77c83babc8185c6f564a2886633"

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -3,11 +3,7 @@ cask "visual-studio-code" do
 
   if MacOS.version <= :yosemite
     version "1.55.2"
-    if Hardware::CPU.intel?
-      sha256 "be3a1ebfac2c6c5e882714304adc518aff8bac6b663e194a9e73524c62065b94"
-    else
-      sha256 "c3621a13c9a927e99563513f95593d4d605f70a123e538681fba6d3ef6ec9dee"
-    end
+    sha256 "be3a1ebfac2c6c5e882714304adc518aff8bac6b663e194a9e73524c62065b94"
   else
     version "1.63.2"
     if Hardware::CPU.intel?

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,7 +1,6 @@
 cask "visual-studio-code" do
   arch = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
 
-  
   if MacOS.version <= :yosemite
     version "1.55.2"
     if Hardware::CPU.intel?
@@ -16,12 +15,6 @@ cask "visual-studio-code" do
     else
       sha256 "be22b8fcea0af2d2416f47fbe0cae7f8199f21ad0c3ba28402027752d4f93630"
     end
-  end
-
-  if Hardware::CPU.intel?
-    sha256 "1ef5957499ecbf92cc14fd9f49eef6251f3fc77c83babc8185c6f564a2886633"
-  else
-    sha256 "be22b8fcea0af2d2416f47fbe0cae7f8199f21ad0c3ba28402027752d4f93630"
   end
 
   url "https://update.code.visualstudio.com/#{version}/#{arch}/stable"


### PR DESCRIPTION
Latest VSCode requires OS X 10.11 and up, latest version that supported 10.10 was 1.55.2, this cask modifying should load correct version on specified version

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.