### PR TITLE
Update Microsoft Office apps casks to support older macOS versions

### DIFF
--- a/Casks/microsoft-auto-update.rb
+++ b/Casks/microsoft-auto-update.rb
@@ -1,7 +1,11 @@
 cask "microsoft-auto-update" do
-  version "4.43.22011101"
-  sha256 "e3f1ee36f7977f3aa52d31bae9f7ec084606fdc059514f31a7b1856914c0b507"
-
+  if MacOS.version <= :el_capitan
+    version "4.40.21101001"
+    sha256 ""
+  else
+    version "4.43.22011101"
+    sha256 "e3f1ee36f7977f3aa52d31bae9f7ec084606fdc059514f31a7b1856914c0b507"
+    
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_#{version}_Updater.pkg"
   name "Microsoft Auto Update"
   desc "Provides updates to various Microsoft products"

--- a/Casks/microsoft-auto-update.rb
+++ b/Casks/microsoft-auto-update.rb
@@ -1,11 +1,12 @@
 cask "microsoft-auto-update" do
   if MacOS.version <= :el_capitan
     version "4.40.21101001"
-    sha256 ""
+    sha256 "f638f7e0da9ee659c323f2ede0f176804bfe9a615a8f8b6320bd2e69d91ef2b2"
   else
     version "4.43.22011101"
     sha256 "e3f1ee36f7977f3aa52d31bae9f7ec084606fdc059514f31a7b1856914c0b507"
-    
+  end
+
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_#{version}_Updater.pkg"
   name "Microsoft Auto Update"
   desc "Provides updates to various Microsoft products"

--- a/Casks/microsoft-excel.rb
+++ b/Casks/microsoft-excel.rb
@@ -1,6 +1,20 @@
 cask "microsoft-excel" do
-  version "16.57.22011101"
-  sha256 "18fe5ff159ac09512926ab9a187f4cbe3d9a115a8e4591cb4efaec8f4ac4a181"
+  if MacOS.version <= :el_capitan
+    version "16.16.20101200"
+    sha256 "bdd23b696d54e5ffeb40f30a9bd7f968d2936380ab78a6eaf29d05f5fc8eb78e"
+  elsif MacOS.version <= :sierra
+    version "16.30.19101301"
+    sha256 "9886b661067f4a99de544d140980fb0f8ef2f4871baa519024781fb814a02fe5"
+  elsif MacOS.version <= :high_sierra
+    version "16.43.20110804"
+    sha256 "2711a1b8864f7474458086b4b0a56673fee0097d2049f276788c50e004c47d72"
+  elsif MacOS.version <= :mojave
+    version "16.54.21101001"
+    sha256 "e09fe9f49a36b37af3745673a385be4de9ae8ec774965fd1753f8479a775fc54"
+  else
+    version "16.57.22011101"
+    sha256 "18fe5ff159ac09512926ab9a187f4cbe3d9a115a8e4591cb4efaec8f4ac4a181"
+  end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_#{version}_Installer.pkg",
       verified: "officecdnmac.microsoft.com/"
@@ -16,7 +30,7 @@ cask "microsoft-excel" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_Excel_#{version}_Installer.pkg",
       choices: [

--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -1,6 +1,21 @@
 cask "microsoft-outlook" do
   version "16.57.22011101"
   sha256 "63dd37ee10f934abf8ee08f0baad986b9a92d3fc9d9435e4b40d20ca413d39d3"
+  if MacOS.version <= :yosemite
+    version "16.16.20101200"
+    sha256 "aafedfe466b7bf10f96fdfbf6b0f9bcf84e94a5097e5fccb3740d3d0cc666f26"
+  elsif MacOS.version <= :sierra
+    version "16.30.19101301"
+    sha256 "a131eb9ea7d0f498376f678198b27eab3139ec264a3a4d873be522ec8fe48845"
+  elsif MacOS.version <= :high_sierra
+    version "16.43.20110804"
+    sha256 ""
+  elsif MacOS.version <= :mojave
+    version "16.54.21101001"
+    sha256 ""
+  else
+    version "16.57.22011101"
+    sha256 "63dd37ee10f934abf8ee08f0baad986b9a92d3fc9d9435e4b40d20ca413d39d3"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg",
       verified: "officecdnmac.microsoft.com/"
@@ -16,7 +31,7 @@ cask "microsoft-outlook" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_Outlook_#{version}_Installer.pkg",
       choices: [

--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -1,7 +1,5 @@
 cask "microsoft-outlook" do
-  version "16.57.22011101"
-  sha256 "63dd37ee10f934abf8ee08f0baad986b9a92d3fc9d9435e4b40d20ca413d39d3"
-  if MacOS.version <= :yosemite
+  if MacOS.version <= :el_capitan
     version "16.16.20101200"
     sha256 "aafedfe466b7bf10f96fdfbf6b0f9bcf84e94a5097e5fccb3740d3d0cc666f26"
   elsif MacOS.version <= :sierra
@@ -9,10 +7,10 @@ cask "microsoft-outlook" do
     sha256 "a131eb9ea7d0f498376f678198b27eab3139ec264a3a4d873be522ec8fe48845"
   elsif MacOS.version <= :high_sierra
     version "16.43.20110804"
-    sha256 ""
+    sha256 "0e53acefafc25d1eebbf257f343de0d0a5258099c154f7ba5d99aa709fb50d08"
   elsif MacOS.version <= :mojave
     version "16.54.21101001"
-    sha256 ""
+    sha256 "c7b3ced52462b611a9762941088fa05e42d79b26349ca62b705a9bcbce00b41e"
   else
     version "16.57.22011101"
     sha256 "63dd37ee10f934abf8ee08f0baad986b9a92d3fc9d9435e4b40d20ca413d39d3"

--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -14,6 +14,7 @@ cask "microsoft-outlook" do
   else
     version "16.57.22011101"
     sha256 "63dd37ee10f934abf8ee08f0baad986b9a92d3fc9d9435e4b40d20ca413d39d3"
+  end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg",
       verified: "officecdnmac.microsoft.com/"

--- a/Casks/microsoft-powerpoint.rb
+++ b/Casks/microsoft-powerpoint.rb
@@ -1,6 +1,20 @@
 cask "microsoft-powerpoint" do
-  version "16.57.22011101"
-  sha256 "0071a45a7855e0f7053060719403c665ae31c4f1331019fab91970d0c78af50f"
+  if MacOS.version <= :el_capitan
+    version "16.16.20101200"
+    sha256 "0c898068408082124f7fe45717e3fb4b4f5647b609b54dc5fa6c90e295f499c3"
+  elsif MacOS.version <= :sierra
+    version "16.30.19101301"
+    sha256 "d0b16f96bb390a225c52808952a66f0e02bf3f355234cbe733b250d37bb44c72"
+  elsif MacOS.version <= :high_sierra
+    version "16.43.20110804"
+    sha256 "a89e0aed18e5b1e56293b1f9eaccc3e3f5089eb37a9eec64bb6f3a3fa90587eb"
+  elsif MacOS.version <= :mojave
+    version "16.54.21101001"
+    sha256 "75a57c82b46d0e2558c454f19610576b7a48baf1ccc5cd1fa61b69cca5bf0bd1"
+  else
+    version "16.57.22011101"
+    sha256 "0071a45a7855e0f7053060719403c665ae31c4f1331019fab91970d0c78af50f"
+  end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_PowerPoint_#{version}_Installer.pkg",
       verified: "officecdnmac.microsoft.com/"
@@ -16,7 +30,7 @@ cask "microsoft-powerpoint" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_PowerPoint_#{version}_Installer.pkg",
       choices: [

--- a/Casks/microsoft-word.rb
+++ b/Casks/microsoft-word.rb
@@ -10,7 +10,7 @@ cask "microsoft-word" do
     sha256 "3d957d534fb2142f6e95a688552890a31f0d942796f0128ca837a3e98405d413"
   elsif MacOS.version <= :mojave
     version "16.54.21101001"
-    sha256 ""
+    sha256 "7f3ed397b517aac3637d8b8f8b4233f9e7132941f0657eaca8ec423ac068616e"
   else
     version "16.57.22011101"
     sha256 "b47b5ef70336e0f591583ac52d895ea57ab81ad870737734aedfe05ffac239d1"

--- a/Casks/microsoft-word.rb
+++ b/Casks/microsoft-word.rb
@@ -1,6 +1,20 @@
 cask "microsoft-word" do
-  version "16.57.22011101"
-  sha256 "b47b5ef70336e0f591583ac52d895ea57ab81ad870737734aedfe05ffac239d1"
+  if MacOS.version <= :el_capitan
+    version "16.16.20101200"
+    sha256 "0c61b7db7a6a13653270795c085a909aa54668e8de2f2ca749257ce6aa5957d1"
+  elsif MacOS.version <= :sierra
+    version "16.30.19101301"
+    sha256 "6abd7939b0d935023ebb8fabeb206c4cbbe8eb8f9a3ff7d318448d2ba5f332e4"
+  elsif MacOS.version <= :high_sierra
+    version "16.43.20110804"
+    sha256 "3d957d534fb2142f6e95a688552890a31f0d942796f0128ca837a3e98405d413"
+  elsif MacOS.version <= :mojave
+    version "16.54.21101001"
+    sha256 ""
+  else
+    version "16.57.22011101"
+    sha256 "b47b5ef70336e0f591583ac52d895ea57ab81ad870737734aedfe05ffac239d1"
+  end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Word_#{version}_Installer.pkg",
       verified: "officecdnmac.microsoft.com/"
@@ -16,7 +30,7 @@ cask "microsoft-word" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_Word_#{version}_Installer.pkg",
       choices: [


### PR DESCRIPTION
Should load 16.16 on Yosemite and El Capitan (which, however, is Office 2016 and maybe can be not suitable here, if that, let me know in the comments), 16.30 on Sierra, 16.43 on High Sierra, 16.54 on Mojave and 16.57 on Catalina and up.

Auto updater should be 4.40 on Yosemite and El Capitan, 4.43 on Sierra and up.

---
To-Do:
- [x] Update Microsoft Outlook cask to support 10.10, 10.12, 10.13, 10.14, 10.15 and up
- [x] Update MAU cask to support 10.10, 10.12 and up
- [x] Update Microsoft Word cask to support 10.10, 10.12, 10.13, 10.14, 10.15 and up
- [x] Update Microsoft Excel cask to support 10.10, 10.12, 10.13, 10.14, 10.15 and up
- [x] Update Microsoft PowerPoint cask to support 10.10, 10.12, 10.13, 10.14, 10.15 and up

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
