### PR TITLE
chronoagent: fix livecheck with Timeout::Error

### DIFF
--- a/Casks/chronoagent.rb
+++ b/Casks/chronoagent.rb
@@ -8,8 +8,8 @@ cask "chronoagent" do
   homepage "https://www.econtechnologies.com/"
 
   livecheck do
-    url "https://www.econtechnologies.com/chronoagent/whats-new.html"
-    regex(/>\s*Version:?\s*(\d+(?:\.\d+)+)\s*</i)
+    url "https://www.econtechnologies.com/downloads/downloads.html"
+    regex(/>\s*ChronoAgent.*?Version\s+(\d+(?:\.\d+)+)[\s<]+/i)
   end
 
   pkg "Install.pkg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.