### PR TITLE
Revert "Update pycharm-ce from 2021.3.1 to 2021.3.2 (#118337)"

### DIFF
--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -1,12 +1,12 @@
 cask "pycharm-ce" do
   arch = Hardware::CPU.intel? ? "" : "-aarch64"
 
-  version "2021.3.2,213.6777.50"
+  version "2021.3.1,213.6461.77"
 
   if Hardware::CPU.intel?
-    sha256 "2153f488fbd77123e379642c603045f26a2137245f52ee9d8b588c0c388a6f23"
+    sha256 "aec1cb259c1418adfb864118ca6fc1df8ac845478c19e1f742aaa54e111638f4"
   else
-    sha256 "567db4a722703fd44343e5fda1240bddd5ff62f2a5aa73ac4ee811425ef13bcd"
+    sha256 "0eef9121c16bc2bce32ae6d4d2b1ab788977e0d2044efdee1ec0904942dfa1f9"
   end
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version.csv.first}#{arch}.dmg"


### PR DESCRIPTION
This reverts commit 8497eed5cc47d8fa6fefd7659cbd724b2999aa7a.

JetBrains' download page lists 2021.3.1 as the current version, as of 30 Jan 2022 02:22:30 UTC.

Fixes https://github.com/Homebrew/homebrew-core/issues/94051.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
