### PR TITLE
Fix sha256 mismatch on suspicious-package

### DIFF
--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -2,19 +2,19 @@ cask "suspicious-package" do
   if MacOS.version <= :yosemite
     version "3.2"
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-    sha256 "770db2942eb5132f3da5b064ce4471fa6e7aba75e46d6b91d7b10f620f81cce0"
+    sha256 "b8b038663f071ad55ea21ccf3a8aa09ae54a1bd1586a803e7e5413a1a3fecaae"
   elsif MacOS.version <= :sierra
     version "3.4.1"
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-    sha256 "a9c4da2cfe4a8f116594eb327d8d8754d47037c62f41bd81bd4f427307efe032"
+    sha256 "e4673a0c590e7dcb711789d98fcadd2283c2152d262b7809dfd8c8a1b3e9094b"
   elsif MacOS.version <= :high_sierra
     version "3.5.3"
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-    sha256 "2177e278cb8046c2151e72bb066822b6ed4e5e5b7e601643a3423360e3531b1d"
+    sha256 "fad69db99a60058f8136954653fa2de81667f12cb731957a6d921d36ceaf195d"
   elsif MacOS.version <= :mojave
     version "4.0"
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-    sha256 "b224c8e4625ff818cc17e38cf001b9097f77d70938709e14e4ba598ba74a66c4"
+    sha256 "844708fb75f8aa102f3ede8ddef3c20180f469b7bc8ec65bbc0370ce9f7db33c"
   else
     version "4.1,880"
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage.dmg"


### PR DESCRIPTION
Looks like I specified incorrect checksums, as I tried installing suspicious-package via homebrew after update, it showed me an sha256 mismatch error, now it should work as intended.

```
$ brew install --cask suspicious-package
==> Downloading https://www.mothersruin.com/software/downloads/SuspiciousPackage-4.0.dmg
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: b224c8e4625ff818cc17e38cf001b9097f77d70938709e14e4ba598ba74a66c4
  Actual: 844708fb75f8aa102f3ede8ddef3c20180f469b7bc8ec65bbc0370ce9f7db33c
    File: /Users/whitebear60/Library/Caches/Homebrew/downloads/eb12722d934dfcedc2f94916204410127159259a2eab2fecaf638131f69b789d--SuspiciousPackage-4.0.dmg
To retry an incomplete download, remove the file above.
```