### PR TITLE
bonitastudiocommunity: fix livecheck

### DIFF
--- a/Casks/bonitastudiocommunity.rb
+++ b/Casks/bonitastudiocommunity.rb
@@ -9,9 +9,9 @@ cask "bonitastudiocommunity" do
   homepage "https://www.bonitasoft.com/downloads"
 
   livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+(?:[a-z\d_-]+))["' >]}i)
+    url "https://go.bonitasoft.com/l/148721/2021-09-24/5rq47g"
+    strategy :header_match
+    regex(/filename=BonitaStudioCommunity[._-]v?(\d+(?:\.\d+)+(?:[a-z\d_-]+))[._-]x86_64\.dmg/i)
   end
 
   installer script: {


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

The latest version as per `homepage` is no longer available on GitHub. `livecheck` currently says `Unable to get versions` but would be presenting an outdated version if it kept checking GitHub. The new `livecheck` `url` (taken from `homepage`) seemed to be the same prior to the latest version bump, if I didn't get confused among the multiple archive.org tabs.