### PR TITLE
Update qtspim from 9.1.21 to 9.1.23

### DIFF
--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -10,7 +10,7 @@ cask "qtspim" do
 
   livecheck do
     url "https://sourceforge.net/projects/spimsimulator/files/"
-    regex(/QtSpim_(\d+\.\d+\.\d+)_mac\.(?:mpkg|pkg)(?:\.zip)?/i)
+    regex(/QtSpim[._-]v?(\d+\.\d+\.\d+)[._-]mac\.(?:mpkg|pkg)(?:\.zip)?/i)
   end
 
   pkg "QtSpim.mpkg/Contents/Packages/QtSpim.pkg"

--- a/Casks/qtspim.rb
+++ b/Casks/qtspim.rb
@@ -1,8 +1,8 @@
 cask "qtspim" do
-  version "9.1.21"
-  sha256 "14fea7dd17e01c01820c9a52dfe577f764765ca7c4e9f7e99881e8badbe04595"
+  version "9.1.23"
+  sha256 "3e5bc9ec15169483cbb51eb4de7687bbad025cabfcab65883f5c6ed7434ecb61"
 
-  url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.pkg",
+  url "https://downloads.sourceforge.net/spimsimulator/QtSpim_#{version}_mac.mpkg.zip",
       verified: "downloads.sourceforge.net/spimsimulator/"
   name "QtSpim"
   desc "Simulator that runs MIPS32 assembly language programs"
@@ -10,10 +10,10 @@ cask "qtspim" do
 
   livecheck do
     url "https://sourceforge.net/projects/spimsimulator/files/"
-    regex(/QtSpim[._-]?(\d+(?:\.\d+)*)[._-]?mac\.pkg/i)
+    regex(/QtSpim_(\d+\.\d+\.\d+)_mac\.(?:mpkg|pkg)(?:\.zip)?/i)
   end
 
-  pkg "QtSpim_#{version}_mac.pkg"
+  pkg "QtSpim.mpkg/Contents/Packages/QtSpim.pkg"
 
   uninstall pkgutil: "org.larusstone.pkg.QtSpim"
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, because of changes to `pkg` and `livecheck`:

- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew livecheck --debug <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
