### PR TITLE
Upgrade surge-xt to 1.0.1

### DIFF
--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -1,6 +1,6 @@
 cask "surge-xt" do
-  version "1.0.0"
-  sha256 "d0a481745e7526b02ba41267be9bf61a90377f0fed80ffcebc655777cd9c5a4f"
+  version "1.0.1"
+  sha256 "644efd84e2a8c62e6211f3d1c1311c8f5a0386c6e91d69c5a37e5a1aaebc504a"
 
   url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
       verified: "github.com/surge-synthesizer/releases-xt/"


### PR DESCRIPTION
Today we did a small point release to fix a few early bugs
and have upgraded surge-xt to 1.0.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
