### PR TITLE
platypus: revert livecheck strategy switch

### DIFF
--- a/Casks/platypus.rb
+++ b/Casks/platypus.rb
@@ -1,5 +1,5 @@
 cask "platypus" do
-  version "5.3"
+  version "5.3,1113"
   sha256 "efc66e943e6327896d0c1b82b0c1798c9ea17cffa03581e4949541c30d9833b0"
 
   url "https://sveinbjorn.org/files/software/platypus/platypus#{version.csv.first}.zip"
@@ -8,7 +8,8 @@ cask "platypus" do
   homepage "https://sveinbjorn.org/platypus"
 
   livecheck do
-    url "https://github.com/sveinbjornt/Platypus"
+    url "https://sveinbjorn.org/files/appcasts/PlatypusAppcast.xml"
+    strategy :sparkle
   end
 
   auto_updates true
@@ -16,8 +17,8 @@ cask "platypus" do
   app "Platypus.app"
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.sveinbjorn.platypus.sfl2",
     "~/Library/Application Support/Platypus",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.sveinbjorn.platypus.sfl2",
     "~/Library/Caches/org.sveinbjorn.Platypus",
     "~/Library/Preferences/org.sveinbjorn.Platypus.plist",
   ]

--- a/Casks/platypus.rb
+++ b/Casks/platypus.rb
@@ -17,8 +17,8 @@ cask "platypus" do
   app "Platypus.app"
 
   zap trash: [
-    "~/Library/Application Support/Platypus",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.sveinbjorn.platypus.sfl2",
+    "~/Library/Application Support/Platypus",
     "~/Library/Caches/org.sveinbjorn.Platypus",
     "~/Library/Preferences/org.sveinbjorn.Platypus.plist",
   ]


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Sparkle file is back online.