### PR TITLE
dbschema: undo checksumming, still updated in-place

### DIFF
--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -1,6 +1,6 @@
 cask "dbschema" do
   version "8.5.0"
-  sha256 "265eaee98e233ff672566c711fa43c0fae5491a55116e7644c3c734ae477dfba"
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.dbschema.com/download/DbSchema_macos_#{version.dots_to_underscores}.tgz"
   name "DbSchema"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.