### PR TITLE
Update ableton-live from 11.0.12 to 11.1

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,8 +1,14 @@
 cask "ableton-live-intro" do
-  version "11.0.12"
-  sha256 "0847be19873fcb7d5f40f706b365b90b7a2e3c09df31cfff4b5a8416c8dd1cc8"
+  arch = MacOS.version >= :mojave ? "universal" : "intel"
+  version "11.1"
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_64.dmg"
+  if MacOS.version >= :mojave
+    sha256 "f581b9e36b655b00f922616b940831cac9b7a84c1247d630a229822bbad21bbf"
+  else
+    sha256 "91064b1551ded54c841d61d8f30a538c6f2f177d1caf2a39f823ea952093f38e"
+  end
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_#{arch}.dmg"
   name "Ableton Live Intro"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,8 +1,14 @@
 cask "ableton-live-lite" do
-  version "11.0.12"
-  sha256 "184aa95440aa154425e7c3f9e84a916ef34b44fdd67a9b5d408bcc2e908b84ab"
+  arch = MacOS.version >= :mojave ? "universal" : "intel"
+  version "11.1"
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_64.dmg"
+  if MacOS.version >= :mojave
+    sha256 "b02982b0e32aa3bb792c81d163bf9e238ef7b5ed4ca263e5e826d6617e79c29d"
+  else
+    sha256 "023422eed26c159c3b67a3e9e520428702ce7dea0b687b00c795823d408e1d2c"
+  end
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_#{arch}.dmg"
   name "Ableton Live Lite"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/products/live-lite/"

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,8 +1,14 @@
 cask "ableton-live-standard" do
-  version "11.0.12"
-  sha256 "5195d68cbc0fc926bfd8c293d1bee7566eac4ae5b4af1fbb195e84945dcea838"
+  arch = MacOS.version >= :mojave ? "universal" : "intel"
+  version "11.1"
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_64.dmg"
+  if MacOS.version >= :mojave
+    sha256 "0f7589cbca877b0ba7233c36c0c8a0f1b6360221fe9cc2da3ad2425a1bebee59"
+  else
+    sha256 "1da2aeb846cd75c7ee7a98a62b61eaf6cf4f8adddd1dec0b9abf392b4ab23f44"
+  end
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_#{arch}.dmg"
   name "Ableton Live Standard"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,8 +1,14 @@
 cask "ableton-live-suite" do
-  version "11.0.12"
-  sha256 "291b277b42485d5b4ce959883b0600d7dbb7743056eac5007e3c73237672c9ea"
+  arch = MacOS.version >= :mojave ? "universal" : "intel"
+  version "11.1"
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_64.dmg"
+  if MacOS.version >= :mojave
+    sha256 "3712379f7e1d8ef163cbc3d6e31564046584a01f117b529552b93bc104f6be4f"
+  else
+    sha256 "0e1779d22c087993a4e5f11f9f2a83a429dccfafa92c5e7aa05c87219de39c90"
+  end
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_#{arch}.dmg"
   name "Ableton Live Suite"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"


### PR DESCRIPTION
Includes:
 * ableton-live-intro
 * ableton-live-lite
 * ableton-live-standard
 * ableton-live-suite

The download is split by macOS version and architecture as per the [installation notes](https://help.ableton.com/hc/en-us/articles/4415259263250) (universal for >= Mojave; intel otherwise).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.