### PR TITLE
Add Polypane v8.0.0

### DIFF
--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -8,10 +8,6 @@ cask "polypane" do
   desc "Browser for ambitious developers"
   homepage "https://polypane.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
   app "Polypane.app"
 
   zap trash: [

--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -1,9 +1,16 @@
 cask "polypane" do
-  version "8.0.0"
-  sha256 "4faac4a9b9fbb8c3805ee890809394fe92ee9aed326cf98557b33803fd83fc92"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  url "https://github.com/firstversionist/polypane/releases/download/v#{version}/Polypane-#{version}-universal.dmg",
-      verified: "github.com/firstversionist/polypane"
+  version "8.0.0"
+
+  if Hardware::CPU.intel?
+    sha256 "5c8cfa59f24e9fc8e3c54b43a2fca62644fadc6a6b7fa34ebaa986ee8cc5babc"
+  else
+    sha256 "f6626a6777cdf0e0e7e34f30521ad54fadd6393f73fd3d04fe971ba3d8103f18"
+  end
+
+  url "https://github.com/firstversionist/polypane/releases/download/v#{version}/Polypane-v#{version}#{arch}.dmg",
+      verified: "github.com/firstversionist/polypane/"
   name "Polypane"
   desc "Browser for ambitious developers"
   homepage "https://polypane.app/"
@@ -12,8 +19,8 @@ cask "polypane" do
 
   zap trash: [
     "~/Library/Application Support/Polypane",
-    "~/Library/Caches/com.firstversionist.polypane",
     "~/Library/Caches/com.firstversionist.polypane.ShipIt",
+    "~/Library/Caches/com.firstversionist.polypane",
     "~/Library/Logs/Polypane",
     "~/Library/Preferences/com.firstversionist.polypane.plist",
     "~/Library/Saved Application State/com.firstversionist.polypane.savedState",

--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -9,7 +9,7 @@ cask "polypane" do
     sha256 "f6626a6777cdf0e0e7e34f30521ad54fadd6393f73fd3d04fe971ba3d8103f18"
   end
 
-  url "https://github.com/firstversionist/polypane/releases/download/v#{version}/Polypane-v#{version}#{arch}.dmg",
+  url "https://github.com/firstversionist/polypane/releases/download/v#{version}/Polypane-#{version}#{arch}.dmg",
       verified: "github.com/firstversionist/polypane/"
   name "Polypane"
   desc "Browser for ambitious developers"

--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -1,0 +1,21 @@
+cask "polypane" do
+  version "8.0.0"
+  sha256 "4faac4a9b9fbb8c3805ee890809394fe92ee9aed326cf98557b33803fd83fc92"
+
+  url "https://github.com/firstversionist/polypane/releases/download/v#{version}/Polypane-#{version}-universal.dmg",
+      verified: "github.com/firstversionist/polypane"
+  name "Polypane"
+  desc "Browser for ambitious developers"
+  homepage "https://polypane.app/"
+
+  app "Polypane.app"
+
+  zap trash: [
+    "~/Library/Application Support/Polypane",
+    "~/Library/Caches/com.firstversionist.polypane",
+    "~/Library/Caches/com.firstversionist.polypane.ShipIt",
+    "~/Library/Logs/Polypane",
+    "~/Library/Preferences/com.firstversionist.polypane.plist",
+    "~/Library/Saved Application State/com.firstversionist.polypane.savedState",
+  ]
+end

--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -7,12 +7,12 @@ cask "polypane" do
   name "Polypane"
   desc "Browser for ambitious developers"
   homepage "https://polypane.app/"
-  app "Polypane.app"
 
   livecheck do
     url :url
     strategy :github_latest
   end
+  app "Polypane.app"
 
   zap trash: [
     "~/Library/Application Support/Polypane",

--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -7,8 +7,12 @@ cask "polypane" do
   name "Polypane"
   desc "Browser for ambitious developers"
   homepage "https://polypane.app/"
-
   app "Polypane.app"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   zap trash: [
     "~/Library/Application Support/Polypane",


### PR DESCRIPTION
Hi there,

This PR adds [Polypane](https://polypane.app) v8.0.0.

`brew audit --cask polypane` currently fails because the [GitHub repository](https://github.com/firstversionist/polypane/) is not notable enough.


```
GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

Nevertheless, I believe this falls under the _Exceptions to the Notability Threshold_ category, section 1:

> A popular app that has their own website but the developers use GitHub for hosting the binaries. That repository won’t be notable but the app may be.

Best regards.

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask polypane` is error-free.
- [x] `brew style --fix polypane` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask polypane` worked successfully.
- [x] `brew install --cask polypane` worked successfully.
- [x] `brew uninstall --cask polypane` worked successfully.
