### PR TITLE
sdm: switch livecheck strategy + use sha256

### DIFF
--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -1,15 +1,20 @@
 cask "sdm" do
-  version "15.45.0"
-  sha256 :no_check
+  version "15.45.0,D6A5C8C512E194970DEC7F47B7C4CD7B6FC31676"
+  sha256 "45fc1b07ca923dee4184579badee901c6b50dead615954a4c66881720c8f11aa"
 
-  url "https://app.strongdm.com/downloads/client/darwin"
+  url "https://sdm-releases-production.s3.amazonaws.com/builds/sdm-gui/#{version.csv.first}/darwin/#{version.csv.second}/SDM-#{version.csv.first}.zip"
   name "sdm"
   desc "Strongdm client"
   homepage "https://www.strongdm.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://app.strongdm.com/releases/client/darwin/0.0.0"
+    strategy :page_match do |page|
+      match = page.match(%r{https:.*?/(\h+)/SDM[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
+    end
   end
 
   app "SDM.app"

--- a/Casks/sdm.rb
+++ b/Casks/sdm.rb
@@ -2,7 +2,8 @@ cask "sdm" do
   version "15.45.0,D6A5C8C512E194970DEC7F47B7C4CD7B6FC31676"
   sha256 "45fc1b07ca923dee4184579badee901c6b50dead615954a4c66881720c8f11aa"
 
-  url "https://sdm-releases-production.s3.amazonaws.com/builds/sdm-gui/#{version.csv.first}/darwin/#{version.csv.second}/SDM-#{version.csv.first}.zip"
+  url "https://sdm-releases-production.s3.amazonaws.com/builds/sdm-gui/#{version.csv.first}/darwin/#{version.csv.second}/SDM-#{version.csv.first}.zip",
+      verified: "sdm-releases-production.s3.amazonaws.com/builds/sdm-gui/"
   name "sdm"
   desc "Strongdm client"
   homepage "https://www.strongdm.com/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

Many thanks to @jmccarthy for working with me on this!