### PR TITLE
Update eloston-chromium from 97.0.4692.99-1.1 to 98.0.4758.80-1.1 (x86-64)

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -2,8 +2,8 @@ cask "eloston-chromium" do
   arch = Hardware::CPU.intel? ? "x86-64" : "arm64"
 
   if Hardware::CPU.intel?
-    version "97.0.4692.99-1.1,1642829547"
-    sha256 "cb62374873c04497b2e257cec8fa81565d8147311ddfda13f552acac8ec747f3"
+    version "98.0.4758.80-1.1,1643761345"
+    sha256 "5900644b3bdfcbe8f5c158a85afa9988e440e36ef209bdf337e431434ffe7568"
   else
     version "97.0.4692.99-1.1,1642868666"
     sha256 "790164b7b166c22fad1e830523e6eb3abc41b54b57ce8c7c8ca2a5dfbe5ca282"


### PR DESCRIPTION


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.