### PR TITLE
kitty: zap ~/.config/kitty

### DIFF
--- a/Casks/kitty.rb
+++ b/Casks/kitty.rb
@@ -22,6 +22,7 @@ cask "kitty" do
   end
 
   zap trash: [
+    "~/.config/kitty",
     "~/Library/Caches/kitty",
     "~/Library/Preferences/kitty",
     "~/Library/Preferences/net.kovidgoyal.kitty.plist",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.