### PR TITLE
Update OpenAudible from 3.3 -> 3.4.1

### DIFF
--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -1,6 +1,13 @@
 cask "openaudible" do
-  version "3.3"
-  sha256 "4c59d640368b605f5abe2ef907bfe2faa3d69e64ae5b615c9f25c6e8be614c89"
+  arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
+
+  version "3.4.1"
+
+  if Hardware::CPU.intel?
+    sha256 "27a6785dbef62f16bfe20894fe3c09f1ae11f84ef75113a36ded9d074fc1e9b4"
+  else
+    sha256 "b7389a6f1f6cae5a72e76f3e5598cbd3b048fdfdec9b5fea03738fe1a3b59e8a"
+  end
 
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}.dmg",
       verified: "github.com/openaudible/"


### PR DESCRIPTION
Update from 3.3 -> 3.4.1, including adding support for aarch64 releases.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
