### PR TITLE
update kindaVim to 1b25

### DIFF
--- a/Casks/kindavim.rb
+++ b/Casks/kindavim.rb
@@ -1,5 +1,5 @@
 cask "kindavim" do
-  version "1b24,0.9.24"
+  version "1b25,0.9.25"
   sha256 :no_check
 
   url "https://kindavim.app/releases/kindaVim.zip"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
