### PR TITLE
Point Duplicati `livecheck` to homepage

### DIFF
--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -9,15 +9,8 @@ cask "duplicati" do
   homepage "https://www.duplicati.com/"
 
   livecheck do
-    url :url
-    strategy :git do |tags|
-      tags.map do |tag|
-        match = tag.match(/^v(\d+(?:\.\d+)+)-(?:\d+(?:\.\d+)+)_(beta|canary|experimental)_(\d+(?:-\d+)*)$/i)
-        next if match.blank?
-
-        "#{match[1]},#{match[2]},#{match[3]}" if match
-      end.compact
-    end
+    url "https://updates.duplicati.com/beta/latest-installers.js"
+    regex(%r{^\s+"name":\s+"duplicati-(.*)\.dmg",$}i)
   end
 
   depends_on formula: "mono"

--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -9,7 +9,7 @@ cask "duplicati" do
 
   livecheck do
     url "https://updates.duplicati.com/beta/latest-installers.js"
-    regex(%r{^\s+"name":\s+"duplicati-(.*)\.dmg",$}i)
+    regex(/^\s+"name":\s+"duplicati-(.*)\.dmg",$/i)
   end
 
   depends_on formula: "mono"

--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -1,9 +1,8 @@
 cask "duplicati" do
-  version "2.0.6.100,canary,2021-08-11"
-  sha256 "434cdedbd15b3562cf943b55114515b7b00bdaa1cccf06ea22b9f625bd3f0a02"
+  version "2.0.6.3_beta_2021-06-17"
+  sha256 "7a26fd69b7016e88a23ff03474eb78e174da463c4967b90c0b54f07a94027e18"
 
-  url "https://github.com/duplicati/duplicati/releases/download/v#{version.csv.first}-#{version.csv.first}_#{version.csv.second}_#{version.csv.third}/duplicati-#{version.csv.first}_#{version.csv.second}_#{version.csv.third}.dmg",
-      verified: "github.com/duplicati/duplicati/"
+  url "https://updates.duplicati.com/beta/duplicati-#{version}.dmg"
   name "Duplicati"
   desc "Store securely encrypted backups in the cloud"
   homepage "https://www.duplicati.com/"

--- a/Casks/duplicati.rb
+++ b/Casks/duplicati.rb
@@ -9,7 +9,7 @@ cask "duplicati" do
 
   livecheck do
     url "https://updates.duplicati.com/beta/latest-installers.js"
-    regex(/^\s+"name":\s+"duplicati-(.*)\.dmg",$/i)
+    regex(/^\s+"name":\s+"duplicati[._-]v?(.+)\.dmg",$/i)
   end
 
   depends_on formula: "mono"


### PR DESCRIPTION
Closes #118671 

[Duplicati's download page](https://www.duplicati.com/download) is populated client-side from https://updates.duplicati.com/beta/latest-installers.js, which is a build artifact containing the download locations for each distribution. Duplicati's supported "stable" version is their beta release as documented in the linked issue.

This updates the `livecheck` to use a regex to find the named `dmg` package and exact the full version slug.

Due to the extent of the change, I tested locally with `livecheck`, `fetch`, `install`, & `uninstall`.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- ~Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).~
- ~Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).~
- ~Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask)~
- ~`brew audit --new-cask <cask>` worked successfully.~
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
