### PR TITLE
webex: Enable autoupdate

### DIFF
--- a/Casks/webex.rb
+++ b/Casks/webex.rb
@@ -14,6 +14,8 @@ cask "webex" do
     strategy :extract_plist
   end
 
+  auto_updates true
+
   app "Webex.app"
 
   uninstall signal: ["TERM", "Cisco-Systems.Spark"]


### PR DESCRIPTION
Webex does auto updates and may update to a version later than what is
available publicly when the user is on a pre-release channel.

This prevents brew from accidentally downgrading Webex in these cases.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
