### PR TITLE
jdownloader: switch to versioning, add desc+livecheck+auto_updates

### DIFF
--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -1,11 +1,16 @@
 cask "jdownloader" do
-  version :latest
+  version "45328"
   sha256 :no_check
 
   url "http://installer.jdownloader.org/clean/JD2Setup.dmg",
       user_agent: :fake
   name "JDownloader"
   homepage "https://jdownloader.org/"
+
+  livecheck do
+    url "https://svn.jdownloader.org/build.php"
+    regex(/Revision:.*?(\d+)[\s<]/i)
+  end
 
   preflight do
     system_command "#{staged_path}/JDownloader Installer.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -5,6 +5,7 @@ cask "jdownloader" do
   url "http://installer.jdownloader.org/clean/JD2Setup.dmg",
       user_agent: :fake
   name "JDownloader"
+  desc "Download manager"
   homepage "https://jdownloader.org/"
 
   livecheck do

--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -12,6 +12,8 @@ cask "jdownloader" do
     regex(/Revision:.*?(\d+)[\s<]/i)
   end
 
+  auto_updates true
+
   preflight do
     system_command "#{staged_path}/JDownloader Installer.app/Contents/MacOS/JavaApplicationStub",
                    args:         [


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Addresses https://github.com/Homebrew/homebrew-cask/issues/118720.