### PR TITLE
Update MediaElch from 2.8.12 to 2.8.14

### DIFF
--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,6 +1,6 @@
 cask "mediaelch" do
   version "2.8.14,2022-02-06,84e18bb2"
-  sha256 "a849c3b2e152776a7c60e17f58941c7ac11db362c19e2c64ec8f3d10e3182243"
+  sha256 "df4ec3bc87919924517d2fb3f34ec680047cddbae550282905d63d8eaf28221f"
   url "https://github.com/Komet/MediaElch/releases/download/v#{version.csv.first}/MediaElch_macOS_#{version.csv.first}_#{version.csv.second}_git-#{version.csv.third}.dmg",
       verified: "github.com/Komet/MediaElch/"
   name "MediaElch"

--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,8 +1,7 @@
 cask "mediaelch" do
-  version "2.8.12,2021-05-10_06-33,08ebf8c0"
-  sha256 "75390642ca0228d2f0086fd99363ec9d9708aafc92aaa8b01f1acd1f2f8e7465"
-
-  url "https://github.com/Komet/MediaElch/releases/download/v#{version.csv.first}/MediaElch_macOS_#{version.csv.first}_#{version.csv.second}_git-master-#{version.csv.third}.dmg",
+  version "2.8.14,2022-02-06,84e18bb"
+  sha256 "a849c3b2e152776a7c60e17f58941c7ac11db362c19e2c64ec8f3d10e3182243"
+  url "https://github.com/Komet/MediaElch/releases/download/v#{version.csv.first}/MediaElch_macOS_#{version.csv.first}_#{version.csv.second}_git-#{version.csv.third}.dmg",
       verified: "github.com/Komet/MediaElch/"
   name "MediaElch"
   desc "Media Manager for Kodi"
@@ -10,7 +9,7 @@ cask "mediaelch" do
 
   livecheck do
     url "https://github.com/Komet/MediaElch/releases/latest"
-    regex(%r{href=.*?/MediaElch_macOS_(\d+(?:\.\d+)*)_(\d+(?:.\d+)*)_git-master-([^/]*?)\.dmg}i)
+    regex(%r{href=.*?/MediaElch_macOS_(\d+(?:\.\d+)*)_(\d+(?:.\d+)*)_git-([^/]*?)\.dmg}i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?

--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,5 +1,5 @@
 cask "mediaelch" do
-  version "2.8.14,2022-02-06,84e18bb"
+  version "2.8.14,2022-02-06,84e18bb2"
   sha256 "a849c3b2e152776a7c60e17f58941c7ac11db362c19e2c64ec8f3d10e3182243"
   url "https://github.com/Komet/MediaElch/releases/download/v#{version.csv.first}/MediaElch_macOS_#{version.csv.first}_#{version.csv.second}_git-#{version.csv.third}.dmg",
       verified: "github.com/Komet/MediaElch/"

--- a/Casks/mediaelch.rb
+++ b/Casks/mediaelch.rb
@@ -1,6 +1,7 @@
 cask "mediaelch" do
   version "2.8.14,2022-02-06,84e18bb2"
   sha256 "df4ec3bc87919924517d2fb3f34ec680047cddbae550282905d63d8eaf28221f"
+
   url "https://github.com/Komet/MediaElch/releases/download/v#{version.csv.first}/MediaElch_macOS_#{version.csv.first}_#{version.csv.second}_git-#{version.csv.third}.dmg",
       verified: "github.com/Komet/MediaElch/"
   name "MediaElch"


### PR DESCRIPTION
This commit updates MediaElch to the latest release.
Furthermore, it updates the livecheck as the version name pattern was updated.
The previous release v2.8.12 mistakenly had the git branch name in it (this was not intended).

---------------

Notes: I personally do not use Homebrew but am the maintainer of MediaElch. I therefore didn't check the last two necessary check-boxes.

If this PR is not welcome, please let me know.

However, it would be awesome if somebody could run `brew audit --cask mediaelch` as well as `brew style --fix mediaelch`.

--------------

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
