### PR TITLE
Update fastrawviewer from 2.0.2.1891 to 2.0.3.1902

### DIFF
--- a/Casks/fastrawviewer.rb
+++ b/Casks/fastrawviewer.rb
@@ -1,6 +1,6 @@
 cask "fastrawviewer" do
-  version "2.0.2.1891"
-  sha256 "a26a384659e881f189f6e761adb1eb731b62707b4e096ca80fed932393c80dfe"
+  version "2.0.3.1902"
+  sha256 "56ff931453b0cd591ec7d31c438d29389642928f09ce147f0447e23d9ba6e25d"
 
   url "https://updates.fastrawviewer.com/data/FastRawViewer-#{version}.dmg"
   name "FastRawViewer"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.