### PR TITLE
Remove `livecheck` block from discontinued casks

### DIFF
--- a/Casks/coda.rb
+++ b/Casks/coda.rb
@@ -7,11 +7,6 @@ cask "coda" do
   desc "Text editor"
   homepage "https://panic.com/coda/"
 
-  livecheck do
-    url "https://www.panic.com/updates/update.php?appName=Coda%202&appVersion=1"
-    strategy :sparkle
-  end
-
   auto_updates true
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/hookshot.rb
+++ b/Casks/hookshot.rb
@@ -7,11 +7,6 @@ cask "hookshot" do
   desc "Window snapping tool"
   homepage "https://hookshot.app/"
 
-  livecheck do
-    url "https://hookshot.app/downloads/updates.xml"
-    strategy :sparkle
-  end
-
   auto_updates true
   depends_on macos: ">= :sierra"
 

--- a/Casks/samsung-dex.rb
+++ b/Casks/samsung-dex.rb
@@ -7,12 +7,6 @@ cask "samsung-dex" do
   desc "Extend some Samsung devices into a desktop-like experience"
   homepage "https://www.samsung.com/us/explore/dex/"
 
-  livecheck do
-    url "https://org.downloadcenter.samsung.com/downloadfile/ContentsFile.aspx?CDSite=COMMON&CttFileID=8385137"
-    strategy :header_match
-    regex(%r{(\d+)/SamsungDeXSetupMac\.dmg}i)
-  end
-
   pkg "Install Samsung DeX.pkg"
 
   uninstall pkgutil: [

--- a/Casks/tn3270-x.rb
+++ b/Casks/tn3270-x.rb
@@ -7,11 +7,6 @@ cask "tn3270-x" do
   desc "Terminal emulator for connecting to computers which use IBM 3270 terminal"
   homepage "https://www.brown.edu/cis/tn3270/index.html"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/tn3270_X_(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   depends_on macos: "<= :mojave"
 
   app "tn3270 X.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes `livecheck` blocks from discontinued casks, so they will be automatically skipped. Ideally, this should be done when `discontinued` is added to a cask but I understand that it's easy to overlook or forget.