### PR TITLE
spectacle: fix url

### DIFF
--- a/Casks/spectacle.rb
+++ b/Casks/spectacle.rb
@@ -2,8 +2,8 @@ cask "spectacle" do
   version "1.2,672"
   sha256 "766d5bf3b404ec567110a25de1d221290bc829302283b28ed0fbe73b9557f30c"
 
-  url "https://spectacle.s3.amazonaws.com/downloads/Spectacle+#{version.csv.first}.zip",
-      verified: "spectacle.s3.amazonaws.com/"
+  url "https://github.com/eczarny/spectacle/releases/download/#{version.csv.first}/Spectacle+#{version.csv.first}.zip",
+      verified: "github.com/eczarny/spectacle/"
   name "Spectacle"
   desc "Move and resize windows with ease"
   homepage "https://www.spectacleapp.com/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Fixes https://github.com/Homebrew/homebrew-cask/issues/118799.