### PR TITLE
hoststool: various updates and rename to hostsx

### DIFF
--- a/Casks/hoststool.rb
+++ b/Casks/hoststool.rb
@@ -1,13 +1,13 @@
 cask "hoststool" do
-  version "2.7.0"
-  sha256 "52a8c777210dff249e5d37c839ec711910e3c87f68dfe127cb0b9b4719736782"
+  version "2.8.0"
+  sha256 "20f87eca89f92957e9d35c1854318659998a5663038162778016d9e2d581a07d"
 
-  url "https://github.com/ZzzM/HostsX/releases/download/#{version}/HostsToolForMac.zip"
-  name "Hosts tool for Mac"
+  url "https://github.com/ZzzM/HostsX/releases/download/#{version}/HostsX.dmg"
+  name "HostsX"
   desc "Local hosts update tool"
   homepage "https://github.com/ZzzM/HostsX"
 
   depends_on macos: ">= :sierra"
 
-  app "HostsToolForMac.app"
+  app "HostsX.app"
 end

--- a/Casks/hoststool.rb
+++ b/Casks/hoststool.rb
@@ -2,10 +2,10 @@ cask "hoststool" do
   version "2.7.0"
   sha256 "52a8c777210dff249e5d37c839ec711910e3c87f68dfe127cb0b9b4719736782"
 
-  url "https://github.com/ZzzM/HostsToolforMac/releases/download/#{version}/HostsToolForMac.zip"
+  url "https://github.com/ZzzM/HostsX/releases/download/#{version}/HostsToolForMac.zip"
   name "Hosts tool for Mac"
   desc "Local hosts update tool"
-  homepage "https://github.com/ZzzM/HostsToolforMac/"
+  homepage "https://github.com/ZzzM/HostsX"
 
   depends_on macos: ">= :sierra"
 

--- a/Casks/hostsx.rb
+++ b/Casks/hostsx.rb
@@ -1,4 +1,4 @@
-cask "hoststool" do
+cask "hostsx" do
   version "2.8.0"
   sha256 "20f87eca89f92957e9d35c1854318659998a5663038162778016d9e2d581a07d"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.