### PR TITLE
cutesdr: update livecheck

### DIFF
--- a/Casks/cutesdr.rb
+++ b/Casks/cutesdr.rb
@@ -8,12 +8,13 @@ cask "cutesdr" do
   homepage "https://sourceforge.net/projects/cutesdr/"
 
   livecheck do
-    url "https://sourceforge.net/projects/cutesdr/rss"
-    strategy :page_match do |page|
-      match = page.match(/CuteSdr(\d+?)(\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}"
+    url :url
+    regex(%r{url=.*?/CuteSdr[._-]?v?(\d+(?:\.\d+)*)\.dmg}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map do |match|
+        # Naively convert filename versions like `120` to `1.20`
+        match[0].include?(".") ? match[0] : match[0].insert(1, ".")
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `cutesdr` takes a similar approach to the built-in `Sourceforge` strategy (checking a project/folder's RSS feed) but manually uses the `PageMatch` strategy instead. This should simply use `url :url`, which will use the `Sourceforge` strategy and convert the `url` to the same RSS feed URL. It's generally better to lean on built-in strategies where we can instead of re-implementing their behavior in `livecheck` blocks (i.e., one change to a strategy can apply to many formulae/casks but making the same change to `livecheck` blocks must be done individually).

This also moves the regex out of the `strategy` block, establishing the regex before the `strategy` block using `#regex` and passing it in. This is the preferred approach for `strategy` blocks that don't need to use more than one regex. It will be the preferred approach in all circumstances after I modify `#regex` to support more than one regex in the future (when I have time to wrap up the related work and create a brew PR).

Similarly, this updates the regex to better follow standard `Sourceforge` regexes. The filenames don't currently include a delimiter between the software name and version (e.g., `CuteSdr120.dmg`) but the regex allows for an optional delimiter, so it would continue to match if that small change happens in the future.

I've reworked the `strategy` block to use an approach that will handle all matches in the RSS feed, not just the first match that appears. The `page.scan(regex).map` approach is better overall than the `match = page.match(regex); next if match.blank?` approach and most, if not all, of the 200+ existing instances in homebrew/cask should be brought in line.

Lastly, this reworks how the `livecheck` block naively converts filename versions without periods in them (e.g.,`120`) to the expected version format (e.g., `1.20`). The existing capture group approach wouldn't match a correct version with periods, so it would miss a version from a filename like `CuteSdr1.23.dmg`. It's better to craft this regex so it matches the current format (no periods in the version) but will also match a proper version format if it appears in the future.

In general, I try to avoid inserting periods into a set of numbers to reconstitute the version because it can be error-prone if/when our assumptions fail (e.g., this wouldn't work properly if the major version is 2+ digits (10, 100, etc.) or if there are 3+ version parts (1.2.3, 1.2.3.4, etc.)). The alternative is to check the release history in the `readme.txt` file for version information but there hasn't been a release in four years, so it's unclear whether the README will be kept up to date in the future. I think the approach in this PR is fine for now and we can always modify it in the future if/when necessary.