### PR TITLE
32-bit macOS dependency add depends_on

### DIFF
--- a/Casks/ireadfast.rb
+++ b/Casks/ireadfast.rb
@@ -6,12 +6,12 @@ cask "ireadfast" do
   name "iReadFast"
   desc "Speed reading program"
   homepage "https://www.gengis.net/prodotti/iReadFast_Mac/en/index.php"
-  
+
   livecheck do
     url :homepage
     regex(%r{href=.*?/iReadFast\s*v?(\d+(?:\.\d+)+)\.dmg}i)
   end
-  
+
   depends_on macos: "<= :mojave"
 
   app "iReadFast.app"

--- a/Casks/ireadfast.rb
+++ b/Casks/ireadfast.rb
@@ -6,6 +6,8 @@ cask "ireadfast" do
   name "iReadFast"
   desc "Speed reading program"
   homepage "https://www.gengis.net/prodotti/iReadFast_Mac/en/index.php"
+  
+  depends_on macos: "<= :mojave"
 
   livecheck do
     url :homepage

--- a/Casks/ireadfast.rb
+++ b/Casks/ireadfast.rb
@@ -7,12 +7,12 @@ cask "ireadfast" do
   desc "Speed reading program"
   homepage "https://www.gengis.net/prodotti/iReadFast_Mac/en/index.php"
   
-  depends_on macos: "<= :mojave"
-
   livecheck do
     url :homepage
     regex(%r{href=.*?/iReadFast\s*v?(\d+(?:\.\d+)+)\.dmg}i)
   end
+  
+  depends_on macos: "<= :mojave"
 
   app "iReadFast.app"
 end


### PR DESCRIPTION
Mojave was the last version of macOS to support 32-bit applications. Unfortunately, this application doesn’t have a 64-bit version for either Intel or Apple Silicon.
So I have added a dependency for Mojave or below.

"Starting with macOS Catalina, 32-bit apps are no longer compatible with macOS.” - Apple

From [Discussion 2935](https://github.com/Homebrew/discussions/discussions/2935#discussioncomment-2133944)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
