### PR TITLE
hp-eprint: discontinued

### DIFF
--- a/Casks/hp-eprint.rb
+++ b/Casks/hp-eprint.rb
@@ -5,7 +5,7 @@ cask "hp-eprint" do
   url "https://ftp.hp.com/pub/softlib/software13/COL43009/ds-104730-8/HP-ePrint_v#{version}.dmg"
   name "HP ePrint"
   desc "Mobile printing solution"
-  homepage "http://h20331.www2.hp.com/hpsub/us/en/eprint/overview.html"
+  homepage "https://h20331.www2.hp.com/hpsub/us/en/eprint/overview.html"
 
   pkg "HP ePrint Installer.pkg"
 

--- a/Casks/hp-eprint.rb
+++ b/Casks/hp-eprint.rb
@@ -4,6 +4,7 @@ cask "hp-eprint" do
 
   url "https://ftp.hp.com/pub/softlib/software13/COL43009/ds-104730-8/HP-ePrint_v#{version}.dmg"
   name "HP ePrint"
+  desc "Mobile printing solution"
   homepage "http://h20331.www2.hp.com/hpsub/us/en/eprint/overview.html"
 
   pkg "HP ePrint Installer.pkg"

--- a/Casks/hp-eprint.rb
+++ b/Casks/hp-eprint.rb
@@ -15,4 +15,8 @@ cask "hp-eprint" do
     "~/Library/Containers/com.hp.cloudprint.HP-ePrint-Mobile",
     "~/Library/PDF Services/HP ePrint",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

`homepage` redirects to page without any mention of "ePrint". Found [this](https://twitter.com/hpsupport/status/849310425103691777) and [that](https://h30434.www3.hp.com/t5/Desktop-Wireless-and-Networking/The-HP-ePrint-app-for-IOS-has-been-discontinued/td-p/6339631) mentioning discontinuation, although for unknown OS (former) and iOS (latter).