### PR TITLE
davmail: update livecheck

### DIFF
--- a/Casks/davmail.rb
+++ b/Casks/davmail.rb
@@ -9,12 +9,10 @@ cask "davmail" do
   homepage "https://davmail.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/davmail/rss"
-    strategy :page_match do |page|
-      match = page.match(/DavMail[._-]MacOSX[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:\.\d+)*).app.zip/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    url "https://sourceforge.net/projects/davmail/rss?path=/davmail"
+    regex(%r{url=.*?/DavMail-MacOSX[._-]v?(\d+(?:\.\d+)+)-(\d+(?:\.\d+)*)\.app\.zip}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `davmail` takes a similar approach to the built-in `Sourceforge` strategy (checking a project/folder's RSS feed) but manually uses the `PageMatch` strategy instead. This updates the `livecheck` block to use `strategy :sourceforge` (aligning with the default strategy for the URL) and modifies the RSS feed `url` to restrict it to the stable `davmail` directory (excluding the unstable `davmail trunk` directory).

This moves the regex out of the `strategy` block, establishing the regex before the `strategy` block using `#regex` and passing it in, as this is preferred. I also updated the regex to better follow standard `Sourceforge` regexes and escape periods.

I've reworked the `strategy` block to use the `page.scan(regex).map` approach, as it will handle all matches in the RSS feed, not just the first match that appears.