### PR TITLE
fix hashes for idafree

### DIFF
--- a/Casks/idafree.rb
+++ b/Casks/idafree.rb
@@ -4,9 +4,9 @@ cask "idafree" do
   version "7.7"
 
   if Hardware::CPU.intel?
-    sha256 "1141a984567f3eab8bda2b372a15d03757fa06919f67e007e1a948d52acc8377"
+    sha256 "75f623b3f438aac5d5207fc48fee14db262db6dcf0393d3f636d1117f480f337"
   else
-    sha256 "161b7ef7b7415e03dd95e401c32173b6711074b632d46de8a89115999ecd83a6"
+    sha256 "1594c4dc719d888d4c1cb5da5faf45793d5923b5a8830346ed785f4abab0cc2b"
   end
 
   url "https://out7.hex-rays.com/files/#{arch}#{version.no_dots}_mac.app.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Hashes verification:

```
➜  ~ shasum -a 256 ~/Desktop/arm_idafree77_mac.app.zip 
1594c4dc719d888d4c1cb5da5faf45793d5923b5a8830346ed785f4abab0cc2b  /Users/toma/Desktop/arm_idafree77_mac.app.zip
➜  ~ shasum ~/Desktop/arm_idafree77_mac.app.zip       
d11fde87bc8550c2f2b91a913a6b3b549c1fd287  /Users/toma/Desktop/arm_idafree77_mac.app.zip
➜  ~ shasum ~/Desktop/idafree77_mac.app.zip    
195ced3615ea9975953271a68a4b58a8b754f67e  /Users/toma/Desktop/idafree77_mac.app.zip
➜  ~ shasum -a 256 ~/Desktop/idafree77_mac.app.zip
75f623b3f438aac5d5207fc48fee14db262db6dcf0393d3f636d1117f480f337  /Users/toma/Desktop/idafree77_mac.app.zip
```

Excerpt from [their website](https://hex-rays.com/ida-free/)
```
d11fde87bc8550c2f2b91a913a6b3b549c1fd287  arm_idafree77_mac.app.zip
42038657317ebea44954b484a236e7f8cbc7d2fa  idafree77_linux.run
195ced3615ea9975953271a68a4b58a8b754f67e  idafree77_mac.app.zip
1f815be20a119cc835e7678a32032ab130834d49  idafree77_windows.exe
```
