### PR TITLE
Update parallels-access from 5.5.0 to 7.0.0

### DIFF
--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -4,7 +4,7 @@ cask "parallels-access" do
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name "Parallels Access"
-  desc "Simplest remote access to your Mac from anywhere"
+  desc "Simplest remote access to your computer from anywhere"
   homepage "https://www.parallels.com/products/access/"
 
   livecheck do

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -10,7 +10,7 @@ cask "parallels-access" do
   livecheck do
     url "https://www.parallels.com/products/access/download/"
     strategy :page_match
-    regex(%r{href=.*?/ParallelsAccess-(\d+(?:\.\d+)*)-mac\.dmg}i)
+    regex(%r{href=.*?/ParallelsAccess-(\d+(?:.\d+)*)-mac\.dmg}i)
   end
 
   # This .dmg cannot be extracted normally

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -11,7 +11,9 @@ cask "parallels-access" do
     skip "No version information available"
   end
 
-  container type: :dmg
+  # This .dmg cannot be extracted normally
+  # Original discussion: https://github.com/Homebrew/homebrew-cask/issues/26872
+  container type: :naked
 
   preflight do
     system_command "/usr/bin/hdiutil",

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -4,11 +4,14 @@ cask "parallels-access" do
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name "Parallels Access"
+  desc "The fastest, simplest, most reliable remote access to your computer from anywhere. Access all your applications, files, and computers in one place."
   homepage "https://www.parallels.com/products/access/"
 
-  # This .dmg cannot be extracted normally
-  # Original discussion: https://github.com/Homebrew/homebrew-cask/issues/26872
-  container type: :naked
+  livecheck do
+    skip "No version information available"
+  end
+
+  container type: :dmg
 
   preflight do
     system_command "/usr/bin/hdiutil",
@@ -47,8 +50,4 @@ cask "parallels-access" do
     "~/Library/Preferences/com.parallels.Parallels Access.plist.sdb",
     "~/Library/Preferences/com.parallels.mobile.plist",
   ]
-
-  livecheck do
-    skip "No version information available"
-  end
 end

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -1,5 +1,5 @@
 cask "parallels-access" do
-  version "7.0.0-39895"
+  version "7.0.0,39895"
   sha256 "c80dae90a90aea8fd1ec81da914c8b4258e33ff5d49f1d381b58eed130e4f91e"
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
@@ -9,8 +9,14 @@ cask "parallels-access" do
 
   livecheck do
     url "https://www.parallels.com/products/access/download/"
-    strategy :page_match
-    regex(%r{href=.*?/ParallelsAccess-(\d+(?:.\d+)*)-mac\.dmg}i)
+    regex(/href=.*?ParallelsAccess-(\d+(?:.\d+)*)-mac\.dmg/)
+
+    strategy :page_match do |page|
+      match = page.match(/href=.*?ParallelsAccess-(\d+(?:\.\d+)*)-(\d+).*-mac\.dmg/)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   # This .dmg cannot be extracted normally

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -25,6 +25,7 @@ cask "parallels-access" do
     "com.parallels.mobile.dispatcher.launchdaemon",
     "com.parallels.mobile.kextloader.launchdaemon",
     "com.parallels.mobile.prl_deskctl_agent.launchagent",
+    "com.parallels.mobile.audioloader",
   ],
             quit:      [
               "com.parallels.inputmethod.ParallelsIM",
@@ -46,4 +47,8 @@ cask "parallels-access" do
     "~/Library/Preferences/com.parallels.Parallels Access.plist.sdb",
     "~/Library/Preferences/com.parallels.mobile.plist",
   ]
+
+  livecheck do
+    skip "No version information available"
+  end
 end

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -4,7 +4,7 @@ cask "parallels-access" do
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name "Parallels Access"
-  desc "The simplest remote access to your computer from anywhere"
+  desc "Simplest remote access to your Mac from anywhere"
   homepage "https://www.parallels.com/products/access/"
 
   livecheck do

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -1,6 +1,6 @@
 cask "parallels-access" do
-  version "5.5.0-36378"
-  sha256 "8a7e85adae4b9402fb413557c9e6f0913d8cf02f81ac286d0bc846ac17ad1e07"
+  version "7.0.0-39895"
+  sha256 "c80dae90a90aea8fd1ec81da914c8b4258e33ff5d49f1d381b58eed130e4f91e"
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name "Parallels Access"

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -1,5 +1,5 @@
 cask "parallels-access" do
-  version "7.0.0,39895"
+  version "7.0.0-39895"
   sha256 "c80dae90a90aea8fd1ec81da914c8b4258e33ff5d49f1d381b58eed130e4f91e"
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
@@ -15,7 +15,7 @@ cask "parallels-access" do
       match = page.match(/href=.*?ParallelsAccess-(\d+(?:\.\d+)*)-(\d+).*-mac\.dmg/)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      "#{match[1]}-#{match[2]}"
     end
   end
 

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -4,7 +4,7 @@ cask "parallels-access" do
 
   url "https://download.parallels.com/pmobile/v#{version.major}/#{version}/ParallelsAccess-#{version}-mac.dmg"
   name "Parallels Access"
-  desc "The fastest, simplest, most reliable remote access to your computer from anywhere. Access all your applications, files, and computers in one place."
+  desc "The simplest remote access to your computer from anywhere"
   homepage "https://www.parallels.com/products/access/"
 
   livecheck do

--- a/Casks/parallels-access.rb
+++ b/Casks/parallels-access.rb
@@ -8,7 +8,9 @@ cask "parallels-access" do
   homepage "https://www.parallels.com/products/access/"
 
   livecheck do
-    skip "No version information available"
+    url "https://www.parallels.com/products/access/download/"
+    strategy :page_match
+    regex(%r{href=.*?/ParallelsAccess-(\d+(?:\.\d+)*)-mac\.dmg}i)
   end
 
   # This .dmg cannot be extracted normally


### PR DESCRIPTION
Several people have problems with the old version: https://forum.parallels.com/threads/continuous-error-on-startup.356441/#post-899793
The new version worked fine for me.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask <cask>` is error-free.
- [x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
