### PR TITLE
intel-psxe-ce-c-plus-plus: discontinued

### DIFF
--- a/Casks/intel-psxe-ce-c-plus-plus.rb
+++ b/Casks/intel-psxe-ce-c-plus-plus.rb
@@ -15,6 +15,7 @@ cask "intel-psxe-ce-c-plus-plus" do
   }
 
   caveats do
+    discontinued
     license "https://software.intel.com/en-us/articles/end-user-license-agreement"
     free_license "https://software.intel.com/en-us/articles/qualify-for-free-software"
   end

--- a/Casks/intel-psxe-ce-c-plus-plus.rb
+++ b/Casks/intel-psxe-ce-c-plus-plus.rb
@@ -4,6 +4,7 @@ cask "intel-psxe-ce-c-plus-plus" do
 
   url "https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/#{version.csv.second}/m_ccompxe_#{version.csv.first}.dmg"
   name "Intel Parallel Studio XE Composer Edition for C++"
+  desc "Software development tools"
   homepage "https://software.intel.com/en-us/parallel-studio-xe"
 
   installer manual: "m_ccompxe_#{version.csv.first}.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
> Intel Parallel Studio XE was rebranded and repackaged [...]. Intel oneAPI Base Toolkit + Intel oneAPI HPC toolkit contain all the tools in Parallel Studio XE and more. [Wikipedia](https://en.wikipedia.org/wiki/Intel_Parallel_Studio)

See also [`homepage`](https://software.intel.com/en-us/parallel-studio-xe).
