### PR TITLE
Update vscodium from 1.64.1 to 1.64.2

### DIFF
--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,6 +1,6 @@
 cask "vscodium" do
-  version "1.64.1"
-  sha256 "71432276c15ed3da47e5e986701c75f5ac5d2b7df135b64bf57895820bbe1244"
+  version "1.64.2"
+  sha256 "900f9fb9b39758440c4392e50e570a48500af0b595b1dbc5ec335060cada59ce"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.x64.#{version}.dmg"
   name "VSCodium"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
