### PR TITLE
Update flame from 2.6.0 to 3.0.0,80

### DIFF
--- a/Casks/flame.rb
+++ b/Casks/flame.rb
@@ -1,8 +1,9 @@
 cask "flame" do
-  version "2.6.0"
-  sha256 "fc86b75a0f2be52be3ec6ce2e260fa816fffe8e0d14caf87c3e8050ed0ec0b1a"
+  version "3.0.0,80"
+  sha256 "cc09216769022fc4acb20eaddd37898ace0d3a9ca8d9f53fbc06cdbfd45868e0"
 
-  url "https://github.com/tominsam/flametouch/releases/download/#{version}/Flame_#{version}.zip",
+  # Tag version format is 1.2.3(45) but zip file uses 1.2.3.45
+  url "https://github.com/tominsam/flametouch/releases/download/#{version.csv.first}(#{version.csv.second})/Flame.#{version.csv.first}.#{version.csv.second}.zip",
       verified: "github.com/tominsam/flametouch/"
   name "Flame"
   desc "Rendezvous service browser for iPhone / iPod touch"
@@ -10,8 +11,12 @@ cask "flame" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^(\d+(?:\.\d+)*)$/i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+){1,2})(?:\s*[(._-](\d+)\)?)?["' >]}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `flame` to the latest version on GitHub, 3.0.0(80). One thing worth noting is that newer tags use a version format like 1.2.3(45) but the zip file version currently uses a 1.2.3.45 format. This seems to have varied a bit in past releases, so this may need to be updated again in the future.

I've updated the `livecheck` block to also handle the newer 1.2.3(45) tag format. This will match tags like 2.0, 2.2.0, 2.6.1(75), or 3.0.0.80 (even 1.2.3-45). To be able to separate the fourth numeric part of a tag like 3.0.0.80, we have to restrict the repeating `(?:\.\d+)` part to 1-2 instances (i.e., a numeric version with 2-3 parts in total). It's a more complex regex than I would like but it's necessary to separate this part of the version due to the upstream mismatch between the tag and and zip file version formats. If upstream aligned these two formats (and maintained it consistently), then we could reduce the complexity of some of these changes.

One other thing to mention is that the release before this, 2.6.1(75), didn't include a zip file. If this happens again, livecheck will report a new version but the cask can't be updated unless/until the related zip file is made available. I've preemptively set this to use the `GithubLatest` strategy, so we at least don't have to worry about any potential lag between when a tag is created and the related release is published.

If we run into issues in the future with releases without a zip download available, we may have to check the releases page for zip files instead. [We avoid this approach except in very rare circumstances because release pages are paginated (10 per page) and, in some scenarios, it's possible for the first page to contain no matches (e.g., when a project regularly publishes pre-release versions). It's less of a concern for this project at the moment, so it could be a usable approach if it becomes necessary in the future.]