### PR TITLE
Update xamarin-mac.rb depends_on

### DIFF
--- a/Casks/xamarin-mac.rb
+++ b/Casks/xamarin-mac.rb
@@ -12,7 +12,7 @@ cask "xamarin-mac" do
     regex(%r{/xamarin\.mac[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
   end
 
-  depends_on cask: "homebrew/cask-versions/mono-mdk-for-visual-studio"
+  depends_on cask: "homebrew/cask/mono-mdk"
 
   pkg "xamarin.mac-#{version}.pkg"
 


### PR DESCRIPTION
The version of mono-mdk in homebrew/homebrew-cask and homebrew/homebrew-cask-versions are currently the same. It would be good to be able to use the mono-mdk from homebrew/homebrew-cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
