### PR TITLE
fluor: update livecheck

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -9,7 +9,7 @@ cask "fluor" do
 
   livecheck do
     url :url
-    strategy :git
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `fluor` unnecessarily uses `strategy :git`, as the `Git` strategy is already used for the `url` by default. We only use `#strategy` when the default strategy for a URL needs to be overridden or when we're using a `strategy` block.

This also adds the standard regex for Git tags like 1.2.3/v1.2.3, to omit an unstable version tag (i.e., 1.0RC1) that livecheck wouldn't naturally filter out if this `livecheck` block was omitted. If not for this, the existing `livecheck` block would have simply been replicating livecheck's default behavior and it would have been appropriate to remove this `livecheck` block entirely.