### PR TITLE
Update fpc-laz from 3.2.0,2.0.12 to 3.2.2,2.2.0

### DIFF
--- a/Casks/fpc-laz.rb
+++ b/Casks/fpc-laz.rb
@@ -17,6 +17,8 @@ cask "fpc-laz" do
   end
 
   conflicts_with formula: "fpc"
+  
+  pkg "fpc-#{version.csv.first}-intelarm64-macosx.mpkg/Contents/Packages/fpc-#{version.csv.first}-intelarm64-macosx.pkg"
 
   uninstall pkgutil: [
     "org.freepascal.freePascalCompiler320.fpcinst386",

--- a/Casks/fpc-laz.rb
+++ b/Casks/fpc-laz.rb
@@ -21,6 +21,7 @@ cask "fpc-laz" do
   pkg "fpc-#{version.csv.first}-intelarm64-macosx.mpkg/Contents/Packages/fpc-#{version.csv.first}-intelarm64-macosx.pkg"
 
   uninstall pkgutil: [
+    "org.freepascal.freePascalCompiler322.fpcinstintelarm64",
     "org.freepascal.freePascalCompiler320.fpcinst386",
     "org.freepascal.fpc",
   ]

--- a/Casks/fpc-laz.rb
+++ b/Casks/fpc-laz.rb
@@ -1,26 +1,22 @@
 cask "fpc-laz" do
-  version "3.2.0,2.0.12"
-  sha256 "77a55f4ab985124bb550e6fa80dfbb2c3ee449c41261325f2623e01a6afd13ad"
+  version "3.2.2,2.2.0"
+  sha256 "05d4510c8c887e3c68de20272abf62171aa5b2ef1eba6bce25e4c0bc41ba8b7d"
 
-  url "https://downloads.sourceforge.net/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20#{version.csv.second}/fpc-#{version.csv.first}.intel-macosx.dmg",
+  url "https://downloads.sourceforge.net/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20#{version.csv.second}/fpc-#{version.csv.first}.intelarm64-macosx.dmg",
       verified: "sourceforge.net/lazarus/"
   name "Pascal compiler for Lazarus"
   desc "Pascal compiler for Lazarus"
   homepage "https://www.lazarus-ide.org/"
 
   livecheck do
-    url "https://sourceforge.net/projects/lazarus/rss"
-    strategy :page_match do |page|
-      match = page.match(%r{Lazarus%20(\d+(?:.\d+)*)/fpc-(\d+(?:.\d+)*)\.intel-macosx\.dmg}i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    url "https://sourceforge.net/projects/lazarus/rss?path=/Lazarus%20macOS%20x86-64"
+    regex(%r{url=.*?/Lazarus(?:%20|[._-])v?(\d+(?:\.\d+)+)/fpc[._-]v?(\d+(?:\.\d+)+)[^"' >]+?\.(?:dmg|pkg)}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 
   conflicts_with formula: "fpc"
-
-  pkg "fpc-#{version.csv.first}-intel-macosx.pkg"
 
   uninstall pkgutil: [
     "org.freepascal.freePascalCompiler320.fpcinst386",

--- a/Casks/fpc-laz.rb
+++ b/Casks/fpc-laz.rb
@@ -17,7 +17,7 @@ cask "fpc-laz" do
   end
 
   conflicts_with formula: "fpc"
-  
+
   pkg "fpc-#{version.csv.first}-intelarm64-macosx.mpkg/Contents/Packages/fpc-#{version.csv.first}-intelarm64-macosx.pkg"
 
   uninstall pkgutil: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `fpc-laz` to the respective 3.2.2 and 2.2.0 versions (I'll create a similar `fpc-src-laz` PR in a bit). I removed the `pkg` specification, as this is using a dmg file. I'm not well-versed with the cask DSL, so do let me know if we need to keep this.

Besides updating this to the latest version(s), this PR reworks the `livecheck` block to:

* Check the RSS feed for the `Lazarus macOS x86-64` subdirectory, so we only work with the version information we're interested in (i.e., we don't have to worry about this information getting pushed out of the main project RSS feed).
* Move the regex out of the `strategy` block, as we should establish it using `#regex` and pass it in instead.
* Replace the explicit `\.intel-macosx\.dmg` ending in the regex with a looser `[^"' >]+?\.(?:dmg|pkg)`. The suffix and file type have fluctuated a bit over time and this looseness may help us to not miss versions in the future.
* Use the `Sourceforge` strategy instead of `PageMatch`. Granted, when we're using a custom URL, regex, and `strategy` block, this doesn't make a functional difference but it's potentially useful for tracking which strategies we're using and where.
* Use the `page.scan(regex).map` approach in the `strategy` block, which will collect all matches in the RSS feed, not just the first match.