### PR TITLE
Update fpc-src-laz from 3.2.0-2,2.0.12 to 3.2.2-20210709,2.2.0

### DIFF
--- a/Casks/fpc-src-laz.rb
+++ b/Casks/fpc-src-laz.rb
@@ -1,24 +1,22 @@
 cask "fpc-src-laz" do
-  version "3.2.0-2,2.0.12"
-  sha256 "8f85c873c3a224961a98fd24e97320a2134bbcc7f91c6d8153e53b36beb7fe74"
+  version "3.2.2-20210709,2.2.0"
+  sha256 "c0ed6b9261679ba040cdf07f4f5d13d915184a4164b1addf5a81e19b0738e87a"
 
-  url "https://downloads.sourceforge.net/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20#{version.csv.second}/fpc-src-#{version.csv.first}-laz.pkg",
+  url "https://downloads.sourceforge.net/lazarus/Lazarus%20macOS%20x86-64/Lazarus%20#{version.csv.second}/fpc-src-#{version.csv.first}-macosx.dmg",
       verified: "sourceforge.net/lazarus/"
   name "Pascal compiler source files for Lazarus"
   desc "Pascal compiler source files for Lazarus"
   homepage "https://www.lazarus-ide.org/"
 
   livecheck do
-    url "https://sourceforge.net/projects/lazarus/rss"
-    strategy :page_match do |page|
-      match = page.match(%r{Lazarus%20(\d+(?:.\d+)*)/fpc-src-(\d+(?:.\d+)*)-laz\.pkg}i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
+    url "https://sourceforge.net/projects/lazarus/rss?path=/Lazarus%20macOS%20x86-64"
+    regex(%r{url=.*?/Lazarus(?:%20|[._-])v?(\d+(?:\.\d+)+)/fpc-src[._-]v?(\d+(?:[.-]\d+)+)[^"' >]+?\.(?:dmg|pkg)}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 
-  pkg "fpc-src-#{version.csv.first}-laz.pkg"
+  pkg "fpcsrc-#{version.csv.first}.pkg"
 
   uninstall pkgutil: [
     "org.freepascal.fpc.source",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `fpc-src-laz` to the respective 3.2.2-20210709 and 2.2.0 versions. I updated the `pkg` argument to align with the `fpc-laz` changes in #119151 but please check my work. The `uninstall` stanza may need changes but I'm not familiar with how to approach it.

Besides updating this to the latest version(s), this PR reworks the `livecheck` block to:

* Check the RSS feed for the `Lazarus macOS x86-64` subdirectory, so we only work with the version information we're interested in (i.e., we don't have to worry about this information getting pushed out of the main project RSS feed).
* Move the regex out of the `strategy` block, as we should establish it using `#regex` and pass it in instead.
* Replace the (potentially mistaken?) use of the match anything `.` in the regex with `[.-]`, which is appropriate for the repeating part of the version (and will handle versions like 3.2.0, 3.2.0-2, 3.2.2-20210709, etc.).
* Replace the explicit `-laz\.pkg` ending in the regex with a looser `[^"' >]+?\.(?:dmg|pkg)`. The suffix and file type have fluctuated a bit over time and this looseness may help us to not miss versions in the future.
* Use the `Sourceforge` strategy instead of `PageMatch`. Granted, when we're using a custom URL, regex, and `strategy` block, this doesn't make a functional difference but it's potentially useful for tracking which strategies we're using and where.
* Use the `page.scan(regex).map` approach in the `strategy` block, which will collect all matches in the RSS feed, not just the first match.