### PR TITLE
lego-digital-designer: discontinued

### DIFF
--- a/Casks/lego-digital-designer.rb
+++ b/Casks/lego-digital-designer.rb
@@ -7,17 +7,13 @@ cask "lego-digital-designer" do
   desc "Build models using virtual Lego bricks"
   homepage "https://www.lego.com/en-us/ldd"
 
-  livecheck do
-    url "https://www.lego.com/en-us/ldd/download"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/SetupLDD-MAC-(\d+(?:_\d+)*)\.zip}i, 1]
-      v.tr("_", ".")
-    end
-  end
-
   depends_on macos: "<= :mojave"
 
   pkg "LDD.pkg"
 
   uninstall pkgutil: "com.LEGO.LDD"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
[Discontinued](https://www.brothers-brick.com/2022/01/12/lego-fully-discontinuing-lego-digital-designer-in-favor-of-bricklink-studio/): LEGO® BrickLink Studio to replace LEGO Digital Designer as the LEGO Group’s official 3D building app. `homepage` forwards to replacement.