### PR TITLE
cask for thinlinc

### DIFF
--- a/Casks/thinlinc-client.rb
+++ b/Casks/thinlinc-client.rb
@@ -9,7 +9,7 @@ cask "thinlinc-client" do
 
   livecheck do
     url "https://www.cendio.com/thinlinc/download"
-    regex(/tl[._-]v?(\d+(?:.\d+)+)[._-]client[._-]macos\.iso/i)
+    regex(/tl[._-]v?(\d+(?:[._]\d+)+)[._-]client[._-]macos\.iso/i)
   end
 
   app "ThinLinc Client.app"

--- a/Casks/thinlinc-client.rb
+++ b/Casks/thinlinc-client.rb
@@ -14,8 +14,6 @@ cask "thinlinc-client" do
 
   app "ThinLinc Client.app"
 
-  # zap as discussed https://github.com/Homebrew/homebrew-cask/pull/119225#pullrequestreview-883188247
-  # it appears as thinlinc dosnt persist data anywhere else except saved state
   zap trash: [
     "~/.thinlinc",
   ]

--- a/Casks/thinlinc-client.rb
+++ b/Casks/thinlinc-client.rb
@@ -1,15 +1,15 @@
-cask "thinlinc" do
+cask "thinlinc-client" do
   version "4.14.0_2324"
   sha256 "3b89908d84d18aeebce842eefb482985771d2b46fdc7bb87104efa1878e4d952"
 
   url "https://www.cendio.com/downloads/clients/tl-#{version}-client-macos.iso"
-  name "Thinlinc"
-  desc "Cendios thinlinc client - kinda like vnc over ssh"
+  name "ThinLinc"
+  desc "Linux remote desktop server"
   homepage "https://www.cendio.com/thinlinc"
 
   livecheck do
     url "https://www.cendio.com/thinlinc/download"
-    regex(/tl-([0-9]+\.[0-9]+\.[0-9]+_[0-9]+)-client-macos\.iso/i)
+    regex(/tl[._-]v?(\d+(?:.\d+)+)[._-]client[._-]macos\.iso/i)
   end
 
   app "ThinLinc Client.app"

--- a/Casks/thinlinc-client.rb
+++ b/Casks/thinlinc-client.rb
@@ -13,4 +13,10 @@ cask "thinlinc-client" do
   end
 
   app "ThinLinc Client.app"
+
+  # zap as discussed https://github.com/Homebrew/homebrew-cask/pull/119225#pullrequestreview-883188247
+  # it appears as thinlinc dosnt persist data anywhere else except saved state
+  zap trash: [
+    "~/.thinlinc",
+  ]
 end

--- a/Casks/thinlinc.rb
+++ b/Casks/thinlinc.rb
@@ -1,0 +1,16 @@
+cask "thinlinc" do
+  version "4.14.0_2324"
+  sha256 "3b89908d84d18aeebce842eefb482985771d2b46fdc7bb87104efa1878e4d952"
+
+  url "https://www.cendio.com/downloads/clients/tl-#{version}-client-macos.iso"
+  name "Thinlinc"
+  desc "Cendios thinlinc client - kinda like vnc over ssh"
+  homepage "https://www.cendio.com/thinlinc"
+
+  livecheck do
+    url "https://www.cendio.com/thinlinc/download"
+    regex(/tl-([0-9]+\.[0-9]+\.[0-9]+_[0-9]+)-client-macos\.iso/i)
+  end
+
+  app "ThinLinc Client.app"
+end


### PR DESCRIPTION
Request to include a cask for the Thinlinc Client from Cendio.
This is a vnc over ssh client, with its own server and is actively used.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
