### PR TITLE
Provide legacy artifact for Jamulus

### DIFF
--- a/Casks/jamulus.rb
+++ b/Casks/jamulus.rb
@@ -1,8 +1,15 @@
 cask "jamulus" do
   version "3.8.1"
-  sha256 "79fffe5c72c38260e6e5edff07ecccb355995c502d8a4a8c710eeccff8284624"
 
-  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac.dmg",
+  if MacOS.version <= :sierra
+    sha256 "d425ab355ae03849638829f68a71b8497139b5919cb3ce52a9f6742ba2101d62"
+    suffix = "_legacy"
+  else
+    sha256 "79fffe5c72c38260e6e5edff07ecccb355995c502d8a4a8c710eeccff8284624"
+    suffix = ""
+  end
+
+  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac#{suffix}.dmg",
       verified: "downloads.sourceforge.net/llcon/"
   name "Jamulus"
   desc "Play music online with friends"


### PR DESCRIPTION
Related to https://github.com/Homebrew/discussions/discussions/2961#discussioncomment-2184802
Adds the legacy build of Jamulus for old versions of macOS.
I can't test this yet but hope the CI will. Sorry for the bad branch name. I edited it online.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
