### PR TITLE
Fix URL for "inso" formula

### DIFF
--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -9,7 +9,7 @@ cask "inso" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases?q=Inso+CLI"
+    url "https://github.com/Kong/insomnia/releases?q=prerelease%3Afalse+Inso+CLI"
     strategy :page_match
     regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+)+)\.zip/i)
   end

--- a/Casks/inso.rb
+++ b/Casks/inso.rb
@@ -9,7 +9,7 @@ cask "inso" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases"
+    url "https://github.com/Kong/insomnia/releases?q=Inso+CLI"
     strategy :page_match
     regex(/href=.*?inso-macos-(?:latest-)*(\d+(?:\.\d+)+)\.zip/i)
   end


### PR DESCRIPTION
This is a similar change to https://github.com/Homebrew/homebrew-cask-versions/pull/13338 but for the non-beta rendition of the formula.

Working on a 3rd change for the `insomnia` formula.