### PR TITLE
Fix URL for "insomnia" formula

### DIFF
--- a/Casks/insomnia.rb
+++ b/Casks/insomnia.rb
@@ -9,7 +9,7 @@ cask "insomnia" do
   homepage "https://insomnia.rest/"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases/"
+    url "https://github.com/Kong/insomnia/releases?q=prerelease%3Afalse"
     strategy :page_match
     regex(/Insomnia[._-]Core[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end


### PR DESCRIPTION
A similar change to https://github.com/Homebrew/homebrew-cask-versions/pull/13338 and https://github.com/Homebrew/homebrew-cask/pull/119280