### PR TITLE
sweet-home3d: update livecheck

### DIFF
--- a/Casks/sweet-home3d.rb
+++ b/Casks/sweet-home3d.rb
@@ -9,8 +9,8 @@ cask "sweet-home3d" do
   homepage "https://www.sweethome3d.com/"
 
   livecheck do
-    url "https://sourceforge.net/projects/sweethome3d/rss"
-    regex(%r{url=.*?/SweetHome3D[._-]?v?(\d+(?:\.\d+)+)-macosx\.dmg}i)
+    url "https://sourceforge.net/projects/sweethome3d/rss?path=/SweetHome3D"
+    regex(%r{url=.*?/SweetHome3D[._-]v?(\d+(?:\.\d+)+)-macosx\.dmg}i)
   end
 
   app "Sweet Home 3D.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

As part of working through some casks that duplicate the default `Sourceforge` strategy URL in the `livecheck` block, I found that this `livecheck` block could be improved by restricting the RSS feed to the `/SweetHome3D` directory where related release files are found. The main RSS feed contains files from a variety of directories, so this change will avoid the potential issue where the files we're interested in could be pushed out by other files over time (leading to an `Unable to get versions` error).

Besides that, this makes a slight tweak to the regex to bring it in line with typical `Sourceforge` regexes (i.e., from what I've seen, there's no reason to make the `[._-]` delimiter optional for this particular cask). It's not a meaningful change from a functional standpoint but standardizing regexes can make life a little easier at times (e.g., when using `grep` to find certain `livecheck` block patterns).