### PR TITLE
Remove `auto_updates true` from syncthing.rb

### DIFF
--- a/Casks/syncthing.rb
+++ b/Casks/syncthing.rb
@@ -14,7 +14,6 @@ cask "syncthing" do
     regex(%r{href=.*?/tag/v?(\d+(?:[._-]\d+)+)["' >]}i)
   end
 
-  auto_updates true
   depends_on macos: ">= :sierra"
 
   app "Syncthing.app"


### PR DESCRIPTION
The syncthing-macos app uses Sparkle to handle auto-updates, but when the app is installed via Homebrew, Sparkle doesn't work; so I think we should remove the `auto_updates true` flag so that `brew upgrade` will update the package when there is a new version available.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
