### PR TITLE
Update xournal-plus-plus from 1.1.0 to 1.1.1

### DIFF
--- a/Casks/xournal-plus-plus.rb
+++ b/Casks/xournal-plus-plus.rb
@@ -1,8 +1,8 @@
 cask "xournal-plus-plus" do
-  version "1.1.0"
-  sha256 "fe713a9fb3d796a71bbeb6eefac24c11e8c3e4a907dc90cb6c0ea90695d18246"
+  version "1.1.1"
+  sha256 "9368414dc210ce6746735cf4def6692a1dee05e847ee3fb5b3a06b0fe45ef963"
 
-  url "https://github.com/xournalpp/xournalpp/releases/download/#{version}/xournalpp-#{version}-macos.zip"
+  url "https://github.com/xournalpp/xournalpp/releases/download/v#{version}/xournalpp-#{version}-macos.zip"
   name "Xournal++"
   desc "Handwriting notetaking software"
   homepage "https://github.com/xournalpp/xournalpp"


### PR DESCRIPTION
Automatic version bump failed because the maintainers switched tag naming conventions,
see 'Note to distro maintainers' at https://github.com/xournalpp/xournalpp/releases/tag/v1.1.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
