### PR TITLE
tresorit: update version to 3.5.2194.2571

### DIFF
--- a/Casks/tresorit.rb
+++ b/Casks/tresorit.rb
@@ -1,5 +1,5 @@
 cask "tresorit" do
-  version "3.5.2161.2400"
+  version "3.5.2194.2571"
   sha256 :no_check
 
   url "https://installerstorage.blob.core.windows.net/public/install/Tresorit.dmg",
@@ -14,6 +14,8 @@ cask "tresorit" do
       headers["x-ms-meta-version"]
     end
   end
+
+  auto_updates true
 
   app "Tresorit.app"
 


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask tresorit` is error-free.
- [x] `brew style --fix tresorit` reports no offenses.

---

This is kind of a follow-up from https://github.com/Homebrew/homebrew-cask/pull/119200. I added the `livecheck` since I saw a Azure blob header provided a version for the dmg file. Thought it'd be useful to help ensure the latest version is recorded. However, Tresorit updates itself, and the dmg URL itself isn't versioned.

_Guidance requested:_

Poking around other Casks, docs https://docs.brew.sh/Cask-Cookbook#version-latest & https://docs.brew.sh/Cask-Cookbook#optional-stanzas, and reading https://github.com/Homebrew/homebrew-cask/issues/48384 I'm wondering if (1) changing the version to `:latest` (plus removing `livecheck`) or (2) setting `auto_updates` (maintaining there's a version, but the app will update) would be more appropriate for this Cask.
Sorry for the back-and-forth changes, I wasn't really aware of `:latest`/`auto_updates` as options earlier.
~Opening this PR changing to `:latest` just to have something.~ Added two commits for `:latest`, then `auto_updates` just... because. Happy to update to whatever's deemed most befitting for the Cask and fix up commits after.

If neither of those changes are desired, Tresorit has already bumped to a new version (`3.5.2194.2571`) and I can at least bump the Cask version to that.

---

Update: from comments, went ahead and cleaned up comments to just be version update & set `auto_updates`. Cleaned up commits like I mentioned