### PR TITLE
Add licenses to Coriolis Casks

### DIFF
--- a/Casks/idefrag.rb
+++ b/Casks/idefrag.rb
@@ -17,7 +17,12 @@ cask "idefrag" do
     regex(%r{href=.*?/iDefrag[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: "<= :high_sierra"
 
   app "iDefrag.app"
+
+  caveats do
+    discontinued
+    free_license "https://coriolis-systems.com/downloads/iDefrag.png"
+  end
 end

--- a/Casks/ipartition.rb
+++ b/Casks/ipartition.rb
@@ -17,7 +17,14 @@ cask "ipartition" do
     regex(%r{href=.*?/iPartition[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
+  depends_on macos: "<= :high_sierra"
+
   app "iPartition.app"
 
   zap trash: "~/Library/Preferences/com.coriolis-systems.iPartition.plist"
+
+  caveats do
+    discontinued
+    free_license "https://coriolis-systems.com/downloads/iPartition.png"
+  end
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask i{defrag,partition}` is error-free.
- [x] `brew style --fix i{defrag,partition}` reports no offenses.

---

Was reading https://github.com/Homebrew/homebrew-cask/pull/119175 yesterday/today, figured I'd take a crack at adding the licenses described.

Added a `caveat` block with `discontinued`/`free_license`. Cargo-culted from https://github.com/Homebrew/homebrew-cask/pull/9255/files. `brew info idefrag` includes this now:
<img width="504" alt="Screen Shot 2022-02-17 at 2 59 10 PM" src="https://user-images.githubusercontent.com/3777891/154585615-77f7a92f-fd53-47a1-8a19-f302f883555c.png">

I also updated/added a `depends_on` for the macOS version since site states upper bound is 10.13.