### PR TITLE
Update Another-Redis-Desktop-Manager 1.5.2 (wrong sha256) 

### DIFF
--- a/Casks/another-redis-desktop-manager.rb
+++ b/Casks/another-redis-desktop-manager.rb
@@ -6,7 +6,7 @@ cask "another-redis-desktop-manager" do
   if Hardware::CPU.intel?
     sha256 "a734bd5c095eeb29863a3d4c05b6d1d2c9d1ba64fab7b2f7007a5eff50b50835"
   else
-    sha256 "2c7febc52dea1e860d4ba6ec528e9a8e7516df9f0067cd188c978f479f593334"
+    sha256 "653b977987407b42fd82fb5fe1830583d7d1fbb8bf32b5ae70f3ed96f238fd92"
   end
 
   url "https://github.com/qishibo/AnotherRedisDesktopManager/releases/download/v#{version}/Another-Redis-Desktop-Manager#{arch}#{version}.dmg"


### PR DESCRIPTION
Hi guys,

this is my first PR here, I hope I got everything worked out correctly. 

This PR should fix the mismatching SHA256 value which you receive whilst trying to update/install `Another-Redis-Desktop-Manager` version `1.5.2` for Macs with the M1 chip.

<img width="600" alt="grafik" src="https://user-images.githubusercontent.com/89104892/154754574-67e82578-e0b3-4c4e-8b5a-e9e029873968.png">

The owner itself (@qishibo) writes it here if you want to clarify/check. 

- https://github.com/qishibo/AnotherRedisDesktopManager/issues/793

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask another-redis-desktop-manager` is error-free.
- [x] `brew style --fix another-redis-desktop-manager` reports no offenses.