### PR TITLE
Remove redundant livecheck strategy calls

### DIFF
--- a/Casks/aquamacs.rb
+++ b/Casks/aquamacs.rb
@@ -10,8 +10,7 @@ cask "aquamacs" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^Aquamacs-(\d+(?:\.\d+)+)$/i)
+    regex(/^Aquamacs[._-](\d+(?:\.\d+)+)$/i)
   end
 
   app "Aquamacs.app"

--- a/Casks/c0re100-qbittorrent.rb
+++ b/Casks/c0re100-qbittorrent.rb
@@ -9,8 +9,7 @@ cask "c0re100-qbittorrent" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^release-(\d+(?:\.\d+)+)$/i)
+    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/couchpotato.rb
+++ b/Casks/couchpotato.rb
@@ -10,8 +10,7 @@ cask "couchpotato" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(%r{^build/(\d+(?:\.\d+)+)$}i)
+    regex(%r{^build/v?(\d+(?:\.\d+)+)$}i)
   end
 
   app "CouchPotato.app"

--- a/Casks/envkey.rb
+++ b/Casks/envkey.rb
@@ -10,8 +10,7 @@ cask "envkey" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^darwin-x64-prod-v(\d+(?:\.\d+)*)$/i)
+    regex(/^darwin-x64-prod[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "EnvKey.app"

--- a/Casks/firefly.rb
+++ b/Casks/firefly.rb
@@ -10,8 +10,7 @@ cask "firefly" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^desktop-(\d+(?:\.\d+)*)$/i)
+    regex(/^desktop[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "Firefly.app"

--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -10,8 +10,7 @@ cask "hammerspoon" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/keepingyouawake.rb
+++ b/Casks/keepingyouawake.rb
@@ -10,8 +10,7 @@ cask "keepingyouawake" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/kyokan-bob.rb
+++ b/Casks/kyokan-bob.rb
@@ -10,7 +10,6 @@ cask "kyokan-bob" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/luxmark.rb
+++ b/Casks/luxmark.rb
@@ -10,8 +10,7 @@ cask "luxmark" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^luxmark_v?(\d+(?:\.\d+)*)$/i)
+    regex(/^luxmark[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "LuxMark.app"

--- a/Casks/netnewswire.rb
+++ b/Casks/netnewswire.rb
@@ -10,8 +10,7 @@ cask "netnewswire" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^mac-(\d+(?:\.\d+)*)$/i)
+    regex(/^mac[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/netron.rb
+++ b/Casks/netron.rb
@@ -9,8 +9,7 @@ cask "netron" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/picgo.rb
+++ b/Casks/picgo.rb
@@ -9,8 +9,7 @@ cask "picgo" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "PicGo.app"

--- a/Casks/ptpwebcam.rb
+++ b/Casks/ptpwebcam.rb
@@ -10,8 +10,7 @@ cask "ptpwebcam" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v(\d+(?:\.\d+)*)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   pkg "PTP_Webcam-v#{version}.pkg"

--- a/Casks/pynsource.rb
+++ b/Casks/pynsource.rb
@@ -10,7 +10,6 @@ cask "pynsource" do
 
   livecheck do
     url :url
-    strategy :git
     regex(/^version[._-]v?(\d+(?:\.\d+)+)$/)
   end
 

--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -10,8 +10,7 @@ cask "sequel-pro" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^release-(\d+(?:\.\d+)*)$/i)
+    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "Sequel Pro.app"

--- a/Casks/shimeike-formulatepro.rb
+++ b/Casks/shimeike-formulatepro.rb
@@ -9,8 +9,7 @@ cask "shimeike-formulatepro" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*)[a-z]?$/)
+    regex(/^v?(\d+(?:\.\d+)+)[a-z]?$/)
   end
 
   app "FormulatePro.app"

--- a/Casks/supercollider.rb
+++ b/Casks/supercollider.rb
@@ -10,8 +10,7 @@ cask "supercollider" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^Version-(\d+(?:\.\d+)+)$/i)
+    regex(/^Version[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "SuperCollider.app"

--- a/Casks/textadept.rb
+++ b/Casks/textadept.rb
@@ -10,8 +10,7 @@ cask "textadept" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^textadept_(\d+(?:\.\d+)*)$/i)
+    regex(/^textadept[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "textadept_#{version}.macOS/Textadept.app"

--- a/Casks/time-tracker.rb
+++ b/Casks/time-tracker.rb
@@ -4,12 +4,12 @@ cask "time-tracker" do
 
   url "https://github.com/rburgst/time-tracker-mac/releases/download/v#{version}-binary/Time.Tracker-#{version}-bin.zip"
   name "TimeTracker"
+  desc "Time tracking app"
   homepage "https://github.com/rburgst/time-tracker-mac"
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*)-binary$/i)
+    regex(/^v?(\d+(?:\.\d+)+)-binary$/i)
   end
 
   app "Time Tracker.app"

--- a/Casks/uncolored.rb
+++ b/Casks/uncolored.rb
@@ -10,8 +10,7 @@ cask "uncolored" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?\.?(\d+(?:\.\d+)*)$/i)
+    regex(/^v?\.?(\d+(?:\.\d+)+)$/i)
   end
 
   app "Uncolored.app"

--- a/Casks/unetbootin.rb
+++ b/Casks/unetbootin.rb
@@ -10,8 +10,7 @@ cask "unetbootin" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^(\d+(?:\.\d+)*)$/i)
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
   end
 
   app "unetbootin.app"

--- a/Casks/xaos.rb
+++ b/Casks/xaos.rb
@@ -5,12 +5,12 @@ cask "xaos" do
   url "https://github.com/xaos-project/XaoS/releases/download/release-#{version}/XaoS-#{version}.dmg",
       verified: "github.com/xaos-project/XaoS/"
   name "GNU XaoS"
+  desc "Real-time interactive fractal zoomer"
   homepage "https://xaos-project.github.io/"
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^release-(\d+(?:\.\d+)*)$/i)
+    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "XaoS.app"

--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -9,8 +9,7 @@ cask "xit" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*(?:b\d+)?)$/i)
+    regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` blocks in this PR include a redundant `#strategy` call, as the argument is the same as the default strategy for the livecheck URL. For example, the `livecheck` block in `aquamacs` contains `strategy :git` but the default strategy for the cask `url` is already `Git`, so there's no value in using `strategy` in this scenario. We only use `#strategy` when we need to override the strategy that's selected for the livecheck URL by default or we're using a `strategy` block.

Besides that, this also updates the existing regexes to bring them more in line with prevailing standards. These are generally small tweaks and I'll be creating separate PRs for more substantial changes.

I added a `desc` to a couple casks (to pass `brew audit`) but feel free to suggest changes if you see any room for improvement.