### PR TITLE
xournal-plus-plus: add minimum OS version

### DIFF
--- a/Casks/xournal-plus-plus.rb
+++ b/Casks/xournal-plus-plus.rb
@@ -7,6 +7,8 @@ cask "xournal-plus-plus" do
   desc "Handwriting notetaking software"
   homepage "https://github.com/xournalpp/xournalpp"
 
+  depends_on macos: ">= :catalina"
+
   app "Xournal++.app"
 
   zap trash: [


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.