### PR TITLE
Remove unnecessary livecheck blocks

### DIFF
--- a/Casks/graphsketcher.rb
+++ b/Casks/graphsketcher.rb
@@ -7,10 +7,5 @@ cask "graphsketcher" do
   desc "Graph drawing and data plotting app"
   homepage "https://github.com/graphsketcher/GraphSketcher"
 
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   app "GraphSketcher/GraphSketcher.app"
 end

--- a/Casks/mac2imgur.rb
+++ b/Casks/mac2imgur.rb
@@ -4,12 +4,8 @@ cask "mac2imgur" do
 
   url "https://github.com/mileswd/mac2imgur/releases/download/b#{version}/mac2imgur.zip"
   name "mac2imgur"
+  desc "Upload images and screenshots to Imgur"
   homepage "https://github.com/mileswd/mac2imgur"
-
-  livecheck do
-    url :url
-    strategy :git
-  end
 
   app "mac2imgur.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The two casks in this PR contain a `livecheck` block that uses the same URL and `strategy` as the default check, which doesn't provide any value in these particular cases. The related repositories use unusual tag formats (e.g., `v2.0_test_46`, `b226`) but they're handled by the default `Git` strategy regex and there aren't any unrelated tags yet, so I think we're better off simply removing these `livecheck` blocks and using the default checks for now.

Past that, I added a `desc` to the `mac2imgur` cask to resolve the related audit. As before, feel free to suggest changes to the description language.