### PR TITLE
Update electronmail from 4.13.4 to 4.13.5

### DIFF
--- a/Casks/electronmail.rb
+++ b/Casks/electronmail.rb
@@ -1,6 +1,6 @@
 cask "electronmail" do
-  version "4.13.4"
-  sha256 "4060533485b0591a84ba8f5c299bb33760a3f318031350c7f3faec1a9993e383"
+  version "4.13.5"
+  sha256 "0926c7d63cdf4a70b1ea51ce684bf7e318ec1ed7f4543cf04fefcaf9dc77f6f7"
 
   url "https://github.com/vladimiry/ElectronMail/releases/download/v#{version}/electron-mail-#{version}-mac-x64.dmg"
   name "ElectronMail"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.