### PR TITLE
apache-directory-studio: update livecheck

### DIFF
--- a/Casks/apache-directory-studio.rb
+++ b/Casks/apache-directory-studio.rb
@@ -8,8 +8,8 @@ cask "apache-directory-studio" do
   homepage "https://directory.apache.org/studio/"
 
   livecheck do
-    url "https://archive.apache.org/dist/directory/studio/"
-    regex(%r{href="(\d+(?:\.\d+)*.*)/"}i)
+    url :url
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+[^/]*?)/?["' >]}i)
   end
 
   app "ApacheDirectoryStudio.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `apache-directory-studio` is manually replicating the behavior of the `Apache` strategy and the only difference is that the regex is a bit different to account for potential versions like `2.0.0.v20130628` or `2.0.0.v20210717-M17` (instead of just `2.0.0`).

This PR updates the `livecheck` block to simply use `url :url`, which will use the `Apache` strategy by default and end up checking the same URL as before. This also updates the regex to better align with the prevailing pattern for matching versions from directory links and to replace the open-ended `.*` with the more contextually-appropriate `[^/]*?` (which should stay within the bounds of the `href` attribute).