### PR TITLE
Update Gargoyle to 2022.1, add ARM build

### DIFF
--- a/Casks/gargoyle.rb
+++ b/Casks/gargoyle.rb
@@ -1,8 +1,14 @@
 cask "gargoyle" do
-  version "2019.1"
-  sha256 "239cd26ba6063a302c6cd12d8241cff0f2837f31ce89f9dc2718e4dcd4cfecc7"
+  arch = Hardware::CPU.intel? ? "mac-intel" : "mac-arm64"
 
-  url "https://github.com/garglk/garglk/releases/download/#{version}/gargoyle-#{version}-mac-nota.dmg"
+  version "2022.1"
+  if Hardware::CPU.intel?
+    sha256 "68448156799315e9204079559b451b6012f8e2d7e1368e32412b1f32f01157e4"
+  else
+    sha256 "46c286890de2fef2ce517f277a0fe3c88c7a75cc2283542e7b9c1d24353cddf8"
+  end
+
+  url "https://github.com/garglk/garglk/releases/download/#{version}/gargoyle-#{version}-#{arch}.dmg"
   name "Gargoyle"
   desc "IO layer for interactive fiction players"
   homepage "https://github.com/garglk/garglk"
@@ -11,7 +17,7 @@ cask "gargoyle" do
   livecheck do
     url "https://github.com/garglk/garglk/releases"
     strategy :page_match
-    regex(%r{href=.*?/gargoyle-(\d+(?:\.\d+)*)-mac-nota\.dmg}i)
+    regex(%r{href=.*?/gargoyle-(\d+(?:\.\d+)*)-#{arch}\.dmg}i)
   end
 
   app "Gargoyle.app"

--- a/Casks/gargoyle.rb
+++ b/Casks/gargoyle.rb
@@ -2,6 +2,7 @@ cask "gargoyle" do
   arch = Hardware::CPU.intel? ? "mac-intel" : "mac-arm64"
 
   version "2022.1"
+
   if Hardware::CPU.intel?
     sha256 "68448156799315e9204079559b451b6012f8e2d7e1368e32412b1f32f01157e4"
   else

--- a/Casks/gargoyle.rb
+++ b/Casks/gargoyle.rb
@@ -22,4 +22,10 @@ cask "gargoyle" do
   end
 
   app "Gargoyle.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.googlecode.garglk.launcher.sfl2",
+    "~/Library/Preferences/com.googlecode.garglk.Launcher.plist",
+    "~/Library/Saved Application State/com.googlecode.garglk.Launcher.savedState",
+  ]
 end

--- a/Casks/gargoyle.rb
+++ b/Casks/gargoyle.rb
@@ -18,7 +18,7 @@ cask "gargoyle" do
   livecheck do
     url "https://github.com/garglk/garglk/releases"
     strategy :page_match
-    regex(%r{href=.*?/gargoyle-(\d+(?:\.\d+)*)-#{arch}\.dmg}i)
+    regex(/href=.*?gargoyle[._-]v?(\d+(?:\.\d+)+)-#{arch}\.dmg/i)
   end
 
   app "Gargoyle.app"


### PR DESCRIPTION
Update Gargoyle to the latest version 2022.1, adapt to the new file naming convention, add ARM build.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) [Gargoyle 2022.1](https://github.com/garglk/garglk/releases/tag/2022.1)
- [x] `brew audit --cask gargoyle` is error-free.
- [x] `brew style --fix gargoyle` reports no offenses.
