### PR TITLE
gcc-arm-embedded 11.2-2022.02 update

### DIFF
--- a/Casks/gcc-aarch64-embedded.rb
+++ b/Casks/gcc-aarch64-embedded.rb
@@ -1,0 +1,66 @@
+cask "gcc-aarch64-embedded" do
+  # Exists as a cask because it is impractical as a formula:
+  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
+  version "11.2-2022.02"
+  gcc_version = "11.2.1"
+  sha256 "172f70df0146a0ba6bc08971edcacdd786ffb6ec5142bb9041cabaef91984d4f"
+
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/gcc-arm-#{version}-darwin-x86_64-aarch64-none-elf.pkg"
+  name "GCC ARM Embedded"
+  desc "Pre-built GNU bare-metal toolchain for 64-bit Arm processors"
+  homepage "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain"
+
+  livecheck do
+    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
+    regex(/href=.*?gcc-arm-(\d+\.\d+-\d+\.\d+)-darwin-(?:\w+)-aarch64-none-elf.pkg/i)
+  end
+
+  depends_on arch: :x86_64
+
+  pkg "gcc-arm-#{version}-darwin-x86_64-aarch64-none-elf.pkg"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-addr2line"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-ar"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-as"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-c++"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-c++filt"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-cpp"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-elfedit"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-g++"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-#{gcc_version}"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-ar"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-nm"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-ranlib"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcov"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcov-dump"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcov-tool"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gdb"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gdb-add-index"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gfortran"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-gprof"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-ld"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-ld.bfd"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-lto-dump"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-nm"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-objcopy"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-objdump"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-ranlib"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-readelf"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-size"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-strings"
+  binary "#{appdir}/ARM/bin/aarch64-none-elf-strip"
+
+  uninstall pkgutil: "gcc-arm-#{version}-darwin-x86_64-aarch64-none-elf",
+            delete:  [
+              "/Applications/ARM/#{version}-darwin-x86_64-aarch64-none-elf-manifest",
+              "/Applications/ARM/bin/aarch64-none-elf-*",
+              "/Applications/ARM/aarch64-none-elf",
+              "/Applications/ARM/lib/gcc/aarch64-none-elf",
+              "/Applications/ARM/libexec/gcc/aarch64-none-elf",
+              "/Applications/ARM/share/doc/aarch64-none-elf",
+              "/Applications/ARM/share/man/man1/aarch64-none-elf-*.1",
+              "/Applications/ARM/share/man/man5/aarch64-none-elf-gdbinit.5",
+            ]
+
+  zap delete: "/Application/ARM"
+end

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -1,20 +1,23 @@
 cask "gcc-arm-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  version "10.3-2021.10"
-  sha256 "e3888a1d0af798be7f98d67a3e6dc4fc96d92d5b57fc635e0c021a4a36087b5d"
+  version "11.2-2022.02"
+  gcc_version = "11.2.1"
+  sha256 "105ac7f9b2be62c55d6853a099a92488c16f08bb296a694ef8430e5ddf8dead8"
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu-rm/#{version}/gcc-arm-none-eabi-#{version}-mac.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/gcc-arm-#{version}-darwin-x86_64-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
-  homepage "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm"
+  homepage "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain"
 
   livecheck do
-    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads"
-    regex(/href=.*?gcc-arm-none-eabi-(\d+\.\d+-\d+\.\d+)-mac.pkg/i)
+    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
+    regex(/href=.*?gcc-arm-(\d+\.\d+-\d+\.\d+)-darwin-(?:\w+)-arm-none-eabi.pkg/i)
   end
 
-  pkg "gcc-arm-none-eabi-#{version}-mac.pkg"
+  depends_on arch: :x86_64
+
+  pkg "gcc-arm-#{version}-darwin-x86_64-arm-none-eabi.pkg"
   binary "#{appdir}/ARM/bin/arm-none-eabi-addr2line"
   binary "#{appdir}/ARM/bin/arm-none-eabi-ar"
   binary "#{appdir}/ARM/bin/arm-none-eabi-as"
@@ -24,7 +27,7 @@ cask "gcc-arm-embedded" do
   binary "#{appdir}/ARM/bin/arm-none-eabi-elfedit"
   binary "#{appdir}/ARM/bin/arm-none-eabi-g++"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gcc"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-10.3.1"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-#{gcc_version}"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ar"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-nm"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ranlib"
@@ -33,8 +36,7 @@ cask "gcc-arm-embedded" do
   binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-tool"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gdb"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index-py"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-py"
+  binary "#{appdir}/ARM/bin/arm-none-eabi-gfortran"
   binary "#{appdir}/ARM/bin/arm-none-eabi-gprof"
   binary "#{appdir}/ARM/bin/arm-none-eabi-ld"
   binary "#{appdir}/ARM/bin/arm-none-eabi-ld.bfd"
@@ -48,6 +50,18 @@ cask "gcc-arm-embedded" do
   binary "#{appdir}/ARM/bin/arm-none-eabi-strings"
   binary "#{appdir}/ARM/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "gcc.arm-none-eabi-#{version[/^(\d{2})/]}",
-            delete:  "/Applications/ARM"
+  uninstall pkgutil: "gcc-arm-#{version}-darwin-x86_64-arm-none-eabi",
+            delete:  [
+              "/Applications/ARM/#{version}-darwin-x86_64-arm-none-eabi-manifest",
+              "/Applications/ARM/bin/arm-none-eabi-*",
+              "/Applications/ARM/arm-none-eabi",
+              "/Applications/ARM/lib/gcc/arm-none-eabi",
+              "/Applications/ARM/libexec/gcc/arm-none-eabi",
+              "/Applications/ARM/share/doc/arm-none-eabi",
+              "/Applications/ARM/share/gcc-arm-none-eabi",
+              "/Applications/ARM/share/man/man1/arm-none-eabi-*.1",
+              "/Applications/ARM/share/man/man5/arm-none-eabi-gdbinit.5",
+            ]
+
+  zap delete: "/Application/ARM"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Also contains a new gcc-aarch64-embedded cask, with the same version.

Note:  this unavoidably regresses uninstall behavior in one particular sense:  the two casks’ packages both install under `/Applications/ARM` and share some content within it.  I've attempted to enumerate all the parts that _are_ specific to each cask, but installing and then uninstalling both will leave behind all the shared stuff.  I'm unsure how to address this; ideas are welcome!