### PR TITLE
ghidra: change version separator

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,8 +1,8 @@
 cask "ghidra" do
-  version "10.1.2,20220125"
+  version "10.1.2+20220125"
   sha256 "ac96fbdde7f754e0eb9ed51db020e77208cdb12cf58c08657a2ab87cb2694940"
 
-  url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.csv.first}_build/ghidra_#{version.csv.first}_PUBLIC_#{version.csv.second}.zip",
+  url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.split("+", 2).first}_build/ghidra_#{version.split("+", 2).first}_PUBLIC_#{version.split("+", 2).second}.zip",
       verified: "github.com/NationalSecurityAgency/ghidra/"
   name "Ghidra"
   desc "Software reverse engineering (SRE) suite of tools"
@@ -12,13 +12,13 @@ cask "ghidra" do
     url "https://github.com/NationalSecurityAgency/ghidra/releases"
     strategy :page_match do |page|
       page.scan(/href=.*?ghidra[._-]v?(\d+(?:\.\d+)+)[._-]PUBLIC[._-](\d+)\.zip/i)
-          .map { |matches| "#{matches[0]},#{matches[1]}" }
+          .map { |matches| "#{matches[0]}+#{matches[1]}" }
     end
   end
 
   conflicts_with cask: "homebrew/cask-versions/ghidra-beta"
 
-  binary "ghidra_#{version.csv.first}_PUBLIC/ghidraRun"
+  binary "ghidra_#{version.split("+", 2).first}_PUBLIC/ghidraRun"
 
   zap trash: "~/.ghidra"
 


### PR DESCRIPTION
`,` in the cask's own pathname is interpreted by Log4j (used by Ghidra) as a path separator, causing unwanted path truncation:
```
ERROR StatusLogger Invalid URL jar:file:/usr/local/Caskroom/ghidra/10.1.2
 java.net.MalformedURLException: no !/ in spec
	at java.base/java.net.URL.<init>(URL.java:708)
	at java.base/java.net.URL.fromURI(URL.java:748)
	at java.base/java.net.URI.toURL(URI.java:1139)
	at org.apache.logging.log4j.core.config.ConfigurationSource.fromUri(ConfigurationSource.java:330)
	at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:505)
	at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:498)
	at org.apache.logging.log4j.core.config.ConfigurationFactory$Factory.getConfiguration(ConfigurationFactory.java:404)
	at org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(ConfigurationFactory.java:323)
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:695)
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:716)
	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:270)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:245)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:47)
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:176)
	at ghidra.framework.LoggingInitialization.installConfigFile(LoggingInitialization.java:68)
	at ghidra.framework.LoggingInitialization.initializeLoggingSystem(LoggingInitialization.java:46)
	at ghidra.framework.Application.initializeLogging(Application.java:180)
	at ghidra.framework.Application.initializeLogging(Application.java:146)
	at ghidra.framework.Application.initialize(Application.java:94)
	at ghidra.framework.Application.initializeApplication(Application.java:114)
	at ghidra.GhidraRun.lambda$launch$1(GhidraRun.java:77)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NullPointerException: no !/ in spec
	at java.base/sun.net.www.protocol.jar.Handler.parseAbsoluteSpec(Handler.java:177)
	at java.base/sun.net.www.protocol.jar.Handler.parseURL(Handler.java:162)
	at java.base/java.net.URL.<init>(URL.java:703)
	... 21 more
```

Fixes https://github.com/Homebrew/homebrew-cask/issues/119618.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
