### PR TITLE
fix: update SHA256 for tla-plus-toolbox

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,6 +1,6 @@
 cask "tla-plus-toolbox" do
   version "1.8.0"
-  sha256 "0353bd93f318b90608f1d1bc0c7bc6b43f4631476f22b90d30be793e156bdb03"
+  sha256 "81cd2276215ceda37ca629f30886c82bdce5987133d585d3fcadd47cd3df861e"
 
   url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip",
       verified: "github.com/tlaplus/tlaplus/"


### PR DESCRIPTION
Not sure where the initial SHA256 came from, but it does not match what's currently coming from https://github.com/tlaplus/tlaplus/releases

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.