### PR TITLE
macvim: update livecheck

### DIFF
--- a/Casks/macvim.rb
+++ b/Casks/macvim.rb
@@ -9,7 +9,7 @@ cask "macvim" do
 
   livecheck do
     url :url
-    strategy :git
+    regex(/^snapshot[._-]v?(\d+(?:\.\d+)*)$/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `macvim` unnecessarily uses `strategy :git`, which is the same strategy that livecheck already uses on the cask `url`. This PR removes the `strategy` call and also adds a regex to ensure that livecheck only matches snapshot versions (e.g., `snapshot-172`) and avoids unrelated tags like `v7-4-017`.