### PR TITLE
x-moto: update livecheck

### DIFF
--- a/Casks/x-moto.rb
+++ b/Casks/x-moto.rb
@@ -5,11 +5,12 @@ cask "x-moto" do
   url "https://github.com/xmoto/xmoto/releases/download/#{version}/xmoto-#{version}.dmg",
       verified: "github.com/xmoto/xmoto/"
   name "X-Moto"
+  desc "2D motocross platform game"
   homepage "https://xmoto.tuxfamily.org/"
 
   livecheck do
     url :url
-    strategy :git
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   # Renamed for consistency: app name is different in the Finder and in a shell.


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `x-moto` unnecessarily uses `strategy :git`, as the default strategy for the `url` is already `Git`. This PR removes the `strategy` call and adds the standard regex for Git tags like `1.2.3`/`v1.2.3`, to omit the `00` version from the unrelated `several_physics_00` tag.