### PR TITLE
gcollazo-mongodb: update livecheck

### DIFF
--- a/Casks/gcollazo-mongodb.rb
+++ b/Casks/gcollazo-mongodb.rb
@@ -10,8 +10,7 @@ cask "gcollazo-mongodb" do
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*-build\.\d+)$/i)
+    regex(/^v?(\d+(?:\.\d+)+(?:-build[._-]?\d+)?)$/i)
   end
 
   app "MongoDB.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `gcollazo-mongodb` unnecessarily includes `strategy :git`, as livecheck already uses the `Git` strategy on the `url` by default. This PR removes the `strategy` call accordingly.

This also updates the regex to:

* Better align with prevailing standards (i.e., using the `+` form of the standard regex for versions like `1.2.3`/`v1.2.3`, as the looser `*` form isn't necessary/appropriate here).
* Loosen the `build` suffix delimiter to match a tag that didn't follow the normal format (i.e., `3.0.2-build-4`, where other tags use a `.` to separate `build` from the number like `3.0.2-build.3`).
* Make the `build` suffix optional, to match existing tags like `3.0.2`.