### PR TITLE
Fix sha245 to be sha256 in r.rb

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -23,8 +23,7 @@ cask "r" do
 
   livecheck do
     url "https://cloud.r-project.org/bin/macosx/"
-    strategy :page_match
-    regex(/href=.*?R-(\d+(?:\.\d+)*)\.pkg/i)
+    regex(/href=.*?R[._-]v?(\d+(?:\.\d+)*)\.pkg/i)
   end
 
   depends_on macos: ">= :el_capitan"

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,7 +1,7 @@
 cask "r" do
   if MacOS.version <= :yosemite
     version "3.3.3"
-    sha245 "77d7a145d1f7d5c3f5bd7310ae2beb7349118528d938e519845ce7d205b4c864"
+    sha256 "77d7a145d1f7d5c3f5bd7310ae2beb7349118528d938e519845ce7d205b4c864"
     url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   elsif MacOS.version <= :sierra
     version "3.6.3.nn"


### PR DESCRIPTION
Presumably this was a typo. I noticed when running:

```
formulae.brew.sh % /usr/bin/rake cask

brew ruby script/generate-cask.rb Homebrew/cask
Warning: Unexpected method 'sha245' called on Cask r.
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs

```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
