### PR TITLE
Update perforce from 2021.2,2220431 to 2021.2,2252059

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask "perforce" do
-  version "2021.2,2220431"
-  sha256 "da19454f275ad6645591acd1adec12d6d813f5b1a92c1ea23b06a7ad60aa8ecc"
+  version "2021.2,2252059"
+  sha256 "b9ae113bbf4552d1068b7591fafa7a1a517173c0af8f571c5c3dcddea2031f51"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
   name "Perforce Helix Core Server"


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

This PR was generated by [a script](https://github.com/gitgitgadget/keep-homebrew-perforce-up-to-date/blob/master/run.sh) running in [an Azure Pipeline](https://dev.azure.com/gitgitgadget/git/_build?definitionId=11&_a=summary).
