### PR TITLE
Add Rambox version 2.0.1

### DIFF
--- a/Casks/rambox2.rb
+++ b/Casks/rambox2.rb
@@ -1,0 +1,36 @@
+cask "rambox2" do
+  version "2.0.1"
+  sha256 "cd7f3a0016fc4b46813d70dc3e2c2ebf00b59cedb858a2acea7e8abf977a80fa"
+
+  url "https://github.com/ramboxapp/download/releases/download/v#{version}/Rambox-#{version}-mac.zip",
+      verified: "github.com/ramboxapp/download/"
+  name "Rambox"
+  desc "Free and Open Source messaging and emailing app"
+  homepage "https://rambox.pro/"
+
+  app "Rambox.app"
+
+  zap trash: [
+    "~/Library/Application Support/CrashReporter/Rambox Helper_*.plist",
+    "~/Library/Application Support/CrashReporter/Rambox_*.plist",
+    "~/Library/Application Support/Rambox",
+    "~/Library/Caches/com.grupovrs.ramboxce",
+    "~/Library/Caches/com.grupovrs.ramboxce.ShipIt",
+    "~/Library/Caches/com.grupovrs.rambox",
+    "~/Library/Caches/com.grupovrs.rambox.ShipIt",
+    "~/Library/Caches/com.saenzramiro.rambox",
+    "~/Library/Logs/Rambox",
+    "~/Library/Preferences/ByHost/com.grupovrs.ramboxce.ShipIt.*.plist",
+    "~/Library/Preferences/com.grupovrs.ramboxce.helper.plist",
+    "~/Library/Preferences/com.grupovrs.ramboxce.plist",
+    "~/Library/Preferences/ByHost/com.grupovrs.rambox.ShipIt.*.plist",
+    "~/Library/Preferences/com.grupovrs.rambox.helper.plist",
+    "~/Library/Preferences/com.grupovrs.rambox.plist",
+    "~/Library/Preferences/com.rambox.helper.plist",
+    "~/Library/Preferences/com.rambox.plist",
+    "~/Library/Saved Application State/com.grupovrs.ramboxce.savedState",
+    "~/Library/Saved Application State/com.rambox.savedState",
+    "~/Library/Saved Application State/com.saenzramiro.rambox.savedState",
+    "~/Library/WebKit/com.saenzramiro.rambox",
+  ]
+end


### PR DESCRIPTION
A new cask is created, since Rambox (CE) 0.x still exists, and no migration is handled to version 2.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
