### PR TITLE
powershell: update livecheck

### DIFF
--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -15,9 +15,8 @@ cask "powershell" do
   homepage "https://github.com/PowerShell/PowerShell"
 
   livecheck do
-    url :homepage
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*)$/)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   depends_on formula: "openssl"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `powershell` checks the `homepage` (the GitHub repository), though we prefer to align checks with the `url` source when possible. The `url` and `homepage` are the same source, so this PR uses `url :url` instead.

This also removes the unnecessary `strategy :git` call, as the default check for the `url` is already the `Git` strategy. We only use `#strategy` when it's necessary to override the strategy for a URL or we're using a `strategy` block.

This updates the regex to use the `+` form of the standard regex for Git tags like `1.2.3`/`v1.2.3` instead of the looser `*` form. We only use the `*` form when it's contextually appropriate (not the case here), otherwise the `+` form should be used by default. This is a common issue in homebrew/cask but we can't bulk update offending regexes, as we need to check the context for appropriateness, so I'm fixing these as I go along.

Lastly, this updates the regex to be case insensitive, as this is the norm unless the regex explicitly needs to be case sensitive to function (very rare).