### PR TITLE
gcc-*-embedded: fix zap

### DIFF
--- a/Casks/gcc-aarch64-embedded.rb
+++ b/Casks/gcc-aarch64-embedded.rb
@@ -60,5 +60,5 @@ cask "gcc-aarch64-embedded" do
               "/Applications/ARM/share/man/man5/aarch64-none-elf-gdbinit.5",
             ]
 
-  zap delete: "/Application/ARM"
+  zap delete: "/Applications/ARM"
 end

--- a/Casks/gcc-aarch64-embedded.rb
+++ b/Casks/gcc-aarch64-embedded.rb
@@ -60,5 +60,5 @@ cask "gcc-aarch64-embedded" do
               "/Applications/ARM/share/man/man5/aarch64-none-elf-gdbinit.5",
             ]
 
-  zap delete: "/Applications/ARM"
+  zap trash: "/Applications/ARM"
 end

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -61,5 +61,5 @@ cask "gcc-arm-embedded" do
               "/Applications/ARM/share/man/man5/arm-none-eabi-gdbinit.5",
             ]
 
-  zap delete: "/Application/ARM"
+  zap delete: "/Applications/ARM"
 end

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -61,5 +61,5 @@ cask "gcc-arm-embedded" do
               "/Applications/ARM/share/man/man5/arm-none-eabi-gdbinit.5",
             ]
 
-  zap delete: "/Applications/ARM"
+  zap trash: "/Applications/ARM"
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
Not sure why `zap delete` was chosen but using `trash` instead should allow for easier zap error recovery.