### PR TITLE
flycast: add legacy+current config dirs to zap

### DIFF
--- a/Casks/flycast.rb
+++ b/Casks/flycast.rb
@@ -13,5 +13,9 @@ cask "flycast" do
 
   app "Flycast.app"
 
-  zap rmdir: "~/.flycast"
+  zap rmdir: [
+    "~/.reicast",
+    "~/.flycast",
+    "/Library/Application Support/Flycast/",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
This adds the current config dir and another legacy config dir to `zap rmdir`, which was chosen over `zap trash` because it contains, among others, files created by the user. See https://github.com/Homebrew/homebrew-cask/pull/119571#discussion_r815334997.