### PR TITLE
google-chrome: use only the universal url

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,10 +1,8 @@
 cask "google-chrome" do
-  arch = Hardware::CPU.intel? ? "" : "universal/"
-
   version "99.0.4844.51"
   sha256 :no_check
 
-  url "https://dl.google.com/chrome/mac/#{arch}stable/GGRO/googlechrome.dmg"
+  url "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"
   name "Google Chrome"
   desc "Web browser"
   homepage "https://www.google.com/chrome/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

URL `https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg` is Chrome **98**, not Chrome **99**. Seems that google only provides universal version of Chrome **99**.