### PR TITLE
subtitle-master: update livecheck

### DIFF
--- a/Casks/subtitle-master.rb
+++ b/Casks/subtitle-master.rb
@@ -4,12 +4,12 @@ cask "subtitle-master" do
 
   url "https://github.com/subtitle-master/subtitlemaster/releases/download/v#{version}-SNAPSHOT/Subtitle.Master-osx-v#{version}-SNAPSHOT.zip"
   name "Subtitle Master"
-  homepage "https://github.com/subtitle-master/subtitlemaster/releases"
+  desc "Search for subtitles"
+  homepage "https://github.com/subtitle-master/subtitlemaster"
 
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*)-SNAPSHOT$/i)
+    regex(/^v?(\d+(?:\.\d+)+)(?:-SNAPSHOT)?$/i)
   end
 
   app "Subtitle Master.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `subtitle-master` unnecessarily uses `strategy :git`, as the `Git` strategy is already the default for the `url`. We only use `#strategy` when we need to override the default strategy selection for a URL or we're using a `strategy` block.

This updates the regex to use the `+` form of the standard regex for versions like `1.2.3`/`v1.2.3`, as we only use the `*` form when it's necessary (not the case here). This also makes the `-SNAPSHOT` suffix optional, as there are currently only two tags in the repository (`2.0.0-beta1`, `v2.0.1-SNAPSHOT`) and the current release is from 2014, so there's no guarantee the next tag would include this suffix.

Lastly, this adds a `desc` (feel free to provide feedback or update this to use a different description), and updates the `homepage` to point to the main GitHub repository page instead of the releases page.