### PR TITLE
Remove livecheck blocks from discontinued casks

### DIFF
--- a/Casks/idefrag.rb
+++ b/Casks/idefrag.rb
@@ -12,11 +12,6 @@ cask "idefrag" do
   desc "Disk optimizer and defragmentation tool"
   homepage "https://coriolis-systems.com/iDefrag/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/iDefrag[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   depends_on macos: "<= :high_sierra"
 
   app "iDefrag.app"

--- a/Casks/ipartition.rb
+++ b/Casks/ipartition.rb
@@ -12,11 +12,6 @@ cask "ipartition" do
   desc "Disk partitioning tool"
   homepage "https://coriolis-systems.com/iPartition/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/iPartition[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   depends_on macos: "<= :high_sierra"
 
   app "iPartition.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `idefrag` and `ipartition` casks have been marked as discontinued, so there's no need for `brew livecheck` to check for new versions. This PR removes the existing `livecheck` blocks for these casks, so they will be automatically skipped as discontinued.