### PR TITLE
google-chrome: fix livecheck regex

### DIFF
--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -9,7 +9,7 @@ cask "google-chrome" do
 
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac"
-    regex(/"version": "(\d+(?:\.\d+)+)"/i)
+    regex(/"version":"(\d+(?:\.\d+)+)"/i)
   end
 
   auto_updates true

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -9,7 +9,9 @@ cask "google-chrome" do
 
   livecheck do
     url "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac"
-    regex(/"version":"(\d+(?:\.\d+)+)"/i)
+    strategy :page_match do |page|
+      JSON.parse(page)[0]["version"]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.