### PR TITLE
dust3d: update livecheck

### DIFF
--- a/Casks/dust3d.rb
+++ b/Casks/dust3d.rb
@@ -5,12 +5,14 @@ cask "dust3d" do
   url "https://github.com/huxingyi/dust3d/releases/download/#{version}/dust3d-#{version}.dmg",
       verified: "github.com/huxingyi/dust3d/"
   name "Dust3D"
+  desc "Open-source 3D modeling software"
   homepage "https://dust3d.org/"
 
+  # TODO: Update this regex to only match stable versions once 1.0.0 stabilizes:
+  # regex(/^v?(\d+(?:\.\d+)+)$/i)
   livecheck do
     url :url
-    strategy :git
-    regex(/^(\d+(?:\.\d+)*(?:-rc\.\d+)?)$/i)
+    regex(/^v?(\d+(?:\.\d+)+(?:-rc\.?\d*)?)$/i)
   end
 
   app "dust3d-#{version}.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `dust3d` unnecessarily uses `strategy :git`, as the default strategy for the `url` is already `Git`. We only use `#strategy` to override the default strategy for a URL or if we're using a `strategy` block, so this PR removes the `strategy` call.

This tweaks the regex to better align with typical regexes for Git tags like `1.2.3`/`v1.2.3`. This also loosens the suffix to potentially match a tag format like `1.2.3-rc`, as there's an earlier `1.0.0-beta` tag that signals this could technically be a possibility. I've also added a comment to explain that this regex should be restricted to stable versions if/when 1.0.0 stabilizes.

Lastly, this adds a `desc` to resolve the audit error. Feel free to tweak the language if it can be improved.