### PR TITLE
reaper: fix sha256 for old macOS versions

### DIFF
--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -2,7 +2,7 @@ cask "reaper" do
   version "6.50"
 
   if MacOS.version <= :mojave
-    sha256 "7eb0fb7df77e8ab2e2b14b49d45b08f9c1973421fc5a8f5672c00778feb122bd"
+    sha256 "fcb2d3a6a7ab455426cf13c8c6f49aa97fe986556464a0dbd34766c25f40b971"
     url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
   else
     sha256 "1fb3eb979b1a6c1f6ed5c11fb7c63952d69e2cd75d53c15b6b18f47be52e3e3d"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.