### PR TITLE
Add arm64 support to radarr

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -1,8 +1,15 @@
 cask "radarr" do
-  version "4.0.4.5922"
-  sha256 "eb8fd9912ecafd013c3a5632d9ff9a7617fec8213e76cadec9a4cabadb61d141"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.master.#{version}.osx-app-core-x64.zip",
+  version "4.0.4.5922"
+
+  if Hardware::CPU.intel?
+    sha256 "eb8fd9912ecafd013c3a5632d9ff9a7617fec8213e76cadec9a4cabadb61d141"
+  else
+    sha256 "70378b2032706e3422e893dfd2f015dfbc40e5f331cea77c298e31acd5b13754"
+  end
+
+  url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.master.#{version}.osx-app-core-#{arch}.zip",
       verified: "github.com/Radarr/Radarr/"
   name "Radarr"
   desc "Fork of Sonarr to work with movies à la Couchpotato"


### PR DESCRIPTION
Added support for arm64 architecture (separate download).


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.