### PR TITLE
outline-manager: use built-in Electron livecheck

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -10,9 +10,7 @@ cask "outline-manager" do
 
   livecheck do
     url "https://github.com/Jigsaw-Code/outline-releases/raw/master/manager/latest-mac.yml"
-    strategy :page_match do |page|
-      YAML.safe_load(page)["version"]
-    end
+    strategy :electron_builder
   end
 
   app "Outline Manager.app"

--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -9,7 +9,7 @@ cask "outline-manager" do
   homepage "https://www.getoutline.org/"
 
   livecheck do
-    url "https://github.com/Jigsaw-Code/outline-releases/raw/master/manager/latest-mac.yml"
+    url "https://raw.githubusercontent.com/Jigsaw-Code/outline-releases/master/manager/latest-mac.yml"
     strategy :electron_builder
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.