### PR TITLE
opera-mobile-emulator: discontinued

### DIFF
--- a/Casks/opera-mobile-emulator.rb
+++ b/Casks/opera-mobile-emulator.rb
@@ -4,7 +4,12 @@ cask "opera-mobile-emulator" do
 
   url "https://get.geo.opera.com/pub/opera/sdlbream/1210/Opera_Mobile_Emulator_#{version}_Mac.dmg"
   name "Opera Mobile Classic Emulator"
+  desc "Browser emulator"
   homepage "https://www.opera.com/developer/mobile-emulator"
 
   app "Opera Mobile Emulator.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
This emulates Opera Mobile 12 from 2012. It still works on Monterey but I am not sure how useful this is. `homepage` redirects to https://www.opera.com/browsers/opera-mini, no mentions of a "Opera mobile emulator" to be found.

```
==> Analytics
install: 3 (30 days), 19 (90 days), 51 (365 days)
```