### PR TITLE
Change TLA+ Toolbox version to stable

### DIFF
--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -1,6 +1,6 @@
 cask "tla-plus-toolbox" do
-  version "1.8.0"
-  sha256 "81cd2276215ceda37ca629f30886c82bdce5987133d585d3fcadd47cd3df861e"
+  version "1.7.1"
+  sha256 "78e7d0ecbcba63ef7f13f9f315bfb0365a4f1d952caaa11a0a6f86a1bae5ac99"
 
   url "https://github.com/tlaplus/tlaplus/releases/download/v#{version}/TLAToolbox-#{version}-macosx.cocoa.x86_64.zip",
       verified: "github.com/tlaplus/tlaplus/"

--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -8,10 +8,10 @@ cask "tla-plus-toolbox" do
   desc "IDE for TLA+"
   homepage "https://lamport.azurewebsites.net/tla/toolbox.html"
 
-  app "TLA+ Toolbox.app"
-
   livecheck do
     url :homepage
     regex(%r{href=.*?github.com/tlaplus/tlaplus/releases/tag/v?(\d+(?:\.\d+)+)[\s"]}i)
   end
+
+  app "TLA+ Toolbox.app"
 end

--- a/Casks/tla-plus-toolbox.rb
+++ b/Casks/tla-plus-toolbox.rb
@@ -9,4 +9,9 @@ cask "tla-plus-toolbox" do
   homepage "https://lamport.azurewebsites.net/tla/toolbox.html"
 
   app "TLA+ Toolbox.app"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?github.com/tlaplus/tlaplus/releases/tag/v?(\d+(?:\.\d+)+)[\s"]}i)
+  end
 end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -32,7 +32,6 @@
   "splitshow": "all",
   "steveschow-gfxcardstatus": "all",
   "themeengine": "all",
-  "tla-plus-toolbox": "all",
   "toggl-track": "all",
   "xit": "all"
 }


### PR DESCRIPTION
v.1.8.0 [is pre-release](https://github.com/tlaplus/tlaplus/releases), and the current cask on master is broken right now because the SHA is out of date.

It was recently updated in 3ee2cb466fad1c674513e0857ae1f6e123f99cef only 10 days ago, so we shouldn't expect the SHA to be stable for very long on a pre-release version.

[Homebrew docs](https://docs.brew.sh/Acceptable-Casks#stable-versions) also require stable versions for this repo.

I went and found the latest stable release that distributed a macos archive on the project's releases page, and have updated the package to use that instead.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
