### PR TITLE
sapmachine-jdk: update livecheck

### DIFF
--- a/Casks/sapmachine-jdk.rb
+++ b/Casks/sapmachine-jdk.rb
@@ -15,10 +15,11 @@ cask "sapmachine-jdk" do
   desc "OpenJDK distribution from SAP"
   homepage "https://sapmachine.io/"
 
+  # The version information on the homepage is rendered client-side from the
+  # following JSON file, so we have to check it instead.
   livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{href=.*/sapmachine-jdk-(\d+(?:\.\d+)*(?:\+\d+(?:\.\d+)*)?)_macos-#{arch}_bin\.dmg}i)
+    url "https://sap.github.io/SapMachine/assets/data/sapmachine_releases.json"
+    regex(/["']tag["']:\s*["']sapmachine[._-]v?(\d+(?:\.\d+)+)["']/i)
   end
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-jdk-#{version}.jdk"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `sapmachine-jdk` checks the "latest" release on GitHub but the repository maintains more than one major version, so it can fluctuate between 17.x and 11.x depending on the order releases are made. Currently, the "latest" release on GitHub is `11.0.14.1` because the release was made after `17.0.2` (the actual latest version).

The `GithubLatest` strategy is used for this cask to avoid the releases marked as pre-release but we only use this strategy when it's both correct and necessary. Neither of those conditions are true here.

We can resolve this issue by using the `Git` strategy with a `/^sapmachine[._-]v?(\d+(?:\.\d+)+)$/i` regex (which will omit the pre-release versions that use a +number suffix) but checking the tags may not be the best approach, since the cask uses a download asset from a release. That is to say, there may be lag time between when a tag is created and the related release is created, so livecheck may report a new version before the related files are available to download.

Instead, the `livecheck` block in this PR checks the `sapmachine_releases.json` file from the homepage. This file contains release/file information and is used to render the download interface on the homepage. Identifying versions from the information in this file will ensure that the related files for a given release are available when livecheck reports a new version.