### PR TITLE
dropbox: update livecheck

### DIFF
--- a/Casks/dropbox.rb
+++ b/Casks/dropbox.rb
@@ -1,6 +1,5 @@
 cask "dropbox" do
   arch = Hardware::CPU.intel? ? "" : "&arch=arm64"
-  livecheck_folder = Hardware::CPU.intel? ? "" : "arm64"
 
   version "143.4.4161"
   sha256 :no_check
@@ -12,8 +11,8 @@ cask "dropbox" do
 
   livecheck do
     url :url
+    regex(%r{/Dropbox(?:%20|[._-])v?(\d+(?:\.\d+)+)}i)
     strategy :header_match
-    regex(/Dropbox%20v?(\d+(?:\.\d+)+)(?:.#{livecheck_folder})?\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This is a follow-up to #120131. Same as that PR, I noticed that the check for `dropbox` wasn't working properly on ARM64 and I created a fix last night with the intention of opening a PR in the morning 😅

The regex in this PR is a bit looser, as it doesn't account for text in the filename after the version (e.g., `.dmg`, `.arm64.dmg`). With this approach, we only use one regex regardless of the execution architecture and we may not need to update the regex if the filename suffix changes further in the future (i.e., the check would continue to return version information instead of an error) . Since this regex is matching within the `location` header string, using a looser regex isn't as much of a concern in this context (unlike most body content like HTML, JSON, etc.).

Besides that, `#regex` should come before `#strategy` in a `livecheck` block and this PR also addresses that. For what it's worth, the existing regex intends to match a dot in text like `.arm64` but the dot isn't escaped like it should be (i.e., `\.`), so it matches any character in that location. This isn't an issue with this PR but it's something to be careful about in the future.

@bevanjkay Thoughts on this approach?