### PR TITLE
netbeans: update livecheck

### DIFF
--- a/Casks/netbeans.rb
+++ b/Casks/netbeans.rb
@@ -7,9 +7,11 @@ cask "netbeans" do
   desc "Development environment, tooling platform and application framework"
   homepage "https://netbeans.apache.org/"
 
+  # Major releases sometimes only use the major version (13) instead of
+  # major/minor (13.0).
   livecheck do
     url "https://netbeans.apache.org/download/index.html"
-    regex(/NetBeans\s*v?(\d+(?:\.\d+)+)</i)
+    regex(/>\s*Apache\s*NetBeans\s*v?(\d+(?:\.\d+)*)\s*</im)
   end
 
   pkg "Apache NetBeans #{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `netbeans` is currently giving an `Unable to get versions error` because the latest version, 13, only uses a major version instead of major/minor (e.g., 13.0) like previous major releases. This PR resolves the issue by switching to the looser `*` form of the standard regex for versions like 1.2.3/v1.2.3 (and adding a comment to ensure this isn't accidentally switched back to the `+` form).

We use the stricter `+` form by default because the looser `*` form can sometimes match unintended text and cause problems, so we only use it when it's shown to be technically necessary (as here). [Most of the instances of the `*` regex in homebrew/cask aren't necessary and should be switched to the standard `+` form over time.]

Since this regex is matching flow text on an HTML page, I've updated this to also restrict the start of the regex in hopes that this will only match the text we're interested in. If this ends up being too restrictive, we can revisit this in the future and maybe consider checking version directories instead. For example (adapted from the `Apache` strategy):

```ruby
livecheck do
  url "https://archive.apache.org/dist/netbeans/netbeans/"
  regex(%r{href=["']?v?(\d+(?:\.\d+)*)/?["' >]}i)
end
```

This regex also uses the `m` (multiline) flag and is more flexible about whitespace, as it's easy for a regex like this to break if the HTML formatting changes (e.g., splitting this text onto multiple lines) or whitespace is accidentally added. Under normal circumstances, we don't need to be quite as extreme about whitespace but it arguably makes sense when dealing with less standardized text.