### PR TITLE
pingplotter: fix livecheck

### DIFF
--- a/Casks/pingplotter.rb
+++ b/Casks/pingplotter.rb
@@ -8,8 +8,8 @@ cask "pingplotter" do
   homepage "https://www.pingplotter.com/"
 
   livecheck do
-    url "https://www.pingplotter.com/download/macos/release-notes.html"
-    regex(/<h3>PingPlotter\s+v?(\d+(?:\.\d+)+)[[:space:]<]/i)
+    url "https://www.pingplotter.com/download/release-notes"
+    regex(/<h3>v?(\d+(?:\.\d+)+)[[:space:]<]/i)
   end
 
   app "PingPlotter.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.