### PR TITLE
time-to-leave: update livecheck

### DIFF
--- a/Casks/time-to-leave.rb
+++ b/Casks/time-to-leave.rb
@@ -7,10 +7,12 @@ cask "time-to-leave" do
   desc "Log work hours and get notified when it's time to leave the office"
   homepage "https://github.com/thamara/time-to-leave"
 
+  # A tag using the stable version format is sometimes marked as "Pre-release"
+  # on the GitHub releases page, so we have to use the `GithubLatest` strategy.
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?\.?(\d+(?:\.\d+)*)$/i)
+    regex(%r{href=["']?[^"' >]*?/tag/\D*([^"' >]+?)["' >]}i)
+    strategy :github_latest
   end
 
   app "Time To Leave.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `time-to-leave` checks the `url` using the `Git` strategy and correctly identifies the latest version at the moment. However, there are releases using the stable version format that are marked as pre-release on GitHub (e.g., [v2.0.0](https://github.com/thamara/time-to-leave/releases/tag/v2.0.0)), so the `Git` strategy isn't sufficient in this case. [If the `Git` strategy was sufficient, we would want to remove the unnecessary `strategy :git` call here.]

This PR updates the `livecheck` block to use the `GithubLatest` strategy with a permissive regex that will account for an optional non-numeric prefix (e.g., `stable/`), similar to the default `Git` strategy regex. [Unfortunately, even the releases marked as pre-release still have a corresponding `stable` tag (e.g., `stable/v2.0.0`), so we can't use that to identify stable versions.]