### PR TITLE
turtl: update livecheck

### DIFF
--- a/Casks/turtl.rb
+++ b/Casks/turtl.rb
@@ -5,12 +5,18 @@ cask "turtl" do
   url "https://github.com/turtl/desktop/releases/download/v#{version}/turtl-osx.zip",
       verified: "github.com/turtl/desktop/"
   name "turtl"
+  desc "Secure collaborative notebook"
   homepage "https://turtlapp.com/"
 
+  # A tag using the stable version format is sometimes marked as "Pre-release"
+  # on the GitHub releases page, so we have to use the `GithubLatest` strategy.
+  # Versions with suffixes like `0.7.2.6-sqlite-fix` are also a problem when
+  # using the `Git` strategy, as the suffix is compared alphabetically (so a
+  # newer version may wrongly appear to be older).
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)*.*)$/i)
+    regex(%r{href=["']?[^"' >]*?/tag/\D*([^"' >]+?)["' >]}i)
+    strategy :github_latest
   end
 
   app "Turtl.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `turtl` uses the `Git` strategy with a regex that will match any tag starting with a numeric version like `1.2`, etc. I believe the intention is to be able to match tags like `v0.7.2.6-sqlite-fix` in addition to tags like `v0.7.2.5` but this won't work as intended.

The repository can contain multiple tags with an alphabetical suffix for a given version (e.g., `v0.7.2.6-error-reporting`, `v0.7.2.6-link-notes`, `v0.7.2.6-pre-sync-fix`, `v0.7.2.6-sqlite-fix`). At the moment, livecheck correctly gives `v0.7.2.6-sqlite-fix` as the latest version but this is only a coincidence because the suffix in the tags before it started with a letter that's lower than `s`.

This approach becomes a problem when you have an older tag with a suffix that's alphabetically higher than a newer tag. For example, the `v0.7.1-login-debug` tag was created before the `v0.7.1-logfix` tag but the older tag would be seen as newer from the standpoint of `Version` comparison (because `logi...` is seen as greater than `logf...`).

It's also worth mentioning that tags that tags that use a format that's seemingly stable, like `v0.7.2.6-error-reporting`, are sometimes marked as "pre-release" on GitHub. This isn't evident when checking the `Git` tags, so we could end up matching a pre-release version at some point.

Besides that, this regex also ends up matching release candidate tags like `v0.7.0-rc15`. livecheck only filters out unstable tags when a formula/cask doesn't contain a `livecheck` block. We only want to match stable tags, so this is a problem as well.

---

With that in mind, it's necessary to use the `GithubLatest` strategy with a permissive regex that will account for tags like `v0.7.2.6-sqlite-fix`. This will avoid the suffix comparison issue and avoid releases marked as "pre-release" on GitHub. However, it may end up reporting a release candidate version as newest at some point, as upstream doesn't mark those releases as "pre-release". If this becomes an issue in the future, the only solution will be to ask upstream to mark unstable releases as "pre-release" on GitHub.

The [first-party download page](https://turtlapp.com/download/) lists `v0.7.2.5` as newest, so that's not an option unless 0.7.2.5 is actually the latest stable version (not any of the `v0.7.2.6` tags with a suffix). If I were upstream, I would avoid using text suffixes and figure out an approach that only involves numbers, like simply bumping the last number when there's a feature addition or bug fix. For example, instead of `v0.7.2.4-handler` for the release after `v0.7.2.4`, it would just be `v0.7.2.5`. Even something like `v0.7.2.4-2` would be better.

It's unclear why some changes bump the version and some are handled with a text suffix or why unstable releases aren't reliably marked as "pre-release" but this situation makes it challenging for package managers to determine the latest stable version.