### PR TITLE
Update scribus.rb from 1.4.8 to 1.5.6.1

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,25 +1,13 @@
 cask "scribus" do
-  version "1.4.8"
-  sha256 "9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5"
+  version "1.5.6.1"
+  sha256 "5a79350884a405e223789bc65038d7c40f41c97bf352e8da0d96a9444a0bddd5"
 
-  url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg",
+  url "https://downloads.sourceforge.net/scribus/scribus-devel/#{version}/scribus-#{version}.dmg",
       verified: "sourceforge.net/scribus/"
+  appcast "https://www.scribus.net/downloads/unstable-branch/"
   name "Scribus"
   desc "Free and open-source page layout program"
   homepage "https://www.scribus.net/"
 
-  livecheck do
-    url "https://www.scribus.net/downloads/stable-branch/"
-    regex(/Current\s*stable\s*release:\s*Scribus\s*(\d+(?:\.\d+)*)/i)
-  end
-
-  conflicts_with cask: "homebrew/cask-versions/scribus-dev"
-
   app "Scribus.app"
-
-  zap trash: [
-    "~/Library/Application Support/Scribus",
-    "~/Library/Preferences/Scribus",
-    "~/Library/Saved Application State/net.scribus.savedState",
-  ]
 end


### PR DESCRIPTION
This reverts #109745

https://docs.brew.sh/Installation#macos-requirements says that the system requirements are:
> macOS Catalina (10.15) (or higher)

The change appears to have taken the wrong side of the `if` resulting in something that only works on Mojave (or lower).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
