### PR TITLE
update dropzone from 4.2.6 to 4.2.7

### DIFF
--- a/Casks/dropzone.rb
+++ b/Casks/dropzone.rb
@@ -1,6 +1,6 @@
 cask "dropzone" do
-  version "4.2.6,1480"
-  sha256 "316ce61af6dd111cc16a335033089f5ad115e5f71fe3808a3426dcb002803c3c"
+  version "4.2.7,1505"
+  sha256 "611d8578169ad1b0347ae2e3ddd305684738dda4957805f2f008dd86d1ca2e56"
 
   url "https://aptonic.com/releases/Dropzone-#{version.csv.first}.zip"
   name "Dropzone"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.