### PR TITLE
Update sha265 sum of syntax-hightlight 2.1.10

### DIFF
--- a/Casks/syntax-highlight.rb
+++ b/Casks/syntax-highlight.rb
@@ -1,6 +1,6 @@
 cask "syntax-highlight" do
   version "2.1.10"
-  sha256 "2518eb9c49580cf5b34e6f3bed55b4991824459d33aa69024713f5b810f641a8"
+  sha256 "e3da7d6ce768438be173fa90af3f8d09f820bad5b68cc9e224e4e1ed2038efa0"
 
   url "https://github.com/sbarex/SourceCodeSyntaxHighlight/releases/download/#{version}/Syntax.Highlight.zip"
   name "Syntax Highlight"


### PR DESCRIPTION
The [`Syntax.Highlight.zip` for the 2.1.10 release has been updated "in-place", without pushing new release](https://github.com/sbarex/SourceCodeSyntaxHighlight/issues/154#issuecomment-1065009070), so the hash sum doesn't match.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
