### PR TITLE
Update vmware-fusion from 12.2.1 to 12.2.3

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,8 +1,8 @@
 cask "vmware-fusion" do
-  version "12.2.1,18811640"
-  sha256 "bb87e0a7db38beaf29ec9fd1191a092fd0bcc9f24c4bdc3ceebf65ff52289a52"
+  version "12.2.3,19436697"
+  sha256 "8cd01bd0e7d18b32bfa159bcce54bd885151e3d92d97e5d4a20bcbc09a1c3f4b"
 
-  url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
+  url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}-New/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
   name "VMware Fusion"
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/fusion.html"


### PR DESCRIPTION
Old download URL seems broken, new one is directly taken from VMware's download page.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
