### PR TITLE
forticlient-vpn: update version, url filename

### DIFF
--- a/Casks/forticlient-vpn.rb
+++ b/Casks/forticlient-vpn.rb
@@ -1,8 +1,8 @@
 cask "forticlient-vpn" do
-  version "7.0.0.22"
+  version "7.0"
   sha256 "9bc0fd4a55e468ac0ae9483a544e81489d05cce3ae0aab3edbe29c4d4aa8f057"
 
-  url "https://filestore.fortinet.com/forticlient/downloads/FortiClientVPN_#{version}_OnlineInstaller.dmg",
+  url "https://filestore.fortinet.com/forticlient/downloads/FortiClientVPNOnlineInstaller_#{version}.dmg",
       verified: "filestore.fortinet.com/forticlient/"
   name "FortiClient VPN"
   desc "Free VPN client for FortiClient"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The filename for `forticlient-vpn` has changed format and now only uses `7.0` as the version. This PR updates the `version` and the filename in the `URL` to use the current format.

The file has the same `sha256` as before, so no changes are needed there. The `livecheck` block already reports `7.0` as the latest version, so no changes are needed there either.