### PR TITLE
Update veusz from 3.4 to 3.4.0.1

### DIFF
--- a/Casks/veusz.rb
+++ b/Casks/veusz.rb
@@ -1,17 +1,26 @@
 cask "veusz" do
-  version "3.4"
-  sha256 "c95725d7d73f8cac6c13b8d25b6d6b156bfefc3f00596b4c7e542abc1ea3e453"
+  version "3.4.0.1"
+  sha256 "d075c19b89125e491501398af65a06b7a591774ee79b7dbf2c354d64d5010ef0"
 
-  url "https://github.com/veusz/veusz/releases/download/veusz-#{version}/veusz-#{version}-AppleOSX.dmg",
+  url "https://github.com/veusz/veusz/releases/download/veusz-#{version.major_minor}/veusz-#{version}-AppleOSX.dmg",
       verified: "github.com/veusz/veusz/"
   name "Veusz"
   desc "Scientific plotting application"
   homepage "https://veusz.github.io/"
 
+  # The `GithubLatest` strategy is used here to avoid releases marked as
+  # "pre-release" on GitHub. These generally involve a version with a numeric
+  # part (minor, patch, etc.) of 99 or greater (e.g., 2.99, 2.999, 3.2.991)
+  # but there's enough variability that it may be more reliable to simply
+  # target the "latest" release on GitHub.
+  #
+  # The version can differ between the tag and filename (e.g., `veusz-3.4`,
+  # `veusz-3.4.0.1-AppleOSX.dmg`) and the filename version appears to be more
+  # complete, so the regex matches version from `dmg` filenames.
   livecheck do
     url :url
-    strategy :git
-    regex(/^veusz-(\d+(?:\.\d+)*)$/i)
+    regex(/href=.*?veusz[._-]v?(\d+(?:\.\d+)+)(?:[._-][^"' >]+)?\.dmg/i)
+    strategy :github_latest
   end
 
   app "Veusz.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The 3.4 release of `veusz` contains a 3.4.0.1 version specifically for macOS that includes a fix, so this PR updates the cask accordingly. The `url` format may need to be updated in the future if/when the tag for a release contains more than just the major/minor (e.g., `veusz-3.3.1`). I used this approach for now simply to avoid having to use a version like `3.4.0.1,3.4` which would become redundant for a version like `3.3.1,3.3.1`. Feel free to modify this if a different approach is preferable.

Past that, this updates the `livecheck` block to use the `GithubLatest` strategy as a way of avoiding the versions marked as "pre-release" on GitHub. We can technically use a `strategy` block to omit Git tags where any of the numeric parts of the version are greater than or equal to 90 (e.g., 0.99.0, 1.12.99, 1.26.99, 2.99, 2.999, 3.2.991, 3.3.99) but there's enough variability that it may be more reliable to simply use the `GithubLatest` strategy.

The `livecheck` block regex matches the version from the filename because the version can differ between the tag and filename (e.g., `veusz-3.4` vs. `veusz-3.4.0.1-AppleOSX.dmg`) and the filename version appears to be more complete. For what it's worth, this regex will also work on the [first-party download page](https://veusz.github.io/download/) if we end up needing to check that instead in the future.