### PR TITLE
Remove unnecessary strategy calls

### DIFF
--- a/Casks/ilspy.rb
+++ b/Casks/ilspy.rb
@@ -7,6 +7,9 @@ cask "ilspy" do
   desc "Avalonia-based .NET decompiler"
   homepage "https://github.com/icsharpcode/AvaloniaILSpy"
 
+  # This cask uses an unstable version and this `livecheck` block is only used
+  # to prevent livecheck from skipping pre-release versions by default. This
+  # should be removed/updated if the cask is updated to a stable version.
   livecheck do
     url :url
   end

--- a/Casks/macfusion-ng.rb
+++ b/Casks/macfusion-ng.rb
@@ -4,11 +4,14 @@ cask "macfusion-ng" do
 
   url "https://github.com/macfusion-ng/macfusion#{version.major}/releases/download/#{version}/Macfusion.zip"
   name "Macfusion"
+  desc "Mount SSH and FTP servers as local volumes"
   homepage "https://github.com/macfusion-ng/macfusion#{version.major}/"
 
+  # This cask uses an unstable version and this `livecheck` block is only used
+  # to prevent livecheck from skipping pre-release versions by default. This
+  # should be removed/updated if the cask is updated to a stable version.
   livecheck do
     url :url
-    strategy :git
   end
 
   conflicts_with cask: "macfusion"

--- a/Casks/mongotron.rb
+++ b/Casks/mongotron.rb
@@ -8,9 +8,11 @@ cask "mongotron" do
   desc "Mongo DB management"
   homepage "http://mongotron.io/"
 
+  # This cask uses an unstable version and this `livecheck` block is only used
+  # to prevent livecheck from skipping pre-release versions by default. This
+  # should be removed/updated if the cask is updated to a stable version.
   livecheck do
     url :url
-    strategy :git
   end
 
   app "Mongotron-darwin-x64/Mongotron.app"

--- a/Casks/my-budget.rb
+++ b/Casks/my-budget.rb
@@ -8,9 +8,11 @@ cask "my-budget" do
   desc "Budgeting tool"
   homepage "https://rezach.github.io/my-budget/"
 
+  # This cask uses an unstable version and this `livecheck` block is only used
+  # to prevent livecheck from skipping pre-release versions by default. This
+  # should be removed/updated if the cask is updated to a stable version.
   livecheck do
     url :url
-    strategy :git
   end
 
   app "My Budget.app"

--- a/Casks/ql-ansilove.rb
+++ b/Casks/ql-ansilove.rb
@@ -4,11 +4,14 @@ cask "ql-ansilove" do
 
   url "https://github.com/ansilove/QLAnsilove/releases/download/v#{version}/QLAnsilove-#{version}.zip"
   name "QLAnsilove"
+  desc "Quick Look plugin for text-mode art"
   homepage "https://github.com/ansilove/QLAnsilove"
 
+  # This cask uses an unstable version and this `livecheck` block is only used
+  # to prevent livecheck from skipping pre-release versions by default. This
+  # should be removed/updated if the cask is updated to a stable version.
   livecheck do
     url :url
-    strategy :git
   end
 
   qlplugin "QLAnsilove.qlgenerator"

--- a/Casks/splitshow.rb
+++ b/Casks/splitshow.rb
@@ -4,11 +4,14 @@ cask "splitshow" do
 
   url "https://github.com/mpflanzer/splitshow/releases/download/v#{version}/SplitShow.app.zip"
   name "SplitShow"
+  desc "Dual-head presentation of PDF slides"
   homepage "https://github.com/mpflanzer/splitshow"
 
+  # This cask uses an unstable version and this `livecheck` block is only used
+  # to prevent livecheck from skipping pre-release versions by default. This
+  # should be removed/updated if the cask is updated to a stable version.
   livecheck do
     url :url
-    strategy :git
   end
 
   app "SplitShow.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The casks in this PR currently use an unstable `version`, so it's unfortunately necessary for livecheck to also match unstable versions for now. By default, livecheck will filter out unstable versions that match unstable version keywords that it's familiar with (e.g., alpha, beta, dev, rc, etc.). This behavior doesn't apply when a `livecheck` block is present, so these casks currently contain a redundant `livecheck` block solely for this purpose. If these casks are updated to a stable version in the future (and switch to tracking stable versions), the related `livecheck` block should be removed or updated accordingly.

This PR updates these `livecheck` blocks to remove unnecessary`#strategy` calls, where the strategy is the same as the default strategy for the URL. We only use `#strategy` to override the default strategy or when we're using a `strategy` block. For what it's worth, this should be the last of the unnecessary `#strategy` calls in homebrew/cask (there are a few others in homebrew/cask-versions that I'll take care of as well).

Besides that, this adds descriptions for casks that are missing them, so they will pass the related audit. Feel free to tweak the language as needed.

In the future, these `livecheck` blocks may be replaced with something more explicit, where we simply set an option to disable the unstable filtering (and omit the `url`). This would require some internal changes that I have planned (and implemented) but haven't gotten around to creating a PR for quite yet.