### PR TITLE
Update racket.rb

### DIFF
--- a/Casks/racket.rb
+++ b/Casks/racket.rb
@@ -9,7 +9,7 @@ cask "racket" do
     sha256 "b8d34491e98cea5e0562569b5b0267eab9d301d3524bdceb8dc3ec62754673ce"
   end
 
-  url "https://mirror.racket-lang.org/installers/#{version}/racket-#{version}-#{arch}-macosx-cs.dmg"
+  url "https://download.racket-lang.org/installers/#{version}/racket-#{version}-#{arch}-macosx-cs.dmg"
   name "Racket"
   desc "Modern programming language in the Lisp/Scheme family"
   homepage "https://racket-lang.org/"


### PR DESCRIPTION
The subdomain mirror.racket-lang.org has an expired certificate and gives this error on `brew install --cask racket --verbose`:
`curl: (60) SSL certificate problem: unable to get local issuer certificate`

(to check that the certificate is invalid, opening the links in a browser might also help)

This will use the link in the website with correct certificate instead of the mirror.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
