### PR TITLE
radarr: removed unnecessary `preflight` stanza

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -24,9 +24,5 @@ cask "radarr" do
 
   app "Radarr.app"
 
-  preflight do
-    set_permissions "#{staged_path}/Radarr.app", "0755"
-  end
-
   # No zap stanza required
 end


### PR DESCRIPTION
No longer necessary in recent versions; see [this comment](https://github.com/Homebrew/homebrew-cask/pull/120043#discussion_r825518207).

CC @neutric

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.