### PR TITLE
Remove unversioned skip calls

### DIFF
--- a/Casks/capto.rb
+++ b/Casks/capto.rb
@@ -8,9 +8,5 @@ cask "capto" do
   desc "Screen capture/recorder and video editor"
   homepage "https://www.globaldelight.com/capto/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   app "Capto.app"
 end

--- a/Casks/chrome-remote-desktop-host.rb
+++ b/Casks/chrome-remote-desktop-host.rb
@@ -7,10 +7,6 @@ cask "chrome-remote-desktop-host" do
   desc "Remotely access another computer through the Google Chrome browser"
   homepage "https://chrome.google.com/webstore/detail/chrome-remote-desktop/inomeogfingihgjfjlpeplalcfajhgai"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   pkg "Chrome Remote Desktop Host.pkg"
 
   uninstall script:  {

--- a/Casks/clickcharts.rb
+++ b/Casks/clickcharts.rb
@@ -5,11 +5,8 @@ cask "clickcharts" do
   url "https://www.nchsoftware.com/chart/clickchartspmaci.zip",
       user_agent: :fake
   name "ClickCharts"
+  desc "Diagram and flowchart software"
   homepage "https://www.nchsoftware.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "ClickCharts.app"
 end

--- a/Casks/coccoc.rb
+++ b/Casks/coccoc.rb
@@ -4,11 +4,8 @@ cask "coccoc" do
 
   url "https://files.coccoc.com/browser/mac/coccoc.dmg"
   name "Cốc Cốc"
+  desc "Chromium-based web browser"
   homepage "https://coccoc.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "CocCoc.app"
 

--- a/Casks/evkey.rb
+++ b/Casks/evkey.rb
@@ -8,10 +8,6 @@ cask "evkey" do
   desc "Vietnamese keyboard"
   homepage "https://evkeyvn.com/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   app "EVKey.app"
 
   zap trash: [

--- a/Casks/jandi.rb
+++ b/Casks/jandi.rb
@@ -4,11 +4,8 @@ cask "jandi" do
 
   url "https://cdn.jandi.com/jandi-pc/download/JANDI.dmg"
   name "JANDI"
+  desc "Desktop app for the JANDI collaboration platform"
   homepage "https://www.jandi.com/landing/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "JANDI.app"
 

--- a/Casks/league-of-legends.rb
+++ b/Casks/league-of-legends.rb
@@ -8,10 +8,6 @@ cask "league-of-legends" do
   desc "Multiplayer online battle arena game"
   homepage "https://na.leagueoflegends.com/en-us/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   installer manual: "Install League of Legends na.app"
 
   uninstall delete: "/Applications/League of Legends.app"

--- a/Casks/mikogo.rb
+++ b/Casks/mikogo.rb
@@ -5,11 +5,8 @@ cask "mikogo" do
   url "https://download.mikogo4.com/Mikogo-installer.signed.pkg",
       verified: "mikogo4.com/"
   name "Mikogo"
+  desc "Desktop app for the Mikogo screen-sharing platform"
   homepage "https://www.mikogo.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   pkg "Mikogo-installer.signed.pkg"
 

--- a/Casks/mindmaster.rb
+++ b/Casks/mindmaster.rb
@@ -4,11 +4,8 @@ cask "mindmaster" do
 
   url "https://download.edrawsoft.com/mindmaster_full5378.dmg"
   name "MindMaster"
+  desc "Mind mapping software"
   homepage "https://www.edrawsoft.com/mindmaster/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "MindMaster.app"
 end

--- a/Casks/mylio.rb
+++ b/Casks/mylio.rb
@@ -5,11 +5,8 @@ cask "mylio" do
   url "https://myliodownloads.s3.amazonaws.com/Mylio.dmg",
       verified: "myliodownloads.s3.amazonaws.com/"
   name "Mylio"
+  desc "Photo organizer"
   homepage "https://mylio.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "Mylio.app"
 end

--- a/Casks/native-access.rb
+++ b/Casks/native-access.rb
@@ -7,10 +7,6 @@ cask "native-access" do
   desc "Administration tool for Native Instruments products"
   homepage "https://native-instruments.com/specials/native-access"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   auto_updates true
   depends_on macos: ">= :sierra"
 

--- a/Casks/nifty.rb
+++ b/Casks/nifty.rb
@@ -4,11 +4,8 @@ cask "nifty" do
 
   url "https://niftypm.com/apps/Nifty.dmg"
   name "Nifty"
+  desc "Desktop app for the Nifty project management platform"
   homepage "https://niftypm.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "Nifty.app"
 end

--- a/Casks/perimeter81.rb
+++ b/Casks/perimeter81.rb
@@ -8,10 +8,6 @@ cask "perimeter81" do
   desc "Zero trust network as a service client"
   homepage "https://perimeter81.com/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   pkg "Perimeter81.pkg"
 
   uninstall pkgutil:   "com.safervpn.osx.smb",

--- a/Casks/pokemon-trading-card-game-online.rb
+++ b/Casks/pokemon-trading-card-game-online.rb
@@ -5,12 +5,8 @@ cask "pokemon-trading-card-game-online" do
   url "https://tcgo-installer.s3.amazonaws.com/PokemonInstaller_Mac.dmg",
       verified: "https://tcgo-installer.s3.amazonaws.com/"
   name "Pokemon Trading Card Game Online"
-  desc "PLay the Pokemon TCG online"
+  desc "Play the Pokemon TCG online"
   homepage "https://www.pokemon.com/us/pokemon-tcg/play-online/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "Pokemon Trading Card Game Online.app"
 

--- a/Casks/purevpn.rb
+++ b/Casks/purevpn.rb
@@ -5,11 +5,8 @@ cask "purevpn" do
   url "https://purevpn-dialer-assets.s3.amazonaws.com/mac-2.0/packages/Production/PureVPN.pkg",
       verified: "purevpn-dialer-assets.s3.amazonaws.com/"
   name "PureVPN"
+  desc "VPN client"
   homepage "https://www.purevpn.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   pkg "PureVPN.pkg"
 

--- a/Casks/safeincloud-password-manager.rb
+++ b/Casks/safeincloud-password-manager.rb
@@ -7,9 +7,5 @@ cask "safeincloud-password-manager" do
   desc "Cross-platform AES-256 password manager"
   homepage "https://www.safe-in-cloud.com/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   app "SafeInCloud Password Manager.app"
 end

--- a/Casks/send-anywhere.rb
+++ b/Casks/send-anywhere.rb
@@ -7,9 +7,5 @@ cask "send-anywhere" do
   desc "File sharing app"
   homepage "https://send-anywhere.com/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   app "Send Anywhere.app"
 end

--- a/Casks/switch.rb
+++ b/Casks/switch.rb
@@ -7,9 +7,5 @@ cask "switch" do
   desc "Multiple format audio file converter"
   homepage "https://www.nch.com.au/switch/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   app "Switch.app"
 end

--- a/Casks/teamviewer-quickjoin.rb
+++ b/Casks/teamviewer-quickjoin.rb
@@ -5,11 +5,8 @@ cask "teamviewer-quickjoin" do
   url "https://download.teamviewer.com/download/TeamViewerQJ.dmg"
   name "TeamViewer QuickJoin"
   name "TeamViewer QJ"
+  desc "Standalone TeamViewer app for joining presentations and meetings"
   homepage "https://www.teamviewer.com/"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "TeamViewerQJ.app", target: "TeamViewer QuickJoin.app"

--- a/Casks/timemachineeditor.rb
+++ b/Casks/timemachineeditor.rb
@@ -7,10 +7,6 @@ cask "timemachineeditor" do
   desc "Utility to change the default backup interval of Time Machine"
   homepage "https://tclementdev.com/timemachineeditor/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   pkg "TimeMachineEditor.pkg"
 
   uninstall launchctl: "com.tclementdev.timemachineeditor.scheduler",

--- a/Casks/ultdata.rb
+++ b/Casks/ultdata.rb
@@ -7,10 +7,6 @@ cask "ultdata" do
   desc "iPhone data recovery software"
   homepage "https://www.tenorshare.com/products/iphone-data-recovery.html"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   auto_updates true
   depends_on macos: ">= :yosemite"
 

--- a/Casks/wondershare-uniconverter.rb
+++ b/Casks/wondershare-uniconverter.rb
@@ -7,10 +7,6 @@ cask "wondershare-uniconverter" do
   desc "Video editing software"
   homepage "https://videoconverter.wondershare.com/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   app "Wondershare UniConverter.app"
 
   zap trash: [

--- a/Casks/zenbeats.rb
+++ b/Casks/zenbeats.rb
@@ -7,10 +7,6 @@ cask "zenbeats" do
   desc "Music creation app"
   homepage "https://www.roland.com/us/products/zenbeats/"
 
-  livecheck do
-    skip "unversioned URL"
-  end
-
   pkg "Zenbeats_Installer.pkg"
 
   uninstall pkgutil: "jp.co.roland.zenbeats"

--- a/Casks/zoho-docs.rb
+++ b/Casks/zoho-docs.rb
@@ -5,11 +5,8 @@ cask "zoho-docs" do
   url "https://files-accl.zohopublic.com/public/docsbin/download/393b1306f04a3078b525b2c637d0a727",
       verified: "files-accl.zohopublic.com/"
   name "Zoho Docs"
+  desc "Sync files to/from Zoho Docs"
   homepage "https://www.zoho.com/docs/desktop-sync.html"
-
-  livecheck do
-    skip "unversioned URL"
-  end
 
   app "Zoho Docs.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` blocks in this PR unnecessarily use `skip "unversioned URL"`. Without these `livecheck` blocks, livecheck will automatically skip the casks as unversioned (e.g., `clickcharts : unversioned`). This PR removes the `livecheck` blocks accordingly.

Past that, this adds descriptions to casks without one, to resolve the related audit error. Feel free to modify any of these if they need to be reworded.