### PR TITLE
Remove handling of deleted 02_feature_request.yml

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -37,8 +37,6 @@ puts 'Detecting changes…'
   end
 end
 
-FileUtils.rm repo_dir.join('.github/ISSUE_TEMPLATE/02_feature_request.yml')
-
 workflow = File.read(repo_dir.join('.github/PULL_REQUEST_TEMPLATE.md'))
 File.write repo_dir.join('.github/PULL_REQUEST_TEMPLATE.md'), workflow.gsub(/Homebrew\/homebrew-cask\/(pulls|issues|search)/, "#{repo}/\\1")
 


### PR DESCRIPTION
This template was removed in #120491, but this file wasn't modified accordingly, so the sync flow has been failing.