### PR TITLE
mactex-no-gui: update livecheck

### DIFF
--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -9,13 +9,7 @@ cask "mactex-no-gui" do
   homepage "https://www.tug.org/mactex/"
 
   livecheck do
-    url "https://ctan.org/texarchive/systems/mac/mactex/"
-    strategy :page_match do |page|
-      match = page.match(/href=.*?mactex-(\d{4})(\d{2})(\d{2})\.pkg/)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}#{match[3]}"
-    end
+    cask "mactex"
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `mactex` and `mactex-no-gui` casks both use the same package URL and the `livecheck` blocks are identical. `mactex` is the canonical formula and `mactex-no-gui` is a variant, so the latter can use `#cask` in the `livecheck` block to simply reference the `livecheck` block in `mactex`. With this setup, we only have to maintain the `mactex` `livecheck` block and `mactex-no-gui` will automatically benefit from any changes.

We only use the `#cask` method in situations like this, where there's a clear parent/child relationship (not siblings of equal stature, like `free42-binary`/`free42-decimal`).