### PR TITLE
Updated Seafile-Client v8.0.4 to v8.0.6

### DIFF
--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -1,6 +1,6 @@
 cask "seafile-client" do
-  version "8.0.4"
-  sha256 "b398e2366b14d71a9eeb2b5d20e9bc06be071d381fb9589c1c1fb37ed3dcd054"
+  version "8.0.6"
+  sha256 "d455892c010907affb53d0cab57cdd53fb3cf039191358f2107aa7c072f1d87a"
 
   url "https://download.seadrive.org/seafile-client-#{version}.dmg",
       verified: "seadrive.org/"


### PR DESCRIPTION
Updated Seafile-Client from v8.0.4 to v8.0.6

After making all changes to a cask, verify:
- [x] The submission is for a stable version
- [x] `brew audit --cask seafile-client.rb` is error-free.
- [x] `brew style --fix seafile-client.rb` reports no offenses.