### PR TITLE
Adds component PATH install to brew info

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -36,5 +36,13 @@ cask "google-cloud-sdk" do
 
       for zsh users
         source "#{staged_path}/#{token}/completion.zsh.inc"
+
+    To add gcloud components to your PATH, add this to your profile:
+
+      for bash users
+        source "#{staged_path}/#{token}/path.bash.inc"
+
+      for zsh users
+        source "#{staged_path}/#{token}/path.zsh.inc"
   EOS
 end


### PR DESCRIPTION
Because `gcloud` is [installed headless without confirmation to update the PATH](https://github.com/Homebrew/homebrew-cask/compare/master...Whitespace:google-cloud-sdk-path?expand=1#diff-4acacd9c1819e4ee6c8c8f29465c515a61c8b71e0b0452d3db46ad79c5c2f4dbL15), this is necessary when you want to run commands from components installed through `gcloud`.

```
gcloud component install cbt
cbt # not found
```

It follows the same pattern for bash completion.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.