### PR TITLE
Update eloston-chromium from 99.0.4844.51-1.1 to 99.0.4844.74-1.1 (arm64)

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -5,8 +5,8 @@ cask "eloston-chromium" do
     version "99.0.4844.74-1.1,1647492794"
     sha256 "92beabcc7302114cf6d5489c91a9187e40b2e9cbc8486b0863e792a223e21d93"
   else
-    version "99.0.4844.51-1.1,1646570828"
-    sha256 "93c458af5121f9b61c92ccd5294d01999d3cc1e27728cf3ac1916a87b6bd70d7"
+    version "99.0.4844.74-1.1,1647530108"
+    sha256 "a9a18f53cdf8da9864210a403266e6ea5f30226393ed83568b3f3af6e5961ca0"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version.csv.first}_#{arch}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",


### PR DESCRIPTION


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

