### PR TITLE
Add missing livecheck urls

### DIFF
--- a/Casks/crescendo.rb
+++ b/Casks/crescendo.rb
@@ -8,6 +8,7 @@ cask "crescendo" do
   homepage "https://github.com/SuprHackerSteve/Crescendo"
 
   livecheck do
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/flycast.rb
+++ b/Casks/flycast.rb
@@ -8,6 +8,7 @@ cask "flycast" do
   homepage "https://github.com/flyinghead/flycast"
 
   livecheck do
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/iptvnator.rb
+++ b/Casks/iptvnator.rb
@@ -8,6 +8,7 @@ cask "iptvnator" do
   homepage "https://github.com/4gray/iptvnator"
 
   livecheck do
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/pluginval.rb
+++ b/Casks/pluginval.rb
@@ -9,6 +9,7 @@ cask "pluginval" do
   homepage "https://www.tracktion.com/develop/pluginval"
 
   livecheck do
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/shield.rb
+++ b/Casks/shield.rb
@@ -9,6 +9,7 @@ cask "shield" do
   homepage "https://theevilbit.github.io/shield/"
 
   livecheck do
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/tev.rb
+++ b/Casks/tev.rb
@@ -8,6 +8,7 @@ cask "tev" do
   homepage "https://github.com/Tom94/tev"
 
   livecheck do
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -9,7 +9,8 @@ cask "xemu" do
   homepage "https://xemu.app/"
 
   livecheck do
-    regex(%r{gh-release/(.*)}i)
+    url :url
+    regex(%r{^gh-release/(.*)$}i)
   end
 
   app "Xemu.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

A `url` is required in `livecheck` blocks, with the exception of those using the `ExtractPlist` strategy (as its `#find_versions` method takes a cask argument instead of a URL). The `livecheck` blocks in this PR are missing a `url` but one is required in this context, so this adds appropriate URLs. The only additional change is to update the `xemu` regex to align with the typical format for Git tag regexes (i.e., using `^` and `$` to anchor the start/end).

In the not-too-distant future, the livecheck RuboCops will apply to casks as well (they only work for formulae at the moment, due to how they were implemented). I have most of this work done already (it mostly needs some polish) but I'm preemptively resolving audit errors (as here) before creating a brew PR.

There are six additional `livecheck` blocks that need a `url` but I'll be handling those in separate PRs, as they involve more substantial changes that warrant some explanation.