### PR TITLE
Bump texshop to 4.70

### DIFF
--- a/Casks/texshop.rb
+++ b/Casks/texshop.rb
@@ -1,6 +1,6 @@
 cask "texshop" do
-  version "4.69"
-  sha256 "b784a55be4255d257da260065e7f0c661a09b2b318b38553950f992f81f44790"
+  version "4.70"
+  sha256 "d25032da77c5ddb91cfe6a1ea0866348e9ebfcbb6da059632c705c2b62654f12"
 
   url "https://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   name "TeXShop"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [ x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ x ] `brew audit --cask <cask>` is error-free.
- [ x ] `brew style --fix <cask>` reports no offenses.

FWIW, the 4.69 `.zip` file is not available from the source, but there's 4.70, so moving to that made sense to me.