### PR TITLE
Update Seadrive 2.0.18 to 2.0.20

### DIFF
--- a/Casks/seadrive.rb
+++ b/Casks/seadrive.rb
@@ -1,6 +1,6 @@
 cask "seadrive" do
-  version "2.0.18"
-  sha256 "850a7a732dc50ea8683bda2502d43143a3d8c2fef5c4d9f8f3ced0e26890b6b1"
+  version "2.0.20"
+  sha256 "cd6c1c8055312f34549e2575e807985c3ab6e1577558d2772804e9178af5b990"
 
   url "https://download.seadrive.org/seadrive-#{version}.dmg",
       verified: "download.seadrive.org/"


### PR DESCRIPTION
Updated Seadrive 2.0.18 to 2.0.20

- [x] The submission is for a stable version.
- [x] `brew audit --cask seadriver.rb` is error-free.
- [x] `brew style --fix seadrive.rb` reports no offenses.
