### PR TITLE
Add shim script to qutebrowser

### DIFF
--- a/Casks/qutebrowser.rb
+++ b/Casks/qutebrowser.rb
@@ -9,6 +9,16 @@ cask "qutebrowser" do
   homepage "https://www.qutebrowser.org/"
 
   app "qutebrowser.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/qutebrowser.wrapper.sh"
+  binary shimscript, target: "qutebrowser"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      '#{appdir}/qutebrowser.app/Contents/MacOS/qutebrowser' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/Library/Application Support/qutebrowser",


### PR DESCRIPTION
I tried adding a `binary` without a shim script, but when I actually
tried to run `qutebrowser` in my terminal, Qutebrowser did launch, but
it wasn't behaving properly, and it spewed a bunch of errors in the
terminal.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
