### PR TITLE
Update kicad from 6.0.2-0 to 6.0.4-0

### DIFF
--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -1,6 +1,6 @@
 cask "kicad" do
-  version "6.0.2-0"
-  sha256 "7c43e069666ee52cb5580495f6a006788daecf29e9b6fb15a3d7c4bcac9be6b1"
+  version "6.0.4-0"
+  sha256 "92a1c08b5bdad56437b8dc3ec606a991399a70ce0f44717cf1503f469f9e0cce"
 
   url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-#{version}.dmg",
       verified: "kicad-downloads.s3.cern.ch/"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.