### PR TITLE
Tidal: add support for Apple Silicon

### DIFF
--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -1,6 +1,6 @@
 cask "tidal" do
   arch = Hardware::CPU.intel? ? "" : ".arm64"
-  version "2.29.7"
+  version "2.30.0"
   sha256 :no_check
 
   url "https://download.tidal.com/desktop/TIDAL#{arch}.dmg"

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -1,5 +1,6 @@
 cask "tidal" do
   arch = Hardware::CPU.intel? ? "" : ".arm64"
+
   version "2.30.0"
   sha256 :no_check
 

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -1,8 +1,9 @@
 cask "tidal" do
+  arch = Hardware::CPU.intel? ? "" : ".arm64"
   version "2.29.7"
   sha256 :no_check
 
-  url "https://download.tidal.com/desktop/TIDAL.dmg"
+  url "https://download.tidal.com/desktop/TIDAL#{arch}.dmg"
   name "TIDAL"
   desc "Music streaming service with high fidelity sound and hi-def video quality"
   homepage "https://tidal.com/"


### PR DESCRIPTION
Tidal apparently silently launched Apple Silicon support recently, as I found out when I checked their download page today. I've updated this cask to automatically pull the appropriate build.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.