### PR TITLE
eiskaltdcpp: update livecheck

### DIFF
--- a/Casks/eiskaltdcpp.rb
+++ b/Casks/eiskaltdcpp.rb
@@ -8,7 +8,8 @@ cask "eiskaltdcpp" do
   homepage "https://sourceforge.net/projects/eiskaltdcpp/"
 
   livecheck do
-    regex(/EiskaltDC%2B%2B[._-]v?(\d+(?:\.\d+)+)[._-]x86_64\.dmg/i)
+    url "https://sourceforge.net/projects/eiskaltdcpp/rss?path=/macOS"
+    regex(%r{url=.*?/EiskaltDC%2B%2B[._-]v?(\d+(?:\.\d+)+)(?:-[^"']+?)?\.dmg}i)
   end
 
   app "EiskaltDC++.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `eiskaltdcpp` requires a `url` but is missing one, so this PR adds an appropriate URL. `url :url` would also use a SourceForge RSS feed URL (generated by the `Sourceforge` strategy) but the URL in this `livecheck` block restricts the feed to the `macOS` subdirectory (which contains the dmg files this cask uses). When possible, this helps to avoid an issue where the check could temporarily break if relevant files are pushed out of the RSS feed by irrelevant files (e.g., from other subdirectories).

Besides that, this updates the regex to align with the typical format for the `Sourceforge` strategy and to also loosen the suffix part of the regex. The suffix has varied over time (e.g., `x86`, `x86_64`, `universal`) and could theoretically switch back from `x86_64` to `universal` in the future, so this would help us to not miss new versions simply due to a suffix change. If this looseness ends up causing problems in the future (matching something it shouldn't), we can always revisit it.