### PR TITLE
Use dmg release in android-ndk cask

### DIFF
--- a/Casks/android-ndk.rb
+++ b/Casks/android-ndk.rb
@@ -1,8 +1,8 @@
 cask "android-ndk" do
   version "24"
-  sha256 "162a7000515be07489f2ed70d6d3a117d236150f83f3fcb601c163349429ba23"
+  sha256 "9b67b1aec07aaf707ca167332982d3d86eff901df0843cefa2a3b347fb463333"
 
-  url "https://dl.google.com/android/repository/android-ndk-r#{version}-darwin.zip",
+  url "https://dl.google.com/android/repository/android-ndk-r#{version}-darwin.dmg",
       verified: "dl.google.com/android/repository/"
   name "Android NDK"
   desc "Toolset to implement parts of Android apps in native code"
@@ -18,11 +18,12 @@ cask "android-ndk" do
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/ndk_exec.sh"
   preflight do
-    FileUtils.ln_sf("#{staged_path}/android-ndk-r#{version}", "#{HOMEBREW_PREFIX}/share/android-ndk")
+    build = File.read("#{staged_path}/source.properties").match(/(?<=Pkg.Revision\s=\s\d\d.\d.)\d+/)
+    FileUtils.ln_sf("#{staged_path}/AndroidNDK#{build}.app/Contents/NDK", "#{HOMEBREW_PREFIX}/share/android-ndk")
 
     File.write shimscript, <<~EOS
       #!/bin/bash
-      readonly executable="#{staged_path}/android-ndk-r#{version}/$(basename ${0})"
+      readonly executable="#{staged_path}/AndroidNDK#{build}.app/Contents/NDK/$(basename ${0})"
       test -f "${executable}" && exec "${executable}" "${@}"
     EOS
   end


### PR DESCRIPTION
The binaries in the Android NDK .zip release are not notarised, causing `x can't be opened because Apple can't check it for malicious software` errors. The NDK is also distributed as a notarised .dmg which resolves this.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
