### PR TITLE
Update springtoolsuite.rb to add aarch64

### DIFF
--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,8 +1,14 @@
 cask "springtoolsuite" do
+  arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
   version "4.14.0,4.23.0"
-  sha256 "973b0b6a332e60649bf2b989f0b2f7f8986f9138641e4cfa11e7ff276a2cc598"
 
-  url "https://download.springsource.com/release/STS#{version.major}/#{version.csv.first}.RELEASE/dist/e#{version.csv.second.major_minor}/spring-tool-suite-#{version.major}-#{version.csv.first}.RELEASE-e#{version.csv.second}-macosx.cocoa.x86_64.dmg",
+  if Hardware::CPU.intel?
+    sha256 "973b0b6a332e60649bf2b989f0b2f7f8986f9138641e4cfa11e7ff276a2cc598"
+  else
+    sha256 "c3d1d80669382688d49b2fc6d06b1f54e30fac0371d020ca07dbdf52472b69d0"
+  end
+
+  url "https://download.springsource.com/release/STS#{version.major}/#{version.csv.first}.RELEASE/dist/e#{version.csv.second.major_minor}/spring-tool-suite-#{version.major}-#{version.csv.first}.RELEASE-e#{version.csv.second}-macosx.cocoa.#{arch}.dmg",
       verified: "download.springsource.com/release/"
   name "Spring Tool Suite"
   desc "Next generation tooling for Spring Boot"
@@ -12,7 +18,7 @@ cask "springtoolsuite" do
     url :homepage
     strategy :page_match do |page|
       match = page.match(
-        %r{href=.*?/spring-tool-suite-\d+-(\d+(?:\.\d+)+)\.RELEASE-e(\d+(?:\.\d+)+)-macosx\.cocoa\.x86_64\.dmg}i,
+        %r{href=.*?/spring-tool-suite-\d+-(\d+(?:\.\d+)+)\.RELEASE-e(\d+(?:\.\d+)+)-macosx\.cocoa\.#{arch}\.dmg}i,
       )
       next if match.blank?
 

--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -1,5 +1,6 @@
 cask "springtoolsuite" do
   arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
+
   version "4.14.0,4.23.0"
 
   if Hardware::CPU.intel?


### PR DESCRIPTION
Update springtoolsuite.rb to add aarch64

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.