### PR TITLE
Add Mellel 5.app v5.1.0 (51012)

### DIFF
--- a/Casks/mellel.rb
+++ b/Casks/mellel.rb
@@ -10,9 +10,11 @@ cask "mellel" do
 
   livecheck do
     url "http://www.mellelupdate.com/mellelupdate/latest_update.xml"
-    strategy :page_match do |page|
-      page.scan(%r{<full-version>(\d+(?:\.\d+)+)\.(\d+)</full-version>}i)
-          .map { |match| "#{match[0]},#{match[1]}" }
+    regex(%r{<full-version>v?(\d+(?:\.\d{1,2})+)(?:\.(\d{3,}))?</full-version>}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
     end
   end
 

--- a/Casks/mellel.rb
+++ b/Casks/mellel.rb
@@ -1,0 +1,34 @@
+cask "mellel" do
+  version "5.1.0,51012"
+  sha256 "89fb9e8240ad407fbf3ca8f2949356ec58af7acf1d5f23884f534399d3dfeda4"
+
+  url "https://d1riogbqt3a9uw.cloudfront.net/mellel_#{version.csv.second}.dmg",
+      verified: "d1riogbqt3a9uw.cloudfront.net"
+  name "Mellel"
+  desc "Advanced word processor built for long and complex documents"
+  homepage "https://www.mellel.com/"
+
+  livecheck do
+    url "http://www.mellelupdate.com/mellelupdate/latest_update.xml"
+    strategy :page_match do |page|
+      page.scan(%r{<full-version>(\d+(?:\.\d+)+)\.(\d+)</full-version>}i)
+          .map { |match| "#{match[0]},#{match[1]}" }
+    end
+  end
+
+  auto_updates true
+
+  app "Mellel #{version.major}.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.redlex.mellel",
+    "~/Library/Application Support/Mellel #{version.major}",
+    "~/Library/Application Support/com.redlex.mellel#{version.major}",
+    "~/Library/Caches/com.redlex.mellel#{version.major}",
+    "~/Library/HTTPStorages/com.redlex.mellel#{version.major}",
+    "~/Library/HTTPStorages/com.redlex.mellel#{version.major}.binarycookies",
+    "~/Library/Preferences/com.redlex.mellel#{version.major}.plist",
+    "~/Library/Saved Application State/com.redlex.MellelUpdater.savedState",
+    "~/Library/Saved Application State/com.redlex.mellel#{version.major}.savedState",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Mellel has been available for macOS since the early 2000s (and in recent years on iPadOS), has an active user community, and has been used to author numerous books, doctoral dissertations, and articles. I checked with the authors of Mellel, and they were supportive of my idea to make Mellel available via Homebrew. They pointed me to the URL used in the Livecheck stanza.