### PR TITLE
opensong: update livecheck

### DIFF
--- a/Casks/opensong.rb
+++ b/Casks/opensong.rb
@@ -8,8 +8,11 @@ cask "opensong" do
   desc "Presentation software"
   homepage "http://www.opensong.org/"
 
+  # This regex has to match unstable versions until the cask uses a stable
+  # version again.
   livecheck do
-    regex(/OpenSong[\s._-]+?v?(\d+(?:\.\d+)+)\.pkg/i)
+    url "https://sourceforge.net/projects/opensong/rss?path=/OpenSong"
+    regex(/OpenSong[\s._-]*?v?(\d+(?:[._]\d+)+(?:[\s._-]?(?:B(?:eta)?|RC)\d*)?)(?:[._-][^"']+?)?\.(?:dmg|pkg)/i)
   end
 
   pkg "OpenSong%20#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `opensong` requires a `url` but is missing one, so this PR resolves the issue. Using `url :url` would generate a SourceForge RSS feed URL but it's better to restrict matching to the `OpenSong` subdirectory in this instance.

This also updates the regex to match a wider variety of potential filename formats (looking to releases before 3.4.8 Beta). The current file (`/OpenSong/V3.4.8 Beta/OpenSong 3.4.8.pkg`) doesn't include "Beta" or an architecture suffix in the filename, unlike the version before it (`OpenSong_3_4_7_Beta_x86_64.pkg`). 3.4.7 Beta was released two months before 3.4.8 (and they were both released last year), so it seems reasonable to accommodate more filename formats to help ensure we don't miss versions.

I haven't updated this regex to follow the typical `Sourceforge` strategy regex style (i.e., matching the filename within a `url` attribute) because the regex is long and easily bumps up against the `brew style` 118 character line limit when we have to match encoded whitespace (i.e., using `(?:%20|[._-])?` in multiple places instead of the shorter `[\s._-]*?`). This isn't ideal but there's something to be said for trying to keep the regex within the character limit (for the sake of brevity) instead of using the `x` flag to split it across multiple lines.