### PR TITLE
Add Cask for Free-GPGMail 2021.3.1

### DIFF
--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -1,0 +1,48 @@
+cask 'free-gpgmail' do
+  name "Free-GPGMail"
+  desc "A modification of the Apple Mail plugin for GnuPG encrypted e-mails, so it does not require a support plan."
+  homepage "https://github.com/Free-GPGMail/Free-GPGMail"
+  auto_updates false
+  depends_on macos: ">= :mojave"
+  depends_on cask: "gpg-suite-no-mail"
+
+  preflight do
+    system "rm", "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_*.mailbundle"
+  end
+
+  if MacOS.version <= :mojave
+    version '2021.3'
+    sha256 '7b4eaf2d52ddc1519dfec4087f09bad018657fde87a87021904075f55ac00377'
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_3-#{version}.mailbundle.zip"
+    artifact "Free-GPGMail_3.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_3.mailbundle"
+    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_3.mailbundle"
+  elsif MacOS.version <= :catalina
+    version '2021.3'
+    sha256 'c2fda8cc9a52825cf0c0a9d954036e215076db5ec8b898c35d16d306aa6b1ea4'
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_4-#{version}.mailbundle.zip"
+    artifact "Free-GPGMail_4.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_4.mailbundle"
+    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_4.mailbundle"
+  elsif MacOS.version <= :big_sur
+    version '2021.3'
+    sha256 '438519fa8b5ed04081553efd58b5edf52b6847ea3719fe9b1331e97c8021ca43'
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_5-#{version}.mailbundle.zip"
+    artifact "Free-GPGMail_5.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_5.mailbundle"
+    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_5.mailbundle"
+  elsif MacOS.version >= :monterey
+    version '2021.3'
+    sha256 'a3e9d799ee332093303f4bf7ecc03d084e0bd3e28954cedc7d9149f660ae72e5'
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_6-#{version}.mailbundle.zip"
+    artifact "Free-GPGMail_6.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_6.mailbundle"
+    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_6.mailbundle"
+  end
+
+  caveats "Apple Mail plugin for GnuPG has been updated."
+  caveats "To finalize installation, do the following:"
+  caveats "    In Mail, go to Preferences -> General -> Manage Plugins..."
+  caveats "    - Make sure that 'GPGMailLoader_*.mailbundle', if present, is disabled."
+  caveats "    - Enable the 'Free-GPGMail_<version>.mailbundle'."
+  caveats "    - Apply and Restart Mail."
+  caveats ""
+  caveats "If this is your first time installing Free-GPGMail:"
+  caveats "    In Mail.app, check Preferences -> Free-GPGMail. If it says that you are in Trial Mode or Decryption Only Mode, hit Activate. It will perform a dummy activation routine."
+end

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -11,26 +11,26 @@ cask 'free-gpgmail' do
   end
 
   if MacOS.version <= :mojave
-    version '2021.3'
-    sha256 '7b4eaf2d52ddc1519dfec4087f09bad018657fde87a87021904075f55ac00377'
+    version '2021.3.1'
+    sha256 '584827bde768cad5d7160b22387add35b02e75c1e4e75894cecd30c2edbabc13'
     url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_3-#{version}.mailbundle.zip"
     artifact "Free-GPGMail_3.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_3.mailbundle"
     uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_3.mailbundle"
   elsif MacOS.version <= :catalina
-    version '2021.3'
-    sha256 'c2fda8cc9a52825cf0c0a9d954036e215076db5ec8b898c35d16d306aa6b1ea4'
+    version '2021.3.1'
+    sha256 '3d1fc129589a495527601102080993db61e78f430b1cf2372a219f1a8d4c1fb3'
     url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_4-#{version}.mailbundle.zip"
     artifact "Free-GPGMail_4.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_4.mailbundle"
     uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_4.mailbundle"
   elsif MacOS.version <= :big_sur
-    version '2021.3'
-    sha256 '438519fa8b5ed04081553efd58b5edf52b6847ea3719fe9b1331e97c8021ca43'
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_5-#{version}.mailbundle.zip"
+    version '2021.3.1'
+    sha256 'ee0b1a313afedb5cdf8a9703b00f35040b3109877247bb342c92a60b53944c9a'
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_5-#{version}-signed.mailbundle.zip"
     artifact "Free-GPGMail_5.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_5.mailbundle"
     uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_5.mailbundle"
   elsif MacOS.version >= :monterey
-    version '2021.3'
-    sha256 'a3e9d799ee332093303f4bf7ecc03d084e0bd3e28954cedc7d9149f660ae72e5'
+    version '2021.3.1'
+    sha256 'd15ae3bad7a40c98a078b5be0891dd38d43240cde7acbfd5f7ac03fafad4bbb1'
     url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_6-#{version}.mailbundle.zip"
     artifact "Free-GPGMail_6.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_6.mailbundle"
     uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_6.mailbundle"

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -31,21 +31,5 @@ cask "free-gpgmail" do
 
   artifact "Free-GPGMail_#{version.csv.first}.mailbundle", target: "#{ENV["HOME"]}/Library/Mail/Bundles/Free-GPGMail_#{version.csv.first}.mailbundle"
 
-  preflight do
-    system "rm", "#{ENV["HOME"]}/Library/Mail/Bundles/Free-GPGMail_*.mailbundle"
-  end
-
   uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_#{version.csv.first}.mailbundle"
-
-  caveats "Apple Mail plugin for GnuPG has been updated."
-  caveats "To finalize installation, do the following:"
-  caveats "    In Mail, go to Preferences -> General -> Manage Plugins..."
-  caveats "    - Make sure that 'GPGMailLoader_*.mailbundle', if present, is disabled."
-  caveats "    - Enable the 'Free-GPGMail_<version>.mailbundle'."
-  caveats "    - Apply and Restart Mail."
-  caveats ""
-  caveats "If this is your first time installing Free-GPGMail:"
-  caveats "    In Mail.app, check Preferences -> Free-GPGMail. If it says that you are in"
-  caveats "    Trial Mode or Decryption Only Mode, hit Activate. It will perform a dummy"
-  caveats "    activation routine."
 end

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -15,7 +15,6 @@ cask "free-gpgmail" do
   desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"
 
-
   livecheck do
     url :url
     strategy :git do |tags|

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -15,6 +15,17 @@ cask "free-gpgmail" do
   desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"
 
+
+  livecheck do
+    url :url
+    strategy :git do |tags|
+      tags.map do |tag|
+        match = tag.match(/^v(\d+(?:\.\d+)*)/i)
+        "#{version.csv.first},#{match[1]},#{version.csv.third}" if match
+      end.compact
+    end
+  end
+
   auto_updates false
   depends_on macos: ">= :mojave"
   depends_on cask: "gpg-suite-no-mail"

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -1,40 +1,39 @@
-cask 'free-gpgmail' do
+cask "free-gpgmail" do
+  if MacOS.version <= :mojave
+    version "3,2021.3.1"
+    sha256 "584827bde768cad5d7160b22387add35b02e75c1e4e75894cecd30c2edbabc13"
+  elsif MacOS.version <= :catalina
+    version "4,2021.3.1"
+    sha256 "3d1fc129589a495527601102080993db61e78f430b1cf2372a219f1a8d4c1fb3"
+  elsif MacOS.version <= :big_sur
+    version "5,2021.3.1"
+    sha256 "ee0b1a313afedb5cdf8a9703b00f35040b3109877247bb342c92a60b53944c9a"
+  elsif MacOS.version >= :monterey
+    version "6,2021.3.1"
+    sha256 "d15ae3bad7a40c98a078b5be0891dd38d43240cde7acbfd5f7ac03fafad4bbb1"
+  end
+
+  url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}.mailbundle.zip"
   name "Free-GPGMail"
-  desc "A modification of the Apple Mail plugin for GnuPG encrypted e-mails, so it does not require a support plan."
+  desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   auto_updates false
   depends_on macos: ">= :mojave"
   depends_on cask: "gpg-suite-no-mail"
 
+  artifact "Free-GPGMail_#{version.csv.first}.mailbundle", target: "#{ENV["HOME"]}/Library/Mail/Bundles/Free-GPGMail_#{version.csv.first}.mailbundle"
+
   preflight do
-    system "rm", "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_*.mailbundle"
+    system "rm", "#{ENV["HOME"]}/Library/Mail/Bundles/Free-GPGMail_*.mailbundle"
   end
 
-  if MacOS.version <= :mojave
-    version '2021.3.1'
-    sha256 '584827bde768cad5d7160b22387add35b02e75c1e4e75894cecd30c2edbabc13'
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_3-#{version}.mailbundle.zip"
-    artifact "Free-GPGMail_3.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_3.mailbundle"
-    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_3.mailbundle"
-  elsif MacOS.version <= :catalina
-    version '2021.3.1'
-    sha256 '3d1fc129589a495527601102080993db61e78f430b1cf2372a219f1a8d4c1fb3'
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_4-#{version}.mailbundle.zip"
-    artifact "Free-GPGMail_4.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_4.mailbundle"
-    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_4.mailbundle"
-  elsif MacOS.version <= :big_sur
-    version '2021.3.1'
-    sha256 'ee0b1a313afedb5cdf8a9703b00f35040b3109877247bb342c92a60b53944c9a'
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_5-#{version}-signed.mailbundle.zip"
-    artifact "Free-GPGMail_5.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_5.mailbundle"
-    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_5.mailbundle"
-  elsif MacOS.version >= :monterey
-    version '2021.3.1'
-    sha256 'd15ae3bad7a40c98a078b5be0891dd38d43240cde7acbfd5f7ac03fafad4bbb1'
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version}/Free-GPGMail_6-#{version}.mailbundle.zip"
-    artifact "Free-GPGMail_6.mailbundle", target: "#{ENV['HOME']}/Library/Mail/Bundles/Free-GPGMail_6.mailbundle"
-    uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_6.mailbundle"
-  end
+  uninstall delete: "~/Library/Mail/Bundles/Free-GPGMail_#{version.csv.first}.mailbundle"
 
   caveats "Apple Mail plugin for GnuPG has been updated."
   caveats "To finalize installation, do the following:"
@@ -44,5 +43,7 @@ cask 'free-gpgmail' do
   caveats "    - Apply and Restart Mail."
   caveats ""
   caveats "If this is your first time installing Free-GPGMail:"
-  caveats "    In Mail.app, check Preferences -> Free-GPGMail. If it says that you are in Trial Mode or Decryption Only Mode, hit Activate. It will perform a dummy activation routine."
+  caveats "    In Mail.app, check Preferences -> Free-GPGMail. If it says that you are in"
+  caveats "    Trial Mode or Decryption Only Mode, hit Activate. It will perform a dummy"
+  caveats "    activation routine."
 end

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -1,23 +1,16 @@
 cask "free-gpgmail" do
-  if MacOS.version <= :mojave
-    version "3,2021.3.1"
-    sha256 "584827bde768cad5d7160b22387add35b02e75c1e4e75894cecd30c2edbabc13"
-  elsif MacOS.version <= :catalina
-    version "4,2021.3.1"
-    sha256 "3d1fc129589a495527601102080993db61e78f430b1cf2372a219f1a8d4c1fb3"
+  if MacOS.version <= :catalina
+    version "5,2021.3.1,-unsigned"
+    sha256 "3a3c9290622cc3fe8d4761050363917d009f9fa923eb32d436364f0ae9a161b9"
   elsif MacOS.version <= :big_sur
-    version "5,2021.3.1"
+    version "5,2021.3.1,-signed"
     sha256 "ee0b1a313afedb5cdf8a9703b00f35040b3109877247bb342c92a60b53944c9a"
   elsif MacOS.version >= :monterey
-    version "6,2021.3.1"
+    version "6,2021.3.1,"
     sha256 "d15ae3bad7a40c98a078b5be0891dd38d43240cde7acbfd5f7ac03fafad4bbb1"
   end
 
-  if version.csv.first == 5
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}-signed.mailbundle.zip"
-  else
-    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}.mailbundle.zip"
-  end
+  url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}#{version.csv.third}.mailbundle.zip"
   name "Free-GPGMail"
   desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -15,13 +15,24 @@ cask "free-gpgmail" do
   desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"
 
+  # This restricts matching to new releases that use the same major as the
+  # cask `version` (based on the execution environment). As such, this won't
+  # surface a new major version and that will need to be handled manually.
   livecheck do
     url :url
-    strategy :git do |tags|
-      tags.map do |tag|
-        match = tag.match(/^v(\d+(?:\.\d+)*)/i)
-        "#{version.csv.first},#{match[1]},#{version.csv.third}" if match
-      end.compact
+    regex(/href=.*?Free-GPGMail[._-]v?(\d+)-(\d+(?:\.\d+)+)(-[^"' >]+?)?[._-]mailbundle\.zip/i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map do |match|
+        next if match[0] != version.csv.first
+
+        if match[2].present?
+          next if version.csv.third.present? && match[2] != version.csv.third
+
+          "#{match[0]},#{match[1]},#{match[2]}"
+        else
+          "#{match[0]},#{match[1]}"
+        end
+      end
     end
   end
 

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -15,11 +15,6 @@ cask "free-gpgmail" do
   desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates false
   depends_on macos: ">= :mojave"
   depends_on cask: "gpg-suite-no-mail"

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -13,7 +13,11 @@ cask "free-gpgmail" do
     sha256 "d15ae3bad7a40c98a078b5be0891dd38d43240cde7acbfd5f7ac03fafad4bbb1"
   end
 
-  url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}.mailbundle.zip"
+  if version.csv.first == 5
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}-signed.mailbundle.zip"
+  else
+    url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}.mailbundle.zip"
+  end
   name "Free-GPGMail"
   desc "Apple Mail plugin for GnuPG encrypted e-mails"
   homepage "https://github.com/Free-GPGMail/Free-GPGMail"

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -30,7 +30,7 @@ cask "free-gpgmail" do
 
           "#{match[0]},#{match[1]},#{match[2]}"
         else
-          "#{match[0]},#{match[1]}"
+          "#{match[0]},#{match[1]},"
         end
       end
     end


### PR DESCRIPTION
[`Free-GPGMail`](https://github.com/Free-GPGMail/Free-GPGMail) is a fork of GPG Mail (as part of `gpg-suite`):
> A modification of the Apple Mail plugin for GnuPG encrypted e-mails, so it does not require a support plan.

This PR adds the cask prepared by @EivindArvesen as diskussed in [Free-GPGMail#41](https://github.com/Free-GPGMail/Free-GPGMail/issues/41) as an official Cask.

---

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask free-gpgmail` is error-free.
- [X] `brew style --fix free-gpgmail` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask free-gpgmail` worked successfully.
- [X] `brew install --cask free-gpgmail` worked successfully.
- [X] `brew uninstall --cask free-gpgmail` worked successfully.

---

Many Thanks to @EivindArvesen for his work on this cask!