### PR TITLE
crossover: Enable autoupdate

### DIFF
--- a/Casks/crossover.rb
+++ b/Casks/crossover.rb
@@ -12,6 +12,8 @@ cask "crossover" do
     strategy :sparkle
   end
 
+  auto_updates true
+  
   app "CrossOver.app"
 
   zap trash: [


### PR DESCRIPTION
Crossover automatically updates itself. I updated to the latest version through crossover yesterday, and brew reinstalled that same upgrade this morning. This should prevent unnecessary re-installations.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] brew audit --cask <cask> is error-free.
- [x] brew style --fix <cask> reports no offenses.