### PR TITLE
tv-browser: update livecheck

### DIFF
--- a/Casks/tv-browser.rb
+++ b/Casks/tv-browser.rb
@@ -8,8 +8,11 @@ cask "tv-browser" do
   desc "Electronic TV guide"
   homepage "https://www.tvbrowser.org/"
 
+  # TV-Browser has used a single-digit version (4) for a major version release
+  # in the past, so this has to use the looser (*) version regex format.
   livecheck do
-    regex(%r{url=.*?/tvbrowser/files/.*?[-_/](\d+(?:[-.]\d+)+)[._-]macjava.dmg}i)
+    url :url
+    regex(%r{url=.*?/tvbrowser[._-]v?(\d+(?:\.\d+)*)(?:[._-]mac(?:java)?)?\.dmg}i)
   end
 
   app "TV-Browser.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `tv-browser` requires a `url` but is missing one, so this PR resolves the issue. This also updates the regex to align with the typical format for the `Sourceforge` strategy (and prevailing regex patterns in general). This also includes the following regex changes:

* Omit the leading `/tvbrowser/files/` path for the sake of simplicity/consistency, as it's not required for matching (it's implied in the context of a SourceForge RSS feed).
* Use the standard regex for versions like 1.2.3/v1.2.3, as there aren't any macOS versions that include a hyphen to justify the modified regex. This may have been copied over from another formula/cask where this modification is necessary or the version format for rpm and deb files was assumed to apply to macOS filenames as well. Correct me if I'm wrong, of course.
* Adapt the suffix part a bit, to account for something like `_macjava`, `_mac`, or no suffix. These are the formats I've seen in past filenames but this will need to be adapted further if a new format appears in the future (e.g., to something that's loose like `(?:[_-][^"']+?)?` but shouldn't eat part of the version). A looser approach may lead to other problems, so this is fine for now. 