### PR TITLE
Use versioned url for Speedify cask

### DIFF
--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -2,7 +2,7 @@ cask "speedify" do
   version "11.9.2,8960"
   sha256 :no_check
 
-  url "https://downloads.speedify.com/Speedify-#{version.sub(",", ".")}.dmg"
+  url "https://downloads.speedify.com/Speedify-#{version.csv.first}.#{version.csv.second}.dmg"
   name "Speedify"
   desc "VPN client"
   homepage "https://speedify.com/"

--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -8,7 +8,7 @@ cask "speedify" do
   homepage "https://speedify.com/"
 
   livecheck do
-    url :url
+    url "https://downloads.speedify.com/speedify.php?platform=osx"
     strategy :extract_plist
   end
 

--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -2,7 +2,7 @@ cask "speedify" do
   version "11.9.2,8960"
   sha256 :no_check
 
-  url "https://downloads.speedify.com/speedify.php?platform=osx"
+  url "https://downloads.speedify.com/Speedify-#{version.sub(',','.')}.dmg"
   name "Speedify"
   desc "VPN client"
   homepage "https://speedify.com/"

--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -1,6 +1,6 @@
 cask "speedify" do
   version "11.9.2,8960"
-  sha256 :no_check
+  sha256 "71c0f67a5301e065a696e18f6373d57c8ced97675dc6d0cb1aa84c299a520bed"
 
   url "https://downloads.speedify.com/Speedify-#{version.csv.first}.#{version.csv.second}.dmg"
   name "Speedify"

--- a/Casks/speedify.rb
+++ b/Casks/speedify.rb
@@ -2,7 +2,7 @@ cask "speedify" do
   version "11.9.2,8960"
   sha256 :no_check
 
-  url "https://downloads.speedify.com/Speedify-#{version.sub(',','.')}.dmg"
+  url "https://downloads.speedify.com/Speedify-#{version.sub(",", ".")}.dmg"
   name "Speedify"
   desc "VPN client"
   homepage "https://speedify.com/"


### PR DESCRIPTION
This PR uses the url structure for `.dmg` that I received from the Speedify support team, so it should allow for versioned installs of Speedify versions

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
