### PR TITLE
crossover: fix style issues

### DIFF
--- a/Casks/crossover.rb
+++ b/Casks/crossover.rb
@@ -13,7 +13,7 @@ cask "crossover" do
   end
 
   auto_updates true
-  
+
   app "CrossOver.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `crossover` cask was recently updated in #120917 to include `auto_updates true` but the blank line after it contains spaces. This leads to the following `brew style` offenses:

```
/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/crossover.rb:16:1: C: [Correctable] stanza groups should be separated by a single empty line
/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/crossover.rb:16:1: C: [Correctable] Trailing whitespace detected.
```

This PR fixes the issue and should be merged ASAP, as CI is currently failing in unrelated PRs because of this.