### PR TITLE
minizincide: Update checksum to match re-release

### DIFF
--- a/Casks/minizincide.rb
+++ b/Casks/minizincide.rb
@@ -1,6 +1,6 @@
 cask "minizincide" do
   version "2.6.2"
-  sha256 "5b02880bc53a36ac579ecacb0c6217891693f9148f555731780ac155ffac8290"
+  sha256 "e8578a29a5934e036ef30d75427507024db7a66363f4bee6c970bff89bbf470e"
 
   url "https://github.com/MiniZinc/MiniZincIDE/releases/download/#{version}/MiniZincIDE-#{version}-bundled.dmg",
       verified: "github.com/MiniZinc/MiniZincIDE/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.


---

The MiniZinc team issued a re-release of the latest bundle as it contained a M1-only executable. This PR updates the checksum to match the new file.