### PR TITLE
balenaetcher: Enable autoupdate

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -13,6 +13,8 @@ cask "balenaetcher" do
     strategy :github_latest
   end
 
+  auto_updates true
+
   app "balenaEtcher.app"
 
   uninstall quit: [


### PR DESCRIPTION
Balena Etcher automatically updates itself. This can be seen in the options menu of the application. This should prevent unnecessary re-installations of updates.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

