### PR TITLE
Waterfox (Update to V4.0.8 & Added M1 Support)

### DIFF
--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,21 +1,22 @@
 cask "waterfox" do
-  suffix = Hardware::CPU.intel? ? "Setup" : "ARM.Setup"
+  arch = Hardware::CPU.intel? ? "Setup" : "ARM.Setup"
+
   version "4.0.8"
 
-  url "https://github.com/WaterfoxCo/Waterfox/releases/download/G#{version}/Waterfox.G#{version}.#{suffix}.dmg", verified: "github.com/WaterfoxCo/Waterfox/"
-  name "Waterfox"
-  desc "Web browser"
   if Hardware::CPU.intel?
     sha256 "fe49d8da775d0d1ae7914cd51cf59fa9032cf02d398ac8891f2b722f4c2799b0"
   else
     sha256 "ee65166b3da3ff442e2ba0a9953844e5d4db386e0780ce41f3a39b842a191ce2"
   end
 
+  url "https://github.com/WaterfoxCo/Waterfox/releases/download/G#{version}/Waterfox.G#{version}.#{arch}.dmg", verified: "github.com/WaterfoxCo/Waterfox/"
+  name "Waterfox"
+  desc "Web browser"
   homepage "https://www.waterfox.net/"
 
   livecheck do
-    url "https://api.github.com/repos/WaterfoxCo/Waterfox/releases/latest"
-    regex(%r{browser_download_url.*?/Waterfox\.G(\d+(?:[._-]\d+)+)\.#{suffix}\.dmg}i)
+    url :url
+    regex(/^G?(\d+(?:\.\d+)+)$/i)
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,15 +1,15 @@
 cask "waterfox" do
-  version "3.2.6"
-  sha256 "1aa0442868c503a2b214c023364d6b86e7a3cb6eda94c80d73e19d627996ee3d"
-
-  url "https://cdn.waterfox.net/releases/osx64/installer/Waterfox%20G#{version}%20Setup.dmg"
   name "Waterfox"
   desc "Web browser"
   homepage "https://www.waterfox.net/"
+  version "4.0.8"
+  sha256 "fe49d8da775d0d1ae7914cd51cf59fa9032cf02d398ac8891f2b722f4c2799b0"
+
+  url "https://github.com/WaterfoxCo/Waterfox/releases/download/G#{version}/Waterfox.G#{version}.Setup.dmg"
 
   livecheck do
     url "https://www.waterfox.net/download/"
-    regex(%r{href=.*?/Waterfox%20G(\d+(?:\.\d+)+)%20Setup\.dmg}i)
+    regex(%r{href=.*?/Waterfox\.G(\d+(?:\.\d+)+)\.Setup\.dmg}i)
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -1,15 +1,21 @@
 cask "waterfox" do
+  suffix = Hardware::CPU.intel? ? "Setup" : "ARM.Setup"
+  version "4.0.8"
+
+  url "https://github.com/WaterfoxCo/Waterfox/releases/download/G#{version}/Waterfox.G#{version}.#{suffix}.dmg", verified: "github.com/WaterfoxCo/Waterfox/"
   name "Waterfox"
   desc "Web browser"
-  homepage "https://www.waterfox.net/"
-  version "4.0.8"
-  sha256 "fe49d8da775d0d1ae7914cd51cf59fa9032cf02d398ac8891f2b722f4c2799b0"
+  if Hardware::CPU.intel?
+    sha256 "fe49d8da775d0d1ae7914cd51cf59fa9032cf02d398ac8891f2b722f4c2799b0"
+  else
+    sha256 "ee65166b3da3ff442e2ba0a9953844e5d4db386e0780ce41f3a39b842a191ce2"
+  end
 
-  url "https://github.com/WaterfoxCo/Waterfox/releases/download/G#{version}/Waterfox.G#{version}.Setup.dmg"
+  homepage "https://www.waterfox.net/"
 
   livecheck do
     url "https://www.waterfox.net/download/"
-    regex(%r{href=.*?/Waterfox\.G(\d+(?:\.\d+)+)\.Setup\.dmg}i)
+    regex(%r{href=.*?/Waterfox\.G(\d+(?:\.\d+)+)\.#{suffix}\.dmg}i)
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -14,8 +14,8 @@ cask "waterfox" do
   homepage "https://www.waterfox.net/"
 
   livecheck do
-    url "https://www.waterfox.net/download/"
-    regex(%r{href=.*?/Waterfox\.G(\d+(?:\.\d+)+)\.#{suffix}\.dmg}i)
+    url "https://api.github.com/repos/WaterfoxCo/Waterfox/releases/latest"
+    regex(%r{browser_download_url.*?/Waterfox\.G(\d+(?:[._-]\d+)+)\.#{suffix}\.dmg}i)
   end
 
   depends_on macos: ">= :yosemite"


### PR DESCRIPTION
* Updated Cask to V4.0.8
* Added M1/ARM version check

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.