### PR TITLE
Add Espanso 2.1.4

### DIFF
--- a/Casks/espanso.rb
+++ b/Casks/espanso.rb
@@ -1,0 +1,39 @@
+cask "espanso" do
+  arch = Hardware::CPU.intel? ? "Intel" : "M1"
+
+  version "2.1.5"
+
+  if Hardware::CPU.intel?
+    sha256 "6058ea8b851073ab97a6ffd257127ef7cfd367ccc6c290648217b3b657319539"
+  else
+    sha256 "8e71bf8904f3418ddc54c8faeb9e1f40fe4a57bef81d6c93468dbf0c55bcb210"
+  end
+
+  url "https://github.com/federico-terzi/espanso/releases/download/v#{version}-beta/Espanso-Mac-#{arch}.zip",
+      verified: "github.com/federico-terzi/espanso/"
+  name "Espanso"
+  desc "Cross-platform Text Expander written in Rust"
+  homepage "https://espanso.org/"
+
+  livecheck do
+    url "https://github.com/federico-terzi/espanso/releases/latest"
+    strategy :page_match
+    regex(%r{href=.*?/v(\d+(?:\.\d+)*)(?:-beta)?/Espanso-Mac-(?:Intel|M1)\.zip}i)
+  end
+
+  app "Espanso.app"
+  binary "#{appdir}/Espanso.app/Contents/MacOS/espanso"
+
+  zap trash: [
+    "~/Library/Caches/espanso",
+    "~/Library/LaunchAgents/com.federicoterzi.espanso.plist",
+    "~/Library/Preferences/com.federicoterzi.espanso.plist",
+    "~/Library/Preferences/espanso.plist",
+    "~/Library/Preferences/espanso",
+    "~/Library/Saved Application State/com.federicoterzi.espanso.savedState",
+  ]
+
+  caveats do
+    unsigned_accessibility
+  end
+end

--- a/Casks/espanso.rb
+++ b/Casks/espanso.rb
@@ -1,7 +1,7 @@
 cask "espanso" do
   arch = Hardware::CPU.intel? ? "Intel" : "M1"
 
-  version "2.1.5"
+  version "2.1.5-beta"
 
   if Hardware::CPU.intel?
     sha256 "6058ea8b851073ab97a6ffd257127ef7cfd367ccc6c290648217b3b657319539"
@@ -9,16 +9,15 @@ cask "espanso" do
     sha256 "8e71bf8904f3418ddc54c8faeb9e1f40fe4a57bef81d6c93468dbf0c55bcb210"
   end
 
-  url "https://github.com/federico-terzi/espanso/releases/download/v#{version}-beta/Espanso-Mac-#{arch}.zip",
+  url "https://github.com/federico-terzi/espanso/releases/download/v#{version}/Espanso-Mac-#{arch}.zip",
       verified: "github.com/federico-terzi/espanso/"
   name "Espanso"
   desc "Cross-platform Text Expander written in Rust"
   homepage "https://espanso.org/"
 
   livecheck do
-    url "https://github.com/federico-terzi/espanso/releases/latest"
-    strategy :page_match
-    regex(%r{href=.*?/v(\d+(?:\.\d+)*)(?:-beta)?/Espanso-Mac-(?:Intel|M1)\.zip}i)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:-beta\.?\d*)?)$/i)
   end
 
   app "Espanso.app"


### PR DESCRIPTION
The developer has explained the beta tag in v2.1.4's release notes:

> With this release, the v2 will officially become the stable version,
> while version 0.7.3 (legacy version) will be deprecated. This
> decision comes after months of testing, and we're confident the v2 is
> ready for general adoption!

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Further to the above, it is my understanding that this release meets the "But There Is No Stable Version!" criteria, and I can personally attest that despite officially being a "beta" product since I started relying on it in late 2019, Espanso has been more stable than most of the "stable" software I use.