### PR TITLE
Update confluent-cli from 2.4.0 to 2.8.1

### DIFF
--- a/Casks/confluent-cli.rb
+++ b/Casks/confluent-cli.rb
@@ -1,6 +1,6 @@
 cask "confluent-cli" do
-  version "2.4.0"
-  sha256 "ed89aaa5a9bb35e35648ea472f0d729055fb30ec7f3d768a44f30ccbd23d6ef6"
+  version "2.8.1"
+  sha256 "f9db2237b159a1f185f0625f5661fb7414c7acd854365102fa5b040b9c4b3ba7"
 
   url "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/#{version}/confluent_v#{version}_darwin_amd64.tar.gz",
       verified: "s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/"
@@ -10,8 +10,8 @@ cask "confluent-cli" do
 
   livecheck do
     url "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/latest/confluent_latest_darwin_amd64.tar.gz"
+    regex(/confluent[._-]v?(\d+(?:\.\d+)+)(?:[_-].+?)?\.t/i)
     strategy :header_match
-    regex(/confluent[._-]v?(\d+(?:\.\d+)+)[._-]darwin[._-]amd64\.tar\.gz/i)
   end
 
   binary "confluent/confluent"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


---

This updates `confluent-cli` to the latest stable version, 2.8.1.

Besides that, this updates the `livecheck` block regex as follows:

* Address the `Use .t instead of .tar.gz` Rubocop offense, which will apply to casks in the future (this is a preemptive fix before enabling it).
* Loosen the architecture suffix part of the regex, so this will continue to match if the text changes (or is omitted) in the future. [Using the generic `.+?` is fine in this context because this is matching text from a header. In other contexts, we need to use something more contextually appropriate, like `[^"' >]+?` to stay within the bounds of an HTML attribute.]
* Move the `#strategy` call below the regex, as the regex should come before the `#strategy` call (to make it easy to modify an existing `#strategy` call to include a `strategy` block).