### PR TITLE
Update utools 2.5.2 => 2.6.1

### DIFF
--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -1,12 +1,12 @@
 cask "utools" do
   arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  version "2.5.2"
+  version "2.6.1"
 
   if Hardware::CPU.intel?
-    sha256 "40c68599367d6fe2fcb4d26085c748ce52ba3876e5968a085af566ddba49479d"
+    sha256 "d7625360299cc247b4be0820757308711825d7d465d4ccd057f89fa985630d41"
   else
-    sha256 "020b09e550f7cf007f927b69d742cc51c883ba84ca2593176b36810e4c269cdf"
+    sha256 "963370eb154d70420ec5d8079188f8f75f486d140e78fecad2fc1ce1ae95a003"
   end
 
   url "https://publish.u-tools.cn/version2/uTools-#{version}#{arch}.dmg",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/15716336/160285721-35571f58-b874-4202-a586-f257092585cf.png">
