### PR TITLE
Update isyncer from 3.8.0 to 3.9.0

### DIFF
--- a/Casks/isyncer.rb
+++ b/Casks/isyncer.rb
@@ -1,6 +1,6 @@
 cask "isyncer" do
-  version "3.8.0"
-  sha256 "a3a3df7662cbf21f22b7ed78603b3b900b249635555b5b94ad11bf561d417348"
+  version "3.9.0"
+  sha256 "552e558f99e4ccdec9e2ec1adfda650851676ac0769fd9ceafcd7803b7a7de37"
 
   url "https://www.isyncer.de/system/iSyncerV#{version}mac-installer.tgz"
   name "iSyncer"
@@ -9,7 +9,7 @@ cask "isyncer" do
 
   livecheck do
     url "https://www.isyncer.de/en/releases/"
-    regex(%r{href=.*?/iSyncerv?(\d+(?:\.\d+)+)mac[._-]installer\.tgz}i)
+    regex(/href=.*?iSyncer[._-]?v?(\d+(?:\.\d+)+)[._-]?mac[._-]installer\.t/i)
   end
 
   pkg "iSyncer-installer-#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `isyncer` to the latest stable version, 3.9.0.

Besides that, this updates the `livecheck` block regex as follows:

* Address the `Use .t instead of .tar.gz` Rubocop offense, which will apply to casks in the future (this is a preemptive fix before enabling it).
* Allow for optional delimiters that could conceivably appear but aren't currently used, so we wouldn't miss a version due to simple filename changes.
* Better align with the typical approach for matching a file within an `href` attribute. Namely, allow the leading forward slash (`/`) to be implicitly covered by the `href=.*?` part of the regex, as this will work regardless of whether the URL contains a leading forward slash or not (i.e., if the regex expects a leading forward slash but the URL changes and it's no longer present, the regex would fail to match). [For what it's worth, we use a leading forward slash in `Sourceforge` strategy regexes because we can rely on it being present in RSS feed `url` attributes and there's value in that particular context.]