### PR TITLE
casks-without-zap: from checklist to unordered

### DIFF
--- a/developer/bin/casks-without-zap
+++ b/developer/bin/casks-without-zap
@@ -77,7 +77,7 @@ CASK_LISTS = CASKS_NO_ZAP.each_with_object([]) do |(tap_dir, casks), message|
   message.push("<details><summary>#{tap_dir.dirname.basename.to_path}</summary>")
   message.push("") # Empty line so the markdown still works inside the HTML
 
-  casks.each { message.push("- [ ] [`#{cask_name(_1)}`](#{cask_url(tap_dir, _1)})") }
+  casks.each { message.push("* [`#{cask_name(_1)}`](#{cask_url(tap_dir, _1)})") }
 
   message.push("</details>")
 end.freeze


### PR DESCRIPTION
The list is always rebuilt anyway, so no point to having checkable items.