### PR TITLE
mini-vmac: update livecheck

### DIFF
--- a/Casks/mini-vmac.rb
+++ b/Casks/mini-vmac.rb
@@ -9,8 +9,7 @@ cask "mini-vmac" do
 
   livecheck do
     url "https://www.gryphel.com/d/minivmac/md5.txt"
-    strategy :page_match
-    regex(/minivmac-(\d+(?:\.\d+)*)-mc64.bin\.tgz/i)
+    regex(/minivmac[._-]v?(\d+(?:\.\d+)+)[._-]mc64[._-]bin\.t/i)
   end
 
   app "Mini vMac.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the existing `livecheck` block for `mini-vmac` to remove the unnecessary `#strategy` call (the `PageMatch` strategy is already used for this URL) and to update the regex as follows:

* Address the `Use .t instead of .tar.gz` Rubocop offense, which will apply to casks in the future (this is a preemptive fix before enabling it).
* Loosen the architecture suffix matching a bit, where possible.
* Better align with typical regex formats for matching versions from file names (e.g., using `[._-]` between the software name and version, using the standard regex for versions like 1.2.3/v1.2.3 (as the looser regex doesn't seem to be appropriate)).