### PR TITLE
Add Banana Cake Pop 1.0.0-preview.31

### DIFF
--- a/Casks/banana-cake-pop.rb
+++ b/Casks/banana-cake-pop.rb
@@ -16,7 +16,7 @@ cask "banana-cake-pop" do
 
   livecheck do
     url "https://chillicream.com/docs/bananacakepop"
-    regex(%r{bananacakepop/BananaCakePop-((:?\d+(?:\.|\d+)+)(:?-[A-z]+.\d+)?)-mac-x64\.dmg}i)
+    regex(%r{bananacakepop/BananaCakePop-((:?\d+(?:\.|\d+)+)(:?-[A-z]+.\d+)?)-mac-#{arch}\.dmg}i)
   end
 
   auto_updates true

--- a/Casks/banana-cake-pop.rb
+++ b/Casks/banana-cake-pop.rb
@@ -1,0 +1,35 @@
+cask "banana-cake-pop" do
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+
+  version "1.0.0-preview.31"
+
+  if Hardware::CPU.intel?
+    sha256 "232bf6747abfa38825b602af80af2effe602db65a6645da7ced45ef8351483a7"
+  else
+    sha256 "4559afa617dfeaf88c21bdfa12a9ca68f296568b04c36877869767acee6c9a8a"
+  end
+
+  url "https://download.chillicream.com/bananacakepop/BananaCakePop-#{version}-mac-#{arch}.dmg"
+  name "Banana Cake Pop"
+  desc "IDE to interact with GraphQL servers"
+  homepage "https://chillicream.com/"
+
+  livecheck do
+    url "https://chillicream.com/docs/bananacakepop"
+    regex(%r{bananacakepop/BananaCakePop-((:?\d+(?:\.|\d+)+)(:?-[A-z]+.\d+)?)-mac-x64\.dmg}i)
+  end
+
+  auto_updates true
+
+  app "Banana Cake Pop.app"
+
+  zap trash: [
+    "~/Library/Application Support/bananacakepop",
+    "~/Library/Application Support/@banana-cake-pop",
+    "~/Library/Caches/com.chillicream.bananacakepop.ShipIt",
+    "~/Library/Caches/com.chillicream.bananacakepop",
+    "~/Library/Preferences/ByHost/com.chillicream.bananacakepop.ShipIt.*.plist",
+    "~/Library/Preferenes/com.chillicream.bananacakepop.plist",
+    "~/Library/Saved Application State/com.chillicream.bananacakepop.savedState",
+  ]
+end

--- a/Casks/banana-cake-pop.rb
+++ b/Casks/banana-cake-pop.rb
@@ -15,8 +15,9 @@ cask "banana-cake-pop" do
   homepage "https://chillicream.com/"
 
   livecheck do
-    url "https://chillicream.com/docs/bananacakepop"
-    regex(%r{bananacakepop/BananaCakePop-((:?\d+(?:\.|\d+)+)(:?-[A-z]+.\d+)?)-mac-#{arch}\.dmg}i)
+    # Update to `latest-mac.yml` when stable releases are avaliable
+    url "https://download.chillicream.com/bananacakepop/preview-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true
@@ -29,7 +30,7 @@ cask "banana-cake-pop" do
     "~/Library/Caches/com.chillicream.bananacakepop.ShipIt",
     "~/Library/Caches/com.chillicream.bananacakepop",
     "~/Library/Preferences/ByHost/com.chillicream.bananacakepop.ShipIt.*.plist",
-    "~/Library/Preferenes/com.chillicream.bananacakepop.plist",
+    "~/Library/Preferences/com.chillicream.bananacakepop.plist",
     "~/Library/Saved Application State/com.chillicream.bananacakepop.savedState",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

I believe Banana Cake Pop qualifies for the "But There Is No Stable Version" exception as it is currently only available in preview. The web version of the app is already deployed to https://eat.bananacakepop.com/ and is very sable. In my experience, this version of the desktop is already stable enough for day-to-day usage. When the final version is released, this Cask can be updated accordingly.