### PR TITLE
around: Enable autoupdate

### DIFF
--- a/Casks/around.rb
+++ b/Casks/around.rb
@@ -12,6 +12,8 @@ cask "around" do
     regex(/"desktopappMinVersion":"v?(\d+(?:\.\d+)+)"/i)
   end
 
+  auto_updates true
+
   installer manual: "Install Around.app"
 
   uninstall quit:   "co.teamport.around",

--- a/Casks/around.rb
+++ b/Casks/around.rb
@@ -1,5 +1,5 @@
 cask "around" do
-  version "0.58.27"
+  version "0.59.35"
   sha256 :no_check
 
   url "https://downloads.around.co/Around-mac-installer.zip"

--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask "arq" do
-  version "7.17"
-  sha256 "6c60de3c1b9a48bdeb5a1ab93012eca544afacc89053a487ce071f3eb13b85e4"
+  version "7.18"
+  sha256 "aeb5ac477f52f68c4f0d01bc2e733640e34474bb1574e5ff565db6bfe6e852a1"
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version}.pkg"
   name "Arq"

--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -1,6 +1,6 @@
 cask "arq" do
-  version "7.16"
-  sha256 "591b4c2332ca32a1c04b60a91dbf0cc70bafa0bdac74bef578fcdf5713ae290c"
+  version "7.17"
+  sha256 "6c60de3c1b9a48bdeb5a1ab93012eca544afacc89053a487ce071f3eb13b85e4"
 
   url "https://www.arqbackup.com/download/arqbackup/Arq#{version}.pkg"
   name "Arq"

--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,8 +1,15 @@
 cask "beekeeper-studio" do
   version "3.3.6"
-  sha256 "efe0974855a68db5da6e02f8b9a163e500e234a0dfaf2c0a026f76e66294ba52"
 
-  url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg",
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
+
+  if Hardware::CPU.intel?
+    sha256 "efe0974855a68db5da6e02f8b9a163e500e234a0dfaf2c0a026f76e66294ba52"
+  else
+    sha256 "20e96c547366b6c4a2244edd475d9f3a1c420d4f32101c9968a50ce32254cc11"
+  end
+
+  url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}#{arch}.dmg",
       verified: "github.com/beekeeper-studio/beekeeper-studio/"
   name "Beekeeper Studio"
   desc "Cross platform SQL editor and database management app"

--- a/Casks/beekeeper-studio.rb
+++ b/Casks/beekeeper-studio.rb
@@ -1,6 +1,6 @@
 cask "beekeeper-studio" do
-  version "3.2.1"
-  sha256 "295bde2be2d95699fe4f5e8ee6a2a66a50d4d84e9a81ee9861073d1392231456"
+  version "3.3.6"
+  sha256 "efe0974855a68db5da6e02f8b9a163e500e234a0dfaf2c0a026f76e66294ba52"
 
   url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}.dmg",
       verified: "github.com/beekeeper-studio/beekeeper-studio/"

--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -1,6 +1,6 @@
 cask "bluej" do
-  version "5.0.2a"
-  sha256 "0561e8df9af64f89020d02236923f4177380090d691d516d0570a5f51acc7bf2"
+  version "5.0.3"
+  sha256 "54a6cb9c2013529c3526d42b797004d6e9330d67eb05bde82da2db74606c4ab5"
 
   url "https://www.bluej.org/download/files/BlueJ-mac-#{version.no_dots}.zip"
   name "BlueJ"

--- a/Casks/bob.rb
+++ b/Casks/bob.rb
@@ -1,6 +1,6 @@
 cask "bob" do
-  version "0.8.0"
-  sha256 "042626d373942e6ec2c19dd859e9db82a5c8cc1c9223edf3cba57548ae28a241"
+  version "0.8.1"
+  sha256 "853990df3918df866ab593e24d5545c38d5743f3e251f2745c637938ee752885"
 
   url "https://github.com/ripperhe/Bob/releases/download/v#{version}/Bob.zip"
   name "Bob"

--- a/Casks/cyberduck.rb
+++ b/Casks/cyberduck.rb
@@ -1,6 +1,6 @@
 cask "cyberduck" do
-  version "8.2.3,36880"
-  sha256 "edac85691a21fee1c1d10fc72dfc7ca91230273bc31a37d0a7b8b1e8afa30d80"
+  version "8.3.0,37309"
+  sha256 "da992c3d1082166d3f780c73cc0dd62fa3450a00c502df954f7e6c3886ef1b5e"
 
   url "https://update.cyberduck.io/Cyberduck-#{version.csv.first}.#{version.csv.second}.zip"
   name "Cyberduck"

--- a/Casks/cyberghost-vpn.rb
+++ b/Casks/cyberghost-vpn.rb
@@ -1,6 +1,6 @@
 cask "cyberghost-vpn" do
-  version "8.3.3,149"
-  sha256 "3dc8db0347c3983312e038b7df12adad8e6665c045dc337a04465089f6666e0f"
+  version "8.3.6,157"
+  sha256 "47c5ac5a294a75d5ea08b1c1e3594cf77184f066b0402f2f16c8ee5f2fd44204"
 
   url "https://download.cyberghostvpn.com/mac/updates/v7/CyberGhost-#{version.csv.first}.#{version.csv.second}.dmg"
   name "CyberGhost"

--- a/Casks/devkinsta.rb
+++ b/Casks/devkinsta.rb
@@ -1,5 +1,5 @@
 cask "devkinsta" do
-  version "2.4.1.3185"
+  version "2.5.0.3658"
   sha256 :no_check
 
   url "https://devkinsta-updates.s3.amazonaws.com/DevKinsta.dmg",

--- a/Casks/drawio.rb
+++ b/Casks/drawio.rb
@@ -1,12 +1,12 @@
 cask "drawio" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "17.2.1"
+  version "17.2.4"
 
   if Hardware::CPU.intel?
-    sha256 "a3c60f824bb73f15e4a5c2b7f0a12c047fdfd672dfebb2803805cfeccdb0a588"
+    sha256 "d8bb007103067554df5ed3ede73c1a3368ba8e9ce2cdc52715a12ec33fbb50ce"
   else
-    sha256 "cfd11d4a99a7f094c6c2d95df1a619f35c5c45b0f49cf172191209915ed884df"
+    sha256 "3c7e6e96c60e6538b059985bb5c09e2c9cc4fc0a84c27fda78f93d2f230bd7fd"
   end
 
   url "https://github.com/jgraph/drawio-desktop/releases/download/v#{version}/draw.io-#{arch}-#{version}.dmg",

--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,12 +1,12 @@
 cask "electerm" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "1.20.4"
+  version "1.20.6"
 
   if Hardware::CPU.intel?
-    sha256 "d6b9971ee89d404826002cc6d3500ebb76e2d3b30e61b2494b33b371923c20a9"
+    sha256 "2b92bf43ff96babc5e3f9df7c3663790ec900bd577573c69d5c048d5bc06515c"
   else
-    sha256 "769280488ec3a48496e157488ab1a35af0373aa3e694b84955dfdf24a489dd66"
+    sha256 "3b984b7d28fe2c35f3d4a99ccf3e3511be8196b3a89db351be47eab2db93d2f1"
   end
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg"

--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -1,12 +1,12 @@
 cask "electerm" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "1.19.5"
+  version "1.20.4"
 
   if Hardware::CPU.intel?
-    sha256 "766b3cdd5f5f9cc8392d7d41b6f73b21cf5d52348b21e0d647651567ebe52d72"
+    sha256 "d6b9971ee89d404826002cc6d3500ebb76e2d3b30e61b2494b33b371923c20a9"
   else
-    sha256 "8e23ef3556188810044558d6be0e9e57e436ea0174a701bf87b267261ffc5105"
+    sha256 "769280488ec3a48496e157488ab1a35af0373aa3e694b84955dfdf24a489dd66"
   end
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg"

--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -1,12 +1,12 @@
 cask "electron" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "17.2.0"
+  version "18.0.0"
 
   if Hardware::CPU.intel?
-    sha256 "004a9e1bab9ff10554c96c0f6671d89a0302863c7ee2368ad450657c4d3793a1"
+    sha256 "a065a24cf8a10e31afa28600bb9c2e7060f7826d4ebaed65076a969bd18a0e0c"
   else
-    sha256 "794ab9ac816b92208f29cd3e1656b4eafdb0caf2e7b1c0a27ad2cbecbb6e44a6"
+    sha256 "2798464196f28ae601b6ad2e4a7811b99f37772c440e5031fceb5f3d066a555c"
   end
 
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-#{arch}.zip",

--- a/Casks/electrum.rb
+++ b/Casks/electrum.rb
@@ -1,6 +1,6 @@
 cask "electrum" do
-  version "4.2.0"
-  sha256 "698a7d45be340d8265be2293fd7dca9b7cc49632371f74a767f1b571956c5a4d"
+  version "4.2.1"
+  sha256 "01a65c900c53dff9ad23b77b893ac5194ee9bea08010914abec99a6668f63542"
 
   url "https://download.electrum.org/#{version}/electrum-#{version}.dmg"
   name "Electrum"

--- a/Casks/element.rb
+++ b/Casks/element.rb
@@ -1,6 +1,6 @@
 cask "element" do
-  version "1.10.7"
-  sha256 "f495587bfa232ae9cbc75558a86dff45865724c4f7981f7d3b7c0e8db17c42a8"
+  version "1.10.8"
+  sha256 "8918269976b3abda114802a3af6d4cdc98b45691a1d090ac76c8ef95232078d3"
 
   url "https://packages.riot.im/desktop/install/macos/Element-#{version}-universal.dmg",
       verified: "packages.riot.im/desktop/"

--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -5,8 +5,8 @@ cask "eloston-chromium" do
     version "99.0.4844.84-1.1,1648358143"
     sha256 "404dd6bded3a5eff98bb2587296fef743871eaea52e9d7d6aab60e4ed8c8a309"
   else
-    version "99.0.4844.74-1.1,1647530108"
-    sha256 "a9a18f53cdf8da9864210a403266e6ea5f30226393ed83568b3f3af6e5961ca0"
+    version "99.0.4844.84-1.1,1648493229"
+    sha256 "a03e050833c087fa1924b5222c199efcd02be7ca8ae5077993f0b32dd7ecf90f"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version.csv.first}_#{arch}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",

--- a/Casks/expressvpn.rb
+++ b/Casks/expressvpn.rb
@@ -1,6 +1,6 @@
 cask "expressvpn" do
-  version "10.15.0.63183"
-  sha256 "d4fa01c10713c561268e15218840bc8a9098896ee8b49d158277dcb0ea761da1"
+  version "10.16.0.63977"
+  sha256 "c219dae688184ac96bc2310019d1f7204b62526513c6f55d4dc1b58673a8c4a5"
 
   url "https://www.expressvpn.works/clients/mac/expressvpn_mac_#{version}_release.pkg"
   name "ExpressVPN"

--- a/Casks/firecamp.rb
+++ b/Casks/firecamp.rb
@@ -1,6 +1,6 @@
 cask "firecamp" do
-  version "2.6.0"
-  sha256 "0a4b4807ae459f55d55a9a7012389128f0f3aec41c48c98e13d3034ec396dc35"
+  version "2.6.1"
+  sha256 "8b7df7244da0e577a7a5793822af6144548a65024e6b1f8166513ec2435ccb08"
 
   url "https://firecamp.ams3.digitaloceanspaces.com/versions/mac/Firecamp-#{version}.dmg",
       verified: "firecamp.ams3.digitaloceanspaces.com/"

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -1,11 +1,11 @@
 cask "flrig" do
-  version "1.4.4"
+  version "1.4.5"
 
   if MacOS.version <= :catalina
-    sha256 "d6cdd639c59807e7bde531585e349789ca5ee20d9bb7262dbd8d9966e94d8805"
+    sha256 "ede5c990548312c62b758a6e517f410112d14d899fec09fba2630f83d17c3e6f"
     url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version}_HS.dmg"
   else
-    sha256 "c19d9eb62c899fd6e1eefe6db8bacdae70762e284afb567348e4d4fc311233b6"
+    sha256 "ec6831998bc98b73e3f6ec3faa613997b76d91a007b45ed8217f7c5cb42e9ff2"
     url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version}_BS.dmg"
   end
 

--- a/Casks/flutter.rb
+++ b/Casks/flutter.rb
@@ -1,6 +1,6 @@
 cask "flutter" do
-  version "2.10.3"
-  sha256 "77475dd7e674bf2079a2000183478c19ca9b2eeb404d4819777b1fc12b87ca4a"
+  version "2.10.4"
+  sha256 "09d050c614d21f438630c2df4160dd704c09f44547b651e312bf54fca378286f"
 
   url "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_#{version}-stable.zip",
       verified: "storage.googleapis.com/flutter_infra_release/"

--- a/Casks/fly.rb
+++ b/Casks/fly.rb
@@ -1,6 +1,6 @@
 cask "fly" do
-  version "7.7.0"
-  sha256 "19d71f6c57fbaac9abcddfbf17d99047bf6b9bee7db2da60ef1fc6e4ecf754db"
+  version "7.7.1"
+  sha256 "356226256041e12a58f3494ed6f9266218d6653aecb8cadef998b88c8213810b"
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   name "fly"

--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -1,12 +1,12 @@
 cask "freeplane" do
   arch = Hardware::CPU.intel? ? "intel" : "apple"
 
-  version "1.9.13"
+  version "1.9.14"
 
   if Hardware::CPU.intel?
-    sha256 "59a405906113c3dfe0a8746fb270ee772de8fcde8b04d78b0660ef324b0aa089"
+    sha256 "87a981841c758e38ee888b3ae8481684aab748d48974e603c91f5db2c2949026"
   else
-    sha256 "4f5dbccfec52c25b51653cb460148edc400b54c6c402fbdcc03cc198c36bc56b"
+    sha256 "d93e894e754fd05480d71f29868238a5a36f851c8e74c634a5e3418e7179ac52"
   end
 
   url "https://downloads.sourceforge.net/freeplane/Freeplane-#{version}-#{arch}.dmg",

--- a/Casks/google-chrome.rb
+++ b/Casks/google-chrome.rb
@@ -1,5 +1,5 @@
 cask "google-chrome" do
-  version "99.0.4844.84"
+  version "100.0.4896.60"
   sha256 :no_check
 
   url "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg"

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,5 +1,5 @@
 cask "google-earth-pro" do
-  version "7.3.4.8248"
+  version "7.3.4.8573"
   sha256 :no_check
 
   url "https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg"

--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -1,6 +1,6 @@
 cask "hammerspoon" do
-  version "0.9.95"
-  sha256 "342d2745cf8ab99114243c36776ac27b5f7fcd5c40af8af0bbe7f9fe778783f4"
+  version "0.9.96"
+  sha256 "452f52cd4a296eb5b522f8bd7674a57a6a778da73c6b756a41c5e2731df66f6c"
 
   url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip",
       verified: "github.com/Hammerspoon/hammerspoon/"
@@ -10,7 +10,7 @@ cask "hammerspoon" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/istat-menus.rb
+++ b/Casks/istat-menus.rb
@@ -1,5 +1,5 @@
 cask "istat-menus" do
-  version "6.61"
+  version "6.62"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://cdn.bjango.com/files/istatmenus#{version.major}/istatmenus#{version}.zip"

--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -1,5 +1,5 @@
 cask "jdownloader" do
-  version "45730"
+  version "45752"
   sha256 :no_check
 
   url "http://installer.jdownloader.org/clean/JD2Setup.dmg",

--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -1,12 +1,12 @@
 cask "jetbrains-toolbox" do
   arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  version "1.22,1.22.10970"
+  version "1.23,1.23.11680"
 
   if Hardware::CPU.intel?
-    sha256 "179b0bc023a05382b0b4541f62ca50991b39e8ce42d05afa3d27823fda8fbc10"
+    sha256 "350247f9f5070abdadc3bda28524635591bfcc4ebbac68d218504469d708803c"
   else
-    sha256 "9832d19e3341ff159855f8002da18c3fd1e41ebcf86c6fb94e99272b6fa52e5b"
+    sha256 "a2e6d3a818a1118ab5f1a84a8ba73a5b42110e1e7950d0f5aa0bd669d18bd768"
   end
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version.csv.second}#{arch}.dmg"

--- a/Casks/keka.rb
+++ b/Casks/keka.rb
@@ -1,6 +1,6 @@
 cask "keka" do
-  version "1.2.52"
-  sha256 "62d586d70936177ce1f2e93bd3bd0d935cf5207bab6c6436e3f2b5388dddd5ab"
+  version "1.2.53"
+  sha256 "f651078324237eee619011ef43b1218bec1387fe286b291fa91245b08049346d"
 
   url "https://github.com/aonez/Keka/releases/download/v#{version}/Keka-#{version}.dmg",
       verified: "github.com/aonez/Keka/"

--- a/Casks/kindle.rb
+++ b/Casks/kindle.rb
@@ -1,6 +1,6 @@
 cask "kindle" do
-  version "1.34.63102"
-  sha256 "ee85a1ca57fb99e892cddd04c503866e3b33a6324093f73bf91e469cadd1b751"
+  version "1.35.64250"
+  sha256 "ea8f6fe22fcc754f1ed508b3ecfc4ddc1ca33d311e1af60302f03327ec2f8254"
 
   url "https://kindleformac.s3.amazonaws.com/#{version.patch}/KindleForMac-#{version}.dmg",
       verified: "kindleformac.s3.amazonaws.com/"

--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,5 +1,5 @@
 cask "macupdater" do
-  version "2.1.3,13090"
+  version "2.2.0,13356"
   sha256 :no_check
 
   url "https://www.corecode.io/downloads/macupdater_latest.dmg"

--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,5 +1,5 @@
 cask "macupdater" do
-  version "2.2.0,13356"
+  version "2.2.0,13370"
   sha256 :no_check
 
   url "https://www.corecode.io/downloads/macupdater_latest.dmg"

--- a/Casks/mimestream.rb
+++ b/Casks/mimestream.rb
@@ -1,6 +1,6 @@
 cask "mimestream" do
-  version "0.34.1"
-  sha256 "886657e0cafa165a50fc8d928d116919431f6f9709f25277cb04f8b1c801fe40"
+  version "0.34.2"
+  sha256 "b3323c90f5656baf6e7e5fa0ef2e8a10ea10786554a6bbd36e4591ddda4d3190"
 
   url "https://storage.googleapis.com/mimestream-releases/Mimestream_#{version}.dmg",
       verified: "storage.googleapis.com/mimestream-releases/"

--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -1,12 +1,12 @@
 cask "min" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "1.23.1"
+  version "1.24.0"
 
   if Hardware::CPU.intel?
-    sha256 "7353d2159beebe5f8053ba251288ef01bc6ad846d2785ac40cdbed739772f9a3"
+    sha256 "c8238dae0401afe743a2c3080ef852c6bacf9c2a7d832e9c13bcb3d06ea35761"
   else
-    sha256 "fd6bf57a7f13a9c3b38b3ba4022d1c5cb645a0c596c230be869c7648f4449978"
+    sha256 "4c72c73214b97edaaac631e38c09096c6b07080145c03fda36bbbd07956dc78e"
   end
 
   url "https://github.com/minbrowser/min/releases/download/v#{version}/Min-v#{version}-darwin-#{arch}.zip",

--- a/Casks/mini-vmac.rb
+++ b/Casks/mini-vmac.rb
@@ -9,8 +9,7 @@ cask "mini-vmac" do
 
   livecheck do
     url "https://www.gryphel.com/d/minivmac/md5.txt"
-    strategy :page_match
-    regex(/minivmac-(\d+(?:\.\d+)*)-mc64.bin\.tgz/i)
+    regex(/minivmac[._-]v?(\d+(?:\.\d+)+)[._-]mc64[._-]bin\.t/i)
   end
 
   app "Mini vMac.app"

--- a/Casks/nordvpn.rb
+++ b/Casks/nordvpn.rb
@@ -1,6 +1,6 @@
 cask "nordvpn" do
-  version "7.4.1,185"
-  sha256 "b0ae1e85bb58c773971febaffe7b4805be95ef02bf78f041ef1938dcb92b1dde"
+  version "7.5.0,186"
+  sha256 "d2025a819e1d91af40997490185e7674b35fc5b1d28f0b2d0ecb23f22299c91f"
 
   url "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/#{version.csv.first}/NordVPN.pkg",
       verified: "downloads.nordcdn.com/"

--- a/Casks/nwjs.rb
+++ b/Casks/nwjs.rb
@@ -1,6 +1,6 @@
 cask "nwjs" do
-  version "0.62.0"
-  sha256 "4e585a8ddb34b49c88aaf8a992a67506b929c656d9a188cc20cf1a5b37a36bd6"
+  version "0.62.2"
+  sha256 "150ce5e8aa2b65c5e257e183324e40612e0329bec09d9c495da98970828e2f6a"
 
   url "https://dl.nwjs.io/v#{version}/nwjs-sdk-v#{version}-osx-x64.zip"
   name "NW.js"

--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -1,6 +1,6 @@
 cask "obs" do
-  version "27.2.2"
-  sha256 "e92004767ddeaf13002f530a0f3344c400f24a5a0ed7e079de907f5cbc362d20"
+  version "27.2.4"
+  sha256 "9aeed92816f23fdb4819eb1b0c989c158aaab246e0bd024933429614b06435f2"
 
   url "https://cdn-fastly.obsproject.com/downloads/obs-mac-#{version}.dmg"
   name "OBS"

--- a/Casks/obsidian.rb
+++ b/Casks/obsidian.rb
@@ -1,6 +1,6 @@
 cask "obsidian" do
-  version "0.13.31"
-  sha256 "9bff35bae0e1309275b474d43f0c3ec4d770b1a6023a678db5b8ddc0c0308415"
+  version "0.14.2"
+  sha256 "9ad495bbffadd89268b5582d0ecfd61542ec2c06d128cce99b9292e2267e1389"
 
   url "https://github.com/obsidianmd/obsidian-releases/releases/download/v#{version}/Obsidian-#{version}-universal.dmg",
       verified: "github.com/obsidianmd/"

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -1,5 +1,5 @@
 cask "ocenaudio" do
-  version "3.11.7"
+  version "3.11.8"
   sha256 :no_check
 
   if MacOS.version <= :high_sierra

--- a/Casks/onedrive.rb
+++ b/Casks/onedrive.rb
@@ -1,6 +1,6 @@
 cask "onedrive" do
-  version "22.033.0213.0002"
-  sha256 "8997d70c30bd5d6cd977301a909097360dc77d4335809ea66615db44d0f3c9dd"
+  version "22.045.0227.0004"
+  sha256 "fa4bcac7822963615506b41bdab98e8b91112ccecce77b92cfff062202d74da0"
 
   url "https://oneclient.sfx.ms/Mac/Direct/#{version}/OneDrive.pkg",
       verified: "oneclient.sfx.ms/Mac/Direct/"

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask "opera" do
-  version "85.0.4341.18"
-  sha256 "25ca427bfd6a2f6cb0fcebf8ab19a2e1e6478e7b0b2773c4b86708572cf7039c"
+  version "85.0.4341.28"
+  sha256 "c0ec788558c2833c718c6fd513789360886e97776aaa853b9ab7532f74ed6de5"
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name "Opera"

--- a/Casks/pd.rb
+++ b/Casks/pd.rb
@@ -1,6 +1,6 @@
 cask "pd" do
-  version "0.52-1"
-  sha256 "c8721aa1ec3d433d28e055bd6a64559723d28e0eb49c0ac1401d6ae46621e4db"
+  version "0.52-2"
+  sha256 "06d2cb0f0126170f53675eb1b17d0fd9e95acdcce6d7d881a4135b746bb20533"
 
   url "http://msp.ucsd.edu/Software/pd-#{version}.macos.zip"
   name "Pd"
@@ -12,10 +12,10 @@ cask "pd" do
     regex(/pd[._-]v?(\d+(?:\.\d+)+-\d+)\.macos\.zip/i)
   end
 
-  app "Pd-#{version}-really.app"
+  app "Pd-#{version}.app"
 
   postflight do
-    set_permissions "#{appdir}/Pd-#{version}-really.app", "u+w"
+    set_permissions "#{appdir}/Pd-#{version}.app", "u+w"
   end
 
   zap trash: [

--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,5 +1,5 @@
 cask "perforce" do
-  version "2021.2,2252059"
+  version "2021.2,2264565"
   sha256 "ffc757b9d4d0629b2594e2777edfb18097825e29c70d8f33a444c7482d622806"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"

--- a/Casks/pokemon-trading-card-game-online.rb
+++ b/Casks/pokemon-trading-card-game-online.rb
@@ -1,5 +1,5 @@
 cask "pokemon-trading-card-game-online" do
-  version "2.78.0.5176"
+  version "2.88.0.5535"
   sha256 :no_check
 
   url "https://tcgo-installer.s3.amazonaws.com/PokemonInstaller_Mac.dmg",

--- a/Casks/popo.rb
+++ b/Casks/popo.rb
@@ -1,6 +1,6 @@
 cask "popo" do
-  version "3.45.1"
-  sha256 "e27d452beaa606225459fabdc06533f749a23e52c0ae6b0803d8ef83f913703a"
+  version "3.46.1"
+  sha256 "90569e1780e8a9230a3408a728d110d0688fa1f2eee057762ee456a11ce0a98c"
 
   url "https://popo.netease.com/file/popomac/POPO-setup_#{version.dots_to_underscores}.dmg"
   name "NetEase POPO"

--- a/Casks/porting-kit.rb
+++ b/Casks/porting-kit.rb
@@ -1,6 +1,6 @@
 cask "porting-kit" do
-  version "5.0.5"
-  sha256 "a1985298a96264d5bdedeee294931a53218daaf7c71bc40d052f5f532c009632"
+  version "5.0.8"
+  sha256 "ab0f699efbd276474a16040d3c141b59343c8e15914605eb2da7572cb780fba6"
 
   url "https://github.com/vitor251093/porting-kit-releases/releases/download/v#{version}/Porting-Kit-#{version}.dmg",
       verified: "github.com/vitor251093/porting-kit-releases/"

--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,12 +1,12 @@
 cask "pritunl" do
   arch = Hardware::CPU.intel? ? "" : ".arm64"
 
-  version "1.2.3019.52"
+  version "1.2.3119.63"
 
   if Hardware::CPU.intel?
-    sha256 "94bc6e293f31f293f0d19be631eec9bf7908aa0f953ea0a3a0f23b409e711b9d"
+    sha256 "a553a8cd87f0c02bd67288ce7bf0fe0f01b50de902178ba7c8204e0ea305136f"
   else
-    sha256 "06d0ca35297b52ead7a9f111bc76ee99eb109612110eae75a71b1fd87721bee4"
+    sha256 "9a20f00ecf88304694cb24f47afc816ad549641bfc8d024fc481b44fc3198fe0"
   end
 
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl#{arch}.pkg.zip",

--- a/Casks/quarto.rb
+++ b/Casks/quarto.rb
@@ -1,6 +1,6 @@
 cask "quarto" do
-  version "0.9.141"
-  sha256 "52741146251259a200dcef0d5d0b7a6cd37be44c3f9e1e6e415f439cec129286"
+  version "0.9.155"
+  sha256 "dbf35da463ed63b533500b9ececa58f93b09d5e586a2c4febb9a8cb3973a4778"
 
   url "https://github.com/quarto-dev/quarto-cli/releases/download/v#{version}/quarto-#{version}-macos.pkg",
       verified: "github.com/quarto-dev/quarto-cli/"

--- a/Casks/quicken.rb
+++ b/Casks/quicken.rb
@@ -12,6 +12,7 @@ cask "quicken" do
     strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Quicken.app"

--- a/Casks/raspberry-pi-imager.rb
+++ b/Casks/raspberry-pi-imager.rb
@@ -1,6 +1,6 @@
 cask "raspberry-pi-imager" do
-  version "1.7.1"
-  sha256 "11e5e7d5f92727db988937d58f7d755fee441d8b9e715519d0be0ee241c8b075"
+  version "1.7.2"
+  sha256 "d78a8b188856f9bbf2958f4217a5d2a823f9c822aaba308a930f255bbf596f21"
 
   url "https://downloads.raspberrypi.org/imager/imager_#{version}.dmg"
   name "Raspberry Pi Imager"

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -1,11 +1,11 @@
 cask "reaper" do
-  version "6.52"
+  version "6.53"
 
   if MacOS.version <= :mojave
-    sha256 "4c99ecdbe891c948a9d54ae7d5ce7c2f869a3899186acc4f89a016d61d60fe54"
+    sha256 "5d86ca6b220175453635ce8e1073609e46da602e45f6d01712f5477bd2e75561"
     url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
   else
-    sha256 "009baed086527888a201cb23e8e14d38376248864d503fa8ef1e0e9e8e3ae517"
+    sha256 "b7c24c887d8121042f5b948b93d1945d45149387c3060e329ecc16a82d6d97e7"
     url "https://www.reaper.fm/files/#{version.major}.x/reaper#{version.major_minor.no_dots}_universal.dmg"
   end
 

--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -1,6 +1,6 @@
 cask "rekordbox" do
-  version "6.6.1,20211125100827"
-  sha256 "7d9e0c0d2a9a71c50c9d01770718f878041b5badf3166c22ad85e148ea1fdc44"
+  version "6.6.2,20220328154128"
+  sha256 "3e69f1808ddb6e02c7eb3edae169d3d9c4411611a1d754863c0677a59bcc1e29"
 
   url "https://cdn.rekordbox.com/files/#{version.csv.second}/Install_rekordbox_#{version.csv.first.dots_to_underscores}.pkg_.zip"
   appcast "https://rekordbox.com/en/download/"

--- a/Casks/runelite.rb
+++ b/Casks/runelite.rb
@@ -1,12 +1,12 @@
 cask "runelite" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "2.4.0"
-
   if Hardware::CPU.intel?
-    sha256 "c547f1e9be49b0403517498c50120209c19bd49e6f47753c056892082a1545c4"
+    version "2.4.3"
+    sha256 "0e39d850278a0ea5599fe9d80af2feba785261c4fb60c6254d594047298eb722"
   else
-    sha256 "18fe12a44953b57222e8ad05cfecb889373cede2aa357820ba00b6599e10f3cb"
+    version "2.4.2"
+    sha256 "6deceeb1460259622d0f6d35e2527f94d1613b5a5bc40ebade25b617a970a411"
   end
 
   url "https://github.com/runelite/launcher/releases/download/#{version}/RuneLite-#{arch}.dmg",
@@ -16,9 +16,8 @@ cask "runelite" do
   homepage "https://runelite.net/"
 
   livecheck do
-    url "https://github.com/runelite/launcher/releases"
-    strategy :page_match
-    regex(%r{v?(\d+(?:\.\d+)+)/RuneLite[._-]#{arch}\.dmg}i)
+    url :homepage
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/RuneLite[._-]#{arch}\.dmg}i)
   end
 
   app "RuneLite.app"

--- a/Casks/sapmachine-jdk.rb
+++ b/Casks/sapmachine-jdk.rb
@@ -1,12 +1,12 @@
 cask "sapmachine-jdk" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "17.0.2"
+  version "18"
 
   if Hardware::CPU.intel?
-    sha256 "c00b7a32f7be3e1a400d815c22d0e254cdab0e8f421cb6d63ef8a50c8e8a501a"
+    sha256 "bbdc9db3a47944f3bc8c7bc7ea6747b92e4c9fba40150263af7881b312f46b30"
   else
-    sha256 "7502b95cf9e691197e21637a8e4acfca3a0955aa11f36e47824bf0083085bfc2"
+    sha256 "dc5febf7d11b5e60889d94d3b95ba101999cfea45f3ebc0e22240a71e85d2ce4"
   end
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-#{arch}_bin.dmg",
@@ -19,7 +19,7 @@ cask "sapmachine-jdk" do
   # following JSON file, so we have to check it instead.
   livecheck do
     url "https://sap.github.io/SapMachine/assets/data/sapmachine_releases.json"
-    regex(/["']tag["']:\s*["']sapmachine[._-]v?(\d+(?:\.\d+)+)["']/i)
+    regex(/["']tag["']:\s*["']sapmachine[._-]v?(\d+(?:\.\d+)*)["']/i)
   end
 
   artifact "sapmachine-jdk-#{version}.jdk", target: "/Library/Java/JavaVirtualMachines/sapmachine-jdk-#{version}.jdk"

--- a/Casks/session-manager-plugin.rb
+++ b/Casks/session-manager-plugin.rb
@@ -1,6 +1,6 @@
 cask "session-manager-plugin" do
   version "1.2.295.0"
-  sha256 "67e527dd19b2ae6d5b5de62c75aedb4241f31b2ae177be3e118db8b4d067ad26"
+  sha256 "dad3eb15607c675d20ddc8a4b199c46d458b70ed6188afb7c83fb1a1d7a44911"
 
   url "https://s3.amazonaws.com/session-manager-downloads/plugin/#{version}/mac/session-manager-plugin.pkg",
       verified: "s3.amazonaws.com/session-manager-downloads/"

--- a/Casks/snes9x.rb
+++ b/Casks/snes9x.rb
@@ -1,12 +1,23 @@
 cask "snes9x" do
-  version "1.60"
-  sha256 "99f843f84533a0a8e2aefe0b4f248f47649e06ff58ea2d0c041ff931ee503884"
+  version "1.61"
+  sha256 "dc0fce0eb7db92e6d8827309f595a83e7fa77c84a18fe9c4df541d2dedfd7d1b"
 
-  url "http://www.s9x-w32.de/dl/snes9x-#{version}-macosx-i386.zip",
-      verified: "s9x-w32.de/"
-  appcast "http://www.s9x-w32.de/dl/"
+  url "https://github.com/snes9xgit/snes9x/releases/download/#{version}/snes9x-#{version}-macos.zip",
+      verified: "https://github.com/snes9xgit/snes9x/"
   name "Snes9x"
+  desc "Video game console emulator"
   homepage "https://www.snes9x.com/"
 
-  app "snes9x-#{version}-macosx-i386/Snes9x.app"
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  app "Snes9x.app"
+
+  zap trash: [
+    "~/Library/Application Support/Snes9x",
+    "~/Library/Preferences/com.snes9x.macos.snes9x.plist",
+    "~/Library/Saved Application State/com.snes9x.macos.snes9x.savedState",
+  ]
 end

--- a/Casks/softube-central.rb
+++ b/Casks/softube-central.rb
@@ -1,6 +1,6 @@
 cask "softube-central" do
-  version "1.5.9"
-  sha256 "aba4d5ecd396fe00300e42be4d5a40b9ad0cc7690f43bdba71b6d5b54b68ace3"
+  version "1.5.11"
+  sha256 "153d24700bf2689dd73eac2abace18ee8d067be701a2b773a24ca940ed02c96b"
 
   url "https://softubestorage.b-cdn.net/softubecentral/Softube%20Central-#{version}.pkg",
       verified: "softubestorage.b-cdn.net/"

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -1,12 +1,12 @@
 cask "standard-notes" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
-  version "3.14.0"
+  version "3.14.1"
 
   if Hardware::CPU.intel?
-    sha256 "c0a8e51d4dc55578ae601fba7bafe2851fd0c20fe7054ed8d132ed8c41c941a5"
+    sha256 "5fbfb398e54214bbef118fe1bd2d75b8cec7ff50cfeb18bfe7f957d2d61c413c"
   else
-    sha256 "999e6a347b320506ee0392e74d7370e26977ff1b0a386dc7921dc74d115c6484"
+    sha256 "48d0fb3f5acb604be68018e338d0972d25e6c63f601dcd7ff268db6278e210d7"
   end
 
   url "https://github.com/standardnotes/desktop/releases/download/v#{version}/Standard-Notes-#{version}-mac-#{arch}.zip",

--- a/Casks/stats.rb
+++ b/Casks/stats.rb
@@ -1,6 +1,6 @@
 cask "stats" do
-  version "2.7.9"
-  sha256 "eb9b5f27f6cee28647afa0debc42a127f0166e75080707fad7cf36e84baecdc8"
+  version "2.7.10"
+  sha256 "0f21155bdc54f63ea17a3f6cfba94aee84779cfef3e44b71ff42199bb8614057"
 
   url "https://github.com/exelban/stats/releases/download/v#{version}/Stats.dmg"
   name "Stats"

--- a/Casks/tabby.rb
+++ b/Casks/tabby.rb
@@ -21,6 +21,8 @@ cask "tabby" do
     strategy :github_latest
   end
 
+  auto_updates true
+
   app "Tabby.app"
 
   zap trash: [

--- a/Casks/tabby.rb
+++ b/Casks/tabby.rb
@@ -1,12 +1,12 @@
 cask "tabby" do
   arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
-  version "1.0.173"
+  version "1.0.174"
 
   if Hardware::CPU.intel?
-    sha256 "6c3be59ce05e49de03ebe298e2978e20ddfe2b9d99912a5320067c6fcce89ffa"
+    sha256 "bcb01d55706df4ca2cc3e0674cec93cade02774cebec369d8224cd5058a16a5e"
   else
-    sha256 "817ef7bc292d2adb61d942bb5e0c22f1b21952864d5219ea352434a946e90824"
+    sha256 "8627d36b8436b872a3c529effc8e54750c7962c36763f8309cd2f680415a9b6d"
   end
 
   url "https://github.com/Eugeny/tabby/releases/download/v#{version}/tabby-#{version}-macos-#{arch}.zip",

--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -1,7 +1,7 @@
 cask "termius" do
   arch = Hardware::CPU.intel? ? "mac" : "mac-arm64"
 
-  version "7.36.1"
+  version "7.37.0"
   sha256 :no_check
 
   url "https://autoupdate.termius.com/#{arch}/Termius.dmg"

--- a/Casks/therm.rb
+++ b/Casks/therm.rb
@@ -1,6 +1,6 @@
 cask "therm" do
-  version "0.4.2"
-  sha256 "7300338f81d3bb891852875aef58e93e99b1684f7f204158b99713bc94f8b22a"
+  version "0.5.0"
+  sha256 "c83ab68524cc0f60b57672e06026f1e2d7481e7e6aadd28402f2f0a587686f7f"
 
   url "https://github.com/trufae/Therm/releases/download/#{version}/Therm-#{version}.zip"
   name "Therm"

--- a/Casks/xcodes.rb
+++ b/Casks/xcodes.rb
@@ -1,6 +1,6 @@
 cask "xcodes" do
-  version "1.2.0,8"
-  sha256 "b691d1935058b0ddff2eef1a2f9a73f76e42df2d783d7f4f84112382de15ea93"
+  version "1.3.1,11"
+  sha256 "d8dab272c446eb24b3ef9dfee1b1511b449d01ae5cfccd612279bb3a7283f859"
 
   url "https://github.com/RobotsAndPencils/XcodesApp/releases/download/v#{version.csv.first}b#{version.csv.second}/Xcodes.zip"
   name "Xcodes"

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -1,6 +1,6 @@
 cask "xemu" do
-  version "0.6.2-88-g6e1969001e"
-  sha256 "b117b0a45b093d27f4b79e21c86ea813ec6f1534d95a9ff6ab6377cab54bf515"
+  version "0.6.2-90-g6f507c80af"
+  sha256 "29c552a0dbcc709e5c2fb563ffe83c680075e45d8018ec422eba66c823d94b9b"
 
   url "https://github.com/mborgerson/xemu/releases/download/gh-release%2F#{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"


### PR DESCRIPTION
Around automatically updates itself. This can be seen in the main window of the application.
Additionally, `auto_updates true` gets rid of the `installer manual` error message.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.