### PR TITLE
scilab 6.1.1 arm64

### DIFF
--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -17,8 +17,8 @@ cask "scilab" do
   homepage "https://www.scilab.org/"
 
   livecheck do
-    url "https://www.scilab.org/download/"
-    strategy :header_match
+    url "https://www.utc.fr/~mottelet/scilab_for_macOS.html"
+    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{prefix}#{arch}\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -10,7 +10,7 @@ cask "scilab" do
     sha256 "2f87710fc47c6d8e6777ee280ece589342e536c17290b9c033ea0dfcef3b4912"
   end
 
-  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{prefix}#{arch}.dmg",
+  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{prefix}#{Hardware::CPU.arch}.dmg",
       verified: "utc.fr/~mottelet/scilab/"
   name "Scilab"
   desc "Software for numerical computation"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -11,7 +11,7 @@ cask "scilab" do
   end
 
   url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{prefix}#{arch}.dmg",
-      verified: "utc.fr/~mottelet/scilab/"  
+      verified: "utc.fr/~mottelet/scilab/"
   name "Scilab"
   desc "Software for numerical computation"
   homepage "https://www.scilab.org/"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -1,5 +1,4 @@
 cask "scilab" do
-  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
   prefix = Hardware::CPU.intel? ? "" : "accelerate-" # there is also an "openblas-" version
 
   version "6.1.1"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -1,9 +1,17 @@
 cask "scilab" do
-  version "6.1.1"
-  sha256 "922e879979fe4e1fde83be4b3df02070c0930a56a75cdeb9b5ef46ae29f0ef57"
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
+  prefix = Hardware::CPU.intel? ? "" : "accelerate-" # there is also an "openblas-" version
 
-  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-x86_64.dmg",
-      verified: "utc.fr/~mottelet/scilab/"
+  version "6.1.1"
+
+  if Hardware::CPU.intel?
+    sha256 "922e879979fe4e1fde83be4b3df02070c0930a56a75cdeb9b5ef46ae29f0ef57"
+  else
+    sha256 "2f87710fc47c6d8e6777ee280ece589342e536c17290b9c033ea0dfcef3b4912"
+  end
+
+  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{prefix}#{arch}.dmg",
+      verified: "utc.fr/~mottelet/scilab/"  
   name "Scilab"
   desc "Software for numerical computation"
   homepage "https://www.scilab.org/"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -17,7 +17,7 @@ cask "scilab" do
 
   livecheck do
     url "https://www.utc.fr/~mottelet/scilab_for_macOS.html"
-    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{prefix}#{hardware::CPU.arch}\.dmg/i)
+    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{prefix}#{Hardware::CPU.arch}\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -17,7 +17,7 @@ cask "scilab" do
 
   livecheck do
     url "https://www.utc.fr/~mottelet/scilab_for_macOS.html"
-    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{prefix}#{arch}\.dmg/i)
+    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{prefix}#{hardware::CPU.arch}\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -5,7 +5,7 @@ cask "scilab" do
   version "6.1.1"
 
   if Hardware::CPU.intel?
-    sha256 "922e879979fe4e1fde83be4b3df02070c0930a56a75cdeb9b5ef46ae29f0ef57"
+    sha256 "b417aace594cba882b19c2711aa125d8374d5da8b0a24df2873592765598e457"
   else
     sha256 "2f87710fc47c6d8e6777ee280ece589342e536c17290b9c033ea0dfcef3b4912"
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Notes:
- This was only tested for `arm64`, not `x86_64`.
- I made an almost-arbitrary choice of Accelerate Framework vs OpenBLAS.

From the [download page](https://www.utc.fr/~mottelet/scilab_for_macOS.html):
> _Native arm64 build for Mac M1 machines_
Mac M1 users can also download the native arm64 build below and compare the performance with the x86_64 using Rosetta. Note concerning the native arm64 JDK: If you don't have particular needs for a given version, let Scilab download and install the JDK by itself when it is launched for the first time (it will be downloaded from https://www.azul.com/). Be also warned that this native build cannot use Atoms modules using C/C++ gateways for the moment since these have to be rebuilt in order to include the libraries for both architectures.
_OpenBLAS vs. Accelerate Framework_
We provide two different builds, the first one uses the default Accelerate Framework (which includes the default macOS Apple provided BLAS and LAPACK library) and the second one uses OpenBLAS (see https://www.openblas.net/). Since the Accelerate framework seems to have a only a partial use of the new M1 features, you may experience different performance between the OpenBLAS and the Accelerate build and depending on the kind of computation the faster may be one or the other.