### PR TITLE
 Update eloston-chromium from 99.0.4844.74-1.1 to 99.0.4844.84-1.1 (arm64)

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -5,8 +5,8 @@ cask "eloston-chromium" do
     version "99.0.4844.84-1.1,1648358143"
     sha256 "404dd6bded3a5eff98bb2587296fef743871eaea52e9d7d6aab60e4ed8c8a309"
   else
-    version "99.0.4844.74-1.1,1647530108"
-    sha256 "a9a18f53cdf8da9864210a403266e6ea5f30226393ed83568b3f3af6e5961ca0"
+    version "99.0.4844.84-1.1,1648493229"
+    sha256 "a03e050833c087fa1924b5222c199efcd02be7ca8ae5077993f0b32dd7ecf90f"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version.csv.first}_#{arch}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",


### PR DESCRIPTION


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.