### PR TITLE
Update bitwig-studio from 4.2 to 4.2.2

### DIFF
--- a/Casks/bitwig-studio.rb
+++ b/Casks/bitwig-studio.rb
@@ -1,6 +1,6 @@
 cask "bitwig-studio" do
-  version "4.2"
-  sha256 "3798ff4d388e591c8321ef0053220bdb5fbe9961473f0a8947c11c6812eded91"
+  version "4.2.2"
+  sha256 "ad582ccc198e73bd59bc51d24844e0f152e49ffcb8ef8f7e0bba315438b48616"
 
   url "https://downloads.bitwig.com/stable/#{version}/Bitwig%20Studio%20#{version}.dmg"
   name "Bitwig Studio"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
