### PR TITLE
Update runelite from 2.4.0 to 2.4.3/2.4.2

### DIFF
--- a/Casks/runelite.rb
+++ b/Casks/runelite.rb
@@ -1,12 +1,12 @@
 cask "runelite" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "2.4.0"
-
   if Hardware::CPU.intel?
-    sha256 "c547f1e9be49b0403517498c50120209c19bd49e6f47753c056892082a1545c4"
+    version "2.4.3"
+    sha256 "0e39d850278a0ea5599fe9d80af2feba785261c4fb60c6254d594047298eb722"
   else
-    sha256 "18fe12a44953b57222e8ad05cfecb889373cede2aa357820ba00b6599e10f3cb"
+    version "2.4.2"
+    sha256 "6deceeb1460259622d0f6d35e2527f94d1613b5a5bc40ebade25b617a970a411"
   end
 
   url "https://github.com/runelite/launcher/releases/download/#{version}/RuneLite-#{arch}.dmg",
@@ -16,9 +16,8 @@ cask "runelite" do
   homepage "https://runelite.net/"
 
   livecheck do
-    url "https://github.com/runelite/launcher/releases"
-    strategy :page_match
-    regex(%r{v?(\d+(?:\.\d+)+)/RuneLite[._-]#{arch}\.dmg}i)
+    url :homepage
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/RuneLite[._-]#{arch}\.dmg}i)
   end
 
   app "RuneLite.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The most recent Runelite version differs between x64/ARM64, so this PR updates both versions to the latest appropriate versions. The latest version is 2.4.3 but there's only an x64 file. The latest version with an ARM64 release is 2.4.2. The homepage corroborates this situation, linking to the latest file for each.

---

This also modifies the `livecheck` block to:

* Check the homepage, as this readily provides the latest version for each architecture and we don't have to worry about GitHub releases pagination issues (e.g., livecheck failing to find a version because the latest release with an appropriate file is pushed off the first releases page by other releases).
* Remove the unnecessary `strategy :page_match` call, as this already uses the `PageMatch` strategy by default. 
* Update the regex to better align with regexes that match a file in an `href` attribute.