### PR TITLE
Update around from 0.58.27 to 0.59.35, and enable autoupdate

### DIFF
--- a/Casks/around.rb
+++ b/Casks/around.rb
@@ -12,6 +12,8 @@ cask "around" do
     regex(/"desktopappMinVersion":"v?(\d+(?:\.\d+)+)"/i)
   end
 
+  auto_updates true
+
   installer manual: "Install Around.app"
 
   uninstall quit:   "co.teamport.around",

--- a/Casks/around.rb
+++ b/Casks/around.rb
@@ -1,5 +1,5 @@
 cask "around" do
-  version "0.58.27"
+  version "0.59.35"
   sha256 :no_check
 
   url "https://downloads.around.co/Around-mac-installer.zip"


### PR DESCRIPTION
Around automatically updates itself. This can be seen in the main window of the application.
Additionally, auto_updates true gets rid of the installer manual error message.

Bumped version to satisfy CI.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.