### PR TITLE
Update ubports-installer from 0.8.8-beta to 0.9.5-beta

### DIFF
--- a/Casks/ubports-installer.rb
+++ b/Casks/ubports-installer.rb
@@ -1,17 +1,19 @@
 cask "ubports-installer" do
-  version "0.8.8-beta"
-  sha256 "57b296031cf7d2f72384d7b43e336a5b629ef01e3af9afbd7b8a3a622c6c8bf9"
+  version "0.9.5-beta"
+  sha256 "178ed0bd936888ec6512de3cfe5ff20041a7cd92a507334d85d9873b2256dae6"
 
-  url "https://github.com/ubports/ubports-installer/releases/download/#{version}/ubports-installer_#{version}_mac.dmg",
+  url "https://github.com/ubports/ubports-installer/releases/download/#{version}/ubports-installer_#{version}_mac_x64.dmg",
       verified: "github.com/ubports/ubports-installer/"
   name "ubports-installer"
   desc "Application to install ubports on mobile devices"
   homepage "https://ubports.com/"
 
+  # This Ubuntu Touch installer URL redirects to the appropriate file on GitHub.
+  # NOTE: This is the x64 URL, so this `livecheck` block may need to be updated
+  # if/when they publish an ARM64 dmg.
   livecheck do
-    url "https://github.com/ubports/ubports-installer/releases"
-    strategy :page_match
-    regex(%r{href=.*?/ubports-installer_(\d+(?:\.\d+)*(?:-beta)?)_mac\.dmg}i)
+    url "https://devices.ubuntu-touch.io/installer/dmg"
+    strategy :header_match
   end
 
   app "ubports-installer.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `ubports-installer` to the newest available version, 0.9.5-beta. A stable version isn't available yet, so we have to stick with pre-release versions.

This also updates the `livecheck` block to check an Ubuntu Touch URL that redirects to the latest dmg file from GitHub. This is easier and more reliable than checking the releases page (which would be necessary since some beta versions are marked as "Pre-release", so `GithubLatest` would miss versions).

The only thing to note is that the `livecheck` block may need to be updated in the future if upstream starts publishing ARM64 dmg files alongside the x64 release (the current URL). We would be fine if the current [x64] `livecheck` block URL is used for a universal binary at that time. If they're separate files, then we would probably need to interpolate an `arch` string into the `livecheck` block URL.