### PR TITLE
Correct SHA256 for retroarch

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask "retroarch" do
   version "1.10.2"
-  sha256 "f491cbf4fce1ddce437c02f1e527372a8aaa3255265b7ac8089a06f011f8e586"
+  sha256 "579d2409af2b30b515b65e588dc518a6f7cb20e295b1182986c4d0a5d9febc7d"
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   name "RetroArch"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
This happened before (#114633), the hash is incorrect, updated it to the correct one:

```
wget https://buildbot.libretro.com/stable/1.10.2/apple/osx/x86_64/RetroArch.dmg 
--2022-03-31 11:44:11--  https://buildbot.libretro.com/stable/1.10.2/apple/osx/x86_64/RetroArch.dmg
Resolving buildbot.libretro.com (buildbot.libretro.com)... 172.67.171.197, 104.21.55.171
Connecting to buildbot.libretro.com (buildbot.libretro.com)|172.67.171.197|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 177592359 (169M) [application/x-apple-diskimage]
Saving to: ‘RetroArch.dmg’

RetroArch.dmg        100%[=====================>] 169.37M  7.61MB/s    in 21s     

2022-03-31 11:44:33 (7.98 MB/s) - ‘RetroArch.dmg’ saved [177592359/177592359]


~/
❯ sha256sum RetroArch.dmg
579d2409af2b30b515b65e588dc518a6f7cb20e295b1182986c4d0a5d9febc7d  RetroArch.dmg
```
