### PR TITLE
Update Cog sha to match reality

### DIFF
--- a/Casks/cog.rb
+++ b/Casks/cog.rb
@@ -1,6 +1,6 @@
 cask "cog" do
   version "2155,69ebce32"
-  sha256 "abfb40bb41f93608511ebc41192994748db3e638bbe1f5962b6b1ca2f73d7adb"
+  sha256 "19d0aa7f8deae4853cffe4bcc8b65d91e93b75059e9f4aa25a668274b387dd5d"
 
   url "https://cogcdn.cog.losno.co/Cog-#{version.csv.second}.zip"
   name "Cog"


### PR DESCRIPTION
Seems like they've replaced original zip file, so currently installing
Cog fails with sha mismatch.

Original update commit https://github.com/Homebrew/homebrew-cask/pull/120817/commits/4e463932c2a9b53a07d5abe04cd4423d7eab3646
