### PR TITLE
Remove redundant strategy calls

### DIFF
--- a/Casks/360safe.rb
+++ b/Casks/360safe.rb
@@ -9,7 +9,6 @@ cask "360safe" do
 
   livecheck do
     url "https://www.360totalsecurity.com/en/version/360-total-security-mac/"
-    strategy :page_match
     regex(/version-history-list.*?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/electricbinary.rb
+++ b/Casks/electricbinary.rb
@@ -9,7 +9,6 @@ cask "electricbinary" do
 
   livecheck do
     url "https://ftp.gnu.org/pub/gnu/electric/"
-    strategy :page_match
     regex(/href=.*?electricBinary-(\d+(?:\.\d+)*)\.jar/i)
   end
 

--- a/Casks/launchy.rb
+++ b/Casks/launchy.rb
@@ -9,7 +9,6 @@ cask "launchy" do
 
   livecheck do
     url "https://www.launchy.net/download.php"
-    strategy :page_match
     regex(%r{href=.*?/Launchy(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/leela.rb
+++ b/Casks/leela.rb
@@ -9,7 +9,6 @@ cask "leela" do
 
   livecheck do
     url "https://sjeng.org/leela.html"
-    strategy :page_match
     regex(%r{href=.*?/Leela_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/leksah.rb
+++ b/Casks/leksah.rb
@@ -9,7 +9,6 @@ cask "leksah" do
 
   livecheck do
     url "http://www.leksah.org/packages/"
-    strategy :page_match
     regex(/href=.*?leksah-(\d+(?:\.\d+)*-ghc-\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/licecap.rb
+++ b/Casks/licecap.rb
@@ -9,7 +9,6 @@ cask "licecap" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/v?(\d+(?:\.\d+)*)\s*for\s*macOS/i)
   end
 

--- a/Casks/logicalshift-zoom.rb
+++ b/Casks/logicalshift-zoom.rb
@@ -9,7 +9,6 @@ cask "logicalshift-zoom" do
 
   livecheck do
     url "https://www.logicalshift.co.uk/unix/zoom/older.html"
-    strategy :page_match
     regex(%r{href=.*?/Zoom-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/logicsniffer.rb
+++ b/Casks/logicsniffer.rb
@@ -9,7 +9,6 @@ cask "logicsniffer" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/ols-(\d+(?:\.\d+)*)-full\.dmg}i)
   end
 

--- a/Casks/lynxlet.rb
+++ b/Casks/lynxlet.rb
@@ -9,7 +9,6 @@ cask "lynxlet" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/href=.*?Lynxlet_(\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/macwinzipper.rb
+++ b/Casks/macwinzipper.rb
@@ -9,7 +9,6 @@ cask "macwinzipper" do
 
   livecheck do
     url "https://tida.co.jp/macwinzipper"
-    strategy :page_match
     regex(%r{href=.*?/MacWinZipper-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/maelstrom.rb
+++ b/Casks/maelstrom.rb
@@ -9,7 +9,6 @@ cask "maelstrom" do
 
   livecheck do
     url "https://www.libsdl.org/projects/Maelstrom/binary.html"
-    strategy :page_match
     regex(%r{href=.*?/Maelstrom-(\d+(?:\.\d+)*)-MacOSX\.dmg}i)
   end
 

--- a/Casks/magicplot.rb
+++ b/Casks/magicplot.rb
@@ -9,7 +9,6 @@ cask "magicplot" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/href=.*?MagicPlot(\d+(?:\.\d+)*)\.zip/i)
   end
 

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -16,7 +16,6 @@ cask "mamp" do
 
   livecheck do
     url "https://www.mamp.info/en/downloads/"
-    strategy :page_match
     regex(%r{href=.*?/MAMP[._-]MAMP[._-]PRO[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.pkg}i)
   end
 

--- a/Casks/marble.rb
+++ b/Casks/marble.rb
@@ -8,7 +8,6 @@ cask "marble" do
 
   livecheck do
     url "https://marble.kde.org/install.php"
-    strategy :page_match
     regex(%r{href=.*?/Marble-(\d+(?:\.\d+)*)\.pkg}i)
   end
 

--- a/Casks/markdown-service-tools.rb
+++ b/Casks/markdown-service-tools.rb
@@ -9,7 +9,6 @@ cask "markdown-service-tools" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/MarkdownServiceTools(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/max.rb
+++ b/Casks/max.rb
@@ -21,7 +21,6 @@ cask "max" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/Max-(\d+(?:\.\d+)*b\d+)\.dmg}i)
   end
 

--- a/Casks/mcgimp.rb
+++ b/Casks/mcgimp.rb
@@ -9,7 +9,6 @@ cask "mcgimp" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/McGimp-(\d+(?:\.\d+)*)\.app\.zip}i)
   end
 

--- a/Casks/medibangpaintpro.rb
+++ b/Casks/medibangpaintpro.rb
@@ -9,7 +9,6 @@ cask "medibangpaintpro" do
 
   livecheck do
     url "https://medibangpaint.com/en/app-download/"
-    strategy :page_match
     regex(%r{href=.*?/MediBangPaintPro-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/mesasqlite.rb
+++ b/Casks/mesasqlite.rb
@@ -9,7 +9,6 @@ cask "mesasqlite" do
 
   livecheck do
     url "http://www.desertsandsoftware.com/?page_id=99"
-    strategy :page_match
     regex(/version\s*(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/minitimer.rb
+++ b/Casks/minitimer.rb
@@ -8,7 +8,6 @@ cask "minitimer" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/(\d+(?:\.\d+)*)/miniTimer\.dmg}i)
   end
 

--- a/Casks/mkvtools.rb
+++ b/Casks/mkvtools.rb
@@ -9,7 +9,6 @@ cask "mkvtools" do
 
   livecheck do
     url "https://www.emmgunn.com/mkvtools-home/mkvtools-downloads/"
-    strategy :page_match
     regex(%r{href=.*?/mkvtools(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/modern-csv.rb
+++ b/Casks/modern-csv.rb
@@ -9,7 +9,6 @@ cask "modern-csv" do
 
   livecheck do
     url "https://www.moderncsv.com/latest-version/"
-    strategy :page_match
     regex(/Modern\s*CSV\s*v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/morpheus.rb
+++ b/Casks/morpheus.rb
@@ -10,7 +10,6 @@ cask "morpheus" do
 
   livecheck do
     url "https://imc.zih.tu-dresden.de/morpheus/packages/mac/"
-    strategy :page_match
     regex(/href=.*?Morpheus[._-](\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/mp4tools.rb
+++ b/Casks/mp4tools.rb
@@ -9,7 +9,6 @@ cask "mp4tools" do
 
   livecheck do
     url "https://www.emmgunn.com/mp4tools-home/mp4tools-downloads/"
-    strategy :page_match
     regex(%r{href=.*?/mp4tools(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/mpeg-streamclip.rb
+++ b/Casks/mpeg-streamclip.rb
@@ -10,7 +10,6 @@ cask "mpeg-streamclip" do
 
   livecheck do
     url "http://www.squared5.com/svideo/mpeg-streamclip-mac.html"
-    strategy :page_match
     regex(%r{href=.*?/MPEG_Streamclip_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/nally.rb
+++ b/Casks/nally.rb
@@ -10,7 +10,6 @@ cask "nally" do
 
   livecheck do
     url "https://yllan.org/app/Nally/"
-    strategy :page_match
     regex(%r{href=.*?/Nally-(\d+(?:\.\d+)*)\.app\.zip}i)
   end
 

--- a/Casks/nanostudio.rb
+++ b/Casks/nanostudio.rb
@@ -8,7 +8,6 @@ cask "nanostudio" do
 
   livecheck do
     url "https://www.blipinteractive.co.uk/nanostudio1/"
-    strategy :page_match
     regex(%r{href=.*?/NanoStudio-(\d+(?:\.\d+)*)\.dmg\.zip}i)
   end
 

--- a/Casks/netlogo.rb
+++ b/Casks/netlogo.rb
@@ -9,7 +9,6 @@ cask "netlogo" do
 
   livecheck do
     url "https://ccl.northwestern.edu/netlogo/oldversions.shtml"
-    strategy :page_match
     regex(/NetLogo\s*(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/nisus-thesaurus.rb
+++ b/Casks/nisus-thesaurus.rb
@@ -9,7 +9,6 @@ cask "nisus-thesaurus" do
 
   livecheck do
     url "https://nisus.com/Thesaurus/updates.php"
-    strategy :page_match
     regex(/Version\s*(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/northernspysoftware-colorpicker.rb
+++ b/Casks/northernspysoftware-colorpicker.rb
@@ -9,7 +9,6 @@ cask "northernspysoftware-colorpicker" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/ColorPicker_(\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/not-pacman.rb
+++ b/Casks/not-pacman.rb
@@ -8,7 +8,6 @@ cask "not-pacman" do
 
   livecheck do
     url "https://stabyourself.net/notpacman"
-    strategy :page_match
     regex(%r{href=.*?/dl\.php\?file=notpacman-(\d+)/notpacman-osx\.zip}i)
   end
 

--- a/Casks/not-tetris.rb
+++ b/Casks/not-tetris.rb
@@ -8,7 +8,6 @@ cask "not-tetris" do
 
   livecheck do
     url "https://stabyourself.net/nottetris2/"
-    strategy :page_match
     regex(%r{href=.*?/nottetris(\d+)-osx\.zip}i)
   end
 

--- a/Casks/olive.rb
+++ b/Casks/olive.rb
@@ -9,7 +9,6 @@ cask "olive" do
 
   livecheck do
     url "https://olivevideoeditor.org/download.php"
-    strategy :page_match
     regex(/golegacy\.php\?hash=(.*)&type=/i)
   end
 

--- a/Casks/openscad.rb
+++ b/Casks/openscad.rb
@@ -9,7 +9,6 @@ cask "openscad" do
 
   livecheck do
     url "https://files.openscad.org/"
-    strategy :page_match
     regex(/href=.*?OpenSCAD-(\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/openttd.rb
+++ b/Casks/openttd.rb
@@ -14,7 +14,6 @@ cask "openttd" do
 
   livecheck do
     url "https://www.openttd.org/downloads/openttd-releases/latest.html"
-    strategy :page_match
     regex(%r{href=.*?/openttd-(\d+(?:\.\d+)*)-macos-universal\.zip}i)
   end
 

--- a/Casks/oscar.rb
+++ b/Casks/oscar.rb
@@ -10,7 +10,6 @@ cask "oscar" do
 
   livecheck do
     url "https://www.sleepfiles.com/OSCAR/"
-    strategy :page_match
     regex(%r{href=.*?/OSCAR-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -8,7 +8,6 @@ cask "paragon-ntfs" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/ntfsmac(\d+)_trial\.dmg}i)
   end
 

--- a/Casks/pdf-toolbox.rb
+++ b/Casks/pdf-toolbox.rb
@@ -8,7 +8,6 @@ cask "pdf-toolbox" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Version\s*(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/pflists.rb
+++ b/Casks/pflists.rb
@@ -8,7 +8,6 @@ cask "pflists" do
 
   livecheck do
     url "https://www.hanynet.com/pflists/"
-    strategy :page_match
     regex(%r{href=.*?/pflists-(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/phd2.rb
+++ b/Casks/phd2.rb
@@ -9,7 +9,6 @@ cask "phd2" do
 
   livecheck do
     url "https://openphdguiding.org/changelog/"
-    strategy :page_match
     regex(%r{href=.*?/PHD2-(\d+(?:\.\d+)*)-OSX-64\.zip}i)
   end
 

--- a/Casks/pineapple.rb
+++ b/Casks/pineapple.rb
@@ -9,7 +9,6 @@ cask "pineapple" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/Pineapple-(\d+(?:\.\d+)*)-Python3\.5\.dmg}i)
   end
 

--- a/Casks/pixel-check.rb
+++ b/Casks/pixel-check.rb
@@ -8,7 +8,6 @@ cask "pixel-check" do
 
   livecheck do
     url "http://macguitar.me/apps/pixelcheck/"
-    strategy :page_match
     regex(%r{href=.*?/PXC(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/pixelsnap.rb
+++ b/Casks/pixelsnap.rb
@@ -9,7 +9,6 @@ cask "pixelsnap" do
 
   livecheck do
     url "https://updates.getpixelsnap.com/v#{version.major}/appcast.xml"
-    strategy :page_match
     regex(/sparkle:version="(\d+(?:\.\d+)+)"/i)
   end
 

--- a/Casks/playonmac.rb
+++ b/Casks/playonmac.rb
@@ -14,7 +14,6 @@ cask "playonmac" do
 
   livecheck do
     url "https://www.playonmac.com/en/download.html"
-    strategy :page_match
     regex(%r{href=.*?/PlayOnMac_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -9,7 +9,6 @@ cask "plex-media-player" do
 
   livecheck do
     url "https://plex.tv/api/downloads/3.json"
-    strategy :page_match
     regex(%r{/PlexMediaPlayer-(\d+(?:\.\d+)*-[0-9a-f]+)-macosx-x86_64\.zip}i)
   end
 

--- a/Casks/pngyu.rb
+++ b/Casks/pngyu.rb
@@ -9,7 +9,6 @@ cask "pngyu" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/mac:\s*(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/pock.rb
+++ b/Casks/pock.rb
@@ -9,7 +9,6 @@ cask "pock" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Latest version: (\d+(?:\.\d+)*(?:-\d+)?)/i)
   end
 

--- a/Casks/pokemon-reborn.rb
+++ b/Casks/pokemon-reborn.rb
@@ -8,7 +8,6 @@ cask "pokemon-reborn" do
 
   livecheck do
     url "https://www.rebornevo.com/pr/download/"
-    strategy :page_match
     regex(%r{href=.*?/Reborn(\d+(?:\.\d+)*)%204%20Fruits\.zip}i)
   end
 

--- a/Casks/pomodone.rb
+++ b/Casks/pomodone.rb
@@ -8,7 +8,6 @@ cask "pomodone" do
 
   livecheck do
     url "https://pomodoneapp.com/download-pomodone-app.html"
-    strategy :page_match
     regex(%r{href=.*?/PomoDoneApp-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/popmaker.rb
+++ b/Casks/popmaker.rb
@@ -8,7 +8,6 @@ cask "popmaker" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/PopMaker(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/prince.rb
+++ b/Casks/prince.rb
@@ -9,7 +9,6 @@ cask "prince" do
 
   livecheck do
     url "https://www.princexml.com/download/"
-    strategy :page_match
     regex(%r{href=.*?/prince-(\d+(?:\.\d+)*)-macos\.zip}i)
   end
 

--- a/Casks/prismatik.rb
+++ b/Casks/prismatik.rb
@@ -9,7 +9,6 @@ cask "prismatik" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/Prismatik_(\d+(?:\.\d+)*)_signed\.dmg}i)
   end
 

--- a/Casks/pronterface.rb
+++ b/Casks/pronterface.rb
@@ -9,7 +9,6 @@ cask "pronterface" do
 
   livecheck do
     url "https://github.com/kliment/Printrun/releases/latest"
-    strategy :page_match
     regex(%r{href=.*?/pronterface-macos-app-(\d+(?:\.\d+)*(?:rc\d*)?)\.zip}i)
   end
 

--- a/Casks/protonvpn.rb
+++ b/Casks/protonvpn.rb
@@ -9,7 +9,6 @@ cask "protonvpn" do
 
   livecheck do
     url "https://protonvpn.com/download/macos-update3.xml"
-    strategy :page_match
     regex(/ProtonVPN_mac_v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/publii.rb
+++ b/Casks/publii.rb
@@ -9,7 +9,6 @@ cask "publii" do
 
   livecheck do
     url "https://getpublii.com/download/"
-    strategy :page_match
     regex(%r{href=.*?/Publii-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/pwnagetool.rb
+++ b/Casks/pwnagetool.rb
@@ -8,7 +8,6 @@ cask "pwnagetool" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/PwnageTool_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/qbserve.rb
+++ b/Casks/qbserve.rb
@@ -8,7 +8,6 @@ cask "qbserve" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/Qbserve-(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/qqmacmgr.rb
+++ b/Casks/qqmacmgr.rb
@@ -9,7 +9,6 @@ cask "qqmacmgr" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/QQMacMgr_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/qqplayer.rb
+++ b/Casks/qqplayer.rb
@@ -9,7 +9,6 @@ cask "qqplayer" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/QQPlayer(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/qr-journal.rb
+++ b/Casks/qr-journal.rb
@@ -9,7 +9,6 @@ cask "qr-journal" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/QRJournal(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/quickboot.rb
+++ b/Casks/quickboot.rb
@@ -8,7 +8,6 @@ cask "quickboot" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/QuickBoot-(\d+(?:\.\d+)*-\d+)\.zip}i)
   end
 

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -9,7 +9,6 @@ cask "quicksilver" do
 
   livecheck do
     url "https://qsapp.com/archives/"
-    strategy :page_match
     regex(%r{href=.*?/Quicksilver%20(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/radio-silence.rb
+++ b/Casks/radio-silence.rb
@@ -9,7 +9,6 @@ cask "radio-silence" do
 
   livecheck do
     url "https://radiosilenceapp.com/update"
-    strategy :page_match
     regex(%r{href=.*?/Radio_Silence_(\d+(?:\.\d+)*)\.pkg}i)
   end
 

--- a/Casks/receipts.rb
+++ b/Casks/receipts.rb
@@ -8,7 +8,6 @@ cask "receipts" do
 
   livecheck do
     url "https://www.receipts-app.com/updater.php"
-    strategy :page_match
     regex(%r{href=.*?/Receipts-(\d+(?:\.\d+)*-\d+)\.zip}i)
   end
 

--- a/Casks/redream.rb
+++ b/Casks/redream.rb
@@ -9,7 +9,6 @@ cask "redream" do
 
   livecheck do
     url "https://redream.io/download"
-    strategy :page_match
     regex(/redream\.x86_64-mac-v(\d+(?:\.\d+)*)\.tar\.gz/)
   end
 

--- a/Casks/resilio-sync.rb
+++ b/Casks/resilio-sync.rb
@@ -9,7 +9,6 @@ cask "resilio-sync" do
 
   livecheck do
     url "https://download-cdn.resilio.com/stable/osx/version.txt"
-    strategy :page_match
     regex(/(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/ripcord.rb
+++ b/Casks/ripcord.rb
@@ -9,7 +9,6 @@ cask "ripcord" do
 
   livecheck do
     url "https://cancel.fm/ripcord/updates/v1"
-    strategy :page_match
     regex(%r{/Ripcord_Mac_(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/roaringapps.rb
+++ b/Casks/roaringapps.rb
@@ -9,7 +9,6 @@ cask "roaringapps" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/RoaringApps-(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/rosaimagewriter.rb
+++ b/Casks/rosaimagewriter.rb
@@ -8,7 +8,6 @@ cask "rosaimagewriter" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/RosaImageWriter-(\d+(?:\.\d+)*)-osx\.dmg}i)
   end
 

--- a/Casks/routebuddy.rb
+++ b/Casks/routebuddy.rb
@@ -10,7 +10,6 @@ cask "routebuddy" do
 
   livecheck do
     url "http://routebuddy.com/routebuddy-topo-map-software-for-windows-and-mac-os-x/"
-    strategy :page_match
     regex(%r{href=.*?/RouteBuddy_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/scenebuilder.rb
+++ b/Casks/scenebuilder.rb
@@ -9,7 +9,6 @@ cask "scenebuilder" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/SceneBuilder-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/sf-symbols.rb
+++ b/Casks/sf-symbols.rb
@@ -17,7 +17,6 @@ cask "sf-symbols" do
 
   livecheck do
     url "https://developer.apple.com/sf-symbols/"
-    strategy :page_match
     regex(%r{href=.*?/SF-Symbols-(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/shrinkit.rb
+++ b/Casks/shrinkit.rb
@@ -8,7 +8,6 @@ cask "shrinkit" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/ShrinkIt%20(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/sim-daltonism.rb
+++ b/Casks/sim-daltonism.rb
@@ -9,7 +9,6 @@ cask "sim-daltonism" do
 
   livecheck do
     url "https://littoral.michelf.ca/apps/sim-daltonism/"
-    strategy :page_match
     regex(/href=.*?sim-daltonism-(\d+(?:\.\d+)*)\.zip/i)
   end
 

--- a/Casks/simplesynth.rb
+++ b/Casks/simplesynth.rb
@@ -9,7 +9,6 @@ cask "simplesynth" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/SimpleSynth-(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/skyfonts.rb
+++ b/Casks/skyfonts.rb
@@ -9,7 +9,6 @@ cask "skyfonts" do
 
   livecheck do
     url "https://api.skyfonts.com/api/SkyFontsAppCast?osid=3"
-    strategy :page_match
     regex(%r{href=.*?/Monotype_SkyFonts_Mac64_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -8,7 +8,6 @@ cask "slic3r" do
 
   livecheck do
     url "https://dl.slic3r.org/mac/"
-    strategy :page_match
     regex(/href=.*?slic3r-(\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/slingplayer.rb
+++ b/Casks/slingplayer.rb
@@ -10,7 +10,6 @@ cask "slingplayer" do
 
   livecheck do
     url "https://www.slingbox.com/Products/SlingplayerApps.aspx"
-    strategy :page_match
     regex(%r{href=.*?/SlingplayerDesktop-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/smlnj.rb
+++ b/Casks/smlnj.rb
@@ -10,7 +10,6 @@ cask "smlnj" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/smlnj-amd64-(\d+(?:\.\d+)*)\.pkg}i)
   end
 

--- a/Casks/soduto.rb
+++ b/Casks/soduto.rb
@@ -9,7 +9,6 @@ cask "soduto" do
 
   livecheck do
     url "https://soduto.com/downloads/"
-    strategy :page_match
     regex(%r{href=.*?/Soduto_v?(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/sonic-robo-blast-2.rb
+++ b/Casks/sonic-robo-blast-2.rb
@@ -11,7 +11,6 @@ cask "sonic-robo-blast-2" do
 
   livecheck do
     url "https://www.srb2.org/download/"
-    strategy :page_match
     regex(%r{href=.*?/SRB2-(\d+(?:\.\d+)*)-macOS-Installer.dmg}i)
   end
 

--- a/Casks/space-saver.rb
+++ b/Casks/space-saver.rb
@@ -9,7 +9,6 @@ cask "space-saver" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Download Space Saver \(ver (\d+(?:\.\d+)*)\)/i)
   end
 

--- a/Casks/squidman.rb
+++ b/Casks/squidman.rb
@@ -8,7 +8,6 @@ cask "squidman" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/SquidMan(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/staruml.rb
+++ b/Casks/staruml.rb
@@ -9,7 +9,6 @@ cask "staruml" do
 
   livecheck do
     url "https://staruml.io/"
-    strategy :page_match
     regex(%r{href=.*?/StarUML-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/supersync.rb
+++ b/Casks/supersync.rb
@@ -8,7 +8,6 @@ cask "supersync" do
 
   livecheck do
     url "https://supersync.com/downloads.php"
-    strategy :page_match
     regex(%r{href=.*?/SuperSync_(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/switchresx.rb
+++ b/Casks/switchresx.rb
@@ -9,7 +9,6 @@ cask "switchresx" do
 
   livecheck do
     url "https://www.madrau.com/srx_download/srx_download/history.php"
-    strategy :page_match
     regex(/SwitchResX\s*(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/syncroom.rb
+++ b/Casks/syncroom.rb
@@ -9,7 +9,6 @@ cask "syncroom" do
 
   livecheck do
     url "https://syncroom.yamaha.com/play/dl/"
-    strategy :page_match
     regex(%r{href=.*?/SYNCROOM-JP-mac-(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/synology-chat.rb
+++ b/Casks/synology-chat.rb
@@ -9,7 +9,6 @@ cask "synology-chat" do
 
   livecheck do
     url "https://www.synology.com/en-us/releaseNote/ChatClient"
-    strategy :page_match
     regex(/Version:\s*(\d+(?:\.\d+)*-\d+)/i)
   end
 

--- a/Casks/synology-note-station-client.rb
+++ b/Casks/synology-note-station-client.rb
@@ -9,7 +9,6 @@ cask "synology-note-station-client" do
 
   livecheck do
     url "https://www.synology.com/en-us/releaseNote/NoteStationClient"
-    strategy :page_match
     regex(/Version:\s*(\d+(?:\.\d+)*-\d+)/i)
   end
 

--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -9,7 +9,6 @@ cask "tastyworks" do
 
   livecheck do
     url "https://tastyworks.com/component---src-pages-technology-js-c0073caebcf082ded47f.js"
-    strategy :page_match
     regex(%r{/tastyworks-(\d+(?:\.\d+)*)}i)
   end
 

--- a/Casks/teeworlds.rb
+++ b/Casks/teeworlds.rb
@@ -8,7 +8,6 @@ cask "teeworlds" do
 
   livecheck do
     url "https://teeworlds.com/?page=downloads"
-    strategy :page_match
     regex(%r{href=.*?/teeworlds-(\d+(?:\.\d+)*)-osx\.dmg}i)
   end
 

--- a/Casks/texmaker.rb
+++ b/Casks/texmaker.rb
@@ -9,7 +9,6 @@ cask "texmaker" do
 
   livecheck do
     url "https://www.xm1math.net/texmaker/download.html"
-    strategy :page_match
     regex(%r{href=.*?/texmaker-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/texts.rb
+++ b/Casks/texts.rb
@@ -9,7 +9,6 @@ cask "texts" do
 
   livecheck do
     url "http://www.texts.io/download/"
-    strategy :page_match
     regex(%r{href=.*?/Texts-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -9,7 +9,6 @@ cask "tifig" do
 
   livecheck do
     url "https://www.tifig.net/download/"
-    strategy :page_match
     regex(%r{href=.*?/tifig-(\d+(?:\.\d+)*-\d+)-macosx\.cocoa\.x86_64\.tar\.gz}i)
   end
 

--- a/Casks/tnefs-enough.rb
+++ b/Casks/tnefs-enough.rb
@@ -9,7 +9,6 @@ cask "tnefs-enough" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/TNEF(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/tortoisehg.rb
+++ b/Casks/tortoisehg.rb
@@ -10,7 +10,6 @@ cask "tortoisehg" do
 
   livecheck do
     url "https://www.mercurial-scm.org/release/tortoisehg/macos/"
-    strategy :page_match
     regex(/TortoiseHg-(\d+(?:\.\d+)*)-mac-x64-qt5\.dmg/i)
   end
 

--- a/Casks/touchosc-editor.rb
+++ b/Casks/touchosc-editor.rb
@@ -9,7 +9,6 @@ cask "touchosc-editor" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/touchosc-editor-(\d+(?:\.\d+)*)-macos\.zip}i)
   end
 

--- a/Casks/udig.rb
+++ b/Casks/udig.rb
@@ -8,7 +8,6 @@ cask "udig" do
 
   livecheck do
     url "http://udig.refractions.net/download/"
-    strategy :page_match
     regex(%r{href=.*?/udig-(\d+(?:\.\d+)*)\.macosx\.cocoa\.x86_64\.dmg}i)
   end
 

--- a/Casks/ultracopier.rb
+++ b/Casks/ultracopier.rb
@@ -10,7 +10,6 @@ cask "ultracopier" do
 
   livecheck do
     url "http://ultracopier.first-world.info/download-all.html"
-    strategy :page_match
     regex(/ultracopier[._-]mac[._-]os[._-]x[._-](\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/valley.rb
+++ b/Casks/valley.rb
@@ -9,7 +9,6 @@ cask "valley" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/Unigine_Valley-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/vnc-server.rb
+++ b/Casks/vnc-server.rb
@@ -9,7 +9,6 @@ cask "vnc-server" do
 
   livecheck do
     url "https://www.realvnc.com/en/connect/download/vnc/macos/"
-    strategy :page_match
     regex(%r{href=.*?/VNC-Server-(\d+(?:\.\d+)*)-MacOSX-x86_64\.pkg}i)
   end
 

--- a/Casks/vnc-viewer.rb
+++ b/Casks/vnc-viewer.rb
@@ -9,7 +9,6 @@ cask "vnc-viewer" do
 
   livecheck do
     url "https://www.realvnc.com/en/connect/download/viewer/macos/"
-    strategy :page_match
     regex(%r{href=.*?/VNC-Viewer-(\d+(?:\.\d+)+)-MacOSX-x86_64\.dmg}i)
   end
 

--- a/Casks/vofa-plus.rb
+++ b/Casks/vofa-plus.rb
@@ -10,7 +10,6 @@ cask "vofa-plus" do
 
   livecheck do
     url "https://www.vofa.plus/downloads/"
-    strategy :page_match
     regex(/vofa\+_(\d+(?:\.\d+)*)_amd64\.dmg/i)
   end
 

--- a/Casks/voikkospellservice.rb
+++ b/Casks/voikkospellservice.rb
@@ -8,7 +8,6 @@ cask "voikkospellservice" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/VoikkoSpellService-(\d+(?:\.\d+)*b\d+)\.dmg}i)
   end
 

--- a/Casks/warsow.rb
+++ b/Casks/warsow.rb
@@ -9,7 +9,6 @@ cask "warsow" do
 
   livecheck do
     url "https://www.warsow.net/bundles/client.bundle.js"
-    strategy :page_match
     regex(%r{href=.*?/warsow-(\d+(?:\.\d+)*)\.dmg}i)
   end
 

--- a/Casks/webplotdigitizer.rb
+++ b/Casks/webplotdigitizer.rb
@@ -9,7 +9,6 @@ cask "webplotdigitizer" do
 
   livecheck do
     url "https://automeris.io/WebPlotDigitizer/download.html"
-    strategy :page_match
     regex(%r{href=.*?/WebPlotDigitizer-(\d+(?:\.\d+)*)-darwin-x64\.zip}i)
   end
 

--- a/Casks/youku.rb
+++ b/Casks/youku.rb
@@ -10,7 +10,6 @@ cask "youku" do
 
   livecheck do
     url "https://pd.youku.com/pc"
-    strategy :page_match
     regex(%r{href=.*?/youkumac_(\d+(?:\.\d+)+)\.dmg}i)
   end
 

--- a/Casks/zotero.rb
+++ b/Casks/zotero.rb
@@ -9,7 +9,6 @@ cask "zotero" do
 
   livecheck do
     url "https://www.zotero.org/download/"
-    strategy :page_match
     regex(/standaloneVersions.*?"mac"\s*:\s*"(\d+(?:\.\d+)*)"/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes more redundant `#strategy` calls in `livecheck` blocks, where the strategy that's used for the URL by default is the same as the one specified (e.g., the `livecheck` block uses `strategy :page_match` but livecheck already uses the `PageMatch` strategy for the URL). We only use `#strategy` when we need to override livecheck's strategy selection (specifying a strategy other than the one used for a URL by default) or when we're using a `strategy` block.

It goes without saying but I made sure to confirm that the verbose JSON livecheck output for each of these casks is the same after removing these `strategy` calls (i.e., the behavior remains the same as before).