### PR TITLE
hammerspoon: use special 0.9.93 for Mojave

### DIFF
--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -1,9 +1,19 @@
 cask "hammerspoon" do
-  version "0.9.97"
-  sha256 "ef2ed8658981f8a3157476572dd89ce496a75d097abed6939aa9af9056bc5133"
+  if MacOS.version <= :mojave
+    # A special version for Mojave, signed and notarized, released by the author at
+    #  https://github.com/Hammerspoon/hammerspoon/issues/3023#issuecomment-992980087
+    version "0.9.93"
+    sha256 "eb4eb4b014d51b32ac15f87050eb11bcc2e77bcdbfbf5ab60a95ecc50e55d2a3"
+    url "https://github.com/Hammerspoon/hammerspoon/files/7707382/Hammerspoon-#{version}-for-10.14.zip",
+        verified: "github.com/Hammerspoon/hammerspoon/"
+  else
+    version "0.9.97"
+    sha256 "ef2ed8658981f8a3157476572dd89ce496a75d097abed6939aa9af9056bc5133"
 
-  url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip",
-      verified: "github.com/Hammerspoon/hammerspoon/"
+    url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip",
+        verified: "github.com/Hammerspoon/hammerspoon/"
+  end
+
   name "Hammerspoon"
   desc "Desktop automation application"
   homepage "https://www.hammerspoon.org/"
@@ -14,6 +24,7 @@ cask "hammerspoon" do
   end
 
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   app "Hammerspoon.app"
 

--- a/Casks/hammerspoon.rb
+++ b/Casks/hammerspoon.rb
@@ -1,27 +1,31 @@
 cask "hammerspoon" do
   if MacOS.version <= :mojave
-    # A special version for Mojave, signed and notarized, released by the author at
-    #  https://github.com/Hammerspoon/hammerspoon/issues/3023#issuecomment-992980087
     version "0.9.93"
     sha256 "eb4eb4b014d51b32ac15f87050eb11bcc2e77bcdbfbf5ab60a95ecc50e55d2a3"
+
     url "https://github.com/Hammerspoon/hammerspoon/files/7707382/Hammerspoon-#{version}-for-10.14.zip",
         verified: "github.com/Hammerspoon/hammerspoon/"
+
+    # Specific build provided for Mojave upstream https://github.com/Hammerspoon/hammerspoon/issues/3023#issuecomment-992980087
+    livecheck do
+      skip "Specific build for Mojave and earlier"
+    end
   else
     version "0.9.97"
     sha256 "ef2ed8658981f8a3157476572dd89ce496a75d097abed6939aa9af9056bc5133"
 
     url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip",
         verified: "github.com/Hammerspoon/hammerspoon/"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
   end
 
   name "Hammerspoon"
   desc "Desktop automation application"
   homepage "https://www.hammerspoon.org/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   auto_updates true
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
Hammerspoon drops support for Mojave. I wanna add back a Mojave compatible release in the cask file for hammerspoon.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

No. Not a new cask.