### PR TITLE
raycast: update minimal macOS version requirement

### DIFF
--- a/Casks/raycast.rb
+++ b/Casks/raycast.rb
@@ -14,7 +14,7 @@ cask "raycast" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "Raycast.app"
 


### PR DESCRIPTION
raycast drops support for Mojave since 1.27. Consider they don't
provide a way to download an old version, let's update the os version
requirement.


In fact, I accidentally upgraded raycast through `brew upgrade` and the new raycast doesn't work on one of my old laptop because this very laptop runs Mojave.



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

Nope. This PR is not for a new cask.