### PR TITLE
ganttproject 3.2.3230 (botched upstream release)

### DIFF
--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -2,17 +2,17 @@ cask "ganttproject" do
   version "3.2.3230"
   sha256 "4e6ebd308378d3d1936050ff6407630692d5b8833f05f139428b052cf91982dc"
 
-  ## Normally `version_of_github_release` is the same as `version`, so
-  ## one would say:
-  # version_of_github_release = version()
-  ## ... But currently this isn't the case:
-  version_of_github_release = "3.2.3200"
-
-  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version_of_github_release}/ganttproject-#{version}.dmg",
+  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version}/ganttproject-#{version}.dmg",
       verified: "github.com/bardsoftware/ganttproject/"
   name "GanttProject"
   desc "Gantt chart and project management application"
   homepage "https://www.ganttproject.biz/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/href=.*?ganttproject[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
 
   app "GanttProject.app"
 end

--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,8 +1,8 @@
 cask "ganttproject" do
-  version "3.2.3230"
+  version "3.2.3200,3.2.3230"
   sha256 "4e6ebd308378d3d1936050ff6407630692d5b8833f05f139428b052cf91982dc"
 
-  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version}/ganttproject-#{version}.dmg",
+  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version.csv.first}/ganttproject-#{version.csv.second}.dmg",
       verified: "github.com/bardsoftware/ganttproject/"
   name "GanttProject"
   desc "Gantt chart and project management application"
@@ -10,8 +10,13 @@ cask "ganttproject" do
 
   livecheck do
     url :url
-    strategy :github_latest
-    regex(/href=.*?ganttproject[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(%r{href=.*ganttproject[._-]v?(\d+(?:\.\d+)+)/ganttproject[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :github_latest do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   app "GanttProject.app"

--- a/Casks/ganttproject.rb
+++ b/Casks/ganttproject.rb
@@ -1,8 +1,14 @@
 cask "ganttproject" do
-  version "3.2.3200"
-  sha256 "6dde4a151cabdf69fe84a3ea6d4b943233c8f9cb181bdac9168a6748e74778a6"
+  version "3.2.3230"
+  sha256 "4e6ebd308378d3d1936050ff6407630692d5b8833f05f139428b052cf91982dc"
 
-  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version}/ganttproject-#{version}.dmg",
+  ## Normally `version_of_github_release` is the same as `version`, so
+  ## one would say:
+  # version_of_github_release = version()
+  ## ... But currently this isn't the case:
+  version_of_github_release = "3.2.3200"
+
+  url "https://github.com/bardsoftware/ganttproject/releases/download/ganttproject-#{version_of_github_release}/ganttproject-#{version}.dmg",
       verified: "github.com/bardsoftware/ganttproject/"
   name "GanttProject"
   desc "Gantt chart and project management application"


### PR DESCRIPTION
It looks like the upstream maintainer was not thorough in re-releasing 3.2.3200.
- Add `version_of_github_release` to paper over this
- Use it to construct `url`
- Update sha256


- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask ganttproject` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

