### PR TITLE
Add Tracker.app v6.0.7

### DIFF
--- a/Casks/osp-tracker.rb
+++ b/Casks/osp-tracker.rb
@@ -1,0 +1,27 @@
+cask "osp-tracker" do
+  version "6.0.7"
+  sha256 "df0e0ccd2e2631fee0dc4c6863a7b015215c05eb620a9d913958f8cb8ac68ebe"
+
+  url "https://physlets.org/tracker/installers/download.php?file=Tracker-#{version}-osx-installer.dmg"
+  name "Tracker"
+  desc "Video analysis and modeling tool for physics education"
+  homepage "https://physlets.org/tracker/"
+
+  livecheck do
+    url "https://physlets.org/tracker/"
+    strategy :page_match
+    regex(/href="?.*?file=Tracker-(\d+(?:\.\d+)+)-osx-installer\.dmg"?/i)
+  end
+
+  installer script: {
+    executable: "Tracker-#{version}-osx-installer.app/Contents/MacOS/installbuilder.sh",
+    args:       ["--mode", "unattended"],
+    sudo:       true,
+  }
+
+  uninstall script: {
+    executable: "/usr/local/tracker/uninstall_Tracker.app/Contents/MacOS/installbuilder.sh",
+    args:       ["--mode", "unattended"],
+    sudo:       true,
+  }
+end

--- a/Casks/osp-tracker.rb
+++ b/Casks/osp-tracker.rb
@@ -8,9 +8,8 @@ cask "osp-tracker" do
   homepage "https://physlets.org/tracker/"
 
   livecheck do
-    url "https://physlets.org/tracker/"
-    strategy :page_match
-    regex(/href="?.*?file=Tracker-(\d+(?:\.\d+)+)-osx-installer\.dmg"?/i)
+    url :homepage
+    regex(/href=.*?file=Tracker[._-]v?(\d+(?:\.\d+)+)-osx-installer\.dmg/i)
   end
 
   installer script: {


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

**About the name**: the app itself is called "Tracker" with no qualifiers. I chose to name the cask `osp-tracker` (where OSP is the abbreviation used by Open Source Physics, the organization behind Tracker), given that `tracker` alone would not pass the `--new-cask` audit due to sharing the name with the (completely unrelated) [`tracker` formula](https://formulae.brew.sh/formula/tracker) in core. I believe the `osp-` prefixed name best follows the Cask naming guidelines, but I'm open to renaming the cask if there is a better suggestion.