### PR TITLE
baretorrent: update livecheck

### DIFF
--- a/Casks/baretorrent.rb
+++ b/Casks/baretorrent.rb
@@ -8,9 +8,8 @@ cask "baretorrent" do
   homepage "https://launchpad.net/baretorrent"
 
   livecheck do
-    url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/baretorrent-(\d+(?:\.\d+)+)-osx-x64\.dmg}i)
+    url :url
+    regex(/href=.*?baretorrent[._-]v?(\d+(?:\.\d+)+)(?:[._-][^"' >]+?)?\.dmg/i)
   end
 
   app "baretorrent.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block checks the Launchpad page for `baretorrent` and matches the version from the dmg file URL. This isn't that much different than the `Launchpad` strategy, so it's arguably better to omit the `strategy` call here and let livecheck use the `Launchpad` strategy (for the sake of tracking strategy usage, being able to roll out changes to the strategy that benefit any related formulae/casks, etc.).

I'm using the cask `url` in this `livecheck` block, as it will be turned into the current `homepage` URL by the `Launchpad` strategy. If I have to make a choice among basically equal options, I would prefer to use `url :url` here instead of `url :homepage`, as a change to the homepage could cause the `livecheck` block to no longer align with the cask `url`.

Past that, I've modified the regex to better align with typical regexes for matching a version from a file in an `href` attribute and to loosen the suffix matching (as a dmg file is intended for macOS). If this doesn't end up being reliable over time and we don't specifically need to match versions from the dmg file, we could technically omit this `livecheck` block entirely and simply use the default `Launchpad` approach (which simply matches the latest version from the "Latest version is 1.2.3" text). Keeping the `livecheck` block is probably fine for now, though.