### PR TITLE
updated sha256 value for openvisualtraceroute-2.0.0

### DIFF
--- a/Casks/openvisualtraceroute.rb
+++ b/Casks/openvisualtraceroute.rb
@@ -1,6 +1,6 @@
 cask "openvisualtraceroute" do
   version "2.0.0"
-  sha256 "581417e62d6d269fe8d0e5ccd426e21cc3fdd431b329e6c0aa113fc678c42ae4"
+  sha256 "bf1fecac21fecde1100f495b0e4e5a166b552dcc8477ab1caf90d6f63c610977"
 
   url "https://downloads.sourceforge.net/openvisualtrace/#{version}/OpenVisualTraceRoute#{version}.dmg",
       verified: "downloads.sourceforge.net/openvisualtrace/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
