### PR TITLE
raindropio: update livecheck

### DIFF
--- a/Casks/raindropio.rb
+++ b/Casks/raindropio.rb
@@ -15,10 +15,10 @@ cask "raindropio" do
   desc "All-in-one bookmark manager"
   homepage "https://raindrop.io/"
 
+  # First-party download page links to dmg file from GitHub "latest" release.
   livecheck do
-    url "https://github.com/raindropio/desktop/releases"
-    strategy :page_match
-    regex(%r{v?(\d+(?:\.\d+)+)/Raindrop[._-]#{arch}\.dmg}i)
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `raindropio` checks the GitHub releases page and matches versions from linked dmg files. The [first-party download page](https://raindrop.io/download) simply links to the `Raindrop-x64.dmg` and `Raindrop-arm64.dmg` files from the "latest" GitHub release, so this PR updates the `livecheck` block to simply use the `GithubLatest` strategy.

If we ever encounter a "latest" release that omits the dmg files, we can return to checking the releases page (making sure to filter out prerelease versions) but we only use this approach as a last resort, as there are potential shortcomings to it.