### PR TITLE
basictex 2022.0314

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -1,6 +1,6 @@
 cask "basictex" do
-  version "2021.0325"
-  sha256 "0d8f7c39ac7a2a66b070775f0c684aab01a7fb3c075045c33cd19f9b29317d53"
+  version "2022.0314"
+  sha256 "5ef0678318c2b947b78b77c0cddae09e763359596c6c1fd0362f5cdca9714b78"
 
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"

--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -2,7 +2,7 @@ cask "basictex" do
   version "2022.0314"
   sha256 "5ef0678318c2b947b78b77c0cddae09e763359596c6c1fd0362f5cdca9714b78"
 
-  url "http://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg",
+  url "https://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"
   name "BasicTeX"
   desc "Compact TeX distribution as alternative to the full TeX Live / MacTeX"


### PR DESCRIPTION
It will take some time for all the mirrors around the world to update:

<img width="615" alt="Screen Shot 2022-04-04 at 12 48 38" src="https://user-images.githubusercontent.com/6127163/161475892-49db8c26-1502-4633-90ea-249e17a2cae0.png">

I will keep an eye on my local mirror at https://mirror.aarnet.edu.au/pub/CTAN/systems/mac/mactex/, and when it appears there I will merge this.

If people are impatient, they can download this from the root mirror at http://dante.ctan.org/tex-archive/systems/mac/mactex/