### PR TITLE
mactex-no-gui 2022.0321

### DIFF
--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -1,6 +1,6 @@
 cask "mactex-no-gui" do
-  version "2021.0328"
-  sha256 "e541257d70f911550341853709fc45d9fa9fcd4c93058382000ebb19b284833b"
+  version "2022.0321"
+  sha256 "dc1983c82de2c68f1c434f734d94343959d1338adb6f55132ccce11c787badc1"
 
   url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"
@@ -23,13 +23,13 @@ cask "mactex-no-gui" do
       choices: [
         {
           # Ghostscript
-          "choiceIdentifier" => "org.tug.mactex.ghostscript9.53.3",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript9.55",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },
         {
           # Ghostscript Dynamic Library
-          "choiceIdentifier" => "org.tug.mactex.ghostscript9.53.3libgs",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript9.55-libgs",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },

--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -2,7 +2,7 @@ cask "mactex-no-gui" do
   version "2022.0321"
   sha256 "dc1983c82de2c68f1c434f734d94343959d1338adb6f55132ccce11c787badc1"
 
-  url "http://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
+  url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"
   name "MacTeX"
   desc "Full TeX Live distribution without GUI applications"


### PR DESCRIPTION
It will take some time for all the mirrors around the world to update:

<img width="615" alt="Screen Shot 2022-04-04 at 12 48 38" src="https://user-images.githubusercontent.com/6127163/161475892-49db8c26-1502-4633-90ea-249e17a2cae0.png">

I will keep an eye on my local mirror at https://mirror.aarnet.edu.au/pub/CTAN/systems/mac/mactex/, and when it appears there I will merge this.

If people are impatient, they can download this from the root mirror at http://dante.ctan.org/tex-archive/systems/mac/mactex/