### PR TITLE
Add zaps to ipfs.rb

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -15,4 +15,9 @@ cask "ipfs" do
   auto_updates true
 
   app "IPFS Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/Caches/ipfs-desktop-updater/",
+    "~/Library/Application Support/IPFS Desktop",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
`brew style` says:
```rb
ipfs.rb:1:1: C: [Correctable] No Sorbet sigil found in file. Try a typed: false to start (you can also use rubocop -a to automatically add this).
cask "ipfs" do
^^^^
ipfs.rb:1:1: C: [Correctable] Missing frozen string literal comment.
cask "ipfs" do
^
```

I'm not sure if that's something I'm supposed to add, since I don't see it in other casks.