### PR TITLE
Use \.t instead of tarball extension in regexes

### DIFF
--- a/Casks/cevelop.rb
+++ b/Casks/cevelop.rb
@@ -9,7 +9,7 @@ cask "cevelop" do
 
   livecheck do
     url "https://www.cevelop.com/download/"
-    regex(%r{href=.*?/cevelop[._-]v?(\d+(?:\.\d+)+-\d+)[._-]macosx\.cocoa\.x86_64\.tar\.gz}i)
+    regex(%r{href=.*?/cevelop[._-]v?(\d+(?:\.\d+)+-\d+)[._-]macosx\.cocoa\.x86_64\.t}i)
   end
 
   app "Cevelop.app"

--- a/Casks/crystax-ndk.rb
+++ b/Casks/crystax-ndk.rb
@@ -9,7 +9,7 @@ cask "crystax-ndk" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/crystax[._-]ndk[._-]v?(\d+(?:\.\d+)+)[._-]darwin[._-]x86[._-]64\.tar\.xz}i)
+    regex(%r{href=.*?/crystax[._-]ndk[._-]v?(\d+(?:\.\d+)+)[._-]darwin[._-]x86[._-]64\.t}i)
   end
 
   conflicts_with cask: "android-ndk"

--- a/Casks/isabelle.rb
+++ b/Casks/isabelle.rb
@@ -9,7 +9,7 @@ cask "isabelle" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/Isabelle(\d+(?:.\d+)*)_macos\.tar\.gz}i)
+    regex(%r{href=.*?/Isabelle(\d+(?:.\d+)*)_macos\.t}i)
   end
 
   app "Isabelle#{version}.app"

--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -10,7 +10,7 @@ cask "mpv" do
 
   livecheck do
     url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
-    regex(/mpv-(\d+(?:\.\d+)+)\.tar\.gz/i)
+    regex(/mpv-(\d+(?:\.\d+)+)\.t/i)
   end
 
   conflicts_with formula: "mpv"

--- a/Casks/redream.rb
+++ b/Casks/redream.rb
@@ -9,7 +9,7 @@ cask "redream" do
 
   livecheck do
     url "https://redream.io/download"
-    regex(/redream\.x86_64-mac-v(\d+(?:\.\d+)*)\.tar\.gz/)
+    regex(/redream\.x86_64-mac-v(\d+(?:\.\d+)*)\.t/)
   end
 
   app "redream.app"

--- a/Casks/serviio.rb
+++ b/Casks/serviio.rb
@@ -9,7 +9,7 @@ cask "serviio" do
 
   livecheck do
     url "https://www.serviio.org/download"
-    regex(%r{href=.*?/serviio-(\d+(?:\.\d+)+)-osx\.tar\.gz}i)
+    regex(%r{href=.*?/serviio-(\d+(?:\.\d+)+)-osx\.t}i)
   end
 
   pkg "Serviio-#{version}.pkg"

--- a/Casks/sqlworkbenchj.rb
+++ b/Casks/sqlworkbenchj.rb
@@ -9,7 +9,7 @@ cask "sqlworkbenchj" do
 
   livecheck do
     url "https://www.sql-workbench.eu/download-archive.html"
-    regex(/Workbench[._-]Build(\d+)[._-]Mac\.tgz/i)
+    regex(/Workbench[._-]Build(\d+)[._-]Mac\.t/i)
   end
 
   app "SQLWorkbenchJ.app"

--- a/Casks/tifig.rb
+++ b/Casks/tifig.rb
@@ -9,7 +9,7 @@ cask "tifig" do
 
   livecheck do
     url "https://www.tifig.net/download/"
-    regex(%r{href=.*?/tifig-(\d+(?:\.\d+)*-\d+)-macosx\.cocoa\.x86_64\.tar\.gz}i)
+    regex(%r{href=.*?/tifig-(\d+(?:\.\d+)*-\d+)-macosx\.cocoa\.x86_64\.t}i)
   end
 
   app "Tifig.app"

--- a/Casks/wine-stable.rb
+++ b/Casks/wine-stable.rb
@@ -13,8 +13,8 @@ cask "wine-stable" do
 
   livecheck do
     url "https://github.com/Gcenx/macOS_Wine_builds/releases/"
+    regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.t/i)
     strategy :page_match
-    regex(/wine[._-]stable[._-]v?(\d+(?:\.\d+)+)[._-]osx64\.tar\.xz/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR updates existing `livecheck` blocks to preemptively resolve RuboCop offenses related to using a specific tarball extension in a regex (e.g., "Use .t instead of .tar.gz"). The provided file may change format over time (e.g., from tar.gz to tar.xz) and cause the regex to fail to match, so we simply use the generic `\.t` in regexes.

For what it's worth, there are other issues with these regexes but I'm trying to handle some of these RuboCop fixes in bulk and it's easier to review PRs like this if the diffs are simple/predictable. The only unrelated change in this PR is to move a `#strategy` call below the `#regex` call.