### PR TITLE
Update emacs to latest 28.1 version

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,6 +1,6 @@
 cask "emacs" do
-  version "27.2-3"
-  sha256 "c53b4562538d6d0074bd9a4933d4a0d6ce08c08f0be8922af0d34431215bf475"
+  version "28.1"
+  sha256 "6de2721bc09d5e8f8f904a5cdf020ff48dffc4405d55c8e349e0146b2a10566f"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   name "Emacs"


### PR DESCRIPTION
Updated the binary to latest 28.1 version of emacs

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

