### PR TITLE
Update staruml.rb to add arm64 support

### DIFF
--- a/Casks/staruml.rb
+++ b/Casks/staruml.rb
@@ -1,15 +1,22 @@
 cask "staruml" do
-  version "5.0.1"
-  sha256 "31d72acb8d12e255fb67afc536f952bae7b4400702df67b515adf564100ec87d"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  url "https://staruml.io/download/releases-v#{version.major}/StarUML-#{version}.dmg"
+  version "5.0.1"
+
+  if Hardware::CPU.intel?
+    sha256 "31d72acb8d12e255fb67afc536f952bae7b4400702df67b515adf564100ec87d"
+  else
+    sha256 "259d32508bd843e4defb6ec1b46e016d8408432b4095c60ec045f1cf2e721a88"
+  end
+
+  url "https://staruml.io/download/releases-v#{version.major}/StarUML-#{version}#{arch}.dmg"
   name "StarUML"
   desc "Software modeler"
   homepage "https://staruml.io/"
 
   livecheck do
     url "https://staruml.io/"
-    regex(%r{href=.*?/StarUML-(\d+(?:\.\d+)*)\.dmg}i)
+    regex(%r{href=.*?/StarUML-(\d+(?:\.\d+)*)(-arm64)?\.dmg}i)
   end
 
   app "StarUML.app"


### PR DESCRIPTION
Update staruml.rb to add arm64 support

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.