### PR TITLE
Use case-insensitive regexes

### DIFF
--- a/Casks/audiogridder-plugin.rb
+++ b/Casks/audiogridder-plugin.rb
@@ -16,7 +16,7 @@ cask "audiogridder-plugin" do
 
   livecheck do
     url "https://audiogridder.com/releases/latest.txt"
-    regex(/(\d+(?:\.\d+)+)/)
+    regex(/(\d+(?:\.\d+)+)/i)
   end
 
   pkg "AudioGridderPlugin_#{version}_macOS-#{arch}.pkg"

--- a/Casks/audiogridder-server.rb
+++ b/Casks/audiogridder-server.rb
@@ -16,7 +16,7 @@ cask "audiogridder-server" do
 
   livecheck do
     url "https://audiogridder.com/releases/latest.txt"
-    regex(/(\d+(?:\.\d+)+)/)
+    regex(/(\d+(?:\.\d+)+)/i)
   end
 
   pkg "AudioGridderServer_#{version}_macOS-#{arch}.pkg"

--- a/Casks/azure-data-studio.rb
+++ b/Casks/azure-data-studio.rb
@@ -10,7 +10,7 @@ cask "azure-data-studio" do
 
   livecheck do
     url "https://azuredatastudio-update.azurewebsites.net/api/update/darwin/stable/VERSION"
-    regex(/"productVersion"\s*:\s*"(\d+(:?\.\d+)+)"/)
+    regex(/"productVersion"\s*:\s*"(\d+(:?\.\d+)+)"/i)
   end
 
   auto_updates true

--- a/Casks/bettermouse.rb
+++ b/Casks/bettermouse.rb
@@ -10,7 +10,7 @@ cask "bettermouse" do
   livecheck do
     url :homepage
     strategy :page_match
-    regex(/Version (\d+(?:\.\d+)+)/)
+    regex(/Version (\d+(?:\.\d+)+)/i)
   end
 
   app "BetterMouse.app"

--- a/Casks/cscreen.rb
+++ b/Casks/cscreen.rb
@@ -9,7 +9,7 @@ cask "cscreen" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/(\d{4})/(\d{2})/cscreenIntel\.dmg})
+    regex(%r{href=.*?/(\d{4})/(\d{2})/cscreenIntel\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]}.#{match[1]}" }
     end

--- a/Casks/daisydisk.rb
+++ b/Casks/daisydisk.rb
@@ -9,7 +9,7 @@ cask "daisydisk" do
 
   livecheck do
     url "https://daisydiskapp.com/downloads/appcastReleaseNotes.php?appEdition=Standard&osVersion=10.15"
-    regex(/>\s*?Version\s+?v?(\d+(?:\.\d+)+)\s*?</)
+    regex(/>\s*?Version\s+?v?(\d+(?:\.\d+)+)\s*?</i)
   end
 
   auto_updates true

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -10,7 +10,7 @@ cask "deltawalker" do
 
   livecheck do
     url "http://www.deltawalker.com/download"
-    regex(/href=.*?DeltaWalker[._-]?v?(\d+(?:\.\d+)+)\.dmg/)
+    regex(/href=.*?DeltaWalker[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "DeltaWalker.app"

--- a/Casks/enclave.rb
+++ b/Casks/enclave.rb
@@ -9,7 +9,7 @@ cask "enclave" do
 
   livecheck do
     url "https://install.enclave.io/latest/osx-homebrew-version.txt"
-    regex(/(\d+(?:\.\d+)*)/)
+    regex(/(\d+(?:\.\d+)*)/i)
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/godot-mono.rb
+++ b/Casks/godot-mono.rb
@@ -10,7 +10,7 @@ cask "godot-mono" do
 
   livecheck do
     url "https://github.com/godotengine/godot"
-    regex(/^v?(\d+(?:\.\d+)+)[._-]stable$/)
+    regex(/^v?(\d+(?:\.\d+)+)[._-]stable$/i)
   end
 
   depends_on formula: "mono"

--- a/Casks/godot.rb
+++ b/Casks/godot.rb
@@ -10,7 +10,7 @@ cask "godot" do
 
   livecheck do
     url "https://github.com/godotengine/godot"
-    regex(/^v?(\d+(?:\.\d+)+)[._-]stable$/)
+    regex(/^v?(\d+(?:\.\d+)+)[._-]stable$/i)
   end
 
   app "Godot.app"

--- a/Casks/gzdoom.rb
+++ b/Casks/gzdoom.rb
@@ -10,7 +10,7 @@ cask "gzdoom" do
 
   livecheck do
     url :url
-    regex(/^g?(\d+(?:\.\d+)+)$/)
+    regex(/^g?(\d+(?:\.\d+)+)$/i)
   end
 
   app "GZDoom.app"

--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -10,7 +10,7 @@ cask "hstracker" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/ibm-aspera-connect.rb
+++ b/Casks/ibm-aspera-connect.rb
@@ -10,7 +10,7 @@ cask "ibm-aspera-connect" do
 
   livecheck do
     url "https://d3gcli72yxqn2z.cloudfront.net/connect_latest/v4/connectversions.min.js"
-    regex(/ibm-aspera-connect[._-]v?(\d+(?:\.\d+)+)_macOS_x86_64\.dmg/)
+    regex(/ibm-aspera-connect[._-]v?(\d+(?:\.\d+)+)_macOS_x86_64\.dmg/i)
   end
 
   installer manual: "IBM Aspera Connect Installer.app"

--- a/Casks/kern.rb
+++ b/Casks/kern.rb
@@ -9,7 +9,7 @@ cask "kern" do
 
   livecheck do
     url :homepage
-    regex(/v(\d+(?:\.\d+)+)/)
+    regex(/v(\d+(?:\.\d+)+)/i)
   end
 
   pkg "kern_#{version.dots_to_underscores}_mac.pkg"

--- a/Casks/kotlin-native.rb
+++ b/Casks/kotlin-native.rb
@@ -17,7 +17,7 @@ cask "kotlin-native" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   conflicts_with formula: "kotlin"

--- a/Casks/lynx.rb
+++ b/Casks/lynx.rb
@@ -10,7 +10,7 @@ cask "lynx" do
 
   livecheck do
     url "https://downloads.saharasupport.com/lynx#{version.major}/production/macx/version.txt"
-    regex(/(\d+(?:[._-]\d+)+)/)
+    regex(/(\d+(?:[._-]\d+)+)/i)
   end
 
   auto_updates true

--- a/Casks/nwjs.rb
+++ b/Casks/nwjs.rb
@@ -9,7 +9,7 @@ cask "nwjs" do
 
   livecheck do
     url "https://github.com/nwjs/nw.js"
-    regex(/^nw[._-]v?(\d+(?:\.\d+)+)$/)
+    regex(/^nw[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "nwjs-sdk-v#{version}-osx-x64/nwjs.app"

--- a/Casks/portfolioperformance.rb
+++ b/Casks/portfolioperformance.rb
@@ -17,7 +17,7 @@ cask "portfolioperformance" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/pynsource.rb
+++ b/Casks/pynsource.rb
@@ -10,7 +10,7 @@ cask "pynsource" do
 
   livecheck do
     url :url
-    regex(/^version[._-]v?(\d+(?:\.\d+)+)$/)
+    regex(/^version[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   app "Pynsource.app"

--- a/Casks/redream.rb
+++ b/Casks/redream.rb
@@ -9,7 +9,7 @@ cask "redream" do
 
   livecheck do
     url "https://redream.io/download"
-    regex(/redream\.x86_64-mac-v(\d+(?:\.\d+)*)\.t/)
+    regex(/redream\.x86_64-mac-v(\d+(?:\.\d+)*)\.t/i)
   end
 
   app "redream.app"

--- a/Casks/shimeike-formulatepro.rb
+++ b/Casks/shimeike-formulatepro.rb
@@ -9,7 +9,7 @@ cask "shimeike-formulatepro" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)[a-z]?$/)
+    regex(/^v?(\d+(?:\.\d+)+)[a-z]?$/i)
   end
 
   app "FormulatePro.app"

--- a/Casks/syncplay.rb
+++ b/Casks/syncplay.rb
@@ -10,7 +10,7 @@ cask "syncplay" do
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/the-watcher.rb
+++ b/Casks/the-watcher.rb
@@ -9,7 +9,7 @@ cask "the-watcher" do
 
   livecheck do
     url "https://watcher.app/downloads/latest-version.txt"
-    regex(/(\d+(?:\.\d+)+)/)
+    regex(/(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: ">= :big_sur"

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -9,7 +9,7 @@ cask "virtualbox-extension-pack" do
 
   livecheck do
     url "https://download.virtualbox.org/virtualbox/LATEST.TXT"
-    regex(/(\d+(?:\.\d+)+)/)
+    regex(/(\d+(?:\.\d+)+)/i)
   end
 
   conflicts_with cask: "virtualbox-extension-pack-beta"

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -21,7 +21,7 @@ cask "visual-studio-code" do
 
   livecheck do
     url "https://update.code.visualstudio.com/api/update/#{arch}/stable/VERSION"
-    regex(/"productVersion"\s*:\s*"(\d+(:?\.\d+)+)"/)
+    regex(/"productVersion"\s*:\s*"(\d+(:?\.\d+)+)"/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`livecheck` block regexes should be case-insensitive unless sensitivity is explicitly required for proper matching (exceptions should be handled in `style_exceptions/regex_case_sensitive_allowlist.json`). Case-sensitivity is not required for the regexes in this commit (i.e., livecheck's output is the same without it), so this adds the standard `i` flag to the regexes.

This preemptively resolves the related RuboCop offense before I enable the livecheck cops for casks in the future.