### PR TITLE
wolai: Add auto_updates true

### DIFF
--- a/Casks/wolai.rb
+++ b/Casks/wolai.rb
@@ -20,6 +20,8 @@ cask "wolai" do
     strategy :electron_builder
   end
 
+  auto_updates true
+
   app "wolai.app"
 
   zap trash: [


### PR DESCRIPTION
wolai has added support for auto-update since version 1.2.0, but the feature is optional (i.e., it can be turned off).

<img width="370" alt="software-updates@2x" src="https://user-images.githubusercontent.com/1857158/162394441-aae035d1-c61e-4c1b-b9fc-564a32f8b4fa.png">
<img width="293" alt="changelog@2x" src="https://user-images.githubusercontent.com/1857158/162395219-61ada577-2ba3-4c59-a78a-d66d3a2c53a7.png">

References:

- https://www.wolai.com/wolai/qtL5wkHLqoDNqCrveWd7cV#sHNe5fMmJVumaJsD1ThsM6

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask wolai` is error-free.
- [x] `brew style --fix wolai` reports no offenses.