### PR TITLE
updated sha256 value for podolski 1.2.3,12092

### DIFF
--- a/Casks/podolski.rb
+++ b/Casks/podolski.rb
@@ -1,6 +1,6 @@
 cask "podolski" do
   version "1.2.3,12092"
-  sha256 "c419d14ead23c5229aeafda0d6f43e9a55f70ac2dc14868d32cef00c58687201"
+  sha256 "79bb539a83fd7b98d5955f7b960799d8ec3106b62812037189df8bf4093eb228"
 
   url "https://uhedownloads-heckmannaudiogmb.netdna-ssl.com/releases/Podolski_#{version.csv.first.no_dots}_#{version.csv.second}_Mac.zip",
       verified: "uhedownloads-heckmannaudiogmb.netdna-ssl.com/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
