### PR TITLE
updated sha256 value for publii-0.38.3

### DIFF
--- a/Casks/publii.rb
+++ b/Casks/publii.rb
@@ -1,6 +1,6 @@
 cask "publii" do
   version "0.38.3"
-  sha256 "24d3dc60779eba8ea366613bc6318e3bb1739984a4281544743a86fce9398f8a"
+  sha256 "d395fcfb83f7a99c40d3c14f8e42d7cd576170ac245f1a68d1a34a7a4e8c3455"
 
   url "https://cdn.getpublii.com/Publii-#{version}.dmg"
   name "Publii"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
