### PR TITLE
radarr: added zap stanza

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -24,5 +24,7 @@ cask "radarr" do
 
   app "Radarr.app"
 
-  # No zap stanza required
+  zap trash: [
+    "~/.config/Radarr",
+  ]
 end


### PR DESCRIPTION
It turns out that radarr stores local configuration at `~/.config/Radarr` (and nowhere else), so we need a zap stanza for this.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Requesting a pull to Homebrew:master from alexreg:radarr

Write a message for this pull request. The first block
of text is the title and the rest is the description.