### PR TITLE
Update publii from 0.38.3 to 0.39.1

### DIFF
--- a/Casks/publii.rb
+++ b/Casks/publii.rb
@@ -1,15 +1,26 @@
 cask "publii" do
-  version "0.38.3"
-  sha256 "24d3dc60779eba8ea366613bc6318e3bb1739984a4281544743a86fce9398f8a"
+  arch = Hardware::CPU.intel? ? "intel" : "apple-silicon"
+  version "0.39.1"
 
-  url "https://cdn.getpublii.com/Publii-#{version}.dmg"
+  if Hardware::CPU.intel?
+    sha256 "bdc5d16f66a2004d6f4403081283be13e15ad385ee4b8b9140baefc60a1f4341"
+  else
+    sha256 "4a4210079eaa2e4f1bc1575defde02609fa2993c7f37d6cd44367e2a91531939"
+  end
+
+  url "https://cdn.getpublii.com/Publii-#{version}-#{arch}.dmg"
   name "Publii"
   desc "Static website generator"
   homepage "https://getpublii.com/"
 
   livecheck do
-    url "https://getpublii.com/download/"
-    regex(%r{href=.*?/Publii-(\d+(?:\.\d+)*)\.dmg}i)
+    url "https://github.com/GetPublii/Publii/releases/latest"
+    strategy :page_match do |page|
+      match = page.match(%r{href=.*?/v\.?(\d+(?:\.\d+)+).zip}i)
+      next if match.blank?
+
+      match[1].to_s
+    end
   end
 
   app "Publii.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
