### PR TITLE
Update quicksilver from 2.0.0 to 2.0.3

### DIFF
--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -1,8 +1,9 @@
 cask "quicksilver" do
-  version "2.0.0"
-  sha256 "a0a60697bbd6960604a1f7b199f5273ea0fa28d2d41d27c0df398ea289fcddcb"
+  version "2.0.2"
+  sha256 "23a5b5e82d8802ad8e91e450994a69839133a73b5a26bdfdbf8859423d9ac664"
 
-  url "https://qsapp.com/archives/downloads/Quicksilver%20#{version}.dmg"
+  url "https://github.com/quicksilver/Quicksilver/releases/download/v#{version}/Quicksilver.#{version}.dmg",
+      verified: "github.com/quicksilver/Quicksilver"
   name "Quicksilver"
   desc "Productivity application"
   homepage "https://qsapp.com/"

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -1,6 +1,6 @@
 cask "quicksilver" do
-  version "2.0.2"
-  sha256 "23a5b5e82d8802ad8e91e450994a69839133a73b5a26bdfdbf8859423d9ac664"
+  version "2.0.3"
+  sha256 "cf7f7bc8fac114c9931049715f88297705f4161ffe3d473b261435574ca7b82a"
 
   url "https://github.com/quicksilver/Quicksilver/releases/download/v#{version}/Quicksilver.#{version}.dmg",
       verified: "github.com/quicksilver/Quicksilver"

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -9,8 +9,8 @@ cask "quicksilver" do
   homepage "https://qsapp.com/"
 
   livecheck do
-    url "https://qsapp.com/archives/"
-    regex(%r{href=.*?/Quicksilver%20(\d+(?:\.\d+)*)\.dmg}i)
+    url "https://github.com/quicksilver/Quicksilver/releases"
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -9,7 +9,7 @@ cask "quicksilver" do
   homepage "https://qsapp.com/"
 
   livecheck do
-    url "https://github.com/quicksilver/Quicksilver/releases"
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -9,7 +9,7 @@ cask "quicksilver" do
   homepage "https://qsapp.com/"
 
   livecheck do
-    url :stable
+    url "https://github.com/quicksilver/Quicksilver/releases"
     strategy :github_latest
   end
 

--- a/Casks/quicksilver.rb
+++ b/Casks/quicksilver.rb
@@ -9,7 +9,7 @@ cask "quicksilver" do
   homepage "https://qsapp.com/"
 
   livecheck do
-    url "https://github.com/quicksilver/Quicksilver/releases"
+    url :stable
     strategy :github_latest
   end
 


### PR DESCRIPTION
This should be just a basic bump PR.

The only thing currently complicating that is that the Quicksilver maintainers haven't been pushing the latest bug fix releases to the archives URL that this cask was configured to pull from, AFAICT. I've raised https://github.com/quicksilver/Quicksilver/issues/2713 with them.

I'm not sure what the policy is here. While the latest bug fix releases aren't being pushed to the qsapp.com archive, releases _earlier_ than 2.0.0 weren't being pushed to the GitHub Releases page so there's somewhat conflicting information there. Probably the most prudent thing to do is to wait until they've responded to https://github.com/quicksilver/Quicksilver/issues/2713.

That said I've tested this current change and I was able to successfully update from 2.0.0 to 2.0.3.

The impetus for this PR is https://github.com/quicksilver/Quicksilver/issues/2708 which prevented me from using QS's built-in updater because of a bug introduced in 2.0.0.