### PR TITLE
usbimager: update livecheck

### DIFF
--- a/Casks/usbimager.rb
+++ b/Casks/usbimager.rb
@@ -9,7 +9,8 @@ cask "usbimager" do
   homepage "https://bztsrc.gitlab.io/usbimager/"
 
   livecheck do
-    url "https://gitlab.com/bztsrc/usbimager.git"
+    url :homepage
+    regex(%r{/usbimager[._-]v?(\d+(?:\.\d+)+)[._-][^"' >]*?macosx?[^"' >]*?\.zip}i)
   end
 
   app "USBImager.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `usbimager` checks the Git tags from the upstream repository and this is only currently necessary because `Livecheck#preprocess_url` doesn't handle the type of GitLab URL used in the cask. I'll be creating a brew PR to expand supported GitLab URLs in the future, so this particular `livecheck` block (and another like it) wouldn't be necessary.

That said, checking the Git tags isn't as ideal as checking for the archive files the cask uses. The files are kept in the `binaries` branch of the repository and releases simply link to that branch (instead of linking individual files), so we can't check `releases.json`. The GitLab website uses JavaScript to render the file list (fetching the data from the GraphQL API), so we can't check the `binaries` branch page. Both the REST and GraphQL APIs have a maximum of 100 items per page and I couldn't seem to get sorting to work, so that doesn't seem like a viable solution (e.g., the files we're interested could be easily pushed out).

This PR simply checks the homepage for the latest macOS filename, which is found in some JavaScript on the page. This is arguably better than checking Git tags in this particular context (though we can fallback to that approach if we run into problems with this) and sidesteps any issues with using the GitLab API to try to retrieve file information from the `binaries` branch.