### PR TITLE
stellarium: update to version 0.22

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,8 +1,15 @@
 cask "stellarium" do
-  version "0.21.3"
-  sha256 "d6c7eb5770ec53366d73297742a18feda800e4efad664afe2600efc851b3589c"
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
-  url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}.zip",
+  version "0.22.0"
+
+  if Hardware::CPU.intel?
+    sha256 "8e55d08d87769c2f02d807d0480839560ad00b93eae74ab2d39a1d5a0541b03d"
+  else
+    sha256 "b9fed25a9272de8300155ad656a527e5878fc1e9fd6a091a14f30830442bbd7d"
+  end
+
+  url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-#{arch}.zip",
       verified: "github.com/Stellarium/stellarium/"
   name "Stellarium"
   desc "Tool to render realistic skies in real time on the screen"


### PR DESCRIPTION
Now includes arm64 and x86 versions

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.