### PR TITLE
Update LibreWolf from v98.0.2 to v99.0

### DIFF
--- a/Casks/librewolf.rb
+++ b/Casks/librewolf.rb
@@ -2,11 +2,11 @@ cask "librewolf" do
   arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
 
   if Hardware::CPU.intel?
-    version "98.0.2,1,9a776608fca00d9313ed271769d672de"
-    sha256 "ae70b403ddb40c0460850ad195881e81825591ee3b44ab9dba01036f9041dfd5"
+    version "99.0,1,d6a6b221192d4042226fda02abd5dc6d"
+    sha256 "0cabedf2140b6c57d170dff6d7eb9b2c283ddc70a4f8b88ee145f76a585f7b76"
   else
-    version "98.0.2,1,c36fddcd73795e2073d8657283ce2ce8"
-    sha256 "e8fa10c7d471bf621fb7071508d4c03ba8a544d196038883895693e16ec4508a"
+    version "99.0,1,dde02b2620bfbb7a2ae1e0816f270434"
+    sha256 "bb1fb9ce41591b61f8b1710140c122e5e3e4cc634d73b5188ab291ad7a6769ae"
   end
 
   url "https://gitlab.com/librewolf-community/browser/macos/uploads/#{version.csv.third}/librewolf-#{version.csv.first}-#{version.csv.second}.en-US.mac.#{arch}.dmg",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.