### PR TITLE
Remove unnecessary strategy calls

### DIFF
--- a/Casks/arrsync.rb
+++ b/Casks/arrsync.rb
@@ -9,7 +9,6 @@ cask "arrsync" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/arrsync-(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/bettermouse.rb
+++ b/Casks/bettermouse.rb
@@ -9,7 +9,6 @@ cask "bettermouse" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/Version (\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/cuda-z.rb
+++ b/Casks/cuda-z.rb
@@ -9,7 +9,6 @@ cask "cuda-z" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/CUDA-Z-(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/nightowl.rb
+++ b/Casks/nightowl.rb
@@ -9,7 +9,6 @@ cask "nightowl" do
 
   livecheck do
     url "https://nightowl.kramser.xyz/api/public_update"
-    strategy :page_match
     regex(/"version":\s*"(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/save-hollywood.rb
+++ b/Casks/save-hollywood.rb
@@ -9,7 +9,6 @@ cask "save-hollywood" do
 
   livecheck do
     url "http://s.sudre.free.fr/Software/SaveHollywood/release_notes.html"
-    strategy :page_match
     regex(/Release_notes_Version.*?(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/scidvsmac.rb
+++ b/Casks/scidvsmac.rb
@@ -9,7 +9,6 @@ cask "scidvsmac" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/ScidvsMac-(\d+(?:\.\d+)*)\.dmg/i)
   end
 

--- a/Casks/unexpectedly.rb
+++ b/Casks/unexpectedly.rb
@@ -9,7 +9,6 @@ cask "unexpectedly" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{Version</b>:</td><td>(\d+(?:\.\d+)*\w)}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `#strategy` calls in the `livecheck` blocks in this PR are redundant, as the specified strategy is the same as the default strategy for the `livecheck` block URL. This PR removes these `#strategy` calls, as we only use `#strategy` to override the default strategy or when a `strategy` block is used.

To be clear, the verbose JSON output from `brew livecheck` is unchanged after these `#strategy` call removals, confirming that they were unnecessary.