### PR TITLE
Update free-gpgmail from 6,2021.3.1, to 6,2022.1,

### DIFF
--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -1,10 +1,10 @@
 cask "free-gpgmail" do
   if MacOS.version <= :catalina
-    version "5,2021.3.1,-unsigned"
-    sha256 "3a3c9290622cc3fe8d4761050363917d009f9fa923eb32d436364f0ae9a161b9"
+    version "5,2022.1,"
+    sha256 "bfcb6765ec1ec7141a73d4f464654ebd34d3a8abc418debcdb3a4c272f92b903"
   elsif MacOS.version <= :big_sur
-    version "5,2021.3.1,-signed"
-    sha256 "ee0b1a313afedb5cdf8a9703b00f35040b3109877247bb342c92a60b53944c9a"
+    version "5,2022.1,_signed"
+    sha256 "2dbce4008294f4e06e3c45828a788f7a9586de6f1e9c3d6c1b65de888f09b401"
   elsif MacOS.version >= :monterey
     version "6,2022.1,"
     sha256 "e4d21dbad2fee2d911762e835b9f064b79f6c0ec091ae7255e9250a55ae28b37"

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -20,7 +20,7 @@ cask "free-gpgmail" do
   # surface a new major version and that will need to be handled manually.
   livecheck do
     url :url
-    regex(/href=.*?Free-GPGMail[._-]v?(\d+)-(\d+(?:\.\d+)+)(-[^"' >]+?)?[._-]mailbundle\.zip/i)
+    regex(/href=.*?Free-GPGMail[._-]v?(\d+)-(\d+(?:\.\d+)+)([_-][^"' >]+?)?[._-]mailbundle\.zip/i)
     strategy :github_latest do |page, regex|
       page.scan(regex).map do |match|
         next if match[0] != version.csv.first

--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -6,8 +6,8 @@ cask "free-gpgmail" do
     version "5,2021.3.1,-signed"
     sha256 "ee0b1a313afedb5cdf8a9703b00f35040b3109877247bb342c92a60b53944c9a"
   elsif MacOS.version >= :monterey
-    version "6,2021.3.1,"
-    sha256 "d15ae3bad7a40c98a078b5be0891dd38d43240cde7acbfd5f7ac03fafad4bbb1"
+    version "6,2022.1,"
+    sha256 "e4d21dbad2fee2d911762e835b9f064b79f6c0ec091ae7255e9250a55ae28b37"
   end
 
   url "https://github.com/Free-GPGMail/Free-GPGMail/releases/download/v#{version.csv.second}/Free-GPGMail_#{version.csv.first}-#{version.csv.second}#{version.csv.third}.mailbundle.zip"


### PR DESCRIPTION
Extension of #121738.

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.