### PR TITLE
Add keysafe v1.1.0

### DIFF
--- a/Casks/keysafe.rb
+++ b/Casks/keysafe.rb
@@ -1,0 +1,17 @@
+cask "keysafe" do
+  version "1.1.0"
+  sha256 "6244512d7df893fae569fada5e007011f7ba649334caee3b883ea2460f266933"
+
+  url "https://miln.eu/keysafe/miln-keysafe-v#{version}-darwin-universal.zip"
+  name "Keysafe"
+  desc "Read and decrypt Apple Keychain files"
+  homepage "https://miln.eu/keysafe"
+
+  livecheck do
+    url "https://miln.eu/keysafe/miln-keysafe-darwin-universal.zip"
+    strategy :header_match
+    regex(/miln-keysafe-v(\d+\.\d+\.\d+)-darwin-universal\.zip/i)
+  end
+
+  binary "miln-keysafe-v#{version}-darwin-universal/keysafe"
+end

--- a/Casks/keysafe.rb
+++ b/Casks/keysafe.rb
@@ -10,7 +10,7 @@ cask "keysafe" do
   livecheck do
     url "https://miln.eu/keysafe/miln-keysafe-darwin-universal.zip"
     strategy :header_match
-    regex(/miln-keysafe-v(\d+\.\d+\.\d+)-darwin-universal\.zip/i)
+    regex(/miln-keysafe[._-]v?(\d+(?:\.\d+)+)-darwin-universal\.zip/i)
   end
 
   binary "miln-keysafe-v#{version}-darwin-universal/keysafe"


### PR DESCRIPTION
Add Miln Keysafe v1.1.0 from https://miln.eu/keysafe

Tested with tap `miln-eu/miln-eu`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask keysafe` is error-free.
- [x] `brew style --fix keysafe` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask keysafe` worked successfully.
- [x] `brew install --cask keysafe` worked successfully.
- [x] `brew uninstall --cask keysafe` worked successfully.
