### PR TITLE
Update LibreWolf from v99.0 to v99.0.1

### DIFF
--- a/Casks/librewolf.rb
+++ b/Casks/librewolf.rb
@@ -2,11 +2,11 @@ cask "librewolf" do
   arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
 
   if Hardware::CPU.intel?
-    version "99.0,1,d6a6b221192d4042226fda02abd5dc6d"
-    sha256 "0cabedf2140b6c57d170dff6d7eb9b2c283ddc70a4f8b88ee145f76a585f7b76"
+    version "99.0.1,1,659a83b4fdf2cb6b7e1f7bb0382cd1b4"
+    sha256 "87ee370ee94d8ba701339f7cd5cf0d580b0a16e651b211be5da3cb309f77ab35"
   else
-    version "99.0,1,dde02b2620bfbb7a2ae1e0816f270434"
-    sha256 "bb1fb9ce41591b61f8b1710140c122e5e3e4cc634d73b5188ab291ad7a6769ae"
+    version "99.0.1,1,78700cd8e858117eda792a936bf88358"
+    sha256 "4f193a950b76151bfdc4c59c508689ac0fb72c625be1e9973f0ef67ebf23b685"
   end
 
   url "https://gitlab.com/librewolf-community/browser/macos/uploads/#{version.csv.third}/librewolf-#{version.csv.first}-#{version.csv.second}.en-US.mac.#{arch}.dmg",


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.