### PR TITLE
Update presentation.rb checksum

### DIFF
--- a/Casks/presentation.rb
+++ b/Casks/presentation.rb
@@ -1,6 +1,6 @@
 cask "presentation" do
   version "3.0.0"
-  sha256 "a5aa9d60746eefbe94667ea23dab450e3c604d0033578bb8b746494e86ef78bc"
+  sha256 "11c2a338bbaa1072707051aa9889533a0d293da9e5e8ab8f6c391c8b10f92831"
 
   url "http://iihm.imag.fr/blanch/software/osx-presentation/releases/osx-presentation-#{version}.pkg"
   name "Présentation"


### PR DESCRIPTION
osx-presentation author here:
i have updated the installer package with a notarized version, hence the checksum change

not a brew user though, so can not run the tests.

also: a better livecheck strategy would be to use iihm.imag.fr/blanch/software/osx-presentation/releases/version.txt which is used internally to track current version, but do not know how to do that

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
