### PR TITLE
Update poedit version format

### DIFF
--- a/Casks/poedit.rb
+++ b/Casks/poedit.rb
@@ -1,8 +1,8 @@
 cask "poedit" do
   version "3.0.1,6416"
-  sha256 "3f927041cf4aac86b816aa34c249dd8c9e4c7fb2ab19db5b0bfb530ce7fbf1a4"
+  sha256 "7f83cb329770e2e315f303d0487a431d8ae8804f4f744a47b55839088f89b41a"
 
-  url "https://download.poedit.net/Poedit-#{version.csv.first}.zip"
+  url "https://download.poedit.net/Poedit-#{version.tr(",", ".")}.zip"
   name "Poedit"
   desc "Translation editor"
   homepage "https://poedit.net/"


### PR DESCRIPTION
This pull request updates the download link to include the build number, resolving an issue on macOS 12.3 (https://github.com/vslavik/poedit/issues/733). The build number was previously updated in c17b73dbf5cd8731a3ddeeab8f098a011ba1e157 but did not affect the download link.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.