### PR TITLE
Fix microsoft-azure-storage-explorer checksum

### DIFF
--- a/Casks/microsoft-azure-storage-explorer.rb
+++ b/Casks/microsoft-azure-storage-explorer.rb
@@ -1,6 +1,6 @@
 cask "microsoft-azure-storage-explorer" do
   version "1.23.1"
-  sha256 "571f7979db73ed36146a96be8e611647d272b4c0a0da3197b5be03e4d7b35f95"
+  sha256 "d09d23ff2679ee29ed8b24df5e5c89d17c4b870ccbdb015e0ca33e7af2d2a5fd"
 
   url "https://github.com/microsoft/AzureStorageExplorer/releases/download/v#{version}/Mac_StorageExplorer.zip",
       verified: "github.com/microsoft/AzureStorageExplorer/"


### PR DESCRIPTION
After last version bup of microsoft-azure-storage-explorer to
version 1.23.1 (commit 13bf75529, PR #121914), checksum was not updated.
This commit fixes the checksum.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
