### PR TITLE
Update Alacritty icon to macOS style

### DIFF
--- a/Casks/alacritty.rb
+++ b/Casks/alacritty.rb
@@ -27,6 +27,22 @@ cask "alacritty" do
   manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty.1.gz"
   manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty-msg.1.gz"
 
+  postflight do
+    # Update icon for macOS. Icon is from https://github.com/alacritty/alacritty/pull/4726
+    icon_url = "https://github.com/bouk/alacritty/blob/604686ba061c714f37d1db7002258517f062f0d2/extra/osx/Alacritty.app/Contents/Resources/alacritty.icns?raw=true"
+    apple_script = <<~EOS
+      use framework "AppKit"
+      use scripting additions
+      set iconURL to current application's NSURL's URLWithString:"#{icon_url}"
+      set iconImage to (current application's NSImage's alloc)'s initWithContentsOfURL:iconURL
+      set workspace to current application's NSWorkspace's sharedWorkspace()
+      workspace's setIcon:iconImage forFile:"#{appdir}/Alacritty.app" options:0
+    EOS
+
+    system_command "osascript",
+                   args: ["-e", apple_script]
+  end
+
   zap trash: [
     "~/Library/Preferences/io.alacritty.plist",
     "~/Library/Saved Application State/io.alacritty.savedState",


### PR DESCRIPTION
| Before | After |
|-|-|
|<img width="175" alt="Screen Shot 2022-04-18 at 20 24 31" src="https://user-images.githubusercontent.com/12813829/163808726-0e181369-59bd-466b-8809-ee0ecbbd513a.png">|<img width="169" alt="Screen Shot 2022-04-18 at 20 23 54" src="https://user-images.githubusercontent.com/12813829/163808791-5a64cc94-798f-4056-ba23-d4512dc59b50.png">|

The icon URL is from https://github.com/alacritty/alacritty/pull/4726, a rejected PR from @bouk in Alacritty repo. The icon is created by @jdsimcoe: https://www.figma.com/file/CI8Keod1I0OBlslWjMSiVE/Alacritty-Icon-for-macOS-Big-Sur/duplicate.

The maintainer of Alacritty [clearly states there is no intention to update the app icon on macOS to the new design](https://github.com/alacritty/alacritty/issues/3926#issuecomment-728295412) (also https://github.com/alacritty/alacritty/pull/4726, https://github.com/alacritty/alacritty/pull/4435). To prevent Alacritty from being the only strange looking app on dock, we can only manually patch the icon.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
