### PR TITLE
Update securesafe.rb from 2.14.1 to 2.15.0

### DIFF
--- a/Casks/securesafe.rb
+++ b/Casks/securesafe.rb
@@ -1,6 +1,6 @@
 cask "securesafe" do
-  version "2.14.1"
-  sha256 "59f415252879d83e5ae2aa309ece2c4f36fb4892bf99879f25f400891688f2c1"
+  version "2.15.0"
+  sha256 "4643fbc59193e00771423e4c84ab1de77ad34dd9b0f0fee82d29500fa1ede61b"
 
   url "https://www.securesafe.com/userdata/downloads/securesafe-#{version}.pkg"
   name "SecureSafe"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
