### PR TITLE
Add Descript.app 37.1.2

### DIFF
--- a/Casks/descript.rb
+++ b/Casks/descript.rb
@@ -1,0 +1,45 @@
+cask "descript" do
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
+  archdmgsuffix = Hardware::CPU.intel? ? "" : "-arm64"
+
+  version "37.1.2,20220419.1"
+  sha256
+
+  if Hardware::CPU.intel?
+    sha256 "6acde97dbae4056b57a401ed9ae4f4f589456056fcb7881b99e07ca43a46cb29"
+  else
+    sha256 "1dd8111342037d7ecfd85295f41b922b89c7c7b99895690f86a93c45e052efac"
+  end
+
+  url "https://electron.descript.com/Descript-#{version.csv.first}-release.#{version.csv.second}#{archdmgsuffix}.dmg"
+  name "Descript"
+  desc "Audio and video editor"
+  homepage "https://www.descript.com/"
+
+  livecheck do
+    url "https://web.descript.com/download?platform=mac&arch=#{arch}"
+    strategy :header_match do |headers|
+      version = headers["location"][/Descript-(\d+(?:\.\d+)*)/i, 1]
+      release = headers["location"][/-release.(\d+(?:\.\d+)*).dmg/i, 1]
+      next if version.blank? || release.blank?
+
+      "#{version},#{release}"
+    end
+  end
+
+  auto_updates true
+
+  app "Descript.app"
+
+  zap trash: [
+    "~/Library/Application Support/Descript",
+    "~/Library/Caches/com.descript.Descript-Installer",
+    "~/Library/Caches/com.descript.beachcube",
+    "~/Library/Caches/com.descript.beachcube.ShipIt",
+    "~/Library/Preferences/com.descript.Descript-Installer.plist",
+    "~/Library/Preferences/com.descript.ScreenRecorder.plist",
+    "~/Library/Preferences/com.descript.beachcube.plist",
+    "~/Library/Saved Application State/com.descript.Descript-Installer.savedState",
+    "~/Library/Saved Application State/com.descript.beachcube.savedState",
+  ]
+end

--- a/Casks/descript.rb
+++ b/Casks/descript.rb
@@ -1,8 +1,8 @@
 cask "descript" do
-  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
-  archdmgsuffix = Hardware::CPU.intel? ? "" : "-arm64"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
+  livecheck_folder = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
-  version "37.1.2,20220419.1"
+  version "37.1.2-release.20220419.1"
   sha256
 
   if Hardware::CPU.intel?
@@ -11,20 +11,14 @@ cask "descript" do
     sha256 "1dd8111342037d7ecfd85295f41b922b89c7c7b99895690f86a93c45e052efac"
   end
 
-  url "https://electron.descript.com/Descript-#{version.csv.first}-release.#{version.csv.second}#{archdmgsuffix}.dmg"
+  url "https://electron.descript.com/Descript-#{version}#{arch}.dmg"
   name "Descript"
   desc "Audio and video editor"
   homepage "https://www.descript.com/"
 
   livecheck do
-    url "https://web.descript.com/download?platform=mac&arch=#{arch}"
-    strategy :header_match do |headers|
-      version = headers["location"][/Descript-(\d+(?:\.\d+)*)/i, 1]
-      release = headers["location"][/-release.(\d+(?:\.\d+)*).dmg/i, 1]
-      next if version.blank? || release.blank?
-
-      "#{version},#{release}"
-    end
+    url "https://electron.descript.com/master-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true

--- a/Casks/descript.rb
+++ b/Casks/descript.rb
@@ -1,9 +1,7 @@
 cask "descript" do
   arch = Hardware::CPU.intel? ? "" : "-arm64"
-  livecheck_folder = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
   version "37.1.2-release.20220419.1"
-  sha256
 
   if Hardware::CPU.intel?
     sha256 "6acde97dbae4056b57a401ed9ae4f4f589456056fcb7881b99e07ca43a46cb29"
@@ -27,13 +25,13 @@ cask "descript" do
 
   zap trash: [
     "~/Library/Application Support/Descript",
-    "~/Library/Caches/com.descript.Descript-Installer",
     "~/Library/Caches/com.descript.beachcube",
     "~/Library/Caches/com.descript.beachcube.ShipIt",
+    "~/Library/Caches/com.descript.Descript-Installer",
+    "~/Library/Preferences/com.descript.beachcube.plist",
     "~/Library/Preferences/com.descript.Descript-Installer.plist",
     "~/Library/Preferences/com.descript.ScreenRecorder.plist",
-    "~/Library/Preferences/com.descript.beachcube.plist",
-    "~/Library/Saved Application State/com.descript.Descript-Installer.savedState",
     "~/Library/Saved Application State/com.descript.beachcube.savedState",
+    "~/Library/Saved Application State/com.descript.Descript-Installer.savedState",
   ]
 end


### PR DESCRIPTION
An earlier attempt at adding this app can be found at https://github.com/Homebrew/homebrew-cask/pull/86696, but it was [rejected by @vitorgalvao](https://github.com/Homebrew/homebrew-cask/pull/86696#issuecomment-665788446) because it only downloaded the installer (which then downloaded the DMG and itself installed the app). This PR directly downloads the DMG (now only ~150 MB) and lets Homebrew handle the app. 

This PR also includes livecheck, zap, and auto-update stanzas.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
