### PR TITLE
Update perforce to 2021.2 Patch 4

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask "perforce" do
-  version "2021.2,2264565"
-  sha256 "ffc757b9d4d0629b2594e2777edfb18097825e29c70d8f33a444c7482d622806"
+  version "2021.2,2273812"
+  sha256 "37bc306f0bdfd1d63cfcea113ada132d96f89d53cbb20c282735d51d06223054"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
   name "Perforce Helix Core Server"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.