### PR TITLE
Fix URL for ZEsarUX release & add desc to cask file

### DIFF
--- a/Casks/zesarux.rb
+++ b/Casks/zesarux.rb
@@ -9,7 +9,7 @@ cask "zesarux" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^ZEsarUX-?(\d+(?:\.\d+)+)$/i)
   end
 
   app "ZEsarUX.app"

--- a/Casks/zesarux.rb
+++ b/Casks/zesarux.rb
@@ -4,12 +4,13 @@ cask "zesarux" do
 
   url "https://github.com/chernandezba/zesarux/releases/download/ZEsarUX-#{version}/ZEsarUX_macos-#{version}.dmg"
   name "ZEsarUX"
-  desc "ZX Second-Emulator And Released for UniX"
+  desc "ZX machines emulator"
   homepage "https://github.com/chernandezba/zesarux"
 
   livecheck do
     url :url
-    regex(/^ZEsarUX-?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
+    regex(/href=.*?ZEsarUX[._-]macos[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "ZEsarUX.app"

--- a/Casks/zesarux.rb
+++ b/Casks/zesarux.rb
@@ -4,6 +4,7 @@ cask "zesarux" do
 
   url "https://github.com/chernandezba/zesarux/releases/download/ZEsarUX-#{version}/ZEsarUX_macos-#{version}.dmg"
   name "ZEsarUX"
+  desc "ZX Second-Emulator And Released for UniX"
   homepage "https://github.com/chernandezba/zesarux"
 
   livecheck do

--- a/Casks/zesarux.rb
+++ b/Casks/zesarux.rb
@@ -2,7 +2,7 @@ cask "zesarux" do
   version "10.0"
   sha256 "df45b2d1cf72bcb75ed13d398dfffbf33d293b3d8eccc2545cd61f30fab15b07"
 
-  url "https://github.com/chernandezba/zesarux/releases/download/#{version}/ZEsarUX_macos-#{version}.dmg"
+  url "https://github.com/chernandezba/zesarux/releases/download/ZEsarUX-#{version}/ZEsarUX_macos-#{version}.dmg"
   name "ZEsarUX"
   homepage "https://github.com/chernandezba/zesarux"
 


### PR DESCRIPTION
It appears that the URL has changed slightly and this was preventing me from installing the cask.

I've also added a `desc` string to the cask file as recommended by `brew audit`.

I confirm that I have checked the following:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
