### PR TITLE
Fix for updating r from 4.1.3 to 4.2.0

### DIFF
--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -9,11 +9,11 @@ cask "r" do
     url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   elsif Hardware::CPU.intel?
     version "4.2.0"
-    sha256 "8d1f1f51d04bdf89974f6e3aea7bf178f6db79f3d41d175c2375fa7bcbfef19d"
+    sha256 "efb0a98d407c4a4d621cf3f3c33d674b71071099577301b079f4d114b2fc2d00"
     url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
   else
     version "4.2.0"
-    sha256 "e7967f60f39be65dd62d741553bcd70d107f1c00b1ef3b4b4e59714cfc1182f2"
+    sha256 "b663dbc124c51e842ba15695abb151b1b2ebd09e9810c3c34c51bf50ec4ee206"
     url "https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-#{version}-arm64.pkg"
   end
 
@@ -22,7 +22,7 @@ cask "r" do
   homepage "https://www.r-project.org/"
 
   livecheck do
-    url "https://cloud.r-project.org/bin/macosx/base"
+    url "https://cloud.r-project.org/bin/macosx"
     regex(/href=.*?R[._-]v?(\d+(?:\.\d+)*)\.pkg/i)
   end
 

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -22,7 +22,7 @@ cask "r" do
   homepage "https://www.r-project.org/"
 
   livecheck do
-    url "https://cloud.r-project.org/bin/macosx/"
+    url "https://cloud.r-project.org/bin/macosx/base"
     regex(/href=.*?R[._-]v?(\d+(?:\.\d+)*)\.pkg/i)
   end
 

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -8,12 +8,12 @@ cask "r" do
     sha256 "f2b771e94915af0fe0a6f042bc7a04ebc84fb80cb01aad5b7b0341c4636336dd"
     url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   elsif Hardware::CPU.intel?
-    version "4.1.3"
-    sha256 "fd310672d3c80a335df004d0022c97814ef614545b2c396477197352ea655c88"
+    version "4.2.0"
+    sha256 "8d1f1f51d04bdf89974f6e3aea7bf178f6db79f3d41d175c2375fa7bcbfef19d"
     url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
   else
-    version "4.1.3"
-    sha256 "d973134c1417afeb8c54a8bd0b53ddbc47719e0e30fd9c2122a71d13a57106c4"
+    version "4.2.0"
+    sha256 "e7967f60f39be65dd62d741553bcd70d107f1c00b1ef3b4b4e59714cfc1182f2"
     url "https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-#{version}-arm64.pkg"
   end
 


### PR DESCRIPTION
This fixes a mistake I made in https://github.com/Homebrew/homebrew-cask/pull/122379. I had changed the livecheck URL, but now realize that this URL can point to binaries built but not yet signed, and the delay in updating the original, correct livecheck URL is in signing the binaries. This PR reverts to the original livecheck URL and updates the hashes to the now-signed updated binaries for 4.2.0

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.