### PR TITLE
Update ledger-live homepage

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -6,7 +6,7 @@ cask "ledger-live" do
       verified: "github.com/LedgerHQ/ledger-live-desktop/"
   name "Ledger Live"
   desc "Wallet desktop application to maintain multiple cryptocurrencies"
-  homepage "https://www.ledgerwallet.com/live"
+  homepage "https://www.ledger.com/ledger-live"
 
   livecheck do
     url :url


### PR DESCRIPTION
* The official Ledger website was changed to ledger.com
* The previous homepage url redirects to the updated one

- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.