### PR TITLE
bitcoin-core: Update 23.0, add arm build

### DIFF
--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -1,8 +1,8 @@
 cask "bitcoin-core" do
-  version "22.0"
-  sha256 "3b3e2680f7d9304c13bfebaf6445ada40d72324b4b3e0a07de9db807389a6c5b"
+  version "23.0"
+  sha256 "52eefbaf8cfd292822e470a48a51e1eb51081d43a0a16db7441f34a017ff6097"
 
-  url "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-osx-signed.dmg"
+  url "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-x86_64-apple-darwin.dmg"
   name "Bitcoin Core"
   desc "Bitcoin client and wallet"
   homepage "https://bitcoincore.org/"

--- a/Casks/bitcoin-core.rb
+++ b/Casks/bitcoin-core.rb
@@ -1,8 +1,15 @@
 cask "bitcoin-core" do
-  version "23.0"
-  sha256 "52eefbaf8cfd292822e470a48a51e1eb51081d43a0a16db7441f34a017ff6097"
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
-  url "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-x86_64-apple-darwin.dmg"
+  version "23.0"
+
+  if Hardware::CPU.intel?
+    sha256 "52eefbaf8cfd292822e470a48a51e1eb51081d43a0a16db7441f34a017ff6097"
+  else
+    sha256 "a3059280451d17a77d2260e4671c884be93a14dbff6b6cd19a3c9c8c54421e97"
+  end
+
+  url "https://bitcoincore.org/bin/bitcoin-core-#{version}/bitcoin-#{version}-#{arch}-apple-darwin.dmg"
   name "Bitcoin Core"
   desc "Bitcoin client and wallet"
   homepage "https://bitcoincore.org/"


### PR DESCRIPTION
This PR updates the `bitcoin-core` cask to 23.0 and also adds the ARM build.

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
