### PR TITLE
ci_matrix: use macOS 12 runner

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -9,7 +9,8 @@ module CiMatrix
 
   RUNNERS = {
     { symbol: :catalina, name: "macos-10.15" } => 0.9,
-    { symbol: :big_sur,  name: "macos-11.0" }  => 0.1,
+    { symbol: :big_sur,  name: "macos-11" }  => 0.1,
+    { symbol: :monterey,  name: "macos-12" }  => 0.1,
   }.freeze
 
   def self.filter_runners(cask_content)

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -9,8 +9,8 @@ module CiMatrix
 
   RUNNERS = {
     { symbol: :catalina, name: "macos-10.15" } => 0.9,
-    { symbol: :big_sur,  name: "macos-11" }  => 0.1,
-    { symbol: :monterey,  name: "macos-12" }  => 0.1,
+    { symbol: :big_sur,  name: "macos-11" }    => 0.1,
+    { symbol: :monterey,  name: "macos-12" }   => 0.1,
   }.freeze
 
   def self.filter_runners(cask_content)


### PR DESCRIPTION
I have no idea how this part works but since there is https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources now, let's try and use it.