### PR TITLE
Update opera from 86.0.4363.23 to 86.0.4363.32

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask "opera" do
-  version "86.0.4363.23"
-  sha256 "cdfc760c642922fcff66aa4855decf7c772f2b65d93e783b5d4c6c302d493c26"
+  version "86.0.4363.32"
+  sha256 "932817cabf64bb123bc9a9121640caf2b85c4319c60dc96137775266b9cf0a17"
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name "Opera"


### PR DESCRIPTION
Update opera from 86.0.4363.23 to 86.0.4363.32

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.