### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ _In the following questions `<cask>` is the token of the cask you're submitting.
 After making all changes to a cask, verify:
 
 - [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
-- [ ] `brew audit --cask <cask>` is error-free.
+- [ ] `brew audit --cask --online <cask>` is error-free.
 - [ ] `brew style --fix <cask>` reports no offenses.
 
 Additionally, **if adding a new cask**:


### PR DESCRIPTION
It is worth considering adding the `--online` flag to the requested `brew audit` run. It will help prevent PRs being opened that aren't using `brew bump` or `brew bump-cask-pr` that don't consider livecheck or other variables, and aligns the audit more closely with what will be run by CI - at the expense of a few more network requests on the user side.