### PR TITLE
Update jami from 202112151254 to 2022042616

### DIFF
--- a/Casks/jami.rb
+++ b/Casks/jami.rb
@@ -1,8 +1,8 @@
 cask "jami" do
-  version "202112151254"
-  sha256 "e0d5aa095c56cf2403b4e6b83903c250851d3a7997487cd089744a7eb1f524a2"
+  version "2022042616"
+  sha256 "7dbbcf0cbba81af08e081571668e0bccb697bbeda0cfe4abb498f9b9065423c5"
 
-  url "https://dl.jami.net/mac_osx/jami-#{version}.dmg"
+  url "https://dl.jami.net/mac_osx/jami#{version}.dmg"
   name "Jami"
   name "Savoir-faire Linux Ring"
   desc "Decentralised instant messenger and softphone"
@@ -10,7 +10,7 @@ cask "jami" do
 
   livecheck do
     url "https://dl.jami.net/mac_osx/sparkle-ring.xml"
-    regex(/jami[._-]v?(\d+(?:\.\d+)*)\.dmg/i)
+    regex(/jami(\d+(?:\.\d+)*)\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
The download url and livecheck regex are also updated, since jami has changed the naming scheme of their installer.

Livecheck should start working again.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
N/A
