### PR TITLE
feat: update CouchDB 3.2.2-1 binary

### DIFF
--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -1,8 +1,14 @@
 cask "apache-couchdb" do
   version "3.2.2"
-  sha256 "6a76d33ec0fd4b1323df27b5cc2877d72408f3a7645d0e60517428e72002f0ba"
+  sha256 "985d15aad597699e61c3654597ede37e43b9e13062c3b7e1d69a7cd3e1e71448"
 
-  url "https://couchdbneighbourhoodie.fra1.digitaloceanspaces.com/downloads/#{version}/mac/Apache-CouchDB.zip",
+  # uncomment for next version
+  # url "https://couchdbneighbourhoodie.fra1.digitaloceanspaces.com/downloads/#{version}/mac/Apache-CouchDB.zip",
+  #    verified: "couchdbneighbourhoodie.fra1.digitaloceanspaces.com/"
+
+  # 3.2.2 is the CouchDB version. The binary package here got
+  # a bugfix release 3.2.2-1 with a nonstandard URL
+  url "https://couchdbneighbourhoodie.fra1.digitaloceanspaces.com/downloads/#{version}/mac/3.2.2-1/Apache-CouchDB.zip",
       verified: "couchdbneighbourhoodie.fra1.digitaloceanspaces.com/"
   name "Apache CouchDB"
   desc "Multi-master syncing database"
@@ -10,7 +16,11 @@ cask "apache-couchdb" do
 
   livecheck do
     url "https://neighbourhood.ie/download-apache-couchdb-mac/"
+    # uncomment for next version
+    # 3.2.2 is the CouchDB version. The binary package here got
+    # a bugfix release 3.2.2-1 with a nonstandard URL
     regex(%r{href=.*?/(\d+(?:\.\d+)+)/mac/Apache[._-]?CouchDB\.zip}i)
+    regex(%r{href=.*?/(\d+(?:\.\d+)+)/mac/3.2.2-1/Apache[._-]?CouchDB\.zip}i)
   end
 
   depends_on macos: ">= :yosemite"

--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -2,12 +2,10 @@ cask "apache-couchdb" do
   version "3.2.2"
   sha256 "985d15aad597699e61c3654597ede37e43b9e13062c3b7e1d69a7cd3e1e71448"
 
-  # uncomment for next version
+  # 3.2.2 is the CouchDB version. This binary package
+  # 3.2.2-1 is a bugfix release with a nonstandard URL.
+  # Replace with original url in the next release.
   # url "https://couchdbneighbourhoodie.fra1.digitaloceanspaces.com/downloads/#{version}/mac/Apache-CouchDB.zip",
-  #    verified: "couchdbneighbourhoodie.fra1.digitaloceanspaces.com/"
-
-  # 3.2.2 is the CouchDB version. The binary package here got
-  # a bugfix release 3.2.2-1 with a nonstandard URL
   url "https://couchdbneighbourhoodie.fra1.digitaloceanspaces.com/downloads/#{version}/mac/3.2.2-1/Apache-CouchDB.zip",
       verified: "couchdbneighbourhoodie.fra1.digitaloceanspaces.com/"
   name "Apache CouchDB"
@@ -16,10 +14,10 @@ cask "apache-couchdb" do
 
   livecheck do
     url "https://neighbourhood.ie/download-apache-couchdb-mac/"
-    # uncomment for next version
-    # 3.2.2 is the CouchDB version. The binary package here got
-    # a bugfix release 3.2.2-1 with a nonstandard URL
-    regex(%r{href=.*?/(\d+(?:\.\d+)+)/mac/Apache[._-]?CouchDB\.zip}i)
+    # 3.2.2 is the CouchDB version. This binary package
+    # 3.2.2-1 is a bugfix release with a nonstandard URL.
+    # Replace with original regex in the next release.
+    # regex(%r{href=.*?/(\d+(?:\.\d+)+)/mac/Apache[._-]?CouchDB\.zip}i)
     regex(%r{href=.*?/(\d+(?:\.\d+)+)/mac/3.2.2-1/Apache[._-]?CouchDB\.zip}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

* * *

I’m the maintainer of the binary build and the current one is an x86 build that does not run on M1 Macs. This new one works on either x86 or M1 Macs.