### PR TITLE
Amazon Workspaces Version Bump

### DIFF
--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,6 +1,6 @@
 cask "amazon-workspaces" do
   version "rolling"
-  sha256 "6f4f61172dc62b75cb1de3f8a5afbc2df691ff5326c1c69bcaea4f59d80a6cc3"
+  sha256 :no_check
 
   url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg",
       verified: "d2td7dqidlhjx7.cloudfront.net/prod/global/osx/"

--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,15 +1,15 @@
 cask "amazon-workspaces" do
-  version "4.0.6.2177"
-  sha256 "3ff5cfdf6628c8a208d137f3319d563240948e83ce1534ff5661044fcb736442"
+  version "rolling"
+  sha256 "6f4f61172dc62b75cb1de3f8a5afbc2df691ff5326c1c69bcaea4f59d80a6cc3"
 
-  url "https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpaces_AllProducts_#{version.split(".")[-1]}.zip",
-      verified: "d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/"
+  url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg",
+      verified: "d2td7dqidlhjx7.cloudfront.net/prod/global/osx/"
   name "Amazon Workspaces"
   desc "Cloud native persistent desktop virtualization"
   homepage "https://clients.amazonworkspaces.com/"
 
   livecheck do
-    url "https://d2td7dqidlhjx7.cloudfront.net/prod/iad/osx/WorkSpacesAppCast_macOS_20171023.xml"
+    url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpacesAppCast_macOS_20171023.xml"
     strategy :sparkle
   end
 

--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,5 +1,5 @@
 cask "amazon-workspaces" do
-  version :latest
+  version "4.0.7.2248"
   sha256 :no_check
 
   url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg",
@@ -7,6 +7,11 @@ cask "amazon-workspaces" do
   name "Amazon Workspaces"
   desc "Cloud native persistent desktop virtualization"
   homepage "https://clients.amazonworkspaces.com/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   depends_on macos: ">= :sierra"
 

--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,8 +1,8 @@
 cask "amazon-workspaces" do
-  version "rolling"
-  sha256 :no_check
+  version "4.0.7.2248"
+  sha256 "6f4f61172dc62b75cb1de3f8a5afbc2df691ff5326c1c69bcaea4f59d80a6cc3"
 
-  url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg",
+  url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces_AllProducts_#{version.split(".")[-1]}.zip",
       verified: "d2td7dqidlhjx7.cloudfront.net/prod/global/osx/"
   name "Amazon Workspaces"
   desc "Cloud native persistent desktop virtualization"

--- a/Casks/amazon-workspaces.rb
+++ b/Casks/amazon-workspaces.rb
@@ -1,17 +1,12 @@
 cask "amazon-workspaces" do
-  version "4.0.7.2248"
-  sha256 "6f4f61172dc62b75cb1de3f8a5afbc2df691ff5326c1c69bcaea4f59d80a6cc3"
+  version :latest
+  sha256 :no_check
 
-  url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces_AllProducts_#{version.split(".")[-1]}.zip",
+  url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpaces.pkg",
       verified: "d2td7dqidlhjx7.cloudfront.net/prod/global/osx/"
   name "Amazon Workspaces"
   desc "Cloud native persistent desktop virtualization"
   homepage "https://clients.amazonworkspaces.com/"
-
-  livecheck do
-    url "https://d2td7dqidlhjx7.cloudfront.net/prod/global/osx/WorkSpacesAppCast_macOS_20171023.xml"
-    strategy :sparkle
-  end
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
This PR performs a version bump for Amazon Workspaces, as well as moving it to the Global download endpoint for better latency and pinning to the latest version always as opposed to a specific version