### PR TITLE
Tastyworks upgrade to 1.22

### DIFF
--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -1,16 +1,11 @@
 cask "tastyworks" do
-  version "1.14.2"
-  sha256 "09dec162db321904a25d196134da699dc7d79a1c17fa7134d81fc11677802f1b"
+  version "1.22.0"
+  sha256 "e7e56d8aed91594c6259f47fffb0326c3ca7bda2eb0ad2a10c487d819b11ee26"
 
   url "https://download.tastyworks.com/desktop-#{version.major}.x.x/#{version}/tastyworks-#{version}.dmg"
   name "tastyworks"
   desc "Desktop trading platform for the tastyworks brokerage"
   homepage "https://tastyworks.com/"
-
-  livecheck do
-    url "https://tastyworks.com/component---src-pages-technology-js-c0073caebcf082ded47f.js"
-    regex(%r{/tastyworks-(\d+(?:\.\d+)*)}i)
-  end
 
   auto_updates true
 

--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -6,7 +6,7 @@ cask "tastyworks" do
   name "tastyworks"
   desc "Desktop trading platform for the tastyworks brokerage"
   homepage "https://tastyworks.com/"
-  
+
   livecheck do
     skip "No version information available"
   end

--- a/Casks/tastyworks.rb
+++ b/Casks/tastyworks.rb
@@ -6,6 +6,10 @@ cask "tastyworks" do
   name "tastyworks"
   desc "Desktop trading platform for the tastyworks brokerage"
   homepage "https://tastyworks.com/"
+  
+  livecheck do
+    skip "No version information available"
+  end
 
   auto_updates true
 


### PR DESCRIPTION
The previous method of performing a Livecheck can no longer be performed. I searched for a way to do a check of the current version and there is none. They changed their website to React with Webpacks and the download pages are modals that now dynamically create the download links and Javascript code accessible by a wget/curl does not indicate the current version of Tastyworks.

Even though the application auto-updates itself installing a version prior to 1.21 does not properly upgrade on OS 12.x and will randomly crash because the JVM was not properly upgraded in their upgrade process. The current version in the homebrew-casks is 1.14 which is quite old but installing in on Monterey will lead to random crashes of the app. Tastyworks support confirmed that to fix the crashes is to install a fresh copy of 1.22 from their site so the app has the proper JVM, it sounds like they are not going to fix the upgrade issue because it is an edge-case and reinstalling is a quick fix.

After making all changes to a cask, verify:

- [x] The submission is for an upgrade of Tastyworks
- [X] `brew audit --cask --online tastyworks` report error for livecheck which can no longer be performed
- [X] `brew style --fix tastyworks` reports no offenses.

