### PR TITLE
bria: remove livecheck

### DIFF
--- a/Casks/bria.rb
+++ b/Casks/bria.rb
@@ -8,15 +8,5 @@ cask "bria" do
   desc "Softphone application"
   homepage "https://www.counterpath.com/bria-solo/"
 
-  livecheck do
-    url "https://www.counterpath.com/Bria#{version.major}forMac"
-    strategy :header_match do |headers|
-      match = headers["location"].match(/Bria[._-]v?(\d+(?:\.\d+)+)[_-](\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
-
   app "Bria.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


---

The existing `livecheck` URL for `bria` gives a 404 (Not Found) and I couldn't find an available source of version information, so this PR simply removes the `livecheck` block for now. A working `livecheck` block can be added in a follow-up PR if someone finds a source of version information but this at least ensures that livecheck won't unnecessarily check a URL that we know will 404.