### PR TITLE
Update xemu formulae to v0.6.5

### DIFF
--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -8,6 +8,10 @@ cask "xemu" do
   desc "Original Xbox Emulator"
   homepage "https://xemu.app/"
 
+  livecheck do
+    url :url
+  end
+
   app "Xemu.app"
 
   zap trash: [

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -8,10 +8,6 @@ cask "xemu" do
   desc "Original Xbox Emulator"
   homepage "https://xemu.app/"
 
-  livecheck do
-    url :url
-  end
-
   app "Xemu.app"
 
   zap trash: [

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -1,8 +1,8 @@
 cask "xemu" do
-  version "v0.6.5"
+  version "0.6.5"
   sha256 "16964c0e86a95b7c4320c75503198f4f576eb3160c1edb0c2ad07a76e9009ba1"
 
-  url "https://github.com/mborgerson/xemu/releases/download/#{version}/xemu-macos-universal-release.zip",
+  url "https://github.com/mborgerson/xemu/releases/download/v#{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"
   name "Xemu"
   desc "Original Xbox Emulator"

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -2,7 +2,7 @@ cask "xemu" do
   version "v0.6.5"
   sha256 "16964c0e86a95b7c4320c75503198f4f576eb3160c1edb0c2ad07a76e9009ba1"
 
-  url "https://github.com/mborgerson/xemu/releases/download/{version}/xemu-macos-universal-release.zip",
+  url "https://github.com/mborgerson/xemu/releases/download/#{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"
   name "Xemu"
   desc "Original Xbox Emulator"

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -1,17 +1,12 @@
 cask "xemu" do
-  version "0.6.3-10-g292c9703de"
-  sha256 "1ac9603cb819f76dcd1e10fed53683c6237b4c4c33d202f056d4d9fa6deb69d4"
+  version "v0.6.5"
+  sha256 "16964c0e86a95b7c4320c75503198f4f576eb3160c1edb0c2ad07a76e9009ba1"
 
-  url "https://github.com/mborgerson/xemu/releases/download/gh-release%2F#{version}/xemu-macos-universal-release.zip",
+  url "https://github.com/mborgerson/xemu/releases/download/{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"
   name "Xemu"
   desc "Original Xbox Emulator"
   homepage "https://xemu.app/"
-
-  livecheck do
-    url :url
-    regex(%r{^gh-release/(.*)$}i)
-  end
 
   app "Xemu.app"
 


### PR DESCRIPTION
Since 0.6.5 replaced gh-release/* with xemu-v*, I updated ruby file for new Xemu releases.