### PR TITLE
i1profiler: update livecheck

### DIFF
--- a/Casks/i1profiler.rb
+++ b/Casks/i1profiler.rb
@@ -10,7 +10,7 @@ cask "i1profiler" do
   homepage "https://www.xrite.com/service-support/downloads/I/i1Profiler-i1Publish_V#{version.major_minor_patch.dots_to_underscores}"
 
   livecheck do
-    url "http://www.xrite.com/Downloads/Autoupdate/i1profiler_mac_appcast.xml"
+    url "https://downloads.xrite.com/downloads/autoupdate/i1profiler_mac_appcast.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The URL in the existing `livecheck` block for `i1profiler` redirects from http://www.xrite.com/Downloads/Autoupdate/i1profiler_mac_appcast.xml to https://downloads.xrite.com/downloads/autoupdate/i1profiler_mac_appcast.xml. This PR updates the URL to avoid the unnecessary redirection.