### PR TITLE
Add Mx Power Gadget 1.2 to cask

### DIFF
--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -1,5 +1,5 @@
 cask "mx-power-gadget" do
-    version "1.2"
+    version "1.2,20220322"
     sha256 "702f6ee1e533334bd6ffa42c168b20ad4d39a4c9a197fd0ece7e4b196bfdb929"
   
     url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -1,0 +1,11 @@
+cask "mx-power-gadget" do
+    version "1.2"
+    sha256 "702f6ee1e533334bd6ffa42c168b20ad4d39a4c9a197fd0ece7e4b196bfdb929"
+  
+    url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"
+    name "Mx Power Gadget"
+    desc "Power management and monitoring for Apple Mx processors"
+    homepage "https://www.seense.com/menubarstats/mxpg/"
+  
+    app "Mx Power Gadget.app"
+  end

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -1,21 +1,21 @@
 cask "mx-power-gadget" do
-    version "1.2,20220322"
-    sha256 :no_check
+  version "1.2,20220322"
+  sha256 :no_check
 
-    url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"
-    name "Mx Power Gadget"
-    desc "Power management and monitoring for Apple Mx processors"
-    homepage "https://www.seense.com/menubarstats/mxpg/"
+  url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"
+  name "Mx Power Gadget"
+  desc "Power management and monitoring for Apple Mx processors"
+  homepage "https://www.seense.com/menubarstats/mxpg/"
 
-    livecheck do
-        url "https://www.seense.com/menubarstats/mxpg/updateapp/appcast.xml"
-        strategy :sparkle
-    end
-  
-    app "Mx Power Gadget.app"
+  livecheck do
+    url "https://www.seense.com/menubarstats/mxpg/updateapp/appcast.xml"
+    strategy :sparkle
+  end
 
-    zap trash: [
-        "~/Library/Caches/com.fabriceleyne.MxPowerGadget",
-        "~/Library/Preferences/com.fabriceleyne.MxPowerGadget.plist",
-    ]
+  app "Mx Power Gadget.app"
+
+  zap trash: [
+    "~/Library/Caches/com.fabriceleyne.MxPowerGadget",
+    "~/Library/Preferences/com.fabriceleyne.MxPowerGadget.plist",
+  ]
 end

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -8,4 +8,9 @@ cask "mx-power-gadget" do
     homepage "https://www.seense.com/menubarstats/mxpg/"
   
     app "Mx Power Gadget.app"
+
+    zap trash: [
+        "~/Library/Caches/com.fabriceleyne.MxPowerGadget",
+        "~/Library/Preferences/com.fabriceleyne.MxPowerGadget.plist",
+      ]
   end

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -1,6 +1,6 @@
 cask "mx-power-gadget" do
     version "1.2,20220322"
-    sha256 "702f6ee1e533334bd6ffa42c168b20ad4d39a4c9a197fd0ece7e4b196bfdb929"
+    sha256 :no_check
 
     url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"
     name "Mx Power Gadget"

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -6,6 +6,11 @@ cask "mx-power-gadget" do
     name "Mx Power Gadget"
     desc "Power management and monitoring for Apple Mx processors"
     homepage "https://www.seense.com/menubarstats/mxpg/"
+
+    livecheck do
+        url "https://www.seense.com/menubarstats/mxpg/updateapp/appcast.xml"
+        strategy :sparkle
+    end
   
     app "Mx Power Gadget.app"
 

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -1,7 +1,7 @@
 cask "mx-power-gadget" do
     version "1.2,20220322"
     sha256 "702f6ee1e533334bd6ffa42c168b20ad4d39a4c9a197fd0ece7e4b196bfdb929"
-  
+    
     url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"
     name "Mx Power Gadget"
     desc "Power management and monitoring for Apple Mx processors"
@@ -18,4 +18,4 @@ cask "mx-power-gadget" do
         "~/Library/Caches/com.fabriceleyne.MxPowerGadget",
         "~/Library/Preferences/com.fabriceleyne.MxPowerGadget.plist",
       ]
-  end
+end

--- a/Casks/mx-power-gadget.rb
+++ b/Casks/mx-power-gadget.rb
@@ -1,7 +1,7 @@
 cask "mx-power-gadget" do
     version "1.2,20220322"
     sha256 "702f6ee1e533334bd6ffa42c168b20ad4d39a4c9a197fd0ece7e4b196bfdb929"
-    
+
     url "https://www.seense.com/menubarstats/mxpg/updateapp/mxpg.zip"
     name "Mx Power Gadget"
     desc "Power management and monitoring for Apple Mx processors"
@@ -17,5 +17,5 @@ cask "mx-power-gadget" do
     zap trash: [
         "~/Library/Caches/com.fabriceleyne.MxPowerGadget",
         "~/Library/Preferences/com.fabriceleyne.MxPowerGadget.plist",
-      ]
+    ]
 end

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -8,6 +8,10 @@ cask "xemu" do
   desc "Original Xbox Emulator"
   homepage "https://xemu.app/"
 
+  livecheck do
+    url :url
+  end
+
   app "Xemu.app"
 
   zap trash: [

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -8,10 +8,6 @@ cask "xemu" do
   desc "Original Xbox Emulator"
   homepage "https://xemu.app/"
 
-  livecheck do
-    url :url
-  end
-
   app "Xemu.app"
 
   zap trash: [

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -1,8 +1,8 @@
 cask "xemu" do
-  version "v0.6.5"
+  version "0.6.5"
   sha256 "16964c0e86a95b7c4320c75503198f4f576eb3160c1edb0c2ad07a76e9009ba1"
 
-  url "https://github.com/mborgerson/xemu/releases/download/#{version}/xemu-macos-universal-release.zip",
+  url "https://github.com/mborgerson/xemu/releases/download/v#{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"
   name "Xemu"
   desc "Original Xbox Emulator"

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -2,7 +2,7 @@ cask "xemu" do
   version "v0.6.5"
   sha256 "16964c0e86a95b7c4320c75503198f4f576eb3160c1edb0c2ad07a76e9009ba1"
 
-  url "https://github.com/mborgerson/xemu/releases/download/{version}/xemu-macos-universal-release.zip",
+  url "https://github.com/mborgerson/xemu/releases/download/#{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"
   name "Xemu"
   desc "Original Xbox Emulator"

--- a/Casks/xemu.rb
+++ b/Casks/xemu.rb
@@ -1,17 +1,12 @@
 cask "xemu" do
-  version "0.6.3-10-g292c9703de"
-  sha256 "1ac9603cb819f76dcd1e10fed53683c6237b4c4c33d202f056d4d9fa6deb69d4"
+  version "v0.6.5"
+  sha256 "16964c0e86a95b7c4320c75503198f4f576eb3160c1edb0c2ad07a76e9009ba1"
 
-  url "https://github.com/mborgerson/xemu/releases/download/gh-release%2F#{version}/xemu-macos-universal-release.zip",
+  url "https://github.com/mborgerson/xemu/releases/download/{version}/xemu-macos-universal-release.zip",
       verified: "github.com/mborgerson/xemu/"
   name "Xemu"
   desc "Original Xbox Emulator"
   homepage "https://xemu.app/"
-
-  livecheck do
-    url :url
-    regex(%r{^gh-release/(.*)$}i)
-  end
 
   app "Xemu.app"
 


### PR DESCRIPTION
I've noticed there is AMD and Intel Power Gadgets available but the one for M1s is missing so here it is
