### PR TITLE
Update checksum of kstars

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask "kstars" do
   version "3.5.8"
-  sha256 "1404d114c4340b95ca0bdb1a5320e4db06b1fac6e55ee09500102137714c8173"
+  sha256 "877cf01526f51b8ef6a439dafe2cb7664a26dd97149221d1cde5b589cbf80c62"
 
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg",
       verified: "indilib.org/jdownloads/kstars/"


### PR DESCRIPTION
Looks like the checksum for v3.5.8 changed. This PR fixes the checksum.