### PR TITLE
Update swiftformat-for-xcode from 0.49.7 to 0.49.8

### DIFF
--- a/Casks/swiftformat-for-xcode.rb
+++ b/Casks/swiftformat-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "swiftformat-for-xcode" do
-  version "0.49.7"
-  sha256 "ea86c54aa7a0f42f37c4fb1786b15069a6129ba1cf10c9f9ccf95437374f4157"
+  version "0.49.8"
+  sha256 "1f4e66385a20e8ca1f8a9e09a1656e87eb45a71fe362ce711723cfb5467e6a8d"
 
   url "https://github.com/nicklockwood/SwiftFormat/releases/download/#{version}/SwiftFormat.for.Xcode.app.zip"
   name "SwiftFormat for Xcode"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
