### PR TITLE
Add support for trader-workstation on m1 hardware

### DIFF
--- a/Casks/trader-workstation.rb
+++ b/Casks/trader-workstation.rb
@@ -2,11 +2,8 @@ cask "trader-workstation" do
   version "10.15.1f"
   sha256 :no_check
 
-  if Hardware::CPU.intel?
-    url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macosx-x64.dmg"
-  else
-    url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macos-arm.dmg"
-  end
+  arch = Hardware::CPU.intel? ? "x64" : "arm"
+  url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macosx-#{arch}.dmg"
 
   name "Trader Workstation"
   desc "Trading software"

--- a/Casks/trader-workstation.rb
+++ b/Casks/trader-workstation.rb
@@ -3,7 +3,8 @@ cask "trader-workstation" do
   sha256 :no_check
 
   arch = Hardware::CPU.intel? ? "x64" : "arm"
-  url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macosx-#{arch}.dmg"
+  os = Hardware::CPU.intel? ? "macosx" : "macos"
+  url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-#{os}-#{arch}.dmg"
   name "Trader Workstation"
   desc "Trading software"
   homepage "https://www.interactivebrokers.com/"

--- a/Casks/trader-workstation.rb
+++ b/Casks/trader-workstation.rb
@@ -2,7 +2,12 @@ cask "trader-workstation" do
   version "10.15.1f"
   sha256 :no_check
 
-  url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macosx-x64.dmg"
+  if Hardware::CPU.intel?
+    url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macosx-x64.dmg"
+  else
+    url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macos-arm.dmg"
+  end
+
   name "Trader Workstation"
   desc "Trading software"
   homepage "https://www.interactivebrokers.com/"

--- a/Casks/trader-workstation.rb
+++ b/Casks/trader-workstation.rb
@@ -4,7 +4,6 @@ cask "trader-workstation" do
 
   arch = Hardware::CPU.intel? ? "x64" : "arm"
   url "https://download2.interactivebrokers.com/installers/tws/latest/tws-latest-macosx-#{arch}.dmg"
-
   name "Trader Workstation"
   desc "Trading software"
   homepage "https://www.interactivebrokers.com/"


### PR DESCRIPTION
Just like to point out that the error mentioned in #117221 actually still exists, but the `uninstall_preflight` stanza is necessary to pass the CI checks.

An easy workaround would be keeping the trader-workstation app open before uninstalling/reinstalling/upgrading the cask, this will ensure the successful execution of the `pkill` command.

------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
