### PR TITLE
Remove Intel dependency for kdenlive

### DIFF
--- a/Casks/kdenlive.rb
+++ b/Casks/kdenlive.rb
@@ -14,7 +14,6 @@ cask "kdenlive" do
   end
 
   depends_on macos: ">= :mojave"
-  depends_on arch: :intel
 
   app "kdenlive.app"
 


### PR DESCRIPTION
Removed Intel dependency for kdenlive, as M1 is now officially supported as a platform.

Source: https://kdenlive.org/en/2022/05/kdenlive-22-04-released/

-----------------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
