### PR TITLE
Update eloston-chromium from 101.0.4951.41-1.1 to 101.0.4951.54-1.2

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -2,11 +2,11 @@ cask "eloston-chromium" do
   arch = Hardware::CPU.intel? ? "x86-64" : "arm64"
 
   if Hardware::CPU.intel?
-    version "101.0.4951.41-1.1,1651050697"
-    sha256 "d608032aeee2273d04c1d9c17dd813656befda06537307129965f050b38ac609"
+    version "101.0.4951.54-1.2,1651643571"
+    sha256 "618102f1545d49101cb3221d3a9620c8e1b35d64c71948ab1b1f4eec2319e63e"
   else
-    version "101.0.4951.41-1.1,1651086376"
-    sha256 "6ecc1f6a3df3c27951b49bf08f6f2aec525b4678bb514845b1b89591010b4494"
+    version "101.0.4951.54-1.2,1651683641"
+    sha256 "8620349c6a99add8c9feaf447c4bbd2850e62ec6f06bb573fa3968ca01200fec"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version.csv.first}_#{arch}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.