### PR TITLE
battery-report: discontinued

### DIFF
--- a/Casks/battery-report.rb
+++ b/Casks/battery-report.rb
@@ -7,15 +7,9 @@ cask "battery-report" do
   desc "Creates technical summaries of power supplies"
   homepage "https://www.dssw.co.uk/batteryreport/"
 
-  livecheck do
-    url "https://www.dssw.co.uk/batteryreport/dsswbatteryreport.dmg"
-    strategy :header_match do |headers|
-      match = headers["location"].match(/dsswbatteryreport-(\d+)(\d+)(\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}.#{match[3]}"
-    end
-  end
-
   app "Battery Report.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `battery-report` homepage contains a message at the top saying:

> Legacy: This product is no longer available for sale. These pages about Battery Report remain as a historic reference and are no longer accurate.

There's no value in checking for new versions in this scenario, so this PR updates the `livecheck` block to use `skip`. If this should be discontinued instead, I can update this to add the caveat and remove the `livecheck` block entirely (as it will automatically skip).