### PR TITLE
mindjet-mindmanager: update livecheck

### DIFF
--- a/Casks/mindjet-mindmanager.rb
+++ b/Casks/mindjet-mindmanager.rb
@@ -8,10 +8,9 @@ cask "mindjet-mindmanager" do
   homepage "https://www.mindjet.com/mindmanager/"
 
   livecheck do
-    url "https://www.mindjet.com/latest-release-notes-mac-english"
-    strategy :header_match do |headers|
-      headers["location"][/_(\d+(?:_\d+)*)_/, 1].tr("_", ".")
-    end
+    url "https://www.mindmanager.com/mm-mac-dmg"
+    regex(/MindManager[._-]Mac[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :header_match
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `mindjet-mindmanager` currently gives an `undefined method `tr' for nil:NilClass` error, as the `livecheck` block URL now redirects to a URL that doesn't include version information.

This PR resolves the issue by checking the URL from the [download page](https://www.mindmanager.com/en/support/download-library/) that redirects to the latest dmg file for the Mac desktop application. I've also reworked the regex in the process and removed the now-unnecessary `strategy` block.