### PR TITLE
paddle-easydl: update livecheck

### DIFF
--- a/Casks/paddle-easydl.rb
+++ b/Casks/paddle-easydl.rb
@@ -10,11 +10,9 @@ cask "paddle-easydl" do
 
   livecheck do
     url "https://aip-static.cdn.bcebos.com/paddle-desktop/releases/latest-mac.yml"
-    strategy :page_match do |page|
-      match = page.match(%r{path:.*/飞桨EasyDL-(\d+).(\d+).(\d+).(\d+).zip}i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}.#{match[3]},#{match[4]}"
+    regex(/path:.*?EasyDL[._-]v?(\d+(?:\.\d+)+)[._-](\d{4,})\.zip/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `paddle-easydl` is currently broken (`Unable to get versions`) because the regex expects the `latest-mac.yml` file to have a path that includes a leading forward slash but this isn't the case with the latest version. The XML file contains `url` values like `1.2.0/飞桨EasyDL-1.2.0.1200.zip` but the `path` value, `1.2.0飞桨EasyDL-1.2.0.1200.zip`, doesn't include the forward slash and the regex doesn't match it.

This PR updates the `livecheck` block as follows:

* Modify the regex to omit the forward slash (it will be handled by `.*?`) and to use a less brittle approach to capture the version information. The existing regex expects exactly four numeric version parts (e.g., `1.2.0.1200`) and wouldn't match anything else (e.g., `1.2.1200`, `1.2.0.1.1200`). The approach in this PR will match a more flexible number of numeric version parts before the final, longer number. It's not a perfect approach but it's less brittle than the existing one.
* Move the regex into a `#regex` call before the `strategy` call and pass it as an argument to the `strategy` block.
* Modify the `strategy` block to use the `page#scan` approach, which is generally preferable.

The latter two changes are part of ongoing work to update existing `livcheck` blocks and to preemptively resolve RuboCop offenses before making them apply to casks (not just formulae).