### PR TITLE
cmd/lib/ci_matrix: fix depends_on regex

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -13,11 +13,15 @@ module CiMatrix
     { symbol: :monterey,  name: "macos-12" }   => 0.1,
   }.freeze
 
+  # This string uses regex syntax and is intended to be interpolated into
+  # `Regexp` literals, so the backslashes must be escaped to be preserved.
+  DEPENDS_ON_MACOS_ARRAY_MEMBER = '\\s*"?:([^\\s",]+)"?,?\\s*'
+
   def self.filter_runners(cask_content)
     # Retrieve arguments from `depends_on macos:`
     args = case cask_content
-    when /depends_on macos: \[([\s\S]+)\]\n/
-      Regexp.last_match(1).scan(/\s*"?:([^\s",]+)"?,?\s*/).flatten.map(&:to_sym)
+    when /depends_on macos: \[((?:#{DEPENDS_ON_MACOS_ARRAY_MEMBER})+)\]/o
+      Regexp.last_match(1).scan(/#{DEPENDS_ON_MACOS_ARRAY_MEMBER}/o).flatten.map(&:to_sym)
     when /depends_on macos: "?:([^\s"]+)"?/
       [*Regexp.last_match(1).to_sym]
     when /depends_on macos: "([=<>]=\s:?\S+)"/

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -16,7 +16,7 @@ module CiMatrix
   def self.filter_runners(cask_content)
     # Retrieve arguments from `depends_on macos:`
     args = case cask_content
-    when /depends_on macos: \[((.*,?\s*)*)\]/
+    when /depends_on macos: \[([\s\S]+)\]\n/
       Regexp.last_match(1).scan(/\s*"?:([^\s",]+)"?,?\s*/).flatten.map(&:to_sym)
     when /depends_on macos: "?:([^\s"]+)"?/
       [*Regexp.last_match(1).to_sym]

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -26,6 +26,11 @@ module CiMatrix
       [*Regexp.last_match(1).to_sym]
     when /depends_on macos: "([=<>]=\s:?\S+)"/
       [*Regexp.last_match(1)]
+    when /depends_on macos:/
+      # In this case, `depends_on macos:` is present but wasn't matched by the
+      # previous regexes. We want this to visibly fail so we can address the
+      # shortcoming instead of quietly defaulting to `RUNNERS`.
+      odie "Unhandled `depends_on macos` argument"
     end
     return RUNNERS if args.nil?
 


### PR DESCRIPTION
The regex used in the ci_matrix.rb file is currently returning an error when an array of values is given for `depends_on macos:` as opposed to the usual `>=` quantifiers.

An example of this error is here;
https://github.com/Homebrew/homebrew-cask-drivers/pull/2730
CI run: https://github.com/Homebrew/homebrew-cask-drivers/runs/6033666864?check_suite_focus=true

I couldn't find a better regex, but I imagine @samford can probably suggest something better here?
The regex should match the internal text content of the array (everything inside of `[` and `]`) and pass it to the next function.

```ruby
depends_on macos: [
    :catalina,
    :big_sur,
    :monterey
  ]
```