### PR TITLE
pitch: update livecheck

### DIFF
--- a/Casks/pitch.rb
+++ b/Casks/pitch.rb
@@ -9,11 +9,9 @@ cask "pitch" do
 
   livecheck do
     url "https://desktop-app-builds.pitch.com/latest-mac.yml"
-    strategy :page_match do |page|
-      match = page.match(/Pitch[._-]v?(\d+(?:\.\d+)+)[._-]ci(\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/Pitch[._-]v?(\d+(?:\.\d+)+).*?[._-]ci(\d+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `pitch` is currently giving an `Unable to get versions` error, as the filename format has changed. The regex expects a filename like `Pitch-1.73.0-ci3651924.dmg` but the current filename in the `latest-mac.yml` file is `Pitch-1.75.0-stable.1-ci3776277.dmg`.

This PR updates the regex to allow for indetermine text between the version parts (e.g., `stable.1`). If anyone thinks the middle text may vary over time and we need to include it as part of the version, I can update the regex as requested.

Besides that, this updates the `livecheck` block to use `#regex` (passing the regex into the `strategy` block) and to use the `page.scan` approach to identifying versions. This is part of ongoing cleanup work.