### PR TITLE
Updated seafile-client 8.0.6 to 8.0.7

### DIFF
--- a/Casks/seafile-client.rb
+++ b/Casks/seafile-client.rb
@@ -1,6 +1,6 @@
 cask "seafile-client" do
-  version "8.0.6"
-  sha256 "d455892c010907affb53d0cab57cdd53fb3cf039191358f2107aa7c072f1d87a"
+  version "8.0.7"
+  sha256 "468ae251f01b62884f4e96fefbfe210f7bc7245ecd27d03246edfe1a4c77aeb7"
 
   url "https://download.seadrive.org/seafile-client-#{version}.dmg",
       verified: "seadrive.org/"


### PR DESCRIPTION
Updated Seafile-Client from v8.0.6 to v8.0.7

After making all changes to a cask, verify:
- [x] The submission is for a stable version.
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
