### PR TITLE
`cmd/lib/check.rb`: skip apple system launchjobs

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -124,6 +124,7 @@ module Check
     running_apps = diff[:loaded_launchjobs]
                    .added
                    .grep(/\.\d+\Z/)
+                   .grep_v(/\A(?:application\.)?com\.apple\.(installer|Safari|systemevents|systempreferences)(?:\.|$)/)
                    .map { |id| id.sub(/\A(?:application\.)?(.*?)(?:\.\d+){0,2}\Z/, '\1') }
 
     loaded_launchjobs = diff[:loaded_launchjobs]

--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -1,6 +1,9 @@
+# typed: false
 # frozen_string_literal: true
 
 require "forwardable"
+APPLE_LAUNCHJOBS_REGEX =
+  /\A(?:application\.)?com\.apple\.(installer|Safari|systemevents|systempreferences)(?:\.|$)/.freeze
 
 module Check
   CHECKS = {
@@ -48,7 +51,7 @@ module Check
         system_command!("/bin/launchctl", args: ["list"], print_stderr: false, sudo: sudo)
           .stdout
           .lines.drop(1)
-          .grep_v(/\A(?:application\.)?com\.apple\.(installer|Safari|systemevents|systempreferences)(?:\.|$)/)
+          .grep_v(APPLE_LAUNCHJOBS_REGEX)
       end
 
       [false, true]
@@ -124,7 +127,7 @@ module Check
     running_apps = diff[:loaded_launchjobs]
                    .added
                    .grep(/\.\d+\Z/)
-                   .grep_v(/\A(?:application\.)?com\.apple\.(installer|Safari|systemevents|systempreferences)(?:\.|$)/)
+                   .grep_v(APPLE_LAUNCHJOBS_REGEX)
                    .map { |id| id.sub(/\A(?:application\.)?(.*?)(?:\.\d+){0,2}\Z/, '\1') }
 
     loaded_launchjobs = diff[:loaded_launchjobs]


### PR DESCRIPTION
This is an attempt to skip `com.apple.systemevents` and related applications/bundle_ids when comparing runnings apps in our CI workflow.
We are using this same grep_v function when compiling the list of running launchjobs at the beginning of the comparison but not skipping them in the final comparison.

In my local testing this will solve false-negative CI runs for PRs such as https://github.com/Homebrew/homebrew-cask/pull/123344