### PR TITLE
docs: Update ipfs homepage and desc

### DIFF
--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -7,6 +7,11 @@ cask "ipfs" do
   desc "Menu bar application for the IPFS peer-to-peer network"
   homepage "https://github.com/ipfs/ipfs-desktop"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   auto_updates true
 
   app "IPFS Desktop.app"

--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -2,15 +2,10 @@ cask "ipfs" do
   version "0.20.6"
   sha256 "00f1affd9b96e5b5716345d0970beeec19ca3198c5cbe3f47eabaa9521ceee31"
 
-  url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/IPFS-Desktop-#{version}.dmg"
+  url "https://github.com/ipfs/ipfs-desktop/releases/download/v#{version}/IPFS-Desktop-#{version}.dmg"
   name "IPFS Desktop"
-  desc "An unobtrusive and user-friendly desktop application for IPFS on Windows, Mac and Linux."
+  desc "Menu bar application for the IPFS peer-to-peer network"
   homepage "https://github.com/ipfs/ipfs-desktop"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   auto_updates true
 

--- a/Casks/ipfs.rb
+++ b/Casks/ipfs.rb
@@ -4,8 +4,8 @@ cask "ipfs" do
 
   url "https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v#{version}/IPFS-Desktop-#{version}.dmg"
   name "IPFS Desktop"
-  desc "Menu bar application for the IPFS peer-to-peer network"
-  homepage "https://github.com/ipfs-shipyard/ipfs-desktop"
+  desc "An unobtrusive and user-friendly desktop application for IPFS on Windows, Mac and Linux."
+  homepage "https://github.com/ipfs/ipfs-desktop"
 
   livecheck do
     url :url


### PR DESCRIPTION
Use the latest description from the GitHub repo, and the proper GitHub repository URL as the homepage.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - [ ] pending https://github.com/Homebrew/homebrew-cask/pull/123387
- [x] `brew style --fix <cask>` reports no offenses.

--- 
```bash
brew audit --cask --online ipfs
==> Downloading https://github.com/ipfs-shipyard/ipfs-desktop/releases/download/v0.20.5/IPFS-Desktop-0.20.5.dmg
Already downloaded: /Users/sgtpooki/Library/Caches/Homebrew/downloads/0c586544b1a92be79b8702c3c21f079ce5a40e701ff35124990823513adb2fb3--IPFS-Desktop-0.20.5.dmg
audit for ipfs: failed
 - Version '0.20.5' differs from '0.20.6' retrieved by livecheck.
Error: 1 problem in 1 cask detected
```
   
```
> brew style --fix ipfs
Inspecting 2 files
..

2 files inspected, no offenses detected
```