### PR TITLE
polycom-content: update livecheck

### DIFF
--- a/Casks/polycom-content.rb
+++ b/Casks/polycom-content.rb
@@ -2,15 +2,17 @@ cask "polycom-content" do
   version "1.3.4.73535"
   sha256 "71ef985df0463b26345ed1161abcfe67391810778d2c3c1f50f87406efbd20ce"
 
-  url "https://downloads.polycom.com/video/content-app/PolycomContentApp_#{version.dots_to_underscores}.dmg"
+  url "https://downloads.polycom.com/video/content-app/PolycomContentApp_#{version.dots_to_underscores}.dmg",
+      verified: "downloads.polycom.com"
   name "Polycom Content App"
-  homepage "https://www.polycom.com/content-collaboration/content-sharing/content-app.html"
+  desc "Content sharing app"
+  homepage "https://www.poly.com/us/en/support/products/video-conferencing/accessories/content-app"
 
   livecheck do
-    url "https://support.polycom.com/content/support/north-america/usa/en/support/video/polycom-content-app.html"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/PolycomContentApp_(\d+(?:_\d+)*)\.dmg}i, 1]
-      v.tr("_", ".")
+    url :homepage
+    regex(%r{(?:href|data-path)=.*?/PolycomContentApp[._-]v?(\d+(?:[._]\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `polycom-content` is currently giving `1.3.3.72974` as the latest version instead of `1.3.4.73535`. This is because some download URLs are kept in a `data-path` attribute instead of `href`, so the existing regex doesn't match the [newer?] `data-path` URLs. This PR updates the regex to match both (and to bring it up to standard in general).

This also moves the regex out of the `strategy` block and into a `#regex` call (passing the regex into the `strategy` block), as part of ongoing cleanup.

Lastly, this updates the `homepage` (which was missing) and adds a `desc` to resolve the audit error. The only page I could find for this app only contains the phrase "The easiest way to share content at work", so I've gone with something generic.

I'll update the `polycom-realpresence` cask in a follow-up PR, as there are some related changes.