### PR TITLE
slack: Zap additional HTTPStorages files

### DIFF
--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -39,7 +39,7 @@ cask "slack" do
     "~/Library/Cookies/com.tinyspeck.slackmacgap.binarycookies",
     "~/Library/Group Containers/*.com.tinyspeck.slackmacgap",
     "~/Library/Group Containers/*.slack",
-    "~/Library/HTTPStorages/com.tinyspeck.slackmacgap.binarycookies",
+    "~/Library/HTTPStorages/com.tinyspeck.slackmacgap*",
     "~/Library/Logs/Slack",
     "~/Library/Preferences/ByHost/com.tinyspeck.slackmacgap.ShipIt.*.plist",
     "~/Library/Preferences/com.tinyspeck.slackmacgap.helper.plist",


### PR DESCRIPTION
To also zap 'Library/HTTPStorages/com.tinyspeck.slackmacgap'.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online slack` is error-free.
- [x] `brew style --fix slack` reports no offenses.
