### PR TITLE
polycom-realpresence: update livecheck

### DIFF
--- a/Casks/polycom-realpresence.rb
+++ b/Casks/polycom-realpresence.rb
@@ -2,16 +2,17 @@ cask "polycom-realpresence" do
   version "3.11.3.73575"
   sha256 "5aeb338abc6def5ecd98aa6a2a2f5e8d5fe4e0adaefd55650361641bd2426242"
 
-  url "https://downloads.polycom.com/video/realpresence_desktop/RPDesktop_#{version.dots_to_underscores}.dmg"
+  url "https://downloads.polycom.com/video/realpresence_desktop/RPDesktop_#{version.dots_to_underscores}.dmg",
+      verified: "downloads.polycom.com"
   name "Polycom RealPresence Desktop"
   desc "Video collaboration app"
-  homepage "https://www.polycom.com/products-services/hd-telepresence-video-conferencing/realpresence-desktop/realpresence-desktop.html"
+  homepage "https://www.poly.com/us/en/products/video-conferencing/clariti/realpresence-desktop-video-conferencing-software"
 
   livecheck do
-    url "https://support.polycom.com/content/support/north-america/usa/en/support/video/realpresence-desktop/realpresence-desktop.html"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/RPDesktop_(\d+(?:_\d+)*)\.dmg}i, 1]
-      v.tr("_", ".")
+    url "https://www.poly.com/us/en/support/products/cloud-services-and-software/video-soft-clients/realpresence-desktop"
+    regex(%r{(?:href|data-path)=.*?/RPDesktop[._-]v?(\d+(?:[._]\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #123505, to incorporate some of the changes from the `polycom-content` cask and keep these in line. Changes are as follows:

* Update the `livecheck` block URL to the current URL (avoiding redirections).
* Update the regex to align with `polycom-content`, so it should continue identifying new versions if the support page is updated to use `data-path` attributes as well.
* Move the regex into a `#regex` call and pass it into the `strategy` block.
* Update the `strategy` block to use the `page.scan(regex).map` approach.
* Update the `homepage` to avoid a redirection.
* Add `verified` to the `url`, as the `homepage` uses a different domain.