### PR TITLE
Fix Cave Story app, name stanza

### DIFF
--- a/Casks/cave-story.rb
+++ b/Casks/cave-story.rb
@@ -46,6 +46,7 @@ cask "cave-story" do
   end
 
   name "Cave Story"
+  name "Doukutsu"
   name "洞窟物語"
   desc "Action-adventure game reminiscent of classic 8- and 16-bit games"
   homepage "https://www.cavestory.org/"

--- a/Casks/cave-story.rb
+++ b/Casks/cave-story.rb
@@ -39,7 +39,7 @@ cask "cave-story" do
     end
 
     url "https://www.nakiwo.com/downloads/doukutsu#{version.dots_to_underscores}.dmg",
-        verified: "www.nakiwo.com/downloads/"
+        verified: "nakiwo.com/downloads/"
 
     # Renamed for consistency: app name is different in the Finder and in a shell.
     app "Doukutsu.app", target: "洞窟物語.app"

--- a/Casks/cave-story.rb
+++ b/Casks/cave-story.rb
@@ -17,6 +17,9 @@ cask "cave-story" do
     end
 
     url "https://www.cavestory.org/downloads/cavestory_#{version.csv.first.no_dots}_r#{version.csv.second}.dmg"
+
+    # Renamed for consistency: app name is different in the Finder and in a shell.
+    app "Doukutsu.app", target: "Cave Story.app"
   end
   language "ja" do
     if MacOS.version <= :mojave
@@ -36,17 +39,16 @@ cask "cave-story" do
     end
 
     url "https://www.nakiwo.com/downloads/doukutsu#{version.dots_to_underscores}.dmg",
-        verified: "nakiwo.com/"
+        verified: "www.nakiwo.com/downloads/"
+
+    # Renamed for consistency: app name is different in the Finder and in a shell.
+    app "Doukutsu.app", target: "洞窟物語.app"
   end
 
-  name "Pixel Cave Story"
-  name "Doukutsu"
+  name "Cave Story"
   name "洞窟物語"
   desc "Action-adventure game reminiscent of classic 8- and 16-bit games"
   homepage "https://www.cavestory.org/"
-
-  # Renamed for consistency: app name is different in the Finder and in a shell.
-  app "Doukutsu.app", target: "Cave Story.app"
 
   zap trash: "~/Library/Preferences/com.nakiwo.Doukutsu.plist"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Some notes:

Different app names are set for the English version and the Japanese version.
So I separated app stanza into English and Japanese.
Before this change, the Japanese version of app name was not consistent.
I also removed name stanza "Doukutsu", because it's not app's official name.