### PR TITLE
docker: add missing symlinked binaries

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -48,11 +48,14 @@ cask "docker" do
 
   uninstall delete:    [
     "/Library/PrivilegedHelperTools/com.docker.vmnetd",
+    "/usr/local/bin/com.docker.cli",
+    "/usr/local/bin/docker-compose-v1",
     "/usr/local/bin/docker-compose",
     "/usr/local/bin/docker-credential-desktop",
     "/usr/local/bin/docker-credential-ecr-login",
     "/usr/local/bin/docker-credential-osxkeychain",
     "/usr/local/bin/docker",
+    "/usr/local/bin/hub-tool",
     "/usr/local/bin/hyperkit",
     "/usr/local/bin/kubectl.docker",
     "/usr/local/bin/kubectl",


### PR DESCRIPTION
**Important:** _Do not tick a checkbox if you haven’t performed its action._ Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I was setting up a new M1 and noticed Docker created these additional symlinks:

```sh
$ ls -l /usr/local/bin/ | grep Docker.app
lrwxr-xr-x  62 root 13 May 07:40 com.docker.cli -> /Applications/Docker.app/Contents/Resources/bin/com.docker.cli
lrwxr-xr-x  54 root 15 May 00:32 docker -> /Applications/Docker.app/Contents/Resources/bin/docker
lrwxr-xr-x  62 root 15 May 00:32 docker-compose -> /Applications/Docker.app/Contents/Resources/bin/docker-compose
lrwxr-xr-x  80 root 13 May 07:40 docker-compose-v1 -> /Applications/Docker.app/Contents/Resources/bin/docker-compose-v1/docker-compose
lrwxr-xr-x  73 root 15 May 00:32 docker-credential-desktop -> /Applications/Docker.app/Contents/Resources/bin/docker-credential-desktop
lrwxr-xr-x  75 root 15 May 00:32 docker-credential-ecr-login -> /Applications/Docker.app/Contents/Resources/bin/docker-credential-ecr-login
lrwxr-xr-x  77 root 15 May 00:32 docker-credential-osxkeychain -> /Applications/Docker.app/Contents/Resources/bin/docker-credential-osxkeychain
lrwxr-xr-x  56 root 13 May 07:40 hub-tool -> /Applications/Docker.app/Contents/Resources/bin/hub-tool
lrwxr-xr-x  55 root 15 May 00:32 kubectl -> /Applications/Docker.app/Contents/Resources/bin/kubectl
lrwxr-xr-x  55 root 15 May 00:32 kubectl.docker -> /Applications/Docker.app/Contents/Resources/bin/kubectl
lrwxr-xr-x  65 root 15 May 00:32 vpnkit -> /Applications/Docker.app/Contents/Resources/bin/com.docker.vpnkit
```
