### PR TITLE
publii: update livecheck

### DIFF
--- a/Casks/publii.rb
+++ b/Casks/publii.rb
@@ -14,13 +14,8 @@ cask "publii" do
   homepage "https://getpublii.com/"
 
   livecheck do
-    url "https://github.com/GetPublii/Publii/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/v\.?(\d+(?:\.\d+)+).zip}i)
-      next if match.blank?
-
-      match[1].to_s
-    end
+    url "https://getpublii.com/download/"
+    regex(/href=.*?Publii[._-]v?(\d+(?:\.\d+)+)(?:[._-]#{arch})?\.dmg/i)
   end
 
   app "Publii.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `publii` checks the latest release from GitHub but the cask doesn't use any files from the repository, so the check isn't aligned with the source of the cask `url`. This PR updates the `livecheck` block to check the first-party download page, which links to the dmg file used in the URL.