### PR TITLE
Add Anaconda ARM64 for 2022.05

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -16,7 +16,7 @@ cask "anaconda" do
 
   livecheck do
     url "https://repo.anaconda.com/archive/"
-    regex(/Anaconda3-(\d+(?:\.\d+)+)-MacOSX-(?:x86_64|arm64)\.sh/i)
+    regex(/Anaconda3-(\d+(?:\.\d+)+)-MacOSX-#{arch}\.sh/i)
   end
 
   auto_updates true

--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -1,22 +1,29 @@
 cask "anaconda" do
-  version "2022.05"
-  sha256 "1a10c06660ebe1204e538b4e9d810142441af9dfd74b077eee2761ec6e675f39"
+  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
 
-  url "https://repo.anaconda.com/archive/Anaconda3-#{version}-MacOSX-x86_64.sh"
+  version "2022.05"
+
+  if Hardware::CPU.intel?
+    sha256 "1a10c06660ebe1204e538b4e9d810142441af9dfd74b077eee2761ec6e675f39"
+  else
+    sha256 "457b10272f807879ab4289ffb93d7dcb695362b417bb7c80d24892c8d8557b29"
+  end
+
+  url "https://repo.anaconda.com/archive/Anaconda3-#{version}-MacOSX-#{arch}.sh"
   name "Continuum Analytics Anaconda"
   desc "Distribution of the Python and R programming languages for scientific computing"
   homepage "https://www.anaconda.com/"
 
   livecheck do
     url "https://repo.anaconda.com/archive/"
-    regex(/Anaconda3-(\d+(?:\.\d+)+)-MacOSX-x86_64\.sh/i)
+    regex(/Anaconda3-(\d+(?:\.\d+)+)-MacOSX-(?:x86_64|arm64)\.sh/i)
   end
 
   auto_updates true
   container type: :naked
 
   installer script: {
-    executable: "Anaconda3-#{version}-MacOSX-x86_64.sh",
+    executable: "Anaconda3-#{version}-MacOSX-#{arch}.sh",
     args:       ["-b", "-p", "#{HOMEBREW_PREFIX}/anaconda3"],
     sudo:       true,
   }


### PR DESCRIPTION
Update Cask file to support M1 chip architecture for Anaconda version
2022.05. Intel chip architecture installation is unchanged.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

**Not adding a new cask**

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
