### PR TITLE
Add Apple Silicon support for uvtools cask

### DIFF
--- a/Casks/uvtools.rb
+++ b/Casks/uvtools.rb
@@ -2,7 +2,8 @@ cask "uvtools" do
   version "3.4.2"
   sha256 "6ef3effafe23d46f848dd7f31b21a86bc757cd527b22268c99811d8b8a3aea95"
 
-  url "https://github.com/sn4k3/UVtools/releases/download/v#{version}/UVtools_osx-x64_v#{version}.zip"
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  url "https://github.com/sn4k3/UVtools/releases/download/v#{version}/UVtools_osx-#{arch}_v#{version}.zip"
   name "UVtools"
   desc "MSLA/DLP, file analysis, calibration, repair, conversion and manipulation"
   homepage "https://github.com/sn4k3/UVtools"

--- a/Casks/uvtools.rb
+++ b/Casks/uvtools.rb
@@ -1,6 +1,6 @@
 cask "uvtools" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
-  
+
   version "3.4.2"
   sha256 "6ef3effafe23d46f848dd7f31b21a86bc757cd527b22268c99811d8b8a3aea95"
   

--- a/Casks/uvtools.rb
+++ b/Casks/uvtools.rb
@@ -2,8 +2,13 @@ cask "uvtools" do
   arch = Hardware::CPU.intel? ? "x64" : "arm64"
 
   version "3.4.2"
-  sha256 "6ef3effafe23d46f848dd7f31b21a86bc757cd527b22268c99811d8b8a3aea95"
-  
+
+  if Hardware::CPU.intel?
+    sha256 "6ef3effafe23d46f848dd7f31b21a86bc757cd527b22268c99811d8b8a3aea95"
+  else
+    sha256 "d35deed46b8429154fd6d0e1aa2fbe1bf826b2b75ca02a55db07e041eb84ca92"
+  end
+
   url "https://github.com/sn4k3/UVtools/releases/download/v#{version}/UVtools_osx-#{arch}_v#{version}.zip"
   name "UVtools"
   desc "MSLA/DLP, file analysis, calibration, repair, conversion and manipulation"

--- a/Casks/uvtools.rb
+++ b/Casks/uvtools.rb
@@ -1,8 +1,9 @@
 cask "uvtools" do
+  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  
   version "3.4.2"
   sha256 "6ef3effafe23d46f848dd7f31b21a86bc757cd527b22268c99811d8b8a3aea95"
-
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
+  
   url "https://github.com/sn4k3/UVtools/releases/download/v#{version}/UVtools_osx-#{arch}_v#{version}.zip"
   name "UVtools"
   desc "MSLA/DLP, file analysis, calibration, repair, conversion and manipulation"


### PR DESCRIPTION
Following the style of other casks, detect if a Mac is using Intel to determine whether to install the x86 versus Apple Silicon binary.  The current cask uses the x86 binary and runs on Apple Silicon but under Rosetta (and does runtime binary translation).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- X ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.