### PR TITLE
easyeda: do not delete preferences on updates

### DIFF
--- a/Casks/easyeda.rb
+++ b/Casks/easyeda.rb
@@ -14,7 +14,7 @@ cask "easyeda" do
 
   app "EasyEDA.app"
 
-  uninstall delete: [
+  zap trash: [
     "~/Library/Application Support/EasyEDA",
     "~/Library/Logs/EasyEDA",
     "~/Library/Preferences/com.easyeda.editor.helper.plist",


### PR DESCRIPTION
This commit fixes an issue where `easyeda` preferences get deleted each time this package updates to a new version.
Adopt `zap`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
