### PR TITLE
gridtracker 1.22.0503

### DIFF
--- a/Casks/gridtracker.rb
+++ b/Casks/gridtracker.rb
@@ -1,20 +1,20 @@
 cask "gridtracker" do
-  version "1.21.1217"
-  sha256 "fd32335a82f663be0df1d03f5990c5ba2fa2df7790624e6ad30d862311efc350"
+  version "1.22.0503"
+  sha256 "298c922675c2067530625c1ffe67a42f64d409fc00a37fc00a1e10b56f774841"
 
-  url "https://download.gridtracker.org/v#{version}/GridTracker-#{version}-mac-x64.zip"
+  url "https://storage.googleapis.com/gt_download/v#{version}-2/GridTracker-#{version}-mac-x64.zip"
   name "GridTracker"
   desc "Warehouse of amateur radio information presented in an easy to use interface"
   homepage "https://gridtracker.org/grid-tracker/"
 
   livecheck do
-    url "https://download.gridtracker.org/"
-    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/}i)
+    url "https://storage.googleapis.com/gt_download/"
+    regex(/GridTracker[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]x64\.zip/i)
   end
 
   depends_on macos: ">= :mojave"
 
-  app "GridTracker.app"
+  app "GridTracker-#{version}-mac-x64/GridTracker.app"
 
   zap trash: [
     "~/Library/Application Support/GridTracker",


### PR DESCRIPTION
From the `livecheck` url I am guessing the `-2` in the `url` is a temporary thing that can be removed in the next update.