### PR TITLE
Add Trivial 1.0.6

### DIFF
--- a/Casks/trivial.rb
+++ b/Casks/trivial.rb
@@ -1,0 +1,28 @@
+cask "trivial" do
+  version "1.0.6,01000.67.50"
+  sha256 "1686fc11dd4271d27c0803a8f382b8cf9c9ad917cdeb2203766199cbf7f33136"
+
+  url "https://download.decisivetactics.com/downloads/trivial/Trivial_#{version.csv.first}.zip"
+  name "Trivial"
+  desc "Simple file transfer server supporting many protocols"
+  homepage "https://www.decisivetactics.com/products/trivial/"
+
+  livecheck do
+    url "https://api.decisivetactics.com/api/v1/public/appcast?app=trivial&v=1"
+    strategy :sparkle
+  end
+
+  app "Trivial.app"
+
+  uninstall launchctl: "com.decisivetactics.trivial-server",
+            delete:    [
+              "/Library/Application Support/com.decisivetactics.trivial",
+              "/Library/LaunchDaemons/com.decisivetactics.trivial-server.plist",
+            ]
+
+  zap trash: [
+    "~/Library/Caches/com.decisivetactics.trivial",
+    "~/Library/HTTPStorages/com.decisivetactics.trivial",
+    "~/Library/Preferences/com.decisivetactics.trivial.plist",
+  ]
+end


### PR DESCRIPTION
Introduce a new cask: Trivial (1.0.6), a simple file transfer server by Decisive Tactics

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
