### PR TITLE
next: discontinued

### DIFF
--- a/Casks/next.rb
+++ b/Casks/next.rb
@@ -4,9 +4,14 @@ cask "next" do
 
   url "https://next.atlas.engineer/static/release/next-macos-webkit.dmg"
   name "Next Browser"
+  desc "Web browser"
   homepage "https://next.atlas.engineer/"
 
   app "Next.app"
 
   zap trash: "~/Library/Caches/next.browser"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
From https://nyxt.atlas.engineer/download:

> macOS is not officially supported by Nyxt