### PR TITLE
Ghidra quarantine

### DIFF
--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,5 +1,5 @@
 cask "ghidra" do
-  version "10.1.3,20220421"
+  version "10.1.3,20220519"
   sha256 "9c73b6657413686c0af85909c20581e764107add2a789038ebc6eca49dc4e812"
 
   url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.csv.first}_build/ghidra_#{version.csv.first}_PUBLIC_#{version.csv.second}.zip",
@@ -21,6 +21,10 @@ cask "ghidra" do
   preflight do
     # Log4j misinterprets comma in staged_path as alternative delimiter
     FileUtils.mv(staged_path, "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}")
+    # Remove the quarantine flag, otherwise 'decompile' and 'demangler_gnu_...' gets blocked
+    system_command "xattr",
+               args: ["-dr", "com.apple.quarantine", "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}"]
+
   end
 
   uninstall_preflight do

--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -1,5 +1,5 @@
 cask "ghidra" do
-  version "10.1.3,20220519"
+  version "10.1.3,20220421"
   sha256 "9c73b6657413686c0af85909c20581e764107add2a789038ebc6eca49dc4e812"
 
   url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.csv.first}_build/ghidra_#{version.csv.first}_PUBLIC_#{version.csv.second}.zip",

--- a/Casks/ghidra.rb
+++ b/Casks/ghidra.rb
@@ -23,8 +23,7 @@ cask "ghidra" do
     FileUtils.mv(staged_path, "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}")
     # Remove the quarantine flag, otherwise 'decompile' and 'demangler_gnu_...' gets blocked
     system_command "xattr",
-               args: ["-dr", "com.apple.quarantine", "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}"]
-
+                   args: ["-dr", "com.apple.quarantine", "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}"]
   end
 
   uninstall_preflight do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) 
- [X] `brew audit --cask --online ghidra` is error-free.
- [X] `brew style --fix ghidra` reports no offenses.

By default, ghidra executables are blocked by macOS. 
By removing the quarantine flag, ghidra runs fine. 