### PR TITLE
Update streamlink-twitch-gui to 2.1.0

### DIFF
--- a/Casks/streamlink-twitch-gui.rb
+++ b/Casks/streamlink-twitch-gui.rb
@@ -1,6 +1,6 @@
 cask "streamlink-twitch-gui" do
-  version "2.0.0"
-  sha256 "0ff924d0cec2b37c7581260519974f3c0537a6114d8afb2da74fc0351a3c9289"
+  version "2.1.0"
+  sha256 "a093923ff3926338f3a6aa6041fd1c7ad32c864adeb657d197b5235e97acd020"
 
   url "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v#{version}/streamlink-twitch-gui-v#{version}-macOS.tar.gz"
   name "Streamlink Twitch GUI"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
