### PR TITLE
bettertouchtool: update livecheck

### DIFF
--- a/Casks/bettertouchtool.rb
+++ b/Casks/bettertouchtool.rb
@@ -9,11 +9,9 @@ cask "bettertouchtool" do
 
   livecheck do
     url "https://folivora.ai/releases/"
-    strategy :page_match do |page|
-      page.scan(/btt(\d+(?:[._-]\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
-          .max_by { |(_, time)| Time.parse(time) }
-          .first
-          .tr("-", ",")
+    regex(/btt(\d+(?:[._-]\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).max_by { |match| Time.parse(match[1]) }&.first&.tr("-", ",")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates the existing `livecheck` block for `bettertouchtool` as follows:

* Move the regex into a `#regex` call and pass it into the `strategy` block (this is part of ongoing cleanup work).
* Use the typical `match[1]` notation to access the second capture group within the `#max_by` block (instead of `|(_, time)| Time.parse(time)`. There's something to be said for using the standard approach (for easier comprehension) instead of the clever one in the existing code.
* Use the safe navigation operator (`&.`) after `#max_by`, as this would be `nil` if the regex doesn't match anything in the page content (and `nil.first` would error).