### PR TITLE
Update Warp Cask to use /download endpoint

### DIFF
--- a/Casks/warp.rb
+++ b/Casks/warp.rb
@@ -1,16 +1,16 @@
 cask "warp" do
   version "0.2022.05.16.09.01.stable_01"
-  sha256 "fc912d946eb0ce0b44d8fa5c1ec004112a8a482653bae734251e4fed5c9bfb34"
+  sha256 :no_check
 
-  url "https://warp-releases.storage.googleapis.com/stable/v#{version}/Warp.dmg",
-      verified: "warp-releases.storage.googleapis.com"
+  url "https://app.warp.dev/download"
   name "Warp"
   desc "Rust-based terminal"
   homepage "https://www.warp.dev/"
 
   livecheck do
-    url "https://storage.googleapis.com/warp-releases/channel_versions.json"
+    url :url
     regex(/v(\d+(?:\.\d+)+\.stable_\d+)/i)
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
The Warp cask was directly hitting a GCP endpoint. However, the Warp team is making changes and this URL may not be publically available in the future. To fix, I've changed this cask to hit the `/download` endpoint directly, which will return the most up-to-date version of Warp.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
