### PR TITLE
exifrenamer: update livecheck

### DIFF
--- a/Casks/exifrenamer.rb
+++ b/Casks/exifrenamer.rb
@@ -9,11 +9,9 @@ cask "exifrenamer" do
 
   livecheck do
     url "https://www.qdev.de/versions/ExifRenamer.txt"
-    strategy :page_match do |page|
-      version = page.split
-      next if version.blank?
-
-      "#{version[0]},#{version[1].tr("()", "")}"
+    regex(/v?(\d+(?:\.\d+)+)(?:\s*\((\d+(?:\.\d+)*)\))?/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]}#{"," + match[1] if match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `exifrenamer` uses custom logic in a `strategy` block to extract version information from the `ExifRenamer.txt` content. At present, this file simply contains `2.4.0 (15)`.

The `strategy` block uses `page.split`, which will split on whitespace by default (i.e., `2.4.0 (15)` becomes `["2.4.0", "(15)"]`). This works with the current content format but would fail if the space between the version parts is ever omitted (e.g., `2.4.0(15)`).

This PR reworks the `livecheck` block to take a more typical approach by using a regex. The regex optionally matches whitespace, so it will work in either scenario. The way I've set this up, it will also continue to match if the version only contains the first part (e.g., `2.4.0`) without any trailing parenthetical.