### PR TITLE
Rename qiyimedia.rb to iqiyi.rb

### DIFF
--- a/Casks/iqiyi.rb
+++ b/Casks/iqiyi.rb
@@ -1,5 +1,5 @@
 cask "iqiyi" do
-  version "13.5.0,20220512171701"
+  version "13.5.0,20220517171400"
   sha256 :no_check
 
   url "https://static-d.iqiyi.com/ext/common/iQIYIMedia_271.dmg"

--- a/Casks/iqiyi.rb
+++ b/Casks/iqiyi.rb
@@ -1,4 +1,4 @@
-cask "qiyimedia" do
+cask "iqiyi" do
   version "13.5.0,20220512171701"
   sha256 :no_check
 


### PR DESCRIPTION
"iQIYI" is the official name of this app. It is necessary to change the name of this rb file.
Reference website:
https://apps.apple.com/us/app/iqiyi-video/id1190755526