### PR TITLE
gyazmail: update livecheck

### DIFF
--- a/Casks/gyazmail.rb
+++ b/Casks/gyazmail.rb
@@ -9,12 +9,7 @@ cask "gyazmail" do
 
   livecheck do
     url "http://gyazsquare.com/gyazmail/download.php"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/GyazMail-(\d+)(\d+)(\d+)\.dmg}i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}.#{match[3]}"
-    end
+    regex(/Download\s*GyazMail\s*v?(\d+(?:\.\d+)+)/i)
   end
 
   app "GyazMail.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `gyazmail` checks the related download page to identify version information from the dmg filename but, unfortunately, the filename omits dots from the version (e.g., `GyazMail-165.dmg` for version 1.6.5).

The regex assumes there will always be three version parts but this may not always be true. Additionally, the `strategy` block naively inserts dots between the digits in the filename and this is an approach that I try to minimize (if not avoid) because it doesn't work correctly when one of the version parts is more than one digit. For example, the file on the download page for older macOS versions is `GyazMail-1521.dmg` and this is version 1.5.21 but it wouldn't be handled correctly (it's treated as 15.2.1, due to how the regex is set up). A version with fewer/more than three parts would either fail to match or be parsed incorrectly.

This check will either break (due to the specificity of the regex) or produce an erroneous version over time. This PR updates the `livecheck` block to match the version from the "Download GyazMail 1.6.5" link text instead. Matching text like this can also break if it changes enough to not match but that's less concerning to me than the shortcomings of the existing approach.