### PR TITLE
fix ExpressVPN uninstall script location

### DIFF
--- a/Casks/expressvpn.rb
+++ b/Casks/expressvpn.rb
@@ -16,7 +16,7 @@ cask "expressvpn" do
 
   uninstall launchctl: "com.expressvpn.ExpressVPN.agent",
             script:    {
-              executable: "#{appdir}/ExpressVPN.app/Contents/Resources/uninstall.tool",
+              executable: "/Applications/ExpressVPN.app/Contents/Resources/uninstall.tool",
               input:      ["Yes"],
               sudo:       true,
             },


### PR DESCRIPTION
ExpressVPN is a package cask and it doesn't respect `--appdir`. This PR fixes #124149 when uninstalling and updating this cask.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: No
