### PR TITLE
simplediagrams: update livecheck

### DIFF
--- a/Casks/simplediagrams.rb
+++ b/Casks/simplediagrams.rb
@@ -4,13 +4,14 @@ cask "simplediagrams" do
 
   url "https://www.simplediagrams.com/download/simplediagrams_installer_#{version.dots_to_underscores}.dmg"
   name "SimpleDiagrams"
+  desc "Diagramming app"
   homepage "https://www.simplediagrams.com/"
 
   livecheck do
     url "https://www.simplediagrams.com/downloads"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/simplediagrams_installer_(\d+(?:_\d+)*)\.dmg}i, 1]
-      v.tr("_", ".")
+    regex(/simplediagrams[._-]installer[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `simplediagrams` currently gives an ```undefined method `tr' for nil:NilClass``` error. This is because the related links on the download page are generic URLs for a given major version that redirect to the latest file (e.g., `https://www.simplediagrams.com/download/4/mac/` redirects to `https://simplediagrams-site.s3.us-west-1.amazonaws.com/media/simplediagrams_installer_4_0_28.dmg`). However, the related filename is found in the inner text of the link, so we can match it by loosening the regex to drop the leading `href=.*?`.

[For what it's worth, I'm not in favor of checking the aforementioned redirection link because it's locked to a specific major version and livecheck wouldn't be able to detect a new major version with that setup. In that scenario, the cask would get stuck on a specific version until someone finds the latest version outside of livecheck and updates the cask.]

Outside of the regex change, this PR also updates the `livecheck` block to move the regex into a `#regex` call and pass it into the `strategy` block. This also modifies the `strategy` block to use the common `page.scan(regex).map` approach. This is part of ongoing work to better standardize `strategy` blocks.