### PR TITLE
cmd/lib/check.rb: skip known false positive kexts

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -103,7 +103,9 @@ module Check
       errors << message
     end
 
-    installed_kexts = diff[:installed_kexts].added
+    installed_kexts = diff[:installed_kexts]
+                      .added
+                      .grep_v(/^com\.(softraid\.driver\.SoftRAID|com\.highpoint-tech\.kext\.*)/)
     if installed_kexts.any?
       message = "Some kernel extensions are still installed, add them to #{Formatter.identifier("uninstall kext:")}\n"
       message += installed_kexts.join("\n")


### PR DESCRIPTION
This PR adds a `.grep_v` to skip a couple of kexts that are known to be false positives on the CI machines.
I don't believe there are any casks that should flag these intentionally.


```
Error: Some kernel extensions are still installed, add them to uninstall kext:
com.highpoint-tech.kext.HighPointIOP
com.highpoint-tech.kext.HighPointRR
com.softraid.driver.SoftRAID
```