### PR TITLE
Add older version of Apparency for macOS 10.14

### DIFF
--- a/Casks/apparency.rb
+++ b/Casks/apparency.rb
@@ -1,8 +1,14 @@
 cask "apparency" do
-  version "1.4.1,218"
-  sha256 :no_check
+  if MacOS.version <= :mojave
+    version "1.3"
+    url "https://www.mothersruin.com/software/downloads/Apparency-1.3.dmg"
+    sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
+  else
+    version "1.4.1,218"
+    url "https://mothersruin.com/software/downloads/Apparency.dmg"
+    sha256 :no_check
+  end
 
-  url "https://mothersruin.com/software/downloads/Apparency.dmg"
   name "Apparency"
   desc "Inspect application bundles"
   homepage "https://www.mothersruin.com/software/Apparency/"
@@ -15,7 +21,7 @@ cask "apparency" do
     end
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :mojave"
 
   app "Apparency.app"
 

--- a/Casks/apparency.rb
+++ b/Casks/apparency.rb
@@ -1,7 +1,7 @@
 cask "apparency" do
   if MacOS.version <= :mojave
     version "1.3"
-    url "https://www.mothersruin.com/software/downloads/Apparency-1.3.dmg"
+    url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
     sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
   else
     version "1.4.1,218"


### PR DESCRIPTION
Version 1.3 supported macOS 10.14, so I was decided to add it to the cask to be able to install it on that version of macOS.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
