### PR TITLE
`cask-pr-inspect-download`: update command

### DIFF
--- a/developer/bin/cask-pr-inspect-download
+++ b/developer/bin/cask-pr-inspect-download
@@ -39,7 +39,7 @@ pr_json = JSON.parse(URI(pr_api).read)
 
 abort "PR needs to have a single file" if pr_json.count != 1
 
-file_raw_url = pr_json[0]["raw_url"]
+file_raw_url = pr_json[0]["raw_url"].gsub("%2F", "/")
 file_name = File.basename(file_raw_url)
 local_file = File.join(Dir.mktmpdir, file_name)
 tmp_cache_dir = Dir.mktmpdir

--- a/developer/bin/cask-pr-local-check
+++ b/developer/bin/cask-pr-local-check
@@ -38,7 +38,7 @@ pr_json = JSON.parse(URI(pr_api).read)
 
 abort "PR needs to have a single file" if pr_json.count != 1
 
-file_raw_url = pr_json[0]["raw_url"]
+file_raw_url = pr_json[0]["raw_url"].gsub("%2F", "/")
 file_name = File.basename(file_raw_url)
 local_file = File.join(Dir.mktmpdir, file_name)
 


### PR DESCRIPTION
This may just be an issue on my end, but interested to see if it can be replicated.

Running the cask-pr-inspect-download command before this PR was causing an error, due to a character in the URL being returned encoded - `https://github.com/Homebrew/homebrew-cask/raw/0b279e9bf79c0a2928302ad1ce3098e02a08eaaa/Casks%2Fjulia.rb` - `Casks%2Fjulia.rb` instead of `Casks/julia.rb`

- this also effect the cask-pr-local-check command.