### PR TITLE
Update devmate.com livecheck blocks

### DIFF
--- a/Casks/bestres.rb
+++ b/Casks/bestres.rb
@@ -10,8 +10,12 @@ cask "bestres" do
 
   livecheck do
     url "https://updates.devmate.com/com.icyberon.BestRes.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/BestRes-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/BestRes\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -10,8 +10,12 @@ cask "captin" do
 
   livecheck do
     url "https://updates.devmate.com/com.100hps.captin.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/Captin-\d+\.dmg}i, 1]}"
+    regex(%r{/(\d+)/Captin\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/chatmate-for-facebook.rb
+++ b/Casks/chatmate-for-facebook.rb
@@ -10,8 +10,12 @@ cask "chatmate-for-facebook" do
 
   livecheck do
     url "https://updates.devmate.com/net.coldx.mac.Facebook.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/ChatMateforFacebook-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/ChatMateforFacebook\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/chatmate-for-whatsapp.rb
+++ b/Casks/chatmate-for-whatsapp.rb
@@ -10,8 +10,12 @@ cask "chatmate-for-whatsapp" do
 
   livecheck do
     url "https://updates.devmate.com/net.coldx.mac.WhatsApp.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/ChatMateforWhatsApp-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/ChatMateforWhatsApp\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -10,8 +10,12 @@ cask "dictionaries" do
 
   livecheck do
     url "https://updates.devmate.com/io.dictionaries.Dictionaries.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/Dictionaries-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/Dictionaries\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/geektool.rb
+++ b/Casks/geektool.rb
@@ -10,8 +10,12 @@ cask "geektool" do
 
   livecheck do
     url "https://updates.devmate.com/org.tynsoe.GeekTool.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/GeekTool-(?:\d+(?:\.\d+)*)\.zip}, 1]}"
+    regex(%r{/(\d+)/GeekTool\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -10,8 +10,12 @@ cask "gemini" do
 
   livecheck do
     url "https://updates.devmate.com/com.macpaw.site.Gemini#{version.major}.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/Gemini.*?\.zip}i, 1]}"
+    regex(%r{/(\d+)/Gemini\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/ghosttile.rb
+++ b/Casks/ghosttile.rb
@@ -11,8 +11,12 @@ cask "ghosttile" do
 
   livecheck do
     url "https://updates.devmate.com/im.kernelpanic.GhostTile.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/GhostTile-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/GhostTile\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/ibettercharge.rb
+++ b/Casks/ibettercharge.rb
@@ -10,8 +10,12 @@ cask "ibettercharge" do
 
   livecheck do
     url "https://updates.devmate.com/com.softorino.iBetterCharge.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.url[%r{/(\d+)/iBetterCharge-(?:\d+(?:\.\d+)*)\.zip}i, 1]}"
+    regex(%r{/(\d+)/iBetterCharge\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/qblocker.rb
+++ b/Casks/qblocker.rb
@@ -10,9 +10,12 @@ cask "qblocker" do
 
   livecheck do
     url "https://updates.devmate.com/uk.co.wearecocoon.QBlocker.xml"
-    strategy :sparkle do |item|
-      id = item.url[%r{/(\d+)/QBlocker-\d+\.zip}i, 1]
-      "#{item.short_version},#{item.version},#{id}"
+    regex(%r{/(\d+)/Qblocker\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/rotato.rb
+++ b/Casks/rotato.rb
@@ -10,8 +10,12 @@ cask "rotato" do
 
   livecheck do
     url "https://updates.devmate.com/com.mortenjust.Rendermock.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.url[%r{/(\d+)/DesignCamera-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/DesignCamera\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/ssh-tunnel-manager.rb
+++ b/Casks/ssh-tunnel-manager.rb
@@ -5,12 +5,17 @@ cask "ssh-tunnel-manager" do
   url "https://dl.devmate.com/org.tynsoe.sshtunnelmanager/#{version.csv.first}/#{version.csv.second}/SSHTunnelManager-#{version.csv.first}.zip",
       verified: "dl.devmate.com/org.tynsoe.sshtunnelmanager/"
   name "SSH Tunnel Manager"
+  desc "Application for managing SSH tunnels"
   homepage "https://tynsoe.org/stm/"
 
   livecheck do
     url "https://updates.devmate.com/org.tynsoe.sshtunnelmanager.xml"
-    strategy :sparkle do |item|
-      "#{item.version},#{item.url[%r{/(\d+)/SSHTunnelManager-(?:\d+(?:\.\d+)*)\.zip}i, 1]}"
+    regex(%r{/(\d+)/SSHTunnelManager\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/startupizer.rb
+++ b/Casks/startupizer.rb
@@ -10,11 +10,12 @@ cask "startupizer" do
 
   livecheck do
     url "https://updates.devmate.com/com.gentlebytes.Startupizer#{version.major}.xml"
-    strategy :sparkle do |item|
-      match = item.url.match(%r{/(\d+)/Startupizer(\d+)-\d+\.zip}i)
+    regex(%r{/(\d+)/Startupizer(\d+?)[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
       next if match.blank?
 
-      "#{match[2]},#{item.version},#{match[1]}"
+      "#{match[2]},#{match[3]},#{match[1]}"
     end
   end
 

--- a/Casks/the-archive-browser.rb
+++ b/Casks/the-archive-browser.rb
@@ -10,8 +10,12 @@ cask "the-archive-browser" do
 
   livecheck do
     url "https://updates.devmate.com/cx.c3.thearchivebrowser.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/TheArchiveBrowser-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/TheArchiveBrowser\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/the-unarchiver.rb
+++ b/Casks/the-unarchiver.rb
@@ -10,8 +10,12 @@ cask "the-unarchiver" do
 
   livecheck do
     url "https://updates.devmate.com/com.macpaw.site.theunarchiver.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/TheUnarchiver-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/TheUnarchiver\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -10,8 +10,12 @@ cask "trim-enabler" do
 
   livecheck do
     url "https://updates.devmate.com/org.cindori.TrimEnabler#{version.major}.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/(\d+)/TrimEnabler-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/TrimEnabler\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/waltr-heic-converter.rb
+++ b/Casks/waltr-heic-converter.rb
@@ -10,11 +10,12 @@ cask "waltr-heic-converter" do
 
   livecheck do
     url "https://updates.devmate.com/com.softorino.WaltrHeicConverter.xml"
-    strategy :sparkle do |item|
-      timestamp = item.url.match(%r{/(\d{10})/}i)
-      next if timestamp.blank?
+    regex(%r{/(\d+)/WALTRHEICConverter\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
 
-      "#{item.short_version},#{timestamp[1]}"
+      "#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/xee.rb
+++ b/Casks/xee.rb
@@ -10,8 +10,12 @@ cask "xee" do
 
   livecheck do
     url "https://updates.devmate.com/cx.c3.Xee3.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.version},#{item.url[%r{/([^/]+)/[^/]+\.zip}i, 1]}"
+    regex(%r{/(\d+)/Xee\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The casks in this PR each contain a `livecheck` block that checks a related `https://updates.devmate.com` XML file. There are similarities across all these casks but the `livecheck` blocks varied. This PR standardizes these `livecheck` blocks as much as possible.

The regexes are consistent outside of `startupizer`, which has to capture the trailing digit after the software name in the filename. 17 out of 18 of the `strategy` blocks here differ only in whether the `shortVersion` is prepended to the returned version string. The exception again is `startupizer`, which has a slightly different version format.

The only related cask that this PR doesn't cover is `haptic-touch-bar`, which I'll handle in a separate PR due to changes to the `version`, `url`, etc.