### PR TITLE
haptic-touch-bar: update version, url, livecheck

### DIFF
--- a/Casks/haptic-touch-bar.rb
+++ b/Casks/haptic-touch-bar.rb
@@ -1,16 +1,21 @@
 cask "haptic-touch-bar" do
-  version "2.4.0,1540815050"
+  version "2.4.0,240,1540815050"
   sha256 "c7b044f1516bb0912e863e2e3a3fd080fa06833eaddc0f056caf55a5e9df94b5"
 
-  url "https://dl.devmate.com/com.bopsoft.HapticTouchBar/#{version.csv.first.no_dots}/#{version.csv.second}/HapticTouchBar-#{version.csv.first.no_dots}.zip",
+  url "https://dl.devmate.com/com.bopsoft.HapticTouchBar/#{version.csv.second}/#{version.csv.third}/HapticTouchBar-#{version.csv.second}.zip",
       verified: "dl.devmate.com/com.bopsoft.HapticTouchBar/"
   name "Haptic Touch Bar"
+  desc "Add haptic feedback to Touch Bar buttons"
   homepage "https://www.haptictouchbar.com/"
 
   livecheck do
     url "https://updates.devmate.com/com.bopsoft.HapticTouchBar.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version},#{item.url[%r{/(\d+)/HapticTouchBar-\d+\.zip}i, 1]}"
+    regex(%r{/(\d+)/HapticTouchBar\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates `haptic-touch-bar` to align with other `devmate.com` casks. Namely, this updates the version to use three parts (like `bestres`, for example) and updates the `url` accordingly.

This also updates the `livecheck` block to use the standardized approach in #124383 (made possible by the `version`/`url` changes here).