### PR TITLE
sketchbook: discontinued

### DIFF
--- a/Casks/sketchbook.rb
+++ b/Casks/sketchbook.rb
@@ -8,16 +8,6 @@ cask "sketchbook" do
   desc "Draw, paint, & sketch application"
   homepage "https://www.sketchbook.com/"
 
-  livecheck do
-    url "https://www.autodesk.com/products/sketchbook/free-download"
-    strategy :page_match do |page|
-      match = page.match(%r{sketchbook_(\d+)/sketchbook_v?(\d+(?:\.\d+)*)_mac\.dmg}i)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
-    end
-  end
-
   pkg "SketchBook_v#{version.csv.first}_mac.pkg"
 
   uninstall quit:    "com.autodesk.SketchBook",
@@ -28,4 +18,12 @@ cask "sketchbook" do
     "~/Library/Preferences/com.autodesk.SketchBook.plist",
     "~/Library/Application Support/Autodesk/SketchBook",
   ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      Sketchbook is now handled by Sketchbook, Inc. and Autodesk no longer provides downloads. The app appears to only be available through app stores at this point (see https://www.sketchbook.com/apps).
+    EOS
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [download page](https://www.autodesk.com/products/sketchbook/free-download) in the `livecheck` block for `sketchbook` now redirects to an [overview page](https://www.autodesk.com/products/sketchbook/overview) which states:

> **Sketchbook is no longer available**
>
> As of June 30, 2021, Autodesk is discontinuing SketchBook. We will no longer offer downloads for SketchBook or deliver new versions or updates.
>
> Sketchbook is now offered by Sketchbook, Inc., details are available at [www.sketchbook.com](https://www.sketchbook.com/).

www.sketchbook.com [directs users to app stores for Mac, Windows, iOS, and Android](https://www.sketchbook.com/apps), so there doesn't appear to be a direct download anymore that could be used for this cask. With that in mind, I've set this as `discontinued` (removing the `livecheck` block accordingly) along with an additional explanation in the `caveat`. If anything needs to change here, just let me know.