### PR TITLE
`ci`: update julia uninstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             fi
           fi
           
-          if ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
+          if ! brew uninstall --cask --force julia && ! rm -r /Applications/Julia-*.app; then
             echo '::warning::Removing Julia is no longer necessary.'
           fi
 


### PR DESCRIPTION
This should resolve the issues with `julia` not being uninstalled correctly for CI runs. 

Fix for: https://github.com/Homebrew/homebrew-cask/pull/124372