### PR TITLE
Fixed change in URL

### DIFF
--- a/Casks/shutter-encoder.rb
+++ b/Casks/shutter-encoder.rb
@@ -6,7 +6,7 @@ cask "shutter-encoder" do
   if Hardware::CPU.intel?
     sha256 "651986b16223cb9a08b65fb5c57f4547d92623bb40485c24e7257c5a115da5eb"
   else
-    sha256 "58e85131558d462e173009960c91646a254cee0dcb9ee37ed040cc7a0abfc28c"
+    sha256 "6dd2f9a0c36b2480fbebc08e4b05bed6a3809002820bc9416e2a1696f8c302b0"
   end
 
   url "https://www.shutterencoder.com/Shutter%20Encoder%20#{version}%20#{arch.gsub(" ", "%20")}.pkg"

--- a/Casks/shutter-encoder.rb
+++ b/Casks/shutter-encoder.rb
@@ -1,5 +1,5 @@
 cask "shutter-encoder" do
-  arch = Hardware::CPU.intel? ? "64bits" : "Silicon"
+  arch = Hardware::CPU.intel? ? "Mac 64bits" : "Apple Silicon"
 
   version "16.0"
 
@@ -9,7 +9,7 @@ cask "shutter-encoder" do
     sha256 "58e85131558d462e173009960c91646a254cee0dcb9ee37ed040cc7a0abfc28c"
   end
 
-  url "https://www.shutterencoder.com/Shutter%20Encoder%20#{version}%20Mac%20#{arch}.pkg"
+  url "https://www.shutterencoder.com/Shutter%20Encoder%20#{version}%20#{arch.gsub(" ", "%20")}.pkg"
   name "Shutter Encoder"
   desc "Video, audio and image converter"
   homepage "https://www.shutterencoder.com/"
@@ -19,7 +19,7 @@ cask "shutter-encoder" do
     regex(/^\s*Version\s*(\d+(?:\.\d+)+)/i)
   end
 
-  pkg "Shutter Encoder #{version} Mac #{arch}.pkg"
+  pkg "Shutter Encoder #{version} #{arch}.pkg"
 
   uninstall pkgutil: "com.paulpacifico.shutterencoder",
             quit:    "com.paulpacifico.shutterencoder"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

The second one is left unchecked because the current cask is broken. They changed the file naming scheme so the Apple Silicon version is not downloadable with the current cask code.