### PR TITLE
Update hex-fiend from 2.14.1 to 2.15.0

### DIFF
--- a/Casks/hex-fiend.rb
+++ b/Casks/hex-fiend.rb
@@ -1,8 +1,8 @@
 cask "hex-fiend" do
-  version "2.14.1"
-  sha256 "aeb1c364376b31748761185e6069fc2eb4724ea7d6d33e954460e096aa54470b"
+  version "2.15.0"
+  sha256 "effd7e4ff9c265332725005e6c6c761793c46bccea6c069e955ebdc77a7f923e"
 
-  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version}.dmg",
+  url "https://github.com/ridiculousfish/HexFiend/releases/download/v#{version}/Hex_Fiend_#{version.major_minor_patch.chomp(".0")}.dmg",
       verified: "github.com/ridiculousfish/HexFiend/"
   name "Hex Fiend"
   desc "Hex editor focussing on speed"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Had to do this update manually instead of using `brew bump-cask-pr` to add the `chomp` call in the file version number, given that the developer is dropping the 'patch' version if it is zero as seen in previous commits to this formula.