### PR TITLE
ckb-next: discontinued

### DIFF
--- a/Casks/ckb-next.rb
+++ b/Casks/ckb-next.rb
@@ -16,4 +16,8 @@ cask "ckb-next" do
     "org.ckb-next.daemon",
   ],
             launchctl: "org.ckb-next.daemon"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
New release is out and support for macOS was indeed dropped as announced [here](https://github.com/ckb-next/ckb-next/issues/660).