### PR TITLE
cmd/lib/ci_matrix: only use macos-10.15 when needed; prefer macos-11

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -8,9 +8,9 @@ module CiMatrix
   MAX_JOBS = 256
 
   RUNNERS = {
-    { symbol: :catalina, name: "macos-10.15" } => 0.9,
-    { symbol: :big_sur,  name: "macos-11" }    => 0.1,
-    { symbol: :monterey,  name: "macos-12" }   => 0.1,
+    { symbol: :catalina, name: "macos-10.15" } => 0,
+    { symbol: :big_sur,  name: "macos-11" }    => 0.9,
+    { symbol: :monterey, name: "macos-12" }    => 0.1,
   }.freeze
 
   # This string uses regex syntax and is intended to be interpolated into
@@ -57,7 +57,9 @@ module CiMatrix
   end
 
   def self.random_runner(avalible_runners = RUNNERS)
-    avalible_runners.max_by { |(_, weight)| rand ** (1.0 / weight) }.first
+    avalible_runners.reject { |_, weight| weight.zero? }
+                    .max_by { |(_, weight)| rand ** (1.0 / weight) }
+                    .first
   end
 
   def self.runners(path)


### PR DESCRIPTION
GitHub will be winding down macos-10.15 support over the coming weeks, removing it finally at the end of August.

We however still schedule 90% of PRs to run on it. I've reduced this to 0 - now it's 90% macos-11 and 10% macos-12 (since tha latter is still in beta and will probably have reduced capacity). The exception is when there is a `MacOS.version == :catalina` in the cask, in which case it's beneficial to still test with it and the selection code will do (even with 0 weight).