### PR TITLE
intune-company-portal: use unversioned url

### DIFF
--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -19,10 +19,11 @@ cask "intune-company-portal" do
         },
       ]
 
-  uninstall pkgutil: [
-    "com.microsoft.CompanyPortalMac",
-    "com.microsoft.CompanyPortal",
-  ],
+  uninstall quit:    "com.microsoft.autoupdate2",
+            pkgutil: [
+              "com.microsoft.CompanyPortalMac",
+              "com.microsoft.CompanyPortal",
+            ],
             delete:  [
               "/Applications/Company Portal.app",
             ]

--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -1,24 +1,16 @@
 cask "intune-company-portal" do
-  version "2.12.210101"
-  sha256 "9b327c4b47129b4bb25e0de4ca16387187e8d7f134f2ff4c58c197f7c26b4abc"
+  version :latest
+  sha256 :no_check
 
-  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Installer.pkg"
+  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg"
   name "Company Portal"
   desc "App to manage access to corporate apps, data, and resources"
   homepage "https://docs.microsoft.com/en-us/mem/intune/user-help/enroll-your-device-in-intune-macos-cp"
 
-  livecheck do
-    url "https://go.microsoft.com/fwlink/?linkid=853070"
-    strategy :header_match do |headers|
-      headers["location"][%r{/CompanyPortal_(\d+(?:\.\d+)*)-Installer\.pkg}i, 1]
-    end
-  end
-
-  auto_updates true
   depends_on cask: "microsoft-auto-update"
   depends_on macos: ">= :mojave"
 
-  pkg "CompanyPortal_#{version}-Installer.pkg",
+  pkg "CompanyPortal-Installer.pkg",
       choices: [
         {
           "choiceIdentifier" => "com.microsoft.package.Microsoft_AutoUpdate.app", # Office16_autoupdate_updater.pkg


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `intune-company-portal` no longer works because the pkg file is now unversioned. I looked around and couldn't find any public source of version information (related documentation all seems to point to the aforementioned `livecheck` URL).

This PR removes the `livecheck` block accordingly. I also took a pass at updating this cask to use the current, unversioned pkg URL. My cask knowledge is lacking, so let me know if this isn't the most appropriate approach.