### PR TITLE
couchbase-server-community 7.1.0, livecheck changed to page_match from downloads page

### DIFF
--- a/Casks/couchbase-server-community.rb
+++ b/Casks/couchbase-server-community.rb
@@ -1,6 +1,6 @@
 cask "couchbase-server-community" do
-  version "7.0.2"
-  sha256 "c310713f88b58b23ef6e929c89432bc93a5701335228f398e05359dd1ea65f59"
+  version "7.1.0"
+  sha256 "a57b8a5f3f92a8eff82a65ea9a4201d8219af091eb41d5a85c9ae271a5d0d116"
 
   url "https://packages.couchbase.com/releases/#{version}/couchbase-server-community_#{version}-macos_x86_64.dmg"
   name "Couchbase Server"
@@ -8,8 +8,8 @@ cask "couchbase-server-community" do
   homepage "https://www.couchbase.com/"
 
   livecheck do
-    url "http://appcast.couchbase.com/membasex.xml"
-    strategy :sparkle
+    url "https://www.couchbase.com/downloads"
+    regex(/osx.*?couchbase-server-community-version.*?(\d+(:?\.\d+)+)\s\(Current\)/im)
   end
 
   conflicts_with cask: "couchbase-server-enterprise"


### PR DESCRIPTION
Since old [appcast URL](http://appcast.couchbase.com/membasex.xml) seems dead, I've updated livecheck blocks to check the download page.


I also created a forum post about old appcast https://forums.couchbase.com/t/couchbase-server-for-macos-7-1-0-sparkle-appcast-update/33662, but unfortunately I got no response.

```bash
yusufkursad.kaya@YKKs-MBP: homebrew-cask/Casks% brew livecheck --cask couchbase-server-community.rb --debug

Cask:             couchbase-server-community
Livecheckable?:   Yes

URL:              https://www.couchbase.com/downloads
Strategy:         PageMatch
Regex:            /osx.*?couchbase-server-community-version.*?(\d+(:?\.\d+)+)\s\(Current\)/mi

Matched Versions:
7.1.0, 2.3.0
couchbase-server-community: 7.0.2 ==> 7.1.0
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
