### PR TITLE
couchbase-server-enterprise 7.1.0, livecheck changed to page_match from downloads page

### DIFF
--- a/Casks/couchbase-server-enterprise.rb
+++ b/Casks/couchbase-server-enterprise.rb
@@ -7,8 +7,8 @@ cask "couchbase-server-enterprise" do
 
     app "couchbase-server-enterprise_#{version}/Couchbase Server.app"
   else
-    version "7.0.3"
-    sha256 "02465faaf58a4ed12137c353392897ef9bf7da29852d16207914f62bfa73f531"
+    version "7.1.0"
+    sha256 "9e887b9d6fa58d705720da86e273fe7c93ffea697a3714ffc8d67a5e8056ff06"
 
     url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.dmg"
 
@@ -20,8 +20,8 @@ cask "couchbase-server-enterprise" do
   homepage "https://www.couchbase.com/"
 
   livecheck do
-    url "http://appcast.couchbase.com/membasex.xml"
-    strategy :sparkle
+    url "https://www.couchbase.com/downloads"
+    regex(/osx.*?couchbase-server-enterprise-version.*?(\d+(:?\.\d+)+)\s\(Current\)/im)
   end
 
   conflicts_with cask: "couchbase-server-community"


### PR DESCRIPTION
Since old [appcast URL](http://appcast.couchbase.com/membasex.xml) seems dead, I've updated livecheck blocks to check the download page.


I also created a forum post about old appcast https://forums.couchbase.com/t/couchbase-server-for-macos-7-1-0-sparkle-appcast-update/33662, but unfortunately I got no response.

```bash
yusufkursad.kaya@YKKs-MBP: homebrew-cask/Casks% brew livecheck --cask couchbase-server-enterprise.rb --debug

Cask:             couchbase-server-enterprise
Livecheckable?:   Yes

URL:              https://www.couchbase.com/downloads
Strategy:         PageMatch
Regex:            /osx.*?couchbase-server-enterprise-version.*?(\d+(:?\.\d+)+)\s\(Current\)/mi

Matched Versions:
7.1.0
couchbase-server-enterprise: 7.0.3 ==> 7.1.0
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
