### PR TITLE
Add zsh completions for Nova CLI tool

### DIFF
--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -24,6 +24,7 @@ cask "nova" do
   uninstall delete: [
     "/Library/LaunchDaemons/com.panic.NovaPrivilegedHelper.plist",
     "/Library/PrivilegedHelperTools/com.panic.NovaPrivilegedHelper",
+    "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_nova",
   ]
 
   zap trash: [

--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -18,10 +18,13 @@ cask "nova" do
 
   app "Nova.app"
   binary "#{appdir}/Nova.app/Contents/SharedSupport/nova"
+  artifact "#{appdir}/Nova.app/Contents/Resources/nova_completions.txt",
+           target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_nova"
 
   uninstall delete: [
     "/Library/LaunchDaemons/com.panic.NovaPrivilegedHelper.plist",
     "/Library/PrivilegedHelperTools/com.panic.NovaPrivilegedHelper",
+    "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_nova",
   ]
 
   zap trash: [

--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -3,7 +3,7 @@ cask "nova" do
   sha256 "682e78d38ad3043a27b292721539a9446ed3363993d3374c62b82b79818a83e4"
 
   url "https://download-cdn.panic.com/nova/Nova%20#{version}.zip",
-      verified: "https://download-cdn.panic.com/nova/"
+      verified: "download-cdn.panic.com/nova/"
   name "Panic Nova"
   desc "Native code editor"
   homepage "https://nova.app/"
@@ -24,7 +24,6 @@ cask "nova" do
   uninstall delete: [
     "/Library/LaunchDaemons/com.panic.NovaPrivilegedHelper.plist",
     "/Library/PrivilegedHelperTools/com.panic.NovaPrivilegedHelper",
-    "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_nova",
   ]
 
   zap trash: [


### PR DESCRIPTION
As [discussed in the Nova support docs][1], Nova itself installs a ZSH completion file alongside the CLI binary. Homebrew does not currently do this, and only links the binary. That causes the exact problem discussed in the linked support document, where oh-my-zsh errors during tab completion on the Nova CLI tool.

This commit fixes that problem by installing the Nova completion file alongside the CLI tool, just like Nova.app does.

[1]: https://help.panic.com/nova/cli-zsh-not-working/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.