### PR TITLE
sublime-text: update version format

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,8 +1,8 @@
 cask "sublime-text" do
-  version "4.126"
+  version "4,4126"
   sha256 "06e47f404b3e1c14d505bfbd0b884f8d5a62c9f376a62f735a693dc31d9cc212"
 
-  url "https://download.sublimetext.com/sublime_text_build_#{version.no_dots}_mac.zip"
+  url "https://download.sublimetext.com/sublime_text_build_#{version.csv.second}_mac.zip"
   name "Sublime Text"
   desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/"
@@ -11,10 +11,7 @@ cask "sublime-text" do
     url "https://www.sublimetext.com/download_thanks?target=mac"
     regex(/href=.*?v?(\d+)_mac\.zip/i)
     strategy :page_match do |page, regex|
-      match = page.match(regex)[1]
-      next if match.blank?
-
-      "#{match[0]}.#{match[1..]}"
+      page.scan(regex).map { |match| "#{match[0][0]},#{match[0]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #124526, where I noticed that the `sublime-text` cask was using its own unique version instead of respecting the current version format upstream. In the past, [Sublime Text 2](https://www.sublimetext.com/2) initially used build numbers but switched to versions like `2.0.2` after build 2181. [Sublime Text 3](https://www.sublimetext.com/3) still provided a version like `3.2.2` but started referencing the build as well (e.g., `3.2.2 (build 3211)`) and the current version is listed as "Build 3211".

For [Sublime Text 4](https://www.sublimetext.com/download), the build number alone has been used as the version. The version from the app itself is simply `Build 4126`.

With this in mind, it doesn't feel appropriate for the cask to create its own version scheme from the build number (i.e., `4.126`) and we should simply use the build number instead. The major version (`4`) is used in parts of the cask, so this PR uses a version format like `4,4126`, where the major version and build numbers can be easily accessed.