### PR TITLE
cmd/lib/ci_matrix: raise error if no files were changed

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 require "cask/cask_loader"
@@ -82,6 +83,8 @@ module CiMatrix
     tap.extend(ChangedFiles)
 
     changed_files = tap.changed_files
+
+    odie "No files were modified by the PR" if changed_files[:modified_files].blank?
 
     ruby_files_in_wrong_directory =
       changed_files[:modified_ruby_files] - (


### PR DESCRIPTION
I am unsure if this is the correct approach, but attempting to cause the CI workflow to fail when no files have been modified against the HEAD.

To prevent empty commits such as;
https://github.com/Homebrew/homebrew-cask/pull/124566
https://github.com/Homebrew/homebrew-cask/commit/5f0fad9a6fca6588e69dd6e5947e910be9536f23