### PR TITLE
private-internet-access: update uninstall

### DIFF
--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -24,7 +24,7 @@ cask "private-internet-access" do
             delete:    "/Applications/Private Internet Access.app",
             launchctl: "com.privateinternetaccess.vpn.installhelper"
 
-  # The uninstall script should only be used when with --zap because it removes all preferences
+  # The uninstall script should only be used with --zap because it removes all preference files
   zap script: {
     executable: "/Applications/Private Internet Access.app/Contents/Resources/vpn-installer.sh",
     args:       ["uninstall"],

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -25,7 +25,10 @@ cask "private-internet-access" do
               "/Applications/Private Internet Access.app",
               "/usr/local/bin/piactl",
             ],
-            launchctl: "com.privateinternetaccess.vpn.installhelper"
+            launchctl: [
+              "com.privateinternetaccess.vpn.installhelper",
+              "com.privateinternetaccess.vpn.daemon",
+            ]
 
   # The uninstall script should only be used with --zap because it removes all preference files
   zap script: {

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -20,13 +20,16 @@ cask "private-internet-access" do
     sudo:       true,
   }
 
-  uninstall script: {
+  uninstall quit:      "com.privateinternetaccess.vpn",
+            delete:    "/Applications/Private Internet Access.app",
+            launchctl: "com.privateinternetaccess.vpn.installhelper"
+
+  # The uninstall script should only be used when with --zap because it removes all preferences
+  zap script: {
     executable: "/Applications/Private Internet Access.app/Contents/Resources/vpn-installer.sh",
     args:       ["uninstall"],
     sudo:       true,
-  }
-
-  zap trash: [
+  }, trash: [
     "~/Library/Application Support/com.privateinternetaccess.vpn",
     "~/Library/LaunchAgents/com.privateinternetaccess.vpn",
     "~/Library/LaunchAgents/com.privateinternetaccess.vpn.client.plist",

--- a/Casks/private-internet-access.rb
+++ b/Casks/private-internet-access.rb
@@ -21,7 +21,10 @@ cask "private-internet-access" do
   }
 
   uninstall quit:      "com.privateinternetaccess.vpn",
-            delete:    "/Applications/Private Internet Access.app",
+            delete:    [
+              "/Applications/Private Internet Access.app",
+              "/usr/local/bin/piactl",
+            ],
             launchctl: "com.privateinternetaccess.vpn.installhelper"
 
   # The uninstall script should only be used with --zap because it removes all preference files


### PR DESCRIPTION
The uninstall script for `private-internet-access` deletes all preferences (and is not used by the in-app updater).
I have moved the uninstall script to zap for cleanup purposes, and just remove the necessary files manually (pending CI test).