### PR TITLE
sublime-text: update version format

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,8 +1,9 @@
 cask "sublime-text" do
-  version "4,4126"
+  # NOTE: The first digit of the build number is the major version.
+  version "4126"
   sha256 "06e47f404b3e1c14d505bfbd0b884f8d5a62c9f376a62f735a693dc31d9cc212"
 
-  url "https://download.sublimetext.com/sublime_text_build_#{version.csv.second}_mac.zip"
+  url "https://download.sublimetext.com/sublime_text_build_#{version}_mac.zip"
   name "Sublime Text"
   desc "Text editor for code, markup and prose"
   homepage "https://www.sublimetext.com/"
@@ -10,9 +11,6 @@ cask "sublime-text" do
   livecheck do
     url "https://www.sublimetext.com/download_thanks?target=mac"
     regex(/href=.*?v?(\d+)_mac\.zip/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0][0]},#{match[0]}" }
-    end
   end
 
   auto_updates true
@@ -21,26 +19,26 @@ cask "sublime-text" do
   app "Sublime Text.app"
   binary "#{appdir}/Sublime Text.app/Contents/SharedSupport/bin/subl"
 
-  uninstall quit: "com.sublimetext.#{version.major}"
+  uninstall quit: "com.sublimetext.#{version[0]}"
 
   # Sublime Text 4 uses `Sublime Text 3` and `com.sublimetext.3` dirs if they exist
   # Otherwise, it creates `Sublime Text` and `com.sublimetext.4`
   # More info: https://www.sublimetext.com/docs/side_by_side.html
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sublimetext.#{version.major}.sfl*",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.sublimetext.#{version[0]}.sfl*",
     "~/Library/Application Support/Sublime Text",
     "~/Library/Application Support/Sublime Text (Safe Mode)",
     "~/Library/Application Support/Sublime Text 3",
-    "~/Library/Caches/com.sublimetext.#{version.major}",
+    "~/Library/Caches/com.sublimetext.#{version[0]}",
     "~/Library/Caches/com.sublimetext.3",
     "~/Library/Caches/Sublime Text",
     "~/Library/Caches/Sublime Text (Safe Mode)",
     "~/Library/Caches/Sublime Text 3",
-    "~/Library/HTTPStorages/com.sublimetext.#{version.major}",
+    "~/Library/HTTPStorages/com.sublimetext.#{version[0]}",
     "~/Library/HTTPStorages/com.sublimetext.3",
-    "~/Library/Preferences/com.sublimetext.#{version.major}.plist",
+    "~/Library/Preferences/com.sublimetext.#{version[0]}.plist",
     "~/Library/Preferences/com.sublimetext.3.plist",
-    "~/Library/Saved Application State/com.sublimetext.#{version.major}.savedState",
+    "~/Library/Saved Application State/com.sublimetext.#{version[0]}.savedState",
     "~/Library/Saved Application State/com.sublimetext.3.savedState",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #124563, where I switched the `version` format from the cask-specific `4.126` to `4,4126`. After some discussion in that PR, there's something to be said for only using the build number for the cask `version`, as Sublime Text reliably uses the major version as the first digit of the build number. Including the major version as the first part of the cask `version` was simply to allow use of `version.major` in the cask but we can simply use `version[0]` instead (I added a note above the `version` to explain this).

Using the build number as the `version` will ensure that a more comprehensible version is displayed in situations where only the first part of the version is displayed. I don't think this impacts first-party tooling but it benefits the third-party [`brew-cask-upgrade`](https://github.com/buo/homebrew-cask-upgrade) command and simplifies the `livecheck` block, so I figured it's worth the change.