### PR TITLE
mockoon: update livecheck

### DIFF
--- a/Casks/mockoon.rb
+++ b/Casks/mockoon.rb
@@ -8,11 +8,9 @@ cask "mockoon" do
   desc "Create mock APIs in seconds"
   homepage "https://mockoon.com/"
 
-  # a regex is required to skip tags that relate to mockoon cli
   livecheck do
     url :url
-    strategy :git
-    regex(/^v?(\d+(?:\.\d+)+)/i)
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `mockoon` includes a redundant `#strategy` call, as the `Git` strategy is already used for the `url` by default. We only use the `#strategy` method when we need to override the default strategy for a given URL or we're using a `strategy` block. Additionally, the regex is unbounded at the end, so it could potentially match more than just stable versions (the standard regex for Git tags like `1.2.3`/`v1.2.3` is `/^v?(\d+(?:\.\d+)+)$/i`). Lastly, the preceding comment about needing a regex to skip tags isn't necessary, as it's implied by the use of `#regex` (i.e., this is common for `Git` checks).

That said, this should be checking GitHub releases since the cask `url` is a download file from a release (i.e., in this context we want livecheck to report a version when it's released, not when it's tagged). This PR resolves the aforementioned issues by simply using the `GithubLatest` strategy. [If this becomes a problem in the future, we can switch to checking the [first-party download page](https://mockoon.com/download/).]