### PR TITLE
resolutionator: update livecheck

### DIFF
--- a/Casks/resolutionator.rb
+++ b/Casks/resolutionator.rb
@@ -9,10 +9,13 @@ cask "resolutionator" do
 
   livecheck do
     url "https://manytricks.com/resolutionator/appcast/"
-    strategy :sparkle do |feed|
-      short_version = feed.short_version
-      short_version += ".0" if short_version.split(".").length < 3
-      "#{short_version},#{feed.version}"
+    strategy :sparkle do |item|
+      next if item.short_version.blank? || item.version.blank?
+
+      short_version = item.short_version
+      short_version += ".0" if item.short_version.count(".") < 2
+
+      "#{short_version},#{item.version}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `resolutionator` contains a `strategy` block that uses a non-standard name for the first argument (it should be `item`). Non-standard argument names like `feed` are preferably avoided  but have been technically fine up to now. However, this will lead to an error once Homebrew/brew#13357 is merged, as the only acceptable names for the first argument will be `item` and `items`. [Shorthand blocks like `&:short_version` have been accounted for and will continue to work with one item.]

The changes in that PR to allow for the option of passing all items (instead of only the first item) required us to be strict about the argument name. Thankfully, this is the only `livecheck` block in homebrew/cask that will be affected.

Besides addressing the argument name issue, this improves error-handling (i.e., `short_version` and `version` aren't guaranteed to exist) and replaces `.split(".").length` with `.count(".")`.