### PR TITLE
itools: remove livecheck

### DIFF
--- a/Casks/itools.rb
+++ b/Casks/itools.rb
@@ -7,10 +7,5 @@ cask "itools" do
   name "iTools"
   homepage "https://pro.itools.cn/mac/english"
 
-  livecheck do
-    url "http://dl2.itools.hk/update/iTools64ForMacCast.xml"
-    strategy :sparkle
-  end
-
   app "iTools.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `itools.hk` page in the `itools` `livecheck` block now returns a 403 (Forbidden) response with the `:default` user agent and resolves to a parked domain page with a `:browser` user agent. It appears that the `itools.hk` and `itools.cn` websites have disappeared.

I'm not sure how we want to handle this situation in the grand scheme of things but at the very least we need to remove this `livecheck` block. If any further changes need to be made here (e.g., adding `discontinued` to the `caveats`), just let me know or feel free to update this accordingly.