### PR TITLE
Use qlcolorcode for m1 on arm64

### DIFF
--- a/Casks/qlcolorcode.rb
+++ b/Casks/qlcolorcode.rb
@@ -1,11 +1,18 @@
 cask "qlcolorcode" do
-  version "4.1.0"
-  sha256 "a0f7a97a20cd85eebaef15e399ad29c47711dae2e33e9f51de034f3c8a7a251f"
+  version Hardware::CPU.intel? ? "4.1.0" : "4.1.2+m1"
 
-  url "https://github.com/anthonygelibert/QLColorCode/releases/download/release-#{version}/QLColorCode.qlgenerator.zip"
   name "QLColorCode"
   desc "QuickLook plug-in that renders source code with syntax highlighting"
-  homepage "https://github.com/anthonygelibert/QLColorCode"
+
+  if Hardware::CPU.intel?
+    url "https://github.com/anthonygelibert/QLColorCode/releases/download/release-#{version}/QLColorCode.qlgenerator.zip"
+    sha256 "a0f7a97a20cd85eebaef15e399ad29c47711dae2e33e9f51de034f3c8a7a251f"
+    homepage "https://github.com/anthonygelibert/QLColorCode"
+  else
+    url "https://github.com/jpc/QLColorCode/releases/download/release-#{version}/QLColorCode-#{version}.zip"
+    sha256 "2cd375ed04ad7c164ebfbdf5ea9dbf9dc99bbb104b044fd70fe389dc2a836e91"
+    homepage "https://github.com/jpc/QLColorCode"
+  end
 
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
Update the QlColorCode cask for Apple M1 chipset.
The original repository does not support the M1 chipset but in [this discussion](https://github.com/anthonygelibert/QLColorCode/issues/88#issuecomment-927783435) @jpc has fixed it

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
