### PR TITLE
tweetbot 3.5.8,35800

### DIFF
--- a/Casks/tweetbot.rb
+++ b/Casks/tweetbot.rb
@@ -10,8 +10,13 @@ cask "tweetbot" do
 
   livecheck do
     url "https://tapbots.net/tweetbot4/update.plist"
-    strategy :extract_plist do |version|
-      "#{version.values.map(&:short_version).compact.first},#{version.values.map(&:version).compact.first}"
+    regex(%r{
+      <key>shortVersion</key>.*\n.*<string>(\d+(?:\.\d+)+)</string>
+      (?:.*\n){3}.*
+      <key>version</key>.*\n.*<integer>(\d+)</integer>
+    }ix)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/tweetbot.rb
+++ b/Casks/tweetbot.rb
@@ -1,6 +1,6 @@
 cask "tweetbot" do
-  version "3.5.7,35700"
-  sha256 "6245981493a0a7c919d1945b4405647545760eb705d8918ebeeae7500e0898ca"
+  version "3.5.8,35800"
+  sha256 "c9ee91fd2b68ce464ab2e44270c43cd92b3d7cb4f01ee0cea24036d41c84552c"
 
   url "https://tapbots.net/tweetbot4/Tweetbot.#{version.csv.second}.zip",
       verified: "tapbots.net/"

--- a/Casks/tweetbot.rb
+++ b/Casks/tweetbot.rb
@@ -11,10 +11,10 @@ cask "tweetbot" do
   livecheck do
     url "https://tapbots.net/tweetbot4/update.plist"
     regex(%r{
-      <key>shortVersion</key>.*\n.*<string>(\d+(?:\.\d+)+)</string>
-      (?:.*\n){3}.*
-      <key>version</key>.*\n.*<integer>(\d+)</integer>
-    }ix)
+      <key>shortVersion</key>.*?<string>(\d+(?:\.\d+)+)</string>
+      .*?
+      <key>version</key>.*?<integer>(\d+)</integer>
+    }imx)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end


### PR DESCRIPTION
This PR improves the tweetbot livecheck and bumps the version to 3.5.8.

Currently, the `extract_plist` strategy is used, which causes the livecheck URL to be ignored. Instead, the app itself is downloaded and the version is extracted from there.
With this patch applied, the latest version will be extracted from the `update.plist`. In comparison to the current implementation, this will actually return the latest available version instead of only returning the current version of the cask.

---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
