### PR TITLE
graphicconverter: update livecheck

### DIFF
--- a/Casks/graphicconverter.rb
+++ b/Casks/graphicconverter.rb
@@ -8,13 +8,12 @@ cask "graphicconverter" do
   desc "For browsing, enhancing and converting images"
   homepage "https://www.lemkesoft.de/en/products/graphicconverter/"
 
-  # TODO: Return to using the `Sparkle` strategy once all `item`s are passed
-  # into the `strategy` and we can omit items using the `beta` channel.
+  # The Sparkle feed can contain items on the "beta" channel, so we restrict
+  # matching to the default channel.
   livecheck do
     url "https://www.lemkesoft.info/sparkle/graphicconverter/graphicconverter#{version.major}.xml"
-    regex(/<title>Version\s+(\d+(?:\.\d+)+)\s+Build\s+(\d+)(?:<|\s+\()/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.nice_version
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `graphicconverter` was a temporary workaround to avoid a release on the `beta` channel and allow us to identify the latest stable version (see https://github.com/Homebrew/homebrew-cask/pull/124613#issuecomment-1142363624). The workaround was necessary at the time, as the `Sparkle` strategy was only set up to pass one item into a `strategy` block (not all items) and the channel value wasn't surfaced in `Sparkle::Item` objects.

These shortcomings have been resolved in Homebrew/brew#13357 and Homebrew/brew#13368, so we can now filter items by channel in a `strategy` block. This PR updates `graphicconverter` to use the `Sparkle` strategy again, along with a `strategy` block that identifies the newest item on the default channel.