### PR TITLE
Sign Radarr per install instructions

### DIFF
--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -20,6 +20,10 @@ cask "radarr" do
     strategy :github_latest
   end
 
+  postflight do
+    `codesign --force --deep -s - /Applications/Radarr.app`
+  end
+
   depends_on macos: ">= :high_sierra"
 
   app "Radarr.app"

--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -20,13 +20,13 @@ cask "radarr" do
     strategy :github_latest
   end
 
-  postflight do
-    `codesign --force --deep -s - /Applications/Radarr.app`
-  end
-
   depends_on macos: ">= :high_sierra"
 
   app "Radarr.app"
+
+  postflight do
+    `codesign --force --deep -s - /Applications/Radarr.app`
+  end
 
   zap trash: [
     "~/.config/Radarr",


### PR DESCRIPTION
Radarr apparently doesn't sign their packages, and expects end-users to
do that after putting the .app in /Applications. This PR adds a
postflight step to run the `codesign` command, following the
instructions at https://radarr.video/#downloads-v3-macos.

Without this step, macOS refuses to launch the app, with the usual
unsigned code message "cannot be opened".