### PR TITLE
Update bili-downloader from 1.6.20220521 to 1.6.20220605

### DIFF
--- a/Casks/bili-downloader.rb
+++ b/Casks/bili-downloader.rb
@@ -1,6 +1,6 @@
 cask "bili-downloader" do
-  version "1.6.20220521"
-  sha256 "ebfb5cb55f9662259b5fa2d9ffbcab93b5407b8b505c79c5bb3d47bfced85aed"
+  version "1.6.20220605"
+  sha256 "d1011be8ea088fd6b3e20278a32b8227de4dba02498dee4f27697df993d7a4d7"
 
   url "https://github.com/JimmyLiang-lzm/biliDownloader_GUI/releases/download/V#{version}/BiliDownloader_for_MacOS_X.dmg"
   name "BiliDownloader"


### PR DESCRIPTION
Update the bili-downloader for latest version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

