### PR TITLE
Correct various minimum macOS versions

### DIFF
--- a/Casks/apache-couchdb.rb
+++ b/Casks/apache-couchdb.rb
@@ -21,7 +21,7 @@ cask "apache-couchdb" do
     regex(%r{href=.*?/(\d+(?:\.\d+)+)/mac/3.2.2-1/Apache[._-]?CouchDB\.zip}i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :mojave"
 
   app "Apache CouchDB.app"
 

--- a/Casks/clover.rb
+++ b/Casks/clover.rb
@@ -13,7 +13,7 @@ cask "clover" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "Clover.app"
 

--- a/Casks/deezer.rb
+++ b/Casks/deezer.rb
@@ -13,7 +13,7 @@ cask "deezer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "Deezer.app"
 

--- a/Casks/devonagent.rb
+++ b/Casks/devonagent.rb
@@ -13,7 +13,7 @@ cask "devonagent" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "DEVONagent.app"
 end

--- a/Casks/duplicate-file-finder.rb
+++ b/Casks/duplicate-file-finder.rb
@@ -12,7 +12,7 @@ cask "duplicate-file-finder" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   app "Duplicate File Finder #{version.major}.app"
 

--- a/Casks/fabfilter-micro.rb
+++ b/Casks/fabfilter-micro.rb
@@ -17,7 +17,7 @@ cask "fabfilter-micro" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Micro #{version} Installer.pkg"
 

--- a/Casks/fabfilter-one.rb
+++ b/Casks/fabfilter-one.rb
@@ -17,7 +17,7 @@ cask "fabfilter-one" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter One #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-c.rb
+++ b/Casks/fabfilter-pro-c.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-c" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-C #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-ds.rb
+++ b/Casks/fabfilter-pro-ds.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-ds" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-DS #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-g.rb
+++ b/Casks/fabfilter-pro-g.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-g" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-G #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-l.rb
+++ b/Casks/fabfilter-pro-l.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-l" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-L #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-mb.rb
+++ b/Casks/fabfilter-pro-mb.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-mb" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-MB #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-q.rb
+++ b/Casks/fabfilter-pro-q.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-q" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-Q #{version} Installer.pkg"
 

--- a/Casks/fabfilter-pro-r.rb
+++ b/Casks/fabfilter-pro-r.rb
@@ -17,7 +17,7 @@ cask "fabfilter-pro-r" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Pro-R #{version} Installer.pkg"
 

--- a/Casks/fabfilter-saturn.rb
+++ b/Casks/fabfilter-saturn.rb
@@ -17,7 +17,7 @@ cask "fabfilter-saturn" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Saturn #{version} Installer.pkg"
 

--- a/Casks/fabfilter-simplon.rb
+++ b/Casks/fabfilter-simplon.rb
@@ -17,7 +17,7 @@ cask "fabfilter-simplon" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Simplon #{version} Installer.pkg"
 

--- a/Casks/fabfilter-timeless.rb
+++ b/Casks/fabfilter-timeless.rb
@@ -17,7 +17,7 @@ cask "fabfilter-timeless" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Timeless #{version} Installer.pkg"
 

--- a/Casks/fabfilter-twin.rb
+++ b/Casks/fabfilter-twin.rb
@@ -17,7 +17,7 @@ cask "fabfilter-twin" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Twin #{version} Installer.pkg"
 

--- a/Casks/fabfilter-volcano.rb
+++ b/Casks/fabfilter-volcano.rb
@@ -17,7 +17,7 @@ cask "fabfilter-volcano" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   pkg "FabFilter Volcano #{version} Installer.pkg"
 

--- a/Casks/ff-works.rb
+++ b/Casks/ff-works.rb
@@ -12,7 +12,7 @@ cask "ff-works" do
     regex(/version\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "ff·Works.app"
 

--- a/Casks/focus.rb
+++ b/Casks/focus.rb
@@ -12,7 +12,7 @@ cask "focus" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   app "Focus.app"
 

--- a/Casks/fontforge.rb
+++ b/Casks/fontforge.rb
@@ -18,7 +18,7 @@ cask "fontforge" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :catalina"
 
   app "FontForge.app"
 

--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -21,7 +21,7 @@ cask "gitkraken" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "GitKraken.app"
 

--- a/Casks/imgotv.rb
+++ b/Casks/imgotv.rb
@@ -14,7 +14,7 @@ cask "imgotv" do
     regex(%r{/app/mac/(\d+(?:[._]\d+)+)/mgtv[._-]mango\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   app "芒果TV.app"
 

--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -7,7 +7,7 @@ cask "intel-haxm" do
   desc "Hardware-assisted virtualization engine (hypervisor)"
   homepage "https://github.com/intel/haxm"
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
   depends_on arch: :x86_64
 
   installer script: {

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -802,7 +802,7 @@ cask "libreoffice-language-pack" do
   end
 
   depends_on cask: "libreoffice"
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   installer manual: "LibreOffice Language Pack.app"
 

--- a/Casks/macpass.rb
+++ b/Casks/macpass.rb
@@ -9,7 +9,7 @@ cask "macpass" do
   homepage "https://macpass.github.io/"
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "MacPass.app"
 

--- a/Casks/musescore.rb
+++ b/Casks/musescore.rb
@@ -14,7 +14,7 @@ cask "musescore" do
     regex(%r{href=.*?/MuseScore-(\d+(?:\.\d+)*)\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :mojave"
 
   app "MuseScore #{version.major}.app"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)

--- a/Casks/navicat-data-modeler-essentials.rb
+++ b/Casks/navicat-data-modeler-essentials.rb
@@ -11,7 +11,7 @@ cask "navicat-data-modeler-essentials" do
     cask "navicat-data-modeler"
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :mojave"
 
   app "Navicat Data Modeler Essentials.app"
 end

--- a/Casks/nordpass.rb
+++ b/Casks/nordpass.rb
@@ -14,7 +14,7 @@ cask "nordpass" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "NordPass.app"
 

--- a/Casks/poedit.rb
+++ b/Casks/poedit.rb
@@ -13,7 +13,7 @@ cask "poedit" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "Poedit.app"
 

--- a/Casks/qqlive.rb
+++ b/Casks/qqlive.rb
@@ -15,7 +15,7 @@ cask "qqlive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "QQLive.app"
 

--- a/Casks/receipts.rb
+++ b/Casks/receipts.rb
@@ -12,7 +12,7 @@ cask "receipts" do
     regex(/href=.*?Receipts[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "Receipts.app"
 end

--- a/Casks/rightfont.rb
+++ b/Casks/rightfont.rb
@@ -13,7 +13,7 @@ cask "rightfont" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "RightFont.app"
 

--- a/Casks/runjs.rb
+++ b/Casks/runjs.rb
@@ -14,7 +14,7 @@ cask "runjs" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "RunJS.app"
 

--- a/Casks/stack-stack.rb
+++ b/Casks/stack-stack.rb
@@ -21,7 +21,7 @@ cask "stack-stack" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "Stack.app"
 

--- a/Casks/termius.rb
+++ b/Casks/termius.rb
@@ -15,7 +15,7 @@ cask "termius" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "Termius.app"
 

--- a/Casks/thunder.rb
+++ b/Casks/thunder.rb
@@ -15,7 +15,7 @@ cask "thunder" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "Thunder.app"
 

--- a/Casks/ubersicht.rb
+++ b/Casks/ubersicht.rb
@@ -13,7 +13,7 @@ cask "ubersicht" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :el_capitan"
 
   app "Übersicht.app"
 

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -19,7 +19,7 @@ cask "waterfox" do
     regex(/^G?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :sierra"
 
   app "Waterfox.app"
 

--- a/Casks/xlplayer.rb
+++ b/Casks/xlplayer.rb
@@ -16,7 +16,7 @@ cask "xlplayer" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
+  depends_on macos: ">= :high_sierra"
 
   app "XLPlayer.app"
 


### PR DESCRIPTION
This is stage 1 of removing `:yosemite` references from Homebrew/cask (Yosemite support will be removed from Homebrew 3.5.0).

This PR goes through some `depends_on macos: ">= :yosemite"` and corrects them to the actual minimum supported macOS versions as documented by their respective upstream website or in the `LSMinimumSystemVersion` Info.plist entry.