### PR TITLE
Remove no-op Yosemite dependencies

### DIFF
--- a/Casks/a-better-finder-rename.rb
+++ b/Casks/a-better-finder-rename.rb
@@ -13,7 +13,6 @@ cask "a-better-finder-rename" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "A Better Finder Rename #{version.major}.app"
 

--- a/Casks/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/anka-build-cloud-controller-and-registry.rb
@@ -13,8 +13,6 @@ cask "anka-build-cloud-controller-and-registry" do
     regex(/AnkaControllerRegistry[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "AnkaControllerRegistry-#{version}.pkg"
 
   uninstall script: {

--- a/Casks/ankama.rb
+++ b/Casks/ankama.rb
@@ -12,8 +12,6 @@ cask "ankama" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Ankama Launcher.app"
 
   uninstall quit: "Ankama Launcher"

--- a/Casks/app-cleaner.rb
+++ b/Casks/app-cleaner.rb
@@ -12,8 +12,6 @@ cask "app-cleaner" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "App Cleaner #{version.major}.app"
 
   zap trash: [

--- a/Casks/arq.rb
+++ b/Casks/arq.rb
@@ -13,7 +13,6 @@ cask "arq" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   pkg "Arq#{version}.pkg"
 

--- a/Casks/background-music.rb
+++ b/Casks/background-music.rb
@@ -12,8 +12,6 @@ cask "background-music" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "BackgroundMusic-#{version}.pkg"
 
   uninstall_postflight do

--- a/Casks/baidunetdisk.rb
+++ b/Casks/baidunetdisk.rb
@@ -15,7 +15,6 @@ cask "baidunetdisk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "BaiduNetdisk_mac.app"
 

--- a/Casks/bestres.rb
+++ b/Casks/bestres.rb
@@ -19,7 +19,5 @@ cask "bestres" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "BestRes.app"
 end

--- a/Casks/better-window-manager.rb
+++ b/Casks/better-window-manager.rb
@@ -11,7 +11,5 @@ cask "better-window-manager" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Better Window Manager.app"
 end

--- a/Casks/bluegriffon.rb
+++ b/Casks/bluegriffon.rb
@@ -12,7 +12,5 @@ cask "bluegriffon" do
     regex(%r{href=['"]?(\d+(?:\.\d+)+)/}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "BlueGriffon.app"
 end

--- a/Casks/bluesense.rb
+++ b/Casks/bluesense.rb
@@ -11,8 +11,6 @@ cask "bluesense" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "BlueSense.app"
 
   zap trash: [

--- a/Casks/boom-3d.rb
+++ b/Casks/boom-3d.rb
@@ -13,8 +13,6 @@ cask "boom-3d" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Boom 3D.app"
 
   uninstall launchctl: [

--- a/Casks/boom.rb
+++ b/Casks/boom.rb
@@ -13,8 +13,6 @@ cask "boom" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Boom 2.app"
 
   uninstall kext:      "com.globaldelight.driver.Boom2Device",

--- a/Casks/bootstrap-studio.rb
+++ b/Casks/bootstrap-studio.rb
@@ -13,7 +13,6 @@ cask "bootstrap-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Bootstrap Studio.app"
 

--- a/Casks/ccleaner.rb
+++ b/Casks/ccleaner.rb
@@ -12,8 +12,6 @@ cask "ccleaner" do
     regex(/CCleaner\s*for\s*Mac\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Install CCleaner.pkg"
 
   uninstall quit:      "com.piriform.ccleaner",

--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -31,8 +31,6 @@ cask "choosy" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   uninstall pkgutil: "com.choosyosx.Choosy",
             quit:    "com.choosyosx.Choosy"
 

--- a/Casks/clipy.rb
+++ b/Casks/clipy.rb
@@ -8,8 +8,6 @@ cask "clipy" do
   desc "Clipboard extension app"
   homepage "https://clipy-app.com/"
 
-  depends_on macos: ">= :yosemite"
-
   app "Clipy.app"
 
   uninstall quit: "com.clipy-app.Clipy"

--- a/Casks/coin-wallet.rb
+++ b/Casks/coin-wallet.rb
@@ -9,7 +9,6 @@ cask "coin-wallet" do
   homepage "https://coin.space/"
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Coin Wallet.app"
 

--- a/Casks/default-folder-x.rb
+++ b/Casks/default-folder-x.rb
@@ -13,7 +13,6 @@ cask "default-folder-x" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Default Folder X.app"
 

--- a/Casks/disk-expert.rb
+++ b/Casks/disk-expert.rb
@@ -12,8 +12,6 @@ cask "disk-expert" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Disk Expert #{version.major}.app"
 
   zap trash: [

--- a/Casks/diskmaker-x.rb
+++ b/Casks/diskmaker-x.rb
@@ -20,6 +20,4 @@ cask "diskmaker-x" do
   name "DiskMaker X"
   desc "Tool to build a system install disk"
   homepage "https://diskmakerx.com/"
-
-  depends_on macos: ">= :yosemite"
 end

--- a/Casks/duo-connect.rb
+++ b/Casks/duo-connect.rb
@@ -13,8 +13,6 @@ cask "duo-connect" do
     regex(%r{href=.*?/DuoConnect[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "DuoConnect-#{version}.pkg"
 
   uninstall launchctl: [

--- a/Casks/dvdstyler.rb
+++ b/Casks/dvdstyler.rb
@@ -13,7 +13,5 @@ cask "dvdstyler" do
     regex(/DVDStyler[._-]?(\d+(?:\.\d+)+)[._-]?MacOSX\.dmg/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "DVDStyler.app"
 end

--- a/Casks/easytether.rb
+++ b/Casks/easytether.rb
@@ -12,8 +12,6 @@ cask "easytether" do
     regex(%r{href=.*?/easytether[._-]yosemite[._-]b?(\d+(?:\.\d+)*)\.pkg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "easytether-yosemite-b#{version}.pkg"
 
   uninstall pkgutil:   "com.mobile-stream.pkg.EasyTether",

--- a/Casks/enclave.rb
+++ b/Casks/enclave.rb
@@ -12,8 +12,6 @@ cask "enclave" do
     regex(/(\d+(?:\.\d+)*)/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "enclave_osx-installer-x64-stable-#{version}.pkg"
   binary "/Applications/enclave/enclave"
 

--- a/Casks/f-bar.rb
+++ b/Casks/f-bar.rb
@@ -19,7 +19,6 @@ cask "f-bar" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "F-Bar.app"
 

--- a/Casks/goodsync.rb
+++ b/Casks/goodsync.rb
@@ -12,8 +12,6 @@ cask "goodsync" do
     regex(/GoodSync\s+for\s+Mac\s+v?\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "GoodSync.app"
 
   zap trash: [

--- a/Casks/hackolade.rb
+++ b/Casks/hackolade.rb
@@ -13,8 +13,6 @@ cask "hackolade" do
     regex(/Current\sversion:\sv?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Hackolade-mac-setup-signed.pkg"
 
   uninstall pkgutil: "com.hackolade.pkg.Hackolade"

--- a/Casks/hype.rb
+++ b/Casks/hype.rb
@@ -12,8 +12,6 @@ cask "hype" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   # Renamed for consistency: app name is different in the Finder and in a shell
   app "Hype#{version.major}.app", target: "Hype #{version.major}.app"
 

--- a/Casks/infinity.rb
+++ b/Casks/infinity.rb
@@ -7,8 +7,6 @@ cask "infinity" do
   desc "Customizable work management platform"
   homepage "https://startinfinity.com/"
 
-  depends_on macos: ">= :yosemite"
-
   app "Infinity.app"
 
   uninstall quit: [

--- a/Casks/ios-saver.rb
+++ b/Casks/ios-saver.rb
@@ -7,7 +7,5 @@ cask "ios-saver" do
   name "iOS 8 Lockscreen for OSX"
   homepage "http://littleendiangamestudios.com/project/ios-8-screen-saver/"
 
-  depends_on macos: ">= :yosemite"
-
   screen_saver "iOS Saver.saver"
 end

--- a/Casks/ipe.rb
+++ b/Casks/ipe.rb
@@ -8,8 +8,6 @@ cask "ipe" do
   desc "Drawing editor for creating figures in PDF format"
   homepage "https://ipe.otfried.org/"
 
-  depends_on macos: ">= :yosemite"
-
   app "Ipe.app"
 
   zap trash: [

--- a/Casks/ipepresenter.rb
+++ b/Casks/ipepresenter.rb
@@ -8,7 +8,5 @@ cask "ipepresenter" do
   desc "Make presentations from PDFs"
   homepage "https://ipepresenter.otfried.org/"
 
-  depends_on macos: ">= :yosemite"
-
   app "IpePresenter.app"
 end

--- a/Casks/ipsecuritas.rb
+++ b/Casks/ipsecuritas.rb
@@ -25,8 +25,6 @@ cask "ipsecuritas" do
     regex(%r{href=.*?/ipSecuritas[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "IPSecuritas.app"
 
   zap trash: [

--- a/Casks/itubedownloader.rb
+++ b/Casks/itubedownloader.rb
@@ -13,7 +13,5 @@ cask "itubedownloader" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "iTubeDownloader.app"
 end

--- a/Casks/izip.rb
+++ b/Casks/izip.rb
@@ -12,8 +12,6 @@ cask "izip" do
     regex(%r{<li>Version:\s*(\d+(?:\.\d+)+)</li>}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "iZip.app"
 
   zap trash: "~/Library/Preferences/com.codeius.izip.plist"

--- a/Casks/keyman.rb
+++ b/Casks/keyman.rb
@@ -12,8 +12,6 @@ cask "keyman" do
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   input_method "Install Keyman.app/Contents/MacOS/Keyman.app"
 
   uninstall quit: "keyman.inputmethod.Keyman"

--- a/Casks/kiwi-for-gmail.rb
+++ b/Casks/kiwi-for-gmail.rb
@@ -12,8 +12,6 @@ cask "kiwi-for-gmail" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Kiwi for Gmail.app"
 
   zap trash: [

--- a/Casks/knotes.rb
+++ b/Casks/knotes.rb
@@ -13,8 +13,6 @@ cask "knotes" do
     regex(%r{href=.*?/Knotes[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Knotes.app"
 
   zap trash: [

--- a/Casks/ktalk.rb
+++ b/Casks/ktalk.rb
@@ -13,8 +13,6 @@ cask "ktalk" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Толк.app"
 
   uninstall quit:      "kontur.talk",

--- a/Casks/macdropany.rb
+++ b/Casks/macdropany.rb
@@ -14,8 +14,6 @@ cask "macdropany" do
     regex(%r{href=.*?/MacDropAny\.(\d+(?:\.\d+)*)\.zip}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "MacDropAny.app"
 
   zap trash: "~/Library/Services/Sync via MacDropAny.workflow"

--- a/Casks/memory-cleaner.rb
+++ b/Casks/memory-cleaner.rb
@@ -12,8 +12,6 @@ cask "memory-cleaner" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Memory Cleaner #{version.major}.app"
 
   zap trash: [

--- a/Casks/mendeley-reference-manager.rb
+++ b/Casks/mendeley-reference-manager.rb
@@ -12,8 +12,6 @@ cask "mendeley-reference-manager" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Mendeley Reference Manager.app"
 
   zap trash: [

--- a/Casks/meta.rb
+++ b/Casks/meta.rb
@@ -12,7 +12,5 @@ cask "meta" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Meta.app"
 end

--- a/Casks/microsoft-excel.rb
+++ b/Casks/microsoft-excel.rb
@@ -30,7 +30,6 @@ cask "microsoft-excel" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_Excel_#{version}_Installer.pkg",
       choices: [

--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -30,7 +30,6 @@ cask "microsoft-outlook" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_Outlook_#{version}_Installer.pkg",
       choices: [

--- a/Casks/microsoft-powerpoint.rb
+++ b/Casks/microsoft-powerpoint.rb
@@ -30,7 +30,6 @@ cask "microsoft-powerpoint" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_PowerPoint_#{version}_Installer.pkg",
       choices: [

--- a/Casks/microsoft-word.rb
+++ b/Casks/microsoft-word.rb
@@ -30,7 +30,6 @@ cask "microsoft-word" do
   auto_updates true
   conflicts_with cask: "microsoft-office"
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :yosemite"
 
   pkg "Microsoft_Word_#{version}_Installer.pkg",
       choices: [

--- a/Casks/mkvtoolnix.rb
+++ b/Casks/mkvtoolnix.rb
@@ -27,7 +27,6 @@ cask "mkvtoolnix" do
   end
 
   conflicts_with formula: "mkvtoolnix"
-  depends_on macos: ">= :yosemite"
 
   app "MKVToolNix-#{version}.app"
   binary "#{appdir}/MKVToolNix-#{version}.app/Contents/MacOS/mkvextract"

--- a/Casks/neo4j.rb
+++ b/Casks/neo4j.rb
@@ -14,7 +14,5 @@ cask "neo4j" do
     regex(%r{href=.*?/neo4j-desktop/.*?flavour=osx.*?release=(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Neo4j Desktop.app"
 end

--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -23,8 +23,6 @@ cask "nextcloud" do
     regex(/Nextcloud[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "Nextcloud-#{version}.pkg"
   binary "/Applications/Nextcloud.app/Contents/MacOS/nextcloudcmd"
 

--- a/Casks/nomad.rb
+++ b/Casks/nomad.rb
@@ -6,8 +6,6 @@ cask "nomad" do
   name "NoMAD"
   homepage "https://nomad.menu/"
 
-  depends_on macos: ">= :yosemite"
-
   pkg "NoMAD.pkg"
 
   uninstall pkgutil: "com.trusourcelabs.NoMAD"

--- a/Casks/noun-project.rb
+++ b/Casks/noun-project.rb
@@ -13,7 +13,5 @@ cask "noun-project" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Noun Project.app"
 end

--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -55,7 +55,6 @@ cask "omnigraffle" do
   homepage "https://www.omnigroup.com/omnigraffle/"
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "OmniGraffle.app"
 

--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -36,7 +36,6 @@ cask "omniplan" do
 
   auto_updates true
   conflicts_with cask: "homebrew/cask-versions/omniplan3"
-  depends_on macos: ">= :yosemite"
 
   app "OmniPlan.app"
 

--- a/Casks/openvpn-connect.rb
+++ b/Casks/openvpn-connect.rb
@@ -17,8 +17,6 @@ cask "openvpn-connect" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "OpenVPN_Connect_#{version.csv.first.dots_to_underscores}(#{version.csv.second})_Installer_signed.pkg"
 
   uninstall quit:       "org.openvpn.client.app",

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -45,7 +45,6 @@ cask "openzfs" do
   end
 
   conflicts_with cask: "openzfs-dev"
-  depends_on macos: ">= :yosemite"
 
   postflight do
     set_ownership "/usr/local/zfs"

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -13,7 +13,6 @@ cask "plex-media-player" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Plex Media Player.app"
 

--- a/Casks/postico.rb
+++ b/Casks/postico.rb
@@ -13,8 +13,6 @@ cask "postico" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Postico.app"
 
   zap trash: [

--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -31,7 +31,6 @@ cask "powerphotos" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "PowerPhotos.app"
 end

--- a/Casks/progressive-downloader.rb
+++ b/Casks/progressive-downloader.rb
@@ -12,8 +12,6 @@ cask "progressive-downloader" do
     regex(%r{href=.*?/(\d+(?:\.\d+)+)/PSD\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Progressive Downloader.app"
 
   zap trash: [

--- a/Casks/qbserve.rb
+++ b/Casks/qbserve.rb
@@ -12,7 +12,6 @@ cask "qbserve" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Qbserve.app"
 

--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -19,8 +19,6 @@ cask "remember-the-milk" do
     regex(%r{<b>Version:</b>\s*(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Remember The Milk.app"
 
   zap trash: [

--- a/Casks/removebg.rb
+++ b/Casks/removebg.rb
@@ -12,7 +12,5 @@ cask "removebg" do
     regex(%r{/removebg[._-]for[._-]mac[._-](\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "remove.bg.app"
 end

--- a/Casks/sabnzbd.rb
+++ b/Casks/sabnzbd.rb
@@ -13,8 +13,6 @@ cask "sabnzbd" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "SABnzbd.app"
 
   zap trash: "~/Library/Application Support/SABnzbd"

--- a/Casks/scidavis.rb
+++ b/Casks/scidavis.rb
@@ -13,7 +13,5 @@ cask "scidavis" do
     regex(%r{/scidavis[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]dist\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "scidavis.app"
 end

--- a/Casks/sketchpacks.rb
+++ b/Casks/sketchpacks.rb
@@ -7,7 +7,5 @@ cask "sketchpacks" do
   name "Sketchpacks"
   homepage "https://sketchpacks.com/"
 
-  depends_on macos: ">= :yosemite"
-
   app "Sketchpacks.app"
 end

--- a/Casks/sonobus.rb
+++ b/Casks/sonobus.rb
@@ -12,8 +12,6 @@ cask "sonobus" do
     regex(%r{href=.*?/sonobus[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "SonoBus Installer.pkg"
 
   uninstall pkgutil: [

--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -33,8 +33,6 @@ cask "suspicious-package" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Suspicious Package.app"
   binary "#{appdir}/Suspicious Package.app/Contents/SharedSupport/spkg"
 

--- a/Casks/taskade.rb
+++ b/Casks/taskade.rb
@@ -12,8 +12,6 @@ cask "taskade" do
     regex(%r{href=.*?/Taskade[._-]v?(\d+(?:\.\d+)+)[._-]universal\.dmg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Taskade.app"
 
   zap trash: [

--- a/Casks/tqsl.rb
+++ b/Casks/tqsl.rb
@@ -12,8 +12,6 @@ cask "tqsl" do
     regex(%r{href=.*?/tqsl[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
   end
 
-  depends_on macos: ">= :yosemite"
-
   pkg "tqsl-#{version}.pkg"
 
   uninstall pkgutil: "org.arrl.tqsl"

--- a/Casks/trim-enabler.rb
+++ b/Casks/trim-enabler.rb
@@ -19,8 +19,6 @@ cask "trim-enabler" do
     end
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Trim Enabler.app"
 
   uninstall delete:    "/Library/PrivilegedHelperTools/org.cindori.TEHelper",

--- a/Casks/tripmode.rb
+++ b/Casks/tripmode.rb
@@ -27,7 +27,6 @@ cask "tripmode" do
   homepage "https://www.tripmode.ch/"
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "TripMode.app"
 

--- a/Casks/tunnelblick.rb
+++ b/Casks/tunnelblick.rb
@@ -20,7 +20,6 @@ cask "tunnelblick" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "Tunnelblick.app"
 

--- a/Casks/ultdata.rb
+++ b/Casks/ultdata.rb
@@ -8,7 +8,6 @@ cask "ultdata" do
   homepage "https://www.tenorshare.com/products/iphone-data-recovery.html"
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "UltData.app"
 

--- a/Casks/unclutter.rb
+++ b/Casks/unclutter.rb
@@ -12,8 +12,6 @@ cask "unclutter" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :yosemite"
-
   app "Unclutter.app"
 
   zap trash: [

--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -21,7 +21,6 @@ cask "utools" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   app "uTools.app"
 

--- a/Casks/whatsyoursign.rb
+++ b/Casks/whatsyoursign.rb
@@ -8,8 +8,6 @@ cask "whatsyoursign" do
   desc "Shows a files cryptographic signing information"
   homepage "https://objective-see.com/products/whatsyoursign.html"
 
-  depends_on macos: ">= :yosemite"
-
   installer manual: "WhatsYourSign Installer.app"
 
   uninstall delete: [

--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -13,7 +13,6 @@ cask "witch" do
   end
 
   auto_updates true
-  depends_on macos: ">= :yosemite"
 
   prefpane "Witch.prefPane"
 


### PR DESCRIPTION
This is stage 2 of removing `:yosemite` references from Homebrew/cask (Yosemite support will be removed from Homebrew 3.5.0).

This PR removes all remaining `depends_on macos: ">= :yosemite"` lines. They were already no-op considering we haven't supported < Yosemite in Homebrew for a while now, and those lines are due to throw a deprecation warning soon.

This PR does _not_ remove any conditions like `MacOS.version <= :yosemite`. I do not intend to make any changes that remove Yosemite support until _after_ 3.5.0 - the changes so far should be harmless for Yosemite users.