### PR TITLE
cmd/lib/check.rb: fix regex error

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -105,7 +105,7 @@ module Check
 
     installed_kexts = diff[:installed_kexts]
                       .added
-                      .grep_v(/^com\.(softraid\.driver\.SoftRAID|com\.highpoint-tech\.kext\.*)/)
+                      .grep_v(/^com\.(softraid\.driver\.SoftRAID|highpoint-tech\.kext\.*)/)
     if installed_kexts.any?
       message = "Some kernel extensions are still installed, add them to #{Formatter.identifier("uninstall kext:")}\n"
       message += installed_kexts.join("\n")


### PR DESCRIPTION
Fixes a minor error in a regex.

CI should skip known false positive, however the error in the regex is causing the failure to continue -
https://github.com/Homebrew/homebrew-cask-drivers/runs/6749703857?check_suite_focus=true#step:21:28