### PR TITLE
Jpc qlcolorcode for Mac m1 (arm64)

### DIFF
--- a/Casks/jpc-qlcolorcode.rb
+++ b/Casks/jpc-qlcolorcode.rb
@@ -1,0 +1,15 @@
+cask "jpc-qlcolorcode" do
+  version "4.1.2+m1"
+  sha256 "2cd375ed04ad7c164ebfbdf5ea9dbf9dc99bbb104b044fd70fe389dc2a836e91"
+
+  url "https://github.com/jpc/QLColorCode/releases/download/release-#{version}/QLColorCode-#{version}.zip"
+  name "QLColorCode"
+  desc "QuickLook plug-in that renders source code with syntax highlighting"
+  homepage "https://github.com/jpc/QLColorCode"
+
+  depends_on macos: ">= :mojave"
+
+  qlplugin "QLColorCode.qlgenerator"
+
+  zap trash: "~/Library/Preferences/org.n8gray.QLColorCode.plist"
+end


### PR DESCRIPTION
Create cask for the QlColorCode fork for Apple M1 chipset.
The original repository does not support the M1 chipset but in [this discussion](https://github.com/anthonygelibert/QLColorCode/issues/88#issuecomment-927783435) @jpc has fixed it

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
