### PR TITLE
Update bitwarden version, repo URL and version regex

### DIFF
--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,9 +1,9 @@
 cask "bitwarden" do
-  version "1.33.0"
-  sha256 "75853b87565c5bb729260f56ad8d7cf890c143efc265fc11f9ee9b64d840e2d4"
+  version "2022.5.1"
+  sha256 "7e9775f06142d903fcc8d39ee80fe2384602e21e4ce70eaa7fb1d3bef9632a25"
 
-  url "https://github.com/bitwarden/desktop/releases/download/v#{version}/Bitwarden-#{version}-universal-mac.zip",
-      verified: "github.com/bitwarden/desktop/"
+  url "https://github.com/bitwarden/clients/releases/download/desktop-v#{version}/Bitwarden-#{version}-universal-mac.zip",
+      verified: "github.com/bitwarden/clients/"
   name "Bitwarden"
   desc "Desktop password and login vault"
   homepage "https://bitwarden.com/"
@@ -11,6 +11,7 @@ cask "bitwarden" do
   livecheck do
     url :url
     strategy :github_latest
+    regex(%r{href=.*?/tag/desktop-v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   auto_updates true

--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -1,8 +1,8 @@
 cask "bitwarden" do
   version "2022.5.1"
-  sha256 "7e9775f06142d903fcc8d39ee80fe2384602e21e4ce70eaa7fb1d3bef9632a25"
+  sha256 "cd2adc73ddf91cc0d22484505e680bb44bc4821d3b3d1a2668370ed26ad1818c"
 
-  url "https://github.com/bitwarden/clients/releases/download/desktop-v#{version}/Bitwarden-#{version}-universal-mac.zip",
+  url "https://github.com/bitwarden/clients/releases/download/desktop-v#{version}/Bitwarden-#{version}-universal.dmg",
       verified: "github.com/bitwarden/clients/"
   name "Bitwarden"
   desc "Desktop password and login vault"

--- a/Casks/bitwarden.rb
+++ b/Casks/bitwarden.rb
@@ -11,7 +11,7 @@ cask "bitwarden" do
   livecheck do
     url :url
     strategy :github_latest
-    regex(%r{href=.*?/tag/desktop-v?(\d+(?:\.\d+)+)["' >]}i)
+    regex(/href=.*?Bitwarden[._-]v?(\d+(?:\.\d+)+)-universal\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
Bitwarden Desktop repo has been merged with Clients repo

https://github.com/bitwarden/desktop --> https://github.com/bitwarden/clients

See:
<img width="500" alt="Screen Shot 2022-06-08 at 21 31 27" src="https://user-images.githubusercontent.com/14910943/172690822-86b5300d-14dd-47b9-8f82-3f10867d1613.png">

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
