### PR TITLE
Add sparkle-cli to sparkle 2.1.0

### DIFF
--- a/Casks/sparkle.rb
+++ b/Casks/sparkle.rb
@@ -14,4 +14,5 @@ cask "sparkle" do
   end
 
   app "Sparkle Test App.app"
+  binary "sparkle.app/Contents/MacOS/sparkle"
 end


### PR DESCRIPTION
Sparkle now includes new sparkle CLI tool, that can be used to update Sparkle applications externally: https://sparkle-project.org/documentation/sparkle-cli/

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.