### PR TITLE
dbeaver-community: remove auto_updates stanza

### DIFF
--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -19,8 +19,6 @@ cask "dbeaver-community" do
     strategy :github_latest
   end
 
-  auto_updates true
-
   app "DBeaver.app"
 
   uninstall signal: ["TERM", "org.jkiss.dbeaver.core.product"]


### PR DESCRIPTION
Upgrades initiated from the "Check for Updates" menu item or via "Automatic updates check"  do not actually occur automatically. They still require a manual (and obnoxious) drag and drop step, so auto_updates is inappropriate.

This Cask does not meet the criteria for including the `auto_updates` stanza described in the [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook). Namely, it does not "do the download and installation for you" (it does the download but NOT the installation). So, better to let Homebrew do the work.