### PR TITLE
Update bili-downloader from V1.6.20220605 to V1.6.20220610

### DIFF
--- a/Casks/bili-downloader.rb
+++ b/Casks/bili-downloader.rb
@@ -1,6 +1,6 @@
 cask "bili-downloader" do
-  version "1.6.20220605"
-  sha256 "d1011be8ea088fd6b3e20278a32b8227de4dba02498dee4f27697df993d7a4d7"
+  version "1.6.20220610"
+  sha256 "57e4b328de09519d0c518505763529e080873573d6307f988365e8fbef940a6b"
 
   url "https://github.com/JimmyLiang-lzm/biliDownloader_GUI/releases/download/V#{version}/BiliDownloader_for_MacOS_X.dmg"
   name "BiliDownloader"


### PR DESCRIPTION
Update bili-downloader from V1.6.20220605 to V1.6.202220610.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

