### PR TITLE
Updating SHA256 value

### DIFF
--- a/Casks/anaconda.rb
+++ b/Casks/anaconda.rb
@@ -6,7 +6,7 @@ cask "anaconda" do
   if Hardware::CPU.intel?
     sha256 "1a10c06660ebe1204e538b4e9d810142441af9dfd74b077eee2761ec6e675f39"
   else
-    sha256 "457b10272f807879ab4289ffb93d7dcb695362b417bb7c80d24892c8d8557b29"
+    sha256 "a12119931945a9a1453993582259cc67318a9a75a15731e5ccc15365e7f88a36"
   end
 
   url "https://repo.anaconda.com/archive/Anaconda3-#{version}-MacOSX-#{arch}.sh"


### PR DESCRIPTION
Opening this PR due to a conflict between the _expected_ SHA256 value and the _actual_ one received by the repo. 

```sh
==> Downloading https://repo.anaconda.com/archive/Anaconda3-2022.05-MacOSX-arm64.sh
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 457b10272f807879ab4289ffb93d7dcb695362b417bb7c80d24892c8d8557b29
  Actual: a12119931945a9a1453993582259cc67318a9a75a15731e5ccc15365e7f88a36
    File: /Users/...../Library/Caches/Homebrew/downloads/3924a4fadc9b75022fb09f8c19af5f9893e744a55f5a4b0fd05859c7aa1a7835--Anaconda3-2022.05-MacOSX-arm64.sh
To retry an incomplete download, remove the file above.
```

Replacing the value solved and installed the cask.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.

```
audit for anaconda: passed
``` 

- [x] `brew style --fix <cask>` reports no offenses.

```
1 file inspected, no offenses detected
``` 


