### PR TITLE
Update lbry from 0.53.3 to 0.53.4

### DIFF
--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -1,6 +1,6 @@
 cask "lbry" do
-  version "0.53.3"
-  sha256 "8288629ebe00ec6f80b5d37792b25e36f29a6775fc8661f209511755f0876f80"
+  version "0.53.4"
+  sha256 "06da7802b3fad9023e759288a854a7447e0f3f87e4094b7552e856a8cb49e918"
 
   url "https://github.com/lbryio/lbry-desktop/releases/download/v#{version}/LBRY_#{version}.dmg",
       verified: "github.com/lbryio/lbry-desktop/"
@@ -11,6 +11,7 @@ cask "lbry" do
   livecheck do
     url :url
     strategy :github_latest
+    regex(%r{href=.*?/lbry-desktop/releases/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
The regex of livecheck is also updated, so that it only matches the latest tag for lbry-desktop.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
