### PR TITLE
更新rustdesk.rb

### DIFF
--- a/Casks/rustdesk.rb
+++ b/Casks/rustdesk.rb
@@ -1,6 +1,6 @@
 cask "rustdesk" do
   version "1.1.9"
-  sha256 "3b9662a8d5d8a6cc994f6edee132f116f35dee4a8a17c3612b784376f7da931f"
+  sha256 "48fd33e3ae6f41a747fe07fc0bad594b0b6a65ce4ea28dd0adfa527e18ccdb2d"
 
   url "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}.dmg",
       verified: "github.com/rustdesk/rustdesk/"


### PR DESCRIPTION
Fix rustdesk installation hash verification error

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
```shell
❯ brew audit --cask --online https://raw.githubusercontent.com/Xonline-Tech/homebrew-cask/a63bbc3fe2f01f92210662d20035cac9818acefd/Casks/rustdesk.rb
==> Downloading https://raw.githubusercontent.com/Xonline-Tech/homebrew-cask/a63
######################################################################## 100.0%
==> Downloading https://github.com/rustdesk/rustdesk/releases/download/1.1.9/rus
Already downloaded: /Users/shihanzhang/Library/Caches/Homebrew/downloads/8e251a3ad397acd71604d6fdc17ff826bc62dd8a03fb3b120462a4c111d04205--rustdesk-1.1.9.dmg
audit for rustdesk: passed
```
- [x] `brew style --fix <cask>` reports no offenses.
```shell
❯ brew style --fix https://raw.githubusercontent.com/Xonline-Tech/homebrew-cask/a63bbc3fe2f01f92210662d20035cac9818acefd/Casks/rustdesk.rb
Library/Caches/Homebrew/Cask/rustdesk.rb:1:1: C: [Corrected] Magic comments should be in the following order: encoding, typed, warn_indent, frozen_string_literal.
# frozen_string_literal: true
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Library/Caches/Homebrew/Cask/rustdesk.rb:1:1: C: [Corrected] No Sorbet sigil found in file. Try a typed: false to start (you can also use rubocop -a to automatically add this).
cask "rustdesk" do
^^^^
Library/Caches/Homebrew/Cask/rustdesk.rb:1:1: C: [Corrected] Missing frozen string literal comment.
cask "rustdesk" do
^
Library/Caches/Homebrew/Cask/rustdesk.rb:2:1: C: [Corrected] Add an empty line after magic comments.
# typed: false
^
Library/Caches/Homebrew/Cask/rustdesk.rb:2:1: C: [Corrected] Magic comments should be in the following order: encoding, typed, warn_indent, frozen_string_literal.
# typed: false
^^^^^^^^^^^^^^
Library/Caches/Homebrew/Cask/rustdesk.rb:3:1: C: [Corrected] Add an empty line after magic comments.
cask "rustdesk" do
^
Library/Caches/Homebrew/Cask/rustdesk.rb:3:1: C: [Corrected] Magic comments should be in the following order: encoding, typed, warn_indent, frozen_string_literal.
# typed: false
^^^^^^^^^^^^^^

1 file inspected, 7 offenses detected, 7 offenses corrected
```
Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
