### PR TITLE
Remove Yosemite support

### DIFF
--- a/Casks/cocktail.rb
+++ b/Casks/cocktail.rb
@@ -1,15 +1,5 @@
 cask "cocktail" do
-  if MacOS.version <= :yosemite
-    version "8.9.2"
-    sha256 "acc7d191313fa0eb4109ae56f62f73e7ed6685f7d7d438d5138b85d68e40edd8"
-
-    url "https://www.maintain.se/downloads/sparkle/yosemite/Cocktail_#{version}.zip"
-
-    livecheck do
-      url "https://www.maintain.se/downloads/sparkle/yosemite/yosemite.xml"
-      strategy :sparkle
-    end
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "9.7"
     sha256 "ca6b4a264ca60a08ff45761f82b0b6161cbe3412bd6cbeedd5dbecebc8d26712"
 

--- a/Casks/coconutbattery.rb
+++ b/Casks/coconutbattery.rb
@@ -1,26 +1,18 @@
 cask "coconutbattery" do
-  if MacOS.version <= :yosemite
-    version "3.6.4"
-    sha256 "8e289fb4a75cb117fc1d7861020c9ab2384b09dfd18f066c7fadfc9d42c3ac56"
+  version "3.9.7,bef5cec9"
+  sha256 "44e6c55fbbbd16ac0541301ada7c46eeffd85a6e5fd2baac46b421d588ba6101"
 
-    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version}.zip"
-  else
-    version "3.9.7,bef5cec9"
-    sha256 "44e6c55fbbbd16ac0541301ada7c46eeffd85a6e5fd2baac46b421d588ba6101"
-
-    url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.csv.first.no_dots}_#{version.csv.second}.zip"
-
-    livecheck do
-      url "https://coconut-flavour.com/updates/coconutBattery.xml"
-      strategy :sparkle do |item|
-        "#{item.version},#{item.url[/_\d+_(.*?)\./i, 1]}"
-      end
-    end
-  end
-
+  url "https://www.coconut-flavour.com/downloads/coconutBattery_#{version.csv.first.no_dots}_#{version.csv.second}.zip"
   name "coconutBattery"
   desc "Tool to show live information about the batteries in various devices"
   homepage "https://www.coconut-flavour.com/coconutbattery/"
+
+  livecheck do
+    url "https://coconut-flavour.com/updates/coconutBattery.xml"
+    strategy :sparkle do |item|
+      "#{item.version},#{item.url[/_\d+_(.*?)\./i, 1]}"
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :sierra"

--- a/Casks/coteditor.rb
+++ b/Casks/coteditor.rb
@@ -1,8 +1,5 @@
 cask "coteditor" do
-  if MacOS.version <= :yosemite
-    version "3.2.8"
-    sha256 "73dd20d27b75c7b0c46242a465adb3df5b5f0b901f42c5a9a85777a57c4a17d6"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "3.5.4"
     sha256 "0b2cbf38cc531268e3691f307445e05ae5da64b48ceaf86c4d16b993c9be3e9f"
   elsif MacOS.version <= :mojave

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -1,8 +1,5 @@
 cask "deeper" do
-  if MacOS.version <= :yosemite
-    version "2.0.4"
-    sha256 "70a8ae37e6a62541a03b1b144ff92bac38585ce936b1acc12ce484416db13b8f"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.1.4"
     sha256 "3dc9607644872da14a0b6f20722e36d0cb6cb7ab2528f86de1cf059086cf2848"
   elsif MacOS.version <= :sierra

--- a/Casks/evernote.rb
+++ b/Casks/evernote.rb
@@ -1,10 +1,5 @@
 cask "evernote" do
-  if MacOS.version <= :yosemite
-    version "6.12.3_455520"
-    sha256 "fdda9701f1d8ff56a5e8bcadcf5b04dba66ad7e08511700de4675d20fda2bc71"
-
-    url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "7.2.3_456885"
     sha256 "eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97"
 

--- a/Casks/horos.rb
+++ b/Casks/horos.rb
@@ -1,8 +1,5 @@
 cask "horos" do
-  if MacOS.version <= :yosemite
-    version "1.1.7"
-    sha256 "d15e02d7678e0f41ad12910176307aeb6312e62d7386051bfe5a261a7feb004a"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.0.2"
     sha256 "5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08"
   else

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -1,8 +1,5 @@
 cask "maintenance" do
-  if MacOS.version <= :yosemite
-    version "2.0.7"
-    sha256 "5c926159c0610fe705b0f23b56672f1c5e46c970f92013839c772147379520f9"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.1.8"
     sha256 "f27f5d0736e80cd80c85dcc5390dfeb893183424fe65b32b08e280c90b22b24c"
   elsif MacOS.version <= :sierra

--- a/Casks/mkvtoolnix.rb
+++ b/Casks/mkvtoolnix.rb
@@ -1,8 +1,5 @@
 cask "mkvtoolnix" do
-  if MacOS.version <= :yosemite
-    version "24.0.0"
-    sha256 "758da621d3a92358885333b767d64b024197a8147a339b1a0d14e938673452f9"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "29.0.0"
     sha256 "209578d5d25adb37a2cf857139afb35a421a64b104c2d59af0476d609037244d"
   elsif MacOS.version <= :high_sierra

--- a/Casks/monolingual.rb
+++ b/Casks/monolingual.rb
@@ -1,8 +1,5 @@
 cask "monolingual" do
-  if MacOS.version <= :yosemite
-    version "1.6.7"
-    sha256 "c96175ef35aae6409f760e6c1f70e7cc47d45ab2b769c3238b4a4d979d13756b"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "1.7.3"
     sha256 "24fa5ff0a5903c0eb07cd58a15292e3adab97ea0823f304241dc4187f9252ffc"
   elsif MacOS.version <= :sierra

--- a/Casks/omnifocus.rb
+++ b/Casks/omnifocus.rb
@@ -1,9 +1,5 @@
 cask "omnifocus" do
-  if MacOS.version <= :yosemite
-    version "2.7.4"
-    sha256 "a273e55c15f82540fe305344f9e49ad7d0d9c326ba2c37c312076ffd73780f80"
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniFocus-#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.10"
     sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"

--- a/Casks/omnigraffle.rb
+++ b/Casks/omnigraffle.rb
@@ -1,13 +1,5 @@
 cask "omnigraffle" do
-  if MacOS.version <= :yosemite
-    version "6.6.2"
-    sha256 "f0b05a654686c42703cddef646a2519235b45d26bd06988a6e644aa96c0eb828"
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniGraffle-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version for Yosemite"
-    end
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "7.5"
     sha256 "d8d8963a85ee34270d7d0148aaaa7aee75bc7d3fffc1bb89e64626546c943d34"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniGraffle-#{version}.dmg"

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,9 +1,5 @@
 cask "omnioutliner" do
-  if MacOS.version <= :yosemite
-    version "4.6.1"
-    sha256 "47652e8b46be40a5fc71eff16d7b621fa99bc07951f11f5445cacea5ee15ff2a"
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniOutliner-#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "5.1.4"
     sha256 "91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"

--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -1,9 +1,5 @@
 cask "omniplan" do
-  if MacOS.version <= :yosemite
-    version "2.4.3"
-    sha256 "afbe0b97cdc0147b9cbd71121468529da9230936bb1f8b9329c6d920e9c202a2"
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniPlan-#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "3.7.3"
     sha256 "1a3ab3a1ea22bdbdf9c1afda8cafc9a2fdf60cb4414f142b621c8758f81720bd"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPlan-#{version}.dmg"

--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -1,9 +1,5 @@
 cask "omnipresence" do
-  if MacOS.version <= :yosemite
-    version "1.4.1"
-    sha256 "409bf272e7c4dc488f68abadb3e2ef15d4accde10f8ee9babd8b23f522bfe323"
-    url "https://downloads.omnigroup.com/software/MacOSX/10.10/OmniPresence-#{version}.dmg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "1.5.2"
     sha256 "82d3c6978e644dc7defafd3706a02d15c500e8254ca22076a5095bdd94b786d1"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPresence-#{version}.dmg"

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -1,8 +1,5 @@
 cask "onyx" do
-  if MacOS.version <= :yosemite
-    version "3.0.2"
-    sha256 "9672a1b300501ec7c726508561c885f2b5e82069ef65145796dc40b0d386a8b0"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "3.1.9"
     sha256 "7f8df2c9e97eb465aba88b000fa2f58958421efeba1239303ff0071e9b7b0536"
   elsif MacOS.version <= :sierra

--- a/Casks/openemu.rb
+++ b/Casks/openemu.rb
@@ -1,8 +1,5 @@
 cask "openemu" do
-  if MacOS.version <= :yosemite
-    version "1.0.4"
-    sha256 "c9c3abc2acea4ed4c1e2b62fd6868feae1719251428a79803d9aa8a0de4474ef"
-  elsif MacOS.version <= :high_sierra
+  if MacOS.version <= :high_sierra
     version "2.0.9.1"
     sha256 "c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790"
   else

--- a/Casks/openzfs.rb
+++ b/Casks/openzfs.rb
@@ -1,9 +1,5 @@
 cask "openzfs" do
-  if MacOS.version <= :yosemite
-    version "2.1.0,352"
-    sha256 "4a2029f59b6cc96e898e81aeb448b3306b2d23d0984af4decdf0e53a9de042f5"
-    pkg "OpenZFSonOsX-#{version.csv.first}-Yosemite-10.10.pkg"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "2.1.0,353"
     sha256 "66d74b3650ca3e099bcbec71733ad53664ba7f797a45920e73e0decb89de1a0d"
     pkg "OpenZFSonOsX-#{version.csv.first}-El.Capitan-10.11.pkg"

--- a/Casks/powerphotos.rb
+++ b/Casks/powerphotos.rb
@@ -1,9 +1,5 @@
 cask "powerphotos" do
-  if MacOS.version <= :yosemite
-    version "1.0.6"
-    sha256 "927c1095858d259b9469c86d20ce39cf0bfc350ad0b64ae8ba0ca0557b632305"
-    url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "1.2.3"
     sha256 "b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb"
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,9 +1,5 @@
 cask "r" do
-  if MacOS.version <= :yosemite
-    version "3.3.3"
-    sha256 "77d7a145d1f7d5c3f5bd7310ae2beb7349118528d938e519845ce7d205b4c864"
-    url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
-  elsif MacOS.version <= :sierra
+  if MacOS.version <= :sierra
     version "3.6.3.nn"
     sha256 "f2b771e94915af0fe0a6f042bc7a04ebc84fb80cb01aad5b7b0341c4636336dd"
     url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,9 +1,5 @@
 cask "smartgit" do
-  if MacOS.version <= :yosemite
-    arch = "macosx"
-    version "18.1.5"
-    sha256 "52de2c0f4e4d529063da4c4f9f9de4eed425109139d7ba026944535eb3f0e0b7"
-  elsif MacOS.version <= :sierra
+  if MacOS.version <= :sierra
     arch = "macosx"
     version "20.2.6"
     sha256 "af5fbf8db26edde3d996d99c6e82287332598359fe63ff2cd97c712a1685a2ea"

--- a/Casks/suspicious-package.rb
+++ b/Casks/suspicious-package.rb
@@ -1,9 +1,5 @@
 cask "suspicious-package" do
-  if MacOS.version <= :yosemite
-    version "3.2"
-    url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-    sha256 "b8b038663f071ad55ea21ccf3a8aa09ae54a1bd1586a803e7e5413a1a3fecaae"
-  elsif MacOS.version <= :sierra
+  if MacOS.version <= :sierra
     version "3.4.1"
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
     sha256 "e4673a0c590e7dcb711789d98fcadd2283c2152d262b7809dfd8c8a1b3e9094b"

--- a/Casks/texpad.rb
+++ b/Casks/texpad.rb
@@ -1,8 +1,5 @@
 cask "texpad" do
-  if MacOS.version <= :yosemite
-    version "1.7.45,237,1487350"
-    sha256 "5973da0e221a9f9168228d628e25b1f788bcdc9ca8cae86cb02089804f3240f5"
-  elsif MacOS.version <= :el_capitan
+  if MacOS.version <= :el_capitan
     version "1.8.5,404,f8f30e5"
     sha256 "676a1b071142c022cdfda57668c811f7747b36ded442548073fe6dda1b9ca934"
   elsif MacOS.version <= :high_sierra

--- a/Casks/themeengine.rb
+++ b/Casks/themeengine.rb
@@ -1,16 +1,8 @@
 cask "themeengine" do
-  if MacOS.version <= :yosemite
-    version "0.0.4"
-    sha256 "35a99145577cb300e2383d3432b47c13907e5d6ca24e720c44a83f4a1f990f4a"
+  version "1.0.0,111"
+  sha256 "2f7039bf8a30a20da20b292252759a501d15962f909d3b2274db9c2ec7a3bf39"
 
-    url "https://github.com/alexzielenski/ThemeEngine/releases/download/#{version}/ThemeEngine.zip"
-  else
-    version "1.0.0,111"
-    sha256 "2f7039bf8a30a20da20b292252759a501d15962f909d3b2274db9c2ec7a3bf39"
-
-    url "https://github.com/alexzielenski/ThemeEngine/releases/download/#{version.csv.first}(#{version.csv.second})/ThemeEngine_111.zip"
-  end
-
+  url "https://github.com/alexzielenski/ThemeEngine/releases/download/#{version.csv.first}(#{version.csv.second})/ThemeEngine_111.zip"
   name "ThemeEngine"
   desc "App to edit compiled .car files"
   homepage "https://github.com/alexzielenski/ThemeEngine/"

--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -1,18 +1,9 @@
 cask "unison" do
-  if MacOS.version <= :yosemite
-    version "2.48.3"
-    sha256 "d578196d8b38f35c1e0410a1c86ff4e115a91f7eb211201db7a940a3a3e0f099"
+  version "2.52.1,4.14.0"
+  sha256 "d2c87075e460d74641ae8a955703de5cf5344d9affdf4e2f6a8fc5d971c4246c"
 
-    url "https://github.com/bcpierce00/unison/releases/download/#{version}/Unison-OS-X-#{version}.zip",
-        verified: "github.com/bcpierce00/unison/"
-  else
-    version "2.52.1,4.14.0"
-    sha256 "d2c87075e460d74641ae8a955703de5cf5344d9affdf4e2f6a8fc5d971c4246c"
-
-    url "https://github.com/bcpierce00/unison/releases/download/v#{version.csv.first}/Unison-v#{version.csv.first}.ocaml-#{version.csv.second}.macos-10.15.app.tar.gz",
-        verified: "github.com/bcpierce00/unison/"
-  end
-
+  url "https://github.com/bcpierce00/unison/releases/download/v#{version.csv.first}/Unison-v#{version.csv.first}.ocaml-#{version.csv.second}.macos-10.15.app.tar.gz",
+      verified: "github.com/bcpierce00/unison/"
   name "Unison"
   desc "File synchronizer"
   homepage "https://www.cis.upenn.edu/~bcpierce/unison/"

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,16 +1,12 @@
 cask "visual-studio-code" do
   arch = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
 
-  if MacOS.version <= :yosemite
-    version "1.55.2"
-    sha256 "be3a1ebfac2c6c5e882714304adc518aff8bac6b663e194a9e73524c62065b94"
+  version "1.68.1"
+
+  if Hardware::CPU.intel?
+    sha256 "34ab4f6740e105cfac50e14ec3d2a4d97248325f33351b98f4dd2ac08b594cfa"
   else
-    version "1.68.1"
-    if Hardware::CPU.intel?
-      sha256 "34ab4f6740e105cfac50e14ec3d2a4d97248325f33351b98f4dd2ac08b594cfa"
-    else
-      sha256 "ec6dfb6bc68edd39ea01aff6d623e4ab0e2141189dd964b4be3ce452add4cfad"
-    end
+    sha256 "ec6dfb6bc68edd39ea01aff6d623e4ab0e2141189dd964b4be3ce452add4cfad"
   end
 
   url "https://update.code.visualstudio.com/#{version}/#{arch}/stable"


### PR DESCRIPTION
This is the third and final stage of removing `:yosemite` references from Homebrew/cask.

Homebrew 3.5.0 released on Monday 6th and since that release, `brew` no longer runs on Yosemite. Therefore we can now remove the remaining Yosemite conditionals here.

Homebrew taps are not expected to be backwards compatible with older releases, but I gave a few days of leeway anyway.