### PR TITLE
lightform: Bump final version & discontinue

### DIFF
--- a/Casks/lightform.rb
+++ b/Casks/lightform.rb
@@ -1,12 +1,14 @@
 cask "lightform" do
-  version "2.0.6.920"
-  sha256 "f9e18c15a5648b096f5c38c9554bb3b601b3f1ae5c47d9030cde350452b12341"
+  version "2.2.12.1054"
+  sha256 "60c4d4a30cef2a5a0d4f0d89b80806e920a0263dbe0a01628c4f3f2ce4b1d1b6"
 
   url "https://software.webservices.lumenous3d.com/app/Lightform-#{version}-release-public-macos.dmg",
       verified: "software.webservices.lumenous3d.com/app/"
   name "Lightform Creator"
   desc "AR projection and audio reactivity software for Lightform devices"
   homepage "https://lightform.com/creator"
+
+  depends_on macos: ">= :mojave"
 
   app "Lightform.app"
 
@@ -16,4 +18,8 @@ cask "lightform" do
     "~/Library/Preferences/com.lightform.desktop.plist",
     "~/Library/Saved Application State/com.lightform.desktop.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Hardware has been discontinued and software support ends August 2022.

https://lightform.com/blog/lightforms-sunset

> Today, we are announcing that Lightform is discontinuing all hardware production runs indefinitely and winding down. We will continue to provide cloud services & support through August 2022. Customers should update to the latest software and firmware before this date.