### PR TITLE
add dockutil v3.0.2 cask

### DIFF
--- a/Casks/dockutil.rb
+++ b/Casks/dockutil.rb
@@ -1,0 +1,18 @@
+cask "dockutil" do
+  version "3.0.2"
+  sha256 "175137ea747e83ed221d60b18b712b256ed31531534cde84f679487d337668fd"
+
+  url "https://github.com/kcrawford/dockutil/releases/download/#{version}/dockutil-#{version}.pkg"
+  name "dockutil"
+  desc "Command-line utility for managing dock items"
+  homepage "https://github.com/kcrawford/dockutil"
+
+  conflicts_with formula: "dockutil"
+  depends_on macos: ">= :big_sur"
+
+  pkg "dockutil-#{version}.pkg"
+
+  uninstall pkgutil: "dockutil.cli.tool"
+
+  caveats "v3.x is compatible with macOS 11+. Use the homebrew formula which provides v2.x for earlier OSes."
+end


### PR DESCRIPTION
Verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions).
- [x] `brew audit --cask --online homebrew/cask/dockutil` is error-free.
- [x] `brew style --fix homebrew/cask/dockutil` reports no offenses.

Additionally,

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask homebrew/cask/dockutil` worked successfully.
  - says conflicts with formula but this is expected.
- [x] `brew install --cask dockutil` worked successfully.
- [x] `brew uninstall --cask dockutil` worked successfully.
