### PR TITLE
athens: Fix livecheck

### DIFF
--- a/Casks/athens.rb
+++ b/Casks/athens.rb
@@ -15,6 +15,11 @@ cask "athens" do
   desc "Self-hosted knowledge graph"
   homepage "https://www.athensresearch.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Athens.app"
 
   zap trash: [


### PR DESCRIPTION
Utilizing `:github_latest` due to a large number of pre-releases.