### PR TITLE
better-window-manager: Switch to HTTP

### DIFF
--- a/Casks/better-window-manager.rb
+++ b/Casks/better-window-manager.rb
@@ -2,12 +2,13 @@ cask "better-window-manager" do
   version "1.14,15"
   sha256 "e6d0745aa969b793d78dd157f4447401ea79f56b03686735a2eb4e39b6321335"
 
-  url "https://gngrwzrd.com/BetterWindowManager-#{version.csv.first}.#{version.csv.second}.zip"
+  url "http://gngrwzrd.com/BetterWindowManager-#{version.csv.first}.#{version.csv.second}.zip"
   name "Better Window Manager"
-  homepage "https://www.gngrwzrd.com/better-window-manager/"
+  desc "Tools to save/restore window states"
+  homepage "http://www.gngrwzrd.com/better-window-manager/"
 
   livecheck do
-    url "https://www.gngrwzrd.com/betterwindowmanager-appcast.xml"
+    url "http://www.gngrwzrd.com/betterwindowmanager-appcast.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
TLS certificate expired 16 days ago. Livecheck and install are failing.