### PR TITLE
mia-for-gmail: Switch to HTTP

### DIFF
--- a/Casks/mia-for-gmail.rb
+++ b/Casks/mia-for-gmail.rb
@@ -2,14 +2,14 @@ cask "mia-for-gmail" do
   version "2.4.5,72"
   sha256 "31f94c2c5bafc2550adb50ed36919b45c2939bbd691ce1b27b8486d1094600c5"
 
-  url "https://www.sovapps.com/application/notifier-pro-for-gmail/mia.#{version.csv.first}.zip",
+  url "http://www.sovapps.com/application/notifier-pro-for-gmail/mia.#{version.csv.first}.zip",
       verified: "sovapps.com/application/notifier-pro-for-gmail/"
   name "Mia for Gmail"
   desc "Desktop email client for Gmail"
-  homepage "https://www.miaforgmail.com/"
+  homepage "http://www.miaforgmail.com/"
 
   livecheck do
-    url "https://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml"
+    url "http://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
TLS certificate expired 15 days ago. Livecheck and install are failing.