### PR TITLE
obs-websocket: Fix livecheck

### DIFF
--- a/Casks/obs-websocket.rb
+++ b/Casks/obs-websocket.rb
@@ -8,8 +8,8 @@ cask "obs-websocket" do
   homepage "https://github.com/Palakis/obs-websocket"
 
   livecheck do
-      url :url
-      strategy :github_latest
+    url :url
+    strategy :github_latest
   end
 
   pkg "obs-websocket-#{version}-macOS.pkg"

--- a/Casks/obs-websocket.rb
+++ b/Casks/obs-websocket.rb
@@ -7,6 +7,11 @@ cask "obs-websocket" do
   desc "Remote-control OBS Studio through WebSockets"
   homepage "https://github.com/Palakis/obs-websocket"
 
+  livecheck do
+      url :url
+      strategy :github_latest
+  end
+
   pkg "obs-websocket-#{version}-macOS.pkg"
 
   uninstall pkgutil: "fr.palakis.obs-websocket"


### PR DESCRIPTION
Utilizing `:github_latest` due to multiple pre-releases for the next major version.