### PR TITLE
redis-pro: Fix livecheck

### DIFF
--- a/Casks/redis-pro.rb
+++ b/Casks/redis-pro.rb
@@ -7,6 +7,11 @@ cask "redis-pro" do
   desc "Redis desktop"
   homepage "https://github.com/cmushroom/redis-pro"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "redis-pro.app"
 
   zap trash: [


### PR DESCRIPTION
Utilizing `:github_latest` due to pre-release for the next major version.