### PR TITLE
Created cask for UI Desktop

### DIFF
--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -1,0 +1,36 @@
+cask "ui" do
+  version "0.52.1"
+  sha256 "1ddf876c2701669415ab1c634feee336e2825a876a20c5f69835c57d0b09a48b"
+
+  url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/ecae-macOS-#{version}-fc1b9e29d90248a4b4ebe7e3b53dec8a.pkg",
+      verified: "fw-download.ubnt.com/data/uid-ui-desktop-app/"
+  name "UI Desktop"
+  desc "Corporate Wi-Fi, VPN, SSO, and HR Application"
+  homepage "https://www.ui.com/uid"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "ecae-macOS-0.52.1-fc1b9e29d90248a4b4ebe7e3b53dec8a.pkg"
+
+  uninstall pkgutil:   [
+    "com.ui.uid.desktop",
+  ],
+
+            launchctl: [
+              "application.com.ui.uid.desktop.25686722.25686727",
+              "com.ui.uid.desktop.startup",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/com.ui.uid.desktop/",
+    "~/Users/nilsstreedain/Library/Preferences/com.ui.uid.desktop.plist",
+    "~/Library/Saved Application State/com.ui.uid.desktop.savedState/",
+    "~/Library/Caches/com.ui.uid.desktop/",
+    "/Applications/UI.app/Contents/Library/LoginItems/com.ui.uid.desktop.startup",
+    "~/Library/Logs/UI",
+  ]
+end

--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -18,11 +18,17 @@ cask "ui" do
 
   uninstall pkgutil:   [
     "com.ui.uid.desktop",
+    "com.ui.uid.mac",
   ],
 
             launchctl: [
               "application.com.ui.uid.desktop.25686722.25686727",
               "com.ui.uid.desktop.startup",
+              "com.ui.uid.desktop.privilegedtool",
+            ],
+
+            quit:      [
+              "com.ui.uid.desktop",
             ]
 
   zap trash: [

--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -1,8 +1,8 @@
 cask "ui" do
   version "0.52.1,fc1b9e29d90248a4b4ebe7e3b53dec8a"
-  sha256 "1ddf876c2701669415ab1c634feee336e2825a876a20c5f69835c57d0b09a48b"
+  sha256 "1ddf876c2701669415ab1c634feee336e2825a876a20c5f69835c57d0b09a48b,ecae"
 
-  url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/ecae-macOS-#{version.csv.first}-#{version.csv.second}.pkg",
+  url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg",
       verified: "fw-download.ubnt.com/data/uid-ui-desktop-app/"
   name "UI Desktop"
   desc "Corporate Wi-Fi, VPN, SSO, and HR Application"
@@ -14,7 +14,7 @@ cask "ui" do
 
   depends_on macos: ">= :mojave"
 
-  pkg "ecae-macOS-#{version.csv.first}-#{version.csv.second}.pkg"
+  pkg "#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg"
 
   uninstall pkgutil:   [
     "com.ui.uid.desktop",

--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -1,6 +1,6 @@
 cask "ui" do
-  version "0.52.1,fc1b9e29d90248a4b4ebe7e3b53dec8a"
-  sha256 "1ddf876c2701669415ab1c634feee336e2825a876a20c5f69835c57d0b09a48b,ecae"
+  version "0.52.1,fc1b9e29d90248a4b4ebe7e3b53dec8a,ecae"
+  sha256 "1ddf876c2701669415ab1c634feee336e2825a876a20c5f69835c57d0b09a48b"
 
   url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg",
       verified: "fw-download.ubnt.com/data/uid-ui-desktop-app/"

--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -20,16 +20,12 @@ cask "ui" do
     "com.ui.uid.desktop",
     "com.ui.uid.mac",
   ],
-
             launchctl: [
               "application.com.ui.uid.desktop.25686722.25686727",
-              "com.ui.uid.desktop.startup",
               "com.ui.uid.desktop.privilegedtool",
+              "com.ui.uid.desktop.startup",
             ],
-
-            quit:      [
-              "com.ui.uid.desktop",
-            ]
+            quit:      "com.ui.uid.desktop"
 
   zap trash: [
     "~/Library/Application Support/com.ui.uid.desktop/",

--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -1,8 +1,8 @@
 cask "ui" do
-  version "0.52.1"
+  version "0.52.1,fc1b9e29d90248a4b4ebe7e3b53dec8a"
   sha256 "1ddf876c2701669415ab1c634feee336e2825a876a20c5f69835c57d0b09a48b"
 
-  url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/ecae-macOS-#{version}-fc1b9e29d90248a4b4ebe7e3b53dec8a.pkg",
+  url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/ecae-macOS-#{version.csv.first}-#{version.csv.second}.pkg",
       verified: "fw-download.ubnt.com/data/uid-ui-desktop-app/"
   name "UI Desktop"
   desc "Corporate Wi-Fi, VPN, SSO, and HR Application"
@@ -14,7 +14,7 @@ cask "ui" do
 
   depends_on macos: ">= :mojave"
 
-  pkg "ecae-macOS-0.52.1-fc1b9e29d90248a4b4ebe7e3b53dec8a.pkg"
+  pkg "ecae-macOS-#{version.csv.first}-#{version.csv.second}.pkg"
 
   uninstall pkgutil:   [
     "com.ui.uid.desktop",

--- a/Casks/ui.rb
+++ b/Casks/ui.rb
@@ -33,10 +33,9 @@ cask "ui" do
 
   zap trash: [
     "~/Library/Application Support/com.ui.uid.desktop/",
-    "~/Users/nilsstreedain/Library/Preferences/com.ui.uid.desktop.plist",
-    "~/Library/Saved Application State/com.ui.uid.desktop.savedState/",
     "~/Library/Caches/com.ui.uid.desktop/",
-    "/Applications/UI.app/Contents/Library/LoginItems/com.ui.uid.desktop.startup",
     "~/Library/Logs/UI",
+    "~/Library/Preferences/com.ui.uid.desktop.plist",
+    "~/Library/Saved Application State/com.ui.uid.desktop.savedState/",
   ]
 end


### PR DESCRIPTION
Added the macOS desktop application for the Ubiquiti UID One-Click Wi-Fi/VPN service

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
