### PR TITLE
Playcover: new 1.0.1 dmg

### DIFF
--- a/Casks/playcover.rb
+++ b/Casks/playcover.rb
@@ -12,8 +12,8 @@ cask "playcover" do
     app "PlayCover #{version}/PlayCover.app"
   else
     version "1.0.1"
-    sha256 "4c8f14c539a6f7a3b57eae15f24c23705220db58b57800e34874dd5c221dd9f9"
-    url "https://github.com/iVoider/PlayCover/releases/download/#{version}/PlayCover#{version}.dmg",
+    sha256 "f1f2888b45b1992606c5a71fee1b3b50f9e636fee1704c932b7845512210c933"
+    url "https://github.com/iVoider/PlayCover/releases/download/#{version}/PlayCover.#{version}.dmg",
         verified: "github.com/iVoider/PlayCover/"
 
     app "PlayCover.app"


### PR DESCRIPTION
Playcover: new 1.0.1 dmg

Previous Playcover 1.0.1 dmg had extra attributes on the .App folder,
making macOS complain about corrupted files when trying to run it.
This new upstream dmg fixes it.

Also fixing the URL.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
