### PR TITLE
BetterDisplay: New Cask

### DIFF
--- a/Casks/betterdisplay.rb
+++ b/Casks/betterdisplay.rb
@@ -4,7 +4,7 @@ cask "betterdisplay" do
 
   url "https://github.com/waydabber/BetterDisplay/releases/download/v#{version}/BetterDisplay-v#{version}.dmg"
   name "BetterDisplay"
-  desc "Display Management, Custom Resolutions, Brightness Adjustment and Dummy Displays for Macs (formerly BetterDummy)"
+  desc "Management, Custom Resolution, Brightness & Dummy Displays (fka BetterDummy)"
   homepage "https://github.com/waydabber/BetterDisplay"
 
   livecheck do

--- a/Casks/betterdisplay.rb
+++ b/Casks/betterdisplay.rb
@@ -1,0 +1,26 @@
+cask "betterdisplay" do
+  version "1.2.6"
+  sha256 "2d9d919ee35d73ac0e09a89b1a2b2ddd9ddfe9a966986ebdd7a0fb27febc0d42"
+
+  url "https://github.com/waydabber/BetterDisplay/releases/download/v#{version}/BetterDisplay-v#{version}.dmg"
+  name "BetterDisplay"
+  desc "Display Management, Custom Resolutions, Brightness Adjustment and Dummy Displays for Macs (formerly BetterDummy)"
+  homepage "https://github.com/waydabber/BetterDisplay"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+
+  app "BetterDisplay.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/me.waydabber.BetterDiaplayHelper",
+    "~/Library/Application Scripts/me.waydabber.BetterDisplay",
+    "~/Library/Containers/me.waydabber.BetterDisplayHelper",
+    "~/Library/Containers/me.waydabber.BetterDisplay",
+    "~/Library/Preferences/me.waydabber.BetterDisplay.plist",
+  ]
+end

--- a/Casks/betterdummy.rb
+++ b/Casks/betterdummy.rb
@@ -7,6 +7,10 @@ cask "betterdummy" do
   desc "Deprecated: Now BetterDisplay"
   homepage "https://github.com/waydabber/BetterDummy"
 
+  livecheck do
+    skip "Deprecated - migrate to betterdisplay cask"
+  end
+
   auto_updates true
 
   app "BetterDummy.app"

--- a/Casks/betterdummy.rb
+++ b/Casks/betterdummy.rb
@@ -4,13 +4,8 @@ cask "betterdummy" do
 
   url "https://github.com/waydabber/BetterDummy/releases/download/v#{version}/BetterDummy-v#{version}.dmg"
   name "betterdummy"
-  desc "Dummy Display for Apple Silicon Macs to achieve custom resolutions"
+  desc "Deprecated: Now BetterDisplay"
   homepage "https://github.com/waydabber/BetterDummy"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   auto_updates true
 


### PR DESCRIPTION
Add BetterDisplay, deprecate BetterDummy - no migration, but can use similar method as `zoom`/`zoomus` if desired

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
