### PR TITLE
plex-media-player: add deprecation notice

### DIFF
--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -20,7 +20,11 @@ cask "plex-media-player" do
     discontinued
 
     <<~EOS
-      This software has been deprecated in favor of Plex for Desktop (plex cask) and Plex HTPC (plex-htpc cask).
+      #{name} has been deprecated in favor of Plex for Desktop and Plex HTPC.
+      
+        brew install --cask plex
+        OR
+        brew install --cask plex-htpc
     EOS
   end
 

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -23,7 +23,7 @@ cask "plex-media-player" do
     discontinued
 
     <<~EOS
-      #{name} has been deprecated in favor of Plex for Desktop and Plex HTPC.
+      #{token} has been deprecated in favor of Plex for Desktop and Plex HTPC.
 
         brew install --cask plex
         OR

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -20,7 +20,7 @@ cask "plex-media-player" do
     discontinued
 
     <<~EOS
-      This software has been deprecated in favor of Plex for Desktop (plex cask) and Plex HTPC.
+      This software has been deprecated in favor of Plex for Desktop (plex cask) and Plex HTPC (plex-htpc cask).
     EOS
 
   zap trash: [

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -7,26 +7,9 @@ cask "plex-media-player" do
   desc "Home media player"
   homepage "https://www.plex.tv/"
 
-  livecheck do
-    url "https://plex.tv/api/downloads/3.json"
-    regex(%r{/PlexMediaPlayer-(\d+(?:\.\d+)*-[0-9a-f]+)-macosx-x86_64\.zip}i)
-  end
-
   auto_updates true
 
   app "Plex Media Player.app"
-
-  caveats do
-    discontinued
-
-    <<~EOS
-      #{name} has been deprecated in favor of Plex for Desktop and Plex HTPC.
-      
-        brew install --cask plex
-        OR
-        brew install --cask plex-htpc
-    EOS
-  end
 
   zap trash: [
     "~/Library/Application Support/Plex Media Player",
@@ -35,4 +18,16 @@ cask "plex-media-player" do
     "~/Library/Saved Application State/tv.plex.Plex Media Player.savedState",
     "~/Library/Preferences/tv.plex.Plex Media Player.plist",
   ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      #{name} has been deprecated in favor of Plex for Desktop and Plex HTPC.
+
+        brew install --cask plex
+        OR
+        brew install --cask plex-htpc
+    EOS
+  end
 end

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -16,6 +16,13 @@ cask "plex-media-player" do
 
   app "Plex Media Player.app"
 
+  caveats do
+    discontinued
+
+    <<~EOS
+      This software has been deprecated in favor of Plex for Desktop (plex cask) and Plex HTPC.
+    EOS
+
   zap trash: [
     "~/Library/Application Support/Plex Media Player",
     "~/Library/Caches/Plex Media Player",

--- a/Casks/plex-media-player.rb
+++ b/Casks/plex-media-player.rb
@@ -22,6 +22,7 @@ cask "plex-media-player" do
     <<~EOS
       This software has been deprecated in favor of Plex for Desktop (plex cask) and Plex HTPC (plex-htpc cask).
     EOS
+  end
 
   zap trash: [
     "~/Library/Application Support/Plex Media Player",


### PR DESCRIPTION
Plex Media Player was deprecated a long time ago, see:

https://www.plex.tv/blog/desktop-af/

The replacement is Plex for Desktop for users that do not need HTPC
mode, or Plex HTPC for users that were running PMP for HTPC mode. Will
add Plex HTPC cask as a replacement target later once it is available as
a cask.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
