### PR TITLE
shift 7.2.18

### DIFF
--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,6 +1,6 @@
 cask "shift" do
   version "8.0.41"
-  sha256 "fb6b08a5ccbc6ebf1a85057820eee8667218c6c4507f4106686ce32da3420a18"
+  sha256 "6d779264fad6736675f56c74a9cbd8d778baba7234123f42d7182cfb15667cc0"
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"
   name "Shift"

--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -1,5 +1,5 @@
 cask "shift" do
-  version "8.0.41"
+  version "7.2.18"
   sha256 "6d779264fad6736675f56c74a9cbd8d778baba7234123f42d7182cfb15667cc0"
 
   url "https://update.tryshift.com/download/version/#{version}/osx_64"


### PR DESCRIPTION
The current SHA256 hash for shift cask is wrong. The updated hash is as per the latest binary from the official website as on 25/06/2022

<img width="1728" alt="Screenshot 2022-06-25 at 10 25 57 PM" src="https://user-images.githubusercontent.com/7334295/175783390-ce27dd97-8a2f-4abd-bf10-e9b49d0219fe.png">

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
