### PR TITLE
True-up `zoom-for-it-admins` with `zoom`.

### DIFF
--- a/Casks/zoom-for-it-admins.rb
+++ b/Casks/zoom-for-it-admins.rb
@@ -11,9 +11,7 @@ cask "zoom-for-it-admins" do
     cask "zoom"
   end
 
-  # Do not add `auto_updates`. While supporting an auto-update mechanism, this software is more inconvenient than most
-  # See https://github.com/Homebrew/homebrew-cask/pull/93083
-
+  auto_updates true
   conflicts_with cask: "zoom"
 
   pkg "ZoomInstallerIT.pkg"
@@ -26,6 +24,7 @@ cask "zoom-for-it-admins" do
               "/Library/Audio/Plug-Ins/HAL/ZoomAudioDevice.driver",
               "/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
               "/Library/Logs/DiagnosticReports/zoom.us*",
+              "/Library/PrivilegedHelperTools/us.zoom.ZoomDaemon",
             ]
 
   zap trash: [
@@ -33,23 +32,31 @@ cask "zoom-for-it-admins" do
     "~/.zoomus",
     "~/Desktop/Zoom",
     "~/Documents/Zoom",
+    "~/Library/Application Scripts/*.ZoomClient3rd",
     "~/Library/Application Support/CloudDocs/session/containers/iCloud.us.zoom.videomeetings.plist",
     "~/Library/Application Support/CloudDocs/session/containers/iCloud.us.zoom.videomeetings",
     "~/Library/Application Support/CrashReporter/zoom.us*",
     "~/Library/Application Support/zoom.us",
     "~/Library/Caches/us.zoom.xos",
     "~/Library/Cookies/us.zoom.xos.binarycookies",
+    "~/Library/Group Containers/*.ZoomClient3rd",
+    "~/Library/HTTPStorages/us.zoom.xos",
+    "~/Library/HTTPStorages/us.zoom.xos.binarycookies",
     "~/Library/Internet Plug-Ins/ZoomUsPlugIn.plugin",
     "~/Library/Logs/zoom.us",
     "~/Library/Logs/zoominstall.log",
     "~/Library/Logs/ZoomPhone",
     "~/Library/Mobile Documents/iCloud~us~zoom~videomeetings",
     "~/Library/Preferences/us.zoom.airhost.plist",
+    "~/Library/Preferences/us.zoom.caphost.plist",
+    "~/Library/Preferences/us.zoom.Transcode.plist",
     "~/Library/Preferences/us.zoom.xos.Hotkey.plist",
     "~/Library/Preferences/us.zoom.xos.plist",
+    "~/Library/Preferences/us.zoom.ZoomAutoUpdater.plist",
     "~/Library/Preferences/ZoomChat.plist",
     "~/Library/Safari/PerSiteZoomPreferences.plist",
     "~/Library/SafariTechnologyPreview/PerSiteZoomPreferences.plist",
     "~/Library/Saved Application State/us.zoom.xos.savedState",
+    "~/Library/WebKit/us.zoom.xos",
   ]
 end


### PR DESCRIPTION
Auto-updates were re-enabled for the `zoom` cask in #116131. Let's do it here too.
Also, adding zaps from #106273, #116672, #117141, #124329.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
Received an error saying `https://support.zoom.us/hc/en-us/articles/115001799006-Mass-Deployment-with-Preconfigured-Settings-for-Mac is in the secure connection audit skiplist but does not need to be skipped`, does it need to be removed from https://github.com/Homebrew/homebrew-cask/blob/master/audit_exceptions/secure_connection_audit_skiplist.json?
- [x] `brew style --fix <cask>` reports no offenses.
