### PR TITLE
Change EurKEY source to up-to-date repo

### DIFF
--- a/Casks/eurkey.rb
+++ b/Casks/eurkey.rb
@@ -2,8 +2,8 @@ cask "eurkey" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/jonasdiemer/EurKEY-Mac/archive/master.zip",
-      verified: "github.com/jonasdiemer/EurKEY-Mac/"
+  url "https://github.com/lbschenkel/EurKEY-Mac/archive/master.zip",
+      verified: "github.com/lbschenkel/EurKEY-Mac"
   name "EurKEY keyboard layout"
   desc "Keyboard Layout for Europeans, Coders and Translators"
   homepage "https://eurkey.steffen.bruentjen.eu/"


### PR DESCRIPTION
This PR moves the source repo for the EurKEY cask from https://github.com/jonasdiemer/EurKEY-Mac to https://github.com/lbschenkel/EurKEY-Mac, which is an actively maintained fork of the former.

To cite the author of the original EurKEY:

> Leonardo Brondani Schenkel has completed the layout based on Jonas' work and aims to be 100% compliant with the version presented on this page.
>
> — https://eurkey.steffen.bruentjen.eu/download.html?lang=en

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
