### PR TITLE
zoomus: Skip livecheck

### DIFF
--- a/Casks/zoomus.rb
+++ b/Casks/zoomus.rb
@@ -8,6 +8,10 @@ cask "zoomus" do
   desc "Temporary makeshift alias for the video communication tool Zoom"
   homepage "https://www.zoom.us/"
 
+  livecheck do
+    skip "This cask been renamed to 'zoom'"
+  end
+
   depends_on cask: "zoom"
 
   stage_only true


### PR DESCRIPTION
Livecheck is currently failing on this cask. Not sure if it would be better to finally remove it.

`==> Analytics
install: 1 (30 days), 1 (90 days), 27 (365 days)`