### PR TITLE
ci: Add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -10,6 +10,9 @@ concurrency:
   group: autopublish
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   autopublish:
     if: github.repository == 'Homebrew/homebrew-cask'

--- a/.github/workflows/bump-unversioned-casks.yml
+++ b/.github/workflows/bump-unversioned-casks.yml
@@ -21,6 +21,9 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
 
+permissions:
+  contents: read
+
 jobs:
   bump-unversioned-casks:
     if: startsWith(github.repository, 'Homebrew/')

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,6 +11,9 @@ concurrency:
   group: cache
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update:
     if: startsWith(github.repository, 'Homebrew/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: "${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   generate-matrix:
     outputs:

--- a/.github/workflows/dispatch-command.yml
+++ b/.github/workflows/dispatch-command.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   dispatch-command:
     if: startsWith(github.repository, 'Homebrew/')

--- a/.github/workflows/publish-commit-casks.yml
+++ b/.github/workflows/publish-commit-casks.yml
@@ -15,6 +15,9 @@ env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [rebase-command]
 
+permissions:
+  contents: read
+
 jobs:
   rebase_pull_request:
     name: Rebase Pull Request

--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '30 */3 * * *' # every 3 hours (30 minutes past the hour)
 
+permissions:
+  contents: read
+
 jobs:
   rerun-workflow:
     if: >

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -2,6 +2,9 @@ name: Sync labels.
 
 on: label
 
+permissions:
+  contents: read
+
 jobs:
   sync-labels:
     if: github.repository == 'Homebrew/homebrew-cask'

--- a/.github/workflows/sync-templates-and-ci-config.yml
+++ b/.github/workflows/sync-templates-and-ci-config.yml
@@ -10,6 +10,9 @@ concurrency:
   group: sync-templates-and-ci-config
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sync-templates-and-ci-config:
     if: github.repository == 'Homebrew/homebrew-cask'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,9 @@ concurrency:
   group: "triage-${{ github.event.number }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
