### PR TITLE
Update omegat.rb

### DIFF
--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -12,7 +12,7 @@ cask "omegat" do
     url "https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard"
   end
 
-  conflicts_with cask: "omegat-latest"
+  conflicts_with cask: "homebrew/cask-versions/omegat-latest"
 
   app "OmegaT_#{version}_Mac_Notarized/OmegaT.app"
 

--- a/Casks/omegat.rb
+++ b/Casks/omegat.rb
@@ -12,5 +12,14 @@ cask "omegat" do
     url "https://sourceforge.net/projects/omegat/rss?path=/OmegaT%20-%20Standard"
   end
 
+  conflicts_with cask: "omegat-latest"
+
   app "OmegaT_#{version}_Mac_Notarized/OmegaT.app"
+
+  zap trash: [
+    "~/Library/Application Support/OmegaT",
+    "~/Library/Caches/OmegaT",
+    "~/Library/Preferences/OmegaT",
+    "~/Library/Saved Application State/org.omegat.OmegaT.savedState",
+  ]
 end


### PR DESCRIPTION
Adds `zap` and `conflicts_with` to make it conflict with version 5 sent to https://github.com/Homebrew/homebrew-cask-versions/pull/14241.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
