### PR TITLE
slic3r: Fix URL

### DIFF
--- a/Casks/slic3r.rb
+++ b/Casks/slic3r.rb
@@ -2,14 +2,11 @@ cask "slic3r" do
   version "1.3.0"
   sha256 "a50dbe78c4648dfcd0ffec46335554c9fa3348dd494a1f6c2b60406aea57b5cb"
 
-  url "https://dl.slic3r.org/mac/slic3r-#{version}.dmg"
+  url "https://github.com/slic3r/Slic3r/releases/download/#{version}/slic3r-#{version}.dmg",
+      verified: "github.com/slic3r/Slic3r"
   name "Slic3r"
+  desc "3D printing toolbox"
   homepage "https://slic3r.org/"
-
-  livecheck do
-    url "https://dl.slic3r.org/mac/"
-    regex(/href=.*?slic3r-(\d+(?:\.\d+)*)\.dmg/i)
-  end
 
   app "Slic3r.app"
 


### PR DESCRIPTION
Moving to GitHub due to SSL failures preventing downloads from the homepage.