### PR TITLE
Ensure path is readable before reading lines

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -30,7 +30,8 @@ cask "appcode" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "appcode") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -30,7 +30,8 @@ cask "clion" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "clion") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -30,7 +30,8 @@ cask "datagrip" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "datagrip") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/dataspell.rb
+++ b/Casks/dataspell.rb
@@ -30,7 +30,8 @@ cask "dataspell" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "dataspell") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/goland.rb
+++ b/Casks/goland.rb
@@ -30,7 +30,8 @@ cask "goland" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "goland") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -32,7 +32,8 @@ cask "intellij-idea-ce" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "idea") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -30,7 +30,8 @@ cask "intellij-idea" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "idea") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -30,7 +30,8 @@ cask "mps" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "mps") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -30,7 +30,8 @@ cask "phpstorm" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "pstorm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/pycharm-ce-with-anaconda-plugin.rb
@@ -14,7 +14,8 @@ cask "pycharm-ce-with-anaconda-plugin" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "charm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -31,7 +31,8 @@ cask "pycharm-ce" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "charm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -31,7 +31,8 @@ cask "pycharm-edu" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "charm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/pycharm-with-anaconda-plugin.rb
+++ b/Casks/pycharm-with-anaconda-plugin.rb
@@ -13,7 +13,8 @@ cask "pycharm-with-anaconda-plugin" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "charm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -31,7 +31,8 @@ cask "pycharm" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "charm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -30,7 +30,8 @@ cask "rider" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "rider") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -30,7 +30,8 @@ cask "rubymine" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "mine") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -30,7 +30,8 @@ cask "webstorm" do
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "wstorm") }.each do |path|
-      if File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
+      if File.readable?(path) &&
+         File.readlines(path).grep(/# see com.intellij.idea.SocketLock for the server side of this interface/).any?
         File.delete(path)
       end
     end


### PR DESCRIPTION
All Jetbrains related casks fail upon uninstallation if any of the files in the `uninstall_postflight` does not exist. I had to manually edit the cask in the `.metadata` directory to successfully uninstall the cask. This pull request addresses the issue by making sure the file is readable before reading its content.

Looking into it further, it seems like this is a regression that happened by accident in https://github.com/Homebrew/homebrew-cask/pull/126864.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.