### PR TITLE
fluor: Fix livecheck

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -9,7 +9,7 @@ cask "fluor" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
Switching to `:github_latest` due to differences between release & tags.