### PR TITLE
aware: discontinued

### DIFF
--- a/Casks/aware.rb
+++ b/Casks/aware.rb
@@ -5,7 +5,12 @@ cask "aware" do
   url "https://github.com/josh/Aware/releases/download/v#{version}/Aware.zip",
       verified: "github.com/josh/Aware/"
   name "Aware"
+  desc "Menubar app to track active computer use"
   homepage "https://awaremac.com/"
 
   app "Aware.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `aware`](https://github.com/josh/Aware) has been archived but an explanation wasn't added to the `README` beforehand. The [first-party website ](https://awaremac.com/) doesn't host the software and simply links to the Mac App Store.

With this in mind, this PR sets the cask as discontinued.