### PR TITLE
atomic-wallet: Fix livecheck & version

### DIFF
--- a/Casks/atomic-wallet.rb
+++ b/Casks/atomic-wallet.rb
@@ -1,15 +1,16 @@
 cask "atomic-wallet" do
-  version "2.49.2"
-  sha256 "91cf2f9952efe1681fe19edbf097d205554e0057912ab3d0157cd3eaf9ae7490"
+  version "2.48.2-1180"
+  sha256 "9e63d2c150dc2905da49c31179deca7853e8623c971b323970c0b4ae0fe878fe"
 
-  url "https://releases.atomicwallet.io/AtomicWallet-#{version}.zip"
+  url "https://get.atomicwallet.io/download/atomicwallet-#{version}.dmg"
   name "Atomic Wallet"
   desc "Manage Bitcoin, Ethereum, XRP, Litecoin, XLM and over 300 other coins and tokens"
   homepage "https://atomicwallet.io/"
 
   livecheck do
-    url "https://releases.atomicwallet.io/latest-mac.yml"
-    strategy :electron_builder
+    url "https://get.atomicwallet.io/download/"
+    strategy :page_match
+    regex(/href=.*?atomicwallet[._-](\d+(?:\.\d+)+[._-]\d+)\.dmg/i)
   end
 
   app "Atomic Wallet.app"


### PR DESCRIPTION
Previous livecheck URL now 404's. Latest version on their homepage is 2.48.2.