### PR TITLE
djl-bench: Fix livecheck

### DIFF
--- a/Casks/djl-bench.rb
+++ b/Casks/djl-bench.rb
@@ -9,7 +9,7 @@ cask "djl-bench" do
 
   livecheck do
     url "https://github.com/deepjavalibrary/djl/releases"
-    strategy :git
+    strategy :github_latest
   end
 
   binary "benchmark-#{version}/bin/benchmark", target: "djl-bench"


### PR DESCRIPTION
Switching to `:github_latest` due to differences between release & tags.