### PR TITLE
banksiagui: Skip livecheck & add comment

### DIFF
--- a/Casks/banksiagui.rb
+++ b/Casks/banksiagui.rb
@@ -7,9 +7,10 @@ cask "banksiagui" do
   desc "Chess GUI"
   homepage "https://banksiagui.com/"
 
+  # The homepage uses a WordPress anti-crawler protection plugin which
+  # returns a 403 error when trying to run livecheck
   livecheck do
-    url "https://banksiagui.com/download/"
-    regex(/BanksiaGui[._-]v?(\d+(?:\.\d+)+\w?)[._-]mac\.zip/i)
+    skip "Version information can't be retrieved due to anti-crawler protection"
   end
 
   app "BanksiaGui.app"


### PR DESCRIPTION
This cask's homepage uses a WordPress anti-crawler protection plugin which returns a 403 error when trying to run livecheck. The .dmg itself can be fetched. Open to ideas on other ways to handle this.