### PR TITLE
Update DevUtils to 1.15.0

### DIFF
--- a/Casks/devutils.rb
+++ b/Casks/devutils.rb
@@ -1,6 +1,6 @@
 cask "devutils" do
-  version "1.14.0,127"
-  sha256 "7d14a8ac75ca8ed349ece7f75c86f3af8c64e7042b197330ac29f4d80641e11d"
+  version "1.15.0,132"
+  sha256 "364231fe0bc2fff59608c1aeae1cfc952a86890ad3f8c4128ca400b39ed73417"
 
   url "https://devutils.app/archives/DevUtils-#{version.csv.first}.dmg"
   name "DevUtils"

--- a/Casks/devutils.rb
+++ b/Casks/devutils.rb
@@ -1,5 +1,5 @@
 cask "devutils" do
-  version "1.15.0,132"
+  version "1.15,132"
   sha256 "364231fe0bc2fff59608c1aeae1cfc952a86890ad3f8c4128ca400b39ed73417"
 
   url "https://devutils.app/archives/DevUtils-#{version.csv.first}.dmg"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.