### PR TITLE
cantata: discontinued

### DIFF
--- a/Casks/cantata.rb
+++ b/Casks/cantata.rb
@@ -7,14 +7,11 @@ cask "cantata" do
   desc "Qt5 Graphical MPD Client"
   homepage "https://github.com/cdrummond/cantata"
 
-  # We need to check all releases since not all releases are for macOS.
-  livecheck do
-    url "https://github.com/CDrummond/cantata/releases"
-    strategy :page_match
-    regex(%r{href=.*?/Cantata[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   depends_on macos: ">= :sierra"
 
   app "Cantata.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `cantata`](https://github.com/cdrummond/cantata) has been archived and the `README` states:

> **NOTE** After 10 years, development of Cantata has now ceased, and this repository is read-only. v2.5.0 is the last released version.

This PR sets the cask as discontinued accordingly.