### PR TITLE
nuclear: Change version & skip livecheck

### DIFF
--- a/Casks/nuclear.rb
+++ b/Casks/nuclear.rb
@@ -1,12 +1,16 @@
 cask "nuclear" do
-  version "0.6.17"
-  sha256 "2d5f4040b10ef334abbee29f3b49dc570606dcb2ff8af5952e50ddd9ab28f3ac"
+  version "3f9007"
+  sha256 "e383f8ac88691140c793f5c8ed9332d42f7a37eee0cddeeed550856076971753"
 
-  url "https://github.com/nukeop/nuclear/releases/download/v#{version}/nuclear-v#{version}.dmg",
+  url "https://github.com/nukeop/nuclear/releases/download/#{version}/nuclear-#{version}.dmg",
       verified: "github.com/nukeop/nuclear/"
   name "Nuclear"
   desc "Streaming music player"
   homepage "https://nuclear.js.org/"
+
+  livecheck do
+    skip "Releases are tagged as partial commit hashes"
+  end
 
   app "nuclear.app"
 


### PR DESCRIPTION
Version is frozen at 0.6.17, and releases are tagged with partial commit hashes. Livecheck has no way to determine latest version from this.