### PR TITLE
djview: add livecheck

### DIFF
--- a/Casks/djview.rb
+++ b/Casks/djview.rb
@@ -1,13 +1,22 @@
 cask "djview" do
-  version "4.12,2"
+  version "4.12,3.5.28,2"
   sha256 "c65460282d7d43c239d262551d415e0cf5873d4b8cbd845e434f2134cdd0a859"
 
-  url "https://downloads.sourceforge.net/djvu/DjVuLibre-3.5.28%2BDjView-#{version.csv.first}-universal-#{version.csv.second}.dmg",
+  url "https://downloads.sourceforge.net/djvu/DjVuLibre-#{version.csv.second}%2BDjView-#{version.csv.first}-universal-#{version.csv.third}.dmg",
       verified: "downloads.sourceforge.net/djvu/"
-  appcast "https://sourceforge.net/projects/djvu/rss"
   name "DjView"
   desc "DjVu viewer and browser plugin"
   homepage "https://djvu.sourceforge.io/"
+
+  livecheck do
+    url "https://sourceforge.net/projects/djvu/rss?path=/DjVuLibre_MacOS"
+    regex(%r{url=.*?/DjVuLibre[._-](\d+(?:\.\d+)+)%2BDjView[._-](\d+(?:\.\d+)+)[._-]universal(?:-(\d+))?\.dmg}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map do |match|
+        match[2].present? ? "#{match[1]},#{match[0]},#{match[2]}" : "#{match[1]},#{match[0]}"
+      end
+    end
+  end
 
   app "DjView.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

As requested in https://github.com/Homebrew/homebrew-cask/pull/127477#issuecomment-1179609591, this PR adds a `livecheck` block for `djview`, as the default check doesn't provide the correct latest version.

It's worth noting that this `livecheck` block will only match dmg files with the `-universal` suffix. The trailing digit after the architecture suffix (e.g., `-universal-2`) is specific to that suffix, so we have to either include the suffix in the `version` or restrict matching to a specific suffix, otherwise livecheck may return an incorrect version as newest. For example, the previous file was `DjVuLibre-3.5.28+DjView-4.12-intel64-3.dmg` and the newest file is `DjVuLibre-3.5.28+DjView-4.12-universal-2.dmg`, so the older file would be treated as newest here (as they have the same leading versions but the trailing 3 is greater than 2). That said, if this approach misses a version in the future, we can always revisit it.

This PR also modifies the `version` and `url` formats, as the DjVuLibre version isn't static. Including it in the `version` allows the cask to be updated using `brew bump-cask-pr` instead of having to be manually updated each time. For what it's worth, I haven't labeled this as syntax-only due to the `version` change.