### PR TITLE
fluor: pin to 2.5.0 for macos early then big_sur

### DIFF
--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,6 +1,11 @@
 cask "fluor" do
-  version "2.5.1"
-  sha256 "adcb2651ab81bc10e4682ef264724b27137444f10f1bbb867e7d0bd7b6063d46"
+  if MacOS.version < :big_sur
+    version "2.5.0"
+    sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209"
+  else
+    version "2.5.1"
+    sha256 "adcb2651ab81bc10e4682ef264724b27137444f10f1bbb867e7d0bd7b6063d46"
+  end
 
   url "https://github.com/Pyroh/Fluor/releases/download/#{version}/Fluor.#{version}.dmg"
   name "Fluor"

--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,5 +1,5 @@
 cask "fluor" do
-  if MacOS.version < :big_sur
+  if MacOS.version <= :catalina
     version "2.5.0"
     sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209"
   else

--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,7 +1,7 @@
 cask "fluor" do
   if MacOS.version <= :catalina
     version "2.5.0"
-    sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209"
+    sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209" 
   else
     version "2.5.1"
     sha256 "adcb2651ab81bc10e4682ef264724b27137444f10f1bbb867e7d0bd7b6063d46"
@@ -11,10 +11,16 @@ cask "fluor" do
   name "Fluor"
   desc "Change the behavior of the fn keys depending on the active application"
   homepage "https://github.com/Pyroh/Fluor"
-
-  livecheck do
-    url :url
-    strategy :github_latest
+  
+  if MacOS.version <= :catalina
+    livecheck do
+      skip "Legacy version for Catalina and earlier"
+    end
+  else
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
   end
 
   auto_updates true

--- a/Casks/fluor.rb
+++ b/Casks/fluor.rb
@@ -1,7 +1,7 @@
 cask "fluor" do
   if MacOS.version <= :catalina
     version "2.5.0"
-    sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209" 
+    sha256 "bd7cc7ce2c2f9ac839c8d39bd600c2863c924c938c1c9e2d865bb7124ee84209"
   else
     version "2.5.1"
     sha256 "adcb2651ab81bc10e4682ef264724b27137444f10f1bbb867e7d0bd7b6063d46"
@@ -11,7 +11,7 @@ cask "fluor" do
   name "Fluor"
   desc "Change the behavior of the fn keys depending on the active application"
   homepage "https://github.com/Pyroh/Fluor"
-  
+
   if MacOS.version <= :catalina
     livecheck do
       skip "Legacy version for Catalina and earlier"


### PR DESCRIPTION
See https://github.com/Pyroh/Fluor/commit/2284e405c0648b574364b501f828cba9511d3852

--- 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
