### PR TITLE
headlamp: add livecheck

### DIFF
--- a/Casks/headlamp.rb
+++ b/Casks/headlamp.rb
@@ -15,6 +15,10 @@ cask "headlamp" do
   desc "UI for Kubernetes"
   homepage "https://kinvolk.github.io/headlamp"
 
+  livecheck do
+    url "https://github.com/kinvolk/headlamp.git"
+  end
+
   app "Headlamp.app"
 
   uninstall quit: "com.kinvolk.headlamp"


### PR DESCRIPTION
Hello dear maintainers! I added a `livecheck` stanza to the headlamp cask. I do not see an [autobump GitHub action like this in homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/autobump.yml), though.

How should I handle the update process? Should the upstream headlamp project implement an autobump CI action or do you have any plans on automating the autobump in homebrew-cask itself? 

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.