### PR TITLE
360safe: Remove livecheck & add discontinued

### DIFF
--- a/Casks/360safe.rb
+++ b/Casks/360safe.rb
@@ -7,10 +7,9 @@ cask "360safe" do
   desc "Protection and antivirus security"
   homepage "https://www.360totalsecurity.com/features/360-total-security-mac/"
 
-  livecheck do
-    url "https://www.360totalsecurity.com/en/version/360-total-security-mac/"
-    regex(/version-history-list.*?(\d+(?:\.\d+)+)/i)
-  end
-
   app "360Safe.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Windows version is being actively developed; macOS version has not been updated in almost 4 years.