### PR TITLE
butler: Restore cask

### DIFF
--- a/Casks/butler.rb
+++ b/Casks/butler.rb
@@ -1,0 +1,18 @@
+cask "butler" do
+  version "4.4.5,5123"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/butler"
+  name "Butler"
+  desc "Arrange your tasks in a customizable configuration"
+  homepage "https://manytricks.com/butler/"
+
+  livecheck do
+    url "https://manytricks.com/butler/appcast/"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  app "Butler.app"
+end


### PR DESCRIPTION
Reverts #127924. 

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).