### PR TITLE
displaperture: Restore cask

### DIFF
--- a/Casks/displaperture.rb
+++ b/Casks/displaperture.rb
@@ -1,0 +1,24 @@
+cask "displaperture" do
+  version "2.2,1055"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/displaperture"
+  name "Displaperture"
+  desc "Rounds your display corners"
+  homepage "https://manytricks.com/displaperture/"
+
+  livecheck do
+    url "https://manytricks.com/displaperture/appcast/"
+    strategy :sparkle
+  end
+
+  app "Displaperture.app"
+
+  uninstall quit: "com.manytricks.Displaperture"
+
+  zap trash: [
+    "~/Library/Caches/com.manytricks.Displaperture",
+    "~/Library/Containers/com.manytricks.Displaperture",
+    "~/Library/Preferences/com.manytricks.Displaperture.plist",
+  ]
+end


### PR DESCRIPTION
Reverts #127926.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).