### PR TITLE
key-codes: Restore cask

### DIFF
--- a/Casks/key-codes.rb
+++ b/Casks/key-codes.rb
@@ -1,0 +1,23 @@
+cask "key-codes" do
+  version "2.2.1,2027"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/keycodes"
+  name "Key Codes"
+  desc "Display key code, unicode value and modifier keys state for any key combination"
+  homepage "https://manytricks.com/keycodes/"
+
+  livecheck do
+    url "https://manytricks.com/keycodes/appcast/"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  app "Key Codes.app"
+
+  zap trash: [
+    "~/Library/Caches/com.manytricks.KeyCodes",
+    "~/Library/Preferences/com.manytricks.KeyCodes.plist",
+  ]
+end


### PR DESCRIPTION
Reverts #127929.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).