### PR TITLE
leech: Restore cask

### DIFF
--- a/Casks/leech.rb
+++ b/Casks/leech.rb
@@ -1,0 +1,18 @@
+cask "leech" do
+  version "3.1.7,3161"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/leech"
+  name "Leech"
+  desc "Lightweight download manager"
+  homepage "https://manytricks.com/leech/"
+
+  livecheck do
+    url "https://manytricks.com/leech/appcast/"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  app "Leech.app"
+end


### PR DESCRIPTION
Reverts #127930.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).