### PR TITLE
menuwhere: Restore cask

### DIFF
--- a/Casks/menuwhere.rb
+++ b/Casks/menuwhere.rb
@@ -1,0 +1,23 @@
+cask "menuwhere" do
+  version "2.2.1,31"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/menuwhere"
+  name "Menuwhere"
+  desc "Access the menu from anywhere"
+  homepage "https://manytricks.com/menuwhere/"
+
+  livecheck do
+    url "https://manytricks.com/menuwhere/appcast/"
+    strategy :sparkle
+  end
+
+  app "Menuwhere.app"
+
+  uninstall quit: "com.manytricks.Menuwhere"
+
+  zap trash: [
+    "~/Library/Caches/com.manytricks.Menuwhere",
+    "~/Library/Preferences/com.manytricks.Menuwhere.plist",
+  ]
+end


### PR DESCRIPTION
Reverts #127935.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).