### PR TITLE
name-mangler: Restore cask

### DIFF
--- a/Casks/name-mangler.rb
+++ b/Casks/name-mangler.rb
@@ -1,0 +1,18 @@
+cask "name-mangler" do
+  version "3.7.3,3327"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/namemangler"
+  name "Name Mangler"
+  desc "Multi-file renaming tool"
+  homepage "https://manytricks.com/namemangler/"
+
+  livecheck do
+    url "https://manytricks.com/namemangler/appcast/"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  app "Name Mangler.app"
+end


### PR DESCRIPTION
Reverts #127942.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).