### PR TITLE
time-sink: Restore cask

### DIFF
--- a/Casks/time-sink.rb
+++ b/Casks/time-sink.rb
@@ -1,0 +1,18 @@
+cask "time-sink" do
+  version "2.2.3"
+  sha256 "560ebfb30b2203e3376241954c6fe118f6de47f89e27052c06128655852f5b93"
+
+  url "https://manytricks.com/download/_do_not_hotlink_/timesink#{version.no_dots}.dmg"
+  name "Time Sink"
+  desc "Tracks how you spend your time on your computer"
+  homepage "https://manytricks.com/timesink/"
+
+  livecheck do
+    url "https://manytricks.com/timesink/releasenotes/?rref=appcast"
+    regex(/<h2>Time\s+Sink\s+v?(\d+(?:\.\d+)+)[-\s]/i)
+  end
+
+  auto_updates true
+
+  app "Time Sink.app"
+end


### PR DESCRIPTION
Reverts #127953.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).