### PR TITLE
witch: Restore cask

### DIFF
--- a/Casks/witch.rb
+++ b/Casks/witch.rb
@@ -1,0 +1,26 @@
+cask "witch" do
+  version "4.5.2,3534"
+  sha256 :no_check
+
+  url "https://manytricks.com/download/witch"
+  name "Witch"
+  desc "Switch apps, windows, or tabs"
+  homepage "https://manytricks.com/witch/"
+
+  livecheck do
+    url "https://manytricks.com/witch/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+
+  prefpane "Witch.prefPane"
+
+  uninstall quit:       "com.manytricks.witchdaemon",
+            login_item: "witchdaemon"
+
+  zap trash: [
+    "~/Library/Application Support/Witch",
+    "~/Library/Preferences/com.manytricks.Witch.plist",
+  ]
+end


### PR DESCRIPTION
Reverts #127954.

CloudFlare is no longer blocking traffic per the development team's [Twitter](https://twitter.com/manytricks/status/1547950477228158983?cxt=HHwWjsCl0b6wtvsqAAAA).