### PR TITLE
omit unnecessary files for ukrainian-typographic-keyboard

### DIFF
--- a/Casks/ukrainian-typographic-keyboard.rb
+++ b/Casks/ukrainian-typographic-keyboard.rb
@@ -8,6 +8,6 @@ cask "ukrainian-typographic-keyboard" do
   desc "Combined Ukrainian keyboard layout with typographic symbols"
   homepage "https://denysdovhan.com/ukrainian-typographic-keyboard"
 
-  artifact "ukrainian-typographic-keyboard-#{version}",
+  artifact "ukrainian-typographic-keyboard-#{version}/ukrainian-typographic-keyboard.bundle",
            target: "#{Dir.home}/Library/Keyboard Layouts/ukrainian-typographic-keyboard.bundle"
 end


### PR DESCRIPTION
Previously, this cask contained unnecessary files installing along with the bundle. Now it only copies the bundle.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
