### PR TITLE
Remove syncthing livecheck stanza

### DIFF
--- a/Casks/syncthing.rb
+++ b/Casks/syncthing.rb
@@ -8,12 +8,6 @@ cask "syncthing" do
   desc "Real time file synchronization software"
   homepage "https://syncthing.net/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{href=.*?/tag/v?(\d+(?:[._-]\d+)+)["' >]}i)
-  end
-
   auto_updates true
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
Default :git strategy is inferred and sufficient. [Follows the preference for `:git` over `:github_latest`](https://docs.brew.sh/Brew-Livecheck#general-guidelines). The livecheck was initially introduced in #97640, but simply specified the now default strategy. #118721 changed it to github latest 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
