### PR TITLE
Update `1password-cli` checksum.

### DIFF
--- a/Casks/1password-cli.rb
+++ b/Casks/1password-cli.rb
@@ -1,6 +1,6 @@
 cask "1password-cli" do
   version "2.5.1"
-  sha256 "bf104efd543c2f5a0a309f05ea519dadcd67f49f31669969c3ba2a73a3ef996d"
+  sha256 "7e055ba43819c506a2da69b8d553938c80248b7dee4609fdaaed41d59370f845"
 
   url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_apple_universal_v#{version}.pkg",
       verified: "cache.agilebits.com/dist/1P/op2/pkg/"


### PR DESCRIPTION
Resolves the following checksum warning —

> ❯ brew fetch 1password-cli
> ==> Downloading https://cache.agilebits.com/dist/1P/op2/pkg/v2.5.1/op_apple_universal_v2.5.1.
> ######################################################################## 100.0%
> SHA256: 7e055ba43819c506a2da69b8d553938c80248b7dee4609fdaaed41d59370f845
> Warning: Cask reports different sha256: bf104efd543c2f5a0a309f05ea519dadcd67f49f31669969c3ba2a73a3ef996d


Current results of `brew audit`:
<img width="1351" alt="Screen Shot 2022-07-18 at 12 22 17 PM" src="https://user-images.githubusercontent.com/885841/179600858-a875ff90-9611-4b45-8fe2-918394149d06.png">