### PR TITLE
Revert "corretto 18.0.2.9.1" until corretto-18#38 is resolved

### DIFF
--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -1,12 +1,12 @@
 cask "corretto" do
   arch = Hardware::CPU.intel? ? "x64" : "aarch64"
 
-  version "18.0.2.9.1"
+  version "18.0.1.10.1"
 
   if Hardware::CPU.intel?
-    sha256 "4534fc0e2b6d1b06cc9a127552b5acd395a68a4df0dc95bf08154313f2508337"
+    sha256 "1ca515910ec5a7fbe24b77fcbba5ddbbba6a7c5c0dafbc85f193173bb4199088"
   else
-    sha256 "8c8aaf1a639f78647eec88699bf4bc9b0aab230407042ee12602b4e4c5c9f04d"
+    sha256 "bfdd9b2c41f51e1f536ac57f9416190a238fe56b5ff5dcbae2f8f5bcf941ddaf"
   end
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"


### PR DESCRIPTION
This reverts commit 7f555155aa3e5bd29b73a4d72cdfa8ba976723d6.

Coretto 18.0.2.9.1 does not have working PKG installers at this time, see https://github.com/corretto/corretto-18/issues/38

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
