### PR TITLE
Update SHA256 value for virtualbox-extension-pack

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -1,6 +1,6 @@
 cask "virtualbox-extension-pack" do
   version "6.1.36"
-  sha256 "316e7ce8bd5d1dd1f383ad61f209bd6dd30da45c86f9e37e653b8eb6f1428956"
+  sha256 "3c84f0177a47a1969aff7c98e01ddceedd50348f56cc52d63f4c2dd38ad2ca75"
 
   url "https://download.virtualbox.org/virtualbox/#{version}/Oracle_VM_VirtualBox_Extension_Pack-#{version}.vbox-extpack"
   name "Oracle VirtualBox Extension Pack"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

brew audit --cask --online  virtualbox-extension-pack:
```
==> Downloading https://download.virtualbox.org/virtualbox/6.1.36/Oracle_VM_VirtualBox_Extension_Pack-6.1.36.vbox-extpack
######################################################################## 100.0%
audit for virtualbox-extension-pack: failed
 - download not possible: SHA256 mismatch
Expected: 316e7ce8bd5d1dd1f383ad61f209bd6dd30da45c86f9e37e653b8eb6f1428956
  Actual: 3c84f0177a47a1969aff7c98e01ddceedd50348f56cc52d63f4c2dd38ad2ca75
    File: /Users/isuftin/Library/Caches/Homebrew/downloads/90310990f716299cd777b08dfbebcce467e9c2ad3ea3a83682cdeceda0928c06--Oracle_VM_VirtualBox_Extension_Pack-6.1.36.vbox-extpack
To retry an incomplete download, remove the file above.
Error: 1 problem in 1 cask detected
```

This PR aims to fix the above issue