### PR TITLE
Fix sha256 of smplayer cask v22.7.0

### DIFF
--- a/Casks/smplayer.rb
+++ b/Casks/smplayer.rb
@@ -1,6 +1,6 @@
 cask "smplayer" do
   version "22.7.0"
-  sha256 "0d0ab27a359a5965fe050baaf33f4787115354b8df7c190c563e922e5f29528d"
+  sha256 "f85905d155725fe2a3f642f09c67a95d4cb90f10e4d113a40451a6f5bb0ce88e"
 
   url "https://github.com/smplayer-dev/smplayer/releases/download/v#{version}/smplayer-#{version}.dmg",
       verified: "github.com/smplayer-dev/smplayer/"


### PR DESCRIPTION
### Problem
`brew install --cask smplayer` fails due to sha256 mismatch
```
==> Downloading https://github.com/smplayer-dev/smplayer/releases/download/v22.7.0/smplayer-22.7.0.dmg
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/347905832/7eec8f25-4808-48e3-9e43-0d4c197087e9?X-Amz-Algorithm=AWS4-HMAC-SHA
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 0d0ab27a359a5965fe050baaf33f4787115354b8df7c190c563e922e5f29528d
  Actual: f85905d155725fe2a3f642f09c67a95d4cb90f10e4d113a40451a6f5bb0ce88e
```

### Description:
The pr fixes the sha256 checksum for the smplayer cask.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
