### PR TITLE
couchpotato: discontinued

### DIFF
--- a/Casks/couchpotato.rb
+++ b/Casks/couchpotato.rb
@@ -8,12 +8,11 @@ cask "couchpotato" do
   desc "Automatic Movie Downloading via NZBs & Torrents"
   homepage "https://couchpota.to/"
 
-  livecheck do
-    url :url
-    regex(%r{^build/v?(\d+(?:\.\d+)+)$}i)
-  end
-
   app "CouchPotato.app"
 
   zap trash: "~/Library/Application Support/CouchPotato"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `couchpotato`](https://github.com/CouchPotato/CouchPotatoServer/) has been archived but unfortunately the `README` wasn't updated beforehand to explain the situation. I haven't seen any alternative source for this application (the homepage still references the archived GitHub repository), so it seems like development has simply stopped. This PR sets the cask as discontinued and removes the `livecheck` block accordingly (so the cask will be automatically skipped).