### PR TITLE
Update bili-downloader from V1.6.20220610 to V1.6.20220723

### DIFF
--- a/Casks/bili-downloader.rb
+++ b/Casks/bili-downloader.rb
@@ -1,6 +1,6 @@
 cask "bili-downloader" do
-  version "1.6.20220610"
-  sha256 "57e4b328de09519d0c518505763529e080873573d6307f988365e8fbef940a6b"
+  version "1.6.20220723"
+  sha256 "2e2beae268efb6f601428c0ef745553aefec738d69d04810e4446467498085ed"
 
   url "https://github.com/JimmyLiang-lzm/biliDownloader_GUI/releases/download/V#{version}/BiliDownloader_for_MacOS_X.dmg"
   name "BiliDownloader"


### PR DESCRIPTION
Update bili-downloader from V1.6.20220610 to V1.6.202220723.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

