### PR TITLE
vmware-fusion: add link for macOS 10.15

### DIFF
--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,14 +1,16 @@
 cask "vmware-fusion" do
-  if MacOS.version >= :big_sur
-    version "12.2.4,20071091"
-    sha256 "0b0516f4d5f70e759ae08a40d2e14f487c0b66d84ee467e38972ad013e1f6c7f"
-
-    url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
-  else
+  if MacOS.version <= :catalina
+    livecheck_folder = "core"
     version "12.1.2,17964953"
     sha256 "873049d4080168b56085c5b67be1d4eeb14debc0e6cf176dbd52c78518d0b883"
 
     url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version.csv.first}-#{version.csv.second}.dmg"
+  else
+    livecheck_folder = "x86"
+    version "12.2.4,20071091"
+    sha256 "0b0516f4d5f70e759ae08a40d2e14f487c0b66d84ee467e38972ad013e1f6c7f"
+
+    url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
   end
 
   name "VMware Fusion"
@@ -17,13 +19,9 @@ cask "vmware-fusion" do
 
   livecheck do
     url "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml"
-    strategy :page_match do |page|
-      scan = if MacOS.version >= :big_sur
-        page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/x86}i)
-      else
-        page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/core}i)
-      end
-      scan.map { |match| "#{match[0]},#{match[1]}" }
+    regex(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/#{livecheck_folder}}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -5,10 +5,10 @@ cask "vmware-fusion" do
 
     url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
   else
-    version "12.1.2-17964953"
+    version "12.1.2,17964953"
     sha256 "873049d4080168b56085c5b67be1d4eeb14debc0e6cf176dbd52c78518d0b883"
 
-    url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
+    url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version.csv.first}-#{version.csv.second}.dmg"
   end
 
   name "VMware Fusion"
@@ -18,7 +18,11 @@ cask "vmware-fusion" do
   livecheck do
     url "https://softwareupdate.vmware.com/cds/vmw-desktop/fusion.xml"
     strategy :page_match do |page|
-      scan = page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/x86}i)
+      scan = if MacOS.version >= :big_sur
+        page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/x86}i)
+      else
+        page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/core}i)
+      end
       scan.map { |v| "#{v[0]},#{v[1]}" }
     end
   end

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -23,7 +23,7 @@ cask "vmware-fusion" do
       else
         page.scan(%r{fusion/(\d+(?:\.\d+)+)/(\d+)/core}i)
       end
-      scan.map { |v| "#{v[0]},#{v[1]}" }
+      scan.map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/vmware-fusion.rb
+++ b/Casks/vmware-fusion.rb
@@ -1,8 +1,16 @@
 cask "vmware-fusion" do
-  version "12.2.4,20071091"
-  sha256 "0b0516f4d5f70e759ae08a40d2e14f487c0b66d84ee467e38972ad013e1f6c7f"
+  if MacOS.version >= :big_sur
+    version "12.2.4,20071091"
+    sha256 "0b0516f4d5f70e759ae08a40d2e14f487c0b66d84ee467e38972ad013e1f6c7f"
 
-  url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
+    url "https://download3.vmware.com/software/FUS-#{version.csv.first.no_dots}/VMware-Fusion-#{version.csv.first}-#{version.csv.second}_x86.dmg"
+  else
+    version "12.1.2-17964953"
+    sha256 "873049d4080168b56085c5b67be1d4eeb14debc0e6cf176dbd52c78518d0b883"
+
+    url "https://download3.vmware.com/software/fusion/file/VMware-Fusion-#{version}.dmg"
+  end
+
   name "VMware Fusion"
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/fusion.html"
@@ -17,7 +25,7 @@ cask "vmware-fusion" do
 
   auto_updates true
   conflicts_with cask: "vmware-fusion-tech-preview"
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :catalina"
 
   app "VMware Fusion.app"
   binary "#{appdir}/VMware Fusion.app/Contents/Library/VMware OVF Tool/ovftool"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

--------------------
#112705 updated the minimum requirement for vmware-fusion from 10.15 to 11.0. However, VMware docs mention that earlier releases of major version 12 have compatibility with Catalina [here](https://docs.vmware.com/en/VMware-Fusion/12/com.vmware.fusion.using.doc/GUID-84E34BF1-92A2-4B86-9995-70893A9B04A9.html) and [here](https://kb.vmware.com/s/article/2005196), and the download link for version 12.1.2 still works, as I was able to install it on Catalina using this branch. Since macOS Catalina still receives Apple updates, I created this PR so Catalina users can download the latest compatible VMware version with `brew`.