### PR TITLE
dat: discontinued

### DIFF
--- a/Casks/dat.rb
+++ b/Casks/dat.rb
@@ -2,16 +2,11 @@ cask "dat" do
   version "3.0.1"
   sha256 "f6c89150f72568c2de1f42653bca0fa356cbb24704f31f1ef5e11f75b0095866"
 
-  url "https://github.com/dat-land/dat-desktop/releases/download/v#{version}/dat-desktop-#{version}-mac.zip",
-      verified: "github.com/dat-land/dat-desktop/"
+  url "https://github.com/dat-ecosystem-archive/dat-desktop/releases/download/v#{version}/dat-desktop-#{version}-mac.zip",
+      verified: "github.com/dat-ecosystem-archive/dat-desktop/"
   name "Dat Desktop"
   desc "Peer to peer data sharing app built for humans"
-  homepage "https://datproject.org/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  homepage "https://dat-ecosystem.org/"
 
   app "Dat Desktop.app"
 
@@ -25,4 +20,8 @@ cask "dat" do
     "~/.dat",
     "~/.dat-desktop",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The related GitHub repository for `dat` has been moved to the dat-ecosystem-archive organization and archived. This PR updates the `url`, sets the cask as `discontinued`, and removes the `livecheck` block (so it will be automatically skipped). The datproject.org website has also been deprecated and includes a message directing users to dat-ecosystem.org, so this also updates the `homepage`.