### PR TITLE
github_prerelease_allowlist: Remove ferdium

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -7,7 +7,6 @@
   "drop-to-gif": "all",
   "duplicati": "all",
   "extraterm": "all",
-  "ferdium": "all",
   "freetube": "all",
   "ghdl": "all",
   "graphsketcher": "all",


### PR DESCRIPTION
Ferdium now has stable releases:

https://github.com/ferdium/ferdium-app/releases/latest