### PR TITLE
Fix eqMac checksum

### DIFF
--- a/Casks/eqmac.rb
+++ b/Casks/eqmac.rb
@@ -1,6 +1,6 @@
 cask "eqmac" do
   version "1.5.0"
-  sha256 "a78828dd61ffcbfa434b6ffa0574c445b1181c97733957b7bc71040fdd2decbf"
+  sha256 "56ea5d4852d57df7060596167c0701be187b5fa4e53ada19fbc3133132bf1e0a"
 
   url "https://github.com/bitgapp/eqMac/releases/download/v#{version}/eqMac.pkg",
       verified: "github.com/bitgapp/eqMac/"


### PR DESCRIPTION
eqMac `1.5.0` binary was overridden with `1.5.1` without creating a new release/tag:

```consoole
Installing eqmac
==> Downloading https://github.com/bitgapp/eqMac/releases/download/v1.5.0/eqMac.pkg
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/98095061/2ff259ed-35b7-41b8-ad3e-b954b90a132e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220726%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220726T201339Z&X-Amz-Expires=300&X-Amz-Signature=d47ebd7593ba89e95ff01f1bc198baada9ad81c756370412495af985490c9c7d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=98095061&response-content-disposition=attachment%3B%20filename%3DeqMac.pkg&response-content-type=application%2Foctet-stream
Error: SHA256 mismatch
Expected: a78828dd61ffcbfa434b6ffa0574c445b1181c97733957b7bc71040fdd2decbf
Actual: 56ea5d4852d57df7060596167c0701be187b5fa4e53ada19fbc3133132bf1e0a
```
Maybe wait for a while whether the [author doesn't just actually create a proper release](https://github.com/bitgapp/eqMac/discussions/697#discussioncomment-3255094) before merging:

> No I just overwrote the .pkg file with a patched up version of v1.5.0 :)
Didn't want to do a whole new release just because of a minor fix.


---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
