### PR TITLE
energybar: discontinued

### DIFF
--- a/Casks/energybar.rb
+++ b/Casks/energybar.rb
@@ -4,15 +4,14 @@ cask "energybar" do
 
   url "https://github.com/billziss-gh/EnergyBar/releases/download/v#{version.major_minor}/EnergyBar-#{version}.zip"
   name "EnergyBar"
+  desc "Touch Bar widget application"
   homepage "https://github.com/billziss-gh/EnergyBar"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{href=.*?/EnergyBar-(\d+(?:\.\d+)*)\.zip}i)
-  end
 
   depends_on macos: ">= :high_sierra"
 
   app "EnergyBar.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `energybar`](https://github.com/billziss-gh/EnergyBar) has been archived and the `README` states:

> THIS PROJECT IS NOW ARCHIVED. SEE [FORKS](https://github.com/billziss-gh/EnergyBar/network) OF THIS PROJECT.

This PR sets the cask as discontinued and removes the `livecheck` block accordingly. This also adds a `desc`, to resolve the related audit error.