### PR TITLE
steam-plus-plus: Adjust livecheck

### DIFF
--- a/Casks/steam-plus-plus.rb
+++ b/Casks/steam-plus-plus.rb
@@ -15,6 +15,11 @@ cask "steam-plus-plus" do
   desc "Steam helper tools"
   homepage "https://steampp.net/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :mojave"
 
   app "Steam++.app"


### PR DESCRIPTION
Switch to `:github_latest` due to use of GitHub pre-releases & tag discrepancies.