### PR TITLE
New cask: Livebook

### DIFF
--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -1,0 +1,28 @@
+cask "livebook" do
+  version "0.6.3"
+
+  if Hardware::CPU.intel?
+    arch = "x86_64"
+    sha256 "ebdabcf39edd640092aa5d2ccc985a4cb3426ac1cfb674b8751c48b7e26aba04"
+  else
+    arch = "aarch64"
+    sha256 "f3d205950b4cfeec57a3594f724bc4751661c4ff8fd8410cc046480c31d00840"
+  end
+
+  url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-#{version}-macos-#{arch}.dmg",
+      verified: "github.com/livebook-dev/livebook"
+  name "Livebook"
+  desc "Interactive & collaborative code notebooks in Elixir"
+  homepage "https://livebook.dev/"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  app "Livebook.app"
+
+  zap trash: [
+    "~/Library/Application Support/livebook",
+  ]
+end

--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -4,9 +4,9 @@ cask "livebook" do
   version "0.6.3"
 
   if Hardware::CPU.intel?
-    sha256 "ebdabcf39edd640092aa5d2ccc985a4cb3426ac1cfb674b8751c48b7e26aba04"
+    sha256 "a28bbdba1acba0cbc80209248a051fb57692d4e52cd57ed0eb0ebed33e180bd7"
   else
-    sha256 "f3d205950b4cfeec57a3594f724bc4751661c4ff8fd8410cc046480c31d00840"
+    sha256 "4ade56b044cd6386a50df54dc7033367cb9d72f7645bdb42bad331d806203ccf"
   end
 
   url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-#{version}-macos-#{arch}.dmg",

--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -12,7 +12,7 @@ cask "livebook" do
   url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-#{version}-macos-#{arch}.dmg",
       verified: "github.com/livebook-dev/livebook"
   name "Livebook"
-  desc "Code notebook for Elixir Developers"
+  desc "Code notebooks for Elixir Developers"
   homepage "https://livebook.dev/"
 
   app "Livebook.app"

--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -1,28 +1,21 @@
 cask "livebook" do
+  arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
+
   version "0.6.3"
 
   if Hardware::CPU.intel?
-    arch = "x86_64"
     sha256 "ebdabcf39edd640092aa5d2ccc985a4cb3426ac1cfb674b8751c48b7e26aba04"
   else
-    arch = "aarch64"
     sha256 "f3d205950b4cfeec57a3594f724bc4751661c4ff8fd8410cc046480c31d00840"
   end
 
   url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-#{version}-macos-#{arch}.dmg",
       verified: "github.com/livebook-dev/livebook"
   name "Livebook"
-  desc "Interactive & collaborative code notebooks in Elixir"
+  desc "Code notebook for Elixir Developers"
   homepage "https://livebook.dev/"
-
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
 
   app "Livebook.app"
 
-  zap trash: [
-    "~/Library/Application Support/livebook",
-  ]
+  zap trash: "~/Library/Application Support/livebook"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online livebook` is error-free.
    ```
    audit for livebook: passed
    ```
- [x] `brew style --fix livebook` reports no offenses.
    ```
    1 file inspected, no offenses detected
    ```

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed+livebook&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
    - While the latest is a `v0.X` release, I _believe_ it is appropriate for stable.
- [x] `brew audit --new-cask livebook` worked successfully.
    ```
    audit for livebook: passed
    ```
- [x] `brew install --cask livebook` worked successfully.
    ```
    ...
    🍺  livebook was successfully installed!
    ```
    * I have only tested this on an M1 machine. I have an x86 I can double check the conditional on as well
- [x] `brew uninstall --cask livebook` worked successfully.
    ```
    ==> Uninstalling Cask livebook
    ==> Backing App 'Livebook.app' up to '/opt/homebrew/Caskroom/livebook/0.6.3/Livebook.app'
    ==> Removing App '/Applications/Livebook.app'
    ==> Purging files for version 0.6.3 of Cask livebook
    ```

...

`brew livecheck --debug livebook` also succeeds: `livebook: 0.6.3 ==> 0.6.3`

---

Livebook announced an official desktop app today: https://news.livebook.dev/introducing-the-livebook-desktop-app-4C8dpu. This cask is for the latest, stable release of the desktop app.
