### PR TITLE
mightymike: update homepage, rename to mighty-mike

### DIFF
--- a/Casks/mighty-mike.rb
+++ b/Casks/mighty-mike.rb
@@ -6,13 +6,12 @@ cask "mightymike" do
       verified: "github.com/jorio/MightyMike/"
   name "Mighty Mike"
   desc "Top-down action game from Pangea Software (a.k.a. Power Pete)"
-  homepage "https://pangeasoft.net/mightymike/"
+  homepage "https://jorio.itch.io/mightymike"
 
   app "Mighty Mike.app"
   artifact "Documentation", target: "#{Dir.home}/Library/Application Support/MightyMike"
 
   zap trash: [
-    "~/Library/Application Support/MightyMike",
     "~/Library/Preferences/MightyMike",
     "~/Library/Saved Application State/io.jor.mightymike.savedState",
   ]

--- a/Casks/mighty-mike.rb
+++ b/Casks/mighty-mike.rb
@@ -1,4 +1,4 @@
-cask "mightymike" do
+cask "mighty-mike" do
   version "3.0.1"
   sha256 "8c772b2777ac29b52775c9ce8b4281406fe62f0d4565d478112c15408b3a2efc"
 


### PR DESCRIPTION
This set of game ports now has its own site. Also trims an unnecessary zap path and renames the cask to match the app package name.

---
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
