### PR TITLE
nanosaur: update homepage

### DIFF
--- a/Casks/nanosaur.rb
+++ b/Casks/nanosaur.rb
@@ -5,11 +5,14 @@ cask "nanosaur" do
   url "https://github.com/jorio/Nanosaur/releases/download/v#{version}/Nanosaur-#{version}-mac.dmg",
       verified: "github.com/jorio/Nanosaur/"
   name "Nanosaur"
-  desc "Science fiction 3rd person shooter game from Pangea Software"
-  homepage "https://pangeasoft.net/nano/"
+  desc "Dinosaur 3rd person shooter game from Pangea Software"
+  homepage "https://jorio.itch.io/nanosaur"
 
   app "Nanosaur.app"
   artifact "Documentation", target: "#{Dir.home}/Library/Application Support/Nanosaur"
 
-  zap trash: "~/Library/Preferences/Nanosaur"
+  zap trash: [
+    "~/Library/Preferences/Nanosaur",
+    "~/Library/Saved Application State/io.jor.nanosaur.savedState",
+  ]
 end


### PR DESCRIPTION
This set of game ports now has its own site. Also updates description and adds a zap path.

---
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
