### PR TITLE
imagemin: discontinued

### DIFF
--- a/Casks/imagemin.rb
+++ b/Casks/imagemin.rb
@@ -4,9 +4,14 @@ cask "imagemin" do
 
   url "https://github.com/imagemin/imagemin-app/releases/download/#{version}/imagemin-app-v#{version}-darwin.zip"
   name "imagemin"
+  desc "Desktop image minifier"
   homepage "https://github.com/imagemin/imagemin-app"
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/4701
   app "imagemin-app-v#{version}-darwin/Atom.app", target: "imagemin.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `imagemin`](https://github.com/imagemin/imagemin-app) has been archived and the only release is from 2014-05-21 (though there are a few small commits after it). This cask is specifically for the desktop app, where development appears to have ceased. This PR sets the cask as discontinued accordingly.

Besides that, this adds a `desc` to resolve the related audit error.