### PR TITLE
kitematic: discontinued

### DIFF
--- a/Casks/kitematic.rb
+++ b/Casks/kitematic.rb
@@ -19,4 +19,8 @@ cask "kitematic" do
     "~/Library/Preferences/com.electron.kitematic.helper.plist",
     "~/Library/Saved Application State/com.electron.kitematic.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `kitematic`](https://github.com/docker/kitematic) has been archived and the `README` contains the following message at the top:

> Deprecation Notice: This project and repository is now deprecated and is no longer under active development, see https://github.com/docker/roadmap/issues/67. Please use [Docker Desktop](https://www.docker.com/products/docker-desktop) instead where possible.

kitematic.com also simply redirects to www.docker.com at this point. This PR sets the cask as discontinued accordingly.