### PR TITLE
Update ledger-live from 2.42.0 to 2.45.0

### DIFF
--- a/Casks/ledger-live.rb
+++ b/Casks/ledger-live.rb
@@ -1,16 +1,15 @@
 cask "ledger-live" do
-  version "2.42.0"
-  sha256 "8d1c7087f016b6ee4946ecbd5e6868b03642170421f51849487fa384390bb94c"
+  version "2.45.0"
+  sha256 "5d476f1e9832e76077bd6b851f0ce0714fb8c7017ae259ee710ac3d3772e207c"
 
-  url "https://github.com/LedgerHQ/ledger-live-desktop/releases/download/v#{version}/ledger-live-desktop-#{version}-mac.dmg",
-      verified: "github.com/LedgerHQ/ledger-live-desktop/"
+  url "https://download.live.ledger.com/ledger-live-desktop-#{version}-mac.dmg"
   name "Ledger Live"
   desc "Wallet desktop application to maintain multiple cryptocurrencies"
   homepage "https://www.ledger.com/ledger-live"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://download.live.ledger.com/latest/mac"
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `ledger-live`](https://github.com/LedgerHQ/ledger-live-desktop) was archived with the following message in the `README`:

> ⛔️ DEPRECATED
>
> This repository is now deprecated. We moved to a new mono repository architecture containing all of Ledger Live JavaScript Ecosystem that you can find [here](https://github.com/ledgerhq/ledger-live). You can follow the [migration guide](https://github.com/LedgerHQ/ledger-live/wiki/Migrate-from-previous-repositories#migration) to help you make the transition.

The ledgerhq/ledger-live repository publishes releases for `ledger-live-desktop` but no dmg file is made available. It appears that we'll have to switch to downloading the dmg file from the [first-party website](https://www.ledger.com/ledger-live/) instead.

This PR updates the cask to the latest version, 2.45.0, switching the `url` to the dmg from the first-party website in the process. This also updates the `livecheck` block to align with the new `url` source.