### PR TITLE
`cmd/lib/ci_matrix.rb`: Deprecate `:catalina` runner

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -8,7 +8,6 @@ module CiMatrix
   MAX_JOBS = 256
 
   RUNNERS = {
-    { symbol: :catalina, name: "macos-10.15" } => 0,
     { symbol: :big_sur,  name: "macos-11" }    => 0.9,
     { symbol: :monterey, name: "macos-12" }    => 0.1,
   }.freeze

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -8,8 +8,8 @@ module CiMatrix
   MAX_JOBS = 256
 
   RUNNERS = {
-    { symbol: :big_sur,  name: "macos-11" }    => 0.9,
-    { symbol: :monterey, name: "macos-12" }    => 0.1,
+    { symbol: :big_sur,  name: "macos-11" } => 0.9,
+    { symbol: :monterey, name: "macos-12" } => 0.1,
   }.freeze
 
   # This string uses regex syntax and is intended to be interpolated into


### PR DESCRIPTION
> The macOS 10.15 Actions runner image started our deprecation process on 5/31/22 and will be fully unsupported by 8/30/22. To raise awareness of the upcoming removal, jobs using macOS 10.15 will temporarily fail during scheduled time periods defined below:

    July 21, 12:00 UTC – July 22, 18:00 UTC
    July 27, 00:00 UTC – July 28, 00:00 UTC
    August 3, 00:00 UTC – August 4, 00:00 UTC
    August 15, 00:00 UTC – August 16, 00:00 UTC
    August 26, 00:00 UTC – August 27, 00:00 UTC

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/]]


Blocking: https://github.com/Homebrew/homebrew-cask/pull/129100


