### PR TITLE
added yubihsm2-sdk

### DIFF
--- a/Casks/yubihsm2-sdk.rb
+++ b/Casks/yubihsm2-sdk.rb
@@ -1,0 +1,25 @@
+cask "yubihsm2-sdk" do
+  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
+
+  version "2022-06"
+
+  if Hardware::CPU.intel?
+    sha256 "fddd316127c460a604372ebbf41f01e3b9ef50b28ee5686915b663dd8f88cdc0"
+  else
+    sha256 "7363999e43afc4471853a4d7254de71e4d5f5c84d5e2febd1693d7bf22a1e525"
+  end
+
+  url "https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-#{version}-darwin-#{arch}.pkg"
+  name "YubiHSM 2 SDK"
+  desc "Libraries and utilities to interact with a YubiHSM 2 natively and via PKCS#11"
+  homepage "https://developers.yubico.com/YubiHSM2/"
+
+  livecheck do
+    url "https://developers.yubico.com/YubiHSM2/Releases/"
+    regex(%r{href=.*?/yubihsm2-sdk-(\d\d\d\d-[^-]+)-darwin-#{arch}\.pkg}i)
+  end
+
+  pkg "yubihsm2-sdk-#{version}-darwin-#{arch}.pkg"
+
+  uninstall pkgutil: "com.yubico.yubihsm2-sdk"
+end

--- a/Casks/yubihsm2-sdk.rb
+++ b/Casks/yubihsm2-sdk.rb
@@ -16,7 +16,7 @@ cask "yubihsm2-sdk" do
 
   livecheck do
     url "https://developers.yubico.com/YubiHSM2/Releases/"
-    regex(%r{href=.*?/yubihsm2-sdk-(\d\d\d\d-[^-]+)-darwin-#{arch}\.pkg}i)
+    regex(%r{href=.*?/yubihsm2-sdk[._-]v?(\d+(?:[.-]\d+)+)-darwin-#{arch}\.pkg}i)
   end
 
   pkg "yubihsm2-sdk-#{version}-darwin-#{arch}.pkg"


### PR DESCRIPTION
## YubiHSM 2 SDK

The YubiHSM 2 SDK bundles several utilities together for convenience:

- [yubihsm-setup](https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-setup)
- [yubihsm-connector](https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-connector)
- [yubihsm-shell](https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-shell)
- [yubihsm-auth](https://developers.yubico.com/yubihsm-shell/yubihsm-auth.html)
- [yubihsm-wrap](https://developers.yubico.com/YubiHSM2/Component_Reference/yubihsm-wrap)
- [PKCS#11 driver](https://developers.yubico.com/YubiHSM2/Component_Reference/PKCS_11)
- [libyubihsm](https://developers.yubico.com/YubiHSM2/Component_Reference/libyubihsm)
- [python-yubihsm](https://developers.yubico.com/YubiHSM2/Component_Reference/python-yubihsm)

## Submission checklist

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ X ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ X ] `brew audit --cask --online <cask>` is error-free.
- [ X ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ X ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ X ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ X ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ X ] `brew audit --new-cask <cask>` worked successfully.
- [ X ] `brew install --cask <cask>` worked successfully.
- [ X ] `brew uninstall --cask <cask>` worked successfully.
