### PR TITLE
Upgrade surge-xt to 1.1.0

### DIFF
--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -1,6 +1,6 @@
 cask "surge-xt" do
-  version "1.0.1"
-  sha256 "644efd84e2a8c62e6211f3d1c1311c8f5a0386c6e91d69c5a37e5a1aaebc504a"
+  version "1.1.0"
+  sha256 "03f8970ffe89ec576d436c5580ebf94e229154fe13ac9571118e99f3bbd58600"
 
   url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
       verified: "github.com/surge-synthesizer/releases-xt/"
@@ -18,6 +18,15 @@ cask "surge-xt" do
               "com.surge-synth-team.surge-xt.component.pkg",
               "com.surge-synth-team.surge-xt.resources.pkg",
               "com.surge-synth-team.surge-xt.vst3.pkg",
+
+              "org.surge-synth-team.surge-xt-fx.app.pkg",
+              "org.surge-synth-team.surge-xt-fx.component.pkg",
+              "org.surge-synth-team.surge-xt-fx.vst3.pkg",
+              "org.surge-synth-team.surge-xt-fx.clap.pkg",
+              "org.surge-synth-team.surge-xt.app.pkg",
+              "org.surge-synth-team.surge-xt.component.pkg",
+              "org.surge-synth-team.surge-xt.resources.pkg",
+              "org.surge-synth-team.surge-xt.clap.pkg",
             ],
             delete:  [
               "/Applications/Surge XT Effects.app",

--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -26,6 +26,7 @@ cask "surge-xt" do
               "org.surge-synth-team.surge-xt.app.pkg",
               "org.surge-synth-team.surge-xt.component.pkg",
               "org.surge-synth-team.surge-xt.resources.pkg",
+              "org.surge-synth-team.surge-xt.vst3.pkg",
               "org.surge-synth-team.surge-xt.clap.pkg",
             ],
             delete:  [

--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -18,7 +18,6 @@ cask "surge-xt" do
               "com.surge-synth-team.surge-xt.component.pkg",
               "com.surge-synth-team.surge-xt.resources.pkg",
               "com.surge-synth-team.surge-xt.vst3.pkg",
-
               "org.surge-synth-team.surge-xt-fx.app.pkg",
               "org.surge-synth-team.surge-xt-fx.component.pkg",
               "org.surge-synth-team.surge-xt-fx.vst3.pkg",


### PR DESCRIPTION
Upgrade cask surge-xt.rb to 1.1.0

Also in this update we moved our macOS packjage names to correctly
be org.surge- rather than com.surge- so add delete segments for
both the new and old package names

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
