### PR TITLE
Use `on_{system}` blocks

### DIFF
--- a/Casks/brave-browser.rb
+++ b/Casks/brave-browser.rb
@@ -1,13 +1,13 @@
 cask "brave-browser" do
-  arch = Hardware::CPU.intel? ? "x64" : "arm64"
-  folder = Hardware::CPU.intel? ? "stable" : "stable-arm64"
-
+  arch = "arm64"
+  folder = "stable-arm64"
   version "1.41.100.0,141.100"
+  sha256 "2678abc985e8722403bba515f6272e72f81fbd704a8c3b3d1273d07e46aec71c"
 
-  if Hardware::CPU.intel?
+  on_intel do
+    arch = "x64"
+    folder = "stable"
     sha256 "e0b4f5ddafa8e478b5f0e8fd36e8e042718e8cef394005efedb7cb6cd7ea0f92"
-  else
-    sha256 "2678abc985e8722403bba515f6272e72f81fbd704a8c3b3d1273d07e46aec71c"
   end
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.csv.second}/Brave-Browser-#{arch}.dmg",

--- a/Casks/chromium.rb
+++ b/Casks/chromium.rb
@@ -2,7 +2,11 @@ cask "chromium" do
   version :latest
   sha256 :no_check
 
-  arch = Hardware::CPU.intel? ? "Mac" : "Mac_Arm"
+  arch = "Mac_Arm"
+
+  on_intel do
+    arch = "Mac"
+  end
 
   url "https://download-chromium.appspot.com/dl/#{arch}?type=snapshots",
       verified: "download-chromium.appspot.com/dl/"

--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,11 +1,11 @@
 cask "iterm2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  if MacOS.version <= :high_sierra
+  version "3.4.16"
+  sha256 "b0941a008ead9f680e9f4937698b9b849acbb4e30ed1f3f100e3616cd6d49c0b"
+
+  on_high_sierra :or_older do
     version "3.3.12"
     sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167"
-  else
-    version "3.4.16"
-    sha256 "b0941a008ead9f680e9f4937698b9b849acbb4e30ed1f3f100e3616cd6d49c0b"
   end
 
   url "https://iterm2.com/downloads/stable/iTerm2-#{version.dots_to_underscores}.zip"

--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -1,12 +1,20 @@
 cask "karabiner-elements" do
-  if MacOS.version <= :el_capitan
+  version "14.6.0"
+  sha256 "37e03ff5fc848fb47303f43453615f3388848d4ae935a6868430a73c7f8d9346"
+
+  url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
+      verified: "github.com/pqrs-org/Karabiner-Elements/"
+
+  on_el_capitan :or_older do
     version "11.6.0"
     sha256 "c1b06252ecc42cdd8051eb3d606050ee47b04532629293245ffdfa01bbc2430d"
 
     url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
 
     pkg "Karabiner-Elements.sparkle_guided.pkg"
-  elsif MacOS.version <= :mojave
+  end
+
+  on_mojave :or_older do
     version "12.10.0"
     sha256 "53252f7d07e44f04972afea2a16ac595552c28715aa65ff4a481a1c18c8be2f4"
 
@@ -14,7 +22,9 @@ cask "karabiner-elements" do
         verified: "github.com/pqrs-org/Karabiner-Elements/"
 
     pkg "Karabiner-Elements.sparkle_guided.pkg"
-  elsif MacOS.version <= :catalina
+  end
+
+  on_catalina :or_older do
     version "13.7.0"
     sha256 "9ac5e53a71f3a00d7bdb2f5f5f001f70b6b8b7b2680e10a929e0e4c488c8734b"
 
@@ -26,29 +36,23 @@ cask "karabiner-elements" do
     end
 
     pkg "Karabiner-Elements.pkg"
-  else
-    version "14.6.0"
-    sha256 "37e03ff5fc848fb47303f43453615f3388848d4ae935a6868430a73c7f8d9346"
-
-    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
-        verified: "github.com/pqrs-org/Karabiner-Elements/"
-
-    livecheck do
-      url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
-      strategy :sparkle
-    end
-
-    pkg "Karabiner-Elements.pkg"
   end
 
   name "Karabiner Elements"
   desc "Keyboard customizer"
   homepage "https://pqrs.org/osx/karabiner/"
 
+  livecheck do
+    url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
+    strategy :sparkle
+  end
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
-  if MacOS.version <= :mojave
+  pkg "Karabiner-Elements.pkg"
+
+  on_mojave :or_older do
     uninstall signal:    [
                 ["TERM", "org.pqrs.Karabiner-Menu"],
                 ["TERM", "org.pqrs.Karabiner-NotificationWindow"],
@@ -66,7 +70,9 @@ cask "karabiner-elements" do
                 sudo:       true,
               },
               delete:    "/Library/Application Support/org.pqrs/"
-  else
+  end
+
+  on_catalina :or_newer do
     uninstall early_script: {
                 executable: "/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice/scripts/uninstall/remove_files.sh",
                 sudo:       true,

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,12 +1,13 @@
 cask "libreoffice" do
-  arch, folder = Hardware::CPU.intel? ? ["x86-64", "x86_64"] : ["aarch64", "aarch64"]
-
+  arch = "aarch64"
+  folder = "aarch64"
   version "7.3.5"
+  sha256 "dfd30d5d520959ee1b65a620d748a0ac5535d1a9e811f83fa35a14dc8d3d736d"
 
-  if Hardware::CPU.intel?
+  on_intel do
+    arch = "x86-64"
+    folder = "x86_64"
     sha256 "9534e444b3102a653f3d0c0e3fb54efb20caf2c91ce121b2db00d2531ab8b7fa"
-  else
-    sha256 "dfd30d5d520959ee1b65a620d748a0ac5535d1a9e811f83fa35a14dc8d3d736d"
   end
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",

--- a/Casks/microsoft-auto-update.rb
+++ b/Casks/microsoft-auto-update.rb
@@ -1,10 +1,10 @@
 cask "microsoft-auto-update" do
-  if MacOS.version <= :el_capitan
+  version "4.49.22070801"
+  sha256 "2749a0163267e8e24d212be09012fcb2c09e840ebc2047507d5088da9629ec04"
+
+  on_el_capitan :or_older do
     version "4.40.21101001"
     sha256 "f638f7e0da9ee659c323f2ede0f176804bfe9a615a8f8b6320bd2e69d91ef2b2"
-  else
-    version "4.49.22070801"
-    sha256 "2749a0163267e8e24d212be09012fcb2c09e840ebc2047507d5088da9629ec04"
   end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_#{version}_Updater.pkg"

--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -1,12 +1,12 @@
 cask "ngrok" do
-  arch = Hardware::CPU.intel? ? "amd64" : "arm64"
+  arch = "arm64"
+  version "3.0.6,91H3cQoKGUw,a"
+  sha256 "f17dd2755abc3db298bfac5279c0d633d08fc96e69708a332d9c65b57328a9f6"
 
-  if Hardware::CPU.intel?
+  on_intel do
+    arch = "amd64"
     version "3.0.6,mStkVrofaG9,a"
     sha256 "26695c41b93e6437b797fcc0f6e78242ec8c665e8e57f436aa6305b9237e3ac1"
-  else
-    version "3.0.6,91H3cQoKGUw,a"
-    sha256 "f17dd2755abc3db298bfac5279c0d633d08fc96e69708a332d9c65b57328a9f6"
   end
 
   url "https://bin.equinox.io/#{version.csv.third}/#{version.csv.second}/ngrok-v#{version.major}-#{version.csv.first}-stable-darwin-#{arch}.zip",

--- a/Casks/sourcetree.rb
+++ b/Casks/sourcetree.rb
@@ -1,19 +1,21 @@
 cask "sourcetree" do
-  if MacOS.version <= :sierra
+  version "4.1.9,245"
+  sha256 "54a5848acd01e84949e1ba61f8ca90d661ad11b65e504c615bd2ce5999501ffc"
+
+  url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
+      verified: "atlassian.com/software/sourcetree/"
+
+  on_sierra :or_older do
     version "2.7.6a"
     sha256 "d60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e"
 
     url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip",
         verified: "atlassian.com/software/sourcetree/"
-  elsif MacOS.version <= :high_sierra
+  end
+
+  on_high_sierra :or_older do
     version "3.2.1,225"
     sha256 "4bd82affa3402814c3d07ff613fbc8f45da8b0cda294d498ffbb0667bf729c9f"
-
-    url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
-        verified: "atlassian.com/software/sourcetree/"
-  else
-    version "4.1.9,245"
-    sha256 "54a5848acd01e84949e1ba61f8ca90d661ad11b65e504c615bd2ce5999501ffc"
 
     url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
         verified: "atlassian.com/software/sourcetree/"

--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -1,5 +1,9 @@
 cask "spotify" do
-  arch = Hardware::CPU.intel? ? "" : "ARM64"
+  arch = "ARM64"
+
+  on_intel do
+    arch = ""
+  end
 
   version "1.1.90.859,f1bb1e36,15"
   sha256 :no_check

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -1,12 +1,11 @@
 cask "visual-studio-code" do
-  arch = Hardware::CPU.intel? ? "darwin" : "darwin-arm64"
-
+  arch = "darwin-arm64"
   version "1.69.2"
+  sha256 "da3b2b92d9eabf39f15cf63ca3b2215c7090b7cf94c6af2d4a04247bd9a29981"
 
-  if Hardware::CPU.intel?
+  on_intel do
+    arch = "darwin"
     sha256 "f616025cb4160ea3210eb71766848d3482ad2cb96c8187acbe1341b31c70a1d8"
-  else
-    sha256 "da3b2b92d9eabf39f15cf63ca3b2215c7090b7cf94c6af2d4a04247bd9a29981"
   end
 
   url "https://update.code.visualstudio.com/#{version}/#{arch}/stable"


### PR DESCRIPTION
This PR adds `on_{system}` blocks to 10 casks. This is meant to be a small sample so we can discuss what the format we like best is and what changes should be made before trying to do huge PRs to migrate everything. For now, I've chosen casks that are decently popular and also have some different styles.

CC: @Homebrew/cask and @MikeMcQuaid for your thoughts on the style of the casks in this PR. Please comment on specific cases if you think what I have currently isn't the best solution.
