### PR TITLE
mongodbpreferencepane: discontinued

### DIFF
--- a/Casks/mongodbpreferencepane.rb
+++ b/Casks/mongodbpreferencepane.rb
@@ -4,7 +4,12 @@ cask "mongodbpreferencepane" do
 
   url "https://github.com/remysaissy/mongodb-macosx-prefspane/raw/master/download/MongoDB.prefPane.zip"
   name "MongoDB-PrefsPane"
+  desc "Preference pane to control MongoDB Server"
   homepage "https://github.com/remysaissy/mongodb-macosx-prefspane"
 
   prefpane "MongoDB.prefPane"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `mongodbpreferencepane `](https://github.com/remysaissy/mongodb-macosx-prefspane) has been archived, though the `README` wasn't updated beforehand to explain the situation. Without more insight, this would seem to suggest that development has ceased on the project. This PR sets the cask as discontinued accordingly.