### PR TITLE
Add arm64 builds to darktable

### DIFF
--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,8 +1,15 @@
 cask "darktable" do
+  arch = Hardware::CPU.intel? ? "" : "_arm64"
+  
   version "4.0.0"
-  sha256 "addab784af18bafa303340e754c00084c126e61c3d5b93006f8e6d602f838203"
+  
+  if Hardware::CPU.intel?
+    sha256 "addab784af18bafa303340e754c00084c126e61c3d5b93006f8e6d602f838203"
+  else
+    sha256 "5bcd8e088065bc20815022f494ca1ca0613446562843f378ad60f68ae6917cb7"
+  end
 
-  url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}.dmg",
+  url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}#{arch}.dmg",
       verified: "github.com/darktable-org/darktable/"
   name "darktable"
   desc "Photography workflow application and raw developer"

--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -1,8 +1,8 @@
 cask "darktable" do
   arch = Hardware::CPU.intel? ? "" : "_arm64"
-  
+
   version "4.0.0"
-  
+
   if Hardware::CPU.intel?
     sha256 "addab784af18bafa303340e754c00084c126e61c3d5b93006f8e6d602f838203"
   else


### PR DESCRIPTION
This PR adds the arm64 builds to darktable as suggested by @simon04 in https://github.com/Homebrew/homebrew-cask/issues/127006#issuecomment-1206789936_

The first commit contained 4 offenses which have been corrected by `brew style --fix` in the second commit

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
