### PR TITLE
Add support for the arm64 arch for Molotov

### DIFF
--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,15 +1,32 @@
 cask "molotov" do
   version "4.5.0"
-  sha256 "9366230de159a4b5dffe29e1823b6e3bc0d6e6fd2ddc2c4f1b9e9764319cf995"
 
-  url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-#{version}-mac.zip"
+  arch = Hardware::CPU.intel? ? "" : "arm64"
+
+  if Hardware::CPU.intel?
+    sha256 "9366230de159a4b5dffe29e1823b6e3bc0d6e6fd2ddc2c4f1b9e9764319cf995"
+  else
+    sha256 "4b5303345be7bfcf4f90440424c52f5fd06d912c500969d576cef4eba159d82d"
+  end
+
+  if Hardware::CPU.intel?
+    url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-#{version}-mac.zip"
+  else
+    url "https://desktop-auto-upgrade.molotov.tv/mac/m1/Molotov-#{version}-#{arch}-mac.zip"
+  end
+
   name "Molotov"
   desc "French TV streaming service"
   homepage "https://www.molotov.tv/"
 
   livecheck do
-    url "https://desktop-auto-upgrade.molotov.tv/mac/manifest.json"
-    regex(%r{/Molotov-v?(\d+(?:\.\d+)+)-mac\.zip}i)
+    if Hardware::CPU.intel?
+      url "https://desktop-auto-upgrade.molotov.tv/mac/manifest.json"
+      regex(%r{/Molotov-v?(\d+(?:\.\d+)+)-mac\.zip}i)
+    else
+      url "https://desktop-auto-upgrade.molotov.tv/mac/m1/manifest.json"
+      regex(%r{/Molotov-v?(\d+(?:\.\d+)+)-#{arch}-mac\.zip}i)
+    end
   end
 
   app "Molotov.app"

--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -1,7 +1,8 @@
 cask "molotov" do
   version "4.5.0"
 
-  arch = Hardware::CPU.intel? ? "" : "arm64"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
+  arch_folder = Hardware::CPU.intel? ? "" : "m1/"
 
   if Hardware::CPU.intel?
     sha256 "9366230de159a4b5dffe29e1823b6e3bc0d6e6fd2ddc2c4f1b9e9764319cf995"
@@ -9,24 +10,14 @@ cask "molotov" do
     sha256 "4b5303345be7bfcf4f90440424c52f5fd06d912c500969d576cef4eba159d82d"
   end
 
-  if Hardware::CPU.intel?
-    url "https://desktop-auto-upgrade.molotov.tv/mac/Molotov-#{version}-mac.zip"
-  else
-    url "https://desktop-auto-upgrade.molotov.tv/mac/m1/Molotov-#{version}-#{arch}-mac.zip"
-  end
-
+  url "https://desktop-auto-upgrade.molotov.tv/mac/#{arch_folder}Molotov-#{version}#{arch}-mac.zip"
   name "Molotov"
   desc "French TV streaming service"
   homepage "https://www.molotov.tv/"
 
   livecheck do
-    if Hardware::CPU.intel?
-      url "https://desktop-auto-upgrade.molotov.tv/mac/manifest.json"
-      regex(%r{/Molotov-v?(\d+(?:\.\d+)+)-mac\.zip}i)
-    else
-      url "https://desktop-auto-upgrade.molotov.tv/mac/m1/manifest.json"
-      regex(%r{/Molotov-v?(\d+(?:\.\d+)+)-#{arch}-mac\.zip}i)
-    end
+    url "https://desktop-auto-upgrade.molotov.tv/mac/#{arch_folder}manifest.json"
+    regex(%r{/Molotov-v?(\d+(?:\.\d+)+)#{arch}-mac\.zip}i)
   end
 
   app "Molotov.app"


### PR DESCRIPTION
This PR adds support for the _arm64_ architecture for Molotov.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.