### PR TITLE
pathephone: discontinued

### DIFF
--- a/Casks/pathephone.rb
+++ b/Casks/pathephone.rb
@@ -8,11 +8,6 @@ cask "pathephone" do
   desc "Distributed audio player"
   homepage "https://pathephone.github.io/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
 
   app "Pathephone.app"
@@ -24,4 +19,8 @@ cask "pathephone" do
     "~/Library/Preferences/space.metabin.pathephone.plist",
     "~/Library/Saved Application State/space.metabin.pathephone.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `pathephone`](https://github.com/pathephone/pathephone-desktop) has been archived and the `README` states:

> Development of pathephone-desktop is currently suspended in favor of [pathephone-web](https://github.com/pathephone/pathephone-web). It will be probably reanimated and refactored to use shared UI once pathephone-web will be finished.

However, the referenced pathephone-web repository has also been archived and the last commit was near the end of 2019, so it's probably fair to say this project isn't being actively developed. This PR sets the cask as discontinued and removes the `livecheck` block accordingly.