### PR TITLE
Enable `auto_updates` for babeledit

### DIFF
--- a/Casks/babeledit.rb
+++ b/Casks/babeledit.rb
@@ -12,6 +12,8 @@ cask "babeledit" do
     regex(%r{babeledit/download/v?(\d+(?:\.\d+)+)/mac-64}i)
   end
 
+  auto_updates true
+
   app "BabelEdit.app"
 
   zap trash: "~/Library/Preferences/de.code-and-web.BabelEdit.plist"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online babeledit` is error-free.
- [x] `brew style --fix babeledit` reports no offenses.
