### PR TITLE
monitorcontrol: add livecheck

### DIFF
--- a/Casks/monitorcontrol.rb
+++ b/Casks/monitorcontrol.rb
@@ -16,6 +16,11 @@ cask "monitorcontrol" do
   else
     version "4.1.0"
     sha256 "89ac4cf63efc4aad441f94c2636e3437e0f96c6eaaba4d9d663f13ee7b7d013a"
+
+    livecheck do
+      url "https://monitorcontrol.app/appcast.xml"
+      strategy :sparkle, &:short_version
+    end
   end
 
   url "https://github.com/MonitorControl/MonitorControl/releases/download/v#{version}/MonitorControl.#{version}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This PR adds a livecheck to monitorcontrol, instead of using the default (Git) strategy.
Note: Even though the `appcast.xml` contains some older beta releases, there seem to be plans for separating the beta and stable channel (see https://github.com/MonitorControl/MonitorControl/issues/5#issuecomment-931721945 & https://github.com/MonitorControl/MonitorControl/blob/226f06845826b6c03427d60a62256eb5076d422a/MonitorControl/Enums/PrefKey.swift#L10). The app behaves the same and also uses this file.