### PR TITLE
radiant-player: discontinued

### DIFF
--- a/Casks/radiant-player.rb
+++ b/Casks/radiant-player.rb
@@ -19,4 +19,8 @@ cask "radiant-player" do
     "~/Library/Preferences/com.sajidanwar.Radiant-Player.plist",
     "~/Library/Saved Application State/com.sajidanwar.Radiant-Player.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `radiant-player`](https://github.com/radiant-player/radiant-player-mac) has been archived and the `README` states:

> # Project Deprecated
>
> As Google Play Music [has shut down](https://support.google.com/googleplaymusic/answer/9973710), this repo will be archived as Radiant Player no longer functions. For alternatives that support YouTube Music, consider projects like [GPMDP](https://github.com/MarshallOfSound/Google-Play-Music-Desktop-Player-UNOFFICIAL-).

The PR sets the cask as discontinued accordingly.