### PR TITLE
gcc-arm-embedded: Update to 11.3.rel1 and package structure changes

### DIFF
--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -52,7 +52,7 @@ cask "gcc-arm-embedded" do
             delete:  [
               "/Applications/ArmGNUToolchain/#{version}/arm-none-eabi",
             ],
-            rmdir: [
+            rmdir:   [
               "/Applications/ArmGNUToolchain/#{version}",
               "/Applications/ArmGNUToolchain",
             ]

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -51,5 +51,9 @@ cask "gcc-arm-embedded" do
   uninstall pkgutil: "arm-gnu-toolchain-#{version}-darwin-x86_64-arm-none-eabi",
             delete:  [
               "/Applications/ArmGNUToolchain/#{version}/arm-none-eabi",
+            ],
+            rmdir: [
+              "/Applications/ArmGNUToolchain/#{version}",
+              "/Applications/ArmGNUToolchain",
             ]
 end

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -1,65 +1,55 @@
 cask "gcc-arm-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  version "11.2-2022.02"
-  gcc_version = "11.2.1"
-  sha256 "105ac7f9b2be62c55d6853a099a92488c16f08bb296a694ef8430e5ddf8dead8"
+  version "11.3.rel1"
+  gcc_version = "11.3.1"
+  sha256 "97621c58f246f38135da38f6ca8197a23190c01650c8265be3346895c3fc34d2"
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/gcc-arm-#{version}-darwin-x86_64-arm-none-eabi.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-x86_64-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
   livecheck do
     url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
-    regex(/href=.*?gcc-arm-(\d+\.\d+-\d+\.\d+)-darwin-(?:\w+)-arm-none-eabi.pkg/i)
+    regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-arm-none-eabi.pkg/i)
   end
 
-  pkg "gcc-arm-#{version}-darwin-x86_64-arm-none-eabi.pkg"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-addr2line"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ar"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-as"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-c++"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-c++filt"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-cpp"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-elfedit"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-g++"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-#{gcc_version}"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ar"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-nm"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ranlib"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-dump"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-tool"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gfortran"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gprof"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ld"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ld.bfd"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-lto-dump"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-nm"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-objcopy"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-objdump"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ranlib"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-readelf"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-size"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-strings"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-strip"
+  pkg "arm-gnu-toolchain-#{version}-darwin-x86_64-arm-none-eabi.pkg"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-addr2line"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-as"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-c++"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-c++filt"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-cpp"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-elfedit"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-g++"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-#{gcc_version}"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcov"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcov-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcov-tool"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gdb"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gdb-add-index"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gfortran"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gprof"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ld"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ld.bfd"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-lto-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-objcopy"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-objdump"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-readelf"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-size"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-strings"
+  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "gcc-arm-#{version}-darwin-x86_64-arm-none-eabi",
+  uninstall pkgutil: "arm-gnu-toolchain-#{version}-darwin-x86_64-arm-none-eabi",
             delete:  [
-              "/Applications/ARM/#{version}-darwin-x86_64-arm-none-eabi-manifest",
-              "/Applications/ARM/bin/arm-none-eabi-*",
-              "/Applications/ARM/arm-none-eabi",
-              "/Applications/ARM/lib/gcc/arm-none-eabi",
-              "/Applications/ARM/libexec/gcc/arm-none-eabi",
-              "/Applications/ARM/share/doc/arm-none-eabi",
-              "/Applications/ARM/share/gcc-arm-none-eabi",
-              "/Applications/ARM/share/man/man1/arm-none-eabi-*.1",
-              "/Applications/ARM/share/man/man5/arm-none-eabi-gdbinit.5",
+              "/Applications/ArmGNUToolchain/#{version}/arm-none-eabi",
             ]
-
-  zap trash: "/Applications/ARM"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Note: I removed the zap stanza because there doesn't seem to be a reasonable way to do it for this package without potentially impacting an installed copy of the gcc-aarch64-embedded cask once it's updated.  I believe the updated package for that one will also install into /Applications/ArmGNUToolchain/#{version}, but in a different subdirectory.