### PR TITLE
Add support for the arm64 arch for superproductivity

### DIFF
--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -22,7 +22,5 @@ cask "superproductivity" do
     "~/Library/Logs/superProductivity",
     "~/Library/Preferences/com.super-productivity.app.plist",
     "~/Library/Saved Application State/com.super-productivity.app.savedState",
-    "/var/db/receipts/com.super-productivity.app.bom",
-    "/var/db/receipts/com.super-productivity.app.plist",
   ]
 end

--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -1,8 +1,15 @@
 cask "superproductivity" do
-  version "7.11.5"
-  sha256 "2d857fd6813f2624991ca93e6d672156c417a139e1ed6249baa9b92fc3ea4373"
+  arch = Hardware::CPU.intel? ? "" : "-arm64"
 
-  url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}-mac.zip",
+  version "7.11.5"
+
+  if Hardware::CPU.intel?
+    sha256 "5c6b50db6109939ad1f902c4d2123aae81bce0299095ebc31249e9e6ca452a6f"
+  else
+    sha256 "67665f0d3786c6d3be8705af67f1ffcfc987b38f61415f07ea940b1e95e8dd47"
+  end
+
+  url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}#{arch}.dmg",
       verified: "github.com/johannesjo/super-productivity/"
   name "Super Productivity"
   desc "To-do list and time tracker"
@@ -13,5 +20,9 @@ cask "superproductivity" do
   zap trash: [
     "~/Library/Application Support/superProductivity",
     "~/Library/Logs/superProductivity",
+    "~/Library/Preferences/com.super-productivity.app.plist",
+    "~/Library/Saved Application State/com.super-productivity.app.savedState",
+    "/var/db/receipts/com.super-productivity.app.bom",
+    "/var/db/receipts/com.super-productivity.app.plist",
   ]
 end


### PR DESCRIPTION
This PR adds support for the _arm64_ architecture for superProductivity.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.