### PR TITLE
Use `arch` and `on_arch_conditional` DSLs

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,5 +1,6 @@
 cask "chef-workstation" do
-  arch, macos_version = Hardware::CPU.intel? ? ["x86_64", "10.15"] : ["arm64", "11"]
+  arch arm: "arm64", intel: "x86_64"
+  macos_version = on_arch_conditional arm: "11", intel: "10.15"
 
   version "22.7.1006"
 

--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -1,4 +1,6 @@
 cask "dingtalk" do
+  arch arm: "qd=2022mac-m1"
+
   if Hardware::CPU.intel?
     version "6.5.30.16"
     sha256 "7a664ef4b8940f7cee706ccbd67fe4cf537d6a7535a3cd92f1cd2fd445c5bb04"
@@ -15,12 +17,7 @@ cask "dingtalk" do
   homepage "https://www.dingtalk.com/"
 
   livecheck do
-    livecheck_url = if Hardware::CPU.intel?
-      "https://www.dingtalk.com/mac/d/"
-    else
-      "https://www.dingtalk.com/mac/d/qd=2022mac-m1"
-    end
-    url livecheck_url
+    url "https://www.dingtalk.com/mac/d/#{arch}"
 
     strategy :header_match
   end

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -1,4 +1,6 @@
 cask "eclipse-java" do
+  arch arm: "aarch64", intel: "x86_64"
+
   version "4.24.0,2022-06"
 
   if Hardware::CPU.intel?
@@ -6,8 +8,6 @@ cask "eclipse-java" do
   else
     sha256 "387983833dd7f8296e4bcdba063258a6c9194dba2cb0ed6cddf4b4157369b445"
   end
-
-  arch = Hardware::CPU.intel? ? "x86_64" : "aarch64"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-java-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for Java Developers"

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -1,5 +1,6 @@
 cask "libreoffice-language-pack" do
-  arch, folder = Hardware::CPU.intel? ? ["x86-64", "x86_64"] : ["aarch64", "aarch64"]
+  arch arm: "aarch64", intel: "x86-64"
+  folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
   version "7.3.5"
 

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -1,5 +1,6 @@
 cask "libreoffice" do
-  arch, folder = Hardware::CPU.intel? ? ["x86-64", "x86_64"] : ["aarch64", "aarch64"]
+  arch arm: "aarch64", intel: "x86-64"
+  folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
   version "7.3.5"
 

--- a/Casks/openshift-client.rb
+++ b/Casks/openshift-client.rb
@@ -1,4 +1,6 @@
 cask "openshift-client" do
+  arch arm: "-arm64"
+
   version "4.11.0"
 
   if Hardware::CPU.intel?
@@ -7,7 +9,6 @@ cask "openshift-client" do
     sha256 "9c5875208ce1da5a0463fb847942bbdd08116dbd122a2e0ebb6167e5ebeec127"
   end
 
-  arch = Hardware::CPU.intel? ? "" : "-arm64"
   url "https://mirror.openshift.com/pub/openshift-v#{version.major}/clients/ocp/#{version}/openshift-client-mac#{arch}.tar.gz"
   name "Openshift Client"
   desc "Red Hat OpenShift Container Platform command-line client"

--- a/Casks/webull.rb
+++ b/Casks/webull.rb
@@ -1,5 +1,6 @@
 cask "webull" do
-  dl_arch, livecheck_arch = Hardware::CPU.intel? ? ["us_x64", "qt_mac_global"] : ["us_arm64", "qt_m1_global"]
+  arch arm: "us_arm64", intel: "us_x64"
+  livecheck_arch = on_arch_conditional arm: "qt_m1_global", intel: "qt_mac_global"
 
   version "6.0.5"
 
@@ -9,7 +10,7 @@ cask "webull" do
     sha256 "371b955bd7fb189a26d9d59cefa8a847e6059dc37e25aeb84add011a1e846c96"
   end
 
-  url "https://u1sweb.webullfinance.com/us/desktop/Webull%20Desktop_#{version}_#{dl_arch}_signed.dmg",
+  url "https://u1sweb.webullfinance.com/us/desktop/Webull%20Desktop_#{version}_#{arch}_signed.dmg",
       verified: "u1sweb.webullfinance.com/us/desktop/"
   name "Webull"
   desc "Desktop client for Webull Financial LLC"

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -1,5 +1,6 @@
 cask "wireshark" do
-  url_arch, livecheck_arch = Hardware::CPU.intel? ? ["Intel", "x86-"] : ["Arm", "arm"]
+  arch arm: "Arm", intel: "Intel"
+  livecheck_arch = on_arch_conditional arm: "arm", intel: "x86-"
 
   version "3.6.7"
 
@@ -9,7 +10,7 @@ cask "wireshark" do
     sha256 "ccf2511b3c55ce845b477a975908add1511addb309599eb50f40003a3f6eb8aa"
   end
 
-  url "https://2.na.dl.wireshark.org/osx/Wireshark%20#{version}%20#{url_arch}%2064.dmg"
+  url "https://2.na.dl.wireshark.org/osx/Wireshark%20#{version}%20#{arch}%2064.dmg"
   name "Wireshark"
   desc "Network protocol analyzer"
   homepage "https://www.wireshark.org/"


### PR DESCRIPTION
This PR modifies the remaining casks to use the new `arch` and `on_arch_conditional` DSLs instead of `arch = Hardware::CPU.intel? ? "intel" : "arm"`. The casks in this PR are the ones that needed some sort of manual intervention and `brew style --fix` wasn't able to handle completely.

As with the large PR, I've verified that everything is working as expected by running `brew info --json=v2 --all` before and after the changes in this PR (I check on both Intel and ARM). There were no differences, indicating that all URLs remain the same after these changes.
