### PR TITLE
soundcleod: discontinued

### DIFF
--- a/Casks/soundcleod.rb
+++ b/Casks/soundcleod.rb
@@ -5,7 +5,12 @@ cask "soundcleod" do
   url "https://github.com/salomvary/soundcleod/releases/download/v#{version}/SoundCleod-#{version}.dmg",
       verified: "github.com/salomvary/soundcleod/"
   name "SoundCleod"
+  desc "Unofficial SoundCloud desktop app"
   homepage "https://soundcleod.com/"
 
   app "SoundCleod.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `soundcleod`](https://github.com/salomvary/soundcleod) has been archived and the `README` contains the following message about its discontinuation:

> ## This project is NO LONGER MAINTAINED, do not use it!
>
> 8 years, 11 months, 11 days after the [first commit](https://github.com/salomvary/soundcleod/commit/63c11038cace325d07d25191b01e744ba09a5b19) I realized I've lost interest, motivation and time for maintaining SoundCleod and decided to retire the project. The GitHub repository is read-only from now, the soundcleod.com domain will continue working until it expires on 2022-05-05.
>
> It is strongly recommended to uninstall SoundCleod to prevent future security issues, for which no fixes will be released.
>
> For those seeking alternatives I recommend switching to the official [SoundCloud Desktop Player](https://help.soundcloud.com/hc/en-us/articles/1260803560930-Desktop-Player) or using any modern web browser.

This PR sets the cask as discontinued accordingly. Besides that, this adds a description to resolve the related audit error.

