### PR TITLE
Add HTTPie 2022.12.0

### DIFF
--- a/Casks/httpie.rb
+++ b/Casks/httpie.rb
@@ -3,16 +3,17 @@ cask "httpie" do
 
   version "2022.12.0"
 
-  if Hardware::CPU.intel?
+  on_intel do
     sha256 "3f6b841c16159ed9c6361dbe165e4a5afdba34dbe70aa95f719faf39d699783b"
-  else
+  end
+  on_arm do
     sha256 "934f08b885c7fa483dcf3ee83a569224d9a199a1c86917544024daaad16890cc"
   end
 
   url "https://github.com/httpie/desktop/releases/download/v#{version}/HTTPie-#{version}#{arch}.dmg",
       verified: "github.com/httpie/desktop/"
   name "HTTPie for Desktop"
-  desc "Desktop wrapper for human-friendly command-line HTTP client HTTPie"
+  desc "Desktop wrapper for HTTPie"
   homepage "https://httpie.io/product"
 
   livecheck do

--- a/Casks/httpie.rb
+++ b/Casks/httpie.rb
@@ -1,0 +1,31 @@
+cask "httpie" do
+  arch arm: "-arm64"
+
+  version "2022.12.0"
+
+  if Hardware::CPU.intel?
+    sha256 "3f6b841c16159ed9c6361dbe165e4a5afdba34dbe70aa95f719faf39d699783b"
+  else
+    sha256 "934f08b885c7fa483dcf3ee83a569224d9a199a1c86917544024daaad16890cc"
+  end
+
+  url "https://github.com/httpie/desktop/releases/download/v#{version}/HTTPie-#{version}#{arch}.dmg",
+      verified: "github.com/httpie/desktop/"
+  name "HTTPie for Desktop"
+  desc "Desktop wrapper for human-friendly command-line HTTP client HTTPie"
+  homepage "https://httpie.io/product"
+
+  livecheck do
+    url "https://httpie.io/download"
+    regex(/href=.*?HTTPie[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
+  app "HTTPie.app"
+
+  zap trash: [
+    "~/Library/Application Support/HTTPie",
+    "~/Library/Logs/HTTPie",
+    "~/Library/Preferences/io.httpie.desktop.plist",
+    "~/Library/Saved Application State/io.httpie.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

There is already a `httpie` in homebrew-core, but that is a command-line program, and this is a desktop wrapper for it.