### PR TITLE
sequel-pro: deprecate in favor of sequel-ace

### DIFF
--- a/Casks/sequel-pro.rb
+++ b/Casks/sequel-pro.rb
@@ -8,11 +8,6 @@ cask "sequel-pro" do
   desc "MySQL/MariaDB database management platform"
   homepage "https://www.sequelpro.com/"
 
-  livecheck do
-    url :url
-    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
-  end
-
   app "Sequel Pro.app"
 
   zap trash: [
@@ -21,4 +16,13 @@ cask "sequel-pro" do
     "~/Library/Preferences/com.sequelpro.SequelPro.plist",
     "~/Library/Saved Application State/com.sequelpro.SequelPro.savedState",
   ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      #{token} has been deprecated in favor of Sequel Ace.
+        brew install --cask sequel-ace
+    EOS
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

relates to https://github.com/sequelpro/sequelpro/issues/3705