### PR TITLE
jupyterlab: Add livecheck

### DIFF
--- a/Casks/jupyterlab.rb
+++ b/Casks/jupyterlab.rb
@@ -9,6 +9,11 @@ cask "jupyterlab" do
 
   app "JupyterLab.app"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   uninstall pkgutil: "com.electron.jupyterlab-desktop",
             delete:  [
               "/Applications/JupyterLab.app",


### PR DESCRIPTION
Switching to `:github_latest` due to use of GitHub pre-releases.