### PR TITLE
Create tailscale shim

### DIFF
--- a/Casks/tailscale.rb
+++ b/Casks/tailscale.rb
@@ -16,7 +16,15 @@ cask "tailscale" do
   conflicts_with formula: "tailscale"
 
   app "Tailscale.app"
-  binary "#{appdir}/Tailscale.app/Contents/MacOS/Tailscale", target: "tailscale"
+  shimscript = "#{staged_path}/tailscale.wrapper.sh"
+  binary shimscript, target: "tailscale"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/Tailscale.app/Contents/MacOS/Tailscale' "$@"
+    EOS
+  end
 
   uninstall login_item: "Tailscale",
             quit:       "io.tailscale.ipn.macsys"

--- a/Casks/tailscale.rb
+++ b/Casks/tailscale.rb
@@ -16,6 +16,7 @@ cask "tailscale" do
   conflicts_with formula: "tailscale"
 
   app "Tailscale.app"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/tailscale.wrapper.sh"
   binary shimscript, target: "tailscale"
 


### PR DESCRIPTION
Invoking the app as a symlink doesn't work. Tailscale checks what its invoked as. I created a shim based on the vlc cask. It refers to tailscale by its full path.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

