### PR TITLE
Ignore `com.apple.Preview` in CI.

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -2,8 +2,9 @@
 # frozen_string_literal: true
 
 require "forwardable"
+
 APPLE_LAUNCHJOBS_REGEX =
-  /\A(?:application\.)?com\.apple\.(installer|Safari|systemevents|systempreferences)(?:\.|$)/.freeze
+  /\A(?:application\.)?com\.apple\.(installer|Preview|Safari|systemevents|systempreferences)(?:\.|$)/.freeze
 
 module Check
   CHECKS = {


### PR DESCRIPTION
Should fix CI for https://github.com/Homebrew/homebrew-cask/pull/129699.