### PR TITLE
Upgrade Bob Wallet to v1.0.0 and add ARM release

### DIFF
--- a/Casks/kyokan-bob.rb
+++ b/Casks/kyokan-bob.rb
@@ -1,6 +1,6 @@
 cask "kyokan-bob" do
   arch arm: "arm64", intel: "x86"
-  
+
   version "1.0.0"
 
   on_intel do

--- a/Casks/kyokan-bob.rb
+++ b/Casks/kyokan-bob.rb
@@ -16,6 +16,11 @@ cask "kyokan-bob" do
   desc "Handshake wallet GUI for managing transactions, name auctions, and DNS records"
   homepage "https://bobwallet.io/"
 
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   app "Bob.app"
 
   zap trash: [

--- a/Casks/kyokan-bob.rb
+++ b/Casks/kyokan-bob.rb
@@ -1,11 +1,18 @@
 cask "kyokan-bob" do
-  version "0.9.0"
-  sha256 "fb097ae8405705de007fe86def051b259de38c4b969ffff2f3cd081b80b95eeb"
+  version "1.0.0"
 
-  url "https://github.com/kyokan/bob-wallet/releases/download/v#{version}/Bob-#{version}.dmg",
+  if Hardware::CPU.intel?
+    arch = "x86"
+    sha256 "f4e962e38d8679a5abe7baf181d12ea679bd90876fe991a4c3c01b21f10195c8"
+  else
+    arch = "arm64"
+    sha256 "03c913e5ea5d8779122b4da3a9ef0d63307ce84a7a86e84feae53af82bb6fd36"
+  end
+
+  url "https://github.com/kyokan/bob-wallet/releases/download/v#{version}/Bob-#{version}-#{arch}.dmg",
       verified: "github.com/kyokan/bob-wallet/"
   name "Bob Wallet"
-  desc "Handshake wallet GUI for name auction and DNS record management"
+  desc "Handshake wallet GUI for managing transactions, name auctions, and DNS records"
   homepage "https://bobwallet.io/"
 
   livecheck do

--- a/Casks/kyokan-bob.rb
+++ b/Casks/kyokan-bob.rb
@@ -1,11 +1,12 @@
 cask "kyokan-bob" do
+  arch arm: "arm64", intel: "x86"
+  
   version "1.0.0"
 
-  if Hardware::CPU.intel?
-    arch = "x86"
+  on_intel do
     sha256 "f4e962e38d8679a5abe7baf181d12ea679bd90876fe991a4c3c01b21f10195c8"
-  else
-    arch = "arm64"
+  end
+  on_arm do
     sha256 "03c913e5ea5d8779122b4da3a9ef0d63307ce84a7a86e84feae53af82bb6fd36"
   end
 
@@ -14,11 +15,6 @@ cask "kyokan-bob" do
   name "Bob Wallet"
   desc "Handshake wallet GUI for managing transactions, name auctions, and DNS records"
   homepage "https://bobwallet.io/"
-
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
 
   app "Bob.app"
 


### PR DESCRIPTION
Bump Bob Wallet cask to v1.0.0, which now also provides an M1 release version.

Added a CPU arch conditional to determine specific release to download and tested by running `bump-cask-pr --write-only` and it updated everything as expected.

Didn't find any official docs on managing multi-arch downloads, so let me know if there's a more official way of setting that up.