### PR TITLE
Major update of Processing 3.5.4,0270 -> 4.0.1

### DIFF
--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -27,6 +27,7 @@ cask "processing" do
   end
 
   conflicts_with cask: [
+    "homebrew/cask-versions/processing3",
     "homebrew/cask-versions/processing2",
     "homebrew/cask-versions/processing-beta",
   ]

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -28,7 +28,6 @@ cask "processing" do
 
   conflicts_with cask: [
     "homebrew/cask-versions/processing2",
-    "homebrew/cask-versions/processing3",
     "homebrew/cask-versions/processing-beta",
   ]
   depends_on macos: ">= :catalina"

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -40,6 +40,7 @@ cask "processing" do
   zap trash: [
     "~/Library/Processing",
     "~/Preferences/org.processing.app.plist",
+    "~/Preferences/org.processing.four.plist",
     "~/Preferences/processing.app.tools.plist",
   ]
 end

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,8 +1,17 @@
 cask "processing" do
-  version "4.0.1,1286"
-  sha256 "4d64fe42a6c5c0863cc82e93a036e73731999ee9448be45bc322f91b0010bb6b"
+  arch arm: "aarch64", intel: "x64"
 
-  url "https://github.com/processing/processing4/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macosx.zip",
+  version "4.0.1,1286"
+
+  on_intel do
+    sha256 "6cabb7acd3b98adc4f4d9cf749cf2f3c4c2379c802862634a77fd91c6ca901c2"
+  end
+
+  on_arm do
+    sha256 "aa5b3f8e277fada2f73086677fde16aa7d7a08cd5e8d02ba5227952b295460aa"
+  end
+
+  url "https://github.com/processing/processing4/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macosx-#{arch}.zip",
       verified: "github.com/processing/processing4/"
   name "Processing"
   desc "Flexible software sketchbook and a language for learning how to code"
@@ -22,6 +31,7 @@ cask "processing" do
     "homebrew/cask-versions/processing3",
     "homebrew/cask-versions/processing-beta",
   ]
+  depends_on macos: ">= :catalina"
 
   app "Processing.app"
 

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -11,7 +11,7 @@ cask "processing" do
     sha256 "aa5b3f8e277fada2f73086677fde16aa7d7a08cd5e8d02ba5227952b295460aa"
   end
 
-  url "https://github.com/processing/processing4/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macosx-#{arch}.zip",
+  url "https://github.com/processing/processing4/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macos-#{arch}.zip",
       verified: "github.com/processing/processing4/"
   name "Processing"
   desc "Flexible software sketchbook and a language for learning how to code"

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -6,7 +6,6 @@ cask "processing" do
   on_intel do
     sha256 "6cabb7acd3b98adc4f4d9cf749cf2f3c4c2379c802862634a77fd91c6ca901c2"
   end
-
   on_arm do
     sha256 "aa5b3f8e277fada2f73086677fde16aa7d7a08cd5e8d02ba5227952b295460aa"
   end
@@ -27,9 +26,8 @@ cask "processing" do
   end
 
   conflicts_with cask: [
-    "homebrew/cask-versions/processing3",
     "homebrew/cask-versions/processing2",
-    "homebrew/cask-versions/processing-beta",
+    "homebrew/cask-versions/processing3",
   ]
   depends_on macos: ">= :catalina"
 

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -1,9 +1,9 @@
 cask "processing" do
-  version "3.5.4,0270"
+  version "4.0.1,1286"
   sha256 "4d64fe42a6c5c0863cc82e93a036e73731999ee9448be45bc322f91b0010bb6b"
 
-  url "https://github.com/processing/processing/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macosx.zip",
-      verified: "github.com/processing/processing/"
+  url "https://github.com/processing/processing4/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macosx.zip",
+      verified: "github.com/processing/processing4/"
   name "Processing"
   desc "Flexible software sketchbook and a language for learning how to code"
   homepage "https://processing.org/"
@@ -19,6 +19,7 @@ cask "processing" do
 
   conflicts_with cask: [
     "homebrew/cask-versions/processing2",
+    "homebrew/cask-versions/processing3",
     "homebrew/cask-versions/processing-beta",
   ]
 


### PR DESCRIPTION
### Major update of Processing 3.5.4,0270 -> 4.0.1

- updates from 3 -> 4 
- Uses new GitHub repository
- Added support for both Intel and Apple Silicon platforms
- Added additional plist file to remove on uninstall
- added version 3 to conflicts (I will add 3.5.4,0270 to brew-cask-versions)
         ~~TODO - had to remove to pass testing because brew-cask-versions for v3 isn't published yet~~
        ~~``` cask_loader.rb:64:in `load': Cask 'processing3' is unavailable:```~~
         it has been submitted. https://github.com/Homebrew/homebrew-cask-versions/pull/14499
- added min macOS version as requirement 
-  tested as below

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [n/a ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ n/a] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ n/a] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [n/a ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
