### PR TITLE
Add Trunk launcher 1.1.1

### DIFF
--- a/Casks/trunk-io.rb
+++ b/Casks/trunk-io.rb
@@ -1,0 +1,20 @@
+cask "trunk-io" do
+  version "1.1.1"
+  sha256 "4c6dbeb4c3d88a8cab88f668e8a3a5904b650893ab77782e09b9ff65d8865f79"
+
+  url "https://trunk.io/releases/launcher/#{version}/trunk"
+  name "Trunk Launcher"
+  desc "Developer experience toolkit used to check, test, merge, and monitor code"
+  homepage "https://trunk.io/"
+
+  livecheck do
+    url "https://trunk.io/releases/trunk"
+    regex(/TRUNK_LAUNCHER_VERSION="(\d+(?:\.\d+)+)"/i)
+  end
+
+  binary "trunk"
+
+  zap trash: [
+    "~/.cache/trunk",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

There is already a `trunk` in homebrew-core, so would the current chosen slug of `trunk-io` be acceptable? If not, `trunk-launcher` would also work for us.