### PR TITLE
svgcleaner: discontinued

### DIFF
--- a/Casks/svgcleaner.rb
+++ b/Casks/svgcleaner.rb
@@ -16,4 +16,8 @@ cask "svgcleaner" do
     "~/Library/Preferences/com.svgcleaner.svgcleaner.plist",
     "~/Library/Saved Application State/com.yourcompany.SVGCleaner.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for the `svgcleaner` cask](https://github.com/RazrFalcon/svgcleaner-gui/) has been archived (along with the [main `svgcleaner` repository](https://github.com/RazrFalcon/svgcleaner-gui/)) but the `README` wasn't updated to explain the situation beforehand. Presumably, this means that development has ceased on the project, so this PR sets the cask as discontinued.