### PR TITLE
jupyterlab: add `livecheck`, update `zap`

### DIFF
--- a/Casks/jupyterlab.rb
+++ b/Casks/jupyterlab.rb
@@ -7,6 +7,11 @@ cask "jupyterlab" do
   desc "Desktop application for JupyterLab"
   homepage "https://github.com/jupyterlab/jupyterlab-desktop"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+  
   app "JupyterLab.app"
 
   uninstall pkgutil: "com.electron.jupyterlab-desktop",
@@ -18,7 +23,11 @@ cask "jupyterlab" do
   zap trash: [
     "~/.jupyter",
     "~/Library/Application Support/jupyterlab-desktop",
+    "~/Library/Caches/org.jupyter.jupyterlab-desktop",
+    "~/Library/Caches/org.jupyter.jupyterlab-desktop.ShipIt",
+    "~/Library/HTTPStorages/org.jupyter.jupyterlab-desktop",
     "~/Library/Jupyter",
+    "~/Library/jupyterlab-desktop",
     "~/Library/Logs/jupyterlab-desktop",
     "~/Library/Logs/JupyterLab",
     "~/Library/Preferences/com.electron.jupyterlab-desktop.plist",

--- a/Casks/jupyterlab.rb
+++ b/Casks/jupyterlab.rb
@@ -11,7 +11,7 @@ cask "jupyterlab" do
     url :url
     strategy :github_latest
   end
-  
+
   app "JupyterLab.app"
 
   uninstall pkgutil: "com.electron.jupyterlab-desktop",

--- a/Casks/jupyterlab.rb
+++ b/Casks/jupyterlab.rb
@@ -10,6 +10,7 @@ cask "jupyterlab" do
   livecheck do
     url :url
     strategy :github_latest
+    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 
   app "JupyterLab.app"


### PR DESCRIPTION
Using `:github_latest` to avoid prereleases:
```
|-> brew livecheck --cask --debug jupyterlab

Cask:             jupyterlab
Livecheckable?:   No

URL:              https://github.com/jupyterlab/jupyterlab-desktop/releases/download/v3.3.4-2/JupyterLab-Setup-macOS.dmg
URL (processed):  https://github.com/jupyterlab/jupyterlab-desktop.git
Strategy:         Git

Matched Versions:
0.1.0, 0.1.1, 0.2.0, 3.1.12-1, 3.1.12-2, 3.1.13-1, 3.1.18-1, 3.2.1-1, 3.2.1-2, 3.2.3-1, 3.2.4-1, 3.2.4-2, 3.2.4-3, 3.2.5-1, 3.2.5-2, 3.2.9-1, 3.3.2-1, 3.3.2-2, 3.3.4-1, 3.3.4-2, 3.4.4-1
jupyterlab: 3.3.4-2 ==> 3.4.4-1
```