### PR TITLE
dash-dash: Add livecheck

### DIFF
--- a/Casks/dash-dash.rb
+++ b/Casks/dash-dash.rb
@@ -8,6 +8,11 @@ cask "dash-dash" do
   desc "Dash - Reinventing Cryptocurrency"
   homepage "https://www.dash.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Dash-Qt.app"
 
   preflight do


### PR DESCRIPTION
Switching to `:github_latest` due to use of GitHub prereleases and tag discrepancies.