### PR TITLE
Update gcc-aarch64-embedded and gcc-arm-embedded to 11.3.rel1

### DIFF
--- a/Casks/gcc-aarch64-embedded.rb
+++ b/Casks/gcc-aarch64-embedded.rb
@@ -1,64 +1,53 @@
 cask "gcc-aarch64-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  version "11.2-2022.02"
-  gcc_version = "11.2.1"
-  sha256 "172f70df0146a0ba6bc08971edcacdd786ffb6ec5142bb9041cabaef91984d4f"
+  version "11.3.rel1,b7a7f375702e40828c37fac6edaddf9a,21B1EADBDE363C3F8ED57CB62BFBD51E,1"
+  sha256 "45f0c38264373a3f47e3356257dbb03d83edcf33a0c0335b26ecba6f34431609"
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/gcc-arm-#{version}-darwin-x86_64-aarch64-none-elf.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version.csv.first}/binrel/arm-gnu-toolchain-#{version.csv.first}-darwin-x86_64-aarch64-none-elf.pkg?rev=#{version.csv.second}&hash=#{version.csv.third}"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 64-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
   livecheck do
     url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
-    regex(/href=.*?gcc-arm-(\d+\.\d+-\d+\.\d+)-darwin-(?:\w+)-aarch64-none-elf.pkg/i)
+    regex(/href=.*?gcc-arm-(\d+\.\d+\.rel\d+)-darwin-(?:\w+)-aarch64-none-elf.pkg/i)
   end
 
-  pkg "gcc-arm-#{version}-darwin-x86_64-aarch64-none-elf.pkg"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-addr2line"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-ar"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-as"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-c++"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-c++filt"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-cpp"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-elfedit"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-g++"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-#{gcc_version}"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-ar"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-nm"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcc-ranlib"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcov"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcov-dump"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gcov-tool"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gdb"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gdb-add-index"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gfortran"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-gprof"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-ld"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-ld.bfd"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-lto-dump"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-nm"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-objcopy"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-objdump"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-ranlib"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-readelf"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-size"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-strings"
-  binary "#{appdir}/ARM/bin/aarch64-none-elf-strip"
+  pkg "arm-gnu-toolchain-#{version.csv.first}-darwin-x86_64-aarch64-none-elf.pkg"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-addr2line"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-as"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-c++"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-c++filt"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-cpp"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-elfedit"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-g++"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcc"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcc-#{version.csv.first.major_minor}.#{version.csv.fourth}"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcc-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcc-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcc-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcov"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcov-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gcov-tool"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gdb"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gdb-add-index"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gfortran"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-gprof"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-ld"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-ld.bfd"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-lto-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-objcopy"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-objdump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-readelf"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-size"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-strings"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/aarch64-none-elf/bin/aarch64-none-elf-strip"
 
-  uninstall pkgutil: "gcc-arm-#{version}-darwin-x86_64-aarch64-none-elf",
-            delete:  [
-              "/Applications/ARM/#{version}-darwin-x86_64-aarch64-none-elf-manifest",
-              "/Applications/ARM/bin/aarch64-none-elf-*",
-              "/Applications/ARM/aarch64-none-elf",
-              "/Applications/ARM/lib/gcc/aarch64-none-elf",
-              "/Applications/ARM/libexec/gcc/aarch64-none-elf",
-              "/Applications/ARM/share/doc/aarch64-none-elf",
-              "/Applications/ARM/share/man/man1/aarch64-none-elf-*.1",
-              "/Applications/ARM/share/man/man5/aarch64-none-elf-gdbinit.5",
-            ]
+  uninstall pkgutil: "arm-gnu-toolchain-#{version.csv.first}-darwin-x86_64-aarch64-none-elf"
 
-  zap trash: "/Applications/ARM"
+  zap trash: "#{appdir}/ArmGNUToolchain"
 end

--- a/Casks/gcc-arm-embedded.rb
+++ b/Casks/gcc-arm-embedded.rb
@@ -1,65 +1,53 @@
 cask "gcc-arm-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  version "11.2-2022.02"
-  gcc_version = "11.2.1"
-  sha256 "105ac7f9b2be62c55d6853a099a92488c16f08bb296a694ef8430e5ddf8dead8"
+  version "11.3.rel1,10957d7bd17e41a698273da79ee689e7,E4443C2B8E9F663EABC93098469EBA72,1"
+  sha256 "97621c58f246f38135da38f6ca8197a23190c01650c8265be3346895c3fc34d2"
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/gcc-arm-#{version}-darwin-x86_64-arm-none-eabi.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version.csv.first}/binrel/arm-gnu-toolchain-#{version.csv.first}-darwin-x86_64-arm-none-eabi.pkg?rev=#{version.csv.second}&hash=#{version.csv.third}"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
   livecheck do
     url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
-    regex(/href=.*?gcc-arm-(\d+\.\d+-\d+\.\d+)-darwin-(?:\w+)-arm-none-eabi.pkg/i)
+    regex(/href=.*?gcc-arm-(\d+\.\d+\.rel\d+)-darwin-(?:\w+)-arm-none-eabi.pkg/i)
   end
 
-  pkg "gcc-arm-#{version}-darwin-x86_64-arm-none-eabi.pkg"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-addr2line"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ar"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-as"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-c++"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-c++filt"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-cpp"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-elfedit"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-g++"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-#{gcc_version}"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ar"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-nm"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcc-ranlib"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-dump"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gcov-tool"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gdb-add-index"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gfortran"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-gprof"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ld"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ld.bfd"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-lto-dump"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-nm"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-objcopy"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-objdump"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-ranlib"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-readelf"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-size"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-strings"
-  binary "#{appdir}/ARM/bin/arm-none-eabi-strip"
+  pkg "arm-gnu-toolchain-#{version.csv.first}-darwin-x86_64-arm-none-eabi.pkg"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-addr2line"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-as"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-c++"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-c++filt"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-cpp"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-elfedit"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-g++"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcc"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcc-#{version.csv.first.major_minor}.#{version.csv.fourth}"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcc-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcc-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcc-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcov"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcov-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gcov-tool"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gdb"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gdb-add-index"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gfortran"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-gprof"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-ld"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-ld.bfd"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-lto-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-objcopy"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-objdump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-readelf"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-size"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-strings"
+  binary "#{appdir}/ArmGNUToolchain/#{version.csv.first}/arm-none-eabi/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "gcc-arm-#{version}-darwin-x86_64-arm-none-eabi",
-            delete:  [
-              "/Applications/ARM/#{version}-darwin-x86_64-arm-none-eabi-manifest",
-              "/Applications/ARM/bin/arm-none-eabi-*",
-              "/Applications/ARM/arm-none-eabi",
-              "/Applications/ARM/lib/gcc/arm-none-eabi",
-              "/Applications/ARM/libexec/gcc/arm-none-eabi",
-              "/Applications/ARM/share/doc/arm-none-eabi",
-              "/Applications/ARM/share/gcc-arm-none-eabi",
-              "/Applications/ARM/share/man/man1/arm-none-eabi-*.1",
-              "/Applications/ARM/share/man/man5/arm-none-eabi-gdbinit.5",
-            ]
+  uninstall pkgutil: "arm-gnu-toolchain-#{version.csv.first}-darwin-x86_64-arm-none-eabi"
 
-  zap trash: "/Applications/ARM"
+  zap trash: "#{appdir}/ArmGNUToolchain"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

There is one audit failure in each cask:  livecheck doesn't detect the right version number.  Any help resolving that would be much appreciated!