### PR TITLE
termhere: discontinued

### DIFF
--- a/Casks/termhere.rb
+++ b/Casks/termhere.rb
@@ -20,4 +20,8 @@ cask "termhere" do
     "~/Library/Logs/DiagnosticReports/TermHere Finder Extension*",
     "~/Library/Preferences/ws.hbang.TermHere.plist",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `termhere`](https://github.com/hbang/TermHere) has been archived and the [Apps page on the first-party website](https://hashbang.productions/apps/) lists TermHere in the "Older releases" section. The [Status page](https://hashbang.productions/status/) explains:

> Old products that aren’t listed here have been discontinued and no longer receive support from HASHBANG Productions.

The apps that appear on the status page are the same ones featured on the Apps page, so this implies that TermHere has been discontinued. This PR sets the cask as discontinued accordingly.