### PR TITLE
Fix checksum for element 1.11.2

### DIFF
--- a/Casks/element.rb
+++ b/Casks/element.rb
@@ -1,6 +1,6 @@
 cask "element" do
   version "1.11.2"
-  sha256 "65a50ee7e7663f5bf2301bcde9d608900a6f44a9749381a833639451787195ad"
+  sha256 "2c90eb6b779938f7a79dc7f6ef52da291b3c063e14ad182a0623ba2ea2ac3fb2"
 
   url "https://packages.riot.im/desktop/install/macos/Element-#{version}-universal.dmg",
       verified: "packages.riot.im/desktop/"


### PR DESCRIPTION
The sha256 needs to be updated. I got the correct one like this:
`# curl --remote-name https://packages.riot.im/desktop/install/macos/Element-1.11.2-universal.dmg`
`# shasum -a 256 Element-1.11.2-universal.dmg`
`2c90eb6b779938f7a79dc7f6ef52da291b3c063e14ad182a0623ba2ea2ac3fb2`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `element` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online element` is error-free.
- [x] `brew style --fix element` reports no offenses.