### PR TITLE
Julia 1.8.0 - fix download URL

### DIFF
--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -11,14 +11,14 @@ cask "julia" do
     sha256 "8e113a42fe4eac7b75023136674452f6f09590717755417cd137258707e96540"
   end
 
-  url "https://julialang-s3.julialang.org/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{midfix}64.dmg"
+  url "https://julialang-s3.julialang.org/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{midfix}.dmg"
   name "Julia"
   desc "Programming language for technical computing"
   homepage "https://julialang.org/"
 
   livecheck do
     url "https://julialang.org/downloads/"
-    regex(/href=.*?julia[._-]v?(\d+(?:\.\d+)+)[._-]mac#{midfix}64\.dmg/i)
+    regex(/href=.*?julia[._-]v?(\d+(?:\.\d+)+)[._-]mac#{midfix}\.dmg/i)
   end
 
   app "Julia-#{version.major_minor}.app"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Note: the main issue was a `6464` in the string; perhaps this could be fixed in a better way by doing away with `midfix` but I am not aware of possible side-effects.