### PR TITLE
yandex-music-unofficial: Add livecheck

### DIFF
--- a/Casks/yandex-music-unofficial.rb
+++ b/Casks/yandex-music-unofficial.rb
@@ -16,6 +16,11 @@ cask "yandex-music-unofficial" do
   desc "Unofficial app for Yandex Music"
   homepage "https://yandex-music.juvs.dev/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   auto_updates true
 
   app "Yandex Music Unofficial.app"


### PR DESCRIPTION
Switching to `:github_latest` due to use of GitHub prereleases.