### PR TITLE
turbovnc-viewer: Add arm64, bump to 3.0.1, remove Java dependency

### DIFF
--- a/Casks/turbovnc-viewer.rb
+++ b/Casks/turbovnc-viewer.rb
@@ -1,8 +1,16 @@
 cask "turbovnc-viewer" do
-  version "3.0"
-  sha256 "7e4436dbac6daf00e2828ed1ddbe297de6dd07c4e0200b08b550d1fb138748b6"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://downloads.sourceforge.net/turbovnc/#{version}/TurboVNC-#{version}.dmg",
+  version "3.0.1"
+
+  on_intel do
+    sha256 "0b9f083d753dc65c0a023d8d9c6c95da997184645ea216b60a8e1db72f8baccb"
+  end
+  on_arm do
+    sha256 "76f451817884185f5832dc794831fbfb62d50104a6b416d4c78c6d55ea4b0f12"
+  end
+
+  url "https://downloads.sourceforge.net/turbovnc/#{version}/TurboVNC-#{version}-#{arch}.dmg",
       verified: "sourceforge.net/turbovnc/"
   name "TurboVNC"
   desc "Remote display system"
@@ -15,8 +23,4 @@ cask "turbovnc-viewer" do
               executable: "/opt/TurboVNC/bin/uninstall",
               sudo:       true,
             }
-
-  caveats do
-    depends_on_java "8"
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

Application now includes a custom JRE, so it no longer depends on a separate Java install.