### PR TITLE
Use `sha256 arm: "...", intel: "..."`

### DIFF
--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -2,13 +2,8 @@ cask "burp-suite" do
   arch arm: "MacOsArm64", intel: "MacOsx"
 
   version "2022.8.2"
-
-  on_intel do
-    sha256 "21311ae319d7e235fa5cbfa53eb9e4bb2a9c9056cd849ae9916f20d2d9c6c9e5"
-  end
-  on_arm do
-    sha256 "f1397ed4b7130f076ce05a744ca9e5f59fe7c030b8e2e490090a4b039cd3b0ff"
-  end
+  sha256 arm:   "f1397ed4b7130f076ce05a744ca9e5f59fe7c030b8e2e490090a4b039cd3b0ff",
+         intel: "21311ae319d7e235fa5cbfa53eb9e4bb2a9c9056cd849ae9916f20d2d9c6c9e5"
 
   url "https://portswigger.net/burp/releases/download?product=community&version=#{version}&type=#{arch}"
   name "Burp Suite Community Edition"

--- a/Casks/bzflag.rb
+++ b/Casks/bzflag.rb
@@ -2,13 +2,8 @@ cask "bzflag" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.4.24"
-
-  on_intel do
-    sha256 "736a80cb19e6b86d0632afe831c344b16dd3bbe69d235f5335a77c9a50dee3f5"
-  end
-  on_arm do
-    sha256 "2ee497a006dff98ca7cab6bb01dd10a279c7cea22490bf0baa3cf7d87e50e4a0"
-  end
+  sha256 arm:   "2ee497a006dff98ca7cab6bb01dd10a279c7cea22490bf0baa3cf7d87e50e4a0",
+         intel: "736a80cb19e6b86d0632afe831c344b16dd3bbe69d235f5335a77c9a50dee3f5"
 
   url "https://download.bzflag.org/bzflag/macos/#{version}/BZFlag-#{version}-macOS-#{arch}.zip"
   name "BZFlag"

--- a/Casks/canva.rb
+++ b/Casks/canva.rb
@@ -2,13 +2,8 @@ cask "canva" do
   arch arm: "arm64", intel: "x64"
 
   version "1.50.0"
-
-  on_intel do
-    sha256 "9045f9daca5fd8dd7912b5df58fc73ad9ef09e1e09284687519ac1456f8b1abf"
-  end
-  on_arm do
-    sha256 "304f8f200c55c3939f2b332ae947956fcc04aa33f94daaea73e7a54a5ffce30c"
-  end
+  sha256 arm:   "304f8f200c55c3939f2b332ae947956fcc04aa33f94daaea73e7a54a5ffce30c",
+         intel: "9045f9daca5fd8dd7912b5df58fc73ad9ef09e1e09284687519ac1456f8b1abf"
 
   url "https://desktop-release.canva-deploy.com/Canva-#{version}-#{arch}.dmg",
       verified: "desktop-release.canva-deploy.com/"

--- a/Casks/captain.rb
+++ b/Casks/captain.rb
@@ -2,13 +2,8 @@ cask "captain" do
   arch arm: "-arm64"
 
   version "10.0.3"
-
-  on_intel do
-    sha256 "32209eaa21e8917470d37456388395d79aefac911bceed044011284fb222d186"
-  end
-  on_arm do
-    sha256 "a0a380f4d38d7330bfea534ed8ecc44ebf48971843549017aa5551bd659fb121"
-  end
+  sha256 arm:   "a0a380f4d38d7330bfea534ed8ecc44ebf48971843549017aa5551bd659fb121",
+         intel: "32209eaa21e8917470d37456388395d79aefac911bceed044011284fb222d186"
 
   url "https://github.com/RickWong/Captain/releases/download/v#{version}/Captain-#{version}#{arch}.dmg",
       verified: "github.com/RickWong/Captain"

--- a/Casks/castr.rb
+++ b/Casks/castr.rb
@@ -2,16 +2,11 @@ cask "castr" do
   arch arm: "arm64-mac", intel: "mac"
 
   version "1.0.0"
+  sha256 arm:   "2d4c5b61f0018f2fa3d63000d070bfdab68d3faccb8e8901e7a50e6a1c4c0a84",
+         intel: "7fb499498d4dfb44d0f80a339933ac7f22071ed1c6f65f2164819926c54d9736"
 
   url "https://download.todesktop.com/210610elr9v3cm6/Castr%20#{version}-#{arch}-update.zip",
       verified: "download.todesktop.com/210610elr9v3cm6/"
-  on_intel do
-    sha256 "7fb499498d4dfb44d0f80a339933ac7f22071ed1c6f65f2164819926c54d9736"
-  end
-  on_arm do
-    sha256 "2d4c5b61f0018f2fa3d63000d070bfdab68d3faccb8e8901e7a50e6a1c4c0a84"
-  end
-
   name "castr"
   desc "Desktop application for controlling Castr streaming platform"
   homepage "https://castr.io/"

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -3,13 +3,8 @@ cask "chef-workstation" do
   macos_version = on_arch_conditional arm: "11", intel: "10.15"
 
   version "22.7.1006"
-
-  on_intel do
-    sha256 "6706e3c22248b1a0727f382e26c115d808457f04677f97a09432bfd77d2e5d92"
-  end
-  on_arm do
-    sha256 "f01815513f0e820dc036cabf1bef04b4beca37b1869b3a3e8b206942b6d0469d"
-  end
+  sha256 arm:   "f01815513f0e820dc036cabf1bef04b4beca37b1869b3a3e8b206942b6d0469d",
+         intel: "6706e3c22248b1a0727f382e26c115d808457f04677f97a09432bfd77d2e5d92"
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/#{macos_version}/chef-workstation-#{version}-1.#{arch}.dmg"
   name "Chef Workstation"

--- a/Casks/chia.rb
+++ b/Casks/chia.rb
@@ -2,13 +2,8 @@ cask "chia" do
   arch arm: "-arm64"
 
   version "1.5.0"
-
-  on_intel do
-    sha256 "0db183c1ffb31badbc77899f2cdafaca33eca5432d2f3f01c4cf21f614b663c5"
-  end
-  on_arm do
-    sha256 "d5e18d5571fc5ae5185cdf55d2abae0a41d4f3fade57f15775ac876e7463be0f"
-  end
+  sha256 arm:   "d5e18d5571fc5ae5185cdf55d2abae0a41d4f3fade57f15775ac876e7463be0f",
+         intel: "0db183c1ffb31badbc77899f2cdafaca33eca5432d2f3f01c4cf21f614b663c5"
 
   url "https://github.com/Chia-Network/chia-blockchain/releases/download/#{version}/Chia-#{version}#{arch}.dmg",
       verified: "github.com/Chia-Network/chia-blockchain/"

--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -2,13 +2,8 @@ cask "chromedriver" do
   arch arm: "mac64_m1", intel: "mac64"
 
   version "104.0.5112.79"
-
-  on_intel do
-    sha256 "65766e1c5cecf0e560cfb602bdc62e181d89a35258cf2dfbbb2a8cad37d2f451"
-  end
-  on_arm do
-    sha256 "420d159af6b441f21a2c92c159cf817cdfc6a8069eb7fdc2822bfe625ac33287"
-  end
+  sha256 arm:   "420d159af6b441f21a2c92c159cf817cdfc6a8069eb7fdc2822bfe625ac33287",
+         intel: "65766e1c5cecf0e560cfb602bdc62e181d89a35258cf2dfbbb2a8cad37d2f451"
 
   url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_#{arch}.zip",
       verified: "chromedriver.storage.googleapis.com/"

--- a/Casks/clash-for-windows.rb
+++ b/Casks/clash-for-windows.rb
@@ -2,13 +2,8 @@ cask "clash-for-windows" do
   arch arm: "-arm64"
 
   version "0.19.27"
-
-  on_intel do
-    sha256 "b70a89a3b24c6c744abf95a0007cddd69b298fe0c2c3cf3750fc5c04f77da131"
-  end
-  on_arm do
-    sha256 "73da9d4331ef69e56713565de7078555302df25c953f62ce45428465c84057c2"
-  end
+  sha256 arm:   "73da9d4331ef69e56713565de7078555302df25c953f62ce45428465c84057c2",
+         intel: "b70a89a3b24c6c744abf95a0007cddd69b298fe0c2c3cf3750fc5c04f77da131"
 
   url "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/#{version}/Clash.for.Windows-#{version}#{arch}.dmg"
   name "Clash for Windows"

--- a/Casks/clay.rb
+++ b/Casks/clay.rb
@@ -2,13 +2,8 @@ cask "clay" do
   arch arm: "-arm64"
 
   version "1.9.14"
-
-  on_intel do
-    sha256 "6699a8ed97eac21984d2f7bf45f6d645ffcd7648cf143b71e104da1a73f7e5d6"
-  end
-  on_arm do
-    sha256 "009f6b441aa8dc16d7703f6a53b58aa3d1751d5725e3ac5ab013ee8aa0cab618"
-  end
+  sha256 arm:   "009f6b441aa8dc16d7703f6a53b58aa3d1751d5725e3ac5ab013ee8aa0cab618",
+         intel: "6699a8ed97eac21984d2f7bf45f6d645ffcd7648cf143b71e104da1a73f7e5d6"
 
   url "https://assets.clay.earth/desktop/mac/Clay-#{version}#{arch}.dmg"
   name "clay"

--- a/Casks/clickup.rb
+++ b/Casks/clickup.rb
@@ -2,13 +2,8 @@ cask "clickup" do
   arch arm: "arm64", intel: "x64"
 
   version "3.0.6"
-
-  on_intel do
-    sha256 "0db5873a074fc0a17569fe4495ac7b8ba158481a79a7a660ecf0470f6a8844c6"
-  end
-  on_arm do
-    sha256 "25bd3e4ba0fa3ca1dc68f624922b858a34bcea7a7cacab78b0134552ae593161"
-  end
+  sha256 arm:   "25bd3e4ba0fa3ca1dc68f624922b858a34bcea7a7cacab78b0134552ae593161",
+         intel: "0db5873a074fc0a17569fe4495ac7b8ba158481a79a7a660ecf0470f6a8844c6"
 
   url "https://download.todesktop.com/210531zdwwjv8ke/ClickUp%20#{version}-#{arch}.dmg",
       verified: "download.todesktop.com/210531zdwwjv8ke/"

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -2,13 +2,8 @@ cask "clion" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.54"
-
-  on_intel do
-    sha256 "ba2a8fcf9a1f080ca6b2ef832b13104c440077b9e6a2bb6e26bc97bdea373208"
-  end
-  on_arm do
-    sha256 "af36f7f9a98881d37d89757083875494c472e60d14bd70fe0d08533d284dd4e1"
-  end
+  sha256 arm:   "af36f7f9a98881d37d89757083875494c472e60d14bd70fe0d08533d284dd4e1",
+         intel: "ba2a8fcf9a1f080ca6b2ef832b13104c440077b9e6a2bb6e26bc97bdea373208"
 
   url "https://download.jetbrains.com/cpp/CLion-#{version.csv.first}#{arch}.dmg"
   name "CLion"

--- a/Casks/corretto.rb
+++ b/Casks/corretto.rb
@@ -2,13 +2,8 @@ cask "corretto" do
   arch arm: "aarch64", intel: "x64"
 
   version "18.0.2.9.1"
-
-  on_intel do
-    sha256 "cc5703bc4984e73dd66b18c3623fa1d576e53fda9c33de335f42b3596de01786"
-  end
-  on_arm do
-    sha256 "19f29b4973897d929011a5540db03b859b81ae5a0fc03dc487597b8cf15c8b26"
-  end
+  sha256 arm:   "19f29b4973897d929011a5540db03b859b81ae5a0fc03dc487597b8cf15c8b26",
+         intel: "cc5703bc4984e73dd66b18c3623fa1d576e53fda9c33de335f42b3596de01786"
 
   url "https://corretto.aws/downloads/resources/#{version.sub(/-\d+/, "")}/amazon-corretto-#{version}-macosx-#{arch}.pkg"
   name "AWS Corretto JDK"

--- a/Casks/coscreen.rb
+++ b/Casks/coscreen.rb
@@ -2,13 +2,8 @@ cask "coscreen" do
   arch arm: "arm64", intel: "x64"
 
   version "4.0.67"
-
-  on_intel do
-    sha256 "b59f60e405b713f3fd81cdae656fed4d2f3d8c23e70555f4368e52d9e90a7aa2"
-  end
-  on_arm do
-    sha256 "0cec123742472ed4010650a928b25ce4a05ac596cc8ffe231618dda144c197e1"
-  end
+  sha256 arm:   "0cec123742472ed4010650a928b25ce4a05ac596cc8ffe231618dda144c197e1",
+         intel: "b59f60e405b713f3fd81cdae656fed4d2f3d8c23e70555f4368e52d9e90a7aa2"
 
   url "https://update.coscreen.org/CoScreen-#{version}-stable-#{arch}.dmg",
       verified: "https://update.coscreen.org/"

--- a/Casks/cron.rb
+++ b/Casks/cron.rb
@@ -2,13 +2,8 @@ cask "cron" do
   arch arm: "arm64", intel: "x64"
 
   version "1.109.0"
-
-  on_intel do
-    sha256 "24ec3d5a709313979ab8cd658e03cfee4ce4dec6201943c2fd8d467376328c43"
-  end
-  on_arm do
-    sha256 "d01ada02ea7232147ca2f053a7e000bf00e3bd4ab91800e3e58f438460b7180b"
-  end
+  sha256 arm:   "d01ada02ea7232147ca2f053a7e000bf00e3bd4ab91800e3e58f438460b7180b",
+         intel: "24ec3d5a709313979ab8cd658e03cfee4ce4dec6201943c2fd8d467376328c43"
 
   url "https://download.todesktop.com/210303leazlircz/Cron%20#{version}-#{arch}-mac.zip",
       verified: "download.todesktop.com/210303leazlircz/"

--- a/Casks/cryptomator.rb
+++ b/Casks/cryptomator.rb
@@ -2,13 +2,8 @@ cask "cryptomator" do
   arch arm: "-arm64"
 
   version "1.6.13"
-
-  on_intel do
-    sha256 "7f20cc42e5f690606108f16efa61b8f63fd4abc49b20e2a7bcea80c1858c0e17"
-  end
-  on_arm do
-    sha256 "00464909e421d08a33b333b21336931acbadf6fbd563575633d4c10b058aef12"
-  end
+  sha256 arm:   "00464909e421d08a33b333b21336931acbadf6fbd563575633d4c10b058aef12",
+         intel: "7f20cc42e5f690606108f16efa61b8f63fd4abc49b20e2a7bcea80c1858c0e17"
 
   url "https://github.com/cryptomator/cryptomator/releases/download/#{version}/Cryptomator-#{version}#{arch}.dmg",
       verified: "github.com/cryptomator/cryptomator/"

--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -2,13 +2,8 @@ cask "cutter" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.1.0"
-
-  on_intel do
-    sha256 "d17451bc7904d010546b73c755a3dc0bc9e9116421448a033720b0a1018392f2"
-  end
-  on_arm do
-    sha256 "720d132cde1df3f23c9a11a447e253657587b95a1d8554859cbcd96baa3fcc13"
-  end
+  sha256 arm:   "720d132cde1df3f23c9a11a447e253657587b95a1d8554859cbcd96baa3fcc13",
+         intel: "d17451bc7904d010546b73c755a3dc0bc9e9116421448a033720b0a1018392f2"
 
   url "https://github.com/rizinorg/cutter/releases/download/v#{version}/Cutter-v#{version}-macOS-#{arch}.dmg",
       verified: "github.com/rizinorg/cutter/"

--- a/Casks/darktable.rb
+++ b/Casks/darktable.rb
@@ -2,13 +2,8 @@ cask "darktable" do
   arch arm: "_arm64"
 
   version "4.0.0"
-
-  on_intel do
-    sha256 "addab784af18bafa303340e754c00084c126e61c3d5b93006f8e6d602f838203"
-  end
-  on_arm do
-    sha256 "5bcd8e088065bc20815022f494ca1ca0613446562843f378ad60f68ae6917cb7"
-  end
+  sha256 arm:   "5bcd8e088065bc20815022f494ca1ca0613446562843f378ad60f68ae6917cb7",
+         intel: "addab784af18bafa303340e754c00084c126e61c3d5b93006f8e6d602f838203"
 
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}#{arch}.dmg",
       verified: "github.com/darktable-org/darktable/"

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -2,13 +2,8 @@ cask "datagrip" do
   arch arm: "-aarch64"
 
   version "2022.2.2,222.3739.67"
-
-  on_intel do
-    sha256 "b8494c758971e81c8f02f99caf53c0e05a7305cb988886c0229e135d9241065f"
-  end
-  on_arm do
-    sha256 "22e2aae4e6114dc8f5546fafa184c429a1b429f4147beac1a6e6fee1b5862d3f"
-  end
+  sha256 arm:   "22e2aae4e6114dc8f5546fafa184c429a1b429f4147beac1a6e6fee1b5862d3f",
+         intel: "b8494c758971e81c8f02f99caf53c0e05a7305cb988886c0229e135d9241065f"
 
   url "https://download.jetbrains.com/datagrip/datagrip-#{version.csv.first}#{arch}.dmg"
   name "DataGrip"

--- a/Casks/dataspell.rb
+++ b/Casks/dataspell.rb
@@ -2,13 +2,8 @@ cask "dataspell" do
   arch arm: "-aarch64"
 
   version "2022.2,222.3345.132"
-
-  on_intel do
-    sha256 "bc32f6db5fe8ddf5ce12fa592ea4756d7cfd7f771a5a186c1ee57e80a6d2e504"
-  end
-  on_arm do
-    sha256 "5d0040ae08edfe247b10748076b9bf1be2d1fa14fb1d6b37b1e2a7819db44e48"
-  end
+  sha256 arm:   "5d0040ae08edfe247b10748076b9bf1be2d1fa14fb1d6b37b1e2a7819db44e48",
+         intel: "bc32f6db5fe8ddf5ce12fa592ea4756d7cfd7f771a5a186c1ee57e80a6d2e504"
 
   url "https://download.jetbrains.com/python/dataspell-#{version.csv.first}#{arch}.dmg"
   name "DataSpell"

--- a/Casks/dbeaver-community.rb
+++ b/Casks/dbeaver-community.rb
@@ -2,13 +2,8 @@ cask "dbeaver-community" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "22.1.5"
-
-  on_intel do
-    sha256 "81d2f1cbbe40d6bc6ad1f8b442a3f1d384a77a06cf3d694153679d32d6b9f8f2"
-  end
-  on_arm do
-    sha256 "ec2f141678c659b1616af38d345642f1619e5e42272969ab9cbdcca9bba790fa"
-  end
+  sha256 arm:   "ec2f141678c659b1616af38d345642f1619e5e42272969ab9cbdcca9bba790fa",
+         intel: "81d2f1cbbe40d6bc6ad1f8b442a3f1d384a77a06cf3d694153679d32d6b9f8f2"
 
   url "https://dbeaver.io/files/#{version}/dbeaver-ce-#{version}-macos-#{arch}.dmg"
   name "DBeaver Community Edition"

--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -2,13 +2,8 @@ cask "dbeaver-enterprise" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "22.1.0"
-
-  on_intel do
-    sha256 "0d7392dcb7f220fd77680388a3578684e63983efe6b2691f16dc3d1471883e3f"
-  end
-  on_arm do
-    sha256 "026cfcdca2d619821f3a7d41f8ae36f8f6e1e3c294897311be203f0581b69b98"
-  end
+  sha256 arm:   "026cfcdca2d619821f3a7d41f8ae36f8f6e1e3c294897311be203f0581b69b98",
+         intel: "0d7392dcb7f220fd77680388a3578684e63983efe6b2691f16dc3d1471883e3f"
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos-#{arch}.dmg"
   name "DBeaver Enterprise Edition"

--- a/Casks/dcv-viewer.rb
+++ b/Casks/dcv-viewer.rb
@@ -2,13 +2,8 @@ cask "dcv-viewer" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2022.1.4279"
-
-  on_intel do
-    sha256 "036bab4870ffb2f0240f8813910a1f72e3718b4fa552cda8311f20cd8ed25e7d"
-  end
-  on_arm do
-    sha256 "9d9929a66d8e9e7b43e1e455c246f4da465a28945880416efb35e70066fea33a"
-  end
+  sha256 arm:   "9d9929a66d8e9e7b43e1e455c246f4da465a28945880416efb35e70066fea33a",
+         intel: "036bab4870ffb2f0240f8813910a1f72e3718b4fa552cda8311f20cd8ed25e7d"
 
   url "https://d1uj6qtbmh3dt5.cloudfront.net/#{version.major_minor}/Clients/nice-dcv-viewer-#{version}.#{arch}.dmg",
       verified: "d1uj6qtbmh3dt5.cloudfront.net/"

--- a/Casks/decentr.rb
+++ b/Casks/decentr.rb
@@ -2,13 +2,8 @@ cask "decentr" do
   arch arm: "M1", intel: "x64"
 
   version "1.3.2"
-
-  on_intel do
-    sha256 "9429047b44478fcc6bc48ac5bca73f9064a992e3b07c6ad33a8868f5cfa6d375"
-  end
-  on_arm do
-    sha256 "a15e91def4242b950b23f46dd2d0a18e2348c5f0c7e030b82e4acdcb301c1511"
-  end
+  sha256 arm:   "a15e91def4242b950b23f46dd2d0a18e2348c5f0c7e030b82e4acdcb301c1511",
+         intel: "9429047b44478fcc6bc48ac5bca73f9064a992e3b07c6ad33a8868f5cfa6d375"
 
   url "https://decentr.net/files/MacOS_#{arch}_Decentr_#{version}.zip"
   name "Decentr"

--- a/Casks/decrediton.rb
+++ b/Casks/decrediton.rb
@@ -2,13 +2,8 @@ cask "decrediton" do
   arch arm: "arm64", intel: "amd64"
 
   version "1.7.3"
-
-  on_intel do
-    sha256 "106a0d417163c9c247b5a658e7dda691290af8b9651dcecb99f83cfcda5683a8"
-  end
-  on_arm do
-    sha256 "b29286210fe17fe159b5ccb24f0be572da9235acc6b9093356091d52a218848d"
-  end
+  sha256 arm:   "b29286210fe17fe159b5ccb24f0be572da9235acc6b9093356091d52a218848d",
+         intel: "106a0d417163c9c247b5a658e7dda691290af8b9651dcecb99f83cfcda5683a8"
 
   url "https://github.com/decred/decred-binaries/releases/download/v#{version}/decrediton-#{arch}-v#{version}.dmg"
   name "Decrediton"

--- a/Casks/deltawalker.rb
+++ b/Casks/deltawalker.rb
@@ -2,13 +2,8 @@ cask "deltawalker" do
   arch arm: "aarch64", intel: "x64"
 
   version "2.6.4"
-
-  on_intel do
-    sha256 "8d508521c98c4dec3a7affe1190e4911818032ffc82a17a7fb4a64b0a097246f"
-  end
-  on_arm do
-    sha256 "f92abbf7b971a7e1d986fe0991e26daa3121449f428f380af89fe06eaa7cccea"
-  end
+  sha256 arm:   "f92abbf7b971a7e1d986fe0991e26daa3121449f428f380af89fe06eaa7cccea",
+         intel: "8d508521c98c4dec3a7affe1190e4911818032ffc82a17a7fb4a64b0a097246f"
 
   url "https://deltawalker.s3.amazonaws.com/DeltaWalker-#{version}_#{arch}.dmg",
       verified: "deltawalker.s3.amazonaws.com/"

--- a/Casks/descript.rb
+++ b/Casks/descript.rb
@@ -2,13 +2,8 @@ cask "descript" do
   arch arm: "-arm64"
 
   version "46.3.1-release.20220818.24"
-
-  on_intel do
-    sha256 "4dfd46815ab1d7a83e5d17c24d8ab3427c5ae52c6e09826db4a9968671f8d7be"
-  end
-  on_arm do
-    sha256 "c9e64565838719db2f3de293545d3af53c4185704fbc46b2937768c1a28c66aa"
-  end
+  sha256 arm:   "c9e64565838719db2f3de293545d3af53c4185704fbc46b2937768c1a28c66aa",
+         intel: "4dfd46815ab1d7a83e5d17c24d8ab3427c5ae52c6e09826db4a9968671f8d7be"
 
   url "https://electron.descript.com/Descript-#{version}#{arch}.dmg"
   name "Descript"

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -2,13 +2,8 @@ cask "docker" do
   arch arm: "arm64", intel: "amd64"
 
   version "4.11.1,84025"
-
-  on_intel do
-    sha256 "b2f4ad8fea37dfb7d9147f169a9ceab71d7d0d12ff912057c60b58c0e91aed35"
-  end
-  on_arm do
-    sha256 "a7d84117bef83764cb9bf275cd01b8ba0c43f08dbfe4d4a7d4f05549cdd81f54"
-  end
+  sha256 arm:   "a7d84117bef83764cb9bf275cd01b8ba0c43f08dbfe4d4a7d4f05549cdd81f54",
+         intel: "b2f4ad8fea37dfb7d9147f169a9ceab71d7d0d12ff912057c60b58c0e91aed35"
 
   url "https://desktop.docker.com/mac/main/#{arch}/#{version.csv.second}/Docker.dmg"
   name "Docker Desktop"

--- a/Casks/drawio.rb
+++ b/Casks/drawio.rb
@@ -2,13 +2,8 @@ cask "drawio" do
   arch arm: "arm64", intel: "x64"
 
   version "20.2.3"
-
-  on_intel do
-    sha256 "a05b4471ba5dacb172480e46bdc73f2344495a0d40d6939fd704c7367ac20f05"
-  end
-  on_arm do
-    sha256 "bacd23c19088599c2a184234fcedebe0d87f185bd4497a4f4d7132dc05d64182"
-  end
+  sha256 arm:   "bacd23c19088599c2a184234fcedebe0d87f185bd4497a4f4d7132dc05d64182",
+         intel: "a05b4471ba5dacb172480e46bdc73f2344495a0d40d6939fd704c7367ac20f05"
 
   url "https://github.com/jgraph/drawio-desktop/releases/download/v#{version}/draw.io-#{arch}-#{version}.dmg",
       verified: "github.com/jgraph/drawio-desktop/"

--- a/Casks/dropbox-capture.rb
+++ b/Casks/dropbox-capture.rb
@@ -2,13 +2,8 @@ cask "dropbox-capture" do
   arch arm: "arm64", intel: "x86_64"
 
   version "82.0.12"
-
-  on_intel do
-    sha256 "8f50daf17ea4f9ed6c02f293566b98725dab6100cbb562858959b3c8e2136f57"
-  end
-  on_arm do
-    sha256 "61ab7a00bc0c610ad5fd738faeb0986564c1c0eac6d4fa854c762706c1ace12b"
-  end
+  sha256 arm:   "61ab7a00bc0c610ad5fd738faeb0986564c1c0eac6d4fa854c762706c1ace12b",
+         intel: "8f50daf17ea4f9ed6c02f293566b98725dab6100cbb562858959b3c8e2136f57"
 
   url "https://edge.dropboxstatic.com/dbx-releng/products/dropbox-capture/#{version}/mac.#{arch}/Dropbox_Capture.dmg",
       verified: "edge.dropboxstatic.com/dbx-releng/products/dropbox-capture/"

--- a/Casks/dynobase.rb
+++ b/Casks/dynobase.rb
@@ -2,13 +2,8 @@ cask "dynobase" do
   arch arm: "-arm64"
 
   version "1.10.8"
-
-  on_intel do
-    sha256 "5233d55f06a62de362c39451ca4bebbd8eeb6d31effd664aa6253b41772345bf"
-  end
-  on_arm do
-    sha256 "4b00de2f8bb92f0a607cf80750a6b965d63038c2bdb86b6766bdd423142b7523"
-  end
+  sha256 arm:   "4b00de2f8bb92f0a607cf80750a6b965d63038c2bdb86b6766bdd423142b7523",
+         intel: "5233d55f06a62de362c39451ca4bebbd8eeb6d31effd664aa6253b41772345bf"
 
   url "https://github.com/Dynobase/dynobase/releases/download/v#{version}/Dynobase-#{version}#{arch}.dmg",
       verified: "github.com/Dynobase/dynobase/"

--- a/Casks/eclipse-cpp.rb
+++ b/Casks/eclipse-cpp.rb
@@ -2,13 +2,8 @@ cask "eclipse-cpp" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "5e90b3bb9da55e77d0d5c3f87c28535250a67d9e9707c3fce9dd1186bffb6a8d"
-  end
-  on_arm do
-    sha256 "b68caf64918b286858294c88802a0d333515245bf8f45c0fa0cb4297fc771332"
-  end
+  sha256 arm:   "b68caf64918b286858294c88802a0d333515245bf8f45c0fa0cb4297fc771332",
+         intel: "5e90b3bb9da55e77d0d5c3f87c28535250a67d9e9707c3fce9dd1186bffb6a8d"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-cpp-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for C/C++ Developers"

--- a/Casks/eclipse-dsl.rb
+++ b/Casks/eclipse-dsl.rb
@@ -2,13 +2,8 @@ cask "eclipse-dsl" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "68bb8274be67812bbb15b002a94f914a232f9af24a27a758459ffe350d366268"
-  end
-  on_arm do
-    sha256 "ca3cb132a996f0dc63851d6444d4276337294a10c8a33e0ab9bdc2eb0e52122e"
-  end
+  sha256 arm:   "ca3cb132a996f0dc63851d6444d4276337294a10c8a33e0ab9bdc2eb0e52122e",
+         intel: "68bb8274be67812bbb15b002a94f914a232f9af24a27a758459ffe350d366268"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-dsl-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for Java and DSL Developers"

--- a/Casks/eclipse-ide.rb
+++ b/Casks/eclipse-ide.rb
@@ -2,13 +2,8 @@ cask "eclipse-ide" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "3488dc593a7e0b5dd80a313fbf84a6679b5927d00cd7ccad292fa202e3892ef5"
-  end
-  on_arm do
-    sha256 "aafc3b9d70aa5d4c0174a9e169645c9617704991be50f65358975d06e30a9968"
-  end
+  sha256 arm:   "aafc3b9d70aa5d4c0174a9e169645c9617704991be50f65358975d06e30a9968",
+         intel: "3488dc593a7e0b5dd80a313fbf84a6679b5927d00cd7ccad292fa202e3892ef5"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-committers-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for Eclipse Committers"

--- a/Casks/eclipse-installer.rb
+++ b/Casks/eclipse-installer.rb
@@ -2,13 +2,8 @@ cask "eclipse-installer" do
   arch arm: "aarch64", intel: "mac64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "125e008c6da26301c12c9c6ddaa309090333e9371b152deea507c0cefeeb035e"
-  end
-  on_arm do
-    sha256 "b093b562ba17398075f5cdcca617494436a19819d0d3c4c445adc0890c2ca3e6"
-  end
+  sha256 arm:   "b093b562ba17398075f5cdcca617494436a19819d0d3c4c445adc0890c2ca3e6",
+         intel: "125e008c6da26301c12c9c6ddaa309090333e9371b152deea507c0cefeeb035e"
 
   url "https://eclipse.org/downloads/download.php?file=/oomph/epp/#{version.csv.second}/R/eclipse-inst-#{arch}.tar.gz&r=1"
   name "Eclipse Installer"

--- a/Casks/eclipse-java.rb
+++ b/Casks/eclipse-java.rb
@@ -2,13 +2,8 @@ cask "eclipse-java" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "46636f6d9e82394412cc6660358c84200499fa79c89dda52c77c39e81a9592f7"
-  end
-  on_arm do
-    sha256 "387983833dd7f8296e4bcdba063258a6c9194dba2cb0ed6cddf4b4157369b445"
-  end
+  sha256 arm:   "387983833dd7f8296e4bcdba063258a6c9194dba2cb0ed6cddf4b4157369b445",
+         intel: "46636f6d9e82394412cc6660358c84200499fa79c89dda52c77c39e81a9592f7"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-java-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for Java Developers"

--- a/Casks/eclipse-jee.rb
+++ b/Casks/eclipse-jee.rb
@@ -2,13 +2,8 @@ cask "eclipse-jee" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "84fdae52853e84fe530f002482a5ddddfc1a88932e93c341001192fc54daa8b1"
-  end
-  on_arm do
-    sha256 "a2ccb1dd0180d241dd2e3c49507fe6d3d5535606862081b436d90194970f736b"
-  end
+  sha256 arm:   "a2ccb1dd0180d241dd2e3c49507fe6d3d5535606862081b436d90194970f736b",
+         intel: "84fdae52853e84fe530f002482a5ddddfc1a88932e93c341001192fc54daa8b1"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-jee-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for Java EE Developers"

--- a/Casks/eclipse-modeling.rb
+++ b/Casks/eclipse-modeling.rb
@@ -2,13 +2,8 @@ cask "eclipse-modeling" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "5b0823ae92a3c1fcecb6434f8729f30f4cbfe25e79131625597ddd6d42f4cfb0"
-  end
-  on_arm do
-    sha256 "efe4598f84ef21de4c8f002dc07c40383c2e4f03665892801f6f575bbc92ea25"
-  end
+  sha256 arm:   "efe4598f84ef21de4c8f002dc07c40383c2e4f03665892801f6f575bbc92ea25",
+         intel: "5b0823ae92a3c1fcecb6434f8729f30f4cbfe25e79131625597ddd6d42f4cfb0"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-modeling-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse Modeling Tools"

--- a/Casks/eclipse-php.rb
+++ b/Casks/eclipse-php.rb
@@ -2,13 +2,8 @@ cask "eclipse-php" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "2015ee61c3fa86d652d2473a6313ac2b91727f9c5f296d6de9bdae65846f0a21"
-  end
-  on_arm do
-    sha256 "614a00936254bb3141192e04aedd27d952a5aca909748bfe4ac4cdbe7e4c34cd"
-  end
+  sha256 arm:   "614a00936254bb3141192e04aedd27d952a5aca909748bfe4ac4cdbe7e4c34cd",
+         intel: "2015ee61c3fa86d652d2473a6313ac2b91727f9c5f296d6de9bdae65846f0a21"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-php-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse IDE for PHP Developers"

--- a/Casks/eclipse-platform.rb
+++ b/Casks/eclipse-platform.rb
@@ -2,13 +2,8 @@ cask "eclipse-platform" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24,202206070700"
-
-  on_intel do
-    sha256 "b33bcf7427eb9b969093b8a6cd3e2fb7e357acbc994cbc4baa95e739ab4425cd"
-  end
-  on_arm do
-    sha256 "dd8988a3d60aedc8bc21de79bc5ef299037c0da8d23bdc367ecaf9f3799340d5"
-  end
+  sha256 arm:   "dd8988a3d60aedc8bc21de79bc5ef299037c0da8d23bdc367ecaf9f3799340d5",
+         intel: "b33bcf7427eb9b969093b8a6cd3e2fb7e357acbc994cbc4baa95e739ab4425cd"
 
   url "https://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops#{version.major}/R-#{version.csv.first}-#{version.csv.second}/eclipse-SDK-#{version.csv.first}-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse SDK"

--- a/Casks/eclipse-rcp.rb
+++ b/Casks/eclipse-rcp.rb
@@ -2,13 +2,8 @@ cask "eclipse-rcp" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.24.0,2022-06"
-
-  on_intel do
-    sha256 "4736e9dd5b2f6458ecd3388436e9b99741106a4bedd100285e27ae1e221a4581"
-  end
-  on_arm do
-    sha256 "5951a0f157c7f19975ae9100d0a7e399152fd892d8f8017cd1d2d0440b308cc9"
-  end
+  sha256 arm:   "5951a0f157c7f19975ae9100d0a7e399152fd892d8f8017cd1d2d0440b308cc9",
+         intel: "4736e9dd5b2f6458ecd3388436e9b99741106a4bedd100285e27ae1e221a4581"
 
   url "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/#{version.csv.second}/R/eclipse-rcp-#{version.csv.second}-R-macosx-cocoa-#{arch}.dmg&r=1"
   name "Eclipse for RCP and RAP Developers"

--- a/Casks/electerm.rb
+++ b/Casks/electerm.rb
@@ -2,13 +2,8 @@ cask "electerm" do
   arch arm: "arm64", intel: "x64"
 
   version "1.22.30"
-
-  on_intel do
-    sha256 "7036861bce6abe98a9fbd56e72f68b0ba591f10de01180d09e76c7a0de37b2c2"
-  end
-  on_arm do
-    sha256 "8d1521d79234b56b023cff76d3f8b0b808abef98e5951f00798322042e40bb2b"
-  end
+  sha256 arm:   "8d1521d79234b56b023cff76d3f8b0b808abef98e5951f00798322042e40bb2b",
+         intel: "7036861bce6abe98a9fbd56e72f68b0ba591f10de01180d09e76c7a0de37b2c2"
 
   url "https://github.com/electerm/electerm/releases/download/v#{version}/electerm-#{version}-mac-#{arch}.dmg"
   name "electerm"

--- a/Casks/electron-fiddle.rb
+++ b/Casks/electron-fiddle.rb
@@ -2,13 +2,8 @@ cask "electron-fiddle" do
   arch arm: "arm64", intel: "x64"
 
   version "0.30.0"
-
-  on_intel do
-    sha256 "c7f34ec69be8f06c97360314950549e2692f6b94f2fe3849f73f58f5efc8fa2f"
-  end
-  on_arm do
-    sha256 "dfad9d45a9bd8464b542130d94753ae9b1b559664e569193e7a6a7b525805697"
-  end
+  sha256 arm:   "dfad9d45a9bd8464b542130d94753ae9b1b559664e569193e7a6a7b525805697",
+         intel: "c7f34ec69be8f06c97360314950549e2692f6b94f2fe3849f73f58f5efc8fa2f"
 
   url "https://github.com/electron/fiddle/releases/download/v#{version}/Electron.Fiddle-darwin-#{arch}-#{version}.zip",
       verified: "github.com/electron/fiddle/"

--- a/Casks/electron.rb
+++ b/Casks/electron.rb
@@ -2,13 +2,8 @@ cask "electron" do
   arch arm: "arm64", intel: "x64"
 
   version "20.0.3"
-
-  on_intel do
-    sha256 "6fd3ab4152a609e4923af5776ef8d2c3fb1d1842616706ac3acd1e78fc2cb2a9"
-  end
-  on_arm do
-    sha256 "cc7f3caf673f17b887d803114494cb15babac1574e246780070cda5d79138004"
-  end
+  sha256 arm:   "cc7f3caf673f17b887d803114494cb15babac1574e246780070cda5d79138004",
+         intel: "6fd3ab4152a609e4923af5776ef8d2c3fb1d1842616706ac3acd1e78fc2cb2a9"
 
   url "https://github.com/electron/electron/releases/download/v#{version}/electron-v#{version}-darwin-#{arch}.zip",
       verified: "github.com/electron/electron/"

--- a/Casks/elephicon.rb
+++ b/Casks/elephicon.rb
@@ -2,13 +2,8 @@ cask "elephicon" do
   arch arm: "arm64", intel: "x64"
 
   version "1.10.0"
-
-  on_intel do
-    sha256 "7027e06b185dfda939419dc9438014370c4b23c7828ef2576dc3c67537d714c8"
-  end
-  on_arm do
-    sha256 "6f5cf8b7d9cf167c9f15bcbd74a1fba7b1cf0647d87169ad7252b4a94d547e26"
-  end
+  sha256 arm:   "6f5cf8b7d9cf167c9f15bcbd74a1fba7b1cf0647d87169ad7252b4a94d547e26",
+         intel: "7027e06b185dfda939419dc9438014370c4b23c7828ef2576dc3c67537d714c8"
 
   url "https://github.com/sprout2000/elephicon/releases/download/v#{version}/Elephicon-#{version}-darwin-#{arch}.zip"
   name "Elephicon"

--- a/Casks/epic.rb
+++ b/Casks/epic.rb
@@ -2,13 +2,8 @@ cask "epic" do
   arch arm: "m1"
 
   version "103.0.5060.53"
-
-  on_intel do
-    sha256 "d3e352ae9cd7aa342ff8d9b89f87be9b94e7887c38ac5fb9b92e9e2089a721ba"
-  end
-  on_arm do
-    sha256 "445d5344376c5f586350fb53ed04f7535dd48c48029e0f4a18a5b9be45995b8f"
-  end
+  sha256 arm:   "445d5344376c5f586350fb53ed04f7535dd48c48029e0f4a18a5b9be45995b8f",
+         intel: "d3e352ae9cd7aa342ff8d9b89f87be9b94e7887c38ac5fb9b92e9e2089a721ba"
 
   url "https://cdn.epicbrowser.com/v100/#{arch}/epic_#{version}.dmg"
   name "Epic Privacy Browser"

--- a/Casks/espanso.rb
+++ b/Casks/espanso.rb
@@ -2,13 +2,8 @@ cask "espanso" do
   arch arm: "M1", intel: "Intel"
 
   version "2.1.6-beta"
-
-  on_intel do
-    sha256 "63322c649d4b6aa3c4bfeddd99a1c2c095c77051271238faaaa19ede4f7e9576"
-  end
-  on_arm do
-    sha256 "46137b5e7316a1c85574d45468b510e14a58cd495d5eb74de74f482dd241c447"
-  end
+  sha256 arm:   "46137b5e7316a1c85574d45468b510e14a58cd495d5eb74de74f482dd241c447",
+         intel: "63322c649d4b6aa3c4bfeddd99a1c2c095c77051271238faaaa19ede4f7e9576"
 
   url "https://github.com/espanso/espanso/releases/download/v#{version}/Espanso-Mac-#{arch}.zip",
       verified: "github.com/espanso/espanso/"

--- a/Casks/exodus.rb
+++ b/Casks/exodus.rb
@@ -2,13 +2,8 @@ cask "exodus" do
   arch arm: "macos-arm64", intel: "macos"
 
   version "22.8.12"
-
-  on_intel do
-    sha256 "ae1cf37f921e290d777fbce7a8d19539ac2810e05bda695e3f8c3e45c4938ed6"
-  end
-  on_arm do
-    sha256 "d2f565baa51ebf1515818f65c9377fe6c71ea922e1a8a822071536778581325b"
-  end
+  sha256 arm:   "d2f565baa51ebf1515818f65c9377fe6c71ea922e1a8a822071536778581325b",
+         intel: "ae1cf37f921e290d777fbce7a8d19539ac2810e05bda695e3f8c3e45c4938ed6"
 
   url "https://downloads.exodus.com/releases/exodus-#{arch}-#{version}.dmg"
   name "Exodus"

--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -2,13 +2,8 @@ cask "feishu" do
   arch arm: "arm64", intel: "x64"
 
   version "5.17.6,1a2b3c4d"
-
-  on_intel do
-    sha256 "954a23bd074723803cd752cf3dbf17c46884b0fe61c99c0354e63ea3106a06e7"
-  end
-  on_arm do
-    sha256 "03d88dd8486fa3b46d2e49f0d311287c8195472570d831663cdcb4c0ca826128"
-  end
+  sha256 arm:   "03d88dd8486fa3b46d2e49f0d311287c8195472570d831663cdcb4c0ca826128",
+         intel: "954a23bd074723803cd752cf3dbf17c46884b0fe61c99c0354e63ea3106a06e7"
 
   url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.csv.second}/Feishu-darwin_#{arch}-#{version.csv.first}-signed.dmg",
       verified: "sf3-cn.feishucdn.com/"

--- a/Casks/ferdi.rb
+++ b/Casks/ferdi.rb
@@ -2,13 +2,8 @@ cask "ferdi" do
   arch arm: "-arm64"
 
   version "5.8.1"
-
-  on_intel do
-    sha256 "fa802e2627dc2c9c5ccface1f9c830c5a2e0e9ae7a7339716651010e39928a50"
-  end
-  on_arm do
-    sha256 "ec7ccceba08f1c581290d6ce4f5fa5478bed2c713c592d0298856f7b2719f35d"
-  end
+  sha256 arm:   "ec7ccceba08f1c581290d6ce4f5fa5478bed2c713c592d0298856f7b2719f35d",
+         intel: "fa802e2627dc2c9c5ccface1f9c830c5a2e0e9ae7a7339716651010e39928a50"
 
   url "https://github.com/getferdi/ferdi/releases/download/v#{version}/Ferdi-#{version}#{arch}.dmg",
       verified: "github.com/getferdi/ferdi/"

--- a/Casks/ferdium.rb
+++ b/Casks/ferdium.rb
@@ -2,13 +2,8 @@ cask "ferdium" do
   arch arm: "arm64", intel: "x64"
 
   version "6.0.0"
-
-  on_intel do
-    sha256 "131c29c39275143d294b022581556cf9ac2ed458efc13fea06f677205d854da1"
-  end
-  on_arm do
-    sha256 "c9b4a05a0654e57065df2b2d56738178d83345f4de157ef72daa950b48e51188"
-  end
+  sha256 arm:   "c9b4a05a0654e57065df2b2d56738178d83345f4de157ef72daa950b48e51188",
+         intel: "131c29c39275143d294b022581556cf9ac2ed458efc13fea06f677205d854da1"
 
   url "https://github.com/ferdium/ferdium-app/releases/download/v#{version}/Ferdium-mac-#{version}-#{arch}.dmg",
       verified: "github.com/ferdium/ferdium-app/"

--- a/Casks/figma.rb
+++ b/Casks/figma.rb
@@ -2,13 +2,8 @@ cask "figma" do
   arch arm: "mac-arm", intel: "mac"
 
   version "116.2.4"
-
-  on_intel do
-    sha256 "60e3db6ef10e328577072338add87fd7a3480604ff1da82935de59557e48ad65"
-  end
-  on_arm do
-    sha256 "4a46d7abd0237626641453b9a126727868a8c55e16eeac18b16022ec4fcecac6"
-  end
+  sha256 arm:   "4a46d7abd0237626641453b9a126727868a8c55e16eeac18b16022ec4fcecac6",
+         intel: "60e3db6ef10e328577072338add87fd7a3480604ff1da82935de59557e48ad65"
 
   url "https://desktop.figma.com/#{arch}/Figma-#{version}.zip"
   name "Figma"

--- a/Casks/filebot.rb
+++ b/Casks/filebot.rb
@@ -2,13 +2,8 @@ cask "filebot" do
   arch arm: "arm64", intel: "x64"
 
   version "4.9.6"
-
-  on_intel do
-    sha256 "38935215702be042aae44effad9cd5e82139ece8ecdb55ee86515b875064873a"
-  end
-  on_arm do
-    sha256 "e1804ce4e402dcdda5a8417294d7317217a5eca57569f4fa47f9f701a0a7c61e"
-  end
+  sha256 arm:   "e1804ce4e402dcdda5a8417294d7317217a5eca57569f4fa47f9f701a0a7c61e",
+         intel: "38935215702be042aae44effad9cd5e82139ece8ecdb55ee86515b875064873a"
 
   url "https://get.filebot.net/filebot/FileBot_#{version}/FileBot_#{version}_#{arch}.app.tar.xz"
   name "FileBot"

--- a/Casks/fishing-funds.rb
+++ b/Casks/fishing-funds.rb
@@ -2,13 +2,8 @@ cask "fishing-funds" do
   arch arm: "-arm64"
 
   version "6.2.2"
-
-  on_intel do
-    sha256 "9ec3b8358db25252db93f902f6f14d50029a31516052a9f9017385c7f02294e4"
-  end
-  on_arm do
-    sha256 "f88f88ea326b2605cbaba4d8b837e0a8dd6497f6c209b42fb8c29c15eec4a7ec"
-  end
+  sha256 arm:   "f88f88ea326b2605cbaba4d8b837e0a8dd6497f6c209b42fb8c29c15eec4a7ec",
+         intel: "9ec3b8358db25252db93f902f6f14d50029a31516052a9f9017385c7f02294e4"
 
   url "https://github.com/1zilc/fishing-funds/releases/download/v#{version}/Fishing-Funds-#{version}#{arch}.dmg",
       verified: "github.com/1zilc/fishing-funds/"

--- a/Casks/flutter.rb
+++ b/Casks/flutter.rb
@@ -2,13 +2,8 @@ cask "flutter" do
   arch arm: "_arm64_", intel: "_"
 
   version "3.0.5"
-
-  on_intel do
-    sha256 "e79a04dcfd1b583e5831433fc200800ba0d1e9fe4567cb661479bd2542d4c685"
-  end
-  on_arm do
-    sha256 "d1d09e8d3647729338446965f63a59f3400b4a3f04efbcc9040628def81e6ecf"
-  end
+  sha256 arm:   "d1d09e8d3647729338446965f63a59f3400b4a3f04efbcc9040628def81e6ecf",
+         intel: "e79a04dcfd1b583e5831433fc200800ba0d1e9fe4567cb661479bd2542d4c685"
 
   url "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos#{arch}#{version}-stable.zip",
       verified: "storage.googleapis.com/flutter_infra_release/releases/stable/macos/"

--- a/Casks/franz.rb
+++ b/Casks/franz.rb
@@ -2,13 +2,8 @@ cask "franz" do
   arch arm: "-arm64"
 
   version "5.9.2"
-
-  on_intel do
-    sha256 "9b6907c132624c645e9d39bc9822a239b0e3a7507d40bcc97bf2be6ca3fc171f"
-  end
-  on_arm do
-    sha256 "700342d6d3a6b532e5e7a3767c8b97d9bcfc9eb0959098f02d3b13462fdcfb7d"
-  end
+  sha256 arm:   "700342d6d3a6b532e5e7a3767c8b97d9bcfc9eb0959098f02d3b13462fdcfb7d",
+         intel: "9b6907c132624c645e9d39bc9822a239b0e3a7507d40bcc97bf2be6ca3fc171f"
 
   url "https://github.com/meetfranz/franz/releases/download/v#{version}/franz-#{version}#{arch}.dmg",
       verified: "github.com/meetfranz/franz/"

--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -2,13 +2,8 @@ cask "freeplane" do
   arch arm: "apple", intel: "intel"
 
   version "1.10.3"
-
-  on_intel do
-    sha256 "841a337c1b291920e177e3f37992aa932c7859a12d9237a0c372124c8159fae3"
-  end
-  on_arm do
-    sha256 "7ba4dbf56cb1f62c55ffde17f6c979f07ba403bdb6a33e26f10768248009ad84"
-  end
+  sha256 arm:   "7ba4dbf56cb1f62c55ffde17f6c979f07ba403bdb6a33e26f10768248009ad84",
+         intel: "841a337c1b291920e177e3f37992aa932c7859a12d9237a0c372124c8159fae3"
 
   url "https://downloads.sourceforge.net/freeplane/Freeplane-#{version}-#{arch}.dmg",
       verified: "downloads.sourceforge.net/freeplane/"

--- a/Casks/front.rb
+++ b/Casks/front.rb
@@ -2,13 +2,8 @@ cask "front" do
   arch arm: "arm64", intel: "x64"
 
   version "3.36.14"
-
-  on_intel do
-    sha256 "5a522a2a6ff8df26f672101e12c412bb7dc4551801a450f502842cbeafb50df6"
-  end
-  on_arm do
-    sha256 "2d194488f26c0d38b255228f69f287d8bf676e651c0e74f4a97ae99accef94d4"
-  end
+  sha256 arm:   "2d194488f26c0d38b255228f69f287d8bf676e651c0e74f4a97ae99accef94d4",
+         intel: "5a522a2a6ff8df26f672101e12c412bb7dc4551801a450f502842cbeafb50df6"
 
   url "https://dl.frontapp.com/desktop/builds/#{version}/Front-#{version}-#{arch}.zip",
       verified: "dl.frontapp.com/desktop/builds"

--- a/Casks/fs-uae-launcher.rb
+++ b/Casks/fs-uae-launcher.rb
@@ -2,13 +2,8 @@ cask "fs-uae-launcher" do
   arch arm: "ARM64", intel: "x86-64"
 
   version "3.1.66"
-
-  on_intel do
-    sha256 "89dc35917fceeebee62d7bfaa80c3384b6daf0600908d46ba3508855195effb2"
-  end
-  on_arm do
-    sha256 "03c720ee5f3293c6e4002dd593af9518b05873f869da73bfb8480128a8b586d2"
-  end
+  sha256 arm:   "03c720ee5f3293c6e4002dd593af9518b05873f869da73bfb8480128a8b586d2",
+         intel: "89dc35917fceeebee62d7bfaa80c3384b6daf0600908d46ba3508855195effb2"
 
   url "https://fs-uae.net/files/FS-UAE-Launcher/Stable/#{version}/FS-UAE-Launcher_#{version}_macOS_#{arch}.tar.xz"
   name "FS-UAE Launcher"

--- a/Casks/fs-uae.rb
+++ b/Casks/fs-uae.rb
@@ -2,13 +2,8 @@ cask "fs-uae" do
   arch arm: "ARM64", intel: "x86-64"
 
   version "3.1.66"
-
-  on_intel do
-    sha256 "c0c83858e80e3e150065e74669d1fefd4e9773c90b00b6bfbe9abd43a5b90840"
-  end
-  on_arm do
-    sha256 "7dc51930740a0634505f18a076b78fdbe97de09eed6888a61c7dc2022e94643d"
-  end
+  sha256 arm:   "7dc51930740a0634505f18a076b78fdbe97de09eed6888a61c7dc2022e94643d",
+         intel: "c0c83858e80e3e150065e74669d1fefd4e9773c90b00b6bfbe9abd43a5b90840"
 
   url "https://fs-uae.net/files/FS-UAE/Stable/#{version}/FS-UAE_#{version}_macOS_#{arch}.tar.xz"
   name "FS-UAE"

--- a/Casks/gama-jdk.rb
+++ b/Casks/gama-jdk.rb
@@ -2,13 +2,8 @@ cask "gama-jdk" do
   arch arm: "_M1"
 
   version "1.8.2-RC2"
-
-  on_intel do
-    sha256 "0d161a6aa13a3d40f1643d551b594cdd58d6ef3a81e10ea9ff2d9bc1070f21ac"
-  end
-  on_arm do
-    sha256 "c903608dd09cf511e721bceaa1f521e772a2ea9801eb135b182aa3b1a3053d88"
-  end
+  sha256 arm:   "c903608dd09cf511e721bceaa1f521e772a2ea9801eb135b182aa3b1a3053d88",
+         intel: "0d161a6aa13a3d40f1643d551b594cdd58d6ef3a81e10ea9ff2d9bc1070f21ac"
 
   url "https://github.com/gama-platform/gama.resources/releases/download/#{version}/GAMA_#{version}_MacOS#{arch}_with_JDK.dmg",
       verified: "github.com/gama-platform/gama.resources/"

--- a/Casks/gama.rb
+++ b/Casks/gama.rb
@@ -2,13 +2,8 @@ cask "gama" do
   arch arm: "_M1"
 
   version "1.8.2-RC2"
-
-  on_intel do
-    sha256 "64557bc82b5557dfde221d88f81bbba46e5ac1b66f1538561b72dd863578b6aa"
-  end
-  on_arm do
-    sha256 "d49eeb2122f171b4b0dd85777e20d1c5cd169a145bf128bdd5e5d269e21a197a"
-  end
+  sha256 arm:   "d49eeb2122f171b4b0dd85777e20d1c5cd169a145bf128bdd5e5d269e21a197a",
+         intel: "64557bc82b5557dfde221d88f81bbba46e5ac1b66f1538561b72dd863578b6aa"
 
   url "https://github.com/gama-platform/gama.resources/releases/download/#{version}/GAMA_#{version}_MacOS#{arch}.dmg",
       verified: "github.com/gama-platform/gama.resources/"

--- a/Casks/gargoyle.rb
+++ b/Casks/gargoyle.rb
@@ -2,13 +2,8 @@ cask "gargoyle" do
   arch arm: "mac-arm64", intel: "mac-intel"
 
   version "2022.1"
-
-  on_intel do
-    sha256 "68448156799315e9204079559b451b6012f8e2d7e1368e32412b1f32f01157e4"
-  end
-  on_arm do
-    sha256 "46c286890de2fef2ce517f277a0fe3c88c7a75cc2283542e7b9c1d24353cddf8"
-  end
+  sha256 arm:   "46c286890de2fef2ce517f277a0fe3c88c7a75cc2283542e7b9c1d24353cddf8",
+         intel: "68448156799315e9204079559b451b6012f8e2d7e1368e32412b1f32f01157e4"
 
   url "https://github.com/garglk/garglk/releases/download/#{version}/gargoyle-#{version}-#{arch}.dmg"
   name "Gargoyle"

--- a/Casks/gather.rb
+++ b/Casks/gather.rb
@@ -2,13 +2,8 @@ cask "gather" do
   arch arm: "-arm64"
 
   version "0.3.6"
-
-  on_intel do
-    sha256 "8c4b6c82ceb7797db4e1203867d4268b6c093fe69bd5f068a95b7fb5a8b5eff6"
-  end
-  on_arm do
-    sha256 "170743882eb60a66a6cd7fddea3fd106cd86ca9b35bd373175f75bf1e88386df"
-  end
+  sha256 arm:   "170743882eb60a66a6cd7fddea3fd106cd86ca9b35bd373175f75bf1e88386df",
+         intel: "8c4b6c82ceb7797db4e1203867d4268b6c093fe69bd5f068a95b7fb5a8b5eff6"
 
   url "https://github.com/gathertown/gather-town-desktop-releases/releases/download/v#{version}/Gather-#{version}#{arch}-mac.zip",
       verified: "github.com/gathertown/gather-town-desktop-releases"

--- a/Casks/ghost-browser.rb
+++ b/Casks/ghost-browser.rb
@@ -2,13 +2,8 @@ cask "ghost-browser" do
   arch arm: "_arm64"
 
   version "2.1.4.3"
-
-  on_intel do
-    sha256 "670b47313871ab6870a86cec8853b4ece33f6b11b6baf42b250e414141e3fccd"
-  end
-  on_arm do
-    sha256 "5df32b98b1bcf75aa95647a83d98bf775a9dea53655e89a4ab82cb48716314f8"
-  end
+  sha256 arm:   "5df32b98b1bcf75aa95647a83d98bf775a9dea53655e89a4ab82cb48716314f8",
+         intel: "670b47313871ab6870a86cec8853b4ece33f6b11b6baf42b250e414141e3fccd"
 
   url "https://downloads.ghostbrowser.com/GhostBrowser-#{version}#{arch}.dmg"
   name "Ghost Browser"

--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -3,13 +3,8 @@ cask "github" do
   platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
 
   version "3.0.5-25b66588"
-
-  on_intel do
-    sha256 "987a03547689a44b14b795b4d52424a58424e1fd5691d1dcc68054def8845c4f"
-  end
-  on_arm do
-    sha256 "3d24d135107f3111c641b5ed0fc8baf182e717aac66e79aeef9751575d604ed8"
-  end
+  sha256 arm:   "3d24d135107f3111c641b5ed0fc8baf182e717aac66e79aeef9751575d604ed8",
+         intel: "987a03547689a44b14b795b4d52424a58424e1fd5691d1dcc68054def8845c4f"
 
   url "https://desktop.githubusercontent.com/github-desktop/releases/#{version}/GitHubDesktop-#{arch}.zip",
       verified: "desktop.githubusercontent.com/github-desktop/"

--- a/Casks/gitkraken.rb
+++ b/Casks/gitkraken.rb
@@ -2,13 +2,8 @@ cask "gitkraken" do
   arch arm: "darwin-arm64", intel: "darwin"
 
   version "8.8.0"
-
-  on_intel do
-    sha256 "a7b1762ede268e49ae93d5377d7711d7c7bc88c1a592bd7da8117b6f8bfa79c4"
-  end
-  on_arm do
-    sha256 "51f5fa33b4d5d22f3474bfb7409ff5538cf23b05c8fc00c444103459fd04263e"
-  end
+  sha256 arm:   "51f5fa33b4d5d22f3474bfb7409ff5538cf23b05c8fc00c444103459fd04263e",
+         intel: "a7b1762ede268e49ae93d5377d7711d7c7bc88c1a592bd7da8117b6f8bfa79c4"
 
   url "https://release.axocdn.com/#{arch}/GitKraken-v#{version}.zip",
       verified: "release.axocdn.com/"

--- a/Casks/gogs.rb
+++ b/Casks/gogs.rb
@@ -2,13 +2,8 @@ cask "gogs" do
   arch arm: "arm64", intel: "amd64"
 
   version "0.12.10"
-
-  on_intel do
-    sha256 "c1825303c05ea38af0dbb1db3abfc91f94c4df37f74ec4eb36d3cef526c776fc"
-  end
-  on_arm do
-    sha256 "63aaee6f0679486621bab27bb4245bc3ff910f71bffebe2985f3181bd43bbf40"
-  end
+  sha256 arm:   "63aaee6f0679486621bab27bb4245bc3ff910f71bffebe2985f3181bd43bbf40",
+         intel: "c1825303c05ea38af0dbb1db3abfc91f94c4df37f74ec4eb36d3cef526c776fc"
 
   url "https://github.com/gogs/gogs/releases/download/v#{version}/gogs_#{version}_darwin_#{arch}.zip",
       verified: "github.com/gogs/gogs/"

--- a/Casks/goland.rb
+++ b/Casks/goland.rb
@@ -2,13 +2,8 @@ cask "goland" do
   arch arm: "-aarch64"
 
   version "2022.2.2,222.3739.57"
-
-  on_intel do
-    sha256 "e11f07aebf849ed942c4b8658c11c70ce81b4138186a0301c0ec7cd236f1ff51"
-  end
-  on_arm do
-    sha256 "7098f05847c0524bc90b00766c71c2f1cc1442983da956c79ee1445b48da73fd"
-  end
+  sha256 arm:   "7098f05847c0524bc90b00766c71c2f1cc1442983da956c79ee1445b48da73fd",
+         intel: "e11f07aebf849ed942c4b8658c11c70ce81b4138186a0301c0ec7cd236f1ff51"
 
   url "https://download.jetbrains.com/go/goland-#{version.csv.first}#{arch}.dmg"
   name "Goland"

--- a/Casks/google-chat-electron.rb
+++ b/Casks/google-chat-electron.rb
@@ -2,13 +2,8 @@ cask "google-chat-electron" do
   arch arm: "darwin-arm64", intel: "darwin-x64"
 
   version "2.18.0"
-
-  on_intel do
-    sha256 "1f1182a94d92ce7b5f8aad936bd4497f3b62c588dba8ea67280da27c43797fe3"
-  end
-  on_arm do
-    sha256 "81201263cc7a3a3e07106dce5b23148a8a7c21420d6bd862575a92af58f07cba"
-  end
+  sha256 arm:   "81201263cc7a3a3e07106dce5b23148a8a7c21420d6bd862575a92af58f07cba",
+         intel: "1f1182a94d92ce7b5f8aad936bd4497f3b62c588dba8ea67280da27c43797fe3"
 
   url "https://github.com/ankurk91/google-chat-electron/releases/download/#{version}/google-chat-electron-#{version}-#{arch}.zip"
   name "google-chat-electron"

--- a/Casks/groestlcoin-core.rb
+++ b/Casks/groestlcoin-core.rb
@@ -2,13 +2,8 @@ cask "groestlcoin-core" do
   arch arm: "arm64", intel: "x86_64"
 
   version "23.0"
-
-  on_intel do
-    sha256 "82e6a1862974ca51bd65aeb79f3e5eb5327b5da1f687921e9fb573c83293051c"
-  end
-  on_arm do
-    sha256 "7df0f66ee01e0f2e5faade6bd900e4a96f970cc56043a1a428dd9bf34dc5777b"
-  end
+  sha256 arm:   "7df0f66ee01e0f2e5faade6bd900e4a96f970cc56043a1a428dd9bf34dc5777b",
+         intel: "82e6a1862974ca51bd65aeb79f3e5eb5327b5da1f687921e9fb573c83293051c"
 
   url "https://github.com/groestlcoin/groestlcoin/releases/download/v#{version}/groestlcoin-#{version}-#{arch}-apple-darwin.dmg",
       verified: "github.com/groestlcoin/groestlcoin/"

--- a/Casks/hackolade.rb
+++ b/Casks/hackolade.rb
@@ -2,13 +2,8 @@ cask "hackolade" do
   arch arm: "ARM64", intel: ""
 
   version "6.4.1"
-
-  on_intel do
-    sha256 "df11bee9e746cf00c57bebdeba016c9dc660fee7bcd56ae4d68a9d8ee61d0210"
-  end
-  on_arm do
-    sha256 "cb8a87760e10e3e38777a59c68305b5be2ff453a529080eb95372f4b17fcf08b"
-  end
+  sha256 arm:   "cb8a87760e10e3e38777a59c68305b5be2ff453a529080eb95372f4b17fcf08b",
+         intel: "df11bee9e746cf00c57bebdeba016c9dc660fee7bcd56ae4d68a9d8ee61d0210"
 
   url "https://s3-eu-west-1.amazonaws.com/hackolade/previous/v#{version}/Hackolade-mac#{arch}-setup-signed.pkg",
       verified: "s3-eu-west-1.amazonaws.com/hackolade/"

--- a/Casks/headlamp.rb
+++ b/Casks/headlamp.rb
@@ -2,13 +2,8 @@ cask "headlamp" do
   arch arm: "arm64", intel: "x64"
 
   version "0.12.0"
-
-  on_intel do
-    sha256 "b94592a566b8bd297d8221bd34a57a6add83d1a6fa5f27fb2bfe2ff688803c3d"
-  end
-  on_arm do
-    sha256 "b4d11c4b2ed8fc9f273dfe487f4ceb51dd743fc2408e6c7150f7b43d8f692de1"
-  end
+  sha256 arm:   "b4d11c4b2ed8fc9f273dfe487f4ceb51dd743fc2408e6c7150f7b43d8f692de1",
+         intel: "b94592a566b8bd297d8221bd34a57a6add83d1a6fa5f27fb2bfe2ff688803c3d"
 
   url "https://github.com/kinvolk/headlamp/releases/download/v#{version}/Headlamp-#{version}-mac-#{arch}.dmg",
       verified: "github.com/kinvolk/headlamp/"

--- a/Casks/headset.rb
+++ b/Casks/headset.rb
@@ -2,13 +2,8 @@ cask "headset" do
   arch arm: "arm64", intel: "x64"
 
   version "4.1.2"
-
-  on_intel do
-    sha256 "5252c69b2c3bc02692b013a41d6f4c5638fe01e7dcfcacc6b55908441b1176e7"
-  end
-  on_arm do
-    sha256 "fa58608c4d3f4ffa2dedd07225661fe8a9f7b059391c7d2cab09c94c5016cf1b"
-  end
+  sha256 arm:   "fa58608c4d3f4ffa2dedd07225661fe8a9f7b059391c7d2cab09c94c5016cf1b",
+         intel: "5252c69b2c3bc02692b013a41d6f4c5638fe01e7dcfcacc6b55908441b1176e7"
 
   url "https://github.com/headsetapp/headset-electron/releases/download/v#{version}/Headset-#{version}-#{arch}.dmg",
       verified: "github.com/headsetapp/headset-electron/"

--- a/Casks/helo.rb
+++ b/Casks/helo.rb
@@ -2,13 +2,8 @@ cask "helo" do
   arch arm: "-arm64"
 
   version "1.6.2"
-
-  on_intel do
-    sha256 "a22704a4b8f5bc13a9f1c8f6e893657576c20308fe7372ae87306d58d70dca48"
-  end
-  on_arm do
-    sha256 "b1ef0c2c300d7c644f91cfc664bb28b3066b86257984b0407b52dd0e7ed59d0d"
-  end
+  sha256 arm:   "b1ef0c2c300d7c644f91cfc664bb28b3066b86257984b0407b52dd0e7ed59d0d",
+         intel: "a22704a4b8f5bc13a9f1c8f6e893657576c20308fe7372ae87306d58d70dca48"
 
   url "https://helo.fra1.digitaloceanspaces.com/helo/HELO-#{version}#{arch}.dmg",
       verified: "helo.fra1.digitaloceanspaces.com/helo/"

--- a/Casks/hepta.rb
+++ b/Casks/hepta.rb
@@ -2,13 +2,8 @@ cask "hepta" do
   arch arm: "arm64-mac", intel: "mac"
 
   version "0.188.2"
-
-  on_intel do
-    sha256 "7f0da05f01a3da8b346ff161484b1c701a94ee8cf1813415734a81f66ec2d017"
-  end
-  on_arm do
-    sha256 "626181026d3e57002eedd8a7500ecdf19b1eab9ad422dd69ae39f761078575d2"
-  end
+  sha256 arm:   "626181026d3e57002eedd8a7500ecdf19b1eab9ad422dd69ae39f761078575d2",
+         intel: "7f0da05f01a3da8b346ff161484b1c701a94ee8cf1813415734a81f66ec2d017"
 
   url "https://github.com/heptameta/project-meta/releases/download/v#{version}/Hepta-#{version}-#{arch}.zip",
       verified: "github.com/heptameta/project-meta/"

--- a/Casks/hey.rb
+++ b/Casks/hey.rb
@@ -2,13 +2,8 @@ cask "hey" do
   arch arm: "-arm64"
 
   version "1.2.5"
-
-  on_intel do
-    sha256 "a13b0fca4db8c054d37414c32887b07ddc4870c525cc60ac38d29f0ffc1c4cb1"
-  end
-  on_arm do
-    sha256 "e52204ea81ed2ad30bdd0fac3e38f243f1e26c3e74a1911b9f7e602f7c78701a"
-  end
+  sha256 arm:   "e52204ea81ed2ad30bdd0fac3e38f243f1e26c3e74a1911b9f7e602f7c78701a",
+         intel: "a13b0fca4db8c054d37414c32887b07ddc4870c525cc60ac38d29f0ffc1c4cb1"
 
   url "https://hey-desktop.s3.amazonaws.com/HEY-#{version}#{arch}.dmg",
       verified: "hey-desktop.s3.amazonaws.com/"

--- a/Casks/httpie.rb
+++ b/Casks/httpie.rb
@@ -2,13 +2,8 @@ cask "httpie" do
   arch arm: "-arm64"
 
   version "2022.12.0"
-
-  on_intel do
-    sha256 "3f6b841c16159ed9c6361dbe165e4a5afdba34dbe70aa95f719faf39d699783b"
-  end
-  on_arm do
-    sha256 "934f08b885c7fa483dcf3ee83a569224d9a199a1c86917544024daaad16890cc"
-  end
+  sha256 arm:   "934f08b885c7fa483dcf3ee83a569224d9a199a1c86917544024daaad16890cc",
+         intel: "3f6b841c16159ed9c6361dbe165e4a5afdba34dbe70aa95f719faf39d699783b"
 
   url "https://github.com/httpie/desktop/releases/download/v#{version}/HTTPie-#{version}#{arch}.dmg",
       verified: "github.com/httpie/desktop/"

--- a/Casks/hyper.rb
+++ b/Casks/hyper.rb
@@ -2,13 +2,8 @@ cask "hyper" do
   arch arm: "arm64", intel: "x64"
 
   version "3.3.0"
-
-  on_intel do
-    sha256 "793438488751a834edd1062532f87f79a5cce0829172f4bc90967467e279174a"
-  end
-  on_arm do
-    sha256 "ab9f95b41e74dcb26a88ca162423074905d5e0509d826115c0f52927f254e0ef"
-  end
+  sha256 arm:   "ab9f95b41e74dcb26a88ca162423074905d5e0509d826115c0f52927f254e0ef",
+         intel: "793438488751a834edd1062532f87f79a5cce0829172f4bc90967467e279174a"
 
   url "https://github.com/vercel/hyper/releases/download/v#{version}/Hyper-#{version}-mac-#{arch}.zip",
       verified: "github.com/vercel/hyper/"

--- a/Casks/iconset.rb
+++ b/Casks/iconset.rb
@@ -2,13 +2,8 @@ cask "iconset" do
   arch arm: "arm64-"
 
   version "2.2.0"
-
-  on_intel do
-    sha256 "c2c83113711b81625d0ccce9697c2bcc104f447f15fd21491238f8337b89c3a1"
-  end
-  on_arm do
-    sha256 "b82622a113c2fbdcc7df009b8d24e22f3e5f654054aa959b46c4c2df882f8147"
-  end
+  sha256 arm:   "b82622a113c2fbdcc7df009b8d24e22f3e5f654054aa959b46c4c2df882f8147",
+         intel: "c2c83113711b81625d0ccce9697c2bcc104f447f15fd21491238f8337b89c3a1"
 
   url "https://github.com/IconsetApp/iconset/releases/download/v#{version}/Iconset-#{version}-#{arch}mac.zip",
       verified: "github.com/IconsetApp/iconset/"

--- a/Casks/idafree.rb
+++ b/Casks/idafree.rb
@@ -2,13 +2,8 @@ cask "idafree" do
   arch arm: "arm_idafree", intel: "idafree"
 
   version "8.0"
-
-  on_intel do
-    sha256 "51017c0047b5b06d6cd46c93a65583d4fbf086502de884ebcb8d72033b65e5a0"
-  end
-  on_arm do
-    sha256 "73354d6e4f2fae739943ac2b10b7d98e871ad8004c40e779a2f8b9ab0e40f194"
-  end
+  sha256 arm:   "73354d6e4f2fae739943ac2b10b7d98e871ad8004c40e779a2f8b9ab0e40f194",
+         intel: "51017c0047b5b06d6cd46c93a65583d4fbf086502de884ebcb8d72033b65e5a0"
 
   url "https://out7.hex-rays.com/files/#{arch}#{version.no_dots}_mac.app.zip"
   name "IDA Free"

--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -2,13 +2,8 @@ cask "inkdrop" do
   arch arm: "arm64", intel: "x64"
 
   version "5.5.1"
-
-  on_intel do
-    sha256 "c81e7f26d2b3984058309d65aaad2451d710838fd3f9c9ebb50eb465e70b8133"
-  end
-  on_arm do
-    sha256 "83f386ccc721378ba100435938fc53e8105ba572e1b39e5b9615b532f9ab3bb4"
-  end
+  sha256 arm:   "83f386ccc721378ba100435938fc53e8105ba572e1b39e5b9615b532f9ab3bb4",
+         intel: "c81e7f26d2b3984058309d65aaad2451d710838fd3f9c9ebb50eb465e70b8133"
 
   url "https://d3ip0rje8grhnl.cloudfront.net/v#{version}/Inkdrop-#{version}-#{arch}-Mac.zip",
       verified: "d3ip0rje8grhnl.cloudfront.net/"

--- a/Casks/inkscape.rb
+++ b/Casks/inkscape.rb
@@ -2,13 +2,8 @@ cask "inkscape" do
   arch arm: "arm64", intel: "x86_64"
 
   version "1.2.1"
-
-  on_intel do
-    sha256 "8117d5d864358c9f626ce574d07d2f121ad96fc96a535cc3fddaba3c74bd3279"
-  end
-  on_arm do
-    sha256 "a8e9b49a3c9c92bc82a3914ef47290166c11c542712dd0ea63e3b9e017d5c450"
-  end
+  sha256 arm:   "a8e9b49a3c9c92bc82a3914ef47290166c11c542712dd0ea63e3b9e017d5c450",
+         intel: "8117d5d864358c9f626ce574d07d2f121ad96fc96a535cc3fddaba3c74bd3279"
 
   url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}_#{arch}.dmg"
   name "Inkscape"

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -2,13 +2,8 @@ cask "intellij-idea-ce" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.54"
-
-  on_intel do
-    sha256 "9c1402f8682ecefe84ae9494c65b80da1b763664624a7f6b0104b044b4cb687a"
-  end
-  on_arm do
-    sha256 "4bf843152fe009838dbb5e5a1d8e39ebf98df5f6771254cf1f26ff0b299798fd"
-  end
+  sha256 arm:   "4bf843152fe009838dbb5e5a1d8e39ebf98df5f6771254cf1f26ff0b299798fd",
+         intel: "9c1402f8682ecefe84ae9494c65b80da1b763664624a7f6b0104b044b4cb687a"
 
   url "https://download.jetbrains.com/idea/ideaIC-#{version.csv.first}#{arch}.dmg"
   name "IntelliJ IDEA Community Edition"

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -2,13 +2,8 @@ cask "intellij-idea" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.54"
-
-  on_intel do
-    sha256 "e54a026da11d05d9bb0172f4ef936ba2366f985b5424e7eecf9e9341804d65bf"
-  end
-  on_arm do
-    sha256 "f7b56525adf96d0ac290eebebd08a53b962a799db65942e07cd437aef655fa0e"
-  end
+  sha256 arm:   "f7b56525adf96d0ac290eebebd08a53b962a799db65942e07cd437aef655fa0e",
+         intel: "e54a026da11d05d9bb0172f4ef936ba2366f985b5424e7eecf9e9341804d65bf"
 
   url "https://download.jetbrains.com/idea/ideaIU-#{version.csv.first}#{arch}.dmg"
   name "IntelliJ IDEA Ultimate"

--- a/Casks/ivpn.rb
+++ b/Casks/ivpn.rb
@@ -2,13 +2,8 @@ cask "ivpn" do
   arch arm: "-arm64"
 
   version "3.9.8"
-
-  on_intel do
-    sha256 "b64e2fe7ea8296a63cb3e75274c73379731d64dc492778214e6f3ae728e330d1"
-  end
-  on_arm do
-    sha256 "f915d4954c3f8be86f523b057bca2d976c221628458a8d4ffccfe520417e73f5"
-  end
+  sha256 arm:   "f915d4954c3f8be86f523b057bca2d976c221628458a8d4ffccfe520417e73f5",
+         intel: "b64e2fe7ea8296a63cb3e75274c73379731d64dc492778214e6f3ae728e330d1"
 
   url "https://repo.ivpn.net/macos/bin/IVPN-#{version}#{arch}.dmg"
   name "IVPN"

--- a/Casks/jasper.rb
+++ b/Casks/jasper.rb
@@ -2,13 +2,8 @@ cask "jasper" do
   arch arm: "arm64", intel: "x64"
 
   version "1.1.1"
-
-  on_intel do
-    sha256 "8c30e53b39ab87c94eff5c76c52b7403125efeb33b76e0cc6250c134aaf55fe3"
-  end
-  on_arm do
-    sha256 "860a6d48cfc4542a0060746e10d2bfe06a3da66a0a3aeef028f02454afb3cd66"
-  end
+  sha256 arm:   "860a6d48cfc4542a0060746e10d2bfe06a3da66a0a3aeef028f02454afb3cd66",
+         intel: "8c30e53b39ab87c94eff5c76c52b7403125efeb33b76e0cc6250c134aaf55fe3"
 
   url "https://github.com/jasperapp/jasper/releases/download/v#{version}/jasper_v#{version}_mac_#{arch}.zip",
       verified: "github.com/jasperapp/jasper/"

--- a/Casks/jetbrains-gateway.rb
+++ b/Casks/jetbrains-gateway.rb
@@ -2,13 +2,8 @@ cask "jetbrains-gateway" do
   arch arm: "-aarch64"
 
   version "222.3739.54"
-
-  on_intel do
-    sha256 "9908b84e1a69c59e63824e2ef337aba59dd17020f536f3b7d754abe5221115ee"
-  end
-  on_arm do
-    sha256 "327a8f097c6ae140e8a712b1570a15944b18049684da2cf0e0cdda9f712a2fdd"
-  end
+  sha256 arm:   "327a8f097c6ae140e8a712b1570a15944b18049684da2cf0e0cdda9f712a2fdd",
+         intel: "9908b84e1a69c59e63824e2ef337aba59dd17020f536f3b7d754abe5221115ee"
 
   url "https://download.jetbrains.com/idea/gateway/JetBrainsGateway-#{version}#{arch}.dmg"
   name "jetbrains-gateway"

--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -2,13 +2,8 @@ cask "jetbrains-toolbox" do
   arch arm: "-arm64"
 
   version "1.25,1.25.12627"
-
-  on_intel do
-    sha256 "0f0ce719cbacfd83d10608a07795b3102a57e7fc1652864098fda599fca5323f"
-  end
-  on_arm do
-    sha256 "e420c5660d1ff4d9d725c85a7e432f898b7030d478373e8cc6e3798f767d6191"
-  end
+  sha256 arm:   "e420c5660d1ff4d9d725c85a7e432f898b7030d478373e8cc6e3798f767d6191",
+         intel: "0f0ce719cbacfd83d10608a07795b3102a57e7fc1652864098fda599fca5323f"
 
   url "https://download.jetbrains.com/toolbox/jetbrains-toolbox-#{version.csv.second}#{arch}.dmg"
   name "JetBrains Toolbox"

--- a/Casks/jquake.rb
+++ b/Casks/jquake.rb
@@ -2,13 +2,8 @@ cask "jquake" do
   arch arm: "arm64", intel: "intel"
 
   version "1.7.1"
-
-  on_intel do
-    sha256 "9b72c4c344e1fd93e00e71ac37acad85258b619f756d8749a323d11b65bd36e2"
-  end
-  on_arm do
-    sha256 "e0983211875664bc60422b50a2caf4307e34787cdb46112f39445b2a656fe9bd"
-  end
+  sha256 arm:   "e0983211875664bc60422b50a2caf4307e34787cdb46112f39445b2a656fe9bd",
+         intel: "9b72c4c344e1fd93e00e71ac37acad85258b619f756d8749a323d11b65bd36e2"
 
   url "https://fleneindre.github.io/downloads/JQuake_#{version}_mac_#{arch}.dmg",
       verified: "fleneindre.github.io/downloads/"

--- a/Casks/julia.rb
+++ b/Casks/julia.rb
@@ -2,13 +2,8 @@ cask "julia" do
   arch arm: "aarch64", intel: "x64"
 
   version "1.8.0"
-
-  on_intel do
-    sha256 "29880bb57614c9c597edf5384a351b3f0299fa097b9eb62cd640c93cde58677b"
-  end
-  on_arm do
-    sha256 "8e113a42fe4eac7b75023136674452f6f09590717755417cd137258707e96540"
-  end
+  sha256 arm:   "8e113a42fe4eac7b75023136674452f6f09590717755417cd137258707e96540",
+         intel: "29880bb57614c9c597edf5384a351b3f0299fa097b9eb62cd640c93cde58677b"
 
   url "https://julialang-s3.julialang.org/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg"
   name "Julia"

--- a/Casks/kap.rb
+++ b/Casks/kap.rb
@@ -2,13 +2,8 @@ cask "kap" do
   arch arm: "arm64", intel: "x64"
 
   version "3.5.5"
-
-  on_intel do
-    sha256 "8b6bf654cd140719bd810b65485bd6b490bc90a0ed0dc70336acbd3fa2f240c0"
-  end
-  on_arm do
-    sha256 "b9a36a9fb882eee232a89077c9bbd2776517f5f858b714c14ca745b564e60420"
-  end
+  sha256 arm:   "b9a36a9fb882eee232a89077c9bbd2776517f5f858b714c14ca745b564e60420",
+         intel: "8b6bf654cd140719bd810b65485bd6b490bc90a0ed0dc70336acbd3fa2f240c0"
 
   url "https://github.com/wulkano/kap/releases/download/v#{version.major_minor_patch}/Kap-#{version}-#{arch}.dmg",
       verified: "github.com/wulkano/kap/"

--- a/Casks/keepassxc.rb
+++ b/Casks/keepassxc.rb
@@ -2,16 +2,11 @@ cask "keepassxc" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.7.1"
+  sha256 arm:   "97e7c57b4695cf4a558186cd36b89605ec6d6dec8791f7add043a3a387089f01",
+         intel: "473f994698ec082f16bb20b4824dadbfb744f53a01b737b4016f6cc45f403b83"
 
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-#{arch}.dmg",
       verified: "github.com/keepassxreboot/keepassxc/"
-  on_intel do
-    sha256 "473f994698ec082f16bb20b4824dadbfb744f53a01b737b4016f6cc45f403b83"
-  end
-  on_arm do
-    sha256 "97e7c57b4695cf4a558186cd36b89605ec6d6dec8791f7add043a3a387089f01"
-  end
-
   name "KeePassXC"
   desc "Password manager app"
   homepage "https://keepassxc.org/"

--- a/Casks/keeweb.rb
+++ b/Casks/keeweb.rb
@@ -2,16 +2,11 @@ cask "keeweb" do
   arch arm: "arm64", intel: "x64"
 
   version "1.18.7"
+  sha256 arm:   "6e4870b1660b91e735eaf30e7d751c7bb8dfae623d5b6c47899bd4d5ab1e6cae",
+         intel: "f99146aebc34b59ec5ea56ffde2048c860feb69d69b958643efd7485fa7a0135"
 
   url "https://github.com/keeweb/keeweb/releases/download/v#{version}/KeeWeb-#{version}.mac.#{arch}.dmg",
       verified: "github.com/keeweb/keeweb/"
-  on_intel do
-    sha256 "f99146aebc34b59ec5ea56ffde2048c860feb69d69b958643efd7485fa7a0135"
-  end
-  on_arm do
-    sha256 "6e4870b1660b91e735eaf30e7d751c7bb8dfae623d5b6c47899bd4d5ab1e6cae"
-  end
-
   name "KeeWeb"
   desc "Password manager compatible with KeePass"
   homepage "https://keeweb.info/"

--- a/Casks/koodo-reader.rb
+++ b/Casks/koodo-reader.rb
@@ -2,13 +2,8 @@ cask "koodo-reader" do
   arch arm: "-arm64"
 
   version "1.4.7"
-
-  on_intel do
-    sha256 "66bcea2c2eaab9c04240dfa6c78288b543e9ec01529527a249150587507e35af"
-  end
-  on_arm do
-    sha256 "6affaf67a8026564ddf7e22dba3b9b7622c47792d34940eb09bd8a22a182c570"
-  end
+  sha256 arm:   "6affaf67a8026564ddf7e22dba3b9b7622c47792d34940eb09bd8a22a182c570",
+         intel: "66bcea2c2eaab9c04240dfa6c78288b543e9ec01529527a249150587507e35af"
 
   url "https://github.com/troyeguo/koodo-reader/releases/download/v#{version}/Koodo-Reader-#{version}#{arch}.dmg",
       verified: "github.com/troyeguo/koodo-reader/"

--- a/Casks/kotlin-native.rb
+++ b/Casks/kotlin-native.rb
@@ -2,13 +2,8 @@ cask "kotlin-native" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.7.10"
-
-  on_intel do
-    sha256 "4e9470c25e0c6b3b79e86a59c7eca4d79c5a28ca515e80db93504535b2332a00"
-  end
-  on_arm do
-    sha256 "c02be577f541a5c73e1af75534006eea6e09cf67b3a886f323dae6f0406bcb3e"
-  end
+  sha256 arm:   "c02be577f541a5c73e1af75534006eea6e09cf67b3a886f323dae6f0406bcb3e",
+         intel: "4e9470c25e0c6b3b79e86a59c7eca4d79c5a28ca515e80db93504535b2332a00"
 
   url "https://github.com/JetBrains/kotlin/releases/download/v#{version}/kotlin-native-macos-#{arch}-#{version}.tar.gz",
       verified: "github.com/JetBrains/kotlin/"

--- a/Casks/kubenav.rb
+++ b/Casks/kubenav.rb
@@ -2,13 +2,8 @@ cask "kubenav" do
   arch arm: "arm64", intel: "amd64"
 
   version "3.9.0"
-
-  on_intel do
-    sha256 "81dfd86497a1a5081cec1c4a544eb7959218db0107ddc3758b0b3e5367db950f"
-  end
-  on_arm do
-    sha256 "ad3d0778d85cad9271ba5942f9bc6de0130edcb28d1ecc9cfdb0ee3e4c040222"
-  end
+  sha256 arm:   "ad3d0778d85cad9271ba5942f9bc6de0130edcb28d1ecc9cfdb0ee3e4c040222",
+         intel: "81dfd86497a1a5081cec1c4a544eb7959218db0107ddc3758b0b3e5367db950f"
 
   url "https://github.com/kubenav/kubenav/releases/download/#{version}/kubenav-darwin-#{arch}.zip",
       verified: "github.com/kubenav/kubenav/"

--- a/Casks/kui.rb
+++ b/Casks/kui.rb
@@ -2,13 +2,8 @@ cask "kui" do
   arch arm: "arm64", intel: "x64"
 
   version "11.5.0"
-
-  on_intel do
-    sha256 "4dd77b53f2378e32ceb94d52e9fe07799f06f9acef537de053ec6f75dca3ef08"
-  end
-  on_arm do
-    sha256 "5706d72d5f0cef72260901081d448d56c2ae8cff3090eb2e25cdf77dad016ae1"
-  end
+  sha256 arm:   "5706d72d5f0cef72260901081d448d56c2ae8cff3090eb2e25cdf77dad016ae1",
+         intel: "4dd77b53f2378e32ceb94d52e9fe07799f06f9acef537de053ec6f75dca3ef08"
 
   url "https://github.com/kubernetes-sigs/kui/releases/download/v#{version}/Kui-darwin-#{arch}.tar.bz2"
   name "Kui"

--- a/Casks/kyokan-bob.rb
+++ b/Casks/kyokan-bob.rb
@@ -2,13 +2,8 @@ cask "kyokan-bob" do
   arch arm: "arm64", intel: "x86"
 
   version "1.0.0"
-
-  on_intel do
-    sha256 "f4e962e38d8679a5abe7baf181d12ea679bd90876fe991a4c3c01b21f10195c8"
-  end
-  on_arm do
-    sha256 "03c913e5ea5d8779122b4da3a9ef0d63307ce84a7a86e84feae53af82bb6fd36"
-  end
+  sha256 arm:   "03c913e5ea5d8779122b4da3a9ef0d63307ce84a7a86e84feae53af82bb6fd36",
+         intel: "f4e962e38d8679a5abe7baf181d12ea679bd90876fe991a4c3c01b21f10195c8"
 
   url "https://github.com/kyokan/bob-wallet/releases/download/v#{version}/Bob-#{version}-#{arch}.dmg",
       verified: "github.com/kyokan/bob-wallet/"

--- a/Casks/lagrange.rb
+++ b/Casks/lagrange.rb
@@ -2,13 +2,8 @@ cask "lagrange" do
   arch arm: "macos11.0-arm64", intel: "macos10.13-x86_64"
 
   version "1.13.7"
-
-  on_intel do
-    sha256 "25e118c0bb8d8f362ecf0f0a7df536daa378e85df11b156072c0087df61e0004"
-  end
-  on_arm do
-    sha256 "a61d269771d1dc0c449fa19f4d4efe4247276686bb51c7391f444b8df72b0826"
-  end
+  sha256 arm:   "a61d269771d1dc0c449fa19f4d4efe4247276686bb51c7391f444b8df72b0826",
+         intel: "25e118c0bb8d8f362ecf0f0a7df536daa378e85df11b156072c0087df61e0004"
 
   url "https://github.com/skyjake/lagrange/releases/download/v#{version}/lagrange_v#{version}_#{arch}.tbz",
       verified: "github.com/skyjake/lagrange/"

--- a/Casks/lando.rb
+++ b/Casks/lando.rb
@@ -2,16 +2,11 @@ cask "lando" do
   arch arm: "arm64", intel: "x64"
 
   version "3.6.4"
+  sha256 arm:   "1dfc9bf38f562f99227cb9430d1311ea885f278e338318afe10871a38aae5925",
+         intel: "cc1fd722bd8588837ff9cc51ce809075e08a7c49e6b9f3c328377a8ce04d03ae"
 
   url "https://github.com/lando/lando/releases/download/v#{version}/lando-#{arch}-v#{version}.dmg",
       verified: "github.com/lando/lando/"
-  on_intel do
-    sha256 "cc1fd722bd8588837ff9cc51ce809075e08a7c49e6b9f3c328377a8ce04d03ae"
-  end
-  on_arm do
-    sha256 "1dfc9bf38f562f99227cb9430d1311ea885f278e338318afe10871a38aae5925"
-  end
-
   name "Lando"
   desc "Local development environment and DevOps tool built on Docker"
   homepage "https://lando.dev/"

--- a/Casks/leapp.rb
+++ b/Casks/leapp.rb
@@ -2,13 +2,8 @@ cask "leapp" do
   arch arm: "-arm64"
 
   version "0.14.1"
-
-  on_intel do
-    sha256 "e402ae5a82f9acff0522a9358ad13a411f51858709908ab2cf681748b9df42c0"
-  end
-  on_arm do
-    sha256 "85bc3f78e32af9db69125f3568d9aea9f6cd735193f6664a54c0916bc49e8b46"
-  end
+  sha256 arm:   "85bc3f78e32af9db69125f3568d9aea9f6cd735193f6664a54c0916bc49e8b46",
+         intel: "e402ae5a82f9acff0522a9358ad13a411f51858709908ab2cf681748b9df42c0"
 
   url "https://asset.noovolari.com/#{version}/Leapp-#{version}#{arch}.dmg",
       verified: "asset.noovolari.com/"

--- a/Casks/lens.rb
+++ b/Casks/lens.rb
@@ -2,13 +2,8 @@ cask "lens" do
   arch arm: "-arm64"
 
   version "6.0.1,20220810.2"
-
-  on_intel do
-    sha256 "70e95fd69f41a123006e7da17983eaf88670b0c76a0c0a532612d442caf6d861"
-  end
-  on_arm do
-    sha256 "ae8c9d62db5501515e4a3b653c49fe797cf272dd2b8f243bba98d215670a8f05"
-  end
+  sha256 arm:   "ae8c9d62db5501515e4a3b653c49fe797cf272dd2b8f243bba98d215670a8f05",
+         intel: "70e95fd69f41a123006e7da17983eaf88670b0c76a0c0a532612d442caf6d861"
 
   url "https://api.k8slens.dev/binaries/Lens-#{version.csv.first}-latest.#{version.csv.second}#{arch}.dmg"
   name "Lens"

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -3,13 +3,8 @@ cask "libreoffice" do
   folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
   version "7.4.0"
-
-  on_intel do
-    sha256 "9a1dd24a2e10ea8d7bb7737fbfb688d24552ba5f8db99a074d37dd0324db3b15"
-  end
-  on_arm do
-    sha256 "44159ecf24ab6cf3501a60b099a167d8b38eeb85b38bf4f6f52b96fd3febbd64"
-  end
+  sha256 arm:   "44159ecf24ab6cf3501a60b099a167d8b38eeb85b38bf4f6f52b96fd3febbd64",
+         intel: "9a1dd24a2e10ea8d7bb7737fbfb688d24552ba5f8db99a074d37dd0324db3b15"
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"

--- a/Casks/listen1.rb
+++ b/Casks/listen1.rb
@@ -3,16 +3,11 @@ cask "listen1" do
   arch arm: "arm64", intel: "x64"
 
   version "2.24.0"
+  sha256 arm:   "8fd3e5c832dbdd02cbb9c68edcc902dd6749e67ea62d4d98ff155890c2aee954",
+         intel: "2327464903b24cdd620d1ecbad8e039cd1f6f200f4286b05d6d799e7cc125a29"
 
   url "https://github.com/listen1/listen1_desktop/releases/download/v#{version}/Listen1_#{version}_mac_#{arch}.dmg",
       verified: "github.com/listen1/listen1_desktop/"
-  on_intel do
-    sha256 "2327464903b24cdd620d1ecbad8e039cd1f6f200f4286b05d6d799e7cc125a29"
-  end
-  on_arm do
-    sha256 "8fd3e5c832dbdd02cbb9c68edcc902dd6749e67ea62d4d98ff155890c2aee954"
-  end
-
   name "Listen 1"
   desc "Search and play songs from a variety of online sources"
   homepage "https://listen1.github.io/listen1/"

--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -2,13 +2,8 @@ cask "livebook" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "0.6.3"
-
-  on_intel do
-    sha256 "a28bbdba1acba0cbc80209248a051fb57692d4e52cd57ed0eb0ebed33e180bd7"
-  end
-  on_arm do
-    sha256 "4ade56b044cd6386a50df54dc7033367cb9d72f7645bdb42bad331d806203ccf"
-  end
+  sha256 arm:   "4ade56b044cd6386a50df54dc7033367cb9d72f7645bdb42bad331d806203ccf",
+         intel: "a28bbdba1acba0cbc80209248a051fb57692d4e52cd57ed0eb0ebed33e180bd7"
 
   url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-#{version}-macos-#{arch}.dmg",
       verified: "github.com/livebook-dev/livebook"

--- a/Casks/logseq.rb
+++ b/Casks/logseq.rb
@@ -2,13 +2,8 @@ cask "logseq" do
   arch arm: "arm64", intel: "x64"
 
   version "0.8.1"
-
-  on_intel do
-    sha256 "29f59ee297fe89aa31fca3624101d6f17d98872e2c4141d39e9f9ce83989a8e9"
-  end
-  on_arm do
-    sha256 "4390193fb36c35ac743b58b86e32b5b08395875e6991aa936f706055d4b38574"
-  end
+  sha256 arm:   "4390193fb36c35ac743b58b86e32b5b08395875e6991aa936f706055d4b38574",
+         intel: "29f59ee297fe89aa31fca3624101d6f17d98872e2c4141d39e9f9ce83989a8e9"
 
   url "https://github.com/logseq/logseq/releases/download/#{version}/logseq-darwin-#{arch}-#{version}.dmg"
   name "Logseq"

--- a/Casks/loom.rb
+++ b/Casks/loom.rb
@@ -2,13 +2,8 @@ cask "loom" do
   arch arm: "-arm64"
 
   version "0.139.2"
-
-  on_intel do
-    sha256 "99463bf9fc29aaa91035095e6555697272d9e57b37f4538156206ed5a92cd256"
-  end
-  on_arm do
-    sha256 "95f2920d04eedbece570871ae2ce4a7a88d95d2ad71e11518553a33abfe8835a"
-  end
+  sha256 arm:   "95f2920d04eedbece570871ae2ce4a7a88d95d2ad71e11518553a33abfe8835a",
+         intel: "99463bf9fc29aaa91035095e6555697272d9e57b37f4538156206ed5a92cd256"
 
   url "https://cdn.loom.com/desktop-packages/Loom-#{version}#{arch}.dmg"
   name "Loom"

--- a/Casks/lx-music.rb
+++ b/Casks/lx-music.rb
@@ -2,13 +2,8 @@ cask "lx-music" do
   arch arm: "-arm64"
 
   version "1.22.2"
-
-  on_intel do
-    sha256 "7d44b3c072fb0cb6e6e5949f8087222da0393782cbfebf896872516ab0e96b2a"
-  end
-  on_arm do
-    sha256 "8f30eb1264e300d0bcd543d61b7d84dcfd06c8e372cc7daed1c4645aeba81bc4"
-  end
+  sha256 arm:   "8f30eb1264e300d0bcd543d61b7d84dcfd06c8e372cc7daed1c4645aeba81bc4",
+         intel: "7d44b3c072fb0cb6e6e5949f8087222da0393782cbfebf896872516ab0e96b2a"
 
   url "https://github.com/lyswhut/lx-music-desktop/releases/download/v#{version}/lx-music-desktop-#{version}#{arch}.dmg"
   name "LX Music Assistant Desktop Edition"

--- a/Casks/macintoshjs.rb
+++ b/Casks/macintoshjs.rb
@@ -2,15 +2,10 @@ cask "macintoshjs" do
   arch arm: "arm64", intel: "x64"
 
   version "1.1.0"
+  sha256 arm:   "0af95bbcc075f939d6c3e1fdcdab0d8da2760e5546aecfbc82767e326640740c",
+         intel: "4ca41517f15c594e718da622074a2160754cb8f1293cb1fad908f6d0ae585384"
 
   url "https://github.com/felixrieseberg/macintosh.js/releases/download/v#{version}/macintosh.js-darwin-#{arch}-#{version}.zip"
-  on_intel do
-    sha256 "4ca41517f15c594e718da622074a2160754cb8f1293cb1fad908f6d0ae585384"
-  end
-  on_arm do
-    sha256 "0af95bbcc075f939d6c3e1fdcdab0d8da2760e5546aecfbc82767e326640740c"
-  end
-
   name "macintosh.js"
   desc "Virtual Apple Macintosh with System 8, running in Electron"
   homepage "https://github.com/felixrieseberg/macintosh.js"

--- a/Casks/mambaforge.rb
+++ b/Casks/mambaforge.rb
@@ -2,13 +2,8 @@ cask "mambaforge" do
   arch arm: "arm64", intel: "x86_64"
 
   version "4.13.0-1"
-
-  on_intel do
-    sha256 "bc42d606b67ace370847deb849e7d1ea2879b0be78bb1be51b020c3cb4e5bef2"
-  end
-  on_arm do
-    sha256 "6263560d2b0902942841667721dad3621c05f704f6b080d968ad355aeca51486"
-  end
+  sha256 arm:   "6263560d2b0902942841667721dad3621c05f704f6b080d968ad355aeca51486",
+         intel: "bc42d606b67ace370847deb849e7d1ea2879b0be78bb1be51b020c3cb4e5bef2"
 
   url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Mambaforge-#{version}-MacOSX-#{arch}.sh"
   name "mambaforge"

--- a/Casks/mamp.rb
+++ b/Casks/mamp.rb
@@ -2,15 +2,10 @@ cask "mamp" do
   arch arm: "M1-arm", intel: "Intel-x86"
 
   version "6.6"
+  sha256 arm:   "4eb2a5146c0f0ccacfdaf4ea31e5735317a9e2aab18c0b9b591ab96c17808f1d",
+         intel: "306b101a84251655b8e1d50ef1c4d59901d300f85d0e03910701d8d418d4a4d4"
 
   url "https://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}-#{arch}.pkg"
-  on_intel do
-    sha256 "306b101a84251655b8e1d50ef1c4d59901d300f85d0e03910701d8d418d4a4d4"
-  end
-  on_arm do
-    sha256 "4eb2a5146c0f0ccacfdaf4ea31e5735317a9e2aab18c0b9b591ab96c17808f1d"
-  end
-
   name "MAMP"
   desc "Web development solution with Apache, Nginx, PHP & MySQL"
   homepage "https://www.mamp.info/"

--- a/Casks/manictime.rb
+++ b/Casks/manictime.rb
@@ -2,13 +2,8 @@ cask "manictime" do
   arch arm: "arm64", intel: "x64"
 
   version "2.3.0"
-
-  on_intel do
-    sha256 "2ececb9dfcadfd82fa4f994ae12f09ca5df0d40977b5b0720157aead93ae2b3d"
-  end
-  on_arm do
-    sha256 "11dac09661c4a22881c8b6a042c144127aaa0b92ab6321ebe1ea136f5201bf02"
-  end
+  sha256 arm:   "11dac09661c4a22881c8b6a042c144127aaa0b92ab6321ebe1ea136f5201bf02",
+         intel: "2ececb9dfcadfd82fa4f994ae12f09ca5df0d40977b5b0720157aead93ae2b3d"
 
   url "https://cdn.manictime.com/setup/mac/v#{version.dots_to_underscores}/manictime-#{version}-osx-#{arch}.dmg"
   name "ManicTime"

--- a/Casks/masscode.rb
+++ b/Casks/masscode.rb
@@ -2,13 +2,8 @@ cask "masscode" do
   arch arm: "-arm64"
 
   version "3.4.0"
-
-  on_intel do
-    sha256 "d91eb25fa095837ddc3b975e2dc0ef097d3a375bee9bccaf5a04384f7a90f92d"
-  end
-  on_arm do
-    sha256 "4822c7842bb73174c8edc96e08968cd85e437ef828acba109bab3329d65dc014"
-  end
+  sha256 arm:   "4822c7842bb73174c8edc96e08968cd85e437ef828acba109bab3329d65dc014",
+         intel: "d91eb25fa095837ddc3b975e2dc0ef097d3a375bee9bccaf5a04384f7a90f92d"
 
   url "https://github.com/massCodeIO/massCode/releases/download/v#{version}/massCode-#{version}#{arch}.dmg",
       verified: "https://github.com/massCodeIO/massCode/"

--- a/Casks/mat.rb
+++ b/Casks/mat.rb
@@ -2,13 +2,8 @@ cask "mat" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.13.0.20220615"
-
-  on_intel do
-    sha256 "5e866ce672f2d800b902f017edc266406ef1c895e6defde0aac5d895d7966b98"
-  end
-  on_arm do
-    sha256 "55a7113181a5aea34d83a471752f81f27988720e2f58edc090e6e2565f020532"
-  end
+  sha256 arm:   "55a7113181a5aea34d83a471752f81f27988720e2f58edc090e6e2565f020532",
+         intel: "5e866ce672f2d800b902f017edc266406ef1c895e6defde0aac5d895d7966b98"
 
   url "https://download.eclipse.org/mat/#{version.major_minor_patch}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.#{arch}.dmg"
   name "Eclipse Memory Analyzer"

--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -2,13 +2,8 @@ cask "mattermost" do
   arch arm: "m1", intel: "x64"
 
   version "5.1.1"
-
-  on_intel do
-    sha256 "d7bae51221884dce113b9b5cf23efc1245fc6ad2210a1754c0ee266e644da0cf"
-  end
-  on_arm do
-    sha256 "787e011ade5f058e1037a271fd974855bc1ee43ed5a31d810d8e86759a678d02"
-  end
+  sha256 arm:   "787e011ade5f058e1037a271fd974855bc1ee43ed5a31d810d8e86759a678d02",
+         intel: "d7bae51221884dce113b9b5cf23efc1245fc6ad2210a1754c0ee266e644da0cf"
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac-#{arch}.zip"
   name "Mattermost"

--- a/Casks/mediathekview.rb
+++ b/Casks/mediathekview.rb
@@ -2,13 +2,8 @@ cask "mediathekview" do
   arch arm: "mac-as", intel: "mac"
 
   version "13.9.1"
-
-  on_intel do
-    sha256 "4529bbed37b3736623b5083e99088866bfec98973383df2553c27175738072a9"
-  end
-  on_arm do
-    sha256 "4eb0e2de15f1852b66ac16b84b6fdba1c3dfc18e19a646763c4e636a7c7932b0"
-  end
+  sha256 arm:   "4eb0e2de15f1852b66ac16b84b6fdba1c3dfc18e19a646763c4e636a7c7932b0",
+         intel: "4529bbed37b3736623b5083e99088866bfec98973383df2553c27175738072a9"
 
   url "https://download.mediathekview.de/stabil/MediathekView-#{version}-#{arch}.dmg"
   name "MediathekView"

--- a/Casks/melonds.rb
+++ b/Casks/melonds.rb
@@ -2,16 +2,11 @@ cask "melonds" do
   arch arm: "arm64", intel: "x64"
 
   version "0.9.4"
+  sha256 arm:   "004dbbf06ce7dfa3dac0a3587995d6925002f36907e541ba3b0b63bdad092ecf",
+         intel: "77be2bdd761489afc9b45af4e9d89689a18ecdd4606eb0d93838839ac6f275fc"
 
   url "https://github.com/Arisotura/melonDS/releases/download/#{version}/melonDS_#{version}_mac_#{arch}.dmg",
       verified: "github.com/Arisotura/melonDS/"
-  on_intel do
-    sha256 "77be2bdd761489afc9b45af4e9d89689a18ecdd4606eb0d93838839ac6f275fc"
-  end
-  on_arm do
-    sha256 "004dbbf06ce7dfa3dac0a3587995d6925002f36907e541ba3b0b63bdad092ecf"
-  end
-
   name "melonDS"
   desc "Nintendo DS and DSi emulator"
   homepage "http://melonds.kuribo64.net/"

--- a/Casks/micromamba.rb
+++ b/Casks/micromamba.rb
@@ -2,13 +2,8 @@ cask "micromamba" do
   arch arm: "arm64", intel: "64"
 
   version "0.25.1"
-
-  on_intel do
-    sha256 "bd80ed9cb39748a40ae7dfd124aa18e453bf4793e281daf687710c81272e8be1"
-  end
-  on_arm do
-    sha256 "b39fb2f9f2bed41c5ad885f41f49ba751a4ba5ee01ee96ca8293a84aa603d1b2"
-  end
+  sha256 arm:   "b39fb2f9f2bed41c5ad885f41f49ba751a4ba5ee01ee96ca8293a84aa603d1b2",
+         intel: "bd80ed9cb39748a40ae7dfd124aa18e453bf4793e281daf687710c81272e8be1"
 
   url "https://micro.mamba.pm/api/micromamba/osx-#{arch}/#{version}",
       verified: "micro.mamba.pm/api/micromamba/"

--- a/Casks/microsoft-edge.rb
+++ b/Casks/microsoft-edge.rb
@@ -4,13 +4,8 @@ cask "microsoft-edge" do
   linkid = on_arch_conditional arm: "2093504", intel: "2069148"
 
   version "104.0.1293.63"
-
-  on_intel do
-    sha256 "ba33414fcc930eb8ebb8c000ce91b4f4d6bbdf1cac784cc2fd2dd458004d523c"
-  end
-  on_arm do
-    sha256 "ef7797cc70adf5cad3515e6ed56f217c1827232228a3128864b632ea4819dd6d"
-  end
+  sha256 arm:   "ef7797cc70adf5cad3515e6ed56f217c1827232228a3128864b632ea4819dd6d",
+         intel: "ba33414fcc930eb8ebb8c000ce91b4f4d6bbdf1cac784cc2fd2dd458004d523c"
 
   url "https://officecdn-microsoft-com.akamaized.net/pr/#{folder}/MacAutoupdate/MicrosoftEdge-#{version}.pkg",
       verified: "officecdn-microsoft-com.akamaized.net/"

--- a/Casks/microsoft-openjdk.rb
+++ b/Casks/microsoft-openjdk.rb
@@ -2,13 +2,8 @@ cask "microsoft-openjdk" do
   arch arm: "aarch64", intel: "x64"
 
   version "17.0.4"
-
-  on_intel do
-    sha256 "9d42c26bca136197f4424897b23ddf3051b210f26ae004643636b769f712697e"
-  end
-  on_arm do
-    sha256 "cfcb6c6587ead87550c8d5f4d744dc0f39c554505906dbe33bb9670f92ca7692"
-  end
+  sha256 arm:   "cfcb6c6587ead87550c8d5f4d744dc0f39c554505906dbe33bb9670f92ca7692",
+         intel: "9d42c26bca136197f4424897b23ddf3051b210f26ae004643636b769f712697e"
 
   url "https://aka.ms/download-jdk/microsoft-jdk-#{version}-macos-#{arch}.pkg",
       verified: "aka.ms/download-jdk/"

--- a/Casks/min.rb
+++ b/Casks/min.rb
@@ -2,13 +2,8 @@ cask "min" do
   arch arm: "arm64", intel: "x86"
 
   version "1.25.1"
-
-  on_intel do
-    sha256 "48c21f8d702907b8627b3f4cf939b2447b09e8ed1f06d0dbe8f5a91451a76471"
-  end
-  on_arm do
-    sha256 "88d2515aa2b7c53e590f6291038e895a1f33bdfaec5bde748e0b1df1e3e0d53f"
-  end
+  sha256 arm:   "88d2515aa2b7c53e590f6291038e895a1f33bdfaec5bde748e0b1df1e3e0d53f",
+         intel: "48c21f8d702907b8627b3f4cf939b2447b09e8ed1f06d0dbe8f5a91451a76471"
 
   url "https://github.com/minbrowser/min/releases/download/v#{version}/min-v#{version}-mac-#{arch}.zip",
       verified: "github.com/minbrowser/min/"

--- a/Casks/miniforge.rb
+++ b/Casks/miniforge.rb
@@ -2,13 +2,8 @@ cask "miniforge" do
   arch arm: "arm64", intel: "x86_64"
 
   version "4.13.0-1"
-
-  on_intel do
-    sha256 "9996677f0ca0bfa6399e9a5688556bfaff544389ea123e2ac6e6252d3a1d0658"
-  end
-  on_arm do
-    sha256 "57bef67a4c80bfef04223eb76ee1b49b1bdfd5eeb46ebcf49e65d6c308c84a98"
-  end
+  sha256 arm:   "57bef67a4c80bfef04223eb76ee1b49b1bdfd5eeb46ebcf49e65d6c308c84a98",
+         intel: "9996677f0ca0bfa6399e9a5688556bfaff544389ea123e2ac6e6252d3a1d0658"
 
   url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Miniforge3-#{version}-MacOSX-#{arch}.sh"
   name "miniforge"

--- a/Casks/mockuuups-studio.rb
+++ b/Casks/mockuuups-studio.rb
@@ -2,13 +2,8 @@ cask "mockuuups-studio" do
   arch arm: "arm64-"
 
   version "3.7.0"
-
-  on_intel do
-    sha256 "1b5897be81511a1a8dc7fd3f19824adc3186898fae9bdaed7e1bcd3469e22dcf"
-  end
-  on_arm do
-    sha256 "deefb92a749360fc2c524c427b3c462f0220a8fa5797fe2d634a009f476a03da"
-  end
+  sha256 arm:   "deefb92a749360fc2c524c427b3c462f0220a8fa5797fe2d634a009f476a03da",
+         intel: "1b5897be81511a1a8dc7fd3f19824adc3186898fae9bdaed7e1bcd3469e22dcf"
 
   url "https://binaries.mockuuups.com/Mockuuups%20Studio-#{version}-#{arch}mac.zip",
       verified: "mockuuups.com/"

--- a/Casks/molotov.rb
+++ b/Casks/molotov.rb
@@ -3,13 +3,8 @@ cask "molotov" do
   arch_folder = on_arch_conditional arm: "m1/"
 
   version "4.5.0"
-
-  on_intel do
-    sha256 "9366230de159a4b5dffe29e1823b6e3bc0d6e6fd2ddc2c4f1b9e9764319cf995"
-  end
-  on_arm do
-    sha256 "4b5303345be7bfcf4f90440424c52f5fd06d912c500969d576cef4eba159d82d"
-  end
+  sha256 arm:   "4b5303345be7bfcf4f90440424c52f5fd06d912c500969d576cef4eba159d82d",
+         intel: "9366230de159a4b5dffe29e1823b6e3bc0d6e6fd2ddc2c4f1b9e9764319cf995"
 
   url "https://desktop-auto-upgrade.molotov.tv/mac/#{arch_folder}Molotov-#{version}#{arch}-mac.zip"
   name "Molotov"

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -2,13 +2,8 @@ cask "mps" do
   arch arm: "macos-aarch64", intel: "macos"
 
   version "2021.3.1,213.7172.958"
-
-  on_intel do
-    sha256 "06f06e121a552a7c4ee89ecbdecb4ac7d1978ae87d6c80d04837a19e92e4f90d"
-  end
-  on_arm do
-    sha256 "3104eb7b2a363ef9602b86a8fdca02d9b55264127f481f3eabbed65979b34791"
-  end
+  sha256 arm:   "3104eb7b2a363ef9602b86a8fdca02d9b55264127f481f3eabbed65979b34791",
+         intel: "06f06e121a552a7c4ee89ecbdecb4ac7d1978ae87d6c80d04837a19e92e4f90d"
 
   url "https://download.jetbrains.com/mps/#{version.major_minor}/MPS-#{version.csv.first}-#{arch}.dmg"
   name "JetBrains MPS"

--- a/Casks/mqttx.rb
+++ b/Casks/mqttx.rb
@@ -2,13 +2,8 @@ cask "mqttx" do
   arch arm: "arm64-"
 
   version "1.8.2"
-
-  on_intel do
-    sha256 "4e1659a4a20e67f065e638cff65051334465992231f3eb49e8327bf27d5fbd5e"
-  end
-  on_arm do
-    sha256 "a2da4692f4be5d845605bf3d8d08e44fc521f5bdcc0e55523f9dc4c676f718ee"
-  end
+  sha256 arm:   "a2da4692f4be5d845605bf3d8d08e44fc521f5bdcc0e55523f9dc4c676f718ee",
+         intel: "4e1659a4a20e67f065e638cff65051334465992231f3eb49e8327bf27d5fbd5e"
 
   url "https://github.com/emqx/MQTTX/releases/download/v#{version}/MQTTX-#{version}-#{arch}mac.zip",
       verified: "github.com/emqx/MQTTX/"

--- a/Casks/mysql-connector-python.rb
+++ b/Casks/mysql-connector-python.rb
@@ -2,13 +2,8 @@ cask "mysql-connector-python" do
   arch arm: "arm64", intel: "x86-64bit"
 
   version "8.0.30"
-
-  on_intel do
-    sha256 "673b43fbe5cf3ea4b8997bcb29a4e79390607434e81682e9b15466b502a43aa8"
-  end
-  on_arm do
-    sha256 "bbe251a4a9bea7a73ca1aa0112d8de0ac44f69fe45e3453a3a5c4b02e4661d0b"
-  end
+  sha256 arm:   "bbe251a4a9bea7a73ca1aa0112d8de0ac44f69fe45e3453a3a5c4b02e4661d0b",
+         intel: "673b43fbe5cf3ea4b8997bcb29a4e79390607434e81682e9b15466b502a43aa8"
 
   url "https://dev.mysql.com/get/Downloads/Connector-Python/mysql-connector-python-#{version}-macos12-#{arch}.dmg"
   name "MySQL Connector for Python"

--- a/Casks/nota.rb
+++ b/Casks/nota.rb
@@ -2,13 +2,8 @@ cask "nota" do
   arch arm: "arm64-mac", intel: "mac"
 
   version "0.38.1"
-
-  on_intel do
-    sha256 "548e174254dc7fb76faf7c345021354d0f252098af3c88db674985f2a3b2dbea"
-  end
-  on_arm do
-    sha256 "4369ddf0d3f99500b1cc754777279575c026e560a13d30eee9ce25c03e8bf370"
-  end
+  sha256 arm:   "4369ddf0d3f99500b1cc754777279575c026e560a13d30eee9ce25c03e8bf370",
+         intel: "548e174254dc7fb76faf7c345021354d0f252098af3c88db674985f2a3b2dbea"
 
   url "https://github.com/notaapp/releases/releases/download/#{version}/Nota-#{version}-#{arch}.zip",
       verified: "github.com/notaapp/releases/"

--- a/Casks/ogdesign-eagle.rb
+++ b/Casks/ogdesign-eagle.rb
@@ -2,13 +2,8 @@ cask "ogdesign-eagle" do
   arch arm: "M1-"
 
   version "3.0,10"
-
-  on_intel do
-    sha256 "63429c2e31d558bf37ff748972dbf031cf8fd0b0aaab8cf8177cd6ebd87a1210"
-  end
-  on_arm do
-    sha256 "611268fb1725e2d3aebf7092ea81498a1c2d4d85d915508e72ec3b9ee3e8c67c"
-  end
+  sha256 arm:   "611268fb1725e2d3aebf7092ea81498a1c2d4d85d915508e72ec3b9ee3e8c67c",
+         intel: "63429c2e31d558bf37ff748972dbf031cf8fd0b0aaab8cf8177cd6ebd87a1210"
 
   url "https://r2-app.eagle.cool/releases/Eagle-#{version.csv.first}-#{arch}build#{version.csv.second}.dmg"
   name "Eagle"

--- a/Casks/onlyoffice.rb
+++ b/Casks/onlyoffice.rb
@@ -2,13 +2,8 @@ cask "onlyoffice" do
   arch arm: "arm", intel: "x86_64"
 
   version "7.1.1"
-
-  on_intel do
-    sha256 "f0384110b6ebafb046c6df0d730edc5c6687564c760f84bb9e812a7f836c3abc"
-  end
-  on_arm do
-    sha256 "0d17c802acdb2bc7aa9af7bec05fdae1db6691a9df72e948ce010077c993b4b0"
-  end
+  sha256 arm:   "0d17c802acdb2bc7aa9af7bec05fdae1db6691a9df72e948ce010077c993b4b0",
+         intel: "f0384110b6ebafb046c6df0d730edc5c6687564c760f84bb9e812a7f836c3abc"
 
   url "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v#{version}/ONLYOFFICE-#{arch}.dmg",
       verified: "github.com/ONLYOFFICE/DesktopEditors/"

--- a/Casks/openaudible.rb
+++ b/Casks/openaudible.rb
@@ -2,13 +2,8 @@ cask "openaudible" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "3.5.9"
-
-  on_intel do
-    sha256 "e5b9a122a249cebf0e1bd7adfcab24924274878f711e8a2b501f4e634687bb62"
-  end
-  on_arm do
-    sha256 "2386378e1ed81a7a4c6a65b92b21794fe5675d9925a01534b6ab8f7523ddb281"
-  end
+  sha256 arm:   "2386378e1ed81a7a4c6a65b92b21794fe5675d9925a01534b6ab8f7523ddb281",
+         intel: "e5b9a122a249cebf0e1bd7adfcab24924274878f711e8a2b501f4e634687bb62"
 
   url "https://github.com/openaudible/openaudible/releases/download/v#{version}/OpenAudible_#{version}_#{arch}.dmg",
       verified: "github.com/openaudible/openaudible/"

--- a/Casks/openshift-client.rb
+++ b/Casks/openshift-client.rb
@@ -2,13 +2,8 @@ cask "openshift-client" do
   arch arm: "-arm64"
 
   version "4.11.1"
-
-  on_intel do
-    sha256 "7ddf8dcee068e91f1f67bed64b9a10b178a151ca8ba6b4dc76a06324f2fa51ce"
-  end
-  on_arm do
-    sha256 "157d5f950353f43835ba4c4cc918bc9d90bd61715a370dac3875dfcc916d5f27"
-  end
+  sha256 arm:   "157d5f950353f43835ba4c4cc918bc9d90bd61715a370dac3875dfcc916d5f27",
+         intel: "7ddf8dcee068e91f1f67bed64b9a10b178a151ca8ba6b4dc76a06324f2fa51ce"
 
   url "https://mirror.openshift.com/pub/openshift-v#{version.major}/clients/ocp/#{version}/openshift-client-mac#{arch}.tar.gz"
   name "Openshift Client"

--- a/Casks/openwebstart.rb
+++ b/Casks/openwebstart.rb
@@ -2,13 +2,8 @@ cask "openwebstart" do
   arch arm: "aarch64", intel: "x64"
 
   version "1.6.0"
-
-  on_intel do
-    sha256 "c2a71ce2e22adbf96aab869f0c96b2d26f839eace0d6692bf861070334fb2898"
-  end
-  on_arm do
-    sha256 "c4b738e7a0ddc76d6a40a913bede9f205d421b7b596b329ecb96438a7d048b72"
-  end
+  sha256 arm:   "c4b738e7a0ddc76d6a40a913bede9f205d421b7b596b329ecb96438a7d048b72",
+         intel: "c2a71ce2e22adbf96aab869f0c96b2d26f839eace0d6692bf861070334fb2898"
 
   url "https://github.com/karakun/OpenWebStart/releases/download/v#{version}/OpenWebStart_macos-#{arch}_#{version.dots_to_underscores}.dmg",
       verified: "github.com/karakun/OpenWebStart/"

--- a/Casks/oracle-jdk.rb
+++ b/Casks/oracle-jdk.rb
@@ -2,13 +2,8 @@ cask "oracle-jdk" do
   arch arm: "aarch64", intel: "x64"
 
   version "18.0.2.1"
-
-  on_intel do
-    sha256 "2aabcbbbbf7b6a40590d0ce467b3fb56d5871983a08ce5f9a45eba1b00d16e50"
-  end
-  on_arm do
-    sha256 "d9ee92a70ecb8f0058155734cb42a85a782f57b222293a27f1990e2962f15ce7"
-  end
+  sha256 arm:   "d9ee92a70ecb8f0058155734cb42a85a782f57b222293a27f1990e2962f15ce7",
+         intel: "2aabcbbbbf7b6a40590d0ce467b3fb56d5871983a08ce5f9a45eba1b00d16e50"
 
   url "https://download.oracle.com/java/#{version.major}/archive/jdk-#{version}_macos-#{arch}_bin.dmg"
   name "Oracle Java Standard Edition Development Kit"

--- a/Casks/osu.rb
+++ b/Casks/osu.rb
@@ -2,13 +2,8 @@ cask "osu" do
   arch arm: "Apple.Silicon", intel: "Intel"
 
   version "2022.821.0"
-
-  on_intel do
-    sha256 "555909957d66c176f6ac0c617a945ac7c9684e8ee82474def34a945bcfbd1d55"
-  end
-  on_arm do
-    sha256 "c5c48f8f56342ee884363601f6df1a4faa1feb1eab9495c8e21b3cff9f5139f4"
-  end
+  sha256 arm:   "c5c48f8f56342ee884363601f6df1a4faa1feb1eab9495c8e21b3cff9f5139f4",
+         intel: "555909957d66c176f6ac0c617a945ac7c9684e8ee82474def34a945bcfbd1d55"
 
   url "https://github.com/ppy/osu/releases/download/#{version}/osu.app.#{arch}.zip"
   name "osu!"

--- a/Casks/padloc.rb
+++ b/Casks/padloc.rb
@@ -2,13 +2,8 @@ cask "padloc" do
   arch arm: "arm64", intel: "x64"
 
   version "4.0.2"
-
-  on_intel do
-    sha256 "a2e84055403f35e141a46afc2ef7765e20c210572d26ae8de903fe47fa1db9ed"
-  end
-  on_arm do
-    sha256 "a872d1782d09f2236d27288f2370d193935acc4798ad58656304bf6890128125"
-  end
+  sha256 arm:   "a872d1782d09f2236d27288f2370d193935acc4798ad58656304bf6890128125",
+         intel: "a2e84055403f35e141a46afc2ef7765e20c210572d26ae8de903fe47fa1db9ed"
 
   url "https://github.com/padloc/padloc/releases/download/v#{version}/padloc_#{version}_macos_electron_#{arch}.dmg",
       verified: "github.com/padloc/padloc/"

--- a/Casks/panwriter.rb
+++ b/Casks/panwriter.rb
@@ -2,13 +2,8 @@ cask "panwriter" do
   arch arm: "arm64", intel: "x64"
 
   version "0.8.4"
-
-  on_intel do
-    sha256 "d0e4431d02a7f6185f12958f805ffba97b212f6fc7e2baff0564ac6e5fea0cf0"
-  end
-  on_arm do
-    sha256 "06bf44d2dd81c16dcbc82aefb6f1f71379ffe9abf95ba6de1fcef3ea1b66a886"
-  end
+  sha256 arm:   "06bf44d2dd81c16dcbc82aefb6f1f71379ffe9abf95ba6de1fcef3ea1b66a886",
+         intel: "d0e4431d02a7f6185f12958f805ffba97b212f6fc7e2baff0564ac6e5fea0cf0"
 
   url "https://github.com/mb21/panwriter/releases/download/v#{version}/PanWriter-#{version}-#{arch}.dmg",
       verified: "github.com/mb21/panwriter/"

--- a/Casks/paraview.rb
+++ b/Casks/paraview.rb
@@ -3,13 +3,8 @@ cask "paraview" do
   min_macos_version = on_arch_conditional arm: "11.0", intel: "10.13"
 
   version "5.10.1"
-
-  on_intel do
-    sha256 "21d28f0bfd4129a5e394990e981ad79d27c4613f3da9f171417c17af785ebcba"
-  end
-  on_arm do
-    sha256 "1b6bdf86fee03525b1978b4312624bcc522796bbf5675f370797c5f21e189e5d"
-  end
+  sha256 arm:   "1b6bdf86fee03525b1978b4312624bcc522796bbf5675f370797c5f21e189e5d",
+         intel: "21d28f0bfd4129a5e394990e981ad79d27c4613f3da9f171417c17af785ebcba"
 
   url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX#{min_macos_version}-Python3.9-#{arch}.dmg",
       user_agent: :fake

--- a/Casks/parsify.rb
+++ b/Casks/parsify.rb
@@ -2,13 +2,8 @@ cask "parsify" do
   arch arm: "arm64", intel: "x64"
 
   version "1.9.3"
-
-  on_intel do
-    sha256 "1c42a8d7e96f08b54afe7fd279dfb44fd8b757c52be6ce9c7a03902371d2f6a6"
-  end
-  on_arm do
-    sha256 "bf59ca43fd4f380aed968374b4cb7ddae675353306ee3e29a30a44e98fb5f25b"
-  end
+  sha256 arm:   "bf59ca43fd4f380aed968374b4cb7ddae675353306ee3e29a30a44e98fb5f25b",
+         intel: "1c42a8d7e96f08b54afe7fd279dfb44fd8b757c52be6ce9c7a03902371d2f6a6"
 
   url "https://github.com/parsify-dev/desktop/releases/download/v#{version}/Parsify-Desktop-#{version}-mac-#{arch}.zip",
       verified: "github.com/parsify-dev/desktop/"

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -2,13 +2,8 @@ cask "phpstorm" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.61"
-
-  on_intel do
-    sha256 "ba9cc863c2247e6404b015fac085e8b3427b29aba3d7cb07940840f7c5e3b647"
-  end
-  on_arm do
-    sha256 "b553e1f0249b4d7f89cacdac7bada758895cd35aec8ddac5f81017f61ddc44fb"
-  end
+  sha256 arm:   "b553e1f0249b4d7f89cacdac7bada758895cd35aec8ddac5f81017f61ddc44fb",
+         intel: "ba9cc863c2247e6404b015fac085e8b3427b29aba3d7cb07940840f7c5e3b647"
 
   url "https://download.jetbrains.com/webide/PhpStorm-#{version.csv.first}#{arch}.dmg"
   name "JetBrains PhpStorm"

--- a/Casks/plexamp.rb
+++ b/Casks/plexamp.rb
@@ -2,13 +2,8 @@ cask "plexamp" do
   arch arm: "-arm64"
 
   version "4.3.0"
-
-  on_intel do
-    sha256 "1ead84054eb80d2ed1232ac3b3768fa082685a2c4f5e2018c4c8414b3e6447ab"
-  end
-  on_arm do
-    sha256 "63a74f995963b536b1baaee256a32513c674189b6ef543badf4bf6f5b7ed6cba"
-  end
+  sha256 arm:   "63a74f995963b536b1baaee256a32513c674189b6ef543badf4bf6f5b7ed6cba",
+         intel: "1ead84054eb80d2ed1232ac3b3768fa082685a2c4f5e2018c4c8414b3e6447ab"
 
   url "https://plexamp.plex.tv/plexamp.plex.tv/desktop/Plexamp-#{version}#{arch}.dmg",
       verified: "plexamp.plex.tv/"

--- a/Casks/podman-desktop.rb
+++ b/Casks/podman-desktop.rb
@@ -2,13 +2,8 @@ cask "podman-desktop" do
   arch arm: "arm64", intel: "x64"
 
   version "0.0.6"
-
-  on_intel do
-    sha256 "d736878c3eb40bfd92cc45fb873e08ca89e6d38c49e5fbeae78520f3ff4ad5ca"
-  end
-  on_arm do
-    sha256 "351174f934485c370081e3bfbb551958d7a8eee030fd7e4bfc3f53de7de3022f"
-  end
+  sha256 arm:   "351174f934485c370081e3bfbb551958d7a8eee030fd7e4bfc3f53de7de3022f",
+         intel: "d736878c3eb40bfd92cc45fb873e08ca89e6d38c49e5fbeae78520f3ff4ad5ca"
 
   url "https://github.com/containers/podman-desktop/releases/download/v#{version}/podman-desktop-#{version}-#{arch}.dmg",
       verified: "https://github.com/containers/podman-desktop"

--- a/Casks/poi.rb
+++ b/Casks/poi.rb
@@ -2,13 +2,8 @@ cask "poi" do
   arch arm: "-arm64", intel: ""
 
   version "10.9.2"
-
-  on_intel do
-    sha256 "eab57d10b4e8002231cbfb502589d97fcea9edce85c21850bdd5cbc574ccfa19"
-  end
-  on_arm do
-    sha256 "217444a15bcfaae1dc75807fcf139c66d0b6295fa1f461a45f811bae09008a77"
-  end
+  sha256 arm:   "217444a15bcfaae1dc75807fcf139c66d0b6295fa1f461a45f811bae09008a77",
+         intel: "eab57d10b4e8002231cbfb502589d97fcea9edce85c21850bdd5cbc574ccfa19"
 
   url "https://github.com/poooi/poi/releases/download/v#{version}/poi-#{version}#{arch}.dmg",
       verified: "github.com/poooi/poi/"

--- a/Casks/polymail.rb
+++ b/Casks/polymail.rb
@@ -2,13 +2,8 @@ cask "polymail" do
   arch arm: "-arm64"
 
   version "2.2.6"
-
-  on_intel do
-    sha256 "7f0545b2a99ab9fa515b6f78437a53226e6e1f788a8ed411e6bbd3fff5c09249"
-  end
-  on_arm do
-    sha256 "e5d7ddf964e817ca604612d85ffe26381eb9d3f73962b40af32b5ef071833a2b"
-  end
+  sha256 arm:   "e5d7ddf964e817ca604612d85ffe26381eb9d3f73962b40af32b5ef071833a2b",
+         intel: "7f0545b2a99ab9fa515b6f78437a53226e6e1f788a8ed411e6bbd3fff5c09249"
 
   url "https://sparkle-updater.polymail.io/macos#{arch}/builds/Polymail-v#{version}.zip"
   name "Polymail"

--- a/Casks/polypane.rb
+++ b/Casks/polypane.rb
@@ -2,13 +2,8 @@ cask "polypane" do
   arch arm: "-arm64"
 
   version "10.0.1"
-
-  on_intel do
-    sha256 "303929e6821f4d5c124c10c257104c5fd90fd4a6cbd13c68a288dee4dcc1fd00"
-  end
-  on_arm do
-    sha256 "bf3933c7461d952e19fab0e444712c24567abc64680092bff108993c15a8a205"
-  end
+  sha256 arm:   "bf3933c7461d952e19fab0e444712c24567abc64680092bff108993c15a8a205",
+         intel: "303929e6821f4d5c124c10c257104c5fd90fd4a6cbd13c68a288dee4dcc1fd00"
 
   url "https://github.com/firstversionist/polypane/releases/download/v#{version}/Polypane-#{version}#{arch}.dmg",
       verified: "github.com/firstversionist/polypane/"

--- a/Casks/portfolioperformance.rb
+++ b/Casks/portfolioperformance.rb
@@ -2,13 +2,8 @@ cask "portfolioperformance" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "0.59.1"
-
-  on_intel do
-    sha256 "5bd97c6742036dd5d13dd4badd51672720e470f7f657d8069b4a7da1fda62ba3"
-  end
-  on_arm do
-    sha256 "a100a3601af46c2e7e79f0dc129fce4da7ebf0cc594d795ac17a4aaa418941a9"
-  end
+  sha256 arm:   "a100a3601af46c2e7e79f0dc129fce4da7ebf0cc594d795ac17a4aaa418941a9",
+         intel: "5bd97c6742036dd5d13dd4badd51672720e470f7f657d8069b4a7da1fda62ba3"
 
   url "https://github.com/buchen/portfolio/releases/download/#{version}/PortfolioPerformance-#{version}-#{arch}.dmg",
       verified: "github.com/buchen/portfolio/"

--- a/Casks/portx.rb
+++ b/Casks/portx.rb
@@ -2,14 +2,8 @@ cask "portx" do
   arch arm: "arm64", intel: "x64"
 
   version "2.1.3,10.30"
-
-  on_intel do
-    sha256 "D03E5C1928DF7BCBE79FDC7DCB3F4CC8BF5EF2B067CB456D1C73CD166F879C2C"
-  end
-
-  on_arm do
-    sha256 "0F1AE65B280B8A00CE57E917DE0D5A048509A50306CAD97042BB82713114EEA8"
-  end
+  sha256 arm:   "0F1AE65B280B8A00CE57E917DE0D5A048509A50306CAD97042BB82713114EEA8",
+         intel: "D03E5C1928DF7BCBE79FDC7DCB3F4CC8BF5EF2B067CB456D1C73CD166F879C2C"
 
   url "https://cdn.netsarang.net/0ac7ea20/PortX-#{version.csv.first}-#{arch}.dmg",
       verified: "cdn.netsarang.net/"

--- a/Casks/postman-agent.rb
+++ b/Casks/postman-agent.rb
@@ -2,13 +2,8 @@ cask "postman-agent" do
   arch arm: "osx_arm64", intel: "osx_64"
 
   version "0.4.7"
-
-  on_intel do
-    sha256 "d479f55963ce5fe56f67fb03f349732790511c3c6943e256e6193bae15498af1"
-  end
-  on_arm do
-    sha256 "e76fb6b2c1198c9591be5a711d22d9391a6859ad059b45af111f0f385be16190"
-  end
+  sha256 arm:   "e76fb6b2c1198c9591be5a711d22d9391a6859ad059b45af111f0f385be16190",
+         intel: "d479f55963ce5fe56f67fb03f349732790511c3c6943e256e6193bae15498af1"
 
   url "https://dl-agent.pstmn.io/download/version/#{version}/#{arch}",
       verified: "dl-agent.pstmn.io/download/version/"

--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -2,13 +2,8 @@ cask "postman" do
   arch arm: "osx_arm64", intel: "osx64"
 
   version "9.27.0"
-
-  on_intel do
-    sha256 "466b65935f1aae11571d902e7bbdf7ff130c2382a29b33c4789c5ee88c7bf1b2"
-  end
-  on_arm do
-    sha256 "b92de2cc5a72c5fb47acf2b4a7fc4bb1338a902b9bc75ff4ef4c4538f17e2260"
-  end
+  sha256 arm:   "b92de2cc5a72c5fb47acf2b4a7fc4bb1338a902b9bc75ff4ef4c4538f17e2260",
+         intel: "466b65935f1aae11571d902e7bbdf7ff130c2382a29b33c4789c5ee88c7bf1b2"
 
   url "https://dl.pstmn.io/download/version/#{version}/#{arch}",
       verified: "dl.pstmn.io/download/version/"

--- a/Casks/powershell.rb
+++ b/Casks/powershell.rb
@@ -2,13 +2,8 @@ cask "powershell" do
   arch arm: "arm64", intel: "x64"
 
   version "7.2.6"
-
-  on_intel do
-    sha256 "07ca6ddfbb6a9d98671c2f166cee93df2844f2a2c4132f59e71ac9869577564d"
-  end
-  on_arm do
-    sha256 "05952e8ca2a4f2633d43eddac3a64ee3f1f1edf90ecbf7ef8b638e4bc72075f0"
-  end
+  sha256 arm:   "05952e8ca2a4f2633d43eddac3a64ee3f1f1edf90ecbf7ef8b638e4bc72075f0",
+         intel: "07ca6ddfbb6a9d98671c2f166cee93df2844f2a2c4132f59e71ac9869577564d"
 
   url "https://github.com/PowerShell/PowerShell/releases/download/v#{version}/powershell-#{version}-osx-#{arch}.pkg"
   name "PowerShell"

--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -2,13 +2,8 @@ cask "pritunl" do
   arch arm: ".arm64"
 
   version "1.2.3236.80"
-
-  on_intel do
-    sha256 "47281dab7501d10db66249636f29bec2d4c9b2e9f4971f9fc9967b97f20a60d9"
-  end
-  on_arm do
-    sha256 "d26c375da9b16febace3fea6781405086d3e45129256ad638d54fdb688253f29"
-  end
+  sha256 arm:   "d26c375da9b16febace3fea6781405086d3e45129256ad638d54fdb688253f29",
+         intel: "47281dab7501d10db66249636f29bec2d4c9b2e9f4971f9fc9967b97f20a60d9"
 
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl#{arch}.pkg.zip",
       verified: "github.com/pritunl/pritunl-client-electron/"

--- a/Casks/processing.rb
+++ b/Casks/processing.rb
@@ -2,13 +2,8 @@ cask "processing" do
   arch arm: "aarch64", intel: "x64"
 
   version "4.0.1,1286"
-
-  on_intel do
-    sha256 "6cabb7acd3b98adc4f4d9cf749cf2f3c4c2379c802862634a77fd91c6ca901c2"
-  end
-  on_arm do
-    sha256 "aa5b3f8e277fada2f73086677fde16aa7d7a08cd5e8d02ba5227952b295460aa"
-  end
+  sha256 arm:   "aa5b3f8e277fada2f73086677fde16aa7d7a08cd5e8d02ba5227952b295460aa",
+         intel: "6cabb7acd3b98adc4f4d9cf749cf2f3c4c2379c802862634a77fd91c6ca901c2"
 
   url "https://github.com/processing/processing4/releases/download/processing-#{version.csv.second}-#{version.csv.first}/processing-#{version.csv.first}-macos-#{arch}.zip",
       verified: "github.com/processing/processing4/"

--- a/Casks/projector.rb
+++ b/Casks/projector.rb
@@ -3,13 +3,8 @@ cask "projector" do
   archapp = on_arch_conditional arm: "-arm"
 
   version "1.1.0"
-
-  on_intel do
-    sha256 "a509d7fe44ffdfbb6fb81058172558b47591ac5ac25376782574cf99be58397b"
-  end
-  on_arm do
-    sha256 "a2f51be000977500a0b1e08a6f357495c98600f542d5cd9cdd8e88cc3785679a"
-  end
+  sha256 arm:   "a2f51be000977500a0b1e08a6f357495c98600f542d5cd9cdd8e88cc3785679a",
+         intel: "a509d7fe44ffdfbb6fb81058172558b47591ac5ac25376782574cf99be58397b"
 
   url "https://github.com/JetBrains/projector-client/releases/download/launcher-v#{version}/projector-darwin-signed-#{arch}-launcher-v#{version}.zip",
       verified: "github.com/JetBrains/projector-client/"

--- a/Casks/prosys-opc-ua-browser.rb
+++ b/Casks/prosys-opc-ua-browser.rb
@@ -2,13 +2,8 @@ cask "prosys-opc-ua-browser" do
   arch arm: "aarch64", intel: "x64"
 
   version "4.2.0,33"
-
-  on_intel do
-    sha256 "fa4ce0dd4ed9222a9e2a24ec68934969b4f6a8bc852ef165dcd50ceb2cccc2c4"
-  end
-  on_arm do
-    sha256 "92972a00ba8eb2738322947d26a4f2a1f5e4e6db3ab0f46bfdcf8fedb4ae22a9"
-  end
+  sha256 arm:   "92972a00ba8eb2738322947d26a4f2a1f5e4e6db3ab0f46bfdcf8fedb4ae22a9",
+         intel: "fa4ce0dd4ed9222a9e2a24ec68934969b4f6a8bc852ef165dcd50ceb2cccc2c4"
 
   url "https://www.prosysopc.com/opcua/apps/UaBrowser/dist/#{version.csv.first}-#{version.csv.second}/prosys-opc-ua-browser-mac-#{arch}-#{version.csv.first}-#{version.csv.second}.dmg"
   name "Prosys OPC UA Browser"

--- a/Casks/prowlarr.rb
+++ b/Casks/prowlarr.rb
@@ -2,13 +2,8 @@ cask "prowlarr" do
   arch arm: "arm64", intel: "x64"
 
   version "0.4.4.1947"
-
-  on_intel do
-    sha256 "2ed10f8e52d2541decf293f690ace57c162fc55aac6395218884e2e68eb4694d"
-  end
-  on_arm do
-    sha256 "9b6da817a4bc94452177ecdeb08e3d9624a82db2a138451ce1e4cac9c5a974b0"
-  end
+  sha256 arm:   "9b6da817a4bc94452177ecdeb08e3d9624a82db2a138451ce1e4cac9c5a974b0",
+         intel: "2ed10f8e52d2541decf293f690ace57c162fc55aac6395218884e2e68eb4694d"
 
   url "https://github.com/Prowlarr/Prowlarr/releases/download/v#{version}/Prowlarr.develop.#{version}.osx-app-core-#{arch}.zip",
       verified: "github.com/Prowlarr/Prowlarr/"

--- a/Casks/publii.rb
+++ b/Casks/publii.rb
@@ -2,13 +2,8 @@ cask "publii" do
   arch arm: "apple-silicon", intel: "intel"
 
   version "0.40.2"
-
-  on_intel do
-    sha256 "c5826a1e570ca626df913d72b70a55b5df745a6801991fa2f3707fb68a43cf80"
-  end
-  on_arm do
-    sha256 "eeb32bfd07375bbc5227e6c0e04268683411eaf19583bba75c0a2114fddc04f2"
-  end
+  sha256 arm:   "eeb32bfd07375bbc5227e6c0e04268683411eaf19583bba75c0a2114fddc04f2",
+         intel: "c5826a1e570ca626df913d72b70a55b5df745a6801991fa2f3707fb68a43cf80"
 
   url "https://cdn.getpublii.com/Publii-#{version}-#{arch}.dmg"
   name "Publii"

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -2,13 +2,8 @@ cask "pycharm-ce" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.56"
-
-  on_intel do
-    sha256 "8c2b322cab74cbf52dbe33e0fd9be63fe320d1ade2446790c4eec7309b590eea"
-  end
-  on_arm do
-    sha256 "c3abc618614be830dbf41479b74ae489aa44290d9bbb11e3c4d2cdffb4d569b6"
-  end
+  sha256 arm:   "c3abc618614be830dbf41479b74ae489aa44290d9bbb11e3c4d2cdffb4d569b6",
+         intel: "8c2b322cab74cbf52dbe33e0fd9be63fe320d1ade2446790c4eec7309b590eea"
 
   url "https://download.jetbrains.com/python/pycharm-community-#{version.csv.first}#{arch}.dmg"
   name "Jetbrains PyCharm Community Edition"

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -2,13 +2,8 @@ cask "pycharm-edu" do
   arch arm: "-aarch64"
 
   version "2022.1.3,221.6008.17"
-
-  on_intel do
-    sha256 "9ab4087c65c315cc095a882221b3748bc66b3b9f6699563cde02a49f857ee4d0"
-  end
-  on_arm do
-    sha256 "46e498610a3a026ebaa3269c5cc35fd9e75bf35dca4d45d739828036059edad1"
-  end
+  sha256 arm:   "46e498610a3a026ebaa3269c5cc35fd9e75bf35dca4d45d739828036059edad1",
+         intel: "9ab4087c65c315cc095a882221b3748bc66b3b9f6699563cde02a49f857ee4d0"
 
   url "https://download.jetbrains.com/python/pycharm-edu-#{version.csv.first}#{arch}.dmg"
   name "Jetbrains PyCharm Educational Edition"

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -2,15 +2,10 @@ cask "pycharm" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.56"
+  sha256 arm:   "416ca961042b9c3ae8b23039cc3b84b64e941c1d82478bca3e327089efa4f4d2",
+         intel: "6636139dc9c0e28b90517e91d1c1924e218b5d33d9418cca888b05c11fbf54d9"
 
   url "https://download.jetbrains.com/python/pycharm-professional-#{version.csv.first}#{arch}.dmg"
-  on_intel do
-    sha256 "6636139dc9c0e28b90517e91d1c1924e218b5d33d9418cca888b05c11fbf54d9"
-  end
-  on_arm do
-    sha256 "416ca961042b9c3ae8b23039cc3b84b64e941c1d82478bca3e327089efa4f4d2"
-  end
-
   name "PyCharm"
   name "PyCharm Professional"
   desc "IDE for professional Python development"

--- a/Casks/qobuz.rb
+++ b/Casks/qobuz.rb
@@ -2,13 +2,8 @@ cask "qobuz" do
   arch arm: "arm64/bigsur", intel: "x64/elCapitan_sierra"
 
   version "6.1.1,040"
-
-  on_intel do
-    sha256 "256731c921c8d676d971136979fef1c78f5af21a186a62a6842dceed87a5bb33"
-  end
-  on_arm do
-    sha256 "94228106ff86bff90580539625d335ec66051368d278a2771e097cce0e171852"
-  end
+  sha256 arm:   "94228106ff86bff90580539625d335ec66051368d278a2771e097cce0e171852",
+         intel: "256731c921c8d676d971136979fef1c78f5af21a186a62a6842dceed87a5bb33"
 
   url "https://desktop.qobuz.com/releases/darwin/#{arch}/#{version.csv.first}-b#{version.csv.second}/Qobuz.dmg"
   name "Qobuz"

--- a/Casks/racket.rb
+++ b/Casks/racket.rb
@@ -2,13 +2,8 @@ cask "racket" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "8.6"
-
-  on_intel do
-    sha256 "10c5d35239fe4737cc643633f1802ae309b227c1a055f990d4cc0d76f3317b66"
-  end
-  on_arm do
-    sha256 "fe1527b2f73b1b0f1123179454e200b3819baf875ade3458135411e04992d1a0"
-  end
+  sha256 arm:   "fe1527b2f73b1b0f1123179454e200b3819baf875ade3458135411e04992d1a0",
+         intel: "10c5d35239fe4737cc643633f1802ae309b227c1a055f990d4cc0d76f3317b66"
 
   url "https://mirror.racket-lang.org/installers/#{version}/racket-#{version}-#{arch}-macosx-cs.dmg"
   name "Racket"

--- a/Casks/radarr.rb
+++ b/Casks/radarr.rb
@@ -2,13 +2,8 @@ cask "radarr" do
   arch arm: "arm64", intel: "x64"
 
   version "4.1.0.6175"
-
-  on_intel do
-    sha256 "85094096ef10c789e6b7ac59208f02cb3de0a02dd1acf358cb569e2ff9df984d"
-  end
-  on_arm do
-    sha256 "cba7916c86a54d59b35506677620a4f9dc3de4aa45cea916d0b62d194244e93c"
-  end
+  sha256 arm:   "cba7916c86a54d59b35506677620a4f9dc3de4aa45cea916d0b62d194244e93c",
+         intel: "85094096ef10c789e6b7ac59208f02cb3de0a02dd1acf358cb569e2ff9df984d"
 
   url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.master.#{version}.osx-app-core-#{arch}.zip",
       verified: "github.com/Radarr/Radarr/"

--- a/Casks/raindropio.rb
+++ b/Casks/raindropio.rb
@@ -2,13 +2,8 @@ cask "raindropio" do
   arch arm: "arm64", intel: "x64"
 
   version "5.5.10"
-
-  on_intel do
-    sha256 "29688c40f374e6739674364e6d185477fc7d243d6e44cde0511ebb07a3d1e8aa"
-  end
-  on_arm do
-    sha256 "bf63030598416520d234ef99673128ef5cc8f29904733aa47e10e8557575b4ca"
-  end
+  sha256 arm:   "bf63030598416520d234ef99673128ef5cc8f29904733aa47e10e8557575b4ca",
+         intel: "29688c40f374e6739674364e6d185477fc7d243d6e44cde0511ebb07a3d1e8aa"
 
   url "https://github.com/raindropio/desktop/releases/download/v#{version}/Raindrop-#{arch}.dmg",
       verified: "github.com/raindropio/desktop/"

--- a/Casks/rancher.rb
+++ b/Casks/rancher.rb
@@ -2,13 +2,8 @@ cask "rancher" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.5.1"
-
-  on_intel do
-    sha256 "dbfee08284312d53a0fb5fa3b7359e8ed42d13cdc553f5439f5b9db52da4a7a2"
-  end
-  on_arm do
-    sha256 "4ac3defdbdbd5a48655e7c4514692fdf248afb2d26ac7e5c5c0487b92fb4659a"
-  end
+  sha256 arm:   "4ac3defdbdbd5a48655e7c4514692fdf248afb2d26ac7e5c5c0487b92fb4659a",
+         intel: "dbfee08284312d53a0fb5fa3b7359e8ed42d13cdc553f5439f5b9db52da4a7a2"
 
   url "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v#{version}/Rancher.Desktop-#{version}.#{arch}.dmg",
       verified: "github.com/rancher-sandbox/rancher-desktop/"

--- a/Casks/rar.rb
+++ b/Casks/rar.rb
@@ -2,13 +2,8 @@ cask "rar" do
   arch arm: "arm", intel: "x64"
 
   version "6.12"
-
-  on_intel do
-    sha256 "f607ca12bdc313884c5a6f504fbf662a0511bf39fe04a9b2a694c986cd34bb67"
-  end
-  on_arm do
-    sha256 "491f345712a02eb26a3b424658c30652e22e2201a0c5c547fb97c25a756a264b"
-  end
+  sha256 arm:   "491f345712a02eb26a3b424658c30652e22e2201a0c5c547fb97c25a756a264b",
+         intel: "f607ca12bdc313884c5a6f504fbf662a0511bf39fe04a9b2a694c986cd34bb67"
 
   url "https://www.rarlab.com/rar/rarmacos-#{arch}-#{version.no_dots}.tar.gz"
   name "RAR Archiver"

--- a/Casks/ray.rb
+++ b/Casks/ray.rb
@@ -3,13 +3,8 @@ cask "ray" do
   folder = on_arch_conditional arm: "arm64/"
 
   version "2.0.1"
-
-  on_intel do
-    sha256 "d2a2eda635147a34d136312505f77a3e09123289aa0919e2e942935e379bc7a9"
-  end
-  on_arm do
-    sha256 "75dd6a77e02f9c6c84b1bb95918f706d97a3a3fc6ae8fa0e74c1c0155ba12e78"
-  end
+  sha256 arm:   "75dd6a77e02f9c6c84b1bb95918f706d97a3a3fc6ae8fa0e74c1c0155ba12e78",
+         intel: "d2a2eda635147a34d136312505f77a3e09123289aa0919e2e942935e379bc7a9"
 
   url "https://ray-app.s3.eu-west-1.amazonaws.com/#{folder}Ray-#{version}#{arch}.dmg",
       verified: "ray-app.s3.eu-west-1.amazonaws.com/"

--- a/Casks/razorsql.rb
+++ b/Casks/razorsql.rb
@@ -2,13 +2,8 @@ cask "razorsql" do
   arch arm: "_aarch64"
 
   version "10.0.7"
-
-  on_intel do
-    sha256 "707dad5843d8b77015f8a5bab2407909a8c623c7aaff300529bfebdadfef42be"
-  end
-  on_arm do
-    sha256 "8e65cc0be44bc8e9f91b2de1831bc348a6f7fc30bb1f79b9383a4799311d833d"
-  end
+  sha256 arm:   "8e65cc0be44bc8e9f91b2de1831bc348a6f7fc30bb1f79b9383a4799311d833d",
+         intel: "707dad5843d8b77015f8a5bab2407909a8c623c7aaff300529bfebdadfef42be"
 
   url "https://s3.dualstack.us-east-1.amazonaws.com/downloads.razorsql.com/downloads/#{version.dots_to_underscores}/razorsql#{version.dots_to_underscores}#{arch}.dmg",
       verified: "s3.dualstack.us-east-1.amazonaws.com/"

--- a/Casks/remember-the-milk.rb
+++ b/Casks/remember-the-milk.rb
@@ -2,15 +2,10 @@ cask "remember-the-milk" do
   arch arm: "arm64", intel: "x64"
 
   version "1.3.11"
+  sha256 arm:   "5585a2ff3d09867c870c8255dc91e3235012f2f0dbeac3e38beeab6f0cee0f2b",
+         intel: "6bab4f70f87a95764e646788bef3449877a3938768b5a9b92ade946b348c95d2"
 
   url "https://www.rememberthemilk.com/download/mac/RememberTheMilk-#{version}-#{arch}.zip"
-  on_intel do
-    sha256 "6bab4f70f87a95764e646788bef3449877a3938768b5a9b92ade946b348c95d2"
-  end
-  on_arm do
-    sha256 "5585a2ff3d09867c870c8255dc91e3235012f2f0dbeac3e38beeab6f0cee0f2b"
-  end
-
   name "Remember The Milk"
   desc "To-do app"
   homepage "https://www.rememberthemilk.com/"

--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -2,13 +2,8 @@ cask "rider" do
   arch arm: "-aarch64"
 
   version "2022.2.2,222.3962.23"
-
-  on_intel do
-    sha256 "0a86dfb256154001ee2da50a0fa2126eceb9b85407cbd2d41976f29230367fdb"
-  end
-  on_arm do
-    sha256 "449f219fd48b367ee51ac4627c86a6a6dd77846b6186cebc71ca0567e2adba05"
-  end
+  sha256 arm:   "449f219fd48b367ee51ac4627c86a6a6dd77846b6186cebc71ca0567e2adba05",
+         intel: "0a86dfb256154001ee2da50a0fa2126eceb9b85407cbd2d41976f29230367fdb"
 
   url "https://download.jetbrains.com/rider/JetBrains.Rider-#{version.csv.first}#{arch}.dmg"
   name "JetBrains Rider"

--- a/Casks/roam-research.rb
+++ b/Casks/roam-research.rb
@@ -2,13 +2,8 @@ cask "roam-research" do
   arch arm: "-arm64"
 
   version "0.0.15"
-
-  on_intel do
-    sha256 "c270b957cb7ba0c9fa7b7ff8ff9a2fbe2ed3c8dba24ee2584dfa487022e1cc51"
-  end
-  on_arm do
-    sha256 "4407df5ac97d3013dbf113d09da33d01264d94f8f4c30d5546afe237e6af5834"
-  end
+  sha256 arm:   "4407df5ac97d3013dbf113d09da33d01264d94f8f4c30d5546afe237e6af5834",
+         intel: "c270b957cb7ba0c9fa7b7ff8ff9a2fbe2ed3c8dba24ee2584dfa487022e1cc51"
 
   url "https://roam-electron-deploy.s3.us-east-2.amazonaws.com/Roam+Research-#{version}#{arch}.dmg",
       verified: "roam-electron-deploy.s3.us-east-2.amazonaws.com"

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -2,13 +2,8 @@ cask "rubymine" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.56"
-
-  on_intel do
-    sha256 "885e52fca70605ddb972cba1965ded95ad5012f329095ef4887e825f60c71159"
-  end
-  on_arm do
-    sha256 "ea2c4a9ebc2b0496aa43d4e6ba7ccb60b1a5e0f2fdb01c8f408a45502d6e56de"
-  end
+  sha256 arm:   "ea2c4a9ebc2b0496aa43d4e6ba7ccb60b1a5e0f2fdb01c8f408a45502d6e56de",
+         intel: "885e52fca70605ddb972cba1965ded95ad5012f329095ef4887e825f60c71159"
 
   url "https://download.jetbrains.com/ruby/RubyMine-#{version.csv.first}#{arch}.dmg"
   name "RubyMine"

--- a/Casks/runelite.rb
+++ b/Casks/runelite.rb
@@ -2,13 +2,8 @@ cask "runelite" do
   arch arm: "aarch64", intel: "x64"
 
   version "2.4.4"
-
-  on_intel do
-    sha256 "62f8a097ddbc6dffcee85c6e3b8b2f386b97395e878f575198dad1386df47c28"
-  end
-  on_arm do
-    sha256 "b233def430723a3f6b7229fefb2361a198aeafbdc485358295f1d662f97df766"
-  end
+  sha256 arm:   "b233def430723a3f6b7229fefb2361a198aeafbdc485358295f1d662f97df766",
+         intel: "62f8a097ddbc6dffcee85c6e3b8b2f386b97395e878f575198dad1386df47c28"
 
   url "https://github.com/runelite/launcher/releases/download/#{version}/RuneLite-#{arch}.dmg",
       verified: "github.com/runelite/launcher/"

--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -2,13 +2,8 @@ cask "sage" do
   arch arm: "arm64", intel: "x86_64"
 
   version "9.6,1.4.2"
-
-  on_intel do
-    sha256 "c1ecace231226798e95ee4d7a3f301943ca9bbcef58834addb16ca8f4132430f"
-  end
-  on_arm do
-    sha256 "54a37b6391651ff04b4512cbf311422ab92e3373580a01d0e89349bc370f2562"
-  end
+  sha256 arm:   "54a37b6391651ff04b4512cbf311422ab92e3373580a01d0e89349bc370f2562",
+         intel: "c1ecace231226798e95ee4d7a3f301943ca9bbcef58834addb16ca8f4132430f"
 
   url "https://github.com/3-manifolds/Sage_macOS/releases/download/v#{version.csv.second}/SageMath-#{version.csv.first}-#{version.csv.second}_#{arch}.dmg",
       verified: "github.com/3-manifolds/Sage_macOS/"

--- a/Casks/sapmachine-jdk.rb
+++ b/Casks/sapmachine-jdk.rb
@@ -2,13 +2,8 @@ cask "sapmachine-jdk" do
   arch arm: "aarch64", intel: "x64"
 
   version "18.0.2"
-
-  on_intel do
-    sha256 "80812da1eb3edf40d59c62366d9f85ab1c4b51dd0e075ca0a25bb7226c17f369"
-  end
-  on_arm do
-    sha256 "6d298f7983b2494be94e1304830fc6d8f6b47ea8a2b9be384d8072fd9173f1e5"
-  end
+  sha256 arm:   "6d298f7983b2494be94e1304830fc6d8f6b47ea8a2b9be384d8072fd9173f1e5",
+         intel: "80812da1eb3edf40d59c62366d9f85ab1c4b51dd0e075ca0a25bb7226c17f369"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-#{arch}_bin.dmg",
       verified: "github.com/SAP/SapMachine/"

--- a/Casks/scenebuilder.rb
+++ b/Casks/scenebuilder.rb
@@ -2,13 +2,8 @@ cask "scenebuilder" do
   arch arm: "-aarch64"
 
   version "18.0.0"
-
-  on_intel do
-    sha256 "280a1bf776e39e93d611276d67560b9c0e195c6011ca7c5fd34a2b961165c66b"
-  end
-  on_arm do
-    sha256 "1dfcfd12ce4af94da53f6607c2f28e75bd6b1527b795404b21ae0b6b2f24e4ea"
-  end
+  sha256 arm:   "1dfcfd12ce4af94da53f6607c2f28e75bd6b1527b795404b21ae0b6b2f24e4ea",
+         intel: "280a1bf776e39e93d611276d67560b9c0e195c6011ca7c5fd34a2b961165c66b"
 
   url "https://download2.gluonhq.com/scenebuilder/#{version}/install/mac/SceneBuilder-#{version}#{arch}.dmg"
   name "Scene Builder"

--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -2,13 +2,8 @@ cask "scilab" do
   prefix = on_arch_conditional arm: "accelerate-" # there is also an "openblas-" version
 
   version "6.1.1"
-
-  on_intel do
-    sha256 "b417aace594cba882b19c2711aa125d8374d5da8b0a24df2873592765598e457"
-  end
-  on_arm do
-    sha256 "2f87710fc47c6d8e6777ee280ece589342e536c17290b9c033ea0dfcef3b4912"
-  end
+  sha256 arm:   "2f87710fc47c6d8e6777ee280ece589342e536c17290b9c033ea0dfcef3b4912",
+         intel: "b417aace594cba882b19c2711aa125d8374d5da8b0a24df2873592765598e457"
 
   url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{prefix}#{Hardware::CPU.arch}.dmg",
       verified: "utc.fr/~mottelet/scilab/"

--- a/Casks/screaming-frog-seo-spider.rb
+++ b/Casks/screaming-frog-seo-spider.rb
@@ -2,12 +2,8 @@ cask "screaming-frog-seo-spider" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "17.0"
-
-  if Hardware::CPU.intel?
-    sha256 "349449bf2e9299cb988da4e6f46fbe3acbd7380c5d1a128d764ad1a1ab1c8aa8"
-  else
-    sha256 "7dbeec31e9ba7461d7d182e5a70861283ca4cc409863b8b45351923b836b49c0"
-  end
+  sha256 arm:   "7dbeec31e9ba7461d7d182e5a70861283ca4cc409863b8b45351923b836b49c0",
+         intel: "349449bf2e9299cb988da4e6f46fbe3acbd7380c5d1a128d764ad1a1ab1c8aa8"
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}-#{arch}.dmg"
   name "Screaming Frog SEO Spider"

--- a/Casks/segger-embedded-studio-for-arm.rb
+++ b/Casks/segger-embedded-studio-for-arm.rb
@@ -2,15 +2,10 @@ cask "segger-embedded-studio-for-arm" do
   arch arm: "arm64", intel: "x64"
 
   version "6.34"
+  sha256 arm:   "4a5ab3761dca0c75cfe902253a5c93ce8b1b32161b386593319a812cf7efacff",
+         intel: "4c0b2ed14f46c5df4f560b1f8d0411d4070cd965cbe02801f55c7f93686c574e"
 
   url "https://www.segger.com/downloads/embedded-studio/Setup_EmbeddedStudio_ARM_v#{version.no_dots}_macos_#{arch}.dmg"
-  on_intel do
-    sha256 "4c0b2ed14f46c5df4f560b1f8d0411d4070cd965cbe02801f55c7f93686c574e"
-  end
-  on_arm do
-    sha256 "4a5ab3761dca0c75cfe902253a5c93ce8b1b32161b386593319a812cf7efacff"
-  end
-
   name "SEGGER Embedded Studio for ARM"
   desc "IDE for embedded systems"
   homepage "https://www.segger.com/products/development-tools/embedded-studio"

--- a/Casks/sentinel.rb
+++ b/Casks/sentinel.rb
@@ -2,13 +2,8 @@ cask "sentinel" do
   arch arm: "arm64", intel: "amd64"
 
   version "0.18.11"
-
-  on_intel do
-    sha256 "267f2d2d2bf62476c6b40f112b7c222966da4ee27098cadb99e4446b48e9b68a"
-  end
-  on_arm do
-    sha256 "c6c638426c8ef50b5b8500e082a0e8b116f7311f2ee24d24336f22d64b23c5a0"
-  end
+  sha256 arm:   "c6c638426c8ef50b5b8500e082a0e8b116f7311f2ee24d24336f22d64b23c5a0",
+         intel: "267f2d2d2bf62476c6b40f112b7c222966da4ee27098cadb99e4446b48e9b68a"
 
   url "https://releases.hashicorp.com/sentinel/#{version}/sentinel_#{version}_darwin_#{arch}.zip"
   name "Sentinel"

--- a/Casks/shift.rb
+++ b/Casks/shift.rb
@@ -2,13 +2,8 @@ cask "shift" do
   arch arm: "arm64", intel: "x64"
 
   version "8.0.48.473"
-
-  on_intel do
-    sha256 "50cfaa6b97aefab0af61e26c53dbb0925467fffbc0de50434739769096b105a7"
-  end
-  on_arm do
-    sha256 "5e07cb8f12b64f9f23b0971b1ec8127a9c204272ace6cb2c2084c5c46b71ac58"
-  end
+  sha256 arm:   "5e07cb8f12b64f9f23b0971b1ec8127a9c204272ace6cb2c2084c5c46b71ac58",
+         intel: "50cfaa6b97aefab0af61e26c53dbb0925467fffbc0de50434739769096b105a7"
 
   url "https://updates.tryshift.com/v#{version.major_minor_patch}/stable/shift-v#{version}-stable-#{arch}.dmg"
   name "Shift"

--- a/Casks/shimonote.rb
+++ b/Casks/shimonote.rb
@@ -2,13 +2,8 @@ cask "shimonote" do
   arch arm: "arm64", intel: "x64"
 
   version "2.5.13,66be574"
-
-  on_intel do
-    sha256 "6798b0441ec654b8f46a6818e8d77ed086257239e6bf11e802e8fe865e55a8a5"
-  end
-  on_arm do
-    sha256 "20b460eb53653b0f391b3bc359c1e538127c4b9c8572dca8444063b2fb90cb17"
-  end
+  sha256 arm:   "20b460eb53653b0f391b3bc359c1e538127c4b9c8572dca8444063b2fb90cb17",
+         intel: "6798b0441ec654b8f46a6818e8d77ed086257239e6bf11e802e8fe865e55a8a5"
 
   url "https://as.smvm.cn/panther/shimo/release/darwin/#{arch}/\%e7\%9f\%b3\%e5\%a2\%a8\%e6\%96\%87\%e6\%a1\%a3_v#{version.csv.first}-release.#{version.csv.second}.shimo_darwin-#{arch}.zip",
       verified: "as.smvm.cn/panther/shimo/release/darwin/"

--- a/Casks/shotcut.rb
+++ b/Casks/shotcut.rb
@@ -2,13 +2,8 @@ cask "shotcut" do
   arch arm: "macos-ARM64", intel: "macos"
 
   version "22.06.23"
-
-  on_intel do
-    sha256 "dda1d9f6ebb1013452055214d3d297bfd30adc3d1f97a764c15b15c36f98d1a2"
-  end
-  on_arm do
-    sha256 "d68ab8eaf435deebdc5d7abc2a60915fc58d51d21977d72c89ddb46d4d511759"
-  end
+  sha256 arm:   "d68ab8eaf435deebdc5d7abc2a60915fc58d51d21977d72c89ddb46d4d511759",
+         intel: "dda1d9f6ebb1013452055214d3d297bfd30adc3d1f97a764c15b15c36f98d1a2"
 
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-#{arch}-#{version.no_dots}.dmg",
       verified: "github.com/mltframework/shotcut/"

--- a/Casks/shutter-encoder.rb
+++ b/Casks/shutter-encoder.rb
@@ -2,13 +2,8 @@ cask "shutter-encoder" do
   arch arm: "Apple Silicon", intel: "Mac 64bits"
 
   version "16.2"
-
-  on_intel do
-    sha256 "0b303ded4c58ddad0cc40cc31963041eabc374f63d9b0aa6284b3883eab5c82e"
-  end
-  on_arm do
-    sha256 "59af85baa47c37c4ebd5e6bd244ff8473e5960187fb90496109d03f3338ef2ad"
-  end
+  sha256 arm:   "59af85baa47c37c4ebd5e6bd244ff8473e5960187fb90496109d03f3338ef2ad",
+         intel: "0b303ded4c58ddad0cc40cc31963041eabc374f63d9b0aa6284b3883eab5c82e"
 
   url "https://www.shutterencoder.com/Shutter%20Encoder%20#{version}%20#{arch.gsub(" ", "%20")}.pkg"
   name "Shutter Encoder"

--- a/Casks/sidequest.rb
+++ b/Casks/sidequest.rb
@@ -2,13 +2,8 @@ cask "sidequest" do
   arch arm: "-arm64"
 
   version "0.10.31"
-
-  on_intel do
-    sha256 "6639bf7b29b7cdf274c667d4ff490d600b3732d8323cd052703080a4b4ada80f"
-  end
-  on_arm do
-    sha256 "9d060ae49beb33bb70cbc0253f5ef5b33275ffc146b23d2461b60bf084ae08fa"
-  end
+  sha256 arm:   "9d060ae49beb33bb70cbc0253f5ef5b33275ffc146b23d2461b60bf084ae08fa",
+         intel: "6639bf7b29b7cdf274c667d4ff490d600b3732d8323cd052703080a4b4ada80f"
 
   url "https://github.com/SideQuestVR/SideQuest/releases/download/v#{version}/SideQuest-#{version}#{arch}.dmg",
       verified: "github.com/SideQuestVR/SideQuest/"

--- a/Casks/signal.rb
+++ b/Casks/signal.rb
@@ -2,13 +2,8 @@ cask "signal" do
   arch arm: "arm64", intel: "x64"
 
   version "5.55.0"
-
-  on_intel do
-    sha256 "0997f557924dbffdc477bc8088b3512776a8382c5eae30e191d0e730012fbbd4"
-  end
-  on_arm do
-    sha256 "18ee0df71f071d7c524d1273b8e93f04a4a479d20b753729a7c8bcf077636ed3"
-  end
+  sha256 arm:   "18ee0df71f071d7c524d1273b8e93f04a4a479d20b753729a7c8bcf077636ed3",
+         intel: "0997f557924dbffdc477bc8088b3512776a8382c5eae30e191d0e730012fbbd4"
 
   url "https://updates.signal.org/desktop/signal-desktop-mac-#{arch}-#{version}.dmg"
   name "Signal"

--- a/Casks/slack.rb
+++ b/Casks/slack.rb
@@ -2,13 +2,8 @@ cask "slack" do
   arch arm: "arm64", intel: "x64"
 
   version "4.27.154"
-
-  on_intel do
-    sha256 "76f8038715c792482185a927881186417d960adb62940949de28e03867626c28"
-  end
-  on_arm do
-    sha256 "e6c730b3b29a17a3c94edce5181bd69be3b49af2b030dc094f8487b8347b7bd8"
-  end
+  sha256 arm:   "e6c730b3b29a17a3c94edce5181bd69be3b49af2b030dc094f8487b8347b7bd8",
+         intel: "76f8038715c792482185a927881186417d960adb62940949de28e03867626c28"
 
   url "https://downloads.slack-edge.com/releases/macos/#{version}/prod/#{arch}/Slack-#{version}-macOS.dmg",
       verified: "downloads.slack-edge.com/releases/macos/"

--- a/Casks/slite.rb
+++ b/Casks/slite.rb
@@ -2,13 +2,8 @@ cask "slite" do
   arch arm: "arm64", intel: "x64"
 
   version "1.2.14"
-
-  on_intel do
-    sha256 "8103be5d53d349cf5070ec98e74df8d01ded0f93e8c84b9d18b18c19c6210b76"
-  end
-  on_arm do
-    sha256 "a74ad9345c3dba1874ec682280996be21b2c517824879a1f9fc0ee9896c940df"
-  end
+  sha256 arm:   "a74ad9345c3dba1874ec682280996be21b2c517824879a1f9fc0ee9896c940df",
+         intel: "8103be5d53d349cf5070ec98e74df8d01ded0f93e8c84b9d18b18c19c6210b76"
 
   url "https://download.todesktop.com/20062929x31pwfi/Slite%20#{version}-#{arch}-mac.zip",
       verified: "download.todesktop.com/20062929x31pwfi/"

--- a/Casks/smartsynchronize.rb
+++ b/Casks/smartsynchronize.rb
@@ -2,13 +2,8 @@ cask "smartsynchronize" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.3.1"
-
-  on_intel do
-    sha256 "a35c74d2f0965a4471888bde7e962569f85bd62a6707dd6ab0dff4e99265a287"
-  end
-  on_arm do
-    sha256 "27aa45524cfc673e566d2a2eb7ba382cfb436d13a08e69a7f35466cffe2b2857"
-  end
+  sha256 arm:   "27aa45524cfc673e566d2a2eb7ba382cfb436d13a08e69a7f35466cffe2b2857",
+         intel: "a35c74d2f0965a4471888bde7e962569f85bd62a6707dd6ab0dff4e99265a287"
 
   url "https://www.syntevo.com/downloads/smartsynchronize/smartsynchronize-#{arch}-#{version.dots_to_underscores}.dmg"
   name "SmartSynchronize"

--- a/Casks/sonixd.rb
+++ b/Casks/sonixd.rb
@@ -2,13 +2,8 @@ cask "sonixd" do
   arch arm: "arm64", intel: "x64"
 
   version "0.15.3"
-
-  on_intel do
-    sha256 "384889e0abccdd75771624f874d812a1ed49f50e2f51af03e0bcb286940059dc"
-  end
-  on_arm do
-    sha256 "f2382d64fa216c7fb7734043c77be5b45e1dd5f214da3cca0a5d3c34c2e7acda"
-  end
+  sha256 arm:   "f2382d64fa216c7fb7734043c77be5b45e1dd5f214da3cca0a5d3c34c2e7acda",
+         intel: "384889e0abccdd75771624f874d812a1ed49f50e2f51af03e0bcb286940059dc"
 
   url "https://github.com/jeffvli/sonixd/releases/download/v#{version}/Sonixd-#{version}-mac-#{arch}.dmg"
   name "Sonixd"

--- a/Casks/sparrow.rb
+++ b/Casks/sparrow.rb
@@ -2,13 +2,8 @@ cask "sparrow" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.6.6"
-
-  on_intel do
-    sha256 "ab43a01cfbb8995fa665479df35cb1660cedc7e758710dd6ff043b1219d711be"
-  end
-  on_arm do
-    sha256 "83946a39304b4166c91094c510438579d2527a51d22d94e8cb9c8bd192a0846e"
-  end
+  sha256 arm:   "83946a39304b4166c91094c510438579d2527a51d22d94e8cb9c8bd192a0846e",
+         intel: "ab43a01cfbb8995fa665479df35cb1660cedc7e758710dd6ff043b1219d711be"
 
   url "https://github.com/sparrowwallet/sparrow/releases/download/#{version}/Sparrow-#{version}-#{arch}.dmg",
       verified: "github.com/sparrowwallet/sparrow/"

--- a/Casks/springtoolsuite.rb
+++ b/Casks/springtoolsuite.rb
@@ -2,13 +2,8 @@ cask "springtoolsuite" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "4.15.3,4.24.0"
-
-  on_intel do
-    sha256 "9e69a29355e039ce9a0bb9441a515aabb212ef04131d45e9537710225a026b32"
-  end
-  on_arm do
-    sha256 "8ad1d2c34d7c1b9b6854f89fbb65503463d41ce5953dd433a932da08d103e63f"
-  end
+  sha256 arm:   "8ad1d2c34d7c1b9b6854f89fbb65503463d41ce5953dd433a932da08d103e63f",
+         intel: "9e69a29355e039ce9a0bb9441a515aabb212ef04131d45e9537710225a026b32"
 
   url "https://download.springsource.com/release/STS#{version.major}/#{version.csv.first}.RELEASE/dist/e#{version.csv.second.major_minor}/spring-tool-suite-#{version.major}-#{version.csv.first}.RELEASE-e#{version.csv.second}-macosx.cocoa.#{arch}.dmg",
       verified: "download.springsource.com/release/"

--- a/Casks/standard-notes.rb
+++ b/Casks/standard-notes.rb
@@ -2,13 +2,8 @@ cask "standard-notes" do
   arch arm: "arm64", intel: "x64"
 
   version "3.23.83"
-
-  on_intel do
-    sha256 "d6578b95b14bbe75f7f760852b12881d8d190ad9ca352a182a4092f5588a6267"
-  end
-  on_arm do
-    sha256 "d72ae66293e788b712066d8e961f8889362b5243e7f21738fa1321cfd084276d"
-  end
+  sha256 arm:   "d72ae66293e788b712066d8e961f8889362b5243e7f21738fa1321cfd084276d",
+         intel: "d6578b95b14bbe75f7f760852b12881d8d190ad9ca352a182a4092f5588a6267"
 
   url "https://github.com/standardnotes/app/releases/download/%40standardnotes%2Fdesktop%40#{version}/standard-notes-#{version}-mac-#{arch}.zip",
       verified: "github.com/standardnotes/app/"

--- a/Casks/staruml.rb
+++ b/Casks/staruml.rb
@@ -2,13 +2,8 @@ cask "staruml" do
   arch arm: "-arm64"
 
   version "5.0.2"
-
-  on_intel do
-    sha256 "0df2006e175e8cfccf17bc3ca27d505177fab2cf7dda97b2299f1841b3bd98fe"
-  end
-  on_arm do
-    sha256 "abf41ab3d32d1b33ba6a3938e21ee8fba73766ceda0ee26a5ccafd3a11984596"
-  end
+  sha256 arm:   "abf41ab3d32d1b33ba6a3938e21ee8fba73766ceda0ee26a5ccafd3a11984596",
+         intel: "0df2006e175e8cfccf17bc3ca27d505177fab2cf7dda97b2299f1841b3bd98fe"
 
   url "https://staruml.io/download/releases-v#{version.major}/StarUML-#{version}#{arch}.dmg"
   name "StarUML"

--- a/Casks/steam-plus-plus.rb
+++ b/Casks/steam-plus-plus.rb
@@ -2,13 +2,8 @@ cask "steam-plus-plus" do
   arch arm: "arm64", intel: "x64"
 
   version "2.8.4"
-
-  on_intel do
-    sha256 "dbe227f9d2d819698744cca32b6c52473b88058249480a226501adde8c395b86"
-  end
-  on_arm do
-    sha256 "b321b7b549680bdfcac8201dd5f1945120f3b30fca033f035387e182801dce74"
-  end
+  sha256 arm:   "b321b7b549680bdfcac8201dd5f1945120f3b30fca033f035387e182801dce74",
+         intel: "dbe227f9d2d819698744cca32b6c52473b88058249480a226501adde8c395b86"
 
   url "https://github.com/BeyondDimension/SteamTools/releases/download/#{version}/Steam++_macos_#{arch}_v#{version}.dmg",
       verified: "github.com/BeyondDimension/SteamTools/"

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -2,13 +2,8 @@ cask "stellarium" do
   arch arm: "arm64", intel: "x86_64"
 
   version "0.22.2"
-
-  on_intel do
-    sha256 "5e8c2ee315f8c00a393e7bd22461f9b48355538cec39e1bb771e92a5795bcfb4"
-  end
-  on_arm do
-    sha256 "74acc44f96597d11d92f94015efd19cd18c2ce76e850d90f44c40d636f72ea5f"
-  end
+  sha256 arm:   "74acc44f96597d11d92f94015efd19cd18c2ce76e850d90f44c40d636f72ea5f",
+         intel: "5e8c2ee315f8c00a393e7bd22461f9b48355538cec39e1bb771e92a5795bcfb4"
 
   url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-#{arch}.zip",
       verified: "github.com/Stellarium/stellarium/"

--- a/Casks/stoplight-studio.rb
+++ b/Casks/stoplight-studio.rb
@@ -2,13 +2,8 @@ cask "stoplight-studio" do
   arch arm: "mac-arm64", intel: "mac"
 
   version "2.8.1,7959.git-777e356"
-
-  on_intel do
-    sha256 "8a933c3b633e12da3b8a85e43b004223a3c00ee348a0817d0348ecaf5a586c54"
-  end
-  on_arm do
-    sha256 "d0b50a7da3798b7b797dcb46a1bf2cddcee06269f6ab363724e64bdd3ddf82a0"
-  end
+  sha256 arm:   "d0b50a7da3798b7b797dcb46a1bf2cddcee06269f6ab363724e64bdd3ddf82a0",
+         intel: "8a933c3b633e12da3b8a85e43b004223a3c00ee348a0817d0348ecaf5a586c54"
 
   url "https://github.com/stoplightio/studio/releases/download/v#{version.csv.first}-stable.#{version.csv.second}/stoplight-studio-#{arch}.dmg",
       verified: "github.com/stoplightio/studio/"

--- a/Casks/stretchly.rb
+++ b/Casks/stretchly.rb
@@ -2,13 +2,8 @@ cask "stretchly" do
   arch arm: "-arm64"
 
   version "1.11.0"
-
-  on_intel do
-    sha256 "06afceb398eb479d9221333f6f1c5218844565343e653dd9a01b874c0cd13bb7"
-  end
-  on_arm do
-    sha256 "40a40989c3d74dca1e6957be95cc9552e786ebb8fc07685d57e82ba42a7b6b7d"
-  end
+  sha256 arm:   "40a40989c3d74dca1e6957be95cc9552e786ebb8fc07685d57e82ba42a7b6b7d",
+         intel: "06afceb398eb479d9221333f6f1c5218844565343e653dd9a01b874c0cd13bb7"
 
   url "https://github.com/hovancik/stretchly/releases/download/v#{version}/stretchly-#{version}#{arch}.dmg",
       verified: "github.com/hovancik/stretchly/"

--- a/Casks/studio-3t.rb
+++ b/Casks/studio-3t.rb
@@ -3,13 +3,8 @@ cask "studio-3t" do
   livecheckarch = on_arch_conditional arm: "_aarch64"
 
   version "2022.7.2"
-
-  on_intel do
-    sha256 "2ad327073416c9937edff4b9bb93627ad8882e29b8293c461f5f53bbab25d839"
-  end
-  on_arm do
-    sha256 "f2d7a1d66d3b938c1497d5b81add6cc69816dc9b0907c45facab75f53a3db1dc"
-  end
+  sha256 arm:   "f2d7a1d66d3b938c1497d5b81add6cc69816dc9b0907c45facab75f53a3db1dc",
+         intel: "2ad327073416c9937edff4b9bb93627ad8882e29b8293c461f5f53bbab25d839"
 
   url "https://download.studio3t.com/studio-3t/mac#{arch}/#{version}/Studio-3T.dmg"
   name "Studio 3T"

--- a/Casks/superhuman.rb
+++ b/Casks/superhuman.rb
@@ -2,13 +2,8 @@ cask "superhuman" do
   arch arm: "-arm64"
 
   version "12.1.6"
-
-  on_intel do
-    sha256 "0338447d733fc3d666556dd26d9e3ee1f664b6a7e8d7a1f36ba2a2e7495a8d3c"
-  end
-  on_arm do
-    sha256 "5fdd0502e50ba2f1458d75106feab07d6f815990f369a9d4ce4189f6f7ac3fc5"
-  end
+  sha256 arm:   "5fdd0502e50ba2f1458d75106feab07d6f815990f369a9d4ce4189f6f7ac3fc5",
+         intel: "0338447d733fc3d666556dd26d9e3ee1f664b6a7e8d7a1f36ba2a2e7495a8d3c"
 
   url "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-#{version}#{arch}-latest-mac.zip",
       verified: "storage.googleapis.com/download.superhuman.com/"

--- a/Casks/superproductivity.rb
+++ b/Casks/superproductivity.rb
@@ -2,13 +2,8 @@ cask "superproductivity" do
   arch arm: "-arm64"
 
   version "7.11.5"
-
-  on_intel do
-    sha256 "5c6b50db6109939ad1f902c4d2123aae81bce0299095ebc31249e9e6ca452a6f"
-  end
-  on_arm do
-    sha256 "67665f0d3786c6d3be8705af67f1ffcfc987b38f61415f07ea940b1e95e8dd47"
-  end
+  sha256 arm:   "67665f0d3786c6d3be8705af67f1ffcfc987b38f61415f07ea940b1e95e8dd47",
+         intel: "5c6b50db6109939ad1f902c4d2123aae81bce0299095ebc31249e9e6ca452a6f"
 
   url "https://github.com/johannesjo/super-productivity/releases/download/v#{version}/superProductivity-#{version}#{arch}.dmg",
       verified: "github.com/johannesjo/super-productivity/"

--- a/Casks/superslicer.rb
+++ b/Casks/superslicer.rb
@@ -2,13 +2,8 @@ cask "superslicer" do
   arch arm: "arm", intel: "intel"
 
   version "2.4.58.4,220811"
-
-  on_intel do
-    sha256 "594f10459f4d3b2081ae89ef170bc9aa9ad13ebe62bbf2acac3311c58c114026"
-  end
-  on_arm do
-    sha256 "ddd5f3822c69faefc31124fad194c536d6c4f0ea661e7e5427559c4ba9c4c1f4"
-  end
+  sha256 arm:   "ddd5f3822c69faefc31124fad194c536d6c4f0ea661e7e5427559c4ba9c4c1f4",
+         intel: "594f10459f4d3b2081ae89ef170bc9aa9ad13ebe62bbf2acac3311c58c114026"
 
   url "https://github.com/supermerill/SuperSlicer/releases/download/#{version.csv.first}/SuperSlicer_#{version.csv.first}_macos_#{arch}_#{version.csv.second}.dmg"
   name "SuperSlicer"

--- a/Casks/switchhosts.rb
+++ b/Casks/switchhosts.rb
@@ -2,13 +2,8 @@ cask "switchhosts" do
   arch arm: "arm64", intel: "x64"
 
   version "4.1.2.6086"
-
-  on_intel do
-    sha256 "8a8556ca83496ffd965af493a139e84cec25c38e9f64eb26f1a134a621bc9ec3"
-  end
-  on_arm do
-    sha256 "85c2918308c849c3f70de5436b0e597107e925283c925e7d9b69496c26f31466"
-  end
+  sha256 arm:   "85c2918308c849c3f70de5436b0e597107e925283c925e7d9b69496c26f31466",
+         intel: "8a8556ca83496ffd965af493a139e84cec25c38e9f64eb26f1a134a621bc9ec3"
 
   url "https://github.com/oldj/SwitchHosts/releases/download/v#{version.major_minor_patch}/SwitchHosts_mac_#{arch}_#{version}.dmg",
       verified: "github.com/oldj/SwitchHosts/"

--- a/Casks/syncovery.rb
+++ b/Casks/syncovery.rb
@@ -2,13 +2,8 @@ cask "syncovery" do
   arch arm: "-Apple"
 
   version "9.47w"
-
-  on_intel do
-    sha256 "51dde7d0d28d90167eea9696a021a7adc153c6b730678b9a11bbd4b05f129ac0"
-  end
-  on_arm do
-    sha256 "402861d78da8902888f1bedaaa790bf0d2e10876c1fd060854f096a8fda02427"
-  end
+  sha256 arm:   "402861d78da8902888f1bedaaa790bf0d2e10876c1fd060854f096a8fda02427",
+         intel: "51dde7d0d28d90167eea9696a021a7adc153c6b730678b9a11bbd4b05f129ac0"
 
   url "https://www.syncovery.com/release/SyncoveryMac#{version}#{arch}.dmg"
   name "Syncovery"

--- a/Casks/tabby.rb
+++ b/Casks/tabby.rb
@@ -2,13 +2,8 @@ cask "tabby" do
   arch arm: "arm64", intel: "x86_64"
 
   version "1.0.183"
-
-  on_intel do
-    sha256 "43ba5fb3d776f2d2ed1128c377aaa9d3420d792579cc9389c32e75b1f9c87a6c"
-  end
-  on_arm do
-    sha256 "cfef3fd184b1bdf5070b5aec7dbeae3aa835f624a233e90e200170d51c7ef5a9"
-  end
+  sha256 arm:   "cfef3fd184b1bdf5070b5aec7dbeae3aa835f624a233e90e200170d51c7ef5a9",
+         intel: "43ba5fb3d776f2d2ed1128c377aaa9d3420d792579cc9389c32e75b1f9c87a6c"
 
   url "https://github.com/Eugeny/tabby/releases/download/v#{version}/tabby-#{version}-macos-#{arch}.zip",
       verified: "github.com/Eugeny/tabby/"

--- a/Casks/tagspaces.rb
+++ b/Casks/tagspaces.rb
@@ -2,13 +2,8 @@ cask "tagspaces" do
   arch arm: "arm64", intel: "x64"
 
   version "4.4.3"
-
-  on_intel do
-    sha256 "f40a73828459b5dd5cd31063bd0cfdfeef4736e2a6594951ca1658060bd6965d"
-  end
-  on_arm do
-    sha256 "62faf39ce08575421d3a9d67763399c2ee4a1bca09ebae3401b747fa0867e8dd"
-  end
+  sha256 arm:   "62faf39ce08575421d3a9d67763399c2ee4a1bca09ebae3401b747fa0867e8dd",
+         intel: "f40a73828459b5dd5cd31063bd0cfdfeef4736e2a6594951ca1658060bd6965d"
 
   url "https://github.com/tagspaces/tagspaces/releases/download/v#{version}/tagspaces-mac-#{arch}-#{version}.dmg",
       verified: "github.com/tagspaces/tagspaces/"

--- a/Casks/tandem.rb
+++ b/Casks/tandem.rb
@@ -2,13 +2,8 @@ cask "tandem" do
   arch arm: "arm64", intel: "x64"
 
   version "2.2.307"
-
-  on_intel do
-    sha256 "2a01c9dc79673463e28a6c8e72abd1e4041a3480defaa9092ab85b1869575717"
-  end
-  on_arm do
-    sha256 "3e72e92e27f01178efca1d78f27da0ac4fb28e07c99832bb9f53388ccc541056"
-  end
+  sha256 arm:   "3e72e92e27f01178efca1d78f27da0ac4fb28e07c99832bb9f53388ccc541056",
+         intel: "2a01c9dc79673463e28a6c8e72abd1e4041a3480defaa9092ab85b1869575717"
 
   url "https://download.todesktop.com/200527auaqaacsy/Tandem%20#{version}-#{arch}.dmg",
       verified: "download.todesktop.com/200527auaqaacsy/"

--- a/Casks/tempo.rb
+++ b/Casks/tempo.rb
@@ -2,15 +2,10 @@ cask "tempo" do
   arch arm: "release-arm64", intel: "release"
 
   version "6.0.0"
+  sha256 arm:   "67260ec4260e30da28abc20d847282f08e09d8bce00730594c598caf3a63bdb7",
+         intel: "acfe86aedce23077a34de27717f38920bf4eafb740841088ab31b685fec4e3af"
 
   url "https://download.yourtempo.co/#{arch}/Tempo-#{version}.dmg"
-  on_intel do
-    sha256 "acfe86aedce23077a34de27717f38920bf4eafb740841088ab31b685fec4e3af"
-  end
-  on_arm do
-    sha256 "67260ec4260e30da28abc20d847282f08e09d8bce00730594c598caf3a63bdb7"
-  end
-
   name "Tempo"
   desc "Email client that delivers all email in batches"
   homepage "https://www.yourtempo.co/"

--- a/Casks/temurin.rb
+++ b/Casks/temurin.rb
@@ -2,13 +2,8 @@ cask "temurin" do
   arch arm: "aarch64", intel: "x64"
 
   version "18.0.2,9"
-
-  on_intel do
-    sha256 "aa78eba86b8bda6e1b38240707fc27792065046ff9e13f1b6a52eefa1dfa854c"
-  end
-  on_arm do
-    sha256 "006ee54d7537758036fa0020d92856c8305e1c3e24f63ff89236827abf2431b9"
-  end
+  sha256 arm:   "006ee54d7537758036fa0020d92856c8305e1c3e24f63ff89236827abf2431b9",
+         intel: "aa78eba86b8bda6e1b38240707fc27792065046ff9e13f1b6a52eefa1dfa854c"
 
   url "https://github.com/adoptium/temurin#{version.major}-binaries/releases/download/jdk-#{version.csv.first}%2B#{version.csv.second}/OpenJDK#{version.major}U-jdk_#{arch}_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg",
       verified: "github.com/adoptium/"

--- a/Casks/texmacs.rb
+++ b/Casks/texmacs.rb
@@ -2,13 +2,8 @@ cask "texmacs" do
   arch arm: "-arm"
 
   version "2.1.2"
-
-  on_intel do
-    sha256 "db1f9a525554d76794e0339cc19fb4d45eee79bce5f7a176c8dc8b8667181b08"
-  end
-  on_arm do
-    sha256 "d0a5abf3dafba31073ffc3bbfbeff5300453954a54495affee8a16a2f9196587"
-  end
+  sha256 arm:   "d0a5abf3dafba31073ffc3bbfbeff5300453954a54495affee8a16a2f9196587",
+         intel: "db1f9a525554d76794e0339cc19fb4d45eee79bce5f7a176c8dc8b8667181b08"
 
   url "https://ftp.texmacs.org/TeXmacs/tmftp/macos/TeXmacs-#{version}#{arch}.dmg"
   name "GNU TeXmacs"

--- a/Casks/tinkerwell.rb
+++ b/Casks/tinkerwell.rb
@@ -2,13 +2,8 @@ cask "tinkerwell" do
   arch arm: "-arm64"
 
   version "3.7.0"
-
-  on_intel do
-    sha256 "521ce606c319cbf83a7a93bc80f531ca7c3e2fffcd06f7dc0fab72587b7c063e"
-  end
-  on_arm do
-    sha256 "c49f7a4088ee871c40d7fdc25c7a9074a0e3d84f26b6edd99c27f39e8382a022"
-  end
+  sha256 arm:   "c49f7a4088ee871c40d7fdc25c7a9074a0e3d84f26b6edd99c27f39e8382a022",
+         intel: "521ce606c319cbf83a7a93bc80f531ca7c3e2fffcd06f7dc0fab72587b7c063e"
 
   url "https://download.tinkerwell.app/tinkerwell/Tinkerwell-#{version}#{arch}.dmg"
   name "Tinkerwell"

--- a/Casks/touchdesigner.rb
+++ b/Casks/touchdesigner.rb
@@ -2,13 +2,8 @@ cask "touchdesigner" do
   arch arm: "arm64", intel: "intel"
 
   version "2022.26590"
-
-  on_intel do
-    sha256 "922586506adb9567704cee1da7993525d29ebe6258f72557f5c3185234cbb2ff"
-  end
-  on_arm do
-    sha256 "c2e10ec9a0b3da37302f1fcd154ba6e95fa81a4ff2bd1b0dc68d0e7698573a5e"
-  end
+  sha256 arm:   "c2e10ec9a0b3da37302f1fcd154ba6e95fa81a4ff2bd1b0dc68d0e7698573a5e",
+         intel: "922586506adb9567704cee1da7993525d29ebe6258f72557f5c3185234cbb2ff"
 
   url "https://download.derivative.ca/TouchDesigner.#{version}.#{arch}.dmg"
   name "Derivative TouchDesigner"

--- a/Casks/trezor-suite.rb
+++ b/Casks/trezor-suite.rb
@@ -2,13 +2,8 @@ cask "trezor-suite" do
   arch arm: "arm64", intel: "x64"
 
   version "22.8.2"
-
-  on_intel do
-    sha256 "a8a34656713cd849881fa1e902bc816320187ad347e764ac50279f1cb4a0d722"
-  end
-  on_arm do
-    sha256 "bd4f577faa18215fd2bebdb2cc93e0ce3aa5e968ed5fc03ee9923cd24eb4a2e5"
-  end
+  sha256 arm:   "bd4f577faa18215fd2bebdb2cc93e0ce3aa5e968ed5fc03ee9923cd24eb4a2e5",
+         intel: "a8a34656713cd849881fa1e902bc816320187ad347e764ac50279f1cb4a0d722"
 
   url "https://suite.trezor.io/web/static/desktop/Trezor-Suite-#{version}-mac-#{arch}.dmg"
   name "TREZOR Suite"

--- a/Casks/tropy.rb
+++ b/Casks/tropy.rb
@@ -2,13 +2,8 @@ cask "tropy" do
   arch arm: "-arm64"
 
   version "1.12.0"
-
-  on_intel do
-    sha256 "ef8e62028cd991ed8e668797035286f4e5220190a9d70591fe7e853be90b862d"
-  end
-  on_arm do
-    sha256 "d730a8747596a1a6d0c869cadbdc3bdff5ed371e05b205fad6b397dc5a4b872f"
-  end
+  sha256 arm:   "d730a8747596a1a6d0c869cadbdc3bdff5ed371e05b205fad6b397dc5a4b872f",
+         intel: "ef8e62028cd991ed8e668797035286f4e5220190a9d70591fe7e853be90b862d"
 
   url "https://github.com/tropy/tropy/releases/download/v#{version}/tropy-#{version}#{arch}.dmg",
       verified: "github.com/tropy/tropy/"

--- a/Casks/turbovnc-viewer.rb
+++ b/Casks/turbovnc-viewer.rb
@@ -2,13 +2,8 @@ cask "turbovnc-viewer" do
   arch arm: "arm64", intel: "x86_64"
 
   version "3.0.1"
-
-  on_intel do
-    sha256 "0b9f083d753dc65c0a023d8d9c6c95da997184645ea216b60a8e1db72f8baccb"
-  end
-  on_arm do
-    sha256 "76f451817884185f5832dc794831fbfb62d50104a6b416d4c78c6d55ea4b0f12"
-  end
+  sha256 arm:   "76f451817884185f5832dc794831fbfb62d50104a6b416d4c78c6d55ea4b0f12",
+         intel: "0b9f083d753dc65c0a023d8d9c6c95da997184645ea216b60a8e1db72f8baccb"
 
   url "https://downloads.sourceforge.net/turbovnc/#{version}/TurboVNC-#{version}-#{arch}.dmg",
       verified: "sourceforge.net/turbovnc/"

--- a/Casks/unity.rb
+++ b/Casks/unity.rb
@@ -2,13 +2,8 @@ cask "unity" do
   arch arm: "Arm64"
 
   version "2022.1.14f1,ff7e140968b4"
-
-  on_intel do
-    sha256 "b402869f381df07212d26d584b1e3baa74f989613ba14b32b2b888b27ecc6cfe"
-  end
-  on_arm do
-    sha256 "2a0a1c53c218c4c1830fc0742401aee08c03acc5d2c4e1e7afc01fa5a70dd29f"
-  end
+  sha256 arm:   "2a0a1c53c218c4c1830fc0742401aee08c03acc5d2c4e1e7afc01fa5a70dd29f",
+         intel: "b402869f381df07212d26d584b1e3baa74f989613ba14b32b2b888b27ecc6cfe"
 
   url "https://download.unity3d.com/download_unity/#{version.csv.second}/MacEditorInstaller#{arch}/Unity-#{version.csv.first}.pkg",
       verified: "download.unity3d.com/download_unity/"

--- a/Casks/utools.rb
+++ b/Casks/utools.rb
@@ -2,13 +2,8 @@ cask "utools" do
   arch arm: "-arm64"
 
   version "3.0.2"
-
-  on_intel do
-    sha256 "9b07b20a0c93e2ec3facdbe2b30d9eda9f62dee72eda972d124e3db6b074dd08"
-  end
-  on_arm do
-    sha256 "71fea8e3436b4ec3ecfe4e48cbb0cd0a95335632a8a521be5ceac70d34179b70"
-  end
+  sha256 arm:   "71fea8e3436b4ec3ecfe4e48cbb0cd0a95335632a8a521be5ceac70d34179b70",
+         intel: "9b07b20a0c93e2ec3facdbe2b30d9eda9f62dee72eda972d124e3db6b074dd08"
 
   url "https://publish.u-tools.cn/version2/uTools-#{version}#{arch}.dmg",
       verified: "publish.u-tools.cn/"

--- a/Casks/uvtools.rb
+++ b/Casks/uvtools.rb
@@ -2,13 +2,8 @@ cask "uvtools" do
   arch arm: "arm64", intel: "x64"
 
   version "3.6.2"
-
-  on_intel do
-    sha256 "11c701d1d1001f9a2c0237219decef8230973976f1f10f304ea44a0d18769a0e"
-  end
-  on_arm do
-    sha256 "8582eefc63c96b5eddeab5a541444ab322c531714d361ff57d63512e01dbc7a8"
-  end
+  sha256 arm:   "8582eefc63c96b5eddeab5a541444ab322c531714d361ff57d63512e01dbc7a8",
+         intel: "11c701d1d1001f9a2c0237219decef8230973976f1f10f304ea44a0d18769a0e"
 
   url "https://github.com/sn4k3/UVtools/releases/download/v#{version}/UVtools_osx-#{arch}_v#{version}.zip"
   name "UVtools"

--- a/Casks/v2rayu.rb
+++ b/Casks/v2rayu.rb
@@ -2,13 +2,8 @@ cask "v2rayu" do
   arch arm: "arm64", intel: "64"
 
   version "3.3.0"
-
-  on_intel do
-    sha256 "f20de5fae2308ac4c528d1e6ce9fd1aa071cfc05245d19924408640b2bbfd62b"
-  end
-  on_arm do
-    sha256 "9fb1aa5a2e8d5dc0243c6f5c6b99ee5ac44cf233d0a0280badc5a9709a22421c"
-  end
+  sha256 arm:   "9fb1aa5a2e8d5dc0243c6f5c6b99ee5ac44cf233d0a0280badc5a9709a22421c",
+         intel: "f20de5fae2308ac4c528d1e6ce9fd1aa071cfc05245d19924408640b2bbfd62b"
 
   url "https://github.com/yanue/V2rayU/releases/download/#{version}/V2rayU-#{arch}.dmg"
   name "V2rayU"

--- a/Casks/vassal.rb
+++ b/Casks/vassal.rb
@@ -2,13 +2,8 @@ cask "vassal" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "3.6.7"
-
-  on_intel do
-    sha256 "d5c01584a97aaee4aef222b0f07ada24ada823a7a515a79c357084b1ecddd8a2"
-  end
-  on_arm do
-    sha256 "0b1e00f631aba7b8d79185d8e96065e32af6dae994d8461e1a3fe5f513d9f66e"
-  end
+  sha256 arm:   "0b1e00f631aba7b8d79185d8e96065e32af6dae994d8461e1a3fe5f513d9f66e",
+         intel: "d5c01584a97aaee4aef222b0f07ada24ada823a7a515a79c357084b1ecddd8a2"
 
   url "https://github.com/vassalengine/vassal/releases/download/#{version}/VASSAL-#{version}-macos-#{arch}.dmg",
       verified: "github.com/vassalengine/vassal/"

--- a/Casks/vieb.rb
+++ b/Casks/vieb.rb
@@ -2,13 +2,8 @@ cask "vieb" do
   arch arm: "arm64-"
 
   version "9.0.0"
-
-  on_intel do
-    sha256 "ce68fd4485e58472a0f6b1461cab301d6e11ffb9a38f1ada8d0d22b08edd8cb0"
-  end
-  on_arm do
-    sha256 "a20c80a9b1f8842dc7985a5a1d1409e7b63bcc04e9495ce7a6b21c9471d70fc6"
-  end
+  sha256 arm:   "a20c80a9b1f8842dc7985a5a1d1409e7b63bcc04e9495ce7a6b21c9471d70fc6",
+         intel: "ce68fd4485e58472a0f6b1461cab301d6e11ffb9a38f1ada8d0d22b08edd8cb0"
 
   url "https://github.com/Jelmerro/Vieb/releases/download/#{version}/Vieb-#{version}-#{arch}mac.zip",
       verified: "github.com/Jelmerro/Vieb/"

--- a/Casks/visual-paradigm-ce.rb
+++ b/Casks/visual-paradigm-ce.rb
@@ -2,13 +2,8 @@ cask "visual-paradigm-ce" do
   arch arm: "AArch64", intel: "WithJRE"
 
   version "17.0,20220816"
-
-  on_intel do
-    sha256 "06521bb728f5aa338dd583daf789d5bc512884f1b4e043805cd09dfdb9926112"
-  end
-  on_arm do
-    sha256 "647b1a1facf321fff64af6591905df4f2293a675d56d0dcac0c8e6a74b03172d"
-  end
+  sha256 arm:   "647b1a1facf321fff64af6591905df4f2293a675d56d0dcac0c8e6a74b03172d",
+         intel: "06521bb728f5aa338dd583daf789d5bc512884f1b4e043805cd09dfdb9926112"
 
   url "https://www.visual-paradigm.com/downloads/vpce/Visual_Paradigm_CE_#{version.csv.first.dots_to_underscores}_#{version.csv.second}_OSX_#{arch}.dmg"
   name "Visual Paradigm Community Edition"

--- a/Casks/visual-paradigm.rb
+++ b/Casks/visual-paradigm.rb
@@ -2,13 +2,8 @@ cask "visual-paradigm" do
   arch arm: "AArch64", intel: "WithJRE"
 
   version "17.0,20220816"
-
-  on_intel do
-    sha256 "af1dea5f6b629d2e0e0a7347c53cd612d2ee8063084f272a79a2bbb085593f96"
-  end
-  on_arm do
-    sha256 "3e50ce8a3aed5374df2e85f5102b705d3e434f625816c974ed721262fb556549"
-  end
+  sha256 arm:   "3e50ce8a3aed5374df2e85f5102b705d3e434f625816c974ed721262fb556549",
+         intel: "af1dea5f6b629d2e0e0a7347c53cd612d2ee8063084f272a79a2bbb085593f96"
 
   url "https://www.visual-paradigm.com/downloads/vp#{version.csv.first}/#{version.csv.second}/Visual_Paradigm_#{version.csv.first.dots_to_underscores}_#{version.csv.second}_OSX_#{arch}.dmg"
   name "Visual Paradigm"

--- a/Casks/visual-studio-code.rb
+++ b/Casks/visual-studio-code.rb
@@ -2,13 +2,8 @@ cask "visual-studio-code" do
   arch arm: "darwin-arm64", intel: "darwin"
 
   version "1.70.2"
-
-  on_intel do
-    sha256 "0604e7680372fec22897ce985584117ee68ce9abf0ef1e95e3112c2ddeedc8dd"
-  end
-  on_arm do
-    sha256 "97ce7c68b35ae95ad75f38547c599c26b66741e2f719734c1bc5fbd34971faca"
-  end
+  sha256 arm:   "97ce7c68b35ae95ad75f38547c599c26b66741e2f719734c1bc5fbd34971faca",
+         intel: "0604e7680372fec22897ce985584117ee68ce9abf0ef1e95e3112c2ddeedc8dd"
 
   url "https://update.code.visualstudio.com/#{version}/#{arch}/stable"
   name "Microsoft Visual Studio Code"

--- a/Casks/vlc.rb
+++ b/Casks/vlc.rb
@@ -2,13 +2,8 @@ cask "vlc" do
   arch arm: "arm64", intel: "intel64"
 
   version "3.0.17.3"
-
-  on_intel do
-    sha256 "cca267f2c51ae568e02f3b4d8a6adba87b2bde5f011a2b87c595c102d89f11d8"
-  end
-  on_arm do
-    sha256 "cdee78a660c88758cbaa3424948dfbdb7c969824be1becfcbbe2aef725655200"
-  end
+  sha256 arm:   "cdee78a660c88758cbaa3424948dfbdb7c969824be1becfcbbe2aef725655200",
+         intel: "cca267f2c51ae568e02f3b4d8a6adba87b2bde5f011a2b87c595c102d89f11d8"
 
   url "https://download.videolan.org/vlc/#{version}/macosx/vlc-#{version}-#{arch}.dmg"
   name "VLC media player"

--- a/Casks/volt.rb
+++ b/Casks/volt.rb
@@ -2,16 +2,11 @@ cask "volt" do
   arch arm: "macos_arm64", intel: "macos"
 
   version "0.87"
+  sha256 arm:   "ae933c40c77742317f44a62c273bb8de805c9b5bc627711ddf618217f171cf28",
+         intel: "6ef5b811650bf28e2b5d8e0a57eaa843a8e3f3d235d72ca123d95ab035c5fe03"
 
   url "https://github.com/voltapp/volt/releases/download/#{version}/volt_#{arch}.zip",
       verified: "github.com/voltapp/volt/"
-  on_intel do
-    sha256 "6ef5b811650bf28e2b5d8e0a57eaa843a8e3f3d235d72ca123d95ab035c5fe03"
-  end
-  on_arm do
-    sha256 "ae933c40c77742317f44a62c273bb8de805c9b5bc627711ddf618217f171cf28"
-  end
-
   name "Volt"
   desc "Client for Slack, Discord, Skype, Gmail, Twitter, Facebook, and more"
   homepage "https://volt-app.com/"

--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -2,13 +2,8 @@ cask "vscodium" do
   arch arm: "arm64", intel: "x64"
 
   version "1.70.2.22230"
-
-  on_intel do
-    sha256 "117c099ce22c430dad0c8ca4daa56020e7b0cf0679d984c64d8d74790a8f2f8d"
-  end
-  on_arm do
-    sha256 "423bf7fbcce09c84072c7a0decec9eb3efda9a0e3efe2da31078618958fbb504"
-  end
+  sha256 arm:   "423bf7fbcce09c84072c7a0decec9eb3efda9a0e3efe2da31078618958fbb504",
+         intel: "117c099ce22c430dad0c8ca4daa56020e7b0cf0679d984c64d8d74790a8f2f8d"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{arch}.#{version}.dmg"
   name "VSCodium"

--- a/Casks/wasabi-wallet.rb
+++ b/Casks/wasabi-wallet.rb
@@ -2,13 +2,8 @@ cask "wasabi-wallet" do
   arch arm: "-arm64"
 
   version "2.0.1.4"
-
-  on_intel do
-    sha256 "d2a7076104d5473479b100f3039944efbf7fa599173af43a7dab3c32e7937fc1"
-  end
-  on_arm do
-    sha256 "cd4f7ed70f4470e5f052fc5e42d9afcab090ba5f8896488fd022bb59d30aa101"
-  end
+  sha256 arm:   "cd4f7ed70f4470e5f052fc5e42d9afcab090ba5f8896488fd022bb59d30aa101",
+         intel: "d2a7076104d5473479b100f3039944efbf7fa599173af43a7dab3c32e7937fc1"
 
   url "https://github.com/zkSNACKs/WalletWasabi/releases/download/v#{version}/Wasabi-#{version.chomp(".0")}#{arch}.dmg"
   name "Wasabi Wallet"

--- a/Casks/waterfox.rb
+++ b/Casks/waterfox.rb
@@ -2,13 +2,8 @@ cask "waterfox" do
   arch arm: "ARM.Setup", intel: "Setup"
 
   version "4.1.4"
-
-  on_intel do
-    sha256 "5b36be9e137031ec9dc567c5e47aeef39bfb852841e3294316f29d41af0cc6dc"
-  end
-  on_arm do
-    sha256 "4a602c1ffb65c9131b4be40318f19232547efc12346ab73f53b016cd122f494c"
-  end
+  sha256 arm:   "4a602c1ffb65c9131b4be40318f19232547efc12346ab73f53b016cd122f494c",
+         intel: "5b36be9e137031ec9dc567c5e47aeef39bfb852841e3294316f29d41af0cc6dc"
 
   url "https://github.com/WaterfoxCo/Waterfox/releases/download/G#{version}/Waterfox.G#{version}.#{arch}.dmg", verified: "github.com/WaterfoxCo/Waterfox/"
   name "Waterfox"

--- a/Casks/wavebox.rb
+++ b/Casks/wavebox.rb
@@ -2,13 +2,8 @@ cask "wavebox" do
   arch arm: "macarm64", intel: "mac"
 
   version "10.104.14.2"
-
-  on_intel do
-    sha256 "5dffdce0206e62fc3fd62078578f0bb04366d87cb85250150b4d02499079eb25"
-  end
-  on_arm do
-    sha256 "573470375f8b046c220fd4b897086996dbd4d743f0c3141f4b3c4bba4aa3593f"
-  end
+  sha256 arm:   "573470375f8b046c220fd4b897086996dbd4d743f0c3141f4b3c4bba4aa3593f",
+         intel: "5dffdce0206e62fc3fd62078578f0bb04366d87cb85250150b4d02499079eb25"
 
   url "https://download.wavebox.app/stable/#{arch}/Install%20Wavebox%20#{version}.dmg",
       verified: "download.wavebox.app/"

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -2,13 +2,8 @@ cask "webstorm" do
   arch arm: "-aarch64"
 
   version "2022.2.1,222.3739.57"
-
-  on_intel do
-    sha256 "7d57692ce83dd6c853c80c457bdb8239dd833cf5535c600154a7ebc0be18a05d"
-  end
-  on_arm do
-    sha256 "fa790240b0d00cb134bf0e87c6a85d5a749b73b3f577a9564a890e5819926e53"
-  end
+  sha256 arm:   "fa790240b0d00cb134bf0e87c6a85d5a749b73b3f577a9564a890e5819926e53",
+         intel: "7d57692ce83dd6c853c80c457bdb8239dd833cf5535c600154a7ebc0be18a05d"
 
   url "https://download.jetbrains.com/webstorm/WebStorm-#{version.csv.first}#{arch}.dmg"
   name "WebStorm"

--- a/Casks/webull.rb
+++ b/Casks/webull.rb
@@ -3,13 +3,8 @@ cask "webull" do
   livecheck_arch = on_arch_conditional arm: "qt_m1_global", intel: "qt_mac_global"
 
   version "6.2.5"
-
-  on_intel do
-    sha256 "5a6296a6c6e2f40f6d104ee3ef66dc3ae1f86ac59a76188d5dcfa13cebff3c12"
-  end
-  on_arm do
-    sha256 "47de9ca9e844212861dc6a31df00b189b6b05d782152993835cef40900e88994"
-  end
+  sha256 arm:   "47de9ca9e844212861dc6a31df00b189b6b05d782152993835cef40900e88994",
+         intel: "5a6296a6c6e2f40f6d104ee3ef66dc3ae1f86ac59a76188d5dcfa13cebff3c12"
 
   url "https://u1sweb.webullfintech.com/us/desktop/Webull%20Desktop_#{version}_#{arch}signed.dmg",
       verified: "u1sweb.webullfintech.com/us/desktop/"

--- a/Casks/wechatwebdevtools.rb
+++ b/Casks/wechatwebdevtools.rb
@@ -2,13 +2,8 @@ cask "wechatwebdevtools" do
   arch arm: "arm64", intel: "x64"
 
   version "1.06.2208010"
-
-  on_intel do
-    sha256 "e13b9cab93476d9076847ca74342fcc785854487a9044db6315426775a625942"
-  end
-  on_arm do
-    sha256 "04db8963a098baf726effecfdaf0bf42db24bc7f4e4100243a0d3bd891edb2e5"
-  end
+  sha256 arm:   "04db8963a098baf726effecfdaf0bf42db24bc7f4e4100243a0d3bd891edb2e5",
+         intel: "e13b9cab93476d9076847ca74342fcc785854487a9044db6315426775a625942"
 
   url "https://dldir1.qq.com/WechatWebDev/release/be1ec64cf6184b0fa64091919793f068/wechat_devtools_#{version}_darwin_#{arch}.dmg"
   name "Wechat DevTools"

--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -2,13 +2,8 @@ cask "weka" do
   arch arm: "arm-osx", intel: "osx"
 
   version "3.8.6"
-
-  on_intel do
-    sha256 "282d5ff81960d1ae43ee6e4e8eaa7ae8c341666a214e859728e15214af80383b"
-  end
-  on_arm do
-    sha256 "85de453da3bb41c952da48eee0bf574d1da7ee4fa6fd3a8e2d7a81a89d55d3d7"
-  end
+  sha256 arm:   "85de453da3bb41c952da48eee0bf574d1da7ee4fa6fd3a8e2d7a81a89d55d3d7",
+         intel: "282d5ff81960d1ae43ee6e4e8eaa7ae8c341666a214e859728e15214af80383b"
 
   url "https://downloads.sourceforge.net/weka/weka-#{version.dots_to_hyphens}-azul-zulu-#{arch}.dmg",
       verified: "sourceforge.net/weka/"

--- a/Casks/windows95.rb
+++ b/Casks/windows95.rb
@@ -3,15 +3,10 @@ cask "windows95" do
   arch arm: "arm64", intel: "x64"
 
   version "3.0.0"
+  sha256 arm:   "9197c0c3e7774f8cd9b57a87fd7ac5980cc0f0fae8ba944052f48ef4905996d0",
+         intel: "182f2eadf1c32159351e383130f4945ee87238ee9f6417ef5291d1a8f93be255"
 
   url "https://github.com/felixrieseberg/windows95/releases/download/v#{version}/windows95-darwin-#{arch}-#{version}.zip"
-  on_intel do
-    sha256 "182f2eadf1c32159351e383130f4945ee87238ee9f6417ef5291d1a8f93be255"
-  end
-  on_arm do
-    sha256 "9197c0c3e7774f8cd9b57a87fd7ac5980cc0f0fae8ba944052f48ef4905996d0"
-  end
-
   name "Windows 95"
   desc "Electron Windows 95"
   homepage "https://github.com/felixrieseberg/windows95"

--- a/Casks/wing-personal.rb
+++ b/Casks/wing-personal.rb
@@ -2,13 +2,8 @@ cask "wing-personal" do
   arch arm: "arm64", intel: "intel"
 
   version "8.3.3.0"
-
-  on_intel do
-    sha256 "06214808731fe6e267a7509254a62ffabf529d15f0a6ea0c45acbcd16191162c"
-  end
-  on_arm do
-    sha256 "9ef3113269f165c8a3235827cb39321fe488557440569c2060ff5b136b58a53a"
-  end
+  sha256 arm:   "9ef3113269f165c8a3235827cb39321fe488557440569c2060ff5b136b58a53a",
+         intel: "06214808731fe6e267a7509254a62ffabf529d15f0a6ea0c45acbcd16191162c"
 
   url "https://wingware.com/pub/wing-personal/#{version}/wing-personal-#{version}-#{arch}.dmg"
   name "Wing Personal"

--- a/Casks/wireshark.rb
+++ b/Casks/wireshark.rb
@@ -3,13 +3,8 @@ cask "wireshark" do
   livecheck_arch = on_arch_conditional arm: "arm", intel: "x86-"
 
   version "3.6.7"
-
-  on_intel do
-    sha256 "930fd418cf4b966b1299ceacd888ebd0705cf44269027cf375acc94cb7af49e8"
-  end
-  on_arm do
-    sha256 "ccf2511b3c55ce845b477a975908add1511addb309599eb50f40003a3f6eb8aa"
-  end
+  sha256 arm:   "ccf2511b3c55ce845b477a975908add1511addb309599eb50f40003a3f6eb8aa",
+         intel: "930fd418cf4b966b1299ceacd888ebd0705cf44269027cf375acc94cb7af49e8"
 
   url "https://2.na.dl.wireshark.org/osx/Wireshark%20#{version}%20#{arch}%2064.dmg"
   name "Wireshark"

--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -2,13 +2,8 @@ cask "wiznote" do
   arch arm: "arm64", intel: "x64"
 
   version "0.1.83"
-
-  on_intel do
-    sha256 "3a94e649cdfa05f36306591204c091f7efdf7f209337a0464219ad02823b20aa"
-  end
-  on_arm do
-    sha256 "2afd42ff3cc996f0d9122cd8aac1e590d5b53d7eb90d6f17221311bbfb7dd48d"
-  end
+  sha256 arm:   "2afd42ff3cc996f0d9122cd8aac1e590d5b53d7eb90d6f17221311bbfb7dd48d",
+         intel: "3a94e649cdfa05f36306591204c091f7efdf7f209337a0464219ad02823b20aa"
 
   url "https://get.wiz.cn/x/wiznote-desktop-#{version}-mac-#{arch}.dmg"
   name "WizNote"

--- a/Casks/wolai.rb
+++ b/Casks/wolai.rb
@@ -2,13 +2,8 @@ cask "wolai" do
   arch arm: "-arm64"
 
   version "1.2.3"
-
-  on_intel do
-    sha256 "e33b49fb41a264006d3e59b3ffad431f6aa1e70be24d0a2d07b9c128bf17f5b9"
-  end
-  on_arm do
-    sha256 "7df19bc987f827855524c2250fe81ca478aa05239c448060104c57a4cb30d277"
-  end
+  sha256 arm:   "7df19bc987f827855524c2250fe81ca478aa05239c448060104c57a4cb30d277",
+         intel: "e33b49fb41a264006d3e59b3ffad431f6aa1e70be24d0a2d07b9c128bf17f5b9"
 
   url "https://cdn.wostatic.cn/dist/installers/wolai-#{version}#{arch}.dmg",
       verified: "cdn.wostatic.cn/dist/installers/"

--- a/Casks/wpsoffice-cn.rb
+++ b/Casks/wpsoffice-cn.rb
@@ -2,13 +2,8 @@ cask "wpsoffice-cn" do
   arch arm: "arm64", intel: "x64"
 
   version "4.6.1,7450"
-
-  on_intel do
-    sha256 "fc9ec4881ee4c625a5e7dc311505a5b4710695decada5ce8be582eacccc12866"
-  end
-  on_arm do
-    sha256 "c3d27ce1af44bc8452614101f067798143bd7ffed2ddd93e5b39fc029252cf38"
-  end
+  sha256 arm:   "c3d27ce1af44bc8452614101f067798143bd7ffed2ddd93e5b39fc029252cf38",
+         intel: "fc9ec4881ee4c625a5e7dc311505a5b4710695decada5ce8be582eacccc12866"
 
   url "https://package.mac.wpscdn.cn/mac_wps_pkg/#{version.csv.first}/WPS_Office_#{version.csv.first}(#{version.csv.second})_#{arch}.dmg",
       verified: "package.mac.wpscdn.cn/mac_wps_pkg/"

--- a/Casks/yandex-music-unofficial.rb
+++ b/Casks/yandex-music-unofficial.rb
@@ -2,13 +2,8 @@ cask "yandex-music-unofficial" do
   arch arm: "-arm64"
 
   version "1.7.0"
-
-  on_intel do
-    sha256 "2134d6cedbc5df0a1c936c6168c6fd1826fc696290257f7084d7604bda16842c"
-  end
-  on_arm do
-    sha256 "465efa83db9e9f98d1b32f76584b900aa039dd46bd1664f11b0ad78b59ceb2d2"
-  end
+  sha256 arm:   "465efa83db9e9f98d1b32f76584b900aa039dd46bd1664f11b0ad78b59ceb2d2",
+         intel: "2134d6cedbc5df0a1c936c6168c6fd1826fc696290257f7084d7604bda16842c"
 
   url "https://github.com/juvirez/yandex-music-app/releases/download/v#{version}/Yandex-Music-Unofficial-#{version}#{arch}.dmg",
       verified: "github.com/juvirez/yandex-music-app/"

--- a/Casks/yggdrasil.rb
+++ b/Casks/yggdrasil.rb
@@ -2,13 +2,8 @@ cask "yggdrasil" do
   arch arm: "arm64", intel: "amd64"
 
   version "0.4.4"
-
-  on_intel do
-    sha256 "bbeb5ce175dfa009e3f54f08261a7554c6caf4a6143eb9993ff94bbf9d9f7cff"
-  end
-  on_arm do
-    sha256 "72c2cb3b1b4f3db27a60c948c930c56ebc25eb382fb6350bc137572b49617aaf"
-  end
+  sha256 arm:   "72c2cb3b1b4f3db27a60c948c930c56ebc25eb382fb6350bc137572b49617aaf",
+         intel: "bbeb5ce175dfa009e3f54f08261a7554c6caf4a6143eb9993ff94bbf9d9f7cff"
 
   url "https://github.com/yggdrasil-network/yggdrasil-go/releases/download/v#{version}/yggdrasil-#{version}-macos-#{arch}.pkg"
   name "Yggdrasil"

--- a/Casks/yubihsm2-sdk.rb
+++ b/Casks/yubihsm2-sdk.rb
@@ -2,13 +2,8 @@ cask "yubihsm2-sdk" do
   arch arm: "arm64", intel: "amd64"
 
   version "2022-06"
-
-  on_intel do
-    sha256 "fddd316127c460a604372ebbf41f01e3b9ef50b28ee5686915b663dd8f88cdc0"
-  end
-  on_arm do
-    sha256 "7363999e43afc4471853a4d7254de71e4d5f5c84d5e2febd1693d7bf22a1e525"
-  end
+  sha256 arm:   "7363999e43afc4471853a4d7254de71e4d5f5c84d5e2febd1693d7bf22a1e525",
+         intel: "fddd316127c460a604372ebbf41f01e3b9ef50b28ee5686915b663dd8f88cdc0"
 
   url "https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-#{version}-darwin-#{arch}.pkg"
   name "YubiHSM 2 SDK"

--- a/Casks/yuque.rb
+++ b/Casks/yuque.rb
@@ -2,13 +2,8 @@ cask "yuque" do
   arch arm: "-arm64"
 
   version "1.5.3"
-
-  on_intel do
-    sha256 "bceac42348e8b38cf258cf430c2c50f9bf0996ce7119c17ada012f8154d14e71"
-  end
-  on_arm do
-    sha256 "ccb7a030ecaeb3f2833244c42ec26331dac920947a9c1729a0e9b69be071b1e0"
-  end
+  sha256 arm:   "ccb7a030ecaeb3f2833244c42ec26331dac920947a9c1729a0e9b69be071b1e0",
+         intel: "bceac42348e8b38cf258cf430c2c50f9bf0996ce7119c17ada012f8154d14e71"
 
   url "https://app.nlark.com/yuque-desktop/#{version}/Yuque-#{version}#{arch}.dmg",
       verified: "app.nlark.com/yuque-desktop/"

--- a/Casks/zettlr.rb
+++ b/Casks/zettlr.rb
@@ -2,13 +2,8 @@ cask "zettlr" do
   arch arm: "arm64", intel: "x64"
 
   version "2.3.0"
-
-  on_intel do
-    sha256 "73ee8fbcf481b1cf68a3456f3c215be8a7d8835342220cc44fba6fa0440f37fc"
-  end
-  on_arm do
-    sha256 "0236d873d0d1477e480334fe8e68b795a8a7eb61cdbbf72d300143773e98955d"
-  end
+  sha256 arm:   "0236d873d0d1477e480334fe8e68b795a8a7eb61cdbbf72d300143773e98955d",
+         intel: "73ee8fbcf481b1cf68a3456f3c215be8a7d8835342220cc44fba6fa0440f37fc"
 
   url "https://github.com/Zettlr/Zettlr/releases/download/v#{version}/Zettlr-#{version}-#{arch}.dmg"
   name "Zettlr"

--- a/Casks/zoho-mail.rb
+++ b/Casks/zoho-mail.rb
@@ -2,13 +2,8 @@ cask "zoho-mail" do
   arch arm: "arm64-"
 
   version "1.4.1"
-
-  on_intel do
-    sha256 "8301dd5071e1091917aaa45bf7f16944b2c22cbf3435f28282cb0be57f115076"
-  end
-  on_arm do
-    sha256 "607c5c4614a37493d7dd5a2e06adf627a7f8e548acc81b2f60b637b78fecfbd5"
-  end
+  sha256 arm:   "607c5c4614a37493d7dd5a2e06adf627a7f8e548acc81b2f60b637b78fecfbd5",
+         intel: "8301dd5071e1091917aaa45bf7f16944b2c22cbf3435f28282cb0be57f115076"
 
   url "https://downloads.zohocdn.com/zmail-desktop/mac/zoho-mail-desktop-installer-#{arch}v#{version}.dmg",
       verified: "downloads.zohocdn.com/zmail-desktop/mac/"

--- a/Casks/zoom.rb
+++ b/Casks/zoom.rb
@@ -2,13 +2,8 @@ cask "zoom" do
   arch arm: "arm64/"
 
   version "5.11.9.10046"
-
-  on_intel do
-    sha256 "229a926ee45a66abfcb628bc862ddd7457899431b112d0eb29432fe6e4a64a3a"
-  end
-  on_arm do
-    sha256 "82382d92c043dcb5f04d044137e438417ca5c54fc2028dcc6556d409b56af9ab"
-  end
+  sha256 arm:   "82382d92c043dcb5f04d044137e438417ca5c54fc2028dcc6556d409b56af9ab",
+         intel: "229a926ee45a66abfcb628bc862ddd7457899431b112d0eb29432fe6e4a64a3a"
 
   url "https://cdn.zoom.us/prod/#{version}/#{arch}Zoom.pkg"
   name "Zoom.us"

--- a/Casks/zulip.rb
+++ b/Casks/zulip.rb
@@ -2,16 +2,11 @@ cask "zulip" do
   arch arm: "arm64", intel: "x64"
 
   version "5.9.3"
+  sha256 arm:   "c2bd27cea8654eb58d2b6a6bd1688a799f718accb607d7142416c7f90644b70c",
+         intel: "ac6f1aadc02dfe1ba04193f67f5f081b6f22d2bfde40c18956071e6cec9c390f"
 
   url "https://github.com/zulip/zulip-desktop/releases/download/v#{version}/Zulip-#{version}-#{arch}.dmg",
       verified: "github.com/zulip/zulip-desktop/"
-  on_intel do
-    sha256 "ac6f1aadc02dfe1ba04193f67f5f081b6f22d2bfde40c18956071e6cec9c390f"
-  end
-  on_arm do
-    sha256 "c2bd27cea8654eb58d2b6a6bd1688a799f718accb607d7142416c7f90644b70c"
-  end
-
   name "Zulip"
   desc "Desktop client for the Zulip team chat platform"
   homepage "https://zulipchat.com/apps/"

--- a/Casks/zulu.rb
+++ b/Casks/zulu.rb
@@ -3,13 +3,8 @@ cask "zulu" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "18.0.2,18.32.11-ca"
-
-  on_intel do
-    sha256 "7511ab48ff1f8d6dfad9941f86871d399ebae0ecf1543986b2a59c5cfbde69bd"
-  end
-  on_arm do
-    sha256 "6bfc8f5e839a4f04e43db40bd9ab49e437e738cfaa457cc79269dae94a703f81"
-  end
+  sha256 arm:   "6bfc8f5e839a4f04e43db40bd9ab49e437e738cfaa457cc79269dae94a703f81",
+         intel: "7511ab48ff1f8d6dfad9941f86871d399ebae0ecf1543986b2a59c5cfbde69bd"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/zulu/zulu-mac/"

--- a/Casks/zulufx.rb
+++ b/Casks/zulufx.rb
@@ -3,13 +3,8 @@ cask "zulufx" do
   choice = on_arch_conditional arm: "arm", intel: "x86"
 
   version "17.0.4,17.36.13-ca"
-
-  on_intel do
-    sha256 "ba4a3c89554e7fed10bfbabe4e2691cd8afbcf5413974b5d5d7d4afb62f36e25"
-  end
-  on_arm do
-    sha256 "eb1d209b0f91a7fa8a2149faa3f5a17de878a4c501823034e4982e954d9afbed"
-  end
+  sha256 arm:   "eb1d209b0f91a7fa8a2149faa3f5a17de878a4c501823034e4982e954d9afbed",
+         intel: "ba4a3c89554e7fed10bfbabe4e2691cd8afbcf5413974b5d5d7d4afb62f36e25"
 
   url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-fx-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/"


### PR DESCRIPTION
This PR changes most casks to use the new `sha256 arm: "...", intel: "..."` DSL instead of nesting only a single `sha256` in `on_arm` and `on_intel` blocks. There are a handful of casks that still use old style but with other things that make it a bit more complicated, so I'll open a separate PR to complete those.

The changes in this PR were made by running `brew style --fix homebrew/cask` using the style rules that are being worked on in https://github.com/Homebrew/brew/pull/13703.

As before, I've run `brew info --json=v2 --all` both before and after these changes and compared the results. On both Intel and ARM, there were no differences.

See also: https://github.com/Homebrew/brew/pull/13702
