### PR TITLE
Use arch and macOS version DSLs

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -2,22 +2,19 @@ cask "anki" do
   arch arm: "apple", intel: "intel"
 
   version "2.1.54"
+  sha256 arm:   "44e229181dd6db5b6d5a3f9c4647f4ae92c5acee0b47af99c8646c6a5cf927e1",
+         intel: "92eb39f59f4e7b8b1b025178b337a0ef9d619521144748a32b3e2b8df1c45a00"
 
-  if Hardware::CPU.intel?
-    if MacOS.version >= :mojave
-      sha256 "92eb39f59f4e7b8b1b025178b337a0ef9d619521144748a32b3e2b8df1c45a00"
-      qtversion = 6
-    else
-      sha256 "edc44e5862384bb1c419033267c78167809253090c0302f07114c00c223db07a"
-      qtversion = 5
-    end
-  else
-    sha256 "44e229181dd6db5b6d5a3f9c4647f4ae92c5acee0b47af99c8646c6a5cf927e1"
-    qtversion = 6
+  url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac-#{arch}-qt6.dmg",
+      verified: "github.com/ankitects/anki/"
+
+  on_high_sierra :or_older do
+    sha256 "edc44e5862384bb1c419033267c78167809253090c0302f07114c00c223db07a"
+
+    url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac-#{arch}-qt5.dmg",
+        verified: "github.com/ankitects/anki/"
   end
 
-  url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac-#{arch}-qt#{qtversion}.dmg",
-      verified: "github.com/ankitects/anki/"
   name "Anki"
   desc "Memory training application"
   homepage "https://apps.ankiweb.net/"

--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -1,22 +1,17 @@
 cask "eddie" do
+  arch arm: "arm64", intel: "x64"
+
   version "2.21.8"
+  sha256 arm:   "04edf9a6aa7311a62eb6827db44c7ed8ee677a0e2581d08a76f2bf004cf3ec0f",
+         intel: "9aecfd234ca1b19eee6518b1142643764a503d28b8ee3d873085fda22d25af85"
 
-  if Hardware::CPU.intel?
-    if MacOS.version <= :mojave
-      sha256 "a446563a6beb6f91542d6afbd6f90f6745b7a36fef363a13506cff9d8f078c78"
+  url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}",
+      verified: "eddie.website/"
 
-      url "https://eddie.website/download/?platform=macos-10.9&arch=x64&ui=ui&format=disk.dmg&version=#{version}",
-          verified: "eddie.website/"
-    else
-      sha256 "9aecfd234ca1b19eee6518b1142643764a503d28b8ee3d873085fda22d25af85"
+  on_mojave :or_older do
+    sha256 "a446563a6beb6f91542d6afbd6f90f6745b7a36fef363a13506cff9d8f078c78"
 
-      url "https://eddie.website/download/?platform=macos-10.15&arch=x64&ui=ui&format=disk.dmg&version=#{version}",
-          verified: "eddie.website/"
-    end
-  else
-    sha256 "04edf9a6aa7311a62eb6827db44c7ed8ee677a0e2581d08a76f2bf004cf3ec0f"
-
-    url "https://eddie.website/download/?platform=macos-10.15&arch=arm64&ui=ui&format=disk.dmg&version=#{version}",
+    url "https://eddie.website/download/?platform=macos-10.9&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}",
         verified: "eddie.website/"
   end
 

--- a/Casks/jamulus.rb
+++ b/Casks/jamulus.rb
@@ -1,19 +1,20 @@
 cask "jamulus" do
-  version "3.9.0"
+  arch arm: "_arm64"
 
-  if MacOS.version <= :mojave
+  version "3.9.0"
+  sha256 arm:   "353ed99c0497f2b2b668a910ab4f954a7ba51b8bca8c205c8f1c47db98e87fd5",
+         intel: "65f04e749c997bde9e1d814cd0423dd6a3fb6868ed1c62e5f8a8f9f2a1a5160c"
+
+  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac#{arch}.dmg",
+      verified: "downloads.sourceforge.net/llcon/"
+
+  on_mojave :or_older do
     sha256 "156555cdbd1ff618375f7c9d03a4da5fbd7d19ed57d67db8675ba6f57170e228"
-    suffix = "_legacy"
-  elsif Hardware::CPU.intel?
-    sha256 "65f04e749c997bde9e1d814cd0423dd6a3fb6868ed1c62e5f8a8f9f2a1a5160c"
-    suffix = ""
-  else
-    sha256 "353ed99c0497f2b2b668a910ab4f954a7ba51b8bca8c205c8f1c47db98e87fd5"
-    suffix = "_arm64"
+
+    url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac_legacy.dmg",
+        verified: "downloads.sourceforge.net/llcon/"
   end
 
-  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac#{suffix}.dmg",
-      verified: "downloads.sourceforge.net/llcon/"
   name "Jamulus"
   desc "Play music online with friends"
   homepage "https://jamulus.io/"

--- a/Casks/miniconda.rb
+++ b/Casks/miniconda.rb
@@ -2,12 +2,8 @@ cask "miniconda" do
   arch arm: "arm64", intel: "x86_64"
 
   version "py39_4.12.0"
-
-  if Hardware::CPU.intel?
-    sha256 "007bae6f18dc7b6f2ca6209b5a0c9bd2f283154152f82becf787aac709a51633"
-  else
-    sha256 "4bd112168cc33f8a4a60d3ef7e72b52a85972d588cd065be803eb21d73b625ef"
-  end
+  sha256 arm:   "4bd112168cc33f8a4a60d3ef7e72b52a85972d588cd065be803eb21d73b625ef",
+         intel: "007bae6f18dc7b6f2ca6209b5a0c9bd2f283154152f82becf787aac709a51633"
 
   url "https://repo.anaconda.com/miniconda/Miniconda3-#{version}-MacOSX-#{arch}.sh",
       verified: "repo.anaconda.com/miniconda/"
@@ -20,11 +16,7 @@ cask "miniconda" do
   # https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-#{arch}.sh
   livecheck do
     url "https://repo.anaconda.com/miniconda/"
-    if Hardware::CPU.intel?
-      regex(/>\s*Miniconda3-(py39[._-]\d+(?:\.\d+)+)-MacOSX-#{arch}\.sh\s*</i)
-    else
-      regex(/>\s*Miniconda3-(py38[._-]\d+(?:\.\d+)+)-MacOSX-#{arch}\.sh\s*</i)
-    end
+    regex(/>\s*Miniconda3-(py39[._-]\d+(?:\.\d+)+)-MacOSX-#{arch}\.sh\s*</i)
   end
 
   auto_updates true

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,13 +2,21 @@ cask "ocenaudio" do
   version "3.11.14"
   sha256 :no_check
 
-  if MacOS.version <= :high_sierra
-    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg"
-  elsif MacOS.version <= :catalina
-    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg"
-  elsif Hardware::CPU.intel?
-    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_bigsur.dmg"
-  else
+  on_intel do
+    on_high_sierra :or_older do
+      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg"
+    end
+    on_mojave do
+      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg"
+    end
+    on_catalina do
+      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg"
+    end
+    on_big_sur :or_newer do
+      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_bigsur.dmg"
+    end
+  end
+  on_arm do
     url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_bigsur_arm64.dmg"
   end
 

--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -1,37 +1,26 @@
 cask "qcad" do
+  arch arm: "11-12-arm64", intel: "10.14-12"
+
   version "3.27.6"
+  sha256 arm:   "a49ffa3adf3087ad9ac59de7fc54c7ea5ef131d6ca2950265916bacc86d3c405",
+         intel: "b3861329672b1a44d72de8fe02cc696a955dad6cd7c1cd18da9e064b7ef0f816"
 
-  if Hardware::CPU.intel?
-    if MacOS.version <= :high_sierra
-      sha256 "589a84168c38bf57435441511b19fa081b622e009719c4be7cc1385b7dc55eeb"
-      url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
+  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-#{arch}.dmg"
 
-      livecheck do
-        url "https://www.qcad.org/en/download"
-        regex(/qcad[._-]v?(\d+(?:\.\d+)+)[._-]trial[._-]macos[._-]10\.10[._-]10\.13\.dmg/i)
-      end
-    else
-      sha256 "b3861329672b1a44d72de8fe02cc696a955dad6cd7c1cd18da9e064b7ef0f816"
-      url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.14-12.dmg"
+  on_high_sierra :or_older do
+    sha256 "589a84168c38bf57435441511b19fa081b622e009719c4be7cc1385b7dc55eeb"
 
-      livecheck do
-        url "https://www.qcad.org/en/download"
-        regex(/qcad[._-]v?(\d+(?:\.\d+)+)[._-]trial[._-]macos[._-]10\.14[._-]12\.dmg/i)
-      end
-    end
-  else
-    sha256 "a49ffa3adf3087ad9ac59de7fc54c7ea5ef131d6ca2950265916bacc86d3c405"
-    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-11-12-arm64.dmg"
-
-    livecheck do
-      url "https://www.qcad.org/en/download"
-      regex(/qcad[._-]v?(\d+(?:\.\d+)+)[._-]trial[._-]macos[._-]11[._-]12[._-]arm64\.dmg/i)
-    end
+    url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   end
 
   name "QCAD"
   desc "Free, open source application for computer aided drafting in 2D"
   homepage "https://www.qcad.org/"
+
+  livecheck do
+    url "https://www.qcad.org/en/download"
+    regex(/qcad[._-]v?(\d+(?:\.\d+)+)[._-]trial[._-]macos[._-]#{arch}\.dmg/i)
+  end
 
   app "QCAD.app"
 end

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -1,16 +1,18 @@
 cask "r" do
-  if MacOS.version <= :sierra
+  arch arm: "-arm64"
+  folder = on_arch_conditional arm: "big-sur-arm64/base/", intel: "base/"
+
+  version "4.2.1"
+  sha256 arm:   "9a746270ef98bf038e3cbbc6e962fd3b7081786c49c59d37398261749ba5c693",
+         intel: "972d1e514baa873e4cda238f18163230fcd44d507f4b89d98cf5409e08b16bf9"
+
+  url "https://cloud.r-project.org/bin/macosx/#{folder}R-#{version}#{arch}.pkg"
+
+  on_sierra :or_older do
     version "3.6.3.nn"
     sha256 "f2b771e94915af0fe0a6f042bc7a04ebc84fb80cb01aad5b7b0341c4636336dd"
+
     url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
-  elsif Hardware::CPU.intel?
-    version "4.2.1"
-    sha256 "972d1e514baa873e4cda238f18163230fcd44d507f4b89d98cf5409e08b16bf9"
-    url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
-  else
-    version "4.2.1"
-    sha256 "9a746270ef98bf038e3cbbc6e962fd3b7081786c49c59d37398261749ba5c693"
-    url "https://cloud.r-project.org/bin/macosx/big-sur-arm64/base/R-#{version}-arm64.pkg"
   end
 
   name "R"
@@ -24,11 +26,7 @@ cask "r" do
 
   depends_on macos: ">= :el_capitan"
 
-  if Hardware::CPU.intel?
-    pkg "R-#{version}.pkg"
-  else
-    pkg "R-#{version}-arm64.pkg"
-  end
+  pkg "R-#{version}#{arch}.pkg"
 
   uninstall pkgutil: [
               "org.r-project*",

--- a/Casks/simply-fortran.rb
+++ b/Casks/simply-fortran.rb
@@ -1,28 +1,27 @@
 cask "simply-fortran" do
-  url_string = if MacOS.version <= :big_sur
-    "-x86_64.legacy"
-  else
-    Hardware::CPU.intel? ? "-x86_64" : "-arm64"
-  end
+  arch arm: "-arm64", intel: "-x86_64"
 
   version "3.25.3757"
+  sha256 arm:   "de1c523a1c4a2d2be2623eaa89b117ddca4bbd7edacdda6830e930d2463a3208",
+         intel: "cd177191c7a96d59c0e9c3bb271808a2b471d1001fca17b85cb420aaf55ee05a"
 
-  if MacOS.version <= :big_sur
-    sha256 "0975462a1593bdc976dc87d6a9da88b97d8268a1a97caebeefd359e56ef73195"
-  elsif Hardware::CPU.intel?
-    sha256 "cd177191c7a96d59c0e9c3bb271808a2b471d1001fca17b85cb420aaf55ee05a"
-  else
-    sha256 "de1c523a1c4a2d2be2623eaa89b117ddca4bbd7edacdda6830e930d2463a3208"
+  url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}#{arch}.dmg"
+
+  on_intel do
+    on_big_sur :or_older do
+      sha256 "0975462a1593bdc976dc87d6a9da88b97d8268a1a97caebeefd359e56ef73195"
+
+      url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}-x86_64.legacy.dmg"
+    end
   end
 
-  url "https://download.simplyfortran.com/#{version.major_minor}/macos/simplyfortran-#{version}#{url_string}.dmg"
   name "Simply Fortran"
   desc "Fortran development environment"
   homepage "https://simplyfortran.com/"
 
   livecheck do
     url "https://simplyfortran.com/download/?platform=macos"
-    regex(/href=.*?simplyfortran[._-]v?(\d+(?:\.\d+)+)#{url_string}\.dmg/i)
+    regex(/href=.*?simplyfortran[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
   end
 
   app "Simply Fortran.app"

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -1,19 +1,19 @@
 cask "smartgit" do
-  if MacOS.version <= :sierra
-    arch = "macosx"
-    version "20.2.6"
-    sha256 "af5fbf8db26edde3d996d99c6e82287332598359fe63ff2cd97c712a1685a2ea"
-  elsif Hardware::CPU.intel?
-    arch = "x86_64"
-    version "21.2.3"
-    sha256 "ed21b12d502be1528a163db0f9aea79d7c663ef6c02fdbada422a6d0657948dd"
-  else
-    arch = "aarch64"
-    version "21.2.3"
-    sha256 "6d66ead659cab90f07957945651006e05ed8c8baafd5b7fbacc8e78acdf0c1d0"
-  end
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "21.2.3"
+  sha256 arm:   "6d66ead659cab90f07957945651006e05ed8c8baafd5b7fbacc8e78acdf0c1d0",
+         intel: "ed21b12d502be1528a163db0f9aea79d7c663ef6c02fdbada422a6d0657948dd"
 
   url "https://www.syntevo.com/downloads/smartgit/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
+
+  on_sierra :or_older do
+    version "20.2.6"
+    sha256 "af5fbf8db26edde3d996d99c6e82287332598359fe63ff2cd97c712a1685a2ea"
+
+    url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
+  end
+
   name "SmartGit"
   desc "Git client"
   homepage "https://www.syntevo.com/smartgit/"

--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -1,33 +1,30 @@
 cask "transcribe" do
-  if MacOS.version <= :catalina
+  arch arm: "_arm"
+
+  livecheck_version = "11"
+
+  version "9.21"
+  sha256 :no_check
+
+  url "https://www.seventhstring.com/xscribe/transcribe#{arch}.dmg"
+
+  on_catalina :or_older do
     version "8.75.2"
     sha256 "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
 
     url "https://www.seventhstring.com/xscribe/downmo/transcribe#{version.no_dots}.dmg"
 
-    livecheck do
-      url "https://www.seventhstring.com/xscribe/download_mac.html"
-      regex(/version\s*(\d+(?:\.\d+)+)\s*for\s*Mac\s*OS\s*10/i)
-    end
-  else
-    version "9.21"
-    sha256 :no_check
-
-    if Hardware::CPU.intel?
-      url "https://www.seventhstring.com/xscribe/transcribe.dmg"
-    else
-      url "https://www.seventhstring.com/xscribe/transcribe_arm.dmg"
-    end
-
-    livecheck do
-      url "https://www.seventhstring.com/xscribe/download_mac.html"
-      regex(/version\s*(\d+(?:\.\d+)+)\s*for\s*Mac\s*OS\s*11/i)
-    end
+    livecheck_version = "10"
   end
 
   name "Transcribe!"
   desc "Transcribes recorded music"
   homepage "https://www.seventhstring.com/xscribe/overview.html"
+
+  livecheck do
+    url "https://www.seventhstring.com/xscribe/download_mac.html"
+    regex(/version\s*(\d+(?:\.\d+)+)\s*for\s*Mac\s*OS\s*#{livecheck_version}/i)
+  end
 
   app "Transcribe!.app"
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/130260 and the other DSL change PRs. This PR updates the casks that contain either unusual conditionals or both arch _and_ macOS version conditionals. These casks couldn't be updated with `brew style --fix` (or, if they could be updated, needed to be manually checked).

I've used `brew info --json=v2` on all of these casks to ensure that their JSON files remain the same before and after this PR. I tested on Monterey (ARM and Intel), Mojave (Intel), High Sierra (Intel) and Sierra (Intel) to ensure that there were no unexpected changes.
