### PR TITLE
remnote: add arm64 version

### DIFF
--- a/Casks/remnote.rb
+++ b/Casks/remnote.rb
@@ -1,8 +1,11 @@
 cask "remnote" do
-  version "1.8.17"
-  sha256 "6ca0a1a6555e843322f9d27c05c4c1039ea71bef2b15d224cc71a6ee63aa5aa1"
+  arch arm: "-arm64", intel: ""
 
-  url "https://download.remnote.io/RemNote-#{version}.dmg",
+  version "1.8.17"
+  sha256 arm:   "e03df3f1e18d5e4f2d9edd04a93c9cb1a8991e8b5fc926b5bb0bf3ff03ed4bf2",
+         intel: "6ca0a1a6555e843322f9d27c05c4c1039ea71bef2b15d224cc71a6ee63aa5aa1"
+
+  url "https://download.remnote.io/RemNote-#{version}#{arch}.dmg",
       verified: "remnote.io"
   name "RemNote"
   desc "Spaced-repetition powered note-taking tool"


### PR DESCRIPTION
Add the Apple Silicon version to remnote cask.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.