### PR TITLE
scilab: use `arch` DSL instead of `Hardware::CPU.arch`

### DIFF
--- a/Casks/scilab.rb
+++ b/Casks/scilab.rb
@@ -1,11 +1,11 @@
 cask "scilab" do
-  prefix = on_arch_conditional arm: "accelerate-" # there is also an "openblas-" version
+  arch arm: "accelerate-arm64", intel: "x86_64" # there is also an "openblas-" version
 
   version "6.1.1"
   sha256 arm:   "2f87710fc47c6d8e6777ee280ece589342e536c17290b9c033ea0dfcef3b4912",
          intel: "b417aace594cba882b19c2711aa125d8374d5da8b0a24df2873592765598e457"
 
-  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{prefix}#{Hardware::CPU.arch}.dmg",
+  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{arch}.dmg",
       verified: "utc.fr/~mottelet/scilab/"
   name "Scilab"
   desc "Software for numerical computation"
@@ -13,7 +13,7 @@ cask "scilab" do
 
   livecheck do
     url "https://www.utc.fr/~mottelet/scilab_for_macOS.html"
-    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{prefix}#{Hardware::CPU.arch}\.dmg/i)
+    regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)-#{arch}\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
This PR replaces the existing combination of `on_arch_conditional` and `Hardware::CPU.arch` in this cask to use only the `arch` DSL. This slipped through the style checks that I wrote so it wasn't fixed before. As usual. I've checked using `brew info --json=v2 scilab` on both ARM and Intel to ensure that the URLs have not changed as a result of this change.
