### PR TITLE
texpad: Rename texpad to texifier

### DIFF
--- a/Casks/texifier.rb
+++ b/Casks/texifier.rb
@@ -1,6 +1,6 @@
 cask "texifier" do
-  version "1.9.11,692,31230eb"
-  sha256 "9a331dd961594e4ca236a8c641a5849117653cf1bcb3bf6fb165dd370ae4d486"
+  version "1.9.11,696,9fd036a"
+  sha256 "96275fdf3d317eb4dd04d6e035930f597bba2ab73f5d62f85fdb5405f46ff1da"
 
   url "https://download.texifier.com/apps/osx/updates/Texifier_#{version.csv.first.dots_to_underscores}__#{version.csv.second}__#{version.csv.third}.dmg"
   name "Texpad"
@@ -8,7 +8,7 @@ cask "texifier" do
   homepage "https://www.texifier.com/mac"
 
   livecheck do
-    url "https://www.texpad.com/static-collected/upgrades/texpadappcast.xml"
+    url "https://www.texifier.com/apps/updates/texifier/stable-appcast.xml"
     strategy :sparkle do |item|
       "#{item.short_version},#{item.version},#{item.url[/_([^_]+)\.dmg/i, 1]}"
     end

--- a/Casks/texifier.rb
+++ b/Casks/texifier.rb
@@ -1,20 +1,11 @@
-cask "texpad" do
-  if MacOS.version <= :el_capitan
-    version "1.8.5,404,f8f30e5"
-    sha256 "676a1b071142c022cdfda57668c811f7747b36ded442548073fe6dda1b9ca934"
-  elsif MacOS.version <= :high_sierra
-    version "1.8.15,529,346c842"
-    sha256 "480bf4a3e8fd809c1eb07cb00099ed0d362996738a872efb42cb179488e8c1e1"
-  else
-    version "1.9.9,680,c9a035e"
-    sha256 "43cd70ec07f8602bc7228696d16ea288eeef70755a5355823d0963ec57540f04"
-  end
+cask "texifier" do
+  version "1.9.11,692,31230eb"
+  sha256 "9a331dd961594e4ca236a8c641a5849117653cf1bcb3bf6fb165dd370ae4d486"
 
-  url "https://download.texpadapp.com/apps/osx/updates/Texpad_#{version.csv.first.dots_to_underscores}__#{version.csv.second}__#{version.csv.third}.dmg",
-      verified: "download.texpadapp.com/"
+  url "https://download.texifier.com/apps/osx/updates/Texifier_#{version.csv.first.dots_to_underscores}__#{version.csv.second}__#{version.csv.third}.dmg"
   name "Texpad"
   desc "LaTeX editor"
-  homepage "https://www.texpad.com/mac"
+  homepage "https://www.texifier.com/mac"
 
   livecheck do
     url "https://www.texpad.com/static-collected/upgrades/texpadappcast.xml"
@@ -25,7 +16,7 @@ cask "texpad" do
 
   auto_updates true
 
-  app "Texpad.app"
+  app "Texifier.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.vallettaventures.texpad.sfl2",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
---

[texpad.com](https://www.texpad.com/) now redirects to [textifier.com](https://www.texifier.com/) with the following banner:
> This is a redirect from texpad.com. The LaTeX app Texpad is now called Texifier.

```
==> Analytics
install: 71 (30 days), 211 (90 days), 1,003 (365 days)
```