### PR TITLE
Upgrade surge-xt to 1.1.1

### DIFF
--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -1,6 +1,6 @@
 cask "surge-xt" do
-  version "1.1.0"
-  sha256 "03f8970ffe89ec576d436c5580ebf94e229154fe13ac9571118e99f3bbd58600"
+  version "1.1.1"
+  sha256 "2d0b36ea6a99c9b80e106ad7b4707beb29e1619988d9bd968d597af9865455a4"
 
   url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
       verified: "github.com/surge-synthesizer/releases-xt/"


### PR DESCRIPTION
Upgrade surge-xt to 1.1.1, our latest release

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
