### PR TITLE
Fix arm checksum for sage

### DIFF
--- a/Casks/sage.rb
+++ b/Casks/sage.rb
@@ -2,7 +2,7 @@ cask "sage" do
   arch arm: "arm64", intel: "x86_64"
 
   version "9.6,1.4.2"
-  sha256 arm:   "54a37b6391651ff04b4512cbf311422ab92e3373580a01d0e89349bc370f2562",
+  sha256 arm:   "0a49533f0d5ab6f4fc19ea9a6b5550a3f37d63824e6656fe9097b9bd83ab6adb",
          intel: "c1ecace231226798e95ee4d7a3f301943ca9bbcef58834addb16ca8f4132430f"
 
   url "https://github.com/3-manifolds/Sage_macOS/releases/download/v#{version.csv.second}/SageMath-#{version.csv.first}-#{version.csv.second}_#{arch}.dmg",


### PR DESCRIPTION
The checksum value was obtained from `hashes-9.6-1.4.2_x86_64.json`, which was released alongside \*.dmg files in  the [3-manifolds/Sage\_macOS](https://github.com/3-manifolds/Sage_macOS/releases/tag/v1.4.2) repository.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
