### PR TITLE
jupyterlab: update uninstall

### DIFF
--- a/Casks/jupyterlab.rb
+++ b/Casks/jupyterlab.rb
@@ -16,10 +16,7 @@ cask "jupyterlab" do
   app "JupyterLab.app"
 
   uninstall pkgutil: "com.electron.jupyterlab-desktop",
-            delete:  [
-              "/Applications/JupyterLab.app",
-              "/usr/local/bin/jlab",
-            ]
+            delete:  "/usr/local/bin/jlab"
 
   zap trash: [
     "~/.jupyter",


### PR DESCRIPTION
Removing `JupyterLab.app` is handled by `uninstall pkgutil:`:
```
|-> brew uninstall --zap jupyterlab
==> Implied `brew uninstall --cask jupyterlab`
==> Uninstalling packages; your password may be necessary:
==> Removing files:
/Applications/JupyterLab.app
Password:
/usr/local/bin/jlab
Error: It seems the App source '/Applications/JupyterLab.app' is not there.
```