### PR TITLE
Add two new labels.

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -36,3 +36,11 @@ jobs:
 
             - label: bump-cask-pr
               pr_body_content: Created with `brew bump-cask-pr`
+
+            - label: missing description
+              path: Casks/.+
+              missing_content: \n  desc .+\n
+
+            - label: appcast migration needed
+              path: Casks/.+
+              content: \n  appcast .+\n


### PR DESCRIPTION
About 200 casks are still using `appcast`. This should make them easier to spot if they come up in PRs.

Also, a bunch of casks are still missing descriptions, this should make it a bit more obvious to contributors.