### PR TITLE
ichm: recover ichm chm reader

### DIFF
--- a/Casks/ichm.rb
+++ b/Casks/ichm.rb
@@ -1,0 +1,11 @@
+cask "ichm" do
+  version "1.5.2"
+  sha256 "2630d05f085f24324eb6720131af738358dd01ea9e500bb01686352c679f96f0"
+
+  url "https://github.com/vit9696/iChm/releases/download/#{version}/iChm-#{version}-RELEASE.dmg"
+  name "iChm"
+  desc "CHM reader"
+  homepage "https://github.com/vit9696/iChm"
+
+  app "iChm.app"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

This PR recovers ichm after it was deleted in https://github.com/Homebrew/homebrew-cask/pull/78591. The naming is discussible, but other forks do not provide binary releases let alone signed/sandboxed, look dead, and the amount of changes if fairly significant.