### PR TITLE
Fix android-file-transfer zap

### DIFF
--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -18,9 +18,8 @@ cask "android-file-transfer" do
   app "Android File Transfer.app"
 
   zap trash: [
-        "~/Library/Application Support/Google/Android File Transfer",
-        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.android.mtpviewer.sfl*",
-        "~/Library/Preferences/com.google.android.mtpviewer.plist",
-      ],
-      rmdir: "~/Library/Application Support/Google/"
+    "~/Library/Application Support/Google/Android File Transfer",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.android.mtpviewer.sfl*",
+    "~/Library/Preferences/com.google.android.mtpviewer.plist",
+  ]
 end

--- a/Casks/android-file-transfer.rb
+++ b/Casks/android-file-transfer.rb
@@ -18,8 +18,9 @@ cask "android-file-transfer" do
   app "Android File Transfer.app"
 
   zap trash: [
-    "~/Library/Application Support/Google/Android File Transfer",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.android.mtpviewer.sfl*",
-    "~/Library/Preferences/com.google.android.mtpviewer.plist",
-  ]
+        "~/Library/Application Support/Google/Android File Transfer",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.google.android.mtpviewer.sfl*",
+        "~/Library/Preferences/com.google.android.mtpviewer.plist",
+      ],
+      rmdir: "~/Library/Application Support/Google"
 end


### PR DESCRIPTION
Removed `rmdir: "~/Library/Application Support/Google/"` from `zap`, since this folder is used by way more things than `android-file-transfer`, including things like Google Chrome and Google Drive.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.