### PR TITLE
Update webex-meetings.rb to install "Webex Meetings" instead of "Webex"

### DIFF
--- a/Casks/webex-meetings.rb
+++ b/Casks/webex-meetings.rb
@@ -1,5 +1,5 @@
 cask "webex-meetings" do
-  version "2203.1008.4204.1"
+  version "2208.2620.4209.3"
   sha256 :no_check
 
   on_intel do

--- a/Casks/webex-meetings.rb
+++ b/Casks/webex-meetings.rb
@@ -1,12 +1,12 @@
 cask "webex-meetings" do
-  version "42.8.0.23281"
+  version "2208.24.12550.007649"
   sha256 :no_check
 
   on_intel do
-    url "https://binaries.webex.com/WebexTeamsDesktop-MACOS-Gold/Webex.dmg"
+    url "https://akamaicdn.webex.com/client/webexapp.dmg"
   end
   on_arm do
-    url "https://binaries.webex.com/WebexDesktop-MACOS-Apple-Silicon-Gold/Webex.dmg"
+    url "https://akamaicdn.webex.com/client/Cisco_Webex_Meetings.pkg"
   end
 
   name "Webex Meetings"
@@ -14,12 +14,13 @@ cask "webex-meetings" do
   homepage "https://www.webex.com/"
 
   livecheck do
-    url "https://help.webex.com/en-us/article/mqkve8/Webex-App-|-Release-notes"
-    regex(/Mac[._-—](\d+(?:\.\d+)+)/i)
+    url :url
+    strategy :extract_plist
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+
+  pkg "Cisco_Webex_Meetings.pkg"
 
   uninstall quit:      [
               "com.cisco.webex.webexmta",

--- a/Casks/webex-meetings.rb
+++ b/Casks/webex-meetings.rb
@@ -1,5 +1,5 @@
 cask "webex-meetings" do
-  version "2208.24.12550.007649"
+  version "2203.1008.4204.1"
   sha256 :no_check
 
   on_intel do


### PR DESCRIPTION
Webex Meetings differs from the Webex app See: https://www.webex.com/content/dam/webex/eopi/assets/webex-launch-kits/FAQ_Meetings-to-Webex-upgrade.pdf
This is a manual revert of https://github.com/Homebrew/homebrew-cask/pull/126276 which has been updated to use on_intel/on_arm and has bumped the version
https://github.com/Homebrew/homebrew-cask/blob/master/Casks/webex.rb can be used to install the "Webex" app

--------------------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
