### PR TITLE
livebook: Update sha256 hashes

### DIFF
--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -2,8 +2,8 @@ cask "livebook" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "0.6.3"
-  sha256 arm:   "4ade56b044cd6386a50df54dc7033367cb9d72f7645bdb42bad331d806203ccf",
-         intel: "a28bbdba1acba0cbc80209248a051fb57692d4e52cd57ed0eb0ebed33e180bd7"
+  sha256 arm:   "dc841aaecaabe01ed83f3192d5daccdf0c1ce53a0e89dbc19d71f22510780d5e",
+         intel: "103cc9274b600f69c45a5d73e1743e8080c62d8ee82274efa4d6b08ea8ce0c37"
 
   url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-#{version}-macos-#{arch}.dmg",
       verified: "github.com/livebook-dev/livebook"


### PR DESCRIPTION
I came here because `brew install --cask livebook` throws an error:

> Error: SHA256 mismatch

So I

- downloaded the files from the official [GitHub release v0.6.3](https://github.com/livebook-dev/livebook/releases/tag/v0.6.3),
- ran `sha256sum` on them, and
- copy-pasted the resulting hashes here.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
