### PR TITLE
Basecamp: Add Apple Silicon version

### DIFF
--- a/Casks/basecamp.rb
+++ b/Casks/basecamp.rb
@@ -1,22 +1,18 @@
 cask "basecamp" do
+  arch arm: "_arm64"
+
   version "3,2.3.5"
-  sha256 "7553020b9406cc59fa0d76b009a1721983e4c0c305f402c0b865d19a772d87b8"
+  sha256 arm:   "adfdb4d99790d4cab594da29305b753b81711757c94cb5e23aed12dbaa65fbfa",
+         intel: "7553020b9406cc59fa0d76b009a1721983e4c0c305f402c0b865d19a772d87b8"
 
-  arch_suffix = ""
-
-  on_arm do
-    arch_suffix = "_arm64"
-    sha256 "adfdb4d99790d4cab594da29305b753b81711757c94cb5e23aed12dbaa65fbfa"
-  end
-
-  url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch_suffix}/basecamp#{version.major}-#{version.csv.second}.zip",
+  url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch}/basecamp#{version.major}-#{version.csv.second}.zip",
       verified: "bc3-desktop.s3.amazonaws.com/"
   name "Basecamp"
   desc "All-In-One Toolkit for Working Remotely"
   homepage "https://basecamp.com/help/#{version}/guides/apps/mac"
 
   livecheck do
-    url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch_suffix}/updates.json"
+    url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch}/updates.json"
     strategy :page_match do |page|
       minor_version = JSON.parse(page)["version"]
       major_version = page.match(/basecamp(\d)/i)

--- a/Casks/basecamp.rb
+++ b/Casks/basecamp.rb
@@ -2,14 +2,21 @@ cask "basecamp" do
   version "3,2.3.5"
   sha256 "7553020b9406cc59fa0d76b009a1721983e4c0c305f402c0b865d19a772d87b8"
 
-  url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac/basecamp#{version.major}-#{version.csv.second}.zip",
+  arch_suffix = ""
+
+  on_arm do
+    arch_suffix = "_arm64"
+    sha256 "adfdb4d99790d4cab594da29305b753b81711757c94cb5e23aed12dbaa65fbfa"
+  end
+
+  url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch_suffix}/basecamp#{version.major}-#{version.csv.second}.zip",
       verified: "bc3-desktop.s3.amazonaws.com/"
   name "Basecamp"
   desc "All-In-One Toolkit for Working Remotely"
   homepage "https://basecamp.com/help/#{version}/guides/apps/mac"
 
   livecheck do
-    url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac/updates.json"
+    url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch_suffix}/updates.json"
     strategy :page_match do |page|
       minor_version = JSON.parse(page)["version"]
       major_version = page.match(/basecamp(\d)/i)


### PR DESCRIPTION
The basecamp app provides native version for Apple Silicon macs. Download it when running on Apple Silicon.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online basecamp` is error-free.
- [x] `brew style --fix basecamp` reports no offenses.