### PR TITLE
nova: Require macOS 10.15+

### DIFF
--- a/Casks/nova.rb
+++ b/Casks/nova.rb
@@ -14,7 +14,7 @@ cask "nova" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "Nova.app"
   binary "#{appdir}/Nova.app/Contents/SharedSupport/nova"


### PR DESCRIPTION
Per [the Nova FAQ](https://help.panic.com/nova/purchase-faq/#system-requirements-and-installation), Nova requires macOS 10.15.7 or later.

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.