### PR TITLE
freecad: Fix livecheck & bump version to 0.20-1

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,8 +1,8 @@
 cask "freecad" do
-  version "0.20.0"
-  sha256 "fc62c10c408a00ed9c5c688f559464e4831f2a8aec6c9c374a024ba188f0e0af"
+  version "0.20-1,2022-08-20"
+  sha256 "0896d3fda3f660de86e73b7e824766dcf0e9dbcd56830ecca379717327281723"
 
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.major_minor}/FreeCAD-#{version}-OSX-i386.dmg",
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.csv.first.hyphens_to_dots}/FreeCAD_#{version.csv.first}-#{version.csv.second}-conda-macOS-x86_64-py310.dmg",
       verified: "github.com/FreeCAD/FreeCAD/"
   name "FreeCAD"
   desc "3D parametric modeler"
@@ -10,7 +10,12 @@ cask "freecad" do
 
   livecheck do
     url "https://www.freecadweb.org/downloads.php"
-    regex(/href=.*?FreeCAD[._-]v?(\d+(?:\.\d+)+)-OSX-i386\.dmg/i)
+    strategy :page_match do |page|
+      match = page.match(/href=.*?FreeCAD[._-]v?(\d+(?:\.\d+)-\d+)[._-](\d+(?:-\d+)+).*?\.dmg/i)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   conflicts_with cask: "homebrew/cask-versions/freecad-pre"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.