### PR TITLE
Add BlueBubbles 1.3.0

### DIFF
--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -9,4 +9,13 @@ cask "bluebubbles" do
   homepage "https://bluebubbles.app/"
 
   app "BlueBubbles.app"
+
+  zap trash: [
+    "~/Library/Application Support/@bluebubbles",
+    "~/Library/Application Support/bluebubbles-server",
+    "~/Library/Logs/@bluebubbles",
+    "~/Library/Logs/bluebubbles-server",
+    "~/Library/Preferences/com.BlueBubbles.BlueBubbles-Server.plist",
+    "~/Library/Saved Application State/com.BlueBubbles.BlueBubbles-Server.savedState",
+  ]
 end

--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -10,6 +10,17 @@ cask "bluebubbles" do
 
   app "BlueBubbles.app"
 
+  uninstall launchctl: "com.BlueBubbles.BlueBubbles-Server.ShipIt",
+            login_item: "BlueBubbles",
+            quit: [
+                    "com.BlueBubbles.BlueBubbles-Server",
+                    "com.BlueBubbles.BlueBubbles-Server.helper",
+                    "com.BlueBubbles.BlueBubbles-Server.helper.GPU",
+                    "com.BlueBubbles.BlueBubbles-Server.helper.Plugin",
+                    "com.BlueBubbles.BlueBubbles-Server.helper.Renderer",
+                    "com.bluebubbles.messaging",
+                  ],
+
   zap trash: [
     "~/Library/Application Support/@bluebubbles",
     "~/Library/Application Support/bluebubbles-server",

--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -2,7 +2,8 @@ cask "bluebubbles" do
   version "1.2.3"
   sha256 "06a8dbb3fc4b5b0065434722c738093018738fd4cd066b4e727453d5b9d93ade"
 
-  url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}.dmg"
+  url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}.dmg",
+      verified: "github.com/BlueBubblesApp/bluebubbles-server"
   name "BlueBubbles"
   desc "Server for forwarding iMessages to clients within the BlueBubbles App ecosystem"
   homepage "https://bluebubbles.app/"

--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -1,6 +1,6 @@
 cask "bluebubbles" do
-  version "1.2.3"
-  sha256 "06a8dbb3fc4b5b0065434722c738093018738fd4cd066b4e727453d5b9d93ade"
+  version "1.3.0"
+  sha256 "8c75146268bc92fea080c7eb8cca4b6e30b3c7e44d1fbdfc6fac2315de41039e"
 
   url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}.dmg",
       verified: "github.com/BlueBubblesApp/bluebubbles-server"

--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -10,16 +10,16 @@ cask "bluebubbles" do
 
   app "BlueBubbles.app"
 
-  uninstall launchctl: "com.BlueBubbles.BlueBubbles-Server.ShipIt",
+  uninstall launchctl:  "com.BlueBubbles.BlueBubbles-Server.ShipIt",
             login_item: "BlueBubbles",
-            quit: [
-                    "com.BlueBubbles.BlueBubbles-Server",
-                    "com.BlueBubbles.BlueBubbles-Server.helper",
-                    "com.BlueBubbles.BlueBubbles-Server.helper.GPU",
-                    "com.BlueBubbles.BlueBubbles-Server.helper.Plugin",
-                    "com.BlueBubbles.BlueBubbles-Server.helper.Renderer",
-                    "com.bluebubbles.messaging",
-                  ],
+            quit:       [
+              "com.BlueBubbles.BlueBubbles-Server",
+              "com.BlueBubbles.BlueBubbles-Server.helper",
+              "com.BlueBubbles.BlueBubbles-Server.helper.GPU",
+              "com.BlueBubbles.BlueBubbles-Server.helper.Plugin",
+              "com.BlueBubbles.BlueBubbles-Server.helper.Renderer",
+              "com.bluebubbles.messaging",
+            ]
 
   zap trash: [
     "~/Library/Application Support/@bluebubbles",

--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -1,0 +1,11 @@
+cask "bluebubbles" do
+  version "1.2.3"
+  sha256 "06a8dbb3fc4b5b0065434722c738093018738fd4cd066b4e727453d5b9d93ade"
+
+  url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}.dmg"
+  name "BlueBubbles"
+  desc "Server for forwarding iMessages to clients within the BlueBubbles App ecosystem"
+  homepage "https://bluebubbles.app/"
+
+  app "BlueBubbles.app"
+end


### PR DESCRIPTION
Note that `brew audit --new-cask bluebubbles` and `brew style --fix bluebubbles` are both failing locally with an error seemingly related to system Ruby:

<details>
<summary>`brew audit --new-cask bluebubbles`</summary>
```
➜  homebrew-cask git:(bluebubbles) brew audit --new-cask bluebubbles
==> Installing 'bundler' gem
Error: incompatible marshal file format (can't be read)
	format version 4.8 required; 60.33 given
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/api_set.rb:118:in `load'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/api_set.rb:118:in `versions'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/api_set.rb:55:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/composed_set.rb:55:in `block in find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/composed_set.rb:54:in `map'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/composed_set.rb:54:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/best_set.rb:31:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/installer_set.rb:155:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/installer_set.rb:56:in `add_always_install'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency_installer.rb:478:in `resolve_dependencies'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency_installer.rb:385:in `install'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems.rb:635:in `install'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:88:in `install_gem!'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:106:in `install_gem_setup_path!'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:123:in `install_bundler!'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:138:in `install_bundler_gems!'
/usr/local/Homebrew/Library/Homebrew/style.rb:86:in `run_rubocop'
/usr/local/Homebrew/Library/Homebrew/style.rb:54:in `check_style_impl'
/usr/local/Homebrew/Library/Homebrew/style.rb:36:in `check_style_json'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:175:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:93:in `<main>'
```
</details>

<details>
<summary>`brew style --fix bluebubbles`</summary>
```
➜  homebrew-cask git:(bluebubbles) brew style --fix bluebubbles
==> Installing 'bundler' gem
Error: incompatible marshal file format (can't be read)
	format version 4.8 required; 60.33 given
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/api_set.rb:118:in `load'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/api_set.rb:118:in `versions'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/api_set.rb:55:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/composed_set.rb:55:in `block in find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/composed_set.rb:54:in `map'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/composed_set.rb:54:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/best_set.rb:31:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/installer_set.rb:155:in `find_all'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/resolver/installer_set.rb:56:in `add_always_install'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency_installer.rb:478:in `resolve_dependencies'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency_installer.rb:385:in `install'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems.rb:635:in `install'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:88:in `install_gem!'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:106:in `install_gem_setup_path!'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:123:in `install_bundler!'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:138:in `install_bundler_gems!'
/usr/local/Homebrew/Library/Homebrew/style.rb:86:in `run_rubocop'
/usr/local/Homebrew/Library/Homebrew/style.rb:54:in `check_style_impl'
/usr/local/Homebrew/Library/Homebrew/style.rb:16:in `check_style_and_print'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/style.rb:75:in `style'
/usr/local/Homebrew/Library/Homebrew/brew.rb:93:in `<main>'
```
</details>
---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
