### PR TITLE
Add node-binary v18.8.0

### DIFF
--- a/Casks/node-binary.rb
+++ b/Casks/node-binary.rb
@@ -1,0 +1,22 @@
+cask "node-binary" do
+  arch arm: "arm64", intel: "x64"
+
+  version "18.8.0"
+  sha256 arm:   "a03cb97533447a5005accef871b899df0e9da33d8a805675ac53715a534b3dcb",
+         intel: "f8527a1820f50a5f4c835d933e5c5318c4f93f7382294db5875791e2cb0cc4fa"
+
+  url "https://nodejs.org/dist/v#{version}/node-v#{version}-darwin-#{arch}.tar.xz"
+  name "Node.js"
+  desc "Platform built on V8 to build network applications"
+  homepage "https://nodejs.org/"
+
+  livecheck do
+    url "https://nodejs.org/en/download/current"
+    regex(/node-v(\d+(?:\.\d+)+)\.pkg/i)
+  end
+
+  binary "node-v#{version}-darwin-#{arch}/bin/node", target: "node-binary"
+  binary "node-v#{version}-darwin-#{arch}/bin/npm", target: "npm-binary"
+  binary "node-v#{version}-darwin-#{arch}/bin/npx", target: "npx-binary"
+  binary "node-v#{version}-darwin-#{arch}/bin/corepack", target: "corepack-binary"
+end


### PR DESCRIPTION
Add cask for NodeJS binaries for users who may not wish to compile from source. This includes node, npm, npx, corepack.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
