### PR TITLE
Re-Add/Update XLink Kai.app to v7.4.43

### DIFF
--- a/Casks/xlink-kai.rb
+++ b/Casks/xlink-kai.rb
@@ -1,0 +1,21 @@
+cask "xlink-kai" do
+  version "7.4.43,606669993"
+  sha256 "01ad053900d624e7b98507a7f2d2f15723bd40e08ea70dceee43057c230a0631"
+
+  url "https://cdn.teamxlink.co.uk/kai/XLinkKai-#{version.csv.first}-#{version.csv.second}-macOS_x86_64.dmg"
+  name "XLink Kai"
+  desc "Free online play for all your favourite consoles"
+  homepage "https://www.teamxlink.co.uk/"
+
+  livecheck do
+    url "https://api.teamxlink.co.uk/kai/releases/v2/?platform=macos_x86_64"
+    strategy :page_match do |page|
+      match = page.match(%r{/XLinkKai-(\d+(?:\.\d+)*)-(\d+)-macOS_x86_64\.dmg}i)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  depends_on cask: "wireshark-chmodbpf"
+
+  app "XLink Kai.app"
+end


### PR DESCRIPTION
Re-adding XLink Kai as it was removed for being out of date. We're now back on track!
See: https://github.com/Homebrew/homebrew-cask/pull/112619

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
