### PR TITLE
Add MacForge 1.1.0

### DIFF
--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -18,6 +18,7 @@ cask "macforge" do
   app "MacForge.app"
 
   uninstall launchctl: "com.macenhance.MacForge.Injector",
+            login_item: "MacForgeHelper",
             quit:      [
               "com.macenhance.MacForge",
               "com.macenhance.MacForge.PreferenceLoader",

--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -16,4 +16,30 @@ cask "macforge" do
   auto_updates true
 
   app "MacForge.app"
+
+  uninstall launchctl: "com.macenhance.MacForge.Injector",
+            quit:      [
+              "com.macenhance.MacForge",
+              "com.macenhance.MacForge.PreferenceLoader",
+              "com.macenhance.MacForgeDockTile",
+              "com.macenhance.MacForgeHelper",
+              "com.macenhance.SIPKit",
+            ]
+
+  zap trash: [
+    "/Library/Application Support/MacEnhance",
+    "/Library/LaunchDaemons/com.macenhance.MacForge.Injector.plist",
+    "/Library/PrivilegedHelperTools/com.macenhance.MacForge.Injector",
+    "~/Library/Application Support/MacEnhance",
+    "~/Library/Application Support/com.macenhance.MacForge",
+    "~/Library/Caches/com.macenhance.MacForge",
+    "~/Library/Caches/com.macenhance.MacForgeHelper",
+    "~/Library/HTTPStorages/com.macenhance.MacForge",
+    "~/Library/HTTPStorages/com.macenhance.MacForge.binarycookies",
+    "~/Library/HTTPStorages/com.macenhance.MacForgeHelper",
+    "~/Library/Preferences/com.macenhance.MacForge.plist",
+    "~/Library/Preferences/com.macenhance.MacForgeHelper.plist",
+    "~/Library/Saved Application State/com.macenhance.MacForge.savedState",
+    "~/Library/WebKit/com.macenhance.MacForge",
+  ]
 end

--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -25,14 +25,16 @@ cask "macforge" do
               "com.macenhance.MacForgeDockTile",
               "com.macenhance.MacForgeHelper",
               "com.macenhance.SIPKit",
+            ],
+            delete:     [
+              "/Library/Application Support/MacEnhance",
+              "/Library/LaunchDaemons/com.macenhance.MacForge.Injector.plist",
+              "/Library/PrivilegedHelperTools/com.macenhance.MacForge.Injector",
             ]
 
   zap trash: [
-    "/Library/Application Support/MacEnhance",
-    "/Library/LaunchDaemons/com.macenhance.MacForge.Injector.plist",
-    "/Library/PrivilegedHelperTools/com.macenhance.MacForge.Injector",
-    "~/Library/Application Support/MacEnhance",
     "~/Library/Application Support/com.macenhance.MacForge",
+    "~/Library/Application Support/MacEnhance",
     "~/Library/Caches/com.macenhance.MacForge",
     "~/Library/Caches/com.macenhance.MacForgeHelper",
     "~/Library/HTTPStorages/com.macenhance.MacForge",

--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -1,0 +1,21 @@
+cask "macforge" do
+  version "1.1.0"
+  sha256 "5a28c4f43b9b9bb868e26e45096804a1b7ae604fbf3ae857bed63d495a43ec50"
+
+  url "https://github.com/w0lfschild/app_updates/raw/master/MacForge1/MacForge.#{version}.zip",
+      verified: "github.com/w0lfschild/app_updates"
+  name "MacForge"
+  desc "Plugin, App, and Theme store which includes plugin injection for macOS"
+  homepage "https://www.macenhance.com/macforge"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/w0lfschild/app_updates/master/MacForge1/appcast.xml"
+    strategy :sparkle do |item|
+      item.short_version
+    end
+  end
+
+  auto_updates true
+
+  app "MacForge.app"
+end

--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -5,7 +5,7 @@ cask "macforge" do
   url "https://github.com/w0lfschild/app_updates/raw/master/MacForge1/MacForge.#{version}.zip",
       verified: "github.com/w0lfschild/app_updates"
   name "MacForge"
-  desc "Plugin, App, and Theme store which includes plugin injection for macOS"
+  desc "Plugin, App, and Theme store which includes plugin injection"
   homepage "https://www.macenhance.com/macforge"
 
   livecheck do

--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -10,9 +10,7 @@ cask "macforge" do
 
   livecheck do
     url "https://raw.githubusercontent.com/w0lfschild/app_updates/master/MacForge1/appcast.xml"
-    strategy :sparkle do |item|
-      item.short_version
-    end
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/macforge.rb
+++ b/Casks/macforge.rb
@@ -17,9 +17,9 @@ cask "macforge" do
 
   app "MacForge.app"
 
-  uninstall launchctl: "com.macenhance.MacForge.Injector",
+  uninstall launchctl:  "com.macenhance.MacForge.Injector",
             login_item: "MacForgeHelper",
-            quit:      [
+            quit:       [
               "com.macenhance.MacForge",
               "com.macenhance.MacForge.PreferenceLoader",
               "com.macenhance.MacForgeDockTile",


### PR DESCRIPTION
Add MacForge v1.1.0

The `brew audit --new-cask` notability check is failing because the distribution lives in https://github.com/w0lfschild/app_updates (w0lfschild is the maintainer of MacForge) but the source repo more than meets the requirements: https://github.com/MacEnhance/MacForge

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
