### PR TITLE
Fix regex match in list_login_items_for_app

### DIFF
--- a/developer/bin/list_login_items_for_app
+++ b/developer/bin/list_login_items_for_app
@@ -34,7 +34,7 @@ def usage
 end
 
 def process_args
-  if /^-+h(?:elp)?$/.match?(ARGV.first)
+  if /^-+h(?:elp)?$/.match(ARGV.first)
     puts usage
     exit 0
   elsif ARGV.length == 1


### PR DESCRIPTION
Prior to the fix:

```
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/developer/bin/list_login_items_for_app:37:in `process_args': undefined method `match?' for /^-+h(?:elp)?$/:Regexp (NoMethodError)
Did you mean?  match
	from /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/developer/bin/list_login_items_for_app:65:in `<main>'
```
