### PR TITLE
Add BEAST v2.7.0

### DIFF
--- a/Casks/beast2.rb
+++ b/Casks/beast2.rb
@@ -1,5 +1,5 @@
 cask "beast2" do
-  # note: "2" is not a version number, but an intrinsic part of the product name
+  # NOTE: "2" is not a version number, but an intrinsic part of the product name
   version "2.7.0"
   sha256 "656fee774e82ddbdf630b8787cf90912ab2bca8c1972bbe83ac1305fa3b608cd"
 

--- a/Casks/beast2.rb
+++ b/Casks/beast2.rb
@@ -10,4 +10,12 @@ cask "beast2" do
   homepage "https://www.beast2.org/"
 
   suite "BEAST #{version}"
+
+  zap trash: [
+    "~/Library/Application Support/BEAST/2.7/",
+    "~/Library/Preferences/beast.app.beauti.Beauti.plist",
+    "~/Library/Saved Application State/beastfx.app.beast.BeastMain.savedState",
+    "~/Library/Preferences/tracer.plist",
+    "~/Library/Preferences/viz.DensiTree.plist",
+  ]
 end

--- a/Casks/beast2.rb
+++ b/Casks/beast2.rb
@@ -1,0 +1,14 @@
+# typed: false
+# frozen_string_literal: true
+
+cask "beast2" do
+  version "2.7.0"
+  sha256 "656fee774e82ddbdf630b8787cf90912ab2bca8c1972bbe83ac1305fa3b608cd"
+
+  url "https://github.com/CompEvol/beast2/releases/download/v#{version}/BEAST.v#{version}.Mac.dmg", verified: "https://github.com/CompEvol/beast2"
+  name "BEAST2"
+  desc "Bayesian evolutionary analysis by sampling trees"
+  homepage "https://www.beast2.org/"
+
+  suite "BEAST 2.7.0"
+end

--- a/Casks/beast2.rb
+++ b/Casks/beast2.rb
@@ -1,14 +1,13 @@
-# typed: false
-# frozen_string_literal: true
-
 cask "beast2" do
+  # note: "2" is not a version number, but an intrinsic part of the product name
   version "2.7.0"
   sha256 "656fee774e82ddbdf630b8787cf90912ab2bca8c1972bbe83ac1305fa3b608cd"
 
-  url "https://github.com/CompEvol/beast2/releases/download/v#{version}/BEAST.v#{version}.Mac.dmg", verified: "https://github.com/CompEvol/beast2"
+  url "https://github.com/CompEvol/beast2/releases/download/v#{version}/BEAST.v#{version}.Mac.dmg",
+      verified: "github.com/CompEvol/beast2/"
   name "BEAST2"
   desc "Bayesian evolutionary analysis by sampling trees"
   homepage "https://www.beast2.org/"
 
-  suite "BEAST 2.7.0"
+  suite "BEAST #{version}"
 end

--- a/Casks/beast2.rb
+++ b/Casks/beast2.rb
@@ -12,10 +12,10 @@ cask "beast2" do
   suite "BEAST #{version}"
 
   zap trash: [
-    "~/Library/Application Support/BEAST/2.7/",
+    "~/Library/Application Support/BEAST",
     "~/Library/Preferences/beast.app.beauti.Beauti.plist",
-    "~/Library/Saved Application State/beastfx.app.beast.BeastMain.savedState",
     "~/Library/Preferences/tracer.plist",
     "~/Library/Preferences/viz.DensiTree.plist",
+    "~/Library/Saved Application State/beastfx.app.beast.BeastMain.savedState",
   ]
 end


### PR DESCRIPTION
BEAST2 is a suite many people in science use, many more than the reported github starts, which should satisfy the bare minimum already. It bugs me for a while that it is not available in brew, so here we are.

Some tools contained in the suite have been refused in the passed, but beast2 itself hasn't. please consider this for addition.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
