### PR TITLE
bump Dangerzone to 0.3.2 & update repo

### DIFF
--- a/Casks/dangerzone.rb
+++ b/Casks/dangerzone.rb
@@ -1,9 +1,9 @@
 cask "dangerzone" do
-  version "0.3.1"
-  sha256 "a97719233316006ce2e2981f24f193b61510a2c958e4f67769bfc136d459a508"
+  version "0.3.2"
+  sha256 "95fa7bc2feff03715d33b84fd5a51d0271ffb07902ee616de0106513e4a411d8"
 
-  url "https://github.com/firstlookmedia/dangerzone/releases/download/v#{version}/Dangerzone-#{version}.dmg",
-      verified: "github.com/firstlookmedia/dangerzone/"
+  url "https://github.com/freedomofpress/dangerzone/releases/download/v#{version}/Dangerzone-#{version}.dmg",
+      verified: "github.com/freedomofpress/dangerzone/"
   name "Dangerzone"
   desc "Convert potentially dangerous PDFs or Office documents into safe PDFs"
   homepage "https://dangerzone.rocks/"


### PR DESCRIPTION
The Freedom of the Press Foundation (FPF) [adopted the Dangerzone software](https://freedom.press/news/welcome-to-the-dangerzone/) and because of this it now lives in FPF's github repo.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
