### PR TITLE
sha256 mismatch for VisIt version 3.3.0

### DIFF
--- a/Casks/visit.rb
+++ b/Casks/visit.rb
@@ -7,7 +7,7 @@ cask "visit" do
         verified: "github.com/visit-dav/visit/"
   else
     version "3.3.0"
-    sha256 "9c8c8fc753612afdc08517ec657cb184c729b3c70cccb78dc3910d936a34f26d"
+    sha256 "81cd0da08740b1598bb0cc9a0ba58246d0589c02dc2455e3fdfafa7ea020df90"
 
     url "https://github.com/visit-dav/visit/releases/download/v#{version}/VisIt-#{version}.dmg",
         verified: "github.com/visit-dav/visit/"


### PR DESCRIPTION
There is a sha256 mismatch here. I replaced it by the sequence you can find in https://github.com/visit-dav/visit/releases/download/v3.3.0/visit_sha256_checksums.txt

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
