### PR TITLE
kindle-previewer: Change livecheck

### DIFF
--- a/Casks/kindle-previewer.rb
+++ b/Casks/kindle-previewer.rb
@@ -1,5 +1,5 @@
 cask "kindle-previewer" do
-  version "3.67.0"
+  version "3.67"
   sha256 :no_check
 
   url "https://d2bzeorukaqrvt.cloudfront.net/KindlePreviewerInstaller.pkg",
@@ -9,8 +9,8 @@ cask "kindle-previewer" do
   homepage "https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011"
 
   livecheck do
-    url :homepage
-    regex(/Kindle\s*Previewer\s*(\d+(?:\.\d+)+)/i)
+    url :url
+    strategy :extract_plist
   end
 
   auto_updates true

--- a/Casks/kindle-previewer.rb
+++ b/Casks/kindle-previewer.rb
@@ -9,8 +9,9 @@ cask "kindle-previewer" do
   homepage "https://www.amazon.com/Kindle-Previewer/b?ie=UTF8&node=21381691011"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    # url :homepage
+    # regex(/Kindle\s*Previewer\s*(\d+(?:\.\d+)+)/i)
+    skip "Requires :browser user agent"
   end
 
   auto_updates true


### PR DESCRIPTION
Existing livecheck is broken due to changes on Amazon's side. The page requests you contact Amazon about accessing the page in an automated manner instead of serving the content.

I've changed the strategy to `:extract_plist` which is obviously not ideal, but works.