### PR TITLE
osu: Change livecheck

### DIFF
--- a/Casks/osu.rb
+++ b/Casks/osu.rb
@@ -12,7 +12,7 @@ cask "osu" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
Changing to `:github_latest` due to discrepancies with GitHub tags.