### PR TITLE
Fix nheko SHA256

### DIFF
--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -1,6 +1,6 @@
 cask "nheko" do
   version "0.10.1"
-  sha256 "e7f3822c49164b319fae9b346cfdae270b26604fd98801760b638d81a0de2c0c"
+  sha256 "b2a05b8075bea5606cf8612af7cf678bb5a64819915d98a8885dbe08af473b34"
 
   url "https://github.com/Nheko-Reborn/nheko/releases/download/v#{version}/nheko-v#{version}.dmg",
       verified: "github.com/Nheko-Reborn/nheko/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
# Context
Nheko swapped the files for the [same release](https://github.com/Nheko-Reborn/nheko/releases/tag/v0.10.1) which is causing issues for homebrew users trying to upgrade nheko (like me).
This is a manual fix, trying to follow roughly what `bump-cask-pr` would do as described in `--dry-run` mode.