### PR TITLE
iptvnator: Change livecheck

### DIFF
--- a/Casks/iptvnator.rb
+++ b/Casks/iptvnator.rb
@@ -9,7 +9,7 @@ cask "iptvnator" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   app "iptvnator.app"


### PR DESCRIPTION
Switching to `:github_latest` strategy due to tag discrepancies.