### PR TITLE
fanny: update livecheck

### DIFF
--- a/Casks/fanny.rb
+++ b/Casks/fanny.rb
@@ -4,11 +4,12 @@ cask "fanny" do
 
   url "https://fannywidget.com/FannyWidget.zip"
   name "FannyWidget"
+  desc "Notification Center widget and menu bar application to monitor fans"
   homepage "https://fannywidget.com/"
 
   livecheck do
-    url "https://github.com/DanielStormApps/Fanny/releases"
-    strategy :git
+    url :homepage
+    regex(%r{href=.*?FannyWidget\.zip["' >].*?v?(\d+(?:\.\d+)+).*?</a>}im)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `fanny` checks the Git tags from the [related GitHub repository](https://github.com/DanielStormApps/Fanny) but this has the potential to produce a mismatch if a new version is tagged but `FannyWidget.zip` hasn't been updated on the homepage yet.

This PR updates the `livecheck` block to match the version from the text of the download button (e.g., `Download v2.3.0`), so the livecheck version aligns with the version of `FannyWidget.zip` on the first-party website. I'm not thrilled with the loose `.*?` parts of this regex but, in this particular context, I felt that the looseness may help to prevent the regex from breaking if there are small changes to the HTML of the download button (and that there's currently minimal chance of it causing problems).

Besides that, this adds a `desc` to resolve the related audit error (feel free to tweak it, if it can be improved).