### PR TITLE
templates.rb: add publish-commit-casks.yml

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -19,7 +19,7 @@ puts 'Detecting changes…'
   '.github/*.md',
   '.github/*.yml',
   '.github/ISSUE_TEMPLATE/*.{md,yml}',
-  '.github/workflows/{cache,ci,dispatch-command,rebase,rerun-workflow,review,triage}.yml',
+  '.github/workflows/{cache,ci,dispatch-command,publish-commit-casks,rebase,rerun-workflow,review,triage}.yml',
   '.gitignore',
   '.travis.yml',
   'Casks/.rubocop.yml',


### PR DESCRIPTION
This will add the `publish-commit-casks.yml` workflow to the other Cask repositories.