### PR TITLE
gitup: update urls

### DIFF
--- a/Casks/gitup.rb
+++ b/Casks/gitup.rb
@@ -1,15 +1,15 @@
 cask "gitup" do
   version "1.3.2"
-  sha256 :no_check
+  sha256 "62324db3916658a7b56bd1888a457003d3ba7c184d9cbd0d00ca4d19c8b1413a"
 
-  url "https://gitup-builds.s3.amazonaws.com/stable/GitUp.zip",
-      verified: "gitup-builds.s3.amazonaws.com/"
+  url "https://github.com/git-up/GitUp/releases/download/v#{version}/GitUp.zip",
+      verified: "github.com/git-up/GitUp/"
   name "GitUp"
   desc "Git interface focused on visual interaction"
   homepage "https://gitup.co/"
 
   livecheck do
-    url "https://github.com/git-up/GitUp/releases"
+    url :url
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `url` for `gitup` is unversioned and the homepage doesn't provide any version information, so the `livecheck` block was checking the releases on GitHub as a best guess at the version in `GitUp.zip` (though there's no explicit guarantee that the zip from the homepage will be in parity with GitHub). However, the releases on GitHub provide the same `GitUp.zip` file (i.e., it has the same `sha256` as the AWS file), so we can migrate to a versioned URL if we switch to the zip file from GitHub.

This PR modifies the `url` accordingly, adds a `sha256`, and updates the `livecheck` block to use `url :url`.