### PR TITLE
spotify: Add sha256

### DIFF
--- a/Casks/spotify.rb
+++ b/Casks/spotify.rb
@@ -2,7 +2,7 @@ cask "spotify" do
   arch arm: "ARM64"
 
   version "1.1.93.896,3ae3b4f3,10"
-  sha256 :no_check
+  sha256 "354427a2e113bc6318362ea70f81ae09b8e84205ebb9f1acc7bc9a292adf52d1"
 
   url "https://download.scdn.co/Spotify#{arch}.dmg",
       verified: "download.scdn.co/"


### PR DESCRIPTION
This was marked as `:no_check` [by automation][1] rather than by a human so it seems reasonable to convert it to sha256 sum now.

[1]: https://github.com/timvisher/homebrew-cask/commit/c8cd897435157aa7d79767c667012b3f14f5895b

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions).
- [x] `brew audit --cask --online spotify` is error-free.
- [x] `brew style --fix spotify` reports no offenses.

~Additionally, **if adding a new cask**:~ N/A
