### PR TITLE
Fix Element checksum & app version 1.11.5.

### DIFF
--- a/Casks/element.rb
+++ b/Casks/element.rb
@@ -1,18 +1,16 @@
 cask "element" do
-  # NOTE: currently the file version and application version diverge, for unknown reasons!
   version "1.11.5"
-  file_version = "1.11.2"
-  sha256 "bfa6585340a69b0185f758e546a05697a76f0f19ca8986b58a1661f2b7a34f61"
+  sha256 :no_check
 
-  url "https://packages.riot.im/desktop/install/macos/Element-#{file_version}-universal.dmg",
-      verified: "packages.riot.im/desktop/"
+  url "https://packages.riot.im/desktop/install/macos/Element.dmg",
+      verified: "packages.riot.im/desktop/install/macos/"
   name "Element"
   desc "Matrix collaboration client"
   homepage "https://element.io/get-started"
 
   livecheck do
-    url "https://github.com/vector-im/element-desktop/releases/tag"
-    regex(/v(\d+(?:\.\d+)*)/i)
+    url :url
+    strategy :extract_plist
   end
 
   auto_updates true

--- a/Casks/element.rb
+++ b/Casks/element.rb
@@ -1,8 +1,10 @@
 cask "element" do
-  version "1.11.2"
-  sha256 "ffecde430594c14dc9b71b70be376ce7515f20e00529128a0f256830de99a094"
+  # NOTE: currently the file version and application version diverge, for unknown reasons!
+  version "1.11.5"
+  file_version = "1.11.2"
+  sha256 "bfa6585340a69b0185f758e546a05697a76f0f19ca8986b58a1661f2b7a34f61"
 
-  url "https://packages.riot.im/desktop/install/macos/Element-#{version}-universal.dmg",
+  url "https://packages.riot.im/desktop/install/macos/Element-#{file_version}-universal.dmg",
       verified: "packages.riot.im/desktop/"
   name "Element"
   desc "Matrix collaboration client"

--- a/Casks/element.rb
+++ b/Casks/element.rb
@@ -11,8 +11,8 @@ cask "element" do
   homepage "https://element.io/get-started"
 
   livecheck do
-    url "https://packages.riot.im/desktop/install/macos"
-    regex(/Element[._-]\(?(\d+(?:\.\d+)*)[._-]universal\.dmg/i)
+    url "https://github.com/vector-im/element-desktop/releases/tag"
+    regex(/v(\d+(?:\.\d+)*)/i)
   end
 
   auto_updates true


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Details:
- the Element DMG file/url name still contains version `1.11.2`.
- But the content of the DMG file has changed, meanwhile a 3rd time, which causes a checksum change:
  1. v1.11.3 => PR #129902, 
  2. v1.11.4 => PR #130829.
  3. Current version after installation is v1.11.5, see also https://github.com/vector-im/element-desktop/releases/.
      <img width="396" alt="version screenshot" src="https://user-images.githubusercontent.com/9170345/190018422-57cc2fd9-3443-447e-bc05-4a1540d4c860.png">

This PR tries to manage the divergence of app and DMG file versions, and attempts to fix the livecheck, which previously relied on the version from the DMG file name.