### PR TITLE
Update streamlink-twitch-gui to 2.2.0

### DIFF
--- a/Casks/streamlink-twitch-gui.rb
+++ b/Casks/streamlink-twitch-gui.rb
@@ -1,6 +1,6 @@
 cask "streamlink-twitch-gui" do
-  version "2.1.0"
-  sha256 "a093923ff3926338f3a6aa6041fd1c7ad32c864adeb657d197b5235e97acd020"
+  version "2.2.0"
+  sha256 "1101b5dd4076277dce55be0d86741f4e6a28af472c5498d26e6477c2c608502b"
 
   url "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v#{version}/streamlink-twitch-gui-v#{version}-macOS.tar.gz"
   name "Streamlink Twitch GUI"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online Casks/streamlink-twitch-gui.rb` is error-free.
- [x] `brew style --fix Casks/streamlink-twitch-gui.rb` reports no offenses.