### PR TITLE
Add ARM download URL to mutesync.app cask

### DIFF
--- a/Casks/mutesync.rb
+++ b/Casks/mutesync.rb
@@ -1,17 +1,12 @@
 cask "mutesync" do
+  arch arm: "-arm64", intel: ""
+
   version "5.4.1"
   sha256 arm:   "037980f23abcb95dc879c4caec31985e6129a426a068603447573d51d04c9c45",
          intel: "d9f4e90b9a9de3f779f1a3fbffc6d62b3c63e1d69f1be8a232cba19a5fffd633"
 
-  on_arm do
-    url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}-arm64.dmg",
-        verified: "mutesync.s3.us-west-2.amazonaws.com/"
-  end
-  on_intel do
-    url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}.dmg",
-        verified: "mutesync.s3.us-west-2.amazonaws.com/"
-  end
-
+  url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}#{arch}.dmg",
+      verified: "mutesync.s3.us-west-2.amazonaws.com/"
   name "mütesync"
   desc "Companion app to the mütesync physical button"
   homepage "https://mutesync.com/"

--- a/Casks/mutesync.rb
+++ b/Casks/mutesync.rb
@@ -1,9 +1,17 @@
 cask "mutesync" do
   version "5.4.1"
-  sha256 "d9f4e90b9a9de3f779f1a3fbffc6d62b3c63e1d69f1be8a232cba19a5fffd633"
+  sha256 arm:   "037980f23abcb95dc879c4caec31985e6129a426a068603447573d51d04c9c45",
+         intel: "d9f4e90b9a9de3f779f1a3fbffc6d62b3c63e1d69f1be8a232cba19a5fffd633"
 
-  url "https://mutesync.s3-us-west-2.amazonaws.com/mutesync-#{version}.dmg",
-      verified: "mutesync.s3-us-west-2.amazonaws.com/"
+  on_arm do
+    url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}-arm64.dmg",
+      verified: "mutesync.s3.us-west-2.amazonaws.com/"
+  end
+  on_intel do
+    url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}.dmg",
+      verified: "mutesync.s3.us-west-2.amazonaws.com/"
+  end
+
   name "mütesync"
   desc "Companion app to the mütesync physical button"
   homepage "https://mutesync.com/"

--- a/Casks/mutesync.rb
+++ b/Casks/mutesync.rb
@@ -5,11 +5,11 @@ cask "mutesync" do
 
   on_arm do
     url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}-arm64.dmg",
-      verified: "mutesync.s3.us-west-2.amazonaws.com/"
+        verified: "mutesync.s3.us-west-2.amazonaws.com/"
   end
   on_intel do
     url "https://mutesync.s3.us-west-2.amazonaws.com/mutesync-#{version}.dmg",
-      verified: "mutesync.s3.us-west-2.amazonaws.com/"
+        verified: "mutesync.s3.us-west-2.amazonaws.com/"
   end
 
   name "mütesync"


### PR DESCRIPTION
After installing with the old cask definition, starting the application showed me a pop-up telling me they had released a separate version for M1/M2 Macs. This updates the cask definition to grab the separate DMGs for ARM and Intel.

I found two different ways casks were doing this. Either by setting an `arch` variable that is used within the download URL, or using the `on_` blocks. I went with the latter as I thought an empty string variable for the Intel URL would just be confusing for the next person to read this definition.

---

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
