### PR TITLE
Fix avidemux file route naming for 2.8.1

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -7,9 +7,9 @@ cask "avidemux" do
         verified: "sourceforge.net/avidemux/"
   else
     version "2.8.1"
-    sha256 "816645f5eb2c903019d563ea5c684b5afbbdc1e52c90da9b387406559baf6574"
+    sha256 "b0b8890114172d531d138f6c1413f0393c0e5a87530168106a12d6b11ae44833"
 
-    url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_BigSur_Qt6.dmg",
+    url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}v2_Monterey_Qt6.dmg",
         verified: "sourceforge.net/avidemux/"
   end
 


### PR DESCRIPTION
Fix source filename for route on avidemux 2.8.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

![Screenshot 2022-09-20 at 12 02 35](https://user-images.githubusercontent.com/32466105/191229691-2743b0e6-f612-4c25-9d07-33e24b15403c.png)


Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
