### PR TITLE
Fix sha256sum mismatch error for lookin cask

### DIFF
--- a/Casks/lookin.rb
+++ b/Casks/lookin.rb
@@ -4,6 +4,7 @@ cask "lookin" do
 
   url "https://cdn.lookin.work/release/Lookin-#{version.csv.first.dots_to_hyphens}.zip"
   name "Lookin"
+  desc "App for iOS view debugging"
   homepage "https://lookin.work/"
 
   livecheck do

--- a/Casks/lookin.rb
+++ b/Casks/lookin.rb
@@ -1,6 +1,6 @@
 cask "lookin" do
   version "1.0.1,8"
-  sha256 "59368d8cd30e52e1852c79dce8bde02014d5bd282ae6306d0efed176e581a719"
+  sha256 "7932c8f7dce671170f464e6ecd5daa0eff847e31838e3570d308e46638e00670"
 
   url "https://cdn.lookin.work/release/Lookin-#{version.csv.first.dots_to_hyphens}.zip"
   name "Lookin"


### PR DESCRIPTION
Lookin app has a outdated sha256sum code in `lookin.rb`, this PR fix it.

Evidence:
![image](https://user-images.githubusercontent.com/1164623/191479755-3245ccb1-928c-4117-aedc-b893e959be02.png)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
