### PR TITLE
Update perforce from 2022.1,2305383 to 2022.1,2344699

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask "perforce" do
-  version "2022.1,2305383"
-  sha256 "2500a23fe482a303bd400f0de460b7624ad3f940fef45246004b9f956e90ea45"
+  version "2022.1,2344699"
+  sha256 "c0ad74b749af7bf7fcef7adbe71dfd975407a8163a14f3a8c4fd4b9639531d55"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
   name "Perforce Helix Core Server"
@@ -12,7 +12,7 @@ cask "perforce" do
   homepage "https://www.perforce.com/"
 
   livecheck do
-    url "https://www.perforce.com/perforce/doc.current/user/relnotes.txt"
+    url "https://cdist2.perforce.com/perforce/r22.1/doc/user/relnotes.txt"
     strategy :page_match do |page|
       page.scan(%r{\((\d+(?:\.\d+)+)/(\d+)\)}i).map do |match|
         "#{match[0]},#{match[1]}"


### PR DESCRIPTION
Perforce has updated the tgz found at the download link from 2022.1,2305383 to 2022.1,2344699.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

```shell
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask % brew audit --cask --online perforce
==> Downloading https://cdist2.perforce.com/perforce/r22.1/bin.macosx1015x86_64/helix-core-server.tgz
Already downloaded: /Users/mgd/Library/Caches/Homebrew/downloads/006a645d393c46891382e4d5fdfa92386bf644b2b5b793c6eecc3dc98e4e0861--helix-core-server.tgz
audit for perforce: failed
 - Version '2022.1,2344699' differs from '2022.1,2305383' retrieved by livecheck.
 - Version '2022.1,2344699' differs from '2022.1,2305383' retrieved by livecheck.
Error: 1 problem in 1 cask detected
```
This is exactly what the pull request is supposed to address, that the version has been updated by Perforce at the same download link.

Running without `--online` makes the audit pass:
```shell
martingd@mac/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask 👉 brew audit --cask perforce  
audit for perforce: passed
```

- [x] `brew style --fix <cask>` reports no offenses.
