### PR TITLE
Update perforce from 2022.1,2305383 to 2022.1,2344699

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask "perforce" do
-  version "2022.1,2305383"
-  sha256 "2500a23fe482a303bd400f0de460b7624ad3f940fef45246004b9f956e90ea45"
+  version "2022.1,2344699"
+  sha256 "c0ad74b749af7bf7fcef7adbe71dfd975407a8163a14f3a8c4fd4b9639531d55"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
   name "Perforce Helix Core Server"
@@ -12,7 +12,7 @@ cask "perforce" do
   homepage "https://www.perforce.com/"
 
   livecheck do
-    url "https://www.perforce.com/perforce/doc.current/user/relnotes.txt"
+    url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/doc/user/relnotes.txt"
     strategy :page_match do |page|
       page.scan(%r{\((\d+(?:\.\d+)+)/(\d+)\)}i).map do |match|
         "#{match[0]},#{match[1]}"


### PR DESCRIPTION
Updated cask to accept newest Perforce release 2022.1,2344699:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
