### PR TITLE
cakebrew: Fix URL & discontinue

### DIFF
--- a/Casks/cakebrew.rb
+++ b/Casks/cakebrew.rb
@@ -2,16 +2,10 @@ cask "cakebrew" do
   version "1.3"
   sha256 "a83fc72bd0b4dd62b716adfdfccb0fce3a589b3cba16bea7e2d55d829918e300"
 
-  url "https://cakebrew-377a.kxcdn.com/cakebrew-#{version}.zip",
-      verified: "cakebrew-377a.kxcdn.com/"
+  url "https://github.com/brunophilipe/Cakebrew/releases/download/v#{version}/cakebrew-#{version}-universal.zip"
   name "Cakebrew"
   desc "GUI app for Homebrew"
-  homepage "https://www.cakebrew.com/"
-
-  livecheck do
-    url "https://www.cakebrew.com/appcast/profileInfo.php"
-    strategy :sparkle, &:short_version
-  end
+  homepage "https://github.com/brunophilipe/Cakebrew"
 
   auto_updates true
 
@@ -22,4 +16,8 @@ cask "cakebrew" do
     "~/Library/Preferences/com.brunophilipe.Cakebrew.plist",
     "~/Library/Saved Application State/com.brunophilipe.Cakebrew.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Changing to GitHub repo since homepage is gone. Last release was a year and a half ago, but the cask is still fairly popular so setting it to discontinued.

```
==> Analytics
install: 1,285 (30 days), 3,387 (90 days), 12,122 (365 days)
```