### PR TITLE
Update pritunl from 1.3.3290.45 to 1.3.3300.95

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,9 +1,9 @@
 cask "pritunl" do
   arch arm: ".arm64"
 
-  version "1.3.3290.45"
-  sha256 arm:   "c2747afb41f4cc1a564328ce419cef682f1f77998e55a3e3ff01ca404345a1aa",
-         intel: "87ea50c0977240e7f256edecca1a6a274e67a4920b868b727cc9708b23f0ab4f"
+  version "1.3.3300.95"
+  sha256 arm:   "205f0945570a0dda9cd30bf32193e052dc53f1c2669fb24d5defd9aa7d51090e",
+         intel: "40477be6f3c5303b1a92457db10f001723cf13f314d53f70e1c8f0cddf76c556"
 
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl#{arch}.pkg.zip",
       verified: "github.com/pritunl/pritunl-client-electron/"


### PR DESCRIPTION
Update pritunl from 1.3.3290.45 to 1.3.3300.95

https://github.com/pritunl/pritunl-client-electron/releases/tag/1.3.3300.95