### PR TITLE
bitrix24: Update from 11.1.41.57 to 14.0.16.70 and move to livecheck

### DIFF
--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -5,6 +5,7 @@ cask "bitrix24" do
 
   url "https://dl.bitrix24.com/b24/bitrix24_desktop.dmg"
   name "Bitrix24"
+  desc "Online workspace for your business"
   homepage "https://www.bitrix24.com/apps/mobile-and-desktop-apps.php#desktop_app"
 
   livecheck do

--- a/Casks/bitrix24.rb
+++ b/Casks/bitrix24.rb
@@ -1,12 +1,16 @@
 cask "bitrix24" do
   # NOTE: "24" is not a version number, but an intrinsic part of the product name
-  version "11.1.41.57"
+  version "14.0.16.70"
   sha256 :no_check
 
   url "https://dl.bitrix24.com/b24/bitrix24_desktop.dmg"
-  appcast "https://www.bitrix24.com/osx_version.php"
   name "Bitrix24"
   homepage "https://www.bitrix24.com/apps/mobile-and-desktop-apps.php#desktop_app"
+
+  livecheck do
+    url "https://www.bitrix24.com/osx_version.php"
+    strategy :sparkle
+  end
 
   app "Bitrix24.app"
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Haven't added a description because I legit can't make heads or tails of the page