### PR TITLE
Update jgrennison-openttd from 0.48.3 to 0.48.4

### DIFF
--- a/Casks/jgrennison-openttd.rb
+++ b/Casks/jgrennison-openttd.rb
@@ -1,6 +1,6 @@
 cask "jgrennison-openttd" do
-  version "0.48.3"
-  sha256 "39844a06e16e9916fb594e24c91d5d43f32f07cd1b35895a8a8530bba48310be"
+  version "0.48.4"
+  sha256 "8943613bc94dc5258480c31c227b3f9340da2ef16bf9245ce411aae3e0d828dc"
 
   url "https://github.com/JGRennison/OpenTTD-patches/releases/download/jgrpp-#{version}/openttd-jgrpp-#{version}-macos-universal.dmg"
   name "JGR's OpenTTD Patchpack"


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
