### PR TITLE
Fix for incorrect sha256 sum for fbreader package

### DIFF
--- a/Casks/fbreader.rb
+++ b/Casks/fbreader.rb
@@ -1,6 +1,6 @@
 cask "fbreader" do
   version "1.999.16"
-  sha256 "a2c1bdb5b39452cbd1d241639c34d8f4384363e41a34ae90539e839b1423a9c9"
+  sha256 "4f487bc18f8171e5b6a7af915834acb3d177b53640aa243a5f468ce89ac95513"
 
   url "https://fbreader.org/static/packages/macos/FBReader-#{version}.dmg"
   name "FBReader"


### PR DESCRIPTION
Tried to install fbreader from brew and got the issue with checksum

So for actual version we have an issue

```
$ brew audit --cask --online fbreader
==> Downloading https://fbreader.org/static/packages/macos/FBReader-1.999.16.dmg
Already downloaded: /Users/roman/Library/Caches/Homebrew/downloads/f58e2e79718a97c7418b104ce499894d2fafbfbae7bd7cd8584aa514998f62e9--FBReader-1.999.16.dmg
audit for fbreader: failed
 - download not possible: SHA256 mismatch
Expected: a2c1bdb5b39452cbd1d241639c34d8f4384363e41a34ae90539e839b1423a9c9
  Actual: 4f487bc18f8171e5b6a7af915834acb3d177b53640aa243a5f468ce89ac95513
    File: /Users/roman/Library/Caches/Homebrew/downloads/f58e2e79718a97c7418b104ce499894d2fafbfbae7bd7cd8584aa514998f62e9--FBReader-1.999.16.dmg
To retry an incomplete download, remove the file above.
Error: 1 problem in 1 cask detected
```

And here is just a trivial patch for correct sha256 sum