### PR TITLE
Use avidemux 2.7.4 on MacOS before Monterey

### DIFF
--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -1,5 +1,5 @@
 cask "avidemux" do
-  if MacOS.version <= :mojave
+  if MacOS.version <= :big_sur
     version "2.7.4"
     sha256 "a5c5028ecc954b6658b4c0e6b04c1c186c42a12530e66a5379f51fe7a3ebfcd8"
 

--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -5,6 +5,10 @@ cask "avidemux" do
 
     url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}_Mojava_64Bits_Qt5.dmg",
         verified: "sourceforge.net/avidemux/"
+
+    livecheck do
+      skip "Legacy version for Big Sur and earlier"
+    end
   else
     version "2.8.1"
     sha256 "b0b8890114172d531d138f6c1413f0393c0e5a87530168106a12d6b11ae44833"


### PR DESCRIPTION
avidemux 2.8.1 requires MacOS 12.0.0. Fall back to 2.7.4 on earlier versions. Without this, you will get the following error:

```
Sorry, "Avidemux2.8.app" cannot be run on this version of macOS. Qt requires macOS 12.0.0 or later, you have macOS 10.15.7.
```

Note: `brew audit cask --online` fails presumably because we are trying to download an older version (I am testing this on Catalina). This doesn't seem to be overridable. Without `--online` it passes.

```
> brew audit --cask --online avidemux
==> Downloading https://downloads.sourceforge.net/avidemux/avidemux/2.7.4/Avidemux_2.7
Already downloaded: /Users/jim/Library/Caches/Homebrew/downloads/4f553e0e641c658c579b7da364f691486760dc3f767f52a9c9d943ff1506c203--Avidemux_2.7.4_Mojava_64Bits_Qt5.dmg
audit for avidemux: failed
 - Version '2.7.4' differs from '2.8.1' retrieved by livecheck.
 - Download is hosted on SourceForge, please add a livecheck. See https://docs.brew.sh/Cask-Cookbook#stanza-livecheck
 - Version '2.7.4' differs from '2.8.1' retrieved by livecheck.

> brew audit --cask avidemux
audit for avidemux: passed
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ]  (See above) `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
