### PR TITLE
fix: change depends_on to be catalina for podman-desktop

### DIFF
--- a/Casks/podman-desktop.rb
+++ b/Casks/podman-desktop.rb
@@ -17,7 +17,7 @@ cask "podman-desktop" do
   end
 
   depends_on formula: "podman"
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :catalina"
 
   app "Podman Desktop.app"
 


### PR DESCRIPTION
Podman Desktop depends on Podman and podman requires only catalina as dependency so it should depends on the same macOS version

https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/podman.rb#L39
fixes https://github.com/containers/podman-desktop/discussions/464

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Change-Id: I994e26988f15c0d97d24513f54b21540954e0bcc
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
