### PR TITLE
Update Dictionaries to version 2.0

### DIFF
--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -1,15 +1,15 @@
 cask "dictionaries" do
-  version "2.0"
+  version "2.0,421"
   sha256 "bdddac7d12b9a30a1bea5d7150a2fa41b83461fbfcc8d3b6ae2fb99d4fe2b20e"
 
-  url "https://download.dictionaries.io/mac/Dictionaries-#{version}.zip"
+  url "https://download.dictionaries.io/mac/Dictionaries-#{version.csv.first}.zip"
   name "Dictionaries"
   desc "Translate words without ever opening a dictionary"
   homepage "https://dictionaries.io/"
 
   livecheck do
-    url "https://download.dictionaries.io/mac/"
-    regex(%r{href=.*?/Dictionaries-(\d+(?:\.\d+)+)\.zip}i)
+    url "https://dictionaries.io/updates/mac/v2/appcast"
+    strategy :sparkle
   end
 
   app "Dictionaries.app"
@@ -18,14 +18,4 @@ cask "dictionaries" do
     "~/Library/Containers/io.dictionaries.Dictionaries",
     "~/Library/Preferences/io.dictionaries.Dictionaries.plist",
   ]
-
-  caveats do
-    license "https://dictionaries.io/terms"
-
-    <<~EOS
-      Version 2 is a major upgrade and requires a new license.
-      Previous versions of the application are discontinued and won't receive updates anymore.
-      See https://dictionaries.io/version2 for more details
-    EOS
-  end
 end

--- a/Casks/dictionaries.rb
+++ b/Casks/dictionaries.rb
@@ -1,22 +1,15 @@
 cask "dictionaries" do
-  version "1.8,390,1663318178"
-  sha256 "90f906f8efc907855e6e170392446bb1734fabc5b4204861206735735a162825"
+  version "2.0"
+  sha256 "bdddac7d12b9a30a1bea5d7150a2fa41b83461fbfcc8d3b6ae2fb99d4fe2b20e"
 
-  url "https://dl.devmate.com/io.dictionaries.Dictionaries/#{version.csv.second}/#{version.csv.third}/Dictionaries-#{version.csv.second}.zip",
-      verified: "dl.devmate.com/io.dictionaries.Dictionaries/"
+  url "https://download.dictionaries.io/mac/Dictionaries-#{version}.zip"
   name "Dictionaries"
   desc "Translate words without ever opening a dictionary"
   homepage "https://dictionaries.io/"
 
   livecheck do
-    url "https://updates.devmate.com/io.dictionaries.Dictionaries.xml"
-    regex(%r{/(\d+)/Dictionaries\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
-    strategy :sparkle do |item, regex|
-      match = item.url.match(regex)
-      next if match.blank?
-
-      "#{item.short_version},#{match[2]},#{match[1]}"
-    end
+    url "https://download.dictionaries.io/mac/"
+    regex(%r{href=.*?/Dictionaries-(\d+(?:\.\d+)+)\.zip}i)
   end
 
   app "Dictionaries.app"
@@ -25,4 +18,14 @@ cask "dictionaries" do
     "~/Library/Containers/io.dictionaries.Dictionaries",
     "~/Library/Preferences/io.dictionaries.Dictionaries.plist",
   ]
+
+  caveats do
+    license "https://dictionaries.io/terms"
+
+    <<~EOS
+      Version 2 is a major upgrade and requires a new license.
+      Previous versions of the application are discontinued and won't receive updates anymore.
+      See https://dictionaries.io/version2 for more details
+    EOS
+  end
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Auditing fails on my machine with this message:
```
==> Auditing Cask dictionaries
==> Auditing GitHub prerelease
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
curl: (22) The requested URL returned error: 404
==> key not found: :latest
audit for dictionaries: failed
 - exception while auditing dictionaries: key not found: :latest
Error: 1 problem in 1 cask detected
```
But I'm not able to figure out why, since the cask builds and installs correctly. This is the firs time I'm submitting a cask and I'm not able to figure out where the error comes from, since I don't use `version :latest` anywhere, so I'm hoping for a little help here 😞 