### PR TITLE
Update eloston-chromium to 106.0.5249.61-1.1

### DIFF
--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -2,12 +2,12 @@ cask "eloston-chromium" do
   arch arm: "arm64", intel: "x86-64"
 
   on_intel do
-    version "105.0.5195.127-1.1,1663231722"
-    sha256 "4ffa0b4cfe541e6be30a82ed4155afcec786dd33512b5bd289e5ab01fe2f2d77"
+    version "106.0.5249.61-1.1,1664367337"
+    sha256 "797fffe759687b9d08e377a72d1f5dc7473e0d4bee0c262e13b4ecbd60efebac"
   end
   on_arm do
-    version "105.0.5195.127-1.1,1663365155"
-    sha256 "81b42e73155fa7823cfb8ef8ad7310530eb29d72a124afa60f41deb15ee7671e"
+    version "106.0.5249.61-1.1,1664422151"
+    sha256 "ea7b0b1fc0ecaa86cfd0d8340f9ae31b0826a8501c3c0a2f717df972e0b36fd2"
   end
 
   url "https://github.com/kramred/ungoogled-chromium-macos/releases/download/#{version.csv.first}_#{arch}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",

--- a/Casks/eloston-chromium.rb
+++ b/Casks/eloston-chromium.rb
@@ -17,15 +17,12 @@ cask "eloston-chromium" do
   homepage "https://ungoogled-software.github.io/ungoogled-chromium-binaries/"
 
   livecheck do
-    url "https://github.com/kramred/ungoogled-chromium-macos/releases/"
-    strategy :page_match do |page|
-      match = page.match(%r{
-        releases/download/(\d+(?:[.-]\d+)+)[._-]#{arch}[._-]{2}(\d+)/
-        ungoogled[._-]chromium[._-](\d+(?:[.-]\d+)+)[._-]#{arch}[._-]macos\.dmg
-      }xi)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    url "https://github.com/kramred/ungoogled-chromium-macos/releases?q=prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tree/v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?["' >]}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        (match.length > 1) ? "#{match[0]},#{match[1]}" : match[0]
+      end
     end
   end
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free. *
- [X] `brew style --fix <cask>` reports no offenses.
- 
* Please note the `livecheck` is failing, but it already is failing with the current cask. I have checked the formula, and at least the url and the regex should match.