### PR TITLE
Fix micromamba caveats

### DIFF
--- a/Casks/micromamba.rb
+++ b/Casks/micromamba.rb
@@ -20,7 +20,7 @@ cask "micromamba" do
 
   caveats <<~EOS
     Please run the following to setup your shell:
-      micromamba shell init -s <your-shell> -p ~/micromamba
+      #{HOMEBREW_PREFIX}/bin/micromamba shell init -s <your-shell> -p ~/micromamba
     and restart your terminal.
 
     For more information, see:


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

This adds the full path to the caveats. Before, just executing `micromamba shell init -s <your-shell> -p ~/micromamba ` wouldn't update the shell hooks correctly if another instance of `micromamba` was still installed somewhere else.

`brew audit --cask --online <cask>` is depending on #132597.