### PR TITLE
stellarium: Bump to 1.0

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,12 +1,18 @@
 cask "stellarium" do
-  arch arm: "arm64", intel: "x86_64"
+  version "1.0"
 
-  version "0.22.2"
-  sha256 arm:   "74acc44f96597d11d92f94015efd19cd18c2ce76e850d90f44c40d636f72ea5f",
-         intel: "5e8c2ee315f8c00a393e7bd22461f9b48355538cec39e1bb771e92a5795bcfb4"
+  if MacOS.version <= :catalina
+    sha256 "92649cdc75b2135a62faaf85f4b1617c8c8c850f160c8191f627cd32e1147ec2"
 
-  url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-#{arch}.zip",
-      verified: "github.com/Stellarium/stellarium/"
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-x86_64.zip",
+        verified: "github.com/Stellarium/stellarium/"
+  else
+    sha256 "59c7ca0541322194085fcb6290d9a7637154b290b2c2ca4d504cc1bd3e2aeb72"
+
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-macOS.zip",
+        verified: "github.com/Stellarium/stellarium/"
+  end
+
   name "Stellarium"
   desc "Tool to render realistic skies in real time on the screen"
   homepage "https://stellarium.org/"


### PR DESCRIPTION
Updated urls for new system, using a universal binary for macOS 12+

----

Could do it the anki.rb way, if preferred, but I think not?

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.