### PR TITLE
beast2: Add livecheck

### DIFF
--- a/Casks/beast2.rb
+++ b/Casks/beast2.rb
@@ -9,6 +9,11 @@ cask "beast2" do
   desc "Bayesian evolutionary analysis by sampling trees"
   homepage "https://www.beast2.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   suite "BEAST #{version}"
 
   zap trash: [


### PR DESCRIPTION
Switching to `:github_latest` strategy due to use of prereleases.