### PR TITLE
ExpressVPN now auto-updates.

### DIFF
--- a/Casks/expressvpn.rb
+++ b/Casks/expressvpn.rb
@@ -12,6 +12,8 @@ cask "expressvpn" do
     strategy :header_match
   end
 
+  auto_updates true
+
   pkg "expressvpn_mac_#{version}_release.pkg"
 
   uninstall launchctl: "com.expressvpn.ExpressVPN.agent",


### PR DESCRIPTION
This was previously disabled in [this PR](https://github.com/Homebrew/homebrew-cask/pull/98464), but ExpressVPN now does auto-update & should not be updated as part of `brew upgrade` runs. See [this](https://docs.brew.sh/FAQ#why-arent-some-apps-included-during-brew-upgrade).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
