### PR TITLE
openrct2: convert to on_{macos-version} blocks

### DIFF
--- a/Casks/openrct2.rb
+++ b/Casks/openrct2.rb
@@ -1,11 +1,18 @@
 cask "openrct2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  if MacOS.version <= :sierra
+  on_sierra :or_older do
     version "0.2.6"
     sha256 "0073933b486da10b181bc8a226a140badc64c7cd93f681d769c17b5715221a85"
+    url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86_64.zip",
+        verified: "github.com/OpenRCT2/OpenRCT2/"
+  end
+  on_high_sierra do
+    version "0.3.4.1"
+    sha256 "dbe5f13d2ae391160bcf7cfa80d9a8d7fd5937c12f4dd0dea9254f00038e60c7"
     url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86-64.zip",
         verified: "github.com/OpenRCT2/OpenRCT2/"
-  else
+  end
+  on_mojave :or_newer do
     version "0.4.2"
     sha256 "6f16c13fc14b710ae676b300ab628e171906a4b2f508dd5e5e33c4d79767583a"
     url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-universal.zip",


### PR DESCRIPTION
Convert to using `on_{macos-version}` blocks as mentioned in Homebrew/brew#13794 and described in Homebrew/brew#13451.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
