### PR TITLE
appgate-sdp-client: Convert to `on_{macos_version}` block

### DIFF
--- a/Casks/appgate-sdp-client.rb
+++ b/Casks/appgate-sdp-client.rb
@@ -1,32 +1,13 @@
 cask "appgate-sdp-client" do
-  if MacOS.version <= :high_sierra
+  version "6.0.2"
+  sha256 "e052052094b5c92d94c74128bca3f1c90fef65b3bf441342d889a9b74ed58ac6"
+
+  on_high_sierra :or_older do
     version "5.3.3"
     sha256 "935c87fcec29c6c7ab28ced0b3da8bb98db7f6b51303c3d651c53b14fc17fcbd"
-  else
-    version "6.0.2"
-    sha256 "e052052094b5c92d94c74128bca3f1c90fef65b3bf441342d889a9b74ed58ac6"
 
     livecheck do
-      url :homepage
-      regex(%r{href=.*?/Appgate-SDP[._-](\d+(?:\.\d+)+)[._-]Installer\.dmg}i)
-      strategy :page_match do |page, regex|
-        support_versions =
-          page.scan(%r{href=["']?([^"' >]*?/software-defined-perimeter-support/sdp[._-]v?(\d+(?:[.-]\d+)+))["' >]}i)
-              .sort_by { |match| Version.new(match[1]) }
-        next [] if support_versions.blank?
-
-        # Assume the last-sorted version is newest
-        version_page_path, = support_versions.last
-
-        # Check the page for the newest major/minor version, which links to the
-        # latest disk image file (containing the full version in the file name)
-        version_page = Homebrew::Livecheck::Strategy.page_content(
-          URI.join("https://www.appgate.com/", version_page_path),
-        )
-        next [] if version_page[:content].blank?
-
-        version_page[:content].scan(regex).map(&:first)
-      end
+      skip "Legacy version for High Sierra and earlier"
     end
   end
 
@@ -35,6 +16,29 @@ cask "appgate-sdp-client" do
   name "AppGate SDP Client for macOS"
   desc "Software-defined perimeter for secure network access"
   homepage "https://www.appgate.com/support/software-defined-perimeter-support"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/Appgate-SDP[._-](\d+(?:\.\d+)+)[._-]Installer\.dmg}i)
+    strategy :page_match do |page, regex|
+      support_versions =
+        page.scan(%r{href=["']?([^"' >]*?/software-defined-perimeter-support/sdp[._-]v?(\d+(?:[.-]\d+)+))["' >]}i)
+            .sort_by { |match| Version.new(match[1]) }
+      next [] if support_versions.blank?
+
+      # Assume the last-sorted version is newest
+      version_page_path, = support_versions.last
+
+      # Check the page for the newest major/minor version, which links to the
+      # latest disk image file (containing the full version in the file name)
+      version_page = Homebrew::Livecheck::Strategy.page_content(
+        URI.join("https://www.appgate.com/", version_page_path),
+      )
+      next [] if version_page[:content].blank?
+
+      version_page[:content].scan(regex).map(&:first)
+    end
+  end
 
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.