### PR TITLE
Revert "apparency 1.4.1,218"

### DIFF
--- a/Casks/apparency.rb
+++ b/Casks/apparency.rb
@@ -1,18 +1,12 @@
 cask "apparency" do
-  version "1.4.1,218"
-  sha256 :no_check
-
-  url "https://mothersruin.com/software/downloads/Apparency.dmg"
-
-  on_mojave :or_older do
+  if MacOS.version <= :mojave
     version "1.3"
-    sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
-
     url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version for Mojave and earlier"
-    end
+    sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
+  else
+    version "1.4.1,218"
+    url "https://mothersruin.com/software/downloads/Apparency.dmg"
+    sha256 :no_check
   end
 
   name "Apparency"


### PR DESCRIPTION
This reverts commit f953eb27840ef05672a1e65293194a568542a099.

This broke formulae.brew.sh:
https://github.com/Homebrew/formulae.brew.sh/actions/runs/3195939534/jobs/5217219795