### PR TITLE
Fix 'Cask definition error' in "appcleaner" Cask

### DIFF
--- a/Casks/appcleaner.rb
+++ b/Casks/appcleaner.rb
@@ -5,10 +5,6 @@ cask "appcleaner" do
   on_sierra :or_older do
     version "3.4"
     sha256 "0c60d929478c1c91e0bad76d3c04795665c07a05e45e33321db845429c9aefa8"
-
-    livecheck do
-      skip "Legacy version for Sierra and earlier"
-    end
   end
 
   url "https://www.freemacsoft.net/downloads/AppCleaner_#{version.csv.first}.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

-----

I propose this solution because I encountered this error when searching cask with RayCast on Mac :

Error : Cask 'appcleaner' definition is invalid: 'livecheck' stanza may only appear once.

Hope this is a good solution..