### PR TITLE
Update threads from 0.8.0 to 2.1.9

### DIFF
--- a/Casks/threads.rb
+++ b/Casks/threads.rb
@@ -1,6 +1,6 @@
 cask "threads" do
-  version "0.8.0"
-  sha256 "3868985c198219e6422ffc529f6e1c69c6b4f83a3901c85c2ff5002cbebec98b"
+  version "2.1.9"
+  sha256 "3fca6f20c8cf573948e31bab84c10af977a321396ac8bcefcfc3bca2a23459b3"
 
   url "https://downloads.threads.com/mac/Threads-#{version}.dmg"
   name "Threads"
@@ -8,17 +8,19 @@ cask "threads" do
   homepage "https://threads.com/"
 
   livecheck do
-    url "https://update.threads.com/update/mac/0.0.0"
+    url "https://starupdate.threads.com/update/mac/0.0.0"
     regex(%r{version/(\d+(?:\.\d+)+)/}i)
   end
+
+  auto_updates true
 
   app "Threads.app"
 
   zap trash: [
     "~/Library/Application Support/Threads",
-    "~/Library/Caches/com.threads.mac.Threads",
-    "~/Library/Caches/com.threads.mac.Threads.ShipIt",
-    "~/Library/Preferences/com.threads.mac.Threads.plist",
-    "~/Library/Saved Application State/com.threads.mac.Threads.savedState",
+    "~/Library/Caches/com.threads.mac.Starling",
+    "~/Library/Caches/com.threads.mac.Starling.ShipIt",
+    "~/Library/Preferences/com.threads.mac.Starling.plist",
+    "~/Library/Saved Application State/com.threads.mac.Starling.savedState",
   ]
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
