### PR TITLE
Update yacreader from 9.9.1.2209046 to 9.9.2.2210021

### DIFF
--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -9,9 +9,9 @@ cask "yacreader" do
   homepage "https://www.yacreader.com/"
 
   livecheck do
-    url "https://github.com/YACReader/yacreader/releases"
+    url "https://www.yacreader.com/downloads"
     strategy :page_match
-    regex(%r{href=.*?/YACReader[._-]v?(\d+(?:\.\d+)+)[._-]MacOSX[._-]Intel\.dmg}i)
+    regex(%r{href=.*?/YACReader[._-]v?(\d+(?:\.\d+)+)[._-]MacOSX[._-]Intel\.Qt6\.dmg}i)
   end
 
   app "YACReader.app"

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -1,8 +1,8 @@
 cask "yacreader" do
-  version "9.9.1.2209046"
-  sha256 "7818ff0a35f9ac8d0b947b86a831e15f9d02a26739e670bc9d5ce6cca3ccd646"
+  version "9.9.2.2210021"
+  sha256 "5cde79c68a0a28504c70361a0f5ade587b8010e8f65a14fa5fd3d5d5230438b5"
 
-  url "https://github.com/YACReader/yacreader/releases/download/#{version.major_minor_patch}/YACReader-#{version}.MacOSX-Intel.dmg",
+  url "https://github.com/YACReader/yacreader/releases/download/#{version.major_minor_patch}/YACReader-#{version}.MacOSX-Intel.Qt6.dmg",
       verified: "github.com/YACReader/yacreader/"
   name "YACReader"
   desc "Comic reader"


### PR DESCRIPTION
I tried to use `brew bump-cask-pr` but I couldn't figure out how to change the `url` using the command when it needs the `verified` parameter.

With this version it appears that YACReader is split into qt5 and qt6 versions, and I'm not sure if we need to handle one or both. https://github.com/YACReader/yacreader/releases

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
