### PR TITLE
robo-3t: Discontinue

### DIFF
--- a/Casks/robo-3t.rb
+++ b/Casks/robo-3t.rb
@@ -8,16 +8,6 @@ cask "robo-3t" do
   desc "MongoDB management tool"
   homepage "https://robomongo.org/"
 
-  livecheck do
-    url "https://github.com/Studio3T/robomongo"
-    strategy :github_latest do |page|
-      match = page.match(%r{href=.*?/v?(\d+(?:\.\d+)*)/robo3t-\1-darwin-x86_64-([0-9a-f]+)\.dmg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
-
   app "Robo 3T.app"
 
   uninstall quit: "Robo 3T"
@@ -30,4 +20,8 @@ cask "robo-3t" do
     "~/Library/Saved Application State/com.3tsoftwarelabs.robo3t.savedState",
     "~/Library/Saved Application State/Robo 3T.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
From https://robomongo.org:

>What is happening to Robo 3T?
3T is halting development work on Robo 3T and we are setting the code repository to read-only. Users can continue to download the application but we recommend that they download Studio 3T Free to evaluate it.