### PR TITLE
logdna-agent: Discontinue

### DIFF
--- a/Casks/logdna-agent.rb
+++ b/Casks/logdna-agent.rb
@@ -8,22 +8,20 @@ cask "logdna-agent" do
   desc "Agent streams from log files to your LogDNA account"
   homepage "https://logdna.com/"
 
-  livecheck do
-    url "https://github.com/logdna/logdna-agent/releases/"
-    strategy :page_match
-    regex(/logdna[._-]?agent[._-]?(\d+(?:\.\d+)*)\.pkg/i)
-  end
-
   pkg "logdna-agent-#{version}.pkg"
 
   uninstall pkgutil:   "com.logdna.logdna-agent",
             launchctl: "com.logdna.logdna-agentd"
 
-  caveats <<~EOS
-    When you first start logdna-agent, you must set your LogDNA Ingestion Key with the command:
-      sudo logdna-agent -k <ingestion-key>
+  caveats do
+    discontinued
 
-    To always run logdna-agent in the background, use the command:
-      sudo launchctl load -w /Library/LaunchDaemons/com.logdna.logdna-agent.plist
-  EOS
+    <<~EOS
+      When you first start logdna-agent, you must set your LogDNA Ingestion Key with the command:
+        sudo logdna-agent -k <ingestion-key>
+
+      To always run logdna-agent in the background, use the command:
+        sudo launchctl load -w /Library/LaunchDaemons/com.logdna.logdna-agent.plist
+    EOS
+  end
 end


### PR DESCRIPTION
Repo states:
>⚠️ Deprecation Warning
>
>logdna-agent will soon be deprecated and will cease to have support. Please refer to [LogDNA Agent V2](https://github.com/logdna/logdna-agent-v2) for all future implementations.