### PR TITLE
code42-crashplan: Discontinue

### DIFF
--- a/Casks/code42-crashplan.rb
+++ b/Casks/code42-crashplan.rb
@@ -8,14 +8,6 @@ cask "code42-crashplan" do
   desc "Endpoint backup and recovery"
   homepage "https://www.crashplan.com/"
 
-  livecheck do
-    url "https://support.code42.com/Administrator/6/Planning_and_installing/Code42_server_and_app_downloads"
-    regex(%r{href=.*?/(\d+(?:\.\d+)+)/(\d+)/install/Code42[._-]\1[._-](\d+)[._-]\2[._-]Mac\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[2]},#{match[1]}" }
-    end
-  end
-
   auto_updates true
 
   pkg "Install Code42.pkg"
@@ -26,4 +18,8 @@ cask "code42-crashplan" do
               executable: "Uninstall.app/Contents/Resources/uninstall.sh",
               sudo:       true,
             }
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Per [Code42 support](https://support.code42.com/Terms_and_conditions/Product_lifecycle_policy/End-of-life_for_CrashPlan_On-Premises):

>CrashPlan On-Premises retirement
CrashPlan On-Premises reached end-of-life on February 28, 2022. This means after this date:

>Computers running CrashPlan On-Premises can no longer receive upgrades or patches, including critical security patches.
Code42 cannot guarantee that CrashPlan On-Premises will operate without issues.
If your contract extends beyond the end-of-life date, our Customer Champion team will only continue to provide assistance with issues arising from the use of CrashPlan On-Premises through the end of your contract.
Please refer to the [Product lifecycle policy](https://support.code42.com/Terms_and_conditions/Product_lifecycle_policy) document for our general end of support policy.