### PR TITLE
Monal: move to new upstream url

### DIFF
--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,15 +1,15 @@
 cask "monal" do
-  version "5.3.3,821"
+  version "821"
   sha256 :no_check
 
-  url "https://monal.im/macOS/Monal-macOS.zip"
+  url "https://downloads.monal-im.org/monal-im/beta/macOS/Monal-#{version}.zip"
   name "Monal"
   desc "Tool to securely connect to chat servers"
-  homepage "https://monal.im/"
+  homepage "https://monal-im.org/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://downloads.monal-im.org/monal-im/beta/macOS/latest.txt"
+    regex(/^(\d+)$/i)
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/monal.rb
+++ b/Casks/monal.rb
@@ -1,14 +1,14 @@
 cask "monal" do
-  version "821"
-  sha256 :no_check
+  version "822"
+  sha256 "663f837f25df1d5dc482822064aee2a44639b92560611a545f8d5b018bf07be6"
 
-  url "https://downloads.monal-im.org/monal-im/beta/macOS/Monal-#{version}.zip"
+  url "https://downloads.monal-im.org/monal-im/stable/macOS/Monal-#{version}.zip"
   name "Monal"
   desc "Tool to securely connect to chat servers"
   homepage "https://monal-im.org/"
 
   livecheck do
-    url "https://downloads.monal-im.org/monal-im/beta/macOS/latest.txt"
+    url "https://downloads.monal-im.org/monal-im/stable/macOS/latest.txt"
     regex(/^(\d+)$/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


For verification of the new upstream URL, check the recent blog entry at the old URL: https://monal.im
