### PR TITLE
Replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -63,4 +63,7 @@ modified_paths.each do |modified_path|
 end
 puts
 
-puts '::set-output name=pull_request::true'
+github_output = ENV.fetch("GITHUB_OUTPUT") { raise "GITHUB_OUTPUT is not defined" }
+File.open(github_output, "a") do |f|
+  f.puts "pull_request=true"
+end

--- a/.github/workflows/bump-unversioned-casks.yml
+++ b/.github/workflows/bump-unversioned-casks.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate cache ID
         id: cache-id
         run: |
-          echo "::set-output name=time::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          echo "time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Cache state
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         id: generate-matrix
         run: |
           brew tap homebrew/cask
-          brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" "${{ github.event.pull_request.url }}"
+          brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" "${{ github.event.pull_request.url }}" "${GITHUB_OUTPUT}"
 
   test:
     name: ${{ matrix.name }}
@@ -65,14 +65,14 @@ jobs:
               echo '::warning::Removing Visual Studio is no longer necessary.'
             fi
           fi
-          
+
           if ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
             echo '::warning::Removing Julia is no longer necessary.'
           fi
 
           if ! rm /usr/local/share/man/man1/al.1 || \
              ! sudo rm /etc/paths.d/mono-commands || \
-             ! sudo rm -r /Library/Frameworks/Mono.framework || \
+             ! sudo rm -r /Library/Frameworks/Mono.framework || \
              ! sudo pkgutil --forget com.xamarin.mono-MDK.pkg; then
             echo '::warning::Uninstalling Mono is no longer necessary.'
           fi
@@ -168,13 +168,16 @@ jobs:
             cask_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Cask::Cask) }.map(&:full_name)
             formula_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Formula) }.map(&:full_name)
 
-            puts "::set-output name=was_installed::#{JSON.generate(was_installed)}"
-            puts "::set-output name=manual_installer::#{JSON.generate(manual_installer)}"
-            puts "::set-output name=macos_requirement_satisfied::#{JSON.generate(macos_requirement_satisfied)}"
-            puts "::set-output name=cask_conflicts::#{JSON.generate(cask_conflicts)}"
-            puts "::set-output name=cask_dependencies::#{JSON.generate(cask_dependencies)}"
-            puts "::set-output name=formula_conflicts::#{JSON.generate(formula_conflicts)}"
-            puts "::set-output name=formula_dependencies::#{JSON.generate(formula_dependencies)}"
+            github_output = ENV.fetch("GITHUB_OUTPUT") { raise "GITHUB_OUTPUT is not defined" }
+            File.open(github_output, "a") do |f|
+              f.puts "was_installed=#{JSON.generate(was_installed)}"
+              f.puts "manual_installer=#{JSON.generate(manual_installer)}"
+              f.puts "macos_requirement_satisfied=#{JSON.generate(macos_requirement_satisfied)}"
+              f.puts "cask_conflicts=#{JSON.generate(cask_conflicts)}"
+              f.puts "cask_dependencies=#{JSON.generate(cask_dependencies)}"
+              f.puts "formula_conflicts=#{JSON.generate(formula_conflicts)}"
+              f.puts "formula_dependencies=#{JSON.generate(formula_dependencies)}"
+            end
           EOF
         if: always() && steps.fetch.outcome == 'success' && matrix.cask
 
@@ -199,8 +202,11 @@ jobs:
       - name: Take snapshot of installed and running apps and services
         id: snapshot
         run: |
-          brew ruby -r "$(brew --repository homebrew/cask)/cmd/lib/check.rb" <<'EOF'
-            puts "::set-output name=before::#{JSON.generate(Check.all)}"
+          brew ruby -r "$(brew --repository homebrew/cask)/cmd/lib/check.rb" <<'EOF' -- $GITHUB_OUTPUT
+            github_output, = ARGV
+            File.open(github_output, "a") do |f|
+              f.puts "before=#{JSON.generate(Check.all)}"
+            end
           EOF
         if: always() && steps.info.outcome == 'success'
 

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -5,7 +5,7 @@ require "utils/github/api"
 
 require_relative "ci_matrix"
 
-pr_url, = ARGV
+pr_url, github_output, = ARGV
 
 labels = if pr_url
   pr = GitHub::API.open_rest(pr_url)
@@ -42,4 +42,7 @@ end
 syntax_job[:name] += " (#{syntax_job[:runner]})"
 
 puts JSON.pretty_generate(matrix)
-puts "::set-output name=matrix::#{JSON.generate(matrix)}"
+
+File.open(github_output, "a") do |f|
+  f.puts "matrix=#{JSON.generate(matrix)}"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
