### PR TITLE
unison: update livecheck

### DIFF
--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -9,11 +9,20 @@ cask "unison" do
   homepage "https://www.cis.upenn.edu/~bcpierce/unison/"
 
   livecheck do
-    url :url
-    strategy :github_latest do |page|
-      page.scan(/href=.*?Unison[._-]v?(\d+(?:\.\d+)+)[._-]ocaml[._-]v?(\d+(?:\.\d+)+)[._-]macos/i).map do |match|
-        "#{match[0]},#{match[1]}"
-      end
+    url "https://github.com/bcpierce00/unison/releases/latest"
+    regex(/href=.*?Unison[._-]v?(\d+(?:\.\d+)+)[._-]ocaml[._-]v?(\d+(?:\.\d+)+)[._-]macos/i)
+    strategy :header_match do |headers, regex|
+      next if headers["location"].blank?
+
+      # Identify the latest tag from the response's `location` header
+      latest_tag = File.basename(headers["location"])
+      next if latest_tag.blank?
+
+      # Fetch the assets list HTML for the latest tag and match within it
+      assets_page = Homebrew::Livecheck::Strategy.page_content(
+        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
+      )
+      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `unison` identifies versions from macOS files in the "latest" release assets list. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

In this case, unfortunately the upstream repository doesn't include the OCaml version in the tag, so it's necessary to match the version information from filenames. This PR updates the `livecheck` block to find the tag for the latest release (using the `HeaderMatch` strategy to identify it in the `location` header), fetch the asset list HTML for that release, and match versions in the assets list HTML. This works for now but I intend to come up with a better approach (e.g., creating a strategy for this instead of needing a hefty `strategy` block for each of these) after all of these broken checks are working again.