### PR TITLE
Re-add updated wolfram-engine

### DIFF
--- a/Casks/wolfram-engine.rb
+++ b/Casks/wolfram-engine.rb
@@ -3,15 +3,14 @@ cask "wolfram-engine" do
   sha256 "f7595e229b9c9883d7d1a5cf27237794567ad89b7b884afee2857e9853f40ce9"
 
   url "https://files.wolframcdn.com/packages/Homebrew/#{version}/WolframEngine_#{version.major_minor_patch}_MAC.dmg",
-      verified: "files.wolframcdn.com/packages/"
+      verified: "files.wolframcdn.com/packages/Homebrew/"
   name "Wolfram Engine"
   desc "Evaluator for the Wolfram Language"
   homepage "https://www.wolfram.com/engine/"
 
   livecheck do
     url "https://files.wolframcdn.com/packages/Homebrew/latest.txt"
-    strategy :page_match
-    regex(/^(\d+\.\d+\.\d+\.\d+)$/)
+    regex(/^(\d+(?:\.\d+)+)$/)
   end
 
   depends_on macos: ">= :mojave"
@@ -20,8 +19,8 @@ cask "wolfram-engine" do
   binary "#{appdir}/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents/MacOS/wolframscript"
 
   zap trash: [
-    "~/Library/WolframEngine",
     "~/Library/Caches/Wolfram",
+    "~/Library/WolframEngine",
   ]
 
   caveats do

--- a/Casks/wolfram-engine.rb
+++ b/Casks/wolfram-engine.rb
@@ -1,0 +1,30 @@
+cask "wolfram-engine" do
+  version "13.1.0.0"
+  sha256 "f7595e229b9c9883d7d1a5cf27237794567ad89b7b884afee2857e9853f40ce9"
+
+  url "https://files.wolframcdn.com/packages/Homebrew/#{version}/WolframEngine_#{version.major_minor_patch}_MAC.dmg",
+      verified: "files.wolframcdn.com/packages/"
+  name "Wolfram Engine"
+  desc "Evaluator for the Wolfram Language"
+  homepage "https://www.wolfram.com/engine/"
+
+  livecheck do
+    url "https://files.wolframcdn.com/packages/Homebrew/latest.txt"
+    strategy :page_match
+    regex(/^(\d+\.\d+\.\d+\.\d+)$/)
+  end
+
+  depends_on macos: ">= :mojave"
+
+  app "Wolfram Engine.app"
+  binary "#{appdir}/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents/MacOS/wolframscript"
+
+  zap trash: [
+    "~/Library/WolframEngine",
+    "~/Library/Caches/Wolfram",
+  ]
+
+  caveats do
+    free_license "https://www.wolfram.com/engine/free-license/"
+  end
+end


### PR DESCRIPTION
This PR re-adds the wolfram-engine.rb package script, which was removed in #131414 due to being out of date.

I recognize and appreciate that the maintenance of Homebrew packages often falls to volunteers who are donating their time to this project, so I want to personally apologize for the additional burden that was required of the maintainers due to our lapse in keeping the files used by Homebrew up to date.

We (Wolfram Research) have updated our internal release process to ensure that the URL we provide for Homebrew does not fall out of date again, and that the prior lack of an adequate livecheck won't again cause a mismatch between the version that is reported to be available and the files that are actually available for download.

This new script is nearly identical to the one removed in #131414, with a few modifications:

* It updates the script to download v13.1.0 of the Wolfram Engine. (Previous was v13.0.0).

* It includes an updated `livecheck` section that checks a dedicated `latest.txt` file that we will update at the same time the WolframEngine .dmg for Homebrew is published.

  This fixes an issue the previous livecheck would encounter when a new Wolfram Engine was released to our authenticated accounts download page (the livecheck would show a new version was available, but the dedicated Homebrew path in the CDN had not yet been updated).

  This was previously requested by @miccal [here](https://github.com/Homebrew/homebrew-cask/issues/106909#issuecomment-858199078).

* It adds a `binary` stanza to create a symlink to the `wolframscript` executable provided by Wolfram Engine.

If there are any other changes I can make to improve the long-term maintainability of this package, or information I can provide to assuage concerns on the part of the maintainers, please let me know and I will do so promptly.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- 
  * *Note*: This package was previously added and then removed in #131414. I'm uncertain if that means I should check this box or not. I've attempted to ensure that the issues that lead to its removal don't re-occur.
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
