### PR TITLE
AirDroid: Fix sha256 and move to official CDN

### DIFF
--- a/Casks/airdroid.rb
+++ b/Casks/airdroid.rb
@@ -1,9 +1,8 @@
 cask "airdroid" do
   version "3.7.1.0"
-  sha256 "c0a92cc080546e06a737b5bb43e866534f91a961f4c37a712aa48f09c01446d0"
+  sha256 "89d772b179104b2937f81168d63589d9b0759f9d85ce50394e8acd76c908fa3d"
 
-  url "https://s3.amazonaws.com/dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg",
-      verified: "s3.amazonaws.com/dl.airdroid.com/"
+  url "https://dl.airdroid.com/AirDroid_Desktop_Client_#{version}.dmg"
   name "AirDroid"
   desc "Mobile device management suite"
   homepage "https://www.airdroid.com/"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.