### PR TITLE
psychopy: update livecheck

### DIFF
--- a/Casks/psychopy.rb
+++ b/Casks/psychopy.rb
@@ -10,7 +10,6 @@ cask "psychopy" do
   livecheck do
     url :url
     strategy :github_latest
-    regex(%r{href=.+/StandalonePsychoPy[._-]v?(\d+(?:\.\d+)+)[._-]macOS\.dmg}i)
   end
 
   app "PsychoPy.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


-----

The existing `livecheck` block for `psychopy` identifies versions from the dmg file in the "latest" release assets list. However, GitHub recently updated release pages to omit the assets list from the HTML and it's now fetched separately when the assets list is expanded (see https://github.com/Homebrew/brew/issues/13853), so this check is currently broken.

This PR addresses the issue by removing the regex from the `livecheck` block, so it will use the default regex for the `GithubLatest` strategy (matching the version from tag links). I only saw one recent release that was missing a dmg file (it may have just been a fluke), so I think we're fine using this approach for now. If we run into additional releases without a dmg file in the future, we can consider a more involved approach.