### PR TITLE
fix: `messenger` download url and live check

### DIFF
--- a/Casks/messenger.rb
+++ b/Casks/messenger.rb
@@ -1,18 +1,15 @@
 cask "messenger" do
-  version "155.22.218,380205507"
-  sha256 "7315136efa45f2733eae29190608aef4513f0e304d0137efc68e846e80303a21"
+  version "164.0.0.8.109,406707321"
+  sha256 :no_check
 
-  url "https://www.facebook.com/messenger/desktop/update/#{version.csv.second}.zip",
-      verified: "facebook.com/messenger/desktop/"
+  url "https://www.messenger.com/messenger/desktop/downloadV2/?platform=mac"
   name "Facebook Messenger"
   desc "Native desktop app for Messenger (formerly Facebook Messenger)"
   homepage "https://www.messenger.com/desktop"
 
   livecheck do
-    url "https://www.facebook.com/messenger/desktop/update/latest-mac.yml"
-    strategy :electron_builder do |yml|
-      "#{yml["version"]},#{yml["path"][%r{/(\d+)\.zip}i, 1]}"
-    end
+    url "https://www.facebook.com/messenger/desktop/zeratul/update.xml?target=zeratul&platform=mac"
+    strategy :sparkle
   end
 
   auto_updates true


### PR DESCRIPTION
This PR fixes `messenger`'s download URL and live check strategy, so that new versions can be downloaded and upgraded successfully.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

