### PR TITLE
Improve CI coverage for Casks using `on_os` blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,16 +117,21 @@ jobs:
         id: gems
         run: brew install-bundler-gems
 
+      - name: Run brew readall ${{ matrix.tap }}
+        id: readall
+        run: brew readall '${{ matrix.tap }}'
+        if: always() && steps.gems.outcome == 'success'
+
       - name: Run brew style ${{ matrix.tap }}
         run: brew style '${{ matrix.tap }}'
-        if: always() && steps.gems.outcome == 'success' && !matrix.cask
+        if: always() && steps.readall.outcome == 'success' && !matrix.cask
 
       - name: Run brew fetch --cask ${{ matrix.cask.token }}
         id: fetch
         run: |
           brew fetch --cask --retry --force '${{ matrix.cask.path }}'
         timeout-minutes: 30
-        if: always() && steps.gems.outcome == 'success' && matrix.cask
+        if: always() && steps.readall.outcome == 'success' && matrix.cask
 
       - name: Run brew audit --cask${{ (matrix.cask && ' ') || ' --tap ' }}${{ matrix.cask.token || matrix.tap }}
         id: audit
@@ -134,7 +139,7 @@ jobs:
           brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}'${{ matrix.cask.path || matrix.tap }}'
         timeout-minutes: 30
         if: >
-          always() && steps.gems.outcome == 'success' &&
+          always() && steps.readall.outcome == 'success' &&
           (!matrix.cask || steps.fetch.outcome == 'success') &&
           !matrix.skip_audit
 


### PR DESCRIPTION
Should hopefully reduce the current high frequency of broken cask readability on older OS versions.

* Run `brew readall` in CI to make sure casks are actually readable on all OS versions.
* Adjust the CI matrix logic to consider `on_os` blocks rather than just `MacOS.version` (for full install testing).
* While we're here, adjust the runner allocation to always prioritise `macos-12` over `macos-11` (now that capacity has increased).