### PR TITLE
Revert "Update anka-virtualization from 3.0.1.144 to 3.1.0.151"

### DIFF
--- a/Casks/anka-virtualization.rb
+++ b/Casks/anka-virtualization.rb
@@ -1,11 +1,12 @@
 cask "anka-virtualization" do
-  arch = Hardware::CPU.intel? ? "intel" : "arm"
+  arch arm: "arm", intel: "intel"
 
-  if Hardware::CPU.intel?
+  on_intel do
     version "2.5.7.148"
     sha256 "e600e8144f5ca5134aa94785bc9bbc567193b1065944573df9cc9daf7d8f796e"
     depends_on macos: ">= :big_sur"
-  else
+  end
+  on_arm do
     version "3.1.0.151"
     sha256 "6648a9cd0be56fcde4b5c150b2a59e8302306c477ad1a335f1dd56cb8b42a0ce"
     depends_on macos: ">= :monterey"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#133750

This is causing style issues that cause CI to fail. This can be reviewed again once we have `brew readall` CI coverage.