### PR TITLE
Submitting this Cask for a fun little BASIC interpreter.

### DIFF
--- a/Casks/chipmunk-basic.rb
+++ b/Casks/chipmunk-basic.rb
@@ -1,0 +1,21 @@
+cask "chipmunk-basic" do
+  version "1.368.2202"
+  sha256 "6f941e96fb3a9b721d56681992c2fc569107cdebc036094c4b2582786f2c90d4"
+
+  url "https://www.nicholson.com/rhn/files/Chipmunk_Basic_368b202.dmg"
+  name "Chipmunk BASIC"
+  desc "BASIC interpreter, for retro programs"
+  homepage "https://www.nicholson.com/rhn/basic/"
+
+  livecheck do
+    url :url
+    regex(/<h2>Chipmunk\s+BASIC\s+v?(\d+(?:\.\d+)+)[" <]/i)
+  end
+
+  app "Chipmunk BASIC.app"
+
+  zap trash: [
+    "~/com.nicholson.chipmunkbasic3co.plist",
+    "~/Library/Saved Application State/com.nicholson.chipmunkbasic3co.savedState",
+  ]
+end


### PR DESCRIPTION
Admittedly, I am not a programmer, and reverse-engineered this Cask using the working code from the Audacity entry. As you can see, this developer uses a peculiar naming scheme for how the version number transfers over into the filename, so that version 1.368.2202 becomes “368b202,” dropping the “1.” and changing a “.2” into a “b” in the filename. I confess that I don’t know how to do substitution code to automate this process, so I have simply hardcoded the download link for now. But if the moderators were to automate it properly, I will study the final product in order to handle such issues going forward. Thank you very much.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
