### PR TITLE
plexamp: set auto_updates true

### DIFF
--- a/Casks/plexamp.rb
+++ b/Casks/plexamp.rb
@@ -16,5 +16,7 @@ cask "plexamp" do
     strategy :electron_builder
   end
 
+  auto_updates true
+
   app "Plexamp.app"
 end


### PR DESCRIPTION
Adding auto_updates true as Plexamp automatically updates itself to the latest version whenever you open it.

All of the below is complete with no issues.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

