### PR TITLE
Undo ssh-config-editor beta version bumps

### DIFF
--- a/Casks/ssh-config-editor.rb
+++ b/Casks/ssh-config-editor.rb
@@ -1,6 +1,6 @@
 cask "ssh-config-editor" do
-  version "2.6-b,98"
-  sha256 "57c604f95f7df5e89e132aad62e80fa320350641bf96ff777283cdf4b39b555d"
+  version "2.5.1,96"
+  sha256 "a91a0db47e5a858abe1788baea135d1e306f335bb295468066621cffd996a3bf"
 
   url "https://hejki.org/download/ssheditor/SSHConfigEditor-#{version.csv.second}.dmg"
   name "SSH Config Editor"

--- a/Casks/ssh-config-editor.rb
+++ b/Casks/ssh-config-editor.rb
@@ -9,7 +9,9 @@ cask "ssh-config-editor" do
 
   livecheck do
     url "https://hejki.org/download/ssheditor/appcast#{version.major}.xml"
-    strategy :sparkle
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.nice_version
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
This undoes #130409 and #131006, where `brew bump-cask-pr` was used to update ssh-config-editor to beta versions unlisted on the product home page. They should have gone to [homebrew-cask-versions][]

[homebrew-cask-versions]: https://github.com/Homebrew/homebrew-cask-versions

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.

It reports:
```
==> Downloading https://hejki.org/download/ssheditor/SSHConfigEditor-96.dmg
Already downloaded: /Users/mjg/Library/Caches/Homebrew/downloads/af6e97958fc16d7d076f8050525f891568a3df621c68a81995f138b9d38016d7--SSHConfigEditor-96.dmg
audit for ssh-config-editor: failed
 - Version '2.5.1,96' differs from '2.6-b,98' retrieved by livecheck.
 - Version '2.5.1,96' differs from '2.6-b,98' retrieved by livecheck.
Error: 1 problem in 1 cask detected
```

However, the [ssh-config-editor appcast feed](https://hejki.org/download/ssheditor/appcast2.xml) reports that version is in the `<sparkle:channel>beta</sparkle:channel>`, so it seems there's a bug in the Sparkle strategy's channel support committed earlier this year (Homebrew/brew@c6907f911f12cff4374d78a6f080721675e1d232).

- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

_N/A_
