### PR TITLE
Add auto_updates flag to obsidian 1.0.0

### DIFF
--- a/Casks/obsidian.rb
+++ b/Casks/obsidian.rb
@@ -13,6 +13,8 @@ cask "obsidian" do
     strategy :github_latest
   end
 
+  auto_updates true
+
   app "Obsidian.app"
 
   zap trash: [


### PR DESCRIPTION
![CleanShot 2022-10-21 at 23 17 57@2x](https://user-images.githubusercontent.com/13354491/197272872-9271f3e4-5c25-4d62-9567-b9bc445cdeec.png)

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.