### PR TITLE
Add auto_updates flag to grammarly-desktop 1.13.2.0

### DIFF
--- a/Casks/grammarly-desktop.rb
+++ b/Casks/grammarly-desktop.rb
@@ -12,6 +12,8 @@ cask "grammarly-desktop" do
     strategy :extract_plist
   end
 
+  auto_updates true
+
   app "Grammarly Installer.app", target: "Grammarly Desktop.app"
 
   zap trash: [


### PR DESCRIPTION
Grammarly updates itself silently using Sparkle.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.