### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/tipp10.rb
+++ b/Casks/tipp10.rb
@@ -8,11 +8,6 @@ cask "tipp10" do
   desc "Free touch typing tutor"
   homepage "https://www.tipp10.com/"
 
-  livecheck do
-    url "https://www.tipp10.com/en/download/"
-    regex(/Version\s+(\d+(?:\.\d+)+).*?DMG/i)
-  end
-
   depends_on macos: "<= :mojave"
 
   app "TIPP10.app"

--- a/Casks/zdoom.rb
+++ b/Casks/zdoom.rb
@@ -4,12 +4,8 @@ cask "zdoom" do
 
   url "https://zdoom.org/files/zdoom/#{version.major_minor}/zdoom-#{version}.dmg"
   name "ZDoom"
+  desc "Source port of Doom"
   homepage "https://zdoom.org/index"
-
-  livecheck do
-    url "https://zdoom.org/downloads"
-    regex(/\bZDoom[._-]v?(\d+(?:\.\d+)+)/i)
-  end
 
   app "ZDoom.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR removes `livecheck` blocks from discontinued casks, so livecheck will automatically skip them as discontinued. [Ideally, this should happen in the PR where the cask is set as discontinued but I periodically check casks to correct this type of oversight.]

Past that, this also adds a simple `desc` to `zdoom`, to resolve the related audit error.