### PR TITLE
Update invoker from 2.10.0 to 2.10.0

### DIFF
--- a/Casks/invoker.rb
+++ b/Casks/invoker.rb
@@ -2,8 +2,8 @@ cask "invoker" do
   arch arm: "arm64", intel: "x64"
 
   version "2.10.0"
-  sha256  arm:   "9891d409c43f7b71287059952b543890c59fa3ae45938ceb24bc155c1b785a70",
-          intel: "fca565c3a6a603e349cb30371682c2e8afd380d23ab7c4f261c5ca3a6a7b7e80"
+  sha256  arm:   "86270d221a3da8917a8ace738070d5583d5d43f7a7efae64d2e15d049e0ab54b",
+          intel: "7b5d2323aaac1ae0c0fd142698c340f741ce0a57ccd9839bca4aaece0913544d"
 
   url "https://invokerdev.fra1.digitaloceanspaces.com/invoker/Invoker-#{version}-#{arch}.dmg",
       verified: "invokerdev.fra1.digitaloceanspaces.com/invoker/"


### PR DESCRIPTION
It looks like the hashes have changed on this. Attempting to install the current version fails due to a non-matching hash, so this PR updates the hashes. 🤔

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
