### PR TITLE
Add  Lingon v9 support for Monterey or later, inc Ventura

### DIFF
--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -2,7 +2,7 @@ cask "lingon-x" do
   if MacOS.version <= :high_sierra
     version "6.6.5"
     sha256 "b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8"
-  elsif MacOS.version < :monterey
+  elsif MacOS.version <= :big_sur
     version "8.4.9"
     sha256 "c1c839e8dc13bd295f2080980c5bea22299c33f3333b7c6981161b46d6f021d8"
   else

--- a/Casks/lingon-x.rb
+++ b/Casks/lingon-x.rb
@@ -2,9 +2,12 @@ cask "lingon-x" do
   if MacOS.version <= :high_sierra
     version "6.6.5"
     sha256 "b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8"
-  else
+  elsif MacOS.version < :monterey
     version "8.4.9"
     sha256 "c1c839e8dc13bd295f2080980c5bea22299c33f3333b7c6981161b46d6f021d8"
+  else
+    version "9.0.5"
+    sha256 "d10ea0bb0f6333b5c5862866ad38609af8c6ba9703754977e2cc898fb6036d51"
   end
 
   url "https://www.peterborgapps.com/downloads/LingonX#{version.major}.zip"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Notes: 

- cask still support earlier versions of macOS via versions 8 and 6
- Lingon 9 has new requirements for macOS  Monterey and above
- I haven't fully tested on macOS 13 yet will do later.  However, developer says the app supports macOS 13 Ventura 

> Requires macOS 12 Monterey or later
(works perfectly with macOS Ventura)

^ https://www.peterborgapps.com/lingon/