### PR TITLE
iTerm2: use older version on Mojave as well as High Sierra

### DIFF
--- a/Casks/iterm2.rb
+++ b/Casks/iterm2.rb
@@ -1,6 +1,6 @@
 cask "iterm2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  if MacOS.version <= :high_sierra
+  if MacOS.version <= :mojave
     version "3.3.12"
     sha256 "6811b520699e8331b5d80b5da1e370e0ed467e68bc56906f08ecfa986e318167"
   else


### PR DESCRIPTION
The latest versions of iTerm2 no longer work on Mojave (10.14), but the older version 3.3.12 does. This patch expands the "old OS?" check to include Mojave as well

The audit failed the livecheck, but that is expected and I'm not sure how to indicate that is expected.

Checklist:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free (failed livecheck, but per above, that is expected)
- [x] `brew style --fix <cask>` reports no offenses.

Not adding a new cask, so skipped remainder of template

