### PR TITLE
anka-virtualization: quick fix to pkg name

### DIFF
--- a/Casks/anka-virtualization.rb
+++ b/Casks/anka-virtualization.rb
@@ -24,7 +24,7 @@ cask "anka-virtualization" do
     regex(/Anka[._-]?v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
-  pkg "Anka-#{version}.pkg"
+  pkg "Anka-#{version}#{arch}.pkg"
 
   uninstall launchctl: [
               "com.veertu.anka.ankakbd",


### PR DESCRIPTION
This is a quick fix for the #{arch} added to the end of the pkg name