### PR TITLE
Fix Google Earth Pro (/Casks/google-earth-pro.rb) & Update Google Earth Pro version

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,11 +1,16 @@
 cask "google-earth-pro" do
   version "7.3.6.9264"
-  sha256 :no_check
+  sha256 "2475fc66e672ee42724a282a5471d11532f0285d403ea704565e0bfffa34710c"
 
-  url "https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg"
+  url "https://dl.google.com/dl/earth/client/advanced/current/googleearthpromac-intel-#{version.major_minor_patch}.dmg"
   name "Google Earth Pro"
   desc "Virtual globe"
   homepage "https://www.google.com/earth/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   pkg "Install Google Earth Pro #{version}.pkg"
 
@@ -29,7 +34,5 @@ cask "google-earth-pro" do
         "com.google.keystone.xpcservice",
         "com.google.keystone.system.xpcservice",
       ],
-      pkgutil:   [
-        "com.google.pkg.Keystone",
-      ]
+      pkgutil:   "com.google.pkg.Keystone"
 end

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -8,7 +8,7 @@ cask "google-earth-pro" do
   homepage "https://www.google.com/earth/"
 
   livecheck do
-    url :url
+    url "https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg"
     strategy :extract_plist
   end
 

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,5 +1,5 @@
 cask "google-earth-pro" do
-  version "7.3.4.8642"
+  version "7.3.6.9264"
   sha256 :no_check
 
   url "https://dl.google.com/earth/client/advanced/current/GoogleEarthProMac-Intel.dmg"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: **N/A**

**Additional Note:** the cask did not install properly before I updated its version because the installer expected a specific version number.