### PR TITLE
image-tool: Move to archive.org, discontinue

### DIFF
--- a/Casks/image-tool.rb
+++ b/Casks/image-tool.rb
@@ -2,15 +2,16 @@ cask "image-tool" do
   version "1.4.1"
   sha256 "66ef0c6cdf2e90981bc8bd0d1131e6e0f141744406997712550b8b5a05022d39"
 
-  url "http://www.jimmcgowan.net/diskimages/ImageTool#{version}.dmg"
+  url "https://archive.org/download/jimmcgowan-2000s-software/ImageTool#{version}.dmg"
   name "Image Tool"
   desc "Scale images and convert image file formats"
-  homepage "http://www.jimmcgowan.net/Site/ImageTool.html"
+  homepage "https://archive.org/details/jimmcgowan-2000s-software"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/ImageToolv?(\d+(?:\.\d+)+)\.dmg}i)
-  end
+  depends_on macos: "<= :mojave"
 
   app "Image Tool.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
From the developer's [site](http://www.jimmcgowan.net):

>Hello
>
>The old Mac software that used to be hosted here can now be found on [archive.org](https://archive.org/details/jimmcgowan-2000s-software). My current software is at [malkinware.com](https://www.malkinware.com/). Other things I do are on [Instagram](https://www.instagram.com/jimmcgowan/).
>
>Jim