### PR TITLE
rotki: Fix livecheck

### DIFF
--- a/Casks/rotki.rb
+++ b/Casks/rotki.rb
@@ -8,6 +8,11 @@ cask "rotki" do
   desc "Portfolio tracking and accounting tool"
   homepage "https://rotki.com/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "rotki.app"
 
   zap trash: [


### PR DESCRIPTION
Switching to `:github_latest` strategy due to tag discrepancies.