### PR TITLE
paragon-ntfs: update manual installer path and zap

### DIFF
--- a/Casks/paragon-ntfs.rb
+++ b/Casks/paragon-ntfs.rb
@@ -14,7 +14,7 @@ cask "paragon-ntfs" do
   auto_updates true
   depends_on macos: ">= :sierra"
 
-  installer manual: "Install NTFS for Mac.app"
+  installer manual: "FSInstaller.app"
 
   uninstall kext:      "com.paragon-software.filesystems.ntfs",
             launchctl: "com.paragon-software.ntfs*",
@@ -29,7 +29,7 @@ cask "paragon-ntfs" do
     "~/Library/Application Support/com.paragon-software.ntfs.*",
     "~/Library/Caches/com.paragon-software.ntfs.fsapp",
     "~/Library/HTTPStorages/com.paragon-software.ntfs.*",
-    "~/Library/Preferences/com.paragon-software.ntfs.fsapp.plist",
+    "~/Library/Preferences/com.paragon-software.ntfs.*",
     "~/Library/Saved Application State/com.paragon-software.ntfs.fsapp.savedState",
     "~/Library/WebKit/com.paragon-software.ntfs.fsapp",
   ]


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
The `FSInstaller.app` is indeed a name of installer for trial download that this cask uses. `Install NTFS for Mac.app` is an installer name of paid version, which is downloaded from ParagonBox.

```sh
$ ls /usr/local/Caskroom/paragon-ntfs/15 
FSInstaller.app  Uninstall.app 
```