### PR TITLE
Fix Gittyup release URL

### DIFF
--- a/Casks/gittyup.rb
+++ b/Casks/gittyup.rb
@@ -1,8 +1,8 @@
 cask "gittyup" do
-  version "1.2.0.1"
+  version "1.2.0"
   sha256 "9e6c25f9d24e642c8f15794745ae4f04cf24cfcaf57c2a7dfed97093e4ccdd1d"
 
-  url "https://github.com/Murmele/Gittyup/releases/download/stable/Gittyup-#{version}.dmg",
+  url "https://github.com/Murmele/Gittyup/releases/download/gittyup_v#{version}/Gittyup-#{version}.dmg",
       verified: "github.com/Murmele/Gittyup/"
   name "gittyup"
   desc "Graphical Git client"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I don't own a Mac, so I can't test this

There never was a version `1.2.0.1`, just `1.2.0`. The `stable` tag has been deprecated and the erroneous `.1` was an error on my part.
I fixed the URL to use `gittyup_v1.2.0`, but this might change with the next release to just `v#.#.#`