### PR TITLE
Revert "Update launchcontrol from 2.0 to 2.0.1"

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -3,8 +3,8 @@ cask "launchcontrol" do
     version "1.52.7,1959"
     sha256 "1f9039a66a8ac17573c6501a59bb01e02fd78ec70eea3316bff03f87370773e5"
   else
-    version "2.0.1,2277"
-    sha256 "4f260e9bd4450abfed038098fffbc7f6de488da95e68fc38857597466d9db8cb"
+    version "2.0,2267"
+    sha256 "1b6c814eba927d8899eb815cf43cf748b6b2e3de33f042862c25816af0c33a89"
   end
 
   url "https://www.soma-zone.com/download/files/LaunchControl-#{version.csv.first}.tar.xz"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#134653

This version has even more issues, so reverting.

Ping @p-linnane -- please merge as soon as you can.