### PR TITLE
fsnotes: Fixing sha256 after the original file was replaced

### DIFF
--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -1,6 +1,6 @@
 cask "fsnotes" do
   version "6.0.0"
-  sha256 "dcfa88094a225c3862e1a5261e9d35a8248f14be5c7aab03c68fd11de4efd46b"
+  sha256 "19ed14496e939791cc156a8753fdee959c9394eea4fb51def1d036e042bc4b04"
 
   url "https://github.com/glushchenko/fsnotes/releases/download/#{version}/FSNotes_#{version}.zip",
       verified: "github.com/glushchenko/fsnotes/"


### PR DESCRIPTION
Looks like the developer replaced the file after my commit was approved.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.