### PR TITLE
Add Binocs v0.7.2

### DIFF
--- a/Casks/binocs.rb
+++ b/Casks/binocs.rb
@@ -16,4 +16,6 @@ cask "binocs" do
   end
 
   binary "binocs"
+
+  zap trash: ["~/.binocs"]
 end

--- a/Casks/binocs.rb
+++ b/Casks/binocs.rb
@@ -17,5 +17,5 @@ cask "binocs" do
 
   binary "binocs"
 
-  zap trash: ["~/.binocs"]
+  zap trash: "~/.binocs"
 end

--- a/Casks/binocs.rb
+++ b/Casks/binocs.rb
@@ -1,0 +1,19 @@
+cask "binocs" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "0.7.2"
+  sha256 arm:   "183181127923af570a81558f8b26babcbe47e9fd42d2ff46409526156110b108",
+         intel: "0a66664c8255c0e87d1a38420e13c1a0ee038c0ae64eace4cc4f731f033ca4a7"
+
+  url "https://download.binocs.sh/binocs_#{version}_darwin_#{arch}.gz"
+  name "Binocs"
+  desc "CLI-first uptime and performance monitoring tool for websites, apps and APIs"
+  homepage "https://binocs.sh/"
+
+  livecheck do
+    url "https://download.binocs.sh/VERSION"
+    regex(/v(\d+(?:\.\d+)+)/)
+  end
+
+  binary "binocs"
+end


### PR DESCRIPTION
Add new Cask for Binocs CLI-first web uptime monitoring tool

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x]  `brew uninstall --cask <cask>` worked successfully.

This Cask belongs to the Trial category. Users sign up for a free account and receive free credits, which they can spend on running the monitoring services provided by Binocs. Users can purchase additional credits via [the official website](https://binocs.sh). 
