### PR TITLE
Fix stellarium 1.1.1 download link

### DIFF
--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -1,23 +1,14 @@
 cask "stellarium" do
-  version "1.1"
+  version "1.1.1"
+  sha256 "961a5c9a0eefd06457ebc0ebf24c45dee9d9e1a51ab8fa4c6931584225381578"
 
-  if MacOS.version <= :catalina
-    sha256 "f3b6b4cbcb7322c6c5d3ff861ed3fde4d261eb03e7c8a197714874ee570a8769"
-
-    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-x86_64.zip",
-        verified: "github.com/Stellarium/stellarium/"
-  else
-    sha256 "3225237eeb762bb45eea356df0b2054f2bbf1c34b1235b86ce3777a74916a2f6"
-
-    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor_patch}/Stellarium-#{version}-macOS.zip",
-        verified: "github.com/Stellarium/stellarium/"
-  end
-
+  url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-macOS.zip",
+      verified: "github.com/Stellarium/stellarium/"
   name "Stellarium"
   desc "Tool to render realistic skies in real time on the screen"
   homepage "https://stellarium.org/"
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :big_sur"
 
   app "Stellarium.app"
 

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -8,6 +8,12 @@ cask "stellarium" do
   desc "Tool to render realistic skies in real time on the screen"
   homepage "https://stellarium.org/"
 
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(%r{href=.*?/Stellarium-(\d+(?:\.\d+)*)-macOS\.zip}i)
+  end
+
   depends_on macos: ">= :big_sur"
 
   app "Stellarium.app"

--- a/Casks/stellarium.rb
+++ b/Casks/stellarium.rb
@@ -10,8 +10,7 @@ cask "stellarium" do
 
   livecheck do
     url :homepage
-    strategy :page_match
-    regex(%r{href=.*?/Stellarium-(\d+(?:\.\d+)*)-macOS\.zip}i)
+    regex(%r{href=.*?/Stellarium[._-]v?(\d+(?:\.\d+)*)[._-]macOS\.zip}i)
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
Version 1.1.1 requires macOS 11.0+: https://github.com/Stellarium/stellarium/releases/tag/v1.1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.