### PR TITLE
Update google-earth-pro to 7.3.6.9275, remove unreliable checksum

### DIFF
--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask "google-earth-pro" do
   version "7.3.6.9275"
-  sha256 :no_check
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dl.google.com/dl/earth/client/advanced/current/googleearthpromac-intel-#{version.major_minor_patch}.dmg"
   name "Google Earth Pro"

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,5 +1,5 @@
 cask "google-earth-pro" do
-  version "7.3.6.9264"
+  version "7.3.6.9275"
   sha256 :no_check
 
   url "https://dl.google.com/dl/earth/client/advanced/current/googleearthpromac-intel-#{version.major_minor_patch}.dmg"

--- a/Casks/google-earth-pro.rb
+++ b/Casks/google-earth-pro.rb
@@ -1,6 +1,6 @@
 cask "google-earth-pro" do
   version "7.3.6.9264"
-  sha256 "2475fc66e672ee42724a282a5471d11532f0285d403ea704565e0bfffa34710c"
+  sha256 :no_check
 
   url "https://dl.google.com/dl/earth/client/advanced/current/googleearthpromac-intel-#{version.major_minor_patch}.dmg"
   name "Google Earth Pro"


### PR DESCRIPTION
The version has a number after the patch that can not be represented by a download URL. This means the URL will point to a different file for newer versions, as is the case between 7.3.6.9264 and 7.3.6.9275.

In other words, the checksum is not reliable for the current URL and there is not a better URL for it.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
