### PR TITLE
Upgrade surge-xt to 1.1.2

### DIFF
--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -1,6 +1,6 @@
 cask "surge-xt" do
-  version "1.1.1"
-  sha256 "2d0b36ea6a99c9b80e106ad7b4707beb29e1619988d9bd968d597af9865455a4"
+  version "1.1.2"
+  sha256 "9c205eddf16bea67e87f7e56ef41b87693f76d5eb6e21bd527426e85f8b0860c"
 
   url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
       verified: "github.com/surge-synthesizer/releases-xt/"


### PR DESCRIPTION
We upgraded surge-xt to version 1.1.2 this morning. This change updates the target, sha, etc...

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
