### PR TITLE
Revert "textexpander 7.3.1,731.2"

### DIFF
--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -14,7 +14,7 @@ cask "textexpander" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "TextExpander.app"
 

--- a/Casks/textexpander.rb
+++ b/Casks/textexpander.rb
@@ -1,8 +1,8 @@
 cask "textexpander" do
-  version "7.3.1,731.2"
-  sha256 "3f914ee70f70cbe5b7bf96ee0cb01be52f160e55bcee6ccc17787c7b8d2fc425"
+  version "6.8.5,685.6"
+  sha256 "08533d2c787ceaa04d34ba42e73fea3b7798134f33191acef68d68d38b604958"
 
-  url "https://cdn.textexpander.com/mac/#{version.csv.second}/TextExpander_#{version.csv.first}.dmg",
+  url "https://cdn.textexpander.com/mac/#{version.csv.second}/TextExpander_#{version.csv.first}.zip",
       verified: "cdn.textexpander.com/mac/"
   name "TextExpander"
   desc "Inserts pre-made snippets of text anywhere"


### PR DESCRIPTION
This reverts commit c9f757e275879ffbc0cfd417012e90081a227445.

Changes should not be merged until https://github.com/Homebrew/brew/pull/14037 has been merged.