### PR TITLE
obs: use `sparkle` livecheck strategy

### DIFF
--- a/Casks/obs.rb
+++ b/Casks/obs.rb
@@ -11,8 +11,8 @@ cask "obs" do
   homepage "https://obsproject.com/"
 
   livecheck do
-    url "https://obsproject.com/download/"
-    regex(%r{href=.*?/obs[._-]studio[._-]v?(\d+(?:\.\d+)+).*?\.dmg}i)
+    url "https://obsproject.com/osx_update/stable/updates_#{arch}.xml"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
Use `sparkle` livecheck strategy to align with in-app updates.