### PR TITLE
balenaetcher: Adjust version & url for discontinue

### DIFF
--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -9,7 +9,7 @@ cask "balenaetcher" do
   homepage "https://balena.io/etcher"
 
   livecheck do
-    skip "balenaetcher is no longer updated in homebrew-cask due to the maintenance demand of multiple stable releases per day."
+    skip "balenaetcher is no longer updated in homebrew-cask due to the maintenance demand."
   end
 
   auto_updates true

--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -1,15 +1,15 @@
 cask "balenaetcher" do
-  version "1.8.14"
-  sha256 "4c3ca69f01e72c0c0e677cb1572bb887cc3cc146cfbe1aaf198cbab2266ed68d"
+  version :latest
+  sha256 :no_check
 
-  url "https://github.com/balena-io/etcher/releases/download/v#{version}/balenaEtcher-#{version}.dmg",
+  url "https://github.com/balena-io/etcher/releases/download/v1.8.14/balenaEtcher-1.8.4.dmg",
       verified: "github.com/balena-io/etcher/"
   name "Etcher"
   desc "Tool to flash OS images to SD cards & USB drives"
   homepage "https://balena.io/etcher"
 
   livecheck do
-    skip "homebrew-cask has discontinued support due to extremely frequent releases"
+    skip "balenaetcher is no longer updated in homebrew-cask due to multiple stable releases per day."
   end
 
   auto_updates true
@@ -26,7 +26,6 @@ cask "balenaetcher" do
   ]
 
   caveats <<~EOS
-    Support for future updates of #{token} has been discontinued in homebrew-cask
-    due to extremely frequent stable releases.
+    #{token} is no longer updated in homebrew-cask due to multiple stable releases per day.
   EOS
 end

--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -9,7 +9,7 @@ cask "balenaetcher" do
   homepage "https://balena.io/etcher"
 
   livecheck do
-    skip "balenaetcher is no longer updated in homebrew-cask due to multiple stable releases per day."
+    skip "balenaetcher is no longer updated in homebrew-cask due to the maintenance demand multiple stable releases per day."
   end
 
   auto_updates true

--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -2,7 +2,7 @@ cask "balenaetcher" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/balena-io/etcher/releases/download/v1.8.14/balenaEtcher-1.8.4.dmg",
+  url "https://github.com/balena-io/etcher/releases/download/v1.8.14/balenaEtcher-1.8.14.dmg",
       verified: "github.com/balena-io/etcher/"
   name "Etcher"
   desc "Tool to flash OS images to SD cards & USB drives"

--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -8,12 +8,6 @@ cask "balenaetcher" do
   desc "Tool to flash OS images to SD cards & USB drives"
   homepage "https://balena.io/etcher"
 
-  livecheck do
-    skip "balenaetcher is no longer updated in homebrew-cask due to the maintenance demand."
-  end
-
-  auto_updates true
-
   app "balenaEtcher.app"
 
   uninstall quit: "io.balena.etcher.*"

--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -9,7 +9,7 @@ cask "balenaetcher" do
   homepage "https://balena.io/etcher"
 
   livecheck do
-    skip "balenaetcher is no longer updated in homebrew-cask due to the maintenance demand multiple stable releases per day."
+    skip "balenaetcher is no longer updated in homebrew-cask due to the maintenance demand of multiple stable releases per day."
   end
 
   auto_updates true

--- a/Casks/balenaetcher.rb
+++ b/Casks/balenaetcher.rb
@@ -26,6 +26,6 @@ cask "balenaetcher" do
   ]
 
   caveats <<~EOS
-    #{token} is no longer updated in homebrew-cask due to multiple stable releases per day.
+    #{token} is no longer updated in homebrew-cask due to the maintenance demand of multiple stable releases per day.
   EOS
 end


### PR DESCRIPTION
Some final adjustments to the formatting/text of this cask.

Per [my previous comment](https://github.com/Homebrew/homebrew-cask/pull/135341#issuecomment-1307647519) we are discontinuing furthur support for Balena Etcher due to a new release cadence that has currently seen ~24 stable releases over the last 2 days. Since this is [by design](https://github.com/balena-io/etcher/issues/3853#issuecomment-1307499602) we are no longer going to support this.