### PR TITLE
Add DiffusionBee-HQ to Homebrew-Cask

### DIFF
--- a/Casks/diffusionbee-hq.rb
+++ b/Casks/diffusionbee-hq.rb
@@ -5,14 +5,13 @@ cask "diffusionbee-hq" do
   url "https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/releases/download/#{version}/DiffusionBee-#{version}-arm64_TF_SD1.4_FP32.dmg",
       verified: "github.com/divamgupta/diffusionbee-stable-diffusion-ui"
   name "Diffusion Bee"
-  desc "Run Stable Diffusion locally. HQ Version for Apple Silicon."
+  desc "Run Stable Diffusion locally. HQ Version for Apple Silicon"
   homepage "https://diffusionbee.com/"
 
+  conflicts_with cask: "diffusionbee"
   depends_on arch: :arm64
 
   app "DiffusionBee.app"
-
-  conflicts_with cask: "diffusionbee"
 
   zap trash: [
     "~/.diffusionbee",

--- a/Casks/diffusionbee-hq.rb
+++ b/Casks/diffusionbee-hq.rb
@@ -1,0 +1,21 @@
+cask "diffusionbee-hq" do
+  version "1.4.3"
+  sha256 "be6a9c92aa4e17cc9c030991ecbe3c3afea8959ff7c986cb97feec2aaead4946"
+
+  url "https://github.com/divamgupta/diffusionbee-stable-diffusion-ui/releases/download/#{version}/DiffusionBee-#{version}-arm64_TF_SD1.4_FP32.dmg",
+      verified: "github.com/divamgupta/diffusionbee-stable-diffusion-ui"
+  name "Diffusion Bee"
+  desc "Run Stable Diffusion locally. HQ Version for Apple Silicon."
+  homepage "https://diffusionbee.com/"
+
+  depends_on arch: :arm64
+
+  app "DiffusionBee.app"
+
+  conflicts_with cask: "diffusionbee"
+
+  zap trash: [
+    "~/.diffusionbee",
+    "~/Library/Application Support/DiffusionBee",
+  ]
+end

--- a/Casks/diffusionbee.rb
+++ b/Casks/diffusionbee.rb
@@ -11,9 +11,9 @@ cask "diffusionbee" do
   desc "Run Stable Diffusion locally"
   homepage "https://diffusionbee.com/"
 
-  app "DiffusionBee.app"
-
   conflicts_with cask: "diffusionbee-hq"
+
+  app "DiffusionBee.app"
 
   zap trash: [
     "~/.diffusionbee",

--- a/Casks/diffusionbee.rb
+++ b/Casks/diffusionbee.rb
@@ -13,6 +13,8 @@ cask "diffusionbee" do
 
   app "DiffusionBee.app"
 
+  conflicts_with cask: "diffusionbee-hq"
+
   zap trash: [
     "~/.diffusionbee",
     "~/Library/Application Support/DiffusionBee",


### PR DESCRIPTION
DiffusionBee 1.4.3 started including an HQ version that runs only on Apple Silicon. It runs slower but produces higher quality results.

I named this package `diffusionbee-hq` because the download is titled "HQ Version for Apple Silicon" on https://diffusionbee.com

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
