### PR TITLE
Add restfox cask to Homebrew-Cask

### DIFF
--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -1,6 +1,4 @@
 cask "restfox" do
-  arch intel: "osx64"
-
   version "0.0.6"
   sha256 "c855011459615b181efde6d88a82ce7c4c0a5b257a4b8a35e41d2a2de35aba6e"
 

--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -10,11 +10,6 @@ cask "restfox" do
   desc "Offline-first web HTTP client"
   homepage "https://restfox.dev/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
 
   app "Restfox.app"

--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -2,7 +2,7 @@ cask "restfox" do
   arch intel: "osx64"
 
   version "0.0.6"
-  sha256 :no_check
+  sha256 "c855011459615b181efde6d88a82ce7c4c0a5b257a4b8a35e41d2a2de35aba6e"
 
   url "https://github.com/flawiddsouza/Restfox/releases/download/v#{version}/Restfox-darwin-x64-#{version}.zip",
       verified: "github.com/flawiddsouza/Restfox/releases/download/"
@@ -18,4 +18,8 @@ cask "restfox" do
   auto_updates true
 
   app "Restfox.app"
+  
+  zap trash: [
+    "~/Library/Application Support/Restfox",
+  ]
 end

--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -13,6 +13,6 @@ cask "restfox" do
   auto_updates true
 
   app "Restfox.app"
-  
+
   zap trash: "~/Library/Application Support/Restfox"
 end

--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -19,7 +19,5 @@ cask "restfox" do
 
   app "Restfox.app"
   
-  zap trash: [
-    "~/Library/Application Support/Restfox",
-  ]
+  zap trash: "~/Library/Application Support/Restfox"
 end

--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -1,0 +1,21 @@
+cask "restfox" do
+  arch intel: "osx64"
+
+  version "0.0.6"
+  sha256 :no_check
+
+  url "https://github.com/flawiddsouza/Restfox/releases/download/v#{version}/Restfox-darwin-x64-#{version}.zip",
+      verified: "github.com/flawiddsouza/Restfox/releases/download/"
+  name "Restfox"
+  desc " Offline-first web HTTP client"
+  homepage "https://restfox.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+
+  app "Restfox.app"
+end

--- a/Casks/restfox.rb
+++ b/Casks/restfox.rb
@@ -7,7 +7,7 @@ cask "restfox" do
   url "https://github.com/flawiddsouza/Restfox/releases/download/v#{version}/Restfox-darwin-x64-#{version}.zip",
       verified: "github.com/flawiddsouza/Restfox/releases/download/"
   name "Restfox"
-  desc " Offline-first web HTTP client"
+  desc "Offline-first web HTTP client"
   homepage "https://restfox.dev/"
 
   livecheck do


### PR DESCRIPTION
A new cask for this project [https://github.com/flawiddsouza/Restfox](https://github.com/flawiddsouza/Restfox) with token: `restfox`
Version: 0.0.6
Currently only x64, will try to add support for M1(We need to do tests on a physical device first).
Thank you.

EDIT: Sorry for the many commits.
---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
