### PR TITLE
rsyncosx: Add livecheck

### DIFF
--- a/Casks/rsyncosx.rb
+++ b/Casks/rsyncosx.rb
@@ -7,6 +7,11 @@ cask "rsyncosx" do
   desc "GUI for rsync"
   homepage "https://github.com/rsyncOSX/RsyncOSX"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :big_sur"
 
   app "RsyncOSX.app"


### PR DESCRIPTION
Switching to `:github_latest` strategy due to use of prereleases.