### PR TITLE
Update VoikkoSpellService from 1.0.6b1 to 1.1.0b1

### DIFF
--- a/Casks/voikkospellservice.rb
+++ b/Casks/voikkospellservice.rb
@@ -13,4 +13,6 @@ cask "voikkospellservice" do
   service "VoikkoSpellService.app"
 
   uninstall signal: ["TERM", "org.puimula.VoikkoSpellService"]
+
+  zap trash: ["~/Library/Spelling/Finnish"]
 end

--- a/Casks/voikkospellservice.rb
+++ b/Casks/voikkospellservice.rb
@@ -2,16 +2,11 @@ cask "voikkospellservice" do
   version "1.1.0b1"
   sha256 "c1dec3cda95ed77de2e6246e5e16b4425f40c576a2409d272ea85fb2bc22f285"
 
-  url "https://github.com/walokra/osxspell/releases/download/#{version}/VoikkoSpellService-#{version}.dmg", verified: "github.com/walokra/osxspell/"
+  url "https://github.com/walokra/osxspell/releases/download/#{version}/VoikkoSpellService-#{version}.dmg",
+      verified: "github.com/walokra/osxspell/"
   name "VoikkoSpellService"
   desc "Spell-checking service for Finnish"
   homepage "https://verteksi.net/lab/osxspell/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-    regex(%r{href=.*?/tag/(\d+(?:\.\d+.\S{0,2}[^"])+)["' >]}i)
-  end
 
   depends_on macos: ">= :big_sur"
 

--- a/Casks/voikkospellservice.rb
+++ b/Casks/voikkospellservice.rb
@@ -14,5 +14,5 @@ cask "voikkospellservice" do
 
   uninstall signal: ["TERM", "org.puimula.VoikkoSpellService"]
 
-  zap trash: ["~/Library/Spelling/Finnish"]
+  zap trash: "~/Library/Spelling/Finnish"
 end

--- a/Casks/voikkospellservice.rb
+++ b/Casks/voikkospellservice.rb
@@ -1,6 +1,6 @@
 cask "voikkospellservice" do
   version "1.1.0b1"
-  sha256 "c1dec3cda95ed77de2e6246e5e16b4425f40c576a2409d272ea85fb2bc22f285"
+  sha256 "146f0f8a31e7b1b40a2fa8a6eec77fcdbf5553a7e66d32a16492afcb7b2e9b23"
 
   url "https://github.com/walokra/osxspell/releases/download/#{version}/VoikkoSpellService-#{version}.dmg",
       verified: "github.com/walokra/osxspell/"

--- a/Casks/voikkospellservice.rb
+++ b/Casks/voikkospellservice.rb
@@ -1,15 +1,19 @@
 cask "voikkospellservice" do
-  version "1.0.6b1"
-  sha256 "b94df1e56bab0895831723d369a6e99c03202e99a6db5fe62625af9b4fa17973"
+  version "1.1.0b1"
+  sha256 "c1dec3cda95ed77de2e6246e5e16b4425f40c576a2409d272ea85fb2bc22f285"
 
-  url "https://verteksi.net/files/osxspell/VoikkoSpellService-#{version}.dmg"
+  url "https://github.com/walokra/osxspell/releases/download/#{version}/VoikkoSpellService-#{version}.dmg", verified: "github.com/walokra/osxspell/"
   name "VoikkoSpellService"
+  desc "Spell-checking service for Finnish"
   homepage "https://verteksi.net/lab/osxspell/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/VoikkoSpellService-(\d+(?:\.\d+)*b\d+)\.dmg}i)
+    url :url
+    strategy :github_latest
+    regex(%r{href=.*?/tag/(\d+(?:\.\d+.\S{0,2}[^"])+)["' >]}i)
   end
+
+  depends_on macos: ">= :big_sur"
 
   service "VoikkoSpellService.app"
 


### PR DESCRIPTION
Updating VoikkoSpellService to 1.1.0b1 with binary now served from GitHub releases.