### PR TITLE
pushplaylabs-sidekick: Move to install pkg

### DIFF
--- a/Casks/pushplaylabs-sidekick.rb
+++ b/Casks/pushplaylabs-sidekick.rb
@@ -1,32 +1,23 @@
 cask "pushplaylabs-sidekick" do
-  arch arm: "arm64", intel: "x64"
-  livecheck_folder = on_arch_conditional arm: "macm1", intel: "mac"
+  version "1.0.68"
+  sha256 "5ba0c905bbd9676c2fa712b4a0143af600c8339d4d296e8a2454df14c3109978"
 
-  on_intel do
-    version "104.30.1.25571,90580da"
-    sha256 "81127b87f19506356070f7a17fb6aeeed8920cfe1670a7e6b4ea00bec3e57967"
-  end
-  on_arm do
-    version "104.30.1.25572,78eedd6"
-    sha256 "ba9e6f74940b2a6ad352edc4b00396bb80f1338be98b18d96c3029e876595e3c"
-  end
-
-  url "https://fast-cdn.meetsidekick.com/builds/sidekick-mac-release-#{arch}-#{version.csv.first}-#{version.csv.second}-df.dmg"
+  url "https://fast-cdn.meetsidekick.com/builds/sidekick-mac-installer-#{version}.pkg"
   name "Sidekick"
   desc "Browser designed for modern work"
   homepage "https://www.meetsidekick.com/"
 
   livecheck do
-    url "https://api.meetsidekick.com/downloads/df/#{livecheck_folder}"
-    strategy :header_match do |headers|
-      match = headers["location"].match(/[_-](\d+(?:\.\d+)+)[_-](.+)[._-](?:default|df)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
+    url "https://api.meetsidekick.com/downloads/df/mac"
+    regex(/(\d+(?:\.\d+)+)\.pkg/i)
+    strategy :header_match
   end
 
-  app "Sidekick.app"
+  pkg "sidekick-mac-installer-#{version}.pkg"
+
+  uninstall delete:  "/Applications/Sidekick.app",
+            pkgutil: "org.Sidekick.#{version}",
+            quit:    "com.pushplaylabs.sidekick"
 
   zap trash: [
     "~/Library/Application Support/Sidekick",


### PR DESCRIPTION
The architecture specific .dmg files that were previously offered have been replaced with an installer .pkg. The .pkg contains scripts that pull down the relevant .dmg, but there does not appear to be a way to `livecheck` those any longer.