### PR TITLE
Update affinity-designer/affinity-photo/affinity-publisher to 2.0.0

### DIFF
--- a/Casks/affinity-designer.rb
+++ b/Casks/affinity-designer.rb
@@ -22,7 +22,7 @@ cask "affinity-designer" do
     "~/Library/Caches/com.seriflabs.affinitydesigner2",
     "~/Library/HTTPStorages/com.seriflabs.affinitydesigner2",
     "~/Library/Preferences/com.seriflabs.affinitydesigner2.plist",
-    "~/Library/WebKit/com.seriflabs.affinitydesigner2",
     "~/Library/Saved Application State/com.seriflabs.affinitydesigner2.savedState",
+    "~/Library/WebKit/com.seriflabs.affinitydesigner2",
   ]
 end

--- a/Casks/affinity-designer.rb
+++ b/Casks/affinity-designer.rb
@@ -22,6 +22,6 @@ cask "affinity-designer" do
     "~/Library/HTTPStorages/com.seriflabs.affinitydesigner2",
     "~/Library/Preferences/com.seriflabs.affinitydesigner2.plist",
     "~/Library/WebKit/com.seriflabs.affinitydesigner2",
-    "~/Library/Saved Application State/com.seriflabs.affinitydesigner2.savedState"
+    "~/Library/Saved Application State/com.seriflabs.affinitydesigner2.savedState",
   ]
 end

--- a/Casks/affinity-designer.rb
+++ b/Casks/affinity-designer.rb
@@ -13,6 +13,7 @@ cask "affinity-designer" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Affinity Designer #{version.major}.app"
 

--- a/Casks/affinity-designer.rb
+++ b/Casks/affinity-designer.rb
@@ -19,5 +19,6 @@ cask "affinity-designer" do
   zap trash: [
     "~/Library/Application Support/Affinity Designer",
     "~/Library/Caches/com.seriflabs.affinitydesigner",
+    "~/Library/Saved Application State/com.seriflabs.affinitydesigner.savedState"
   ]
 end

--- a/Casks/affinity-designer.rb
+++ b/Casks/affinity-designer.rb
@@ -1,9 +1,9 @@
 cask "affinity-designer" do
-  version "1.10.5"
+  version "2.0.0"
   sha256 :no_check
 
-  url "https://store.serif.com/download/aa4dee/"
-  name "Affinity Designer"
+  url "https://store.serif.com/download/60f51f/"
+  name "Affinity Designer #{version.major}"
   desc "Professional graphic design software"
   homepage "https://affinity.serif.com/en-us/designer/"
 
@@ -14,11 +14,14 @@ cask "affinity-designer" do
 
   auto_updates true
 
-  app "Affinity Designer.app"
+  app "Affinity Designer #{version.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/Affinity Designer",
-    "~/Library/Caches/com.seriflabs.affinitydesigner",
-    "~/Library/Saved Application State/com.seriflabs.affinitydesigner.savedState"
+    "~/Library/Application Support/Affinity Designer 2",
+    "~/Library/Caches/com.seriflabs.affinitydesigner2",
+    "~/Library/HTTPStorages/com.seriflabs.affinitydesigner2",
+    "~/Library/Preferences/com.seriflabs.affinitydesigner2.plist",
+    "~/Library/WebKit/com.seriflabs.affinitydesigner2",
+    "~/Library/Saved Application State/com.seriflabs.affinitydesigner2.savedState"
   ]
 end

--- a/Casks/affinity-photo.rb
+++ b/Casks/affinity-photo.rb
@@ -13,6 +13,7 @@ cask "affinity-photo" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Affinity Photo #{version.major}.app"
 

--- a/Casks/affinity-photo.rb
+++ b/Casks/affinity-photo.rb
@@ -1,9 +1,9 @@
 cask "affinity-photo" do
-  version "1.10.5"
+  version "2.0.0"
   sha256 :no_check
 
-  url "https://store.serif.com/download/075b51/"
-  name "Affinity Photo"
+  url "https://store.serif.com/download/89007d/"
+  name "Affinity Photo #{version.major}"
   desc "Professional image editing software"
   homepage "https://affinity.serif.com/en-us/photo/"
 
@@ -14,11 +14,14 @@ cask "affinity-photo" do
 
   auto_updates true
 
-  app "Affinity Photo.app"
+  app "Affinity Photo #{version.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/Affinity Photo",
-    "~/Library/Caches/com.seriflabs.affinityphoto",
-    "~/Library/Saved Application State/com.seriflabs.affinityphoto.savedState"
+    "~/Library/Application Support/Affinity Photo 2",
+    "~/Library/Caches/com.seriflabs.affinityphoto2",
+    "~/Library/HTTPStorages/com.seriflabs.affinityphoto2",
+    "~/Library/Preferences/com.seriflabs.affinityphoto2.plist",
+    "~/Library/WebKit/com.seriflabs.affinityphoto2",
+    "~/Library/Saved Application State/com.seriflabs.affinityphoto2.savedState"
   ]
 end

--- a/Casks/affinity-photo.rb
+++ b/Casks/affinity-photo.rb
@@ -19,5 +19,6 @@ cask "affinity-photo" do
   zap trash: [
     "~/Library/Application Support/Affinity Photo",
     "~/Library/Caches/com.seriflabs.affinityphoto",
+    "~/Library/Saved Application State/com.seriflabs.affinityphoto.savedState"
   ]
 end

--- a/Casks/affinity-photo.rb
+++ b/Casks/affinity-photo.rb
@@ -22,7 +22,7 @@ cask "affinity-photo" do
     "~/Library/Caches/com.seriflabs.affinityphoto2",
     "~/Library/HTTPStorages/com.seriflabs.affinityphoto2",
     "~/Library/Preferences/com.seriflabs.affinityphoto2.plist",
-    "~/Library/WebKit/com.seriflabs.affinityphoto2",
     "~/Library/Saved Application State/com.seriflabs.affinityphoto2.savedState",
+    "~/Library/WebKit/com.seriflabs.affinityphoto2",
   ]
 end

--- a/Casks/affinity-photo.rb
+++ b/Casks/affinity-photo.rb
@@ -22,6 +22,6 @@ cask "affinity-photo" do
     "~/Library/HTTPStorages/com.seriflabs.affinityphoto2",
     "~/Library/Preferences/com.seriflabs.affinityphoto2.plist",
     "~/Library/WebKit/com.seriflabs.affinityphoto2",
-    "~/Library/Saved Application State/com.seriflabs.affinityphoto2.savedState"
+    "~/Library/Saved Application State/com.seriflabs.affinityphoto2.savedState",
   ]
 end

--- a/Casks/affinity-publisher.rb
+++ b/Casks/affinity-publisher.rb
@@ -1,9 +1,9 @@
 cask "affinity-publisher" do
-  version "1.10.5"
+  version "2.0.0"
   sha256 :no_check
 
-  url "https://store.serif.com/download/7ef252/"
-  name "Affinity Publisher"
+  url "https://store.serif.com/download/668dfb/"
+  name "Affinity Publisher #{version.major}"
   desc "Professional desktop publishing software"
   homepage "https://affinity.serif.com/en-us/publisher/"
 
@@ -14,11 +14,14 @@ cask "affinity-publisher" do
 
   auto_updates true
 
-  app "Affinity Publisher.app"
+  app "Affinity Publisher #{version.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/Affinity Publisher",
-    "~/Library/Caches/com.seriflabs.affinitypublisher",
-    "~/Library/Saved Application State/com.seriflabs.affinitypublisher.savedState"
+    "~/Library/Application Support/Affinity Publisher 2",
+    "~/Library/Caches/com.seriflabs.affinitypublisher2",
+    "~/Library/HTTPStorages/com.seriflabs.affinitypublisher2",
+    "~/Library/Preferences/com.seriflabs.affinitypublisher2.plist",
+    "~/Library/WebKit/com.seriflabs.affinitypublisher2",
+    "~/Library/Saved Application State/com.seriflabs.affinitypublisher2.savedState"
   ]
 end

--- a/Casks/affinity-publisher.rb
+++ b/Casks/affinity-publisher.rb
@@ -19,5 +19,6 @@ cask "affinity-publisher" do
   zap trash: [
     "~/Library/Application Support/Affinity Publisher",
     "~/Library/Caches/com.seriflabs.affinitypublisher",
+    "~/Library/Saved Application State/com.seriflabs.affinitypublisher.savedState"
   ]
 end

--- a/Casks/affinity-publisher.rb
+++ b/Casks/affinity-publisher.rb
@@ -22,6 +22,6 @@ cask "affinity-publisher" do
     "~/Library/HTTPStorages/com.seriflabs.affinitypublisher2",
     "~/Library/Preferences/com.seriflabs.affinitypublisher2.plist",
     "~/Library/WebKit/com.seriflabs.affinitypublisher2",
-    "~/Library/Saved Application State/com.seriflabs.affinitypublisher2.savedState"
+    "~/Library/Saved Application State/com.seriflabs.affinitypublisher2.savedState",
   ]
 end

--- a/Casks/affinity-publisher.rb
+++ b/Casks/affinity-publisher.rb
@@ -13,6 +13,7 @@ cask "affinity-publisher" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Affinity Publisher #{version.major}.app"
 

--- a/Casks/affinity-publisher.rb
+++ b/Casks/affinity-publisher.rb
@@ -22,7 +22,7 @@ cask "affinity-publisher" do
     "~/Library/Caches/com.seriflabs.affinitypublisher2",
     "~/Library/HTTPStorages/com.seriflabs.affinitypublisher2",
     "~/Library/Preferences/com.seriflabs.affinitypublisher2.plist",
-    "~/Library/WebKit/com.seriflabs.affinitypublisher2",
     "~/Library/Saved Application State/com.seriflabs.affinitypublisher2.savedState",
+    "~/Library/WebKit/com.seriflabs.affinitypublisher2",
   ]
 end


### PR DESCRIPTION
Serif has released a major [new "v2"](https://affinity.serif.com/en-us/whats-new/) for their suite of three apps:

- `affinity-designer`
- `affinity-photo`
- `affinity-publisher`

I believe these should not be new casks, as the current v1 versions [will no longer receive updates](https://affinity.serif.com/en-us/affinity-2-faq/), and v2 is backwards-compatible.

However, it **is** a paid upgrade (new license required), and the current apps **do not** auto-update or prompt user to update (at least not yet).

Could you some advice if I should remove `auto_update` then, but guessing we should leave `true`, at let the software take care of eventually alerting users to new v2 in their own auto-update or notification mechanisms.

The current v1 versions could then move to `cask-versions` as `affinity-[app]-1`, which I'm happy to do if this is accepted.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online affinity-photo affinity-publisher affinity-designer  ` is error-free.
- [x] `brew style --fix affinity-photo affinity-publisher affinity-designer` reports no offenses.