### PR TITLE
Fix Livebook SHA as per remote file

### DIFF
--- a/Casks/livebook.rb
+++ b/Casks/livebook.rb
@@ -1,6 +1,6 @@
 cask "livebook" do
   version "0.7.2"
-  sha256 "046871842b42199707150033dc773874cdb53c28e9587cfcda929a74e852c002"
+  sha256 "65628e0583bc31b76301c50b5313440117cbe4e6290e1bf51860f01f55aa97f2"
 
   url "https://github.com/livebook-dev/livebook/releases/download/v#{version}/LivebookInstall-v#{version}-macos-universal.dmg",
       verified: "github.com/livebook-dev/livebook"


### PR DESCRIPTION
Used `sha256sum LivebookInstall-v0.7.2-macos-universal.dmg` to verify it. Closes #135771.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.