### PR TITLE
Bumped osu! version to 2022.1117.0 & changed it's description

### DIFF
--- a/Casks/osu.rb
+++ b/Casks/osu.rb
@@ -7,7 +7,7 @@ cask "osu" do
 
   url "https://github.com/ppy/osu/releases/download/#{version}/osu.app.#{arch}.zip"
   name "osu!"
-  desc "A free-to-win rhythm game. Rhythm is just a click away!"
+  desc "Free-to-win rhythm game. Rhythm is just a click away!"
   homepage "https://github.com/ppy/osu/"
 
   livecheck do

--- a/Casks/osu.rb
+++ b/Casks/osu.rb
@@ -1,13 +1,13 @@
 cask "osu" do
   arch arm: "Apple.Silicon", intel: "Intel"
 
-  version "2022.1101.0"
-  sha256 arm:   "186be9d324fed096317c927a2f1a1429ac6f0957fc0ed30567a9ef9eff1e36cc",
-         intel: "dc9b363409594fd54b32700f090248fa2a00b0ac03904c6b4da4a6538017af02"
+  version "2022.1117.0"
+  sha256 arm:   "3966b7a0c7f81cb4dde61959917c81aa0ab8b744e645d0072ce0cde506546b9d",
+         intel: "a44d2383af5182d2cdc132e4c007bfcb76b1739eb72bb79e8158093dcbf242da"
 
   url "https://github.com/ppy/osu/releases/download/#{version}/osu.app.#{arch}.zip"
   name "osu!"
-  desc "Rhythm game"
+  desc "A free-to-win rhythm game. Rhythm is just a click away!"
   homepage "https://github.com/ppy/osu/"
 
   livecheck do


### PR DESCRIPTION
Quick bump due to a new release ~10h ago!
Gotta get that latest carpal tunnel somehow...
Also changed the description to match the GitHub README.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.