### PR TITLE
Revert "akiflow: Fix livecheck (#135963)"

### DIFF
--- a/Casks/akiflow.rb
+++ b/Casks/akiflow.rb
@@ -9,7 +9,8 @@ cask "akiflow" do
 
   livecheck do
     url "https://akiflow.com/releases/download"
-    strategy :header_match
+    regex(/href=.*?Akiflow[._-](\d+(?:\.\d+)+)[._-]universal\.dmg/i)
+    strategy :page_match
   end
 
   app "Akiflow.app"


### PR DESCRIPTION
This reverts commit aba07c010f96b17034cfeb209f3f5ce9c8fdcc7b.

They have gone back to having a download page instead of being served directly.