### PR TITLE
slab: use `:git` livecheck strategy instead of `:extract_plist`

### DIFF
--- a/Casks/slab.rb
+++ b/Casks/slab.rb
@@ -11,8 +11,7 @@ cask "slab" do
   homepage "https://slab.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://github.com/slab/desktop-releases/"
   end
 
   auto_updates true


### PR DESCRIPTION
Slab is utilising GitHub releases for distributing the artifacts, and the download URL redirects to here.
We should be able to reliably use the repository for livecheck, with a much lower livecheck overhead.