### PR TITLE
akiflow: Fix livecheck

### DIFF
--- a/Casks/akiflow.rb
+++ b/Casks/akiflow.rb
@@ -9,8 +9,7 @@ cask "akiflow" do
 
   livecheck do
     url "https://akiflow.com/releases/download"
-    regex(/href=.*?Akiflow[._-](\d+(?:\.\d+)+)[._-]universal\.dmg/i)
-    strategy :page_match
+    strategy :header_match
   end
 
   app "Akiflow.app"


### PR DESCRIPTION
This is a final effort to fix the `livecheck` for `akiflow`. Upstream has been bouncing between a dedicated downloads page and serving the binary directly. If they change again, I will skip the `livecheck` due to their inability to maintain a consistent strategy. There has been no change in the last 2 weeks, so hopefully the issue is resolved.

https://github.com/Homebrew/homebrew-cask/pull/135681
https://github.com/Homebrew/homebrew-cask/pull/135963
https://github.com/Homebrew/homebrew-cask/pull/136010