### PR TITLE
Undeprecate and upgrade cerebro to v0.10.0

### DIFF
--- a/Casks/cerebro.rb
+++ b/Casks/cerebro.rb
@@ -8,11 +8,6 @@ cask "cerebro" do
   desc "Open-source launcher"
   homepage "https://cerebroapp.vercel.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   app "Cerebro.app"
 
   uninstall quit: "cerebro"

--- a/Casks/cerebro.rb
+++ b/Casks/cerebro.rb
@@ -1,14 +1,21 @@
 cask "cerebro" do
-  version "0.3.2"
-  sha256 "a4df90aca836d6110ac65cd5c1427fb9121f93bdd36ed8527816befbda3dc833"
+  version "0.10.0"
+  sha256 "90a34e70ad24e99028ebc65059520cf99e8db1688d1c755275c41bd44db46323"
 
   url "https://github.com/cerebroapp/cerebro/releases/download/v#{version}/cerebro-#{version}.dmg",
       verified: "github.com/cerebroapp/cerebro/"
   name "Cerebro"
-  desc "Productivity booster with a brain"
-  homepage "https://cerebroapp.com/"
+  desc "Open-source launcher"
+  homepage "https://cerebroapp.vercel.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "Cerebro.app"
+
+  uninstall quit: "cerebro"
 
   zap trash: [
     "~/Library/Application Support/Cerebro",
@@ -16,8 +23,4 @@ cask "cerebro" do
     "~/Library/Preferences/com.cerebroapp.Cerebro.plist",
     "~/Library/Saved Application State/com.cerebroapp.Cerebro.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end


### PR DESCRIPTION
Since I kind of took ownership of cerebro on mac, I thought I might un-deprecate and update it again on brew :)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
