### PR TITLE
virtualbuddy: adjust min OS

### DIFF
--- a/Casks/virtualbuddy.rb
+++ b/Casks/virtualbuddy.rb
@@ -18,7 +18,7 @@ cask "virtualbuddy" do
   end
 
   depends_on arch: :arm64
-  depends_on macos: :monterey
+  depends_on macos: ">= :monterey"
 
   app "VirtualBuddy.app"
 


### PR DESCRIPTION
When VirtualBuddy was released it required Monterey. Now that Ventura is out we can just this requirement to Monterey & up.