### PR TITLE
Fix Hyperkey minimum macOS version

### DIFF
--- a/Casks/hyperkey.rb
+++ b/Casks/hyperkey.rb
@@ -13,7 +13,7 @@ cask "hyperkey" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "Hyperkey.app"
 


### PR DESCRIPTION
`brew audit` throws the error `Upstream defined 10.12 as minimal OS version and the cask defined 10.13`, however both the `Info.plist` and Sparkle appcast list 10.13 as the minimum version. I assume it's the lack of a `sparkle:shortVersionString` in the appcast?

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.