### PR TITLE
Fix `virtualbox-extension-pack` #134061: validate if Pack is really installed

### DIFF
--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -31,12 +31,20 @@ cask "virtualbox-extension-pack" do
   uninstall_postflight do
     next unless File.exist?("/usr/local/bin/VBoxManage")
 
-    system_command "/usr/local/bin/VBoxManage",
-                   args: [
-                     "extpack", "uninstall",
-                     "Oracle VM VirtualBox Extension Pack"
-                   ],
-                   sudo: true
+    if system_command("/usr/local/bin/VBoxManage", 
+        args: [
+          "list",
+          "extpacks"
+        ],
+        sudo: true
+    ).stdout.match?(/^Pack no. \d+:\s+Oracle VM VirtualBox Extension Pack$/)
+      system_command "/usr/local/bin/VBoxManage",
+      args: [
+        "extpack", "uninstall",
+        "Oracle VM VirtualBox Extension Pack"
+      ],
+      sudo: true
+    end
   end
 
   caveats do

--- a/Casks/virtualbox-extension-pack.rb
+++ b/Casks/virtualbox-extension-pack.rb
@@ -31,19 +31,18 @@ cask "virtualbox-extension-pack" do
   uninstall_postflight do
     next unless File.exist?("/usr/local/bin/VBoxManage")
 
-    if system_command("/usr/local/bin/VBoxManage", 
-        args: [
-          "list",
-          "extpacks"
-        ],
-        sudo: true
-    ).stdout.match?(/^Pack no. \d+:\s+Oracle VM VirtualBox Extension Pack$/)
+    if system_command("/usr/local/bin/VBoxManage",
+                      args: [
+                        "list",
+                        "extpacks",
+                      ],
+                      sudo: true).stdout.match?(/^Pack no. \d+:\s+Oracle VM VirtualBox Extension Pack$/)
       system_command "/usr/local/bin/VBoxManage",
-      args: [
-        "extpack", "uninstall",
-        "Oracle VM VirtualBox Extension Pack"
-      ],
-      sudo: true
+                     args: [
+                       "extpack", "uninstall",
+                       "Oracle VM VirtualBox Extension Pack"
+                     ],
+                     sudo: true
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

Additional notes:

- This PR fixes issue #134061
- Uninstall/reinstall is failing if the `Extension Pack` is not installed (`/usr/local/bin/VBoxManage extpack uninstall "Oracle VM VirtualBox Extension Pack"` exit with `1`). It can happen if `VirtualBox` is upgraded - during an upgrade of `VirtualBox` `Extension Pack` is removed.
- How output of `/usr/local/bin/VBoxManage list extpacks` looks like:
  - Pack not installed:
    ```
    Extension Packs: 0
    ```
  - Pack installed:
    ```
    Extension Packs: 1
    Pack no. 0:   Oracle VM VirtualBox Extension Pack
    Version:        7.0.4
    Revision:       154605
    Edition:
    Description:    Oracle Cloud Infrastructure integration, Host Webcam, VirtualBox RDP, PXE ROM, Disk Encryption, NVMe, full VM encryption.
    VRDE Module:    VBoxVRDP
    Crypto Module:  VBoxPuelCrypto
    Usable:         true
    Why unusable:
    ```
  If there is a better way for checking or handling this error, I'm open to discussion.