### PR TITLE
openshot-video-editor: Add livecheck

### DIFF
--- a/Casks/openshot-video-editor.rb
+++ b/Casks/openshot-video-editor.rb
@@ -8,6 +8,11 @@ cask "openshot-video-editor" do
   desc "Cross-platform video editor"
   homepage "https://openshot.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   conflicts_with cask: "homebrew/cask-versions/openshot-video-editor-daily"
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
Switching to `:github_latest` strategy due to use of prereleases.