### PR TITLE
akiflow: skip livecheck

### DIFF
--- a/Casks/akiflow.rb
+++ b/Casks/akiflow.rb
@@ -8,8 +8,7 @@ cask "akiflow" do
   homepage "https://akiflow.com/"
 
   livecheck do
-    url "https://akiflow.com/releases/download"
-    strategy :header_match
+    skip "Constantly changes between download page and direct download"
   end
 
   app "Akiflow.app"


### PR DESCRIPTION
As I stated in https://github.com/Homebrew/homebrew-cask/pull/136672, I am setting this livecheck to `skip` due to furthur inability for the developer to maintain a consistant scheme for serving the binary.