### PR TITLE
ksdiff: discontinue

### DIFF
--- a/Casks/ksdiff.rb
+++ b/Casks/ksdiff.rb
@@ -7,16 +7,6 @@ cask "ksdiff" do
   desc "Command-line tool for the App Store version of Kaleidoscope"
   homepage "https://kaleidoscope.app/ksdiff#{version.major}"
 
-  livecheck do
-    url "https://kaleidoscope.app/download/latest/ksdiff"
-    strategy :header_match do |headers|
-      match = headers["location"].match(%r{/ksdiff[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.zip}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
-
   conflicts_with cask: [
     "kaleidoscope",
     "homebrew/cask-versions/kaleidoscope2",
@@ -27,8 +17,7 @@ cask "ksdiff" do
 
   uninstall pkgutil: "app.kaleidoscope.v#{version.major}.ksdiff.installer.pkg"
 
-  caveats <<~EOS
-    The #{token} Cask is not needed when installing Kaleidoscope via Cask. It
-    is provided for users who have purchased Kaleidoscope via the App Store.
-  EOS
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
According to [the homepage](https://kaleidoscope.app/ksdiff3) this is now included in App Store releases as of Kaleidoscope v3.6, so this is no longer required for new releases.