### PR TITLE
New cask yubico-authenticator

### DIFF
--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,0 +1,18 @@
+cask "yubico-authenticator" do
+  version "6.0.2"
+  sha256 "bba72407285a715cd028dcade0683f2cbdbefca7ac2c98cfb448e1fccf955f40"
+
+  url "https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-#{version}-mac.dmg"
+  name "Yubico Authenticator"
+  desc "Application for generating TOTP and HOTP codes"
+  homepage "https://www.yubico.com/products/yubico-authenticator/"
+
+  livecheck do
+    url "https://developers.yubico.com/yubioath-flutter/Releases/"
+    regex(%r{<a\shref="yubico-authenticator-(\d+(:?\.\d+)+)-mac\.dmg">.*<\/a>}i)
+  end
+
+  conflicts_with cask: "homebrew/cask-versions/yubico-authenticator-beta"
+
+  app "Yubico Authenticator.app"
+end


### PR DESCRIPTION
Since [Yubico Authenticathor](https://www.yubico.com/products/yubico-authenticator/#h-download-yubico-authenticator) is already in the [release phase](https://developers.yubico.com/yubioath-flutter/Release_Notes.html). I have decided to create this cask, since until now the only cask we had was: `homebrew/cask-versions/yubico-authenticator-beta`


After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online yubico-authenticator` is error-free.
- [x] `brew style --fix yubico-authenticator` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask yubico-authenticator` worked successfully.
- [x] `brew install --cask yubico-authenticator` worked successfully.
- [x] `brew uninstall --cask yubico-authenticator` worked successfully.
