### PR TITLE
qlvideo 2.00

### DIFF
--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -8,13 +8,8 @@ cask "qlvideo" do
   homepage "https://github.com/Marginal/QLVideo"
 
   livecheck do
-    url "https://api.github.com/repos/Marginal/QLVideo/releases"
-    strategy :page_match do |page|
-      match = page.match(/QLVideo[._-]v?(\d+?)(\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}"
-    end
+    url :url
+    strategy :github_latest
   end
 
   app "QuickLook Video.app"

--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -10,7 +10,7 @@ cask "qlvideo" do
   livecheck do
     url "https://api.github.com/repos/Marginal/QLVideo/releases"
     strategy :page_match do |page|
-      match = page.match(/QLVideo_(\d+?)(\d+)\.pkg/i)
+      match = page.match(/QLVideo[._-]v?(\d+?)(\d+)\.dmg/i)
       next if match.blank?
 
       "#{match[1]}.#{match[2]}"

--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -8,8 +8,13 @@ cask "qlvideo" do
   homepage "https://github.com/Marginal/QLVideo"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://api.github.com/repos/Marginal/QLVideo/releases/latest"
+    strategy :page_match do |page|
+      match = page.match(/QLVideo[._-]v?(\d+?)(\d+)\.dmg/i)
+      next if match.blank?
+
+      "#{match[1]}.#{match[2]}"
+    end
   end
 
   app "QuickLook Video.app"

--- a/Casks/qlvideo.rb
+++ b/Casks/qlvideo.rb
@@ -1,10 +1,10 @@
 cask "qlvideo" do
-  version "1.96"
-  sha256 "faf117900c1976f3861bb3d2b07d4409a219562f4f098362549baea5b8a3e456"
+  version "2.00"
+  sha256 "e4ebad7c0fba9f57038f38956931ab57676ac007198d5a8056fbc0c9ad6af96c"
 
-  url "https://github.com/Marginal/QLVideo/releases/download/rel-#{version.no_dots}/QLVideo_#{version.no_dots}.pkg"
+  url "https://github.com/Marginal/QLVideo/releases/download/rel-#{version.no_dots}/QLVideo_#{version.no_dots}.dmg"
   name "QuickLook Video"
-  desc "QuickLook generator for video files"
+  desc "Thumbnails, static previews, cover art and metadata for video files"
   homepage "https://github.com/Marginal/QLVideo"
 
   livecheck do
@@ -17,10 +17,5 @@ cask "qlvideo" do
     end
   end
 
-  pkg "QLVideo_#{version.no_dots}.pkg"
-
-  uninstall pkgutil:   "uk.org.marginal.qlvideo",
-            launchctl: "uk.org.marginal.qlvideo.mdimporter"
-
-  zap trash: "~/Library/Application Support/uk.org.marginal.qlvideo"
+  app "QuickLook Video.app"
 end


### PR DESCRIPTION
I've changed QLVideo from being packaged as an installer package to an app in order to work around various problems with registering QuickLook and Spotlight plugins on Ventura.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  `brew audit --cask --online qlvideo` fails with `Version '2.00' differs from '1.96' retrieved by livecheck`.
  `brew audit --cask --strict qlvideo` passes.
- [x] `brew style --fix <cask>` reports no offenses.
