### PR TITLE
mplabx-ide: leave other Microchip packages alone.

### DIFF
--- a/Casks/mplabx-ide.rb
+++ b/Casks/mplabx-ide.rb
@@ -41,5 +41,16 @@ cask "mplabx-ide" do
               input:      ["y", 3],
               sudo:       true,
             },
-            delete: "/Applications/microchip/mplabx/#{version}"
+            delete: [
+              "/Applications/microchip/mplabx/#{version}",
+              # The below version number needs to be updated
+              # manually each time this Cask is updated
+              "/Applications/microchip/mplabcomm/3.51.00",
+            ],
+            rmdir:  [
+              "/Applications/microchip/mplabx",
+              "/Applications/microchip/mplabcomm",
+            ]
+
+  zap trash: "/Applications/microchip"
 end

--- a/Casks/mplabx-ide.rb
+++ b/Casks/mplabx-ide.rb
@@ -32,7 +32,7 @@ cask "mplabx-ide" do
 
   postflight do
     set_ownership staged_path.to_s
-    set_ownership "/Applications/microchip/mplabx"
+    set_ownership "/Applications/microchip/mplabx/#{version}"
   end
 
   uninstall script: {
@@ -41,5 +41,5 @@ cask "mplabx-ide" do
               input:      ["y", 3],
               sudo:       true,
             },
-            delete: "/Applications/microchip"
+            delete: "/Applications/microchip/mplabx/#{version}"
 end


### PR DESCRIPTION
Other software packages from Microchip may be installed in other
subdirectories of /Applications/microchip, and other versions of MPLABX
IDE may be installed in other versioned subdirectories of
/Applications/microchip/mplabx. Prior to this commit, installing this
cask would cause the entire contents of the /Applications/microchip
directory to have its owner and group changed, and uninstalling this
cask would cause the entire /Applications/microchip directory to be
removed.

This commit restricts this cask to operating only on
/Applications/microchip/mplabx/#{version}, so that other packages are
left alone.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
