### PR TITLE
launchcontrol: fix depends_on for legacy version

### DIFF
--- a/Casks/launchcontrol.rb
+++ b/Casks/launchcontrol.rb
@@ -2,9 +2,22 @@ cask "launchcontrol" do
   if MacOS.version <= :catalina
     version "1.52.7,1959"
     sha256 "16c3d89e41a99cbf43e6996681358e8e7a4bc63fa770b9f8c0bc72c5356a0b8a"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: "<=: catalina"
   else
     version "2.0.3,2310"
     sha256 "bd73e6836ba5b27df04b296d8a47df019e22e2bcc67619b11645a919c0f3dd8f"
+
+    livecheck do
+      url "https://www.soma-zone.com/LaunchControl/a/appcast-update-2.xml"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :big_sur"
   end
 
   url "https://www.soma-zone.com/download/files/LaunchControl-#{version.csv.first}.tar.xz"
@@ -12,13 +25,7 @@ cask "launchcontrol" do
   desc "Create, manage and debug system- and user services"
   homepage "https://www.soma-zone.com/LaunchControl/"
 
-  livecheck do
-    url "https://www.soma-zone.com/LaunchControl/a/appcast-update-2.xml"
-    strategy :sparkle
-  end
-
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "LaunchControl.app"
 


### PR DESCRIPTION
I broke the legacy version in #137257. This method allows us to set `depends_on macos` based off the user's OS.