### PR TITLE
Update checksum of kstars v3.6.2

### DIFF
--- a/Casks/kstars.rb
+++ b/Casks/kstars.rb
@@ -1,6 +1,6 @@
 cask "kstars" do
   version "3.6.2"
-  sha256 "d179cbfb95617932146fad180fcaff920c5fed9416a0a0ac8a8782c748758ba2"
+  sha256 "70c52ac585bd43c5967cb072150c3638110421acab72e5826c8fb63a9dca5ffc"
 
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg",
       verified: "indilib.org/jdownloads/kstars/"


### PR DESCRIPTION
The checksum for kstars v3.6.2 has changed. It has been updated.