### PR TITLE
db-browser-for-sqlite: add arm64

### DIFF
--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,21 +1,12 @@
 cask "db-browser-for-sqlite" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "-arm64"
 
   version "3.12.2"
+  sha256 arm:   "0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8",
+         intel: "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
 
-  on_intel do
-    sha256 "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
-
-    url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-#{version}.dmg",
-        verified: "github.com/sqlitebrowser/sqlitebrowser/"
-  end
-  on_arm do
-    sha256 "0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8"
-
-    url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-arm64-#{version}.dmg",
-        verified: "github.com/sqlitebrowser/sqlitebrowser/"
-  end
-
+  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite#{arch}-#{version}.dmg",
+      verified: "github.com/sqlitebrowser/sqlitebrowser/"
   name "DB Browser for SQLite"
   desc "Browser for SQLite databases"
   homepage "https://sqlitebrowser.org/"

--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -7,13 +7,13 @@ cask "db-browser-for-sqlite" do
     sha256 "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
 
     url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-#{version}.dmg",
-      verified: "github.com/sqlitebrowser/sqlitebrowser/"
+        verified: "github.com/sqlitebrowser/sqlitebrowser/"
   end
   on_arm do
     sha256 "0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8"
 
     url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-arm64-#{version}.dmg",
-      verified: "github.com/sqlitebrowser/sqlitebrowser/"
+        verified: "github.com/sqlitebrowser/sqlitebrowser/"
   end
   
   name "DB Browser for SQLite"

--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -1,9 +1,21 @@
 cask "db-browser-for-sqlite" do
-  version "3.12.2"
-  sha256 "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-#{version}.dmg",
+  version "3.12.2"
+  
+  on_intel do
+    sha256 "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
+
+    url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-#{version}.dmg",
       verified: "github.com/sqlitebrowser/sqlitebrowser/"
+  end
+  on_arm do
+    sha256 "0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8"
+
+    url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-arm64-#{version}.dmg",
+      verified: "github.com/sqlitebrowser/sqlitebrowser/"
+  end
+  
   name "DB Browser for SQLite"
   desc "Browser for SQLite databases"
   homepage "https://sqlitebrowser.org/"

--- a/Casks/db-browser-for-sqlite.rb
+++ b/Casks/db-browser-for-sqlite.rb
@@ -2,7 +2,7 @@ cask "db-browser-for-sqlite" do
   arch arm: "arm64", intel: "x64"
 
   version "3.12.2"
-  
+
   on_intel do
     sha256 "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
 
@@ -15,7 +15,7 @@ cask "db-browser-for-sqlite" do
     url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-arm64-#{version}.dmg",
         verified: "github.com/sqlitebrowser/sqlitebrowser/"
   end
-  
+
   name "DB Browser for SQLite"
   desc "Browser for SQLite databases"
   homepage "https://sqlitebrowser.org/"


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.