### PR TITLE
teleport-tsh: add new cask

### DIFF
--- a/Casks/teleport-tsh.rb
+++ b/Casks/teleport-tsh.rb
@@ -1,0 +1,21 @@
+cask "teleport-tsh" do
+  version "11.1.2"
+  sha256 "3a9efbc794fc4a64b17d7a6f95fd777f5fac457f9456ac5faaace7aa9e966fc2"
+
+  url "https://get.gravitational.com/tsh-#{version}.pkg"
+  name "Teleport TSH"
+  desc "Modern SSH server for teams managing distributed infrastructure (tsh client)"
+  homepage "https://gravitational.com/teleport"
+
+  livecheck do
+    formula "teleport"
+  end
+
+  conflicts_with formula: %w[
+    teleport
+  ]
+
+  pkg "tsh-#{version}.pkg"
+
+  uninstall pkgutil: "(.*).com.gravitational.teleport.tsh"
+end

--- a/Casks/tsh.rb
+++ b/Casks/tsh.rb
@@ -17,4 +17,5 @@ cask "tsh" do
   pkg "tsh-#{version}.pkg"
 
   uninstall pkgutil: "(.*).com.gravitational.teleport.tsh"
+  zap trash: "~/.tsh"
 end

--- a/Casks/tsh.rb
+++ b/Casks/tsh.rb
@@ -1,19 +1,18 @@
-cask "teleport-tsh" do
+cask "tsh" do
   version "11.1.2"
   sha256 "3a9efbc794fc4a64b17d7a6f95fd777f5fac457f9456ac5faaace7aa9e966fc2"
 
   url "https://get.gravitational.com/tsh-#{version}.pkg"
   name "Teleport TSH"
-  desc "Modern SSH server for teams managing distributed infrastructure (tsh client)"
+  desc "SSH server for teams managing distributed infrastructure"
   homepage "https://gravitational.com/teleport"
 
   livecheck do
-    formula "teleport"
+    url "https://goteleport.com/download/"
+    regex(/tsh[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
-  conflicts_with formula: %w[
-    teleport
-  ]
+  conflicts_with formula: "teleport"
 
   pkg "tsh-#{version}.pkg"
 

--- a/Casks/tsh.rb
+++ b/Casks/tsh.rb
@@ -17,5 +17,6 @@ cask "tsh" do
   pkg "tsh-#{version}.pkg"
 
   uninstall pkgutil: "(.*).com.gravitational.teleport.tsh"
+
   zap trash: "~/.tsh"
 end


### PR DESCRIPTION
Adding a `teleport-tsh` cask to install Teleport tsh through their recommended instructions. I realize that `teleport` (the formula) is a good option as well, but given the vendor is advising _against_ using it, I'd like to have the option to install it through the package through brew as well.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference). 
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
