### PR TITLE
buzz: add livecheck

### DIFF
--- a/Casks/buzz.rb
+++ b/Casks/buzz.rb
@@ -7,6 +7,11 @@ cask "buzz" do
   desc "Transcribes and translates audio"
   homepage "https://github.com/chidiwilliams/buzz"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Buzz.app"
 
   zap trash: "~/Library/Logs/Buzz"


### PR DESCRIPTION
Switching to `:github_latest` strategy due to use of prereleases.