### PR TITLE
Skip broken GitHub release page livechecks

### DIFF
--- a/Casks/bluewallet.rb
+++ b/Casks/bluewallet.rb
@@ -9,9 +9,7 @@ cask "bluewallet" do
   homepage "https://bluewallet.io/"
 
   livecheck do
-    url "https://github.com/BlueWallet/BlueWallet/releases/"
-    strategy :page_match
-    regex(/href=.*?BlueWallet.(\d+(?:\.\d+)+)\.dmg/i)
+    skip "No reliable way to get version info"
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/coqide.rb
+++ b/Casks/coqide.rb
@@ -9,9 +9,7 @@ cask "coqide" do
   homepage "https://coq.inria.fr/"
 
   livecheck do
-    url "https://github.com/coq/coq/releases"
-    strategy :page_match
-    regex(/href=.*?coq[._-]?v?(\d+(?:\.\d+)+)-installer-macos\.dmg/i)
+    skip "No reliable way to get version info"
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/cubicsdr.rb
+++ b/Casks/cubicsdr.rb
@@ -9,9 +9,7 @@ cask "cubicsdr" do
   homepage "https://cubicsdr.com/"
 
   livecheck do
-    url "https://github.com/cjcliffe/CubicSDR/releases/"
-    strategy :page_match
-    regex(/CubicSDR[._-]v?(\d+(?:\.\d+)+)[._-]Darwin\.dmg/i)
+    skip "No reliable way to get version info"
   end
 
   app "CubicSDR.app"

--- a/Casks/duckietv.rb
+++ b/Casks/duckietv.rb
@@ -9,9 +9,7 @@ cask "duckietv" do
   homepage "https://schizoduckie.github.io/DuckieTV/"
 
   livecheck do
-    url "https://github.com/SchizoDuckie/DuckieTV/releases"
-    strategy :page_match
-    regex(/href=.*?DuckieTV[._-]?v?(\d+(?:\.\d+)+)[._-]OSX[._-]x64\.pkg/i)
+    skip "No reliable way to get version info"
   end
 
   pkg "DuckieTV-#{version}-OSX-x64.pkg"

--- a/Casks/jandi-statusbar.rb
+++ b/Casks/jandi-statusbar.rb
@@ -8,9 +8,7 @@ cask "jandi-statusbar" do
   homepage "https://github.com/techinpark/Jandi"
 
   livecheck do
-    url "https://github.com/techinpark/Jandi/releases"
-    strategy :page_match
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/jandi\.dmg}i)
+    skip "No reliable way to get version info"
   end
 
   app "jandi.app"

--- a/Casks/magicavoxel.rb
+++ b/Casks/magicavoxel.rb
@@ -9,9 +9,7 @@ cask "magicavoxel" do
   homepage "https://ephtracy.github.io/"
 
   livecheck do
-    url "https://github.com/ephtracy/ephtracy.github.io/releases"
-    strategy :page_match
-    regex(/MagicaVoxel-(\d+(?:\.\d+)*)-macos/i)
+    skip "No reliable way to get version info"
   end
 
   suite staged_path, target: "MagicaVoxel"

--- a/Casks/openineditor-lite.rb
+++ b/Casks/openineditor-lite.rb
@@ -8,9 +8,7 @@ cask "openineditor-lite" do
   homepage "https://github.com/Ji4n1ng/OpenInTerminal"
 
   livecheck do
-    url "https://github.com/Ji4n1ng/OpenInTerminal/releases"
-    strategy :page_match
-    regex(%r{v?(\d+(?:\.\d+)+)/OpenInEditor[._-]Lite\.app\.zip}i)
+    skip "No reliable way to get version info"
   end
 
   app "OpenInEditor-Lite.app"

--- a/Casks/openinterminal-lite.rb
+++ b/Casks/openinterminal-lite.rb
@@ -8,9 +8,7 @@ cask "openinterminal-lite" do
   homepage "https://github.com/Ji4n1ng/OpenInTerminal"
 
   livecheck do
-    url "https://github.com/Ji4n1ng/OpenInTerminal/releases"
-    strategy :page_match
-    regex(%r{v?(\d+(?:\.\d+)+)/OpenInTerminal[._-]Lite\.app\.zip}i)
+    skip "No reliable way to get version info"
   end
 
   app "OpenInTerminal-Lite.app"

--- a/Casks/pablodraw.rb
+++ b/Casks/pablodraw.rb
@@ -8,8 +8,7 @@ cask "pablodraw" do
   homepage "https://github.com/cwensley/pablodraw/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    skip "No reliable way to get version info"
   end
 
   app "PabloDraw.app"

--- a/Casks/prusaslicer.rb
+++ b/Casks/prusaslicer.rb
@@ -9,13 +9,7 @@ cask "prusaslicer" do
   homepage "https://www.prusa3d.com/slic3r-prusa-edition/"
 
   livecheck do
-    url "https://github.com/prusa3d/PrusaSlicer/releases/"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/PrusaSlicer-(\d+(?:\.\d+)*)\+MacOS-universal-(\d+)\.dmg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
+    skip "No reliable way to get version info"
   end
 
   app "PrusaSlicer.app"

--- a/Casks/qwerty-fr.rb
+++ b/Casks/qwerty-fr.rb
@@ -9,9 +9,7 @@ cask "qwerty-fr" do
   homepage "https://qwerty-fr.org/"
 
   livecheck do
-    url "https://github.com/qwerty-fr/qwerty-fr/releases/"
-    regex(%r{v?(\d+(?:\.\d+)+)/qwerty-fr.*?mac\.zip}i)
-    strategy :page_match
+    skip "No reliable way to get version info"
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/thonny-xxl.rb
+++ b/Casks/thonny-xxl.rb
@@ -9,9 +9,7 @@ cask "thonny-xxl" do
   homepage "https://thonny.org/"
 
   livecheck do
-    url "https://github.com/thonny/thonny/releases"
-    regex(%r{v?(\d+(?:\.\d+)+)/thonny-xxl.*?\.pkg}i)
-    strategy :page_match
+    skip "No reliable way to get version info"
   end
 
   conflicts_with cask: "thonny"

--- a/Casks/virtualbuddy.rb
+++ b/Casks/virtualbuddy.rb
@@ -8,13 +8,7 @@ cask "virtualbuddy" do
   homepage "https://github.com/insidegui/VirtualBuddy"
 
   livecheck do
-    url "https://github.com/insidegui/VirtualBuddy/releases"
-    strategy :page_match do |page|
-      match = page.match(/href=.*?VirtualBuddy[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.dmg/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
+    skip "No reliable way to get version info"
   end
 
   depends_on arch: :arm64

--- a/Casks/xdm.rb
+++ b/Casks/xdm.rb
@@ -9,9 +9,7 @@ cask "xdm" do
   homepage "https://xtremedownloadmanager.com/"
 
   livecheck do
-    url "https://github.com/subhra74/xdm/releases/"
-    strategy :page_match
-    regex(%r{(\d+(?:\.\d+)*)/XDMSetup\.dmg}i)
+    skip "No reliable way to get version info"
   end
 
   installer script: {


### PR DESCRIPTION
This skips `livecheck` on the final casks that we have not been able to resolve in https://github.com/Homebrew/brew/issues/13853.

Closes https://github.com/Homebrew/brew/issues/13853.