### PR TITLE
Ved: Remove livecheck, Cloudflare is preventing it from working

### DIFF
--- a/Casks/ved.rb
+++ b/Casks/ved.rb
@@ -5,12 +5,7 @@ cask "ved" do
   url "https://tolp.nl/ved/files/download/mac/ved_#{version}_mac.dmg"
   name "ved"
   desc "External level editor for VVVVVV"
-  homepage "https://tolp.nl/ved/"
-
-  livecheck do
-    url "https://tolp.nl/ved/files/download/mac/"
-    regex(/href=.*?ved[ ._-]v?(\d+(?:\.\d+)+)[ ._-]mac\.dmg/i)
-  end
+  homepage "https://tolp.nl/ved/
 
   app "Ved.app"
 

--- a/Casks/ved.rb
+++ b/Casks/ved.rb
@@ -5,7 +5,7 @@ cask "ved" do
   url "https://tolp.nl/ved/files/download/mac/ved_#{version}_mac.dmg"
   name "ved"
   desc "External level editor for VVVVVV"
-  homepage "https://tolp.nl/ved/
+  homepage "https://tolp.nl/ved/"
 
   app "Ved.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Livecheck gives a 403, likely because the cloudflare botcheck is blocking it. This PR fixes that.