### PR TITLE
sioyek: add binary to /bin

### DIFF
--- a/Casks/sioyek.rb
+++ b/Casks/sioyek.rb
@@ -16,6 +16,16 @@ cask "sioyek" do
   container nested: "build/sioyek.dmg"
 
   app "sioyek.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/sioyek.wrapper.sh"
+  binary shimscript, target: "sioyek"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/sioyek.app/Contents/MacOS/sioyek' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/Library/Application Support/sioyek",


### PR DESCRIPTION
This PR adds a shim script to place the sioyek binary in /bin as well, as it provides a command line interface.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online sioyek` is error-free.
- [x] `brew style --fix sioyek` reports no offenses.
- [x] `brew install --cask sioyek` worked successfully.
- [x] `brew uninstall --cask sioyek` worked successfully.
