### PR TITLE
Update arduino-ide for arch arm

### DIFF
--- a/Casks/arduino-ide.rb
+++ b/Casks/arduino-ide.rb
@@ -1,15 +1,18 @@
 cask "arduino-ide" do
-  version "2.0.3"
-  sha256 "145acd62daa15fe1d7548c569bd00cfc193a82f2e7fc6a4bd5e9028c0f8a74f9"
+  arch arm: "ARM64", intel: "64bit"
 
-  url "https://downloads.arduino.cc/arduino-ide/arduino-ide_#{version}_macOS_64bit.dmg"
+  version "2.0.3"
+  sha256 arm:   "c618a71c5117b8b111238cd975e6e33a44e4d6ea97b09dcebccc99a80463af1f",
+         intel: "145acd62daa15fe1d7548c569bd00cfc193a82f2e7fc6a4bd5e9028c0f8a74f9"
+
+  url "https://downloads.arduino.cc/arduino-ide/arduino-ide_#{version}_macOS_#{arch}.dmg"
   name "Arduino IDE"
   desc "Electronics prototyping platform"
   homepage "https://www.arduino.cc/en/software"
 
   livecheck do
     url "https://www.arduino.cc/en/software/"
-    regex(/href=.*?arduino[._-]ide[._-]?(\d+(?:\.\d+)+)[._-]macos[._-]64bit\.dmg/i)
+    regex(/href=.*?arduino[._-]ide[._-]?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 
   conflicts_with cask: "arduino-ide-nightly"


### PR DESCRIPTION
Update arduino-ide to support arm architecture in addition to x86.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online arduino-ide` is error-free.
- [x] `brew style --fix arduino-ide` reports no offenses.
