### PR TITLE
Update Heroic to 2.5.2 and add checks for either x64 or ARM64 builds.

### DIFF
--- a/Casks/heroic.rb
+++ b/Casks/heroic.rb
@@ -1,8 +1,15 @@
 cask "heroic" do
-  version "2.5.1"
-  sha256 "2131c753b37caf889f4e47f8780d1670ce8fec14c225f13af6419f2e93a2700f"
+  version "2.5.2"
 
-  url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}.dmg"
+  on_intel do
+    url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-x64.dmg"
+    sha256 "39f48a8aa39ee7bf17767e9afca2abb974426f5856fa8794e2364cf7b0fcd9bc"
+  end
+  on_arm do
+    url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-arm64.dmg"
+    sha256 "a82788df9b8e5603911280b9f7ef403c84ee9688e44fc4c90747a0b265646486"
+  end
+
   name "Heroic Games Launcher"
   desc "Open Source Game Launcher"
   homepage "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher"

--- a/Casks/heroic.rb
+++ b/Casks/heroic.rb
@@ -2,14 +2,9 @@ cask "heroic" do
   version "2.5.2"
   arch arm: "arm64", intel: "x64"
 
-  on_intel do
-    url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-x64.dmg"
-    sha256 "39f48a8aa39ee7bf17767e9afca2abb974426f5856fa8794e2364cf7b0fcd9bc"
-  end
-  on_arm do
-    url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-arm64.dmg"
-    sha256 "a82788df9b8e5603911280b9f7ef403c84ee9688e44fc4c90747a0b265646486"
-  end
+  url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-#{arch}.dmg"
+  sha256 intel: "39f48a8aa39ee7bf17767e9afca2abb974426f5856fa8794e2364cf7b0fcd9bc",
+                arm:"a82788df9b8e5603911280b9f7ef403c84ee9688e44fc4c90747a0b265646486"
 
   name "Heroic Games Launcher"
   desc "Open Source Game Launcher"

--- a/Casks/heroic.rb
+++ b/Casks/heroic.rb
@@ -1,11 +1,11 @@
 cask "heroic" do
-  version "2.5.2"
   arch arm: "arm64", intel: "x64"
 
-  url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-#{arch}.dmg"
+  version "2.5.2"
   sha256 intel: "39f48a8aa39ee7bf17767e9afca2abb974426f5856fa8794e2364cf7b0fcd9bc",
-                arm:"a82788df9b8e5603911280b9f7ef403c84ee9688e44fc4c90747a0b265646486"
+         arm:   "a82788df9b8e5603911280b9f7ef403c84ee9688e44fc4c90747a0b265646486"
 
+  url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-#{arch}.dmg"
   name "Heroic Games Launcher"
   desc "Open Source Game Launcher"
   homepage "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher"

--- a/Casks/heroic.rb
+++ b/Casks/heroic.rb
@@ -1,5 +1,6 @@
 cask "heroic" do
   version "2.5.2"
+  arch arm: "arm64", intel: "x64"
 
   on_intel do
     url "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/download/v#{version}/Heroic-#{version}-macOS-x64.dmg"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
