### PR TITLE
teamviewer: convert to `on_system` blocks

### DIFF
--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -41,7 +41,6 @@ cask "teamviewer" do
   on_big_sur :or_newer do
     pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
   end
-  
   on_mojave :or_older do
     uninstall delete:    [
                 "/Applications/TeamViewer.app",

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,12 +1,13 @@
 cask "teamviewer" do
-  if MacOS.version <= :high_sierra
+  on_high_sierra :or_older do
     version "15.2.2756"
 
     livecheck do
       url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.11.1&type=1&channel=1"
       strategy :sparkle
     end
-  else
+  end
+  on_mojave :or_newer do
     version "15.36.6"
 
     livecheck do
@@ -14,6 +15,7 @@ cask "teamviewer" do
       strategy :sparkle
     end
   end
+
   sha256 :no_check
 
   url "https://download.teamviewer.com/download/TeamViewer.dmg"
@@ -25,21 +27,22 @@ cask "teamviewer" do
   conflicts_with cask: "teamviewer-host"
   depends_on macos: ">= :el_capitan"
 
-  if MacOS.version <= :high_sierra
+  on_high_sierra :or_older do
     pkg "Install TeamViewer.pkg"
-  elsif MacOS.version == :catalina
+  end
+  on_mojave do
+    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+  end
+  on_catalina do
     # This Cask should be installed and uninstalled manually on Catalina.
     # See https://github.com/Homebrew/homebrew-cask/issues/76829
     installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
-  else
+  end
+  on_big_sur :or_newer do
     pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
   end
-
-  if MacOS.version == :catalina
-    # This Cask should be installed and uninstalled manually on Catalina.
-    # See https://github.com/Homebrew/homebrew-cask/issues/76829
-    uninstall delete: "#{staged_path}/#{token}"
-  else
+  
+  on_mojave :or_older do
     uninstall delete:    [
                 "/Applications/TeamViewer.app",
                 "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
@@ -58,24 +61,61 @@ cask "teamviewer" do
                 "com.teamviewer.teamviewer",
               ],
               quit:      "com.teamviewer.TeamViewer"
+
+    zap trash: [
+      "~/Library/Application Support/TeamViewer",
+      "~/Library/Caches/com.teamviewer.TeamViewer",
+      "~/Library/Caches/TeamViewer",
+      "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
+      "~/Library/Logs/TeamViewer",
+      "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
+      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
+      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+      "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
+    ]
   end
+  on_catalina do
+    # This Cask should be installed and uninstalled manually on Catalina.
+    # See https://github.com/Homebrew/homebrew-cask/issues/76829
+    uninstall delete: "#{staged_path}/#{token}"
 
-  zap trash: [
-    "~/Library/Application Support/TeamViewer",
-    "~/Library/Caches/com.teamviewer.TeamViewer",
-    "~/Library/Caches/TeamViewer",
-    "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
-    "~/Library/Logs/TeamViewer",
-    "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
-    "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
-    "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
-    "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
-  ]
+    caveats <<~EOS
+      WARNING: #{token} has a bug in Catalina where it doesn't deal well with being uninstalled by other utilities.
+      The recommended way to remove it is by running their uninstaller under:
 
-  caveats <<~EOS
-    WARNING: #{token} has a bug in Catalina where it doesn't deal well with being uninstalled by other utilities.
-    The recommended way to remove it is by running their uninstaller under:
+         Preferences → Advanced
+    EOS
+  end
+  on_big_sur :or_newer do
+    uninstall delete:    [
+                "/Applications/TeamViewer.app",
+                "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+              ],
+              pkgutil:   [
+                "com.teamviewer.remoteaudiodriver",
+                "com.teamviewer.teamviewer.*",
+                "com.teamviewer.AuthorizationPlugin",
+              ],
+              launchctl: [
+                "com.teamviewer.desktop",
+                "com.teamviewer.Helper",
+                "com.teamviewer.service",
+                "com.teamviewer.teamviewer_desktop",
+                "com.teamviewer.teamviewer_service",
+                "com.teamviewer.teamviewer",
+              ],
+              quit:      "com.teamviewer.TeamViewer"
 
-       Preferences → Advanced
-  EOS
+    zap trash: [
+      "~/Library/Application Support/TeamViewer",
+      "~/Library/Caches/com.teamviewer.TeamViewer",
+      "~/Library/Caches/TeamViewer",
+      "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
+      "~/Library/Logs/TeamViewer",
+      "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
+      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
+      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+      "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
+    ]
+  end
 end

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -8,7 +8,7 @@ cask "teamviewer" do
     end
   end
   on_mojave :or_newer do
-    version "15.36.6"
+    version "15.37.3"
 
     livecheck do
       url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"


### PR DESCRIPTION
#137512 

This one got a bit crazy. Mojave and newer have essentially the same stanzas, however due to Catalina requiring some different due to an installer issue, some of the stanzas need to be duplicated for `on_mojave do` and `on_big_sur :or_newer`, with `on_catalina` having it's own stanzas.