### PR TITLE
tigervnc-viewer: fix livecheck

### DIFF
--- a/Casks/tigervnc-viewer.rb
+++ b/Casks/tigervnc-viewer.rb
@@ -10,7 +10,7 @@ cask "tigervnc-viewer" do
 
   livecheck do
     url "https://github.com/TigerVNC/tigervnc"
-    strategy :git
+    strategy :github_latest
   end
 
   app "TigerVNC Viewer #{version}.app"


### PR DESCRIPTION
Switching to `:github_latest` strategy due to tag discrepancies.