### PR TITLE
add sha256 checksum for sync.com cask

### DIFF
--- a/Casks/sync.rb
+++ b/Casks/sync.rb
@@ -1,6 +1,7 @@
 cask "sync" do
   version "2.1.4"
-  sha256 :no_check
+  # https://sync.com/download/sync-packages/osx/VERSION_NUMBER/cur/Sync.dmg.sha256
+  sha256 "50995f191977aee9a656416ad90eec8c7a4e1dbc64e05bc35b5a9326c774b253"
 
   url "https://www.sync.com/download/apple/Sync.dmg"
   name "Sync"


### PR DESCRIPTION
**Why:**
Sync.com is an end-to-end encrypted cloud storage solution. As such, users are more likely to want a checksum included to ensure that the app they downloaded is the app sync.com made

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.