### PR TITLE
Remove `aceinstaller` from Loopback

### DIFF
--- a/Casks/loopback.rb
+++ b/Casks/loopback.rb
@@ -16,17 +16,6 @@ cask "loopback" do
   depends_on macos: ">= :catalina"
 
   app "Loopback.app"
-  installer script: {
-    executable: "Loopback.app/Contents/Resources/aceinstaller",
-    args:       ["install", "--silent"],
-    sudo:       true,
-  }
-
-  uninstall script: {
-    executable: "Loopback.app/Contents/Resources/aceinstaller",
-    args:       ["uninstall", "--silent"],
-    sudo:       true,
-  }
 
   zap trash: [
     "~/Library/Application Support/Loopback",


### PR DESCRIPTION
This removes `aceinstaller` from `loopback`'s `installer` and `uninstall` blocks. This is because:
- None of the other Rogue Amoeba casks that use ACE run it
- This only needs to be ran once for a new ACE version, not for each cask
- ACE should not be uninstalled when uninstalling a single cask as many other applications require ACE:
  - Airfoil
  - Audio Hijack
  - Piezo
  - SoundSource
  - Some [third-party](https://rogueamoeba.com/licensing/ace/#current-licensees) applications