### PR TITLE
universal-gcode-platform: fix livecheck

### DIFF
--- a/Casks/universal-gcode-platform.rb
+++ b/Casks/universal-gcode-platform.rb
@@ -10,7 +10,7 @@ cask "universal-gcode-platform" do
 
   livecheck do
     url "https://github.com/winder/Universal-G-Code-Sender"
-    strategy :git
+    strategy :github_latest
   end
 
   app "Universal Gcode Platform.app"


### PR DESCRIPTION
Switching to `:github_latest` strategy due to use of prereleases.