### PR TITLE
cloudapp: add ssl to url

### DIFF
--- a/Casks/cloudapp.rb
+++ b/Casks/cloudapp.rb
@@ -2,7 +2,7 @@ cask "cloudapp" do
   version "6.6.10,2355"
   sha256 "ec14314e336c562e66e106dde8271b8290e3f3ceff9ce34990a9548facac0597"
 
-  url "http://downloads.getcloudapp.com/mac/CloudApp-#{version.csv.first}.#{version.csv.last}.zip"
+  url "https://downloads.getcloudapp.com/mac/CloudApp-#{version.csv.first}.#{version.csv.last}.zip"
   name "CloudApp"
   desc "Visual communication platform"
   homepage "https://www.getcloudapp.com/"


### PR DESCRIPTION
Add SSL to download URL. There is a typo in the appcast (see https://github.com/Homebrew/homebrew-cask/pull/137728#issuecomment-1350401655) so the audit fails.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.