### PR TITLE
jdownloader: add ssl to url

### DIFF
--- a/Casks/jdownloader.rb
+++ b/Casks/jdownloader.rb
@@ -2,7 +2,7 @@ cask "jdownloader" do
   version "47198"
   sha256 :no_check
 
-  url "http://installer.jdownloader.org/clean/JD2Setup.dmg",
+  url "https://installer.jdownloader.org/clean/JD2Setup.dmg",
       user_agent: :fake
   name "JDownloader"
   desc "Download manager"


### PR DESCRIPTION
Add SSL to download URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.