### PR TITLE
diffmerge: add ssl to url

### DIFF
--- a/Casks/diffmerge.rb
+++ b/Casks/diffmerge.rb
@@ -2,7 +2,7 @@ cask "diffmerge" do
   version "4.2.1.1013"
   sha256 "59efeede7beb69a5b3bf3126787f73930984b3b423094500fe73623656f66d43"
 
-  url "http://download.sourcegear.com/DiffMerge/#{version.major_minor_patch}/DiffMerge.#{version}.intel.stable.dmg"
+  url "https://download.sourcegear.com/DiffMerge/#{version.major_minor_patch}/DiffMerge.#{version}.intel.stable.dmg"
   name "DiffMerge"
   desc "Visually compare and merge files"
   homepage "https://www.sourcegear.com/diffmerge/"


### PR DESCRIPTION
Add SSL to download URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.