### PR TITLE
osbuddy: add ssl to url

### DIFF
--- a/Casks/osbuddy.rb
+++ b/Casks/osbuddy.rb
@@ -2,7 +2,7 @@ cask "osbuddy" do
   version "1.0"
   sha256 :no_check
 
-  url "http://cdn.rsbuddy.com/OSBuddy.dmg"
+  url "https://cdn.rsbuddy.com/OSBuddy.dmg"
   name "OSBuddy"
   desc "RuneScape toolkit"
   homepage "https://rsbuddy.com/osbuddy"


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.