### PR TITLE
1password: Zap more files

### DIFF
--- a/Casks/1password.rb
+++ b/Casks/1password.rb
@@ -22,13 +22,26 @@ cask "1password" do
   app "1Password.app"
 
   zap trash: [
-    "~/Library/Application Scripts/2BUA8C4S2C.com.1password.*",
+    "~/Library/Application Scripts/2BUA8C4S2C.com.1password*",
+    "~/Library/Application Scripts/com.1password.1password-launcher",
     "~/Library/Application Support/1Password",
+    "~/Library/Application Support/Arc/User Data/NativeMessagingHosts/com.1password.1password.json",
     "~/Library/Application Support/CrashReporter/1Password*",
+    "~/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Google/Chrome Dev/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge Beta/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge Canary/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge Dev/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Mozilla/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Vivaldi/NativeMessagingHosts/com.1password.1password.json",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.1password.1password.sfl2",
     "~/Library/Containers/2BUA8C4S2C.com.1password.browser-helper",
-    "~/Library/Containers/com.1password.1password",
+    "~/Library/Containers/com.1password.1password*",
     "~/Library/Group Containers/2BUA8C4S2C.com.1password",
+    "~/Library/Preferences/com.1password.1password.plist",
     "~/Library/Saved Application State/com.1password.1password.savedState",
   ]
 end


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online 1password` is error-free.
- [x] `brew style --fix 1password` reports no offenses.
