### PR TITLE
fawkes: add arm64 build, ssl

### DIFF
--- a/Casks/fawkes.rb
+++ b/Casks/fawkes.rb
@@ -1,14 +1,21 @@
 cask "fawkes" do
   version "1.0"
-  sha256 "115b57a13047b405be3e3cae28930eab8c19724c76d86ad63faeb6d6dc7e7f39"
 
-  url "https://mirror.cs.uchicago.edu/fawkes/files/#{version.major_minor}/Fawkes-#{version}.dmg"
+  on_intel do
+    sha256 "115b57a13047b405be3e3cae28930eab8c19724c76d86ad63faeb6d6dc7e7f39"
+    url "https://mirror.cs.uchicago.edu/fawkes/files/#{version.major_minor}/Fawkes-#{version}.dmg"
+  end
+  on_arm do
+    sha256 "f7afba97843819308ea15f89a273de9e95ef6d080159ce1ba1ddc41d5c4a932d"
+    url "https://mirror.cs.uchicago.edu/fawkes/files/#{version.major_minor}/Fawkes-m1.dmg"
+  end
+
   name "Fawkes"
   desc "Cloaks picture files to circumvent facial recognition"
   homepage "https://sandlab.cs.uchicago.edu/fawkes/"
 
   livecheck do
-    url "http://sandlab.cs.uchicago.edu/fawkes/"
+    url "https://sandlab.cs.uchicago.edu/fawkes/"
     regex(%r{href=.*?/Fawkes-(\d+(?:\.\d+)+)\.dmg}i)
   end
 


### PR DESCRIPTION
Add arm64 build, add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.