### PR TITLE
keyfinder: add SSL

### DIFF
--- a/Casks/keyfinder.rb
+++ b/Casks/keyfinder.rb
@@ -2,13 +2,13 @@ cask "keyfinder" do
   version "2.4"
   sha256 "a44f29e5eaaf5d51c3108bea9cb145599c993dfa8ee0b3770a0ecef4f048dfa3"
 
-  url "http://www.ibrahimshaath.co.uk/keyfinder/bins/KeyFinder-OSX-#{version.dots_to_hyphens}.zip"
+  url "https://www.ibrahimshaath.co.uk/keyfinder/bins/KeyFinder-OSX-#{version.dots_to_hyphens}.zip"
   name "KeyFinder"
   desc "Music key detection tool"
-  homepage "http://www.ibrahimshaath.co.uk/keyfinder/"
+  homepage "https://www.ibrahimshaath.co.uk/keyfinder/"
 
   livecheck do
-    url "http://www.ibrahimshaath.co.uk/keyfinder/"
+    url :homepage
     strategy :page_match do |page|
       v = page[%r{href=.*?/KeyFinder-OSX-(\d+(?:-\d+)*)\.zip}i, 1]
       v.tr("-", ".")


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.