### PR TITLE
algodoo: add SSL to URL

### DIFF
--- a/Casks/algodoo.rb
+++ b/Casks/algodoo.rb
@@ -2,7 +2,7 @@ cask "algodoo" do
   version "2.1.3"
   sha256 "9f3419d0da9cca0f0f5abc0b8a228197221c92fcbc35138ed2bb0b9251820a66"
 
-  url "http://www.algodoo.com/download/Algodoo_#{version.dots_to_underscores}-MacOS.dmg"
+  url "https://www.algodoo.com/download/Algodoo_#{version.dots_to_underscores}-MacOS.dmg"
   name "Algodoo"
   desc "Draw and interact with physical systems"
   homepage "https://www.algodoo.com/"


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.