### PR TITLE
arrsync: add SSL to URL

### DIFF
--- a/Casks/arrsync.rb
+++ b/Casks/arrsync.rb
@@ -5,7 +5,7 @@ cask "arrsync" do
   url "https://downloads.sourceforge.net/arrsync/arrsync-#{version}.dmg"
   name "arRsync"
   desc "Graphical front end for the utility rsync"
-  homepage "http://arrsync.sourceforge.net/"
+  homepage "https://arrsync.sourceforge.net/"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.