### PR TITLE
captin: add SSL to URL

### DIFF
--- a/Casks/captin.rb
+++ b/Casks/captin.rb
@@ -6,7 +6,7 @@ cask "captin" do
       verified: "dl.devmate.com/com.100hps.captin/"
   name "Captin"
   desc "Tool to show caps lock status"
-  homepage "http://captin.strikingly.com/"
+  homepage "https://captin.strikingly.com/"
 
   livecheck do
     url "https://updates.devmate.com/com.100hps.captin.xml"


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.