### PR TITLE
gitx: Fix URL, add description and SSL

### DIFF
--- a/Casks/gitx.rb
+++ b/Casks/gitx.rb
@@ -2,12 +2,13 @@ cask "gitx" do
   version "0.7.1"
   sha256 :no_check
 
-  url "http://frim.frim.nl/GitXStable.app.zip"
+  url "https://gitx.frim.nl/Downloads/GitXStable.app.zip"
   name "GitX"
-  homepage "http://gitx.frim.nl/"
+  desc "Git GUI"
+  homepage "https://gitx.frim.nl/"
 
   livecheck do
-    url "http://gitx.frim.nl/Downloads/appcast.xml"
+    url "https://gitx.frim.nl/Downloads/appcast.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
Fix URL, add description and SSL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.