### PR TITLE
gretl: add SSL to URL

### DIFF
--- a/Casks/gretl.rb
+++ b/Casks/gretl.rb
@@ -9,7 +9,7 @@ cask "gretl" do
   homepage "https://gretl.sourceforge.io/"
 
   livecheck do
-    url "http://gretl.sourceforge.net/osx.html"
+    url "https://gretl.sourceforge.net/osx.html"
     strategy :page_match
     regex(/gretl[._-]v?(\d+\w)[._-]macos[._-]intel\.pkg/i)
   end


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.