### PR TITLE
hugin: add SSL to URL

### DIFF
--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -5,10 +5,10 @@ cask "hugin" do
   url "https://downloads.sourceforge.net/hugin/Hugin-#{version}.dmg"
   name "Hugin"
   desc "Panorama photo stitcher"
-  homepage "http://hugin.sourceforge.net/"
+  homepage "https://hugin.sourceforge.net/"
 
   livecheck do
-    url "http://hugin.sourceforge.net/download/"
+    url "https://hugin.sourceforge.net/download/"
     strategy :page_match
     regex(/Hugin-(\d+(?:\.\d+)*)\.dmg/i)
   end


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.