### PR TITLE
icab: add SSL to URL

### DIFF
--- a/Casks/icab.rb
+++ b/Casks/icab.rb
@@ -6,10 +6,10 @@ cask "icab" do
       verified: "icab.clauss-net.de/icab/"
   name "iCab"
   desc "Alternative web browser"
-  homepage "http://www.icab.de/"
+  homepage "https://www.icab.de/"
 
   livecheck do
-    url "http://www.icab.de/download.html"
+    url "https://www.icab.de/download.html"
     regex(/iCab\sv?(\d+(?:\.\d+)+)/i)
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.