### PR TITLE
ibackup: add SSL to URL

### DIFF
--- a/Casks/ibackup.rb
+++ b/Casks/ibackup.rb
@@ -2,13 +2,13 @@ cask "ibackup" do
   version "7.6"
   sha256 "97e34fd79a16193161e873e2eb77c32597dedb5b63d44ed48a61c40af8aba8e2"
 
-  url "http://www.grapefruit.ch/iBackup/versions/iBackup%20#{version.major}.x/iBackup%20#{version}.dmg"
+  url "https://www.grapefruit.ch/iBackup/versions/iBackup%20#{version.major}.x/iBackup%20#{version}.dmg"
   name "iBackup"
   desc "Backup utility"
-  homepage "http://www.grapefruit.ch/iBackup/"
+  homepage "https://www.grapefruit.ch/iBackup/"
 
   livecheck do
-    url "http://www.grapefruit.ch/iBackup/downloads.html"
+    url "https://www.grapefruit.ch/iBackup/downloads.html"
     regex(%r{href=.*?/iBackup\s*v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.