### PR TITLE
insync: add SSL to URL

### DIFF
--- a/Casks/insync.rb
+++ b/Casks/insync.rb
@@ -2,7 +2,7 @@ cask "insync" do
   version "3.8.4.50481"
   sha256 "766ea065cce79c54ab83f8df2f52090eef03bb97f2f559136ad31e4d69881cb1"
 
-  url "http://cdn.insynchq.com/builds/mac/Insync-#{version}.dmg"
+  url "https://cdn.insynchq.com/builds/mac/Insync-#{version}.dmg"
   name "Insync"
   desc "Manage your Google Drive and OneDrive files"
   homepage "https://www.insynchq.com/"


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.