### PR TITLE
macx-video-converter-pro: add SSL to URL

### DIFF
--- a/Casks/macx-video-converter-pro.rb
+++ b/Casks/macx-video-converter-pro.rb
@@ -8,7 +8,7 @@ cask "macx-video-converter-pro" do
   homepage "https://www.macxdvd.com/mac-video-converter-pro/"
 
   livecheck do
-    url "http://www.macxdvd.com/mac-video-converter-pro/upgrade/video-converter-pro.xml"
+    url "https://www.macxdvd.com/mac-video-converter-pro/upgrade/video-converter-pro.xml"
     regex(%r{LastestVersion</key>\s*<string>(\d+(?:\.\d+)+)<}i)
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.