### PR TITLE
mia-for-gmail: add SSL to URL

### DIFF
--- a/Casks/mia-for-gmail.rb
+++ b/Casks/mia-for-gmail.rb
@@ -2,14 +2,14 @@ cask "mia-for-gmail" do
   version "2.4.5,72"
   sha256 "31f94c2c5bafc2550adb50ed36919b45c2939bbd691ce1b27b8486d1094600c5"
 
-  url "http://www.sovapps.com/application/notifier-pro-for-gmail/mia.#{version.csv.first}.zip",
+  url "https://www.sovapps.com/application/notifier-pro-for-gmail/mia.#{version.csv.first}.zip",
       verified: "sovapps.com/application/notifier-pro-for-gmail/"
   name "Mia for Gmail"
   desc "Desktop email client for Gmail"
-  homepage "http://www.miaforgmail.com/"
+  homepage "https://www.miaforgmail.com/"
 
   livecheck do
-    url "http://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml"
+    url "https://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.