### PR TITLE
overdrive-media-console: add SSL to URL

### DIFF
--- a/Casks/overdrive-media-console.rb
+++ b/Casks/overdrive-media-console.rb
@@ -2,7 +2,7 @@ cask "overdrive-media-console" do
   version "1.2"
   sha256 :no_check
 
-  url "http://static.od-cdn.com/ODMediaConsoleSetup.dmg",
+  url "https://static.od-cdn.com/ODMediaConsoleSetup.dmg",
       verified: "static.od-cdn.com/"
   name "OverDrive Media Console"
   desc "Get eBooks, audiobooks, and videos from your local library"


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.