### PR TITLE
password-gorilla: add description and SSL to URL

### DIFF
--- a/Casks/password-gorilla.rb
+++ b/Casks/password-gorilla.rb
@@ -2,13 +2,14 @@ cask "password-gorilla" do
   version "15373"
   sha256 "51c443fb58a3628c2a45bd3160096abb9b017f33e6a08628636168f996ad0414"
 
-  url "http://gorilla.dp100.com/downloads/gorilla.mac.#{version}.zip",
+  url "https://gorilla.dp100.com/downloads/gorilla.mac.#{version}.zip",
       verified: "gorilla.dp100.com/"
   name "Password Gorilla"
+  desc "Password database manager"
   homepage "https://github.com/zdia/gorilla"
 
   livecheck do
-    url "http://gorilla.dp100.com/downloads/"
+    url "https://gorilla.dp100.com/downloads/"
     regex(/gorilla\.mac\.(\d+)\.zip/i)
   end
 


### PR DESCRIPTION
Add description and SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.