### PR TITLE
pdfelement: add SSL to URL

### DIFF
--- a/Casks/pdfelement.rb
+++ b/Casks/pdfelement.rb
@@ -8,7 +8,7 @@ cask "pdfelement" do
   homepage "https://pdf.wondershare.com/"
 
   livecheck do
-    url "http://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237&version=latest"
+    url "https://cbs.wondershare.com/go.php?m=upgrade_info&pid=5237&version=latest"
     regex(%r{<Version>(\d+(?:\.\d+)+)</Version>}i)
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.