### PR TITLE
remotehamradio: add SSL to URL

### DIFF
--- a/Casks/remotehamradio.rb
+++ b/Casks/remotehamradio.rb
@@ -9,7 +9,7 @@ cask "remotehamradio" do
   homepage "https://www.remotehamradio.com/"
 
   livecheck do
-    url "http://update.remotehamradio.com/desktop/download?platform=Macintosh"
+    url "https://update.remotehamradio.com/desktop/download?platform=Macintosh"
     regex(/href=.*?RemoteHamRadio[._-]v?(\d+(?:\.\d+)+)-mac\.zip/i)
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.