### PR TITLE
rowmote-helper: Fix sha256 and add SSL to URL

### DIFF
--- a/Casks/rowmote-helper.rb
+++ b/Casks/rowmote-helper.rb
@@ -1,6 +1,6 @@
 cask "rowmote-helper" do
   version "4.2.5"
-  sha256 "9646af824fcfcbddbf71591408bd02137b65554650418574ddc5ba0c45cd59f4"
+  sha256 "acf5bf794d7b7b0da253d33a7dd5bdf6b33f0af83a9411c6e86a8816f899794d"
 
   url "https://regularrateandrhythm.com/rowmote-pro/rh/rowmote-helper-#{version}.zip"
   name "Rowmote Helper"
@@ -8,7 +8,7 @@ cask "rowmote-helper" do
   homepage "https://regularrateandrhythm.com/apps/rowmote-pro/"
 
   livecheck do
-    url "http://www.regularrateandrhythm.com/apps/rowmote-pro/rowmote-helper-versions.php"
+    url "https://www.regularrateandrhythm.com/apps/rowmote-pro/rowmote-helper-versions.php"
     regex(/Rowmote\s+Helper\s+v?(\d+(?:\.\d+)+)/i)
   end
 


### PR DESCRIPTION
Fix sha256 and add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.