### PR TITLE
scidvsmac: add SSL to URL

### DIFF
--- a/Casks/scidvsmac.rb
+++ b/Casks/scidvsmac.rb
@@ -5,7 +5,7 @@ cask "scidvsmac" do
   url "https://downloads.sourceforge.net/scidvspc/ScidvsMac-#{version}.dmg"
   name "Scid vs. Mac"
   desc "Chess toolkit"
-  homepage "http://scidvspc.sourceforge.net/"
+  homepage "https://scidvspc.sourceforge.net/"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.