### PR TITLE
stationtv-link: add SSL to URL

### DIFF
--- a/Casks/stationtv-link.rb
+++ b/Casks/stationtv-link.rb
@@ -2,13 +2,13 @@ cask "stationtv-link" do
   version "1.1.1"
   sha256 "0254447381c1c41d797180ab373fb426c5143e8bf226d1c4ee09cfe0d19305d9"
 
-  url "http://download.pixela.co.jp/products/tv_capture/stationtv_link/data/stationtvlink_#{version.no_dots}.dmg"
+  url "https://www.pixela.co.jp/products/tv_capture/stationtv_link/data/stationtvlink_#{version.no_dots}.dmg"
   name "StationTV® Link"
   desc "DVR and Media Server"
-  homepage "http://www.pixela.co.jp/products/tv_capture/stationtv_link/"
+  homepage "https://www.pixela.co.jp/products/tv_capture/stationtv_link/"
 
   livecheck do
-    url "http://www.pixela.co.jp/products/tv_capture/stationtv_link/support.html#download-mac"
+    url "https://www.pixela.co.jp/products/tv_capture/stationtv_link/support.html#download-mac"
     regex(/\[Ver\.(\d+(?:\.\d+)+)\]/i)
   end
 


### PR DESCRIPTION
Add SSL to URL

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.