### PR TITLE
gobdokumente: convert to `on_system` blocks

### DIFF
--- a/Casks/gobdokumente.rb
+++ b/Casks/gobdokumente.rb
@@ -1,31 +1,20 @@
 cask "gobdokumente" do
-  if MacOS.version <= :catalina
-    version "1.6.8"
-    sha256 :no_check
-    url "https://download.moapp.software/GoBDokumente.zip",
-        verified: "download.moapp.software/"
+  version "2.1"
+  sha256 :no_check
 
-    livecheck do
-      skip "Legacy version for catalina and earlier"
-    end
-  else
-    version "2.1"
-    sha256 :no_check
-    url "https://download.moapp.software/GoBDokumente_BS.zip",
-        verified: "download.moapp.software/"
-
-    livecheck do
-      url "https://sparkle.moapp.software/gobdokumente.xml"
-      strategy :sparkle
-    end
-  end
-
+  url "https://download.moapp.software/GoBDokumente_BS.zip",
+      verified: "download.moapp.software/"
   name "GoBDokumente"
   name "GoBDocuments"
   desc "Document management system"
   homepage "https://gobdokumente.de/"
 
-  depends_on macos: ">= :el_capitan"
+  livecheck do
+    url "https://sparkle.moapp.software/gobdokumente.xml"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :big_sur"
 
   app "GoBDokumente.app"
 end


### PR DESCRIPTION
Convert to `on_system` blocks

See #137512
