### PR TITLE
liteicon: convert to `on_system` blocks

### DIFF
--- a/Casks/liteicon.rb
+++ b/Casks/liteicon.rb
@@ -1,11 +1,13 @@
 cask "liteicon" do
-  if MacOS.version <= :sierra
+  on_sierra :or_older do
     version "3.7.1"
     sha256 "b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432"
-  elsif MacOS.version <= :high_sierra
+  end
+  on_high_sierra do
     version "3.9"
     sha256 "d185503d1c6cbbc6f770517853bd9ef08dc620f4e7ce3de913251a57e4d450d9"
-  else
+  end
+  on_mojave :or_newer do
     version "4.1,1518"
     sha256 "545cff53df31b63fe28e794fb7f45e4c891885f5de57422b1483724f6d7ed4e0"
   end


### PR DESCRIPTION
Convert to `on_system` blocks

See https://github.com/Homebrew/homebrew-cask/issues/137512
