### PR TITLE
macpilot: convert to `on_system` blocks

### DIFF
--- a/Casks/macpilot.rb
+++ b/Casks/macpilot.rb
@@ -1,10 +1,11 @@
 cask "macpilot" do
-  if MacOS.version <= :mojave
+  on_mojave :or_older do
     version "11.1.3"
     sha256 "1990b04414896ef24767e58cd9b56901460375ee8fb805572ca34da019bcda58"
 
     url "https://www.koingosw.com/products/macpilot/download/old/macpilot_#{version}_intel_for_1013to1015.dmg"
-  elsif MacOS.version <= :catalina
+  end
+  on_catalina do
     version "11.1.4"
     sha256 "75fc421d51ebd172ebdf149400fbcd010cf1224529e2e7d3fdf1915e62757f64"
 
@@ -13,7 +14,8 @@ cask "macpilot" do
     livecheck do
       skip "newer versions only available for Big Sur or higher"
     end
-  else
+  end
+  on_big_sur :or_newer do
     version "14.0"
     sha256 :no_check
 
@@ -29,7 +31,7 @@ cask "macpilot" do
   desc "Graphical user interface for the command terminal"
   homepage "https://www.koingosw.com/products/macpilot/"
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :mojave"
 
   app "MacPilot.app"
 


### PR DESCRIPTION
Convert to `on_system` blocks

See https://github.com/Homebrew/homebrew-cask/issues/137512
