### PR TITLE
max: convert to `on_system` blocks

### DIFF
--- a/Casks/max.rb
+++ b/Casks/max.rb
@@ -1,12 +1,13 @@
 cask "max" do
-  if MacOS.version <= :mojave
+  on_mojave :or_older do
     version "0.9.1"
     sha256 "722bf714696d3d39329ba98ffddc9f117f8cc6863f71670507cd12f62a5e5f14"
 
     url "https://files.sbooth.org/Max-#{version}.tar.bz2"
 
     app "Max-#{version}/Max.app"
-  else
+  end
+  on_catalina :or_newer do
     version "0.9.2b4"
     sha256 "4d3d96f2e3fc2f52fc3c7cbeb260be749975665e38f643089d2e3fdb58b8f82b"
 


### PR DESCRIPTION
Convert to `on_system` blocks

See https://github.com/Homebrew/homebrew-cask/issues/137512
