### PR TITLE
mounty: convert to `on_system` blocks

### DIFF
--- a/Casks/mounty.rb
+++ b/Casks/mounty.rb
@@ -1,12 +1,13 @@
 cask "mounty" do
-  if MacOS.version <= :catalina
+  on_catalina :or_older do
     version "1.9"
     sha256 "5fcedfe712f59c14f39c3385dfed9aebc99d4e8d88f6e870f364cc48624590ef"
 
     livecheck do
       skip "newer versions only available for Big Sur or higher"
     end
-  else
+  end
+  on_big_sur :or_newer do
     version "1.15"
     sha256 "8c678c87aa609a7222ca229acb3a650d4a4e2db9fa9ce89a09a9d45ea1b19af1"
 


### PR DESCRIPTION
Convert to `on_system` blocks

See https://github.com/Homebrew/homebrew-cask/issues/137512
