### PR TITLE
natron: convert to `on_system` blocks

### DIFF
--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -1,15 +1,17 @@
 cask "natron" do
   version "2.5.0"
 
-  if MacOS.version <= :mojave
+  on_mojave :or_older do
     sha256 "4bf8ce890fe51446c01fc8480e8159cd559cfaac2445eae1699ae1718121fa7a"
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-OSX109-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"
-  elsif MacOS.version <= :catalina
+  end
+  on_catalina do
     sha256 "1c97a1f373c3adcdbb933f20b02d0ebd4d7737d44e5344a372bd7b9e5211860e"
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-macOS1015-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"
-  else
+  end
+  on_big_sur :or_newer do
     sha256 "90618183b65cab217b7892d6f0ad3254b7efebc57ef47e77790d8504dbcc7b22"
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-macOS12-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"


### PR DESCRIPTION
Convert to `on_system` blocks

See https://github.com/Homebrew/homebrew-cask/issues/137512
