### PR TITLE
omnioutliner: convert to `on_system` blocks

### DIFF
--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -1,21 +1,25 @@
 cask "omnioutliner" do
-  if MacOS.version <= :el_capitan
+  on_el_capitan :or_older do
     version "5.1.4"
     sha256 "91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0"
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
-  elsif MacOS.version <= :sierra
+  end
+  on_sierra do
     version "5.3.4"
     sha256 "dd329a070980ae6fe1aa9c55d398a2ab5b6192082455e7eb3526a9fccb3eaf42"
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
-  elsif MacOS.version <= :high_sierra
+  end
+  on_high_sierra do
     version "5.4.2"
     sha256 "a9364dcf2ee97a871a881530785fa54d269f5e95298e2e4d2e979c70b6365395"
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniOutliner-#{version}(n).dmg"
-  elsif MacOS.version <= :mojave
+  end
+  on_mojave do
     version "5.8.5"
     sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
-  else
+  end
+  on_catalina :or_newer do
     version "5.11.1"
     sha256 "0117a74bdbca04094931e2c482c80ba3b939f0107d5d2039c6c5ab25ec1e8d9d"
     url "https://downloads.omnigroup.com/software/macOS/11/OmniOutliner-#{version}.dmg"


### PR DESCRIPTION
Convert to `on_system` blocks

See https://github.com/Homebrew/homebrew-cask/issues/137512
