### PR TITLE
ci: Update GitHub Actions to avoid set-output deprecation

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -63,4 +63,6 @@ modified_paths.each do |modified_path|
 end
 puts
 
-puts '::set-output name=pull_request::true'
+File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+  f.puts('pull_request=true')
+end

--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -63,6 +63,6 @@ modified_paths.each do |modified_path|
 end
 puts
 
-File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+File.open(ENV.fetch('GITHUB_OUTPUT'), 'a') do |f|
   f.puts('pull_request=true')
 end

--- a/.github/workflows/bump-unversioned-casks.yml
+++ b/.github/workflows/bump-unversioned-casks.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Generate cache ID
         id: cache-id
         run: |
-          echo "::set-output name=time::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          echo "time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       - name: Cache state
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,13 +174,13 @@ jobs:
             formula_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Formula) }.map(&:full_name)
 
             File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
-              puts "was_installed=#{JSON.generate(was_installed)}"
-              puts "manual_installer=#{JSON.generate(manual_installer)}"
-              puts "macos_requirement_satisfied=#{JSON.generate(macos_requirement_satisfied)}"
-              puts "cask_conflicts=#{JSON.generate(cask_conflicts)}"
-              puts "cask_dependencies=#{JSON.generate(cask_dependencies)}"
-              puts "formula_conflicts=#{JSON.generate(formula_conflicts)}"
-              puts "formula_dependencies=#{JSON.generate(formula_dependencies)}"
+              f.puts "was_installed=#{JSON.generate(was_installed)}"
+              f.puts "manual_installer=#{JSON.generate(manual_installer)}"
+              f.puts "macos_requirement_satisfied=#{JSON.generate(macos_requirement_satisfied)}"
+              f.puts "cask_conflicts=#{JSON.generate(cask_conflicts)}"
+              f.puts "cask_dependencies=#{JSON.generate(cask_dependencies)}"
+              f.puts "formula_conflicts=#{JSON.generate(formula_conflicts)}"
+              f.puts "formula_dependencies=#{JSON.generate(formula_dependencies)}"
             end
           EOF
         if: always() && steps.fetch.outcome == 'success' && matrix.cask
@@ -208,7 +208,7 @@ jobs:
         run: |
           brew ruby -r "$(brew --repository homebrew/cask)/cmd/lib/check.rb" <<'EOF'
             File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
-              puts "before=#{JSON.generate(Check.all)}"
+              f.puts "before=#{JSON.generate(Check.all)}"
             end
           EOF
         if: always() && steps.info.outcome == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
             cask_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Cask::Cask) }.map(&:full_name)
             formula_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Formula) }.map(&:full_name)
 
-            File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+            File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
               f.puts "was_installed=#{JSON.generate(was_installed)}"
               f.puts "manual_installer=#{JSON.generate(manual_installer)}"
               f.puts "macos_requirement_satisfied=#{JSON.generate(macos_requirement_satisfied)}"
@@ -207,7 +207,7 @@ jobs:
         id: snapshot
         run: |
           brew ruby -r "$(brew --repository homebrew/cask)/cmd/lib/check.rb" <<'EOF'
-            File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+            File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
               f.puts "before=#{JSON.generate(Check.all)}"
             end
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,13 +173,15 @@ jobs:
             cask_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Cask::Cask) }.map(&:full_name)
             formula_dependencies = cask_and_formula_dependencies.select { |d| d.is_a?(Formula) }.map(&:full_name)
 
-            puts "::set-output name=was_installed::#{JSON.generate(was_installed)}"
-            puts "::set-output name=manual_installer::#{JSON.generate(manual_installer)}"
-            puts "::set-output name=macos_requirement_satisfied::#{JSON.generate(macos_requirement_satisfied)}"
-            puts "::set-output name=cask_conflicts::#{JSON.generate(cask_conflicts)}"
-            puts "::set-output name=cask_dependencies::#{JSON.generate(cask_dependencies)}"
-            puts "::set-output name=formula_conflicts::#{JSON.generate(formula_conflicts)}"
-            puts "::set-output name=formula_dependencies::#{JSON.generate(formula_dependencies)}"
+            File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+              puts "was_installed=#{JSON.generate(was_installed)}"
+              puts "manual_installer=#{JSON.generate(manual_installer)}"
+              puts "macos_requirement_satisfied=#{JSON.generate(macos_requirement_satisfied)}"
+              puts "cask_conflicts=#{JSON.generate(cask_conflicts)}"
+              puts "cask_dependencies=#{JSON.generate(cask_dependencies)}"
+              puts "formula_conflicts=#{JSON.generate(formula_conflicts)}"
+              puts "formula_dependencies=#{JSON.generate(formula_dependencies)}"
+            end
           EOF
         if: always() && steps.fetch.outcome == 'success' && matrix.cask
 
@@ -205,7 +207,9 @@ jobs:
         id: snapshot
         run: |
           brew ruby -r "$(brew --repository homebrew/cask)/cmd/lib/check.rb" <<'EOF'
-            puts "::set-output name=before::#{JSON.generate(Check.all)}"
+            File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+              puts "before=#{JSON.generate(Check.all)}"
+            end
           EOF
         if: always() && steps.info.outcome == 'success'
 

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -42,6 +42,6 @@ end
 syntax_job[:name] += " (#{syntax_job[:runner]})"
 
 puts JSON.pretty_generate(matrix)
-File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
   f.puts "matrix=#{JSON.generate(matrix)}"
 end

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -43,5 +43,5 @@ syntax_job[:name] += " (#{syntax_job[:runner]})"
 
 puts JSON.pretty_generate(matrix)
 File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
-  puts "matrix=#{JSON.generate(matrix)}"
+  f.puts "matrix=#{JSON.generate(matrix)}"
 end

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -42,4 +42,6 @@ end
 syntax_job[:name] += " (#{syntax_job[:runner]})"
 
 puts JSON.pretty_generate(matrix)
-puts "::set-output name=matrix::#{JSON.generate(matrix)}"
+File.open(ENV['GITHUB_OUTPUT'], 'a') do |f|
+  puts "matrix=#{JSON.generate(matrix)}"
+end


### PR DESCRIPTION
Starting 1st June 2023 (planned) workflows, `::set-output name=<name>::<value>` syntax cannot be used. You can see the example warnings here: https://github.com/Homebrew/homebrew-cask/actions/runs/3791792830

ref. [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR fixes the issue by using the `GITHUB_OUTPUT` environment file as instructed in the above article.

(I think this doesn't change the cask itself so I remain the checklist unchecked.)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
