### PR TITLE
deepl: update from 3.7.292629 to 4.0.317085, fix cask

### DIFF
--- a/Casks/deepl.rb
+++ b/Casks/deepl.rb
@@ -1,19 +1,33 @@
 cask "deepl" do
-  version "3.7.292629"
-  sha256 :no_check
+  on_big_sur :or_newer do
+    version "4.0.317085"
+    sha256 "a43836ea319e0b22fc48761e992e531447cb6e28cf94d348c3210121e53352f0"
 
-  url "https://appdownload.deepl.com/macos/DeepL.dmg"
+    livecheck do
+      url "https://appdownload.deepl.com/macos/bigsur/update.json"
+      strategy :page_match do |page|
+        JSON.parse(page)["currentRelease"]
+      end
+    end
+  end
+  on_catalina :or_older do
+    version "3.7.292629"
+    sha256 "efcac4988a606d9793a3bdb8e7e73dce8e3d06ed2249a4434eb54c1624b40b87"
+
+    livecheck do
+      url "https://appdownload.deepl.com/macos/update.json"
+      strategy :page_match do |page|
+        JSON.parse(page)["currentRelease"]
+      end
+    end
+  end
+
+  url "https://appdownload.deepl.com/macos/#{version}/DeepL_#{version}.zip"
   name "DeepL"
   desc "Trains AIs to understand and translate texts"
   homepage "https://www.deepl.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
-
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DeepL.app"
 


### PR DESCRIPTION
Update from 3.7.292629 to 4.0.317085, fix cask

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.