### PR TITLE
a-slower-speed-of-light: discontinue

### DIFF
--- a/Casks/a-slower-speed-of-light.rb
+++ b/Casks/a-slower-speed-of-light.rb
@@ -7,10 +7,9 @@ cask "a-slower-speed-of-light" do
   desc "First-person game"
   homepage "https://gamelab.mit.edu/games/a-slower-speed-of-light/"
 
-  livecheck do
-    url :homepage
-    regex(/title=.*?Download\s*v?(\d+(?:\.\d+)*)\s*For\s*Mac"/i)
-  end
-
   app "A Slower Speed of Light.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Last release was in April 2020. Site has an incomplete certificate chain, so `livecheck` also no longer works.