### PR TITLE
Update telegram from 9.2.1 to 9.3

### DIFF
--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask "telegram" do
   version "9.3,241534"
-  sha256 "MC0CFQC6bGfzy16VoVV+r3PgwUHoiFcu3gIUCWumFZLEwr08aCmWPz9ZdjRtcp8="
+  sha256 "fdf7afecc23b2a40c05e9a196a3b82192f2d39659f52ab3c015041bfdb0338f0"
 
   url "https://osx.telegram.org/updates/Telegram-#{version.csv.first}.#{version.csv.second}.app.zip"
   name "Telegram for macOS"

--- a/Casks/telegram.rb
+++ b/Casks/telegram.rb
@@ -1,6 +1,6 @@
 cask "telegram" do
-  version "9.2.1,240459"
-  sha256 "c45d2f2400468a6a79dae4e24edb78da1177b4b4aafaa3661f4712499119f121"
+  version "9.3,241534"
+  sha256 "MC0CFQC6bGfzy16VoVV+r3PgwUHoiFcu3gIUCWumFZLEwr08aCmWPz9ZdjRtcp8="
 
   url "https://osx.telegram.org/updates/Telegram-#{version.csv.first}.#{version.csv.second}.app.zip"
   name "Telegram for macOS"


### PR DESCRIPTION
Update telegram from 9.2.1 to 9.3
The first time to calculate sha265 for app, it has been corrected now