### PR TITLE
workflows: update autopublish to work on all homebrew-cask-* repositories

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -19,7 +19,7 @@ puts 'Detecting changes…'
   '.github/*.md',
   '.github/*.yml',
   '.github/ISSUE_TEMPLATE/*.{md,yml}',
-  '.github/workflows/{cache,ci,dispatch-command,rebase,rerun-workflow,review,triage}.yml',
+  '.github/workflows/{autopublish,cache,ci,dispatch-command,publish-commity-casks,rebase,rerun-workflow,review,triage}.yml',
   '.gitignore',
   '.travis.yml',
   'Casks/.rubocop.yml',

--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -19,7 +19,7 @@ puts 'Detecting changes…'
   '.github/*.md',
   '.github/*.yml',
   '.github/ISSUE_TEMPLATE/*.{md,yml}',
-  '.github/workflows/{autopublish,cache,ci,dispatch-command,publish-commity-casks,rebase,rerun-workflow,review,triage}.yml',
+  '.github/workflows/{autopublish,cache,ci,dispatch-command,publish-commit-casks,rebase,rerun-workflow,review,triage}.yml',
   '.gitignore',
   '.travis.yml',
   'Casks/.rubocop.yml',

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   autopublish:
-    if: github.repository == 'Homebrew/homebrew-cask'
+    if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
@@ -28,6 +28,6 @@ jobs:
         run: |
           brew pr-automerge --verbose \
                             --publish \
-                            --tap homebrew/cask \
+                            --tap ${{ github.repository }} \
                             --workflow=publish-commit-casks.yml \
                             --without-labels="do not merge,new cask,automerge-skip"

--- a/.github/workflows/publish-commit-casks.yml
+++ b/.github/workflows/publish-commit-casks.yml
@@ -78,13 +78,13 @@ jobs:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CASK_PUBLIC_REPO_EMAIL_TOKEN}}
-        run: brew pr-pull --debug --workflows=ci.yml --committer="$BREWTESTBOT_NAME_EMAIL" --tap homebrew/cask ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
+        run: brew pr-pull --debug --workflows=ci.yml --committer="$BREWTESTBOT_NAME_EMAIL" --tap ${{ github.repository }} ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          directory: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-cask
+          directory: "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/${{ github.event.repository.name }}"
         env:
           GIT_COMMITTER_NAME: BrewTestBot
           GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com


### PR DESCRIPTION
This is an attempt to setup the autopublish workflow to work across all of our `homebrew-cask-*` repositories.

CC: @p-linnane 