### PR TITLE
xampp-vm: discontinue

### DIFF
--- a/Casks/xampp-vm.rb
+++ b/Casks/xampp-vm.rb
@@ -8,10 +8,9 @@ cask "xampp-vm" do
   desc "Virtual machine with apache distribution containing MySQL, PHP, and Perl"
   homepage "https://www.apachefriends.org/index.html"
 
-  livecheck do
-    url "https://www.apachefriends.org/download.html"
-    regex(%r{href=.*?/xampp[._-]osx[._-]v?(\d+(?:\.\d+)+-\d+)[._-]vm\.dmg}i)
-  end
-
   app "xampp-osx-#{version}-vm.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Per the [website](https://www.apachefriends.org/blog/new_xampp_20221229.html):
>The OS X native installer ships x86_64 binaries that are supported by the OS X Rosetta environment for the new OS X M1 and M2 (ARM architecture). The XAMPP VM is not compatible with the ARM architecture, the OS X Rosetta environment does not translate Virtual Machine apps that virtualize x86_64 computer platforms. For this reason XAMPP does no longer support OS X VM but you can download previous versions from the [SourceForge XAMPP for OS X folder](https://sourceforge.net/projects/xampp/files/XAMPP%20Mac%20OS%20X/8.1.6/).