### PR TITLE
adobe-creative-cloud: fix livecheck

### DIFF
--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -12,7 +12,7 @@ cask "adobe-creative-cloud" do
 
   livecheck do
     url "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html"
-    regex(/Version.(\d+(?:\.\d+)+)/i)
+    regex(/Version.(\d+(?:\.\d+)+)\s\(macOS\)/i)
   end
 
   auto_updates true


### PR DESCRIPTION
They are listing web releases on the release notes page now, so tightening this to macOS specifically.