### PR TITLE
Add Soulver CLI

### DIFF
--- a/Casks/soulver-cli.rb
+++ b/Casks/soulver-cli.rb
@@ -1,0 +1,14 @@
+cask "soulver-cli" do
+  version "1.0.0"
+  sha256 "21d5463151181ee4b23c5bdc603c4bb52cf215bf0f29ca7b228ce812e2f2b80c"
+
+  url "https://github.com/soulverteam/Soulver-CLI/releases/download/#{version}/soulver.zip"
+  name "Soulver CLI"
+  desc "Standalone cli for the Soulver calculation engine"
+  homepage "https://github.com/soulverteam/Soulver-CLI"
+
+  depends_on macos: ">= :monterey"
+
+  binary "soulver"
+  zap trash: ["/opt/homebrew/bin/SoulverCore_SoulverCore.bundle"]
+end

--- a/Casks/soulver-cli.rb
+++ b/Casks/soulver-cli.rb
@@ -10,5 +10,6 @@ cask "soulver-cli" do
   depends_on macos: ">= :monterey"
 
   binary "soulver"
-  zap trash: ["/opt/homebrew/bin/SoulverCore_SoulverCore.bundle"]
+
+  zap trash: "/opt/homebrew/bin/SoulverCore_SoulverCore.bundle"
 end

--- a/Casks/soulver-cli.rb
+++ b/Casks/soulver-cli.rb
@@ -11,5 +11,5 @@ cask "soulver-cli" do
 
   binary "soulver"
 
-  zap trash: "/opt/homebrew/bin/SoulverCore_SoulverCore.bundle"
+  zap trash: "#{HOMEBREW_PREFIX}/SoulverCore_SoulverCore.bundle"
 end

--- a/Casks/soulver.rb
+++ b/Casks/soulver.rb
@@ -13,7 +13,7 @@ cask "soulver" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :big_sur"
 
   app "Soulver #{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask (soulver), verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask** (soulver-cli):

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
-  [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
` - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)`
I'm the developer of Soulver, which is fairly well known and has been on the Mac since 2005. There already exists a cask for the main GUI Soulver.app. This is a new standalone command line interface to it, which was only just released. I'd like to have homebrew support out of the box for easier installation.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
