### PR TITLE
password-gorilla: switch back to http

### DIFF
--- a/Casks/password-gorilla.rb
+++ b/Casks/password-gorilla.rb
@@ -2,14 +2,14 @@ cask "password-gorilla" do
   version "15373"
   sha256 "51c443fb58a3628c2a45bd3160096abb9b017f33e6a08628636168f996ad0414"
 
-  url "https://gorilla.dp100.com/downloads/gorilla.mac.#{version}.zip",
+  url "http://gorilla.dp100.com/downloads/gorilla.mac.#{version}.zip",
       verified: "gorilla.dp100.com/"
   name "Password Gorilla"
   desc "Password database manager"
   homepage "https://github.com/zdia/gorilla"
 
   livecheck do
-    url "https://gorilla.dp100.com/downloads/"
+    url "http://gorilla.dp100.com/downloads/"
     regex(/gorilla\.mac\.(\d+)\.zip/i)
   end
 


### PR DESCRIPTION
This partially reverts db63a7d. The certificate chain for this site is incomplete, which causes TLS failures. I had planned to just remove this cask but there are a decent number of downloads:
```
30 days: 21 (#1953)
90 days: 58 (#2074)
365 days: 273 (#1909)
Age: 3203 days (added 2014, March 29)
```