### PR TITLE
Revert "write: add ssl to url"

### DIFF
--- a/Casks/write.rb
+++ b/Casks/write.rb
@@ -2,13 +2,13 @@ cask "write" do
   version "3.0.0"
   sha256 "036e75f00f47c3dc33cdddfe7b2449d5bcff696992389138467de1f9757b6c57"
 
-  url "https://www.styluslabs.com/write/write#{version.no_dots}.dmg"
+  url "http://www.styluslabs.com/write/write#{version.no_dots}.dmg"
   name "Write"
   desc "Word processor for handwriting"
-  homepage "https://www.styluslabs.com/"
+  homepage "http://www.styluslabs.com/"
 
   livecheck do
-    url "https://www.styluslabs.com/download/write-dmg"
+    url "http://www.styluslabs.com/download/write-dmg"
     regex(/write[._-]?v?(\d+)\.dmg/i)
     strategy :header_match do |header, regex|
       version = header["location"].match(regex)[1]


### PR DESCRIPTION
This reverts commit cc77ad22fdcfd45dc7b98330fd994fc9b1e7e4c4.

Certificate chain is incomplete, so https cannot be used.