### PR TITLE
makemkv: add missing binaries

### DIFF
--- a/Casks/makemkv.rb
+++ b/Casks/makemkv.rb
@@ -14,6 +14,9 @@ cask "makemkv" do
 
   app "MakeMKV.app"
   binary "#{appdir}/MakeMKV.app/Contents/MacOS/makemkvcon"
+  binary "#{appdir}/MakeMKV.app/Contents/MacOS/mmccextr"
+  binary "#{appdir}/MakeMKV.app/Contents/MacOS/mmgplsrv"
+  binary "#{appdir}/MakeMKV.app/Contents/MacOS/sdftool"
 
   zap trash: [
     "~/Library/MakeMKV",


### PR DESCRIPTION
Some other binaries (executables in the `/Applications/MakeMKV.app/Contents/MacOS` dir) should be listed for the cask, so they can be symlinked. Otherwise when you try to run `makemkvcon`, you will sometimes get errors like the following.

```
Failed to execute external program 'mmgplsrv' from location '/opt/homebrew/bin/mmgplsrv'
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.