### PR TITLE
microsoft-excel: last supported Catalina version

### DIFF
--- a/Casks/microsoft-excel.rb
+++ b/Casks/microsoft-excel.rb
@@ -15,7 +15,11 @@ cask "microsoft-excel" do
     version "16.54.21101001"
     sha256 "e09fe9f49a36b37af3745673a385be4de9ae8ec774965fd1753f8479a775fc54"
   end
-  on_catalina :or_newer do
+  on_catalina do
+    version "16.66.22101101"
+    sha256 "104a613aa3f4fcd3031dcdd0c445dcdbfdde208268750fb2ab6fba4e0f42c8a9"
+  end
+  on_big_sur :or_newer do
     version "16.68.22121100"
     sha256 "ec860e52e57e903cf1e41a783c8b21ba90e6d8c47c737522b9afb3b3e4358eb6"
   end


### PR DESCRIPTION
Last supported version in macOS 10.15 Catalina is 16.66.22101101

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
