### PR TITLE
microsoft-word: last supported Catalina version (SHA256 mismatch fix)

### DIFF
--- a/Casks/microsoft-word.rb
+++ b/Casks/microsoft-word.rb
@@ -17,7 +17,7 @@ cask "microsoft-word" do
   end
   on_catalina do
     version "16.66.22101101"
-    sha256 "72557bb37386a097672462e4cf267e91e43c5582aeb0fc70c443a6499341bc9d"
+    sha256 "5a6a75d9a5b46cceeff5a1b7925c0eab6e4976cba529149b7b291a0355e7a7c9"
   end
   on_big_sur :or_newer do
     version "16.68.22121100"


### PR DESCRIPTION
Fixed issue with SHA256 mismatch - generated it previously for `Updater` which most probably work the same as `Installer` but they're different files.

Last supported version in macOS 10.15 Catalina is 16.66.22101101. 

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
