### PR TITLE
microsoft-outlook: last supported Catalina version

### DIFF
--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -15,7 +15,11 @@ cask "microsoft-outlook" do
     version "16.54.21101001"
     sha256 "c7b3ced52462b611a9762941088fa05e42d79b26349ca62b705a9bcbce00b41e"
   end
-  on_catalina :or_newer do
+  on_catalina do
+    version "16.66.22102801"
+    sha256 "bddede85956713be21fdb5ab72be07ecefd05552752e8e60c649e6a15fd0a2c2"
+  end
+  on_big_sur :or_newer do
     version "16.68.22121100"
     sha256 "dae88ef71f1e285c6f18dfd84974501052b37488fde7058cb506a6ec80e49dc8"
   end


### PR DESCRIPTION
Last supported version in macOS 10.15 Catalina is 16.66.22102801 - different from other Office apps, special release to solve issues with Outlook.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
