### PR TITLE
utm: add utmctl binary to path

### DIFF
--- a/Casks/utm.rb
+++ b/Casks/utm.rb
@@ -17,6 +17,7 @@ cask "utm" do
   conflicts_with cask: "homebrew/cask-versions/utm-beta"
 
   app "UTM.app"
+  binary "#{appdir}/UTM.app/Contents/MacOS/utmctl"
 
   uninstall quit: "com.utmapp.UTM"
 


### PR DESCRIPTION
see title, UTM has an extra `utmctl` command that is not linked yet

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.