### PR TITLE
Reflects changes in download files in lyx-2.3.7

### DIFF
--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -1,11 +1,12 @@
 cask "lyx" do
   version "2.3.7"
 
-  if MacOS.version <= :monterey
+  on_monterey :or_older do
     sha256 "aaaaa005c5ec4bf574534de31cbd93ab4908dfa655da7535044185874a285c52"
     url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg",
         verified: "ftp.lip6.fr/pub/lyx/"
-  else
+  end
+  on_ventura :or_newer do
     sha256 "4a0e5d9ad2d08f2b379892816934b64b99d815eaeede14157c3219f80fe039d2"
     url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-arm64-cocoa.dmg",
         verified: "ftp.lip6.fr/pub/lyx/"
@@ -20,10 +21,10 @@ cask "lyx" do
     regex(/LyX-(\d+(?:\.\d+)*)\+qt5/i)
   end
 
-  if MacOS.version >= :monterey
+  on_monterey :or_newer do
     depends_on formula: "python"
   end
-  
+
   app "LyX.app"
   binary "#{appdir}/LyX.app/Contents/MacOS/inkscape", target: "lyx-inkscape"
   binary "#{appdir}/LyX.app/Contents/MacOS/lyx"

--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -1,29 +1,19 @@
 cask "lyx" do
   version "2.3.7"
+  sha256 "4a0e5d9ad2d08f2b379892816934b64b99d815eaeede14157c3219f80fe039d2"
 
-  on_monterey :or_older do
-    sha256 "aaaaa005c5ec4bf574534de31cbd93ab4908dfa655da7535044185874a285c52"
-    url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg",
-        verified: "ftp.lip6.fr/pub/lyx/"
-  end
-  on_ventura :or_newer do
-    sha256 "4a0e5d9ad2d08f2b379892816934b64b99d815eaeede14157c3219f80fe039d2"
-    url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-arm64-cocoa.dmg",
-        verified: "ftp.lip6.fr/pub/lyx/"
-  end
-
+  url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-arm64-cocoa.dmg",
+      verified: "ftp.lip6.fr/pub/lyx/bin/"
   name "LyX"
-  desc "Open source, GUI document processor based on the LaTeX typesetting system"
+  desc "GUI document processor based on the LaTeX typesetting system"
   homepage "https://www.lyx.org/"
 
   livecheck do
     url "https://www.lyx.org/Download"
-    regex(/LyX-(\d+(?:\.\d+)*)\+qt5/i)
+    regex(/LyX[._-]v?(\d+(?:\.\d+)+)\+qt5/i)
   end
 
-  on_monterey :or_newer do
-    depends_on formula: "python"
-  end
+  depends_on macos: ">= :mojave"
 
   app "LyX.app"
   binary "#{appdir}/LyX.app/Contents/MacOS/inkscape", target: "lyx-inkscape"
@@ -36,8 +26,8 @@ cask "lyx" do
 
   zap trash: [
     "~/Library/Application Support/LyX-#{version.major_minor}",
-    "~/Library/Preferences/org.lyx.LyX-#{version.major_minor}.plist",
     "~/Library/Caches/com.apple.python/Applications/LyX.app",
+    "~/Library/Preferences/org.lyx.LyX-#{version.major_minor}.plist",
     "~/Library/Preferences/org.lyx.lyx.plist",
     "~/Library/Saved Application State/org.lyx.lyx.savedState",
   ]

--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -1,9 +1,16 @@
 cask "lyx" do
   version "2.3.7"
-  sha256 "aaaaa005c5ec4bf574534de31cbd93ab4908dfa655da7535044185874a285c52"
 
-  url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg",
-      verified: "ftp.lip6.fr/pub/lyx/"
+  if MacOS.version <= :monterey
+    sha256 "aaaaa005c5ec4bf574534de31cbd93ab4908dfa655da7535044185874a285c52"
+    url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-cocoa.dmg",
+        verified: "ftp.lip6.fr/pub/lyx/"
+  else
+    sha256 "4a0e5d9ad2d08f2b379892816934b64b99d815eaeede14157c3219f80fe039d2"
+    url "https://ftp.lip6.fr/pub/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-arm64-cocoa.dmg",
+        verified: "ftp.lip6.fr/pub/lyx/"
+  end
+
   name "LyX"
   desc "Open source, GUI document processor based on the LaTeX typesetting system"
   homepage "https://www.lyx.org/"

--- a/Casks/lyx.rb
+++ b/Casks/lyx.rb
@@ -20,6 +20,10 @@ cask "lyx" do
     regex(/LyX-(\d+(?:\.\d+)*)\+qt5/i)
   end
 
+  if MacOS.version >= :monterey
+    depends_on formula: "python"
+  end
+  
   app "LyX.app"
   binary "#{appdir}/LyX.app/Contents/MacOS/inkscape", target: "lyx-inkscape"
   binary "#{appdir}/LyX.app/Contents/MacOS/lyx"


### PR DESCRIPTION
Current url points to a binary for older versions of MacOS, which is a limited version such that SyncTeX does not work. Modified so that newer MacOS points to a full version (https://www.lyx.org/Download#toc4).

MacOS does not include python since Monterey on which LyX depends. Adding dependencies for users' easy access.
See https://wiki.lyx.org/Mac/Mac#toc2

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
