### PR TITLE
Revert "threads: remove"

### DIFF
--- a/Casks/threads.rb
+++ b/Casks/threads.rb
@@ -1,0 +1,26 @@
+cask "threads" do
+  version "2.2.4"
+  sha256 "7f5b831a1097cdeda629bb760acb40448f59042b11a857e000dfa057cef82a7e"
+
+  url "https://starupdate.threads.com/download/version/#{version}/Threads-darwin-#{version}.zip"
+  name "Threads"
+  desc "Communication tool for focused discussions and decision taking"
+  homepage "https://threads.com/"
+
+  livecheck do
+    url "https://starupdate.threads.com/update/mac/0.0.0"
+    regex(%r{version/(\d+(?:\.\d+)+)/}i)
+  end
+
+  auto_updates true
+
+  app "Threads.app"
+
+  zap trash: [
+    "~/Library/Application Support/Threads",
+    "~/Library/Caches/com.threads.mac.Starling",
+    "~/Library/Caches/com.threads.mac.Starling.ShipIt",
+    "~/Library/Preferences/com.threads.mac.Starling.plist",
+    "~/Library/Saved Application State/com.threads.mac.Starling.savedState",
+  ]
+end


### PR DESCRIPTION
This reverts commit 1b07c440ba097ab6f37a8d9c70162f33a1b3c15d.

Re-enable the `threads` cask since its binary is available again.

The `threads` cask was removed because the package hosted on the Threads website was apparently returning HTTP 503. That's no longer true, as the binary is availble for download now, specifically this URL:

https://starupdate.threads.com/download/version/2.2.4/Threads-darwin-2.2.4.zip

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [✔️] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [✔️] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [✔️] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [✔️] `brew audit --new-cask <cask>` worked successfully.
- [✔️] `brew install --cask <cask>` worked successfully.
- [✔️] `brew uninstall --cask <cask>` worked successfully.
