### PR TITLE
Update Proxyman 4.0.0

### DIFF
--- a/Casks/proxyman.rb
+++ b/Casks/proxyman.rb
@@ -1,6 +1,6 @@
 cask "proxyman" do
-  version "3.15.0,31500"
-  sha256 "0ffe4dfdecd2503127cb0f5d2827566fcdd35782680f4c3df000a467d6b7a0ef"
+  version "4.0.0,40000"
+  sha256 "458bcfeda9b1b852e9f7df0a12efe901309f668d677d91821a2f415fa1f5eac9"
 
   url "https://download.proxyman.io/#{version.csv.second}/Proxyman_#{version.csv.first}.dmg"
   name "Proxyman"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

