### PR TITLE
slimhud: fix minimum macOS version and update bundle identifier

### DIFF
--- a/Casks/slimhud.rb
+++ b/Casks/slimhud.rb
@@ -7,9 +7,9 @@ cask "slimhud" do
   desc "Replacement for the volume, brightness and keyboard backlight HUDs"
   homepage "https://github.com/AlexPerathoner/SlimHUD/"
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :high_sierra"
 
   app "SlimHUD.app"
 
-  zap trash: "~/Library/Preferences/AlexP.SlimHUD.plist"
+  zap trash: "~/Library/Preferences/com.alexpera.SlimHUD.plist"
 end

--- a/Casks/slimhud.rb
+++ b/Casks/slimhud.rb
@@ -1,6 +1,6 @@
 cask "slimhud" do
-  version "1.4.1"
-  sha256 "a9650cc1cfaed88804ca8814b766ff4e66033218b84c1c3e5e3e69ef070d2fd8"
+  version "1.4.2"
+  sha256 "23867d84760630debe22728ba6d088580c40e41c182a9e576ff7c615a9b239de"
 
   url "https://github.com/AlexPerathoner/SlimHUD/releases/download/v#{version}/SlimHUD.zip"
   name "SlimHUD"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
Fails. I guess because I just created another PR for bump to `v1.4.2`, which is still open ( #139525 )
```bash
brew audit --cask --online slimhud
==> Downloading https://github.com/AlexPerathoner/SlimHUD/releases/download/v1.4.1/SlimHUD.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/244
######################################################################## 100.0%
audit for slimhud: failed
 - Version '1.4.1' differs from '1.4.2' retrieved by livecheck.
 - Version '1.4.1' differs from '1.4.2' retrieved by livecheck.
Error: 1 problem in 1 cask detected
```
- [x] `brew style --fix <cask>` reports no offenses.

## Summary of changes
* Fixing minimum OS version for installation: was Mojave, but is actually compatible with High Sierra
* Bundle identifier changed in the last version, so modified `zap trash` accordingly