### PR TITLE
Upgrade nheko to v0.11.0

### DIFF
--- a/Casks/nheko.rb
+++ b/Casks/nheko.rb
@@ -1,8 +1,11 @@
 cask "nheko" do
-  version "0.10.2"
-  sha256 "d554bfbc271f5876b379a07c06c5f5d8cd5f781efbb9f8fa1b44a81d59d5fb81"
+  arch arm: "apple-silicon", intel: "intel"
 
-  url "https://github.com/Nheko-Reborn/nheko/releases/download/v#{version}/nheko-v#{version}.dmg",
+  version "0.11.0"
+  sha256 arm:   "116b087b47162865f662bfa1f31827364896f14649db243e3a3924c761424f4d",
+         intel: "870191d4ae911e02c7c7b7105a06edfdfb76661fdd10843a6870f697b68af414"
+
+  url "https://github.com/Nheko-Reborn/nheko/releases/download/v#{version}/nheko-v#{version}-#{arch}.dmg",
       verified: "github.com/Nheko-Reborn/nheko/"
   name "Nheko"
   desc "Desktop client for the Matrix protocol"
@@ -14,4 +17,11 @@ cask "nheko" do
   end
 
   app "Nheko.app"
+
+  zap trash: [
+    "~/Library/Application Support/nheko",
+    "~/Library/Caches/nheko",
+    "~/Library/Preferences/com.nheko.nheko.plist",
+    "~/Library/Saved Application State/io.github.nheko-reborn.nheko.savedState",
+  ]
 end


### PR DESCRIPTION
Not a trivial upgrade because Nheko moved to a separate binary for Apple Silicon and Intel.

Also added a zap stanza while I was at it.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.