### PR TITLE
Clean up HTTPie cask

### DIFF
--- a/Casks/httpie-desktop.rb
+++ b/Casks/httpie-desktop.rb
@@ -1,4 +1,4 @@
-cask "httpie" do
+cask "httpie-desktop" do
   arch arm: "-arm64"
 
   version "2023.1.1"
@@ -8,7 +8,7 @@ cask "httpie" do
   url "https://github.com/httpie/desktop/releases/download/v#{version}/HTTPie-#{version}#{arch}.dmg",
       verified: "github.com/httpie/desktop/"
   name "HTTPie for Desktop"
-  desc "Desktop wrapper for HTTPie"
+  desc "Testing client for REST, GraphQL, and HTTP APIs"
   homepage "https://httpie.io/product"
 
   livecheck do

--- a/Casks/httpie.rb
+++ b/Casks/httpie.rb
@@ -1,4 +1,4 @@
-cask "httpie-desktop" do
+cask "httpie" do
   arch arm: "-arm64"
 
   version "2023.1.1"


### PR DESCRIPTION
This PR proposes two changes:

1/ Rename the cask from `httpie` to `httpie-desktop` to avoid confusion with the regular [`httpie`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/httpie.rb) formula for [HTTPie for Terminal](https://github.com/httpie/httpie). Or — are there any examples of casks and formulas to share a name? Perhaps another product that has both a CLI and a desktop version.

2/ Correct the description (it’s not a wrapper around the CLI version but a standalone app).

---


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
