### PR TITLE
Install mysqlworkbench 8.0.32 just on intel due to critical upstream bug

### DIFF
--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 cask "mysqlworkbench" do
   on_sierra :or_older do
     version "6.3.10"
@@ -24,14 +27,27 @@ cask "mysqlworkbench" do
     end
   end
   on_big_sur :or_newer do
-    version "8.0.32"
-    sha256 "746549812eae490c94501de2c4b784c178cd936049e5853bb264fea8b802b081"
-    url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-x86_64.dmg"
+    # 8.0.32 is reported to have critical problems on arm <https://bugs.mysql.com/bug.php?id=109671>
+    on_intel do
+      version "8.0.32"
+      sha256 "746549812eae490c94501de2c4b784c178cd936049e5853bb264fea8b802b081"
 
-    livecheck do
-      url "https://dev.mysql.com/downloads/workbench/"
-      regex(/MySQL\s*Workbench\s*(\d+(?:\.\d+)+)/i)
+      livecheck do
+        url "https://dev.mysql.com/downloads/workbench/"
+        regex(/MySQL\s*Workbench\s*(\d+(?:\.\d+)+)/i)
+      end
     end
+
+    on_arm do
+      version "8.0.31"
+      sha256 "6807ac1138c424c57d7e912c08301a838a90935dd0fc7a5658d3ded23f98a865"
+
+      livecheck do
+        skip "8.0.32 is reported to have critical problems on arm"
+      end
+    end
+
+    url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   end
 
   name "MySQL Workbench"


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=109671

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ X] `brew audit --cask --online <cask>` is error-free.
- [ ~] `brew style --fix <cask>` reports no offenses.
No offenses other than ones in the cask before this PR.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
