### PR TITLE
Change oversight dependency to Monterey

### DIFF
--- a/Casks/oversight.rb
+++ b/Casks/oversight.rb
@@ -8,7 +8,7 @@ cask "oversight" do
   desc "Monitors computer mic and webcam"
   homepage "https://objective-see.com/products/oversight.html"
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :monterey"
 
   installer script: {
     executable: "#{staged_path}/OverSight Installer.app/Contents/MacOS/OverSight Installer",


### PR DESCRIPTION
OverSight is supported on macOS 12+, but the current cask does not reflect that

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
