### PR TITLE
Fix completion symlinks sources in google-cloud-sdk

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -23,9 +23,9 @@ cask "google-cloud-sdk" do
   binary "#{token}/bin/gcloud"
   binary "#{token}/bin/git-credential-gcloud.sh", target: "git-credential-gcloud"
   binary "#{token}/bin/gsutil"
-  binary "#{staged_path}/#{token}/completion.bash.inc",
+  binary "#{token}/completion.bash.inc",
          target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/#{token}"
-  binary "#{staged_path}/#{token}/completion.zsh.inc",
+  binary "#{token}/completion.zsh.inc",
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_#{token}"
 
   # Not actually necessary, since it would be deleted anyway.


### PR DESCRIPTION
Resolves: https://github.com/Homebrew/homebrew-cask/issues/139715

The completion files source paths should not prepend the `staged_path`, as it is [already prepended by `Cask::Artifact::Relocated#source`](https://github.com/Homebrew/brew/blob/260ee0ee6af21d31e8c57f6855d661ff6b325fb9/Library/Homebrew/cask/artifact/relocated.rb#L58), and otherwise results in the error:

```
Error: It seems the symlink source '/opt/homebrew/Caskroom/google-cloud-sdk/latest/$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/completion.bash.inc' is not there.
```

Note that while the above error is the real issue, when running `brew install --cask google-cloud-sdk` the above error is masked by another one, which seems to be a confusing byproduct of the same issue: 

```
Error: Cask 'google-cloud-sdk' definition is invalid: installer missing executable
````

This PR fixes both.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
