### PR TITLE
Deprecate protonmail-import-export

### DIFF
--- a/Casks/protonmail-import-export.rb
+++ b/Casks/protonmail-import-export.rb
@@ -8,8 +8,7 @@ cask "protonmail-import-export" do
   homepage "https://proton.me/support/export-emails-import-export-app"
 
   livecheck do
-    url "https://raw.githubusercontent.com/ProtonMail/proton-bridge/master/Changelog.md"
-    regex(/##\s\[IE\s(\d+(?:\.\d+)*)\]/i)
+    skip "vendor removed from repo, plans to refactor"
   end
 
   auto_updates true

--- a/Casks/protonmail-import-export.rb
+++ b/Casks/protonmail-import-export.rb
@@ -7,10 +7,6 @@ cask "protonmail-import-export" do
   desc "Import emails to your secure ProtonMail inbox or make offline backups"
   homepage "https://proton.me/support/export-emails-import-export-app"
 
-  livecheck do
-    skip "vendor removed from repo, plans to refactor"
-  end
-
   auto_updates true
 
   app "ProtonMail Import-Export app.app"
@@ -23,4 +19,8 @@ cask "protonmail-import-export" do
     "~/Library/Caches/ProtonMail Import-Export app",
     "~/Library/Preferences/com.protonmail.import-export.ProtonMail Import-Export app.plist",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Proton noted the removal of their ProtonMail Import-Export app from their proton-bridge GitHub repository in a [change log dated December 15, 2021][changelog].

On April 7, 2022, @andrzejsza [replied][explanation] to ProtonMail/proton-bridge#261 that Proton was planning to refactor the app in "the upcoming months and were [sic] hoping to publish the rewritten code then."

So the previous changelog-based `livecheck` is no longer operational until and unless Proton resumes updating it using the same pattern and re-adds the new source code to the same repo.

[changelog]:
https://github.com/ProtonMail/proton-bridge/releases/tag/v2.0.1

[explanation]:
https://github.com/ProtonMail/proton-bridge/issues/261#issuecomment-1091941596

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
