### PR TITLE
Bump Opera to 94.0.4606.76

### DIFF
--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -1,6 +1,6 @@
 cask "opera" do
-  version "94.0.4606.65"
-  sha256 "bdfc4266b58168a47956cfaf2dad6037fc0c4b7c9b51cead36a990ece83db4cd"
+  version "94.0.4606.76"
+  sha256 "7e6b689fb741dc4b2014845f960cc7cd693970ef3a155737fc507f06433e1e83"
 
   url "https://get.geo.opera.com/pub/opera/desktop/#{version}/mac/Opera_#{version}_Setup.dmg"
   name "Opera"

--- a/Casks/opera.rb
+++ b/Casks/opera.rb
@@ -17,7 +17,10 @@ cask "opera" do
   app "Opera.app"
 
   zap trash: [
-    "~/Library/Application Support/com.operasoftware.Opera/",
+    "~/Library/Application Support/com.operasoftware.Opera",
+    "~/Library/Caches/com.operasoftware.Installer.Opera",
+    "~/Library/Caches/com.operasoftware.Opera",
     "~/Library/Preferences/com.operasoftware.Opera.plist",
+    "~/Library/Saved Application State/com.operasoftware.Opera.savedState",
   ]
 end


### PR DESCRIPTION
Bump Opera to 94.0.4606.76

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.