### PR TITLE
Added zap for coverload

### DIFF
--- a/Casks/coverload.rb
+++ b/Casks/coverload.rb
@@ -14,4 +14,9 @@ cask "coverload" do
   end
 
   app "CoverLoad.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.happeningstudios.coverload",
+    "~/Library/Containers/com.happeningstudios.coverload",
+  ]
 end


### PR DESCRIPTION
Added zap for coverload

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.