### PR TITLE
Added zap for disk-inventory-x

### DIFF
--- a/Casks/disk-inventory-x.rb
+++ b/Casks/disk-inventory-x.rb
@@ -16,4 +16,6 @@ cask "disk-inventory-x" do
   depends_on macos: ">= :high_sierra"
 
   app "Disk Inventory X.app"
+
+  zap trash: "~/Library/Preferences/com.derlien.DiskInventoryX.plist"
 end


### PR DESCRIPTION
Added zap for disk-inventory-x

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.