### PR TITLE
Update SHASUM for vagrant cask

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,6 +1,6 @@
 cask "vagrant" do
   version "2.3.4"
-  sha256 "8fd27ac9b6faa7a42fcf4b74b25150301f957e9251a1f193d1195b31464fe054"
+  sha256 "0015f971c20cce4cd3c97ed758f1e0b528bffe0dc02f0ab55da4b216cb5748b8"
 
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_amd64.dmg",
       verified: "hashicorp.com/vagrant/"


### PR DESCRIPTION
This is required, as users are currently seeing SHASUM mismatches when trying to install the vagrant cask via the official cask. The apple artifacts were resigned and notarized, and shasums were updated, as part of hashicorp maintenance this morning (more info in https://status.hashicorp.com/incidents/xbbwr755y78b). Users will need to run `brew update` to get the latest info: 

```
elle@elle-LD64KN442W Downloads % brew reinstall --cask vagrant
==> Downloading https://releases.hashicorp.com/vagrant/2.3.4/vagrant_2.3.4_darwin_amd64.dmg
Already downloaded: /Users/elle/Library/Caches/Homebrew/downloads/42e309b6a372ee35af42017a677ef41507b8d183dcbd7b4f1af172c9070e4dee--vagrant_2.3.4_darwin_amd64.dmg
Error: SHA256 mismatch
Expected: 8fd27ac9b6faa7a42fcf4b74b25150301f957e9251a1f193d1195b31464fe054
  Actual: 0015f971c20cce4cd3c97ed758f1e0b528bffe0dc02f0ab55da4b216cb5748b8
    File: /Users/elle/Library/Caches/Homebrew/downloads/42e309b6a372ee35af42017a677ef41507b8d183dcbd7b4f1af172c9070e4dee--vagrant_2.3.4_darwin_amd64.dmg
To retry an incomplete download, remove the file above.
```

We've already updated the offical hashicorp homebrew tap at https://github.com/hashicorp/homebrew-tap/commit/92966c57f49e6e9b771b3b3ebc82cc7eb1fcc652.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
