### PR TITLE
Update sentinel SHASUMS

### DIFF
--- a/Casks/sentinel.rb
+++ b/Casks/sentinel.rb
@@ -2,8 +2,8 @@ cask "sentinel" do
   arch arm: "arm64", intel: "amd64"
 
   version "0.19.1"
-  sha256 arm:   "f2fe24cccf1e7c963e00b0355a4b2c6d48498f8c977d50290b83cea7c9a7185e",
-         intel: "5cb2d5dadd216c7d418e08e6d9729c1b74a63beb121bdd154d3d2d9f01960e26"
+  sha256 arm:   "c5e93cbc424dcd665d0228f176436f9df4e0306a1ddf7ba082dabde53c394201",
+         intel: "ce2bdade51782f415b055162f9fdc08ae697e5a195829ed89e17c5c72068672b"
 
   url "https://releases.hashicorp.com/sentinel/#{version}/sentinel_#{version}_darwin_#{arch}.zip"
   name "Sentinel"


### PR DESCRIPTION
This is required, as users are currently seeing SHASUM mismatches when trying to install the vagrant cask via the official cask. The apple artifacts were resigned and notarized, and shasums were updated, as part of hashicorp maintenance this morning (more info in https://status.hashicorp.com/incidents/xbbwr755y78b).

We've already updated the offical hashicorp homebrew tap at https://github.com/hashicorp/homebrew-tap/commit/92966c57f49e6e9b771b3b3ebc82cc7eb1fcc652.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
