### PR TITLE
gimp: replace `binary` with `shimscript`

### DIFF
--- a/Casks/gimp.rb
+++ b/Casks/gimp.rb
@@ -19,10 +19,14 @@ cask "gimp" do
   conflicts_with cask: "homebrew/cask-versions/gimp-dev"
 
   app "GIMP.app"
-  binary "#{appdir}/GIMP.app/Contents/MacOS/gimp"
+  shimscript = "#{staged_path}/gimp.wrapper.sh"
+  binary shimscript, target: "gimp"
 
-  postflight do
-    set_permissions "#{appdir}/GIMP.app/Contents/MacOS/gimp", "a+rx"
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      "#{appdir}/GIMP.app/Contents/MacOS/gimp" "$@"
+    EOS
   end
 
   zap trash: [


### PR DESCRIPTION
Tested on Ventura, on both an Intel and an Arm machine.

Before, running `gimp` from the CLI did not launch `Gimp.app`
```
|-> gimp
../babl-0.1.98/babl/babl-internal.h:214 void babl_log(const char *, ...)()
	WARNING: the babl installation seems broken, no extensions found in queried
BABL_PATH (/opt/local/lib/babl-0.1) this means no SIMD/instructions/special case fast paths and
only slow reference conversions are available, applications might still
run but software relying on babl for conversions will be slow

2023-01-24 09:51:42.685 gimp[14191:402434] *** WARNING: Method userSpaceScaleFactor in class NSView is deprecated on 10.7 and later. It should not be used in new applications. Use convertRectToBacking: instead. 
Session D-Bus not running. Try running `launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist'.
../babl-0.1.98/babl/babl-internal.h:222 void babl_fatal(const char *, ...)()
	const Babl *babl_format(const char *)("CIE Lab double"): not found
sh: gdb: command not found
```

After, running `gimp` from the CLI did successfully launch `Gimp.app`:
```
|-> gimp
GIMP is started as MacOS application
GIMP was built with MacPorts
2023-01-24 10:00:41.326 gimp[15921:418084] *** WARNING: Method userSpaceScaleFactor in class NSView is deprecated on 10.7 and later. It should not be used in new applications. Use convertRectToBacking: instead. 
Session D-Bus not running. Try running `launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist'.
gimp_check_updates_callback: loading of https://www.gimp.org/gimp_versions.json failed: Operation not supported

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.657: g_object_ref: assertion '!object_already_finalized' failed

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.743: g_object_ref: assertion '!object_already_finalized' failed

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.743: g_object_ref: assertion '!object_already_finalized' failed

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.744: g_object_ref: assertion '!object_already_finalized' failed

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.744: g_object_ref: assertion '!object_already_finalized' failed

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.745: g_object_ref: assertion '!object_already_finalized' failed

(gimp:15921): GLib-GObject-CRITICAL **: 10:00:54.745: g_object_ref: assertion '!object_already_finalized' failed
GIMP-Error: Failed to save data:

You have a writable data folder configured (/Users/miccal/Library/Application Support/GIMP/2.10/gradients), but this folder does not exist. Please create the folder or fix your configuration in the Preferences dialog's 'Folders' section.
```