### PR TITLE
blobsaver: add `binary` stanza

### DIFF
--- a/Casks/blobsaver.rb
+++ b/Casks/blobsaver.rb
@@ -11,6 +11,7 @@ cask "blobsaver" do
   homepage "https://github.com/airsquared/blobsaver"
 
   app "blobsaver.app"
+  binary "#{appdir}/blobsaver.app/Contents/MacOS/blobsaver"
 
   zap trash: "~/Library/Preferences/airsquared.blobsaver.app.plist"
 end


### PR DESCRIPTION
There is now a CLI in blobsaver.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.