### PR TITLE
intel-haxm 7.8.0 (update checksum)

### DIFF
--- a/Casks/intel-haxm.rb
+++ b/Casks/intel-haxm.rb
@@ -1,6 +1,6 @@
 cask "intel-haxm" do
   version "7.8.0"
-  sha256 "4d30b68eccd31a8534d976e884de8e728746bf1d568912af23c894c8818481c6"
+  sha256 "44059b3ad33de87562ecd7a6c5a003dce96aa51506667752601467af7b328c29"
 
   url "https://github.com/intel/haxm/releases/download/v#{version}/haxm-macosx_v#{version.dots_to_underscores}.zip"
   name "Intel HAXM"


### PR DESCRIPTION
The upstream files were overwritten.

---
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.