### PR TITLE
chore: replace doctor --debug by config

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -36,7 +36,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Output of `brew doctor --verbose`
+      label: Output of `brew doctor` and `brew config`
       render: shell
     validations:
       required: true


### PR DESCRIPTION
I've never seen an issue reported where this information helped. I'm constantly asking for `config` output though.