### PR TITLE
Add more cache file location for Google Drive

### DIFF
--- a/Casks/google-drive.rb
+++ b/Casks/google-drive.rb
@@ -47,6 +47,7 @@ cask "google-drive" do
         "~/Library/Preferences/com.google.drivefs.plist",
         "~/Library/Preferences/com.google.drivefs.settings.plist",
         "~/Library/Preferences/Google Drive File Stream Helper.plist",
+        "~/Library/CloudStorage/GoogleDrive-*",
       ],
       launchctl: [
         "com.google.keystone.agent",


### PR DESCRIPTION
It seems like that Google Drive will cache file structure at `~/Library/CloudStorage/GoogleDrive-abc@example.com/`. Therefore even if you have uninstalled Google Drive, Spotlight will still be able to index these files, result in difficulty in find actual files you need.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
