### PR TITLE
Anki v2.1.57: Fix checksum Intel Qt5 build

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -9,7 +9,7 @@ cask "anki" do
       verified: "github.com/ankitects/anki/"
 
   on_high_sierra :or_older do
-    sha256 "e2a2f0e2121acf6c98054d4365ac13290df6ce3486b1be13f4f93312202c57c0"
+    sha256 "9e9fe5ba51a3f6c43a568d15aaa4acb74992f013af17a0211b0447e0742588ec"
 
     url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac-#{arch}-qt5.dmg",
         verified: "github.com/ankitects/anki/"


### PR DESCRIPTION
Wasn't updated in #140403