### PR TITLE
Fix plugdata.rb case-sensitivity

### DIFF
--- a/Casks/plugdata.rb
+++ b/Casks/plugdata.rb
@@ -2,14 +2,14 @@ cask "plugdata" do
   version "0.6.4"
   sha256 "3812d9137ef7cee59984a90fd712d296c8a6e59b5038fc39313693c04d15f11f"
 
-  url "https://github.com/timothyschoen/PlugData/releases/download/v#{version}/PlugData-MacOS-Universal.pkg"
+  url "https://github.com/timothyschoen/PlugData/releases/download/v#{version}/plugdata-macOS-Universal.pkg"
   name "PlugData"
   desc "Plugin wrapper for PureData"
   homepage "https://github.com/timothyschoen/PlugData"
 
   auto_updates true
 
-  pkg "PlugData-MacOS-Universal.pkg"
+  pkg "plugData-macOS-Universal.pkg"
 
   uninstall pkgutil: [
     "com.plugdata.app.pkg.plugdata",


### PR DESCRIPTION
Changed package name to match the case of that provided by the PlugData releases, since a mismatch was causing installation to fail on macOS case-sensitive file systems:

```
❯ brew install --cask plugdata
==> Downloading https://github.com/timothyschoen/PlugData/releases/download/v0.6.4/PlugData-MacOS-Universal.pkg
Already downloaded: /Users/leigh/Library/Caches/Homebrew/downloads/6eaaea1db48d61658a20a9669306f459060481a45cd6114f67b61e92e492d740--plugdata-macOS-Universal.pkg
==> Installing Cask plugdata
==> Running installer for plugdata; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
==> Purging files for version 0.6.4 of Cask plugdata
Error: Could not find PKG source file 'PlugData-MacOS-Universal.pkg', found 'plugdata-macOS-Universal.pkg' instead.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
