### PR TITLE
Update confluent-cli from 3.0.0 to 3.0.1

### DIFF
--- a/Casks/confluent-cli.rb
+++ b/Casks/confluent-cli.rb
@@ -1,9 +1,9 @@
 cask "confluent-cli" do
   arch arm: "arm64", intel: "amd64"
 
-  version "3.0.0"
-  sha256 arm:   "5274e870f521f8bbb42923e0dd98d4fef052d3b35c68b989dea0b155b81f5743",
-         intel: "b66b45ae7e6b8785abf958cb4eb1d92579aed75fdad1a09cb94c195311c93cac"
+  version "3.0.1"
+  sha256 arm:   "b08f6d61230f2939614a7f2604d6ef765d55a40a17d9ad685f576b97a84bfcce",
+         intel: "6843e92b98c53c660dcfa9c7279d4ce31c9c7f2f11d69a69d1104485f9336139"
 
   url "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/#{version}/confluent_#{version}_darwin_#{arch}.tar.gz",
       verified: "s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/"
@@ -12,8 +12,8 @@ cask "confluent-cli" do
   homepage "https://docs.confluent.io/confluent-cli/current/overview.html"
 
   livecheck do
-    url "https://docs.confluent.io/confluent-cli/current/_static/documentation_options.js"
-    regex(/VERSION:\s'(\d+(?:\.\d+)+)'/i)
+    url "https://s3-us-west-2.amazonaws.com/confluent.cloud?prefix=confluent-cli/archives/&delimiter=/"
+    regex(%r{<Prefix>confluent-cli/archives/(\d+(?:\.\d+)+)/</Prefix>}i)
   end
 
   binary "confluent/confluent"


### PR DESCRIPTION
URL in livecheck method taken directly from official install script (https://cnfl.io/cli)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
