### PR TITLE
Update microsoft-outlook from 16.69.23010700 to 16.69.23011802

### DIFF
--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -20,8 +20,8 @@ cask "microsoft-outlook" do
     sha256 "bddede85956713be21fdb5ab72be07ecefd05552752e8e60c649e6a15fd0a2c2"
   end
   on_big_sur :or_newer do
-    version "16.69.23010700"
-    sha256 "a4bb58f81773a7fd502b240ff94ece1e2c546f2ad45e40bd253dddbfb99b805b"
+    version "16.69.23011802"
+    sha256 "98671579ccd34371e260784314b08ce85865f9d37ded1a2ae98b53fff154f0a5"
   end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg",
@@ -31,8 +31,8 @@ cask "microsoft-outlook" do
   homepage "https://products.office.com/en-us/outlook/email-and-calendar-software-microsoft-outlook"
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/p/?linkid=525137"
-    strategy :header_match
+    url "https://learn.microsoft.com/en-us/officeupdates/update-history-office-for-mac"
+    regex(%r{href="[^"]+/MacAutoupdate/Microsoft[._-]Outlook[._-]([.\d]+)[._-](?:Updater|Installer)\.pkg"}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
This is a continuation of #140447.
The previously used livecheck seems outdated as [this official resource](https://learn.microsoft.com/en-us/officeupdates/update-history-office-for-mac) lists 16.69.23011802 as the most recent version. I updated the livecheck to use that resource.

If this is deemed acceptable, I would also align #140448, #140449 and #140450 similarly. Either in this PR or in another one, whatever works better.
