### PR TITLE
Calibre stopped supporting catalina on version 6.11.0

### DIFF
--- a/Casks/calibre.rb
+++ b/Casks/calibre.rb
@@ -15,7 +15,15 @@ cask "calibre" do
       skip "Legacy version"
     end
   end
-  on_catalina :or_newer do
+  on_catalina do
+    version "6.11.0"
+    sha256 "d7c40f3f35ba9043c13303632526f135b2c4086471a5c09ceb8b397c55c076fa"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur :or_newer do
     version "6.12.0"
     sha256 "a75bf8007cb018b7304209ff2df61394df9dcc3dffc576669668ca247985e328"
 


### PR DESCRIPTION
According to calibre changelog (https://github.com/kovidgoyal/calibre/blob/master/Changelog.txt) version 6.12.0 now only supports big sur and newer versions of macOS

> - Update bundled Qt to 6.4 this means calibre on macOS is now only supported on Big Sur and newer