### PR TITLE
Update battery.rb

### DIFF
--- a/Casks/battery.rb
+++ b/Casks/battery.rb
@@ -1,6 +1,6 @@
 cask "battery" do
   version "1.0.6"
-  sha256 "b41340a7e991b88f2219ce5ec6be2d2c097ca8ae2c0d6460b56f2bd8038fb67c"
+  sha256 "e8df0969017f17f26381b41b47e9af9d5d04f20b197744fa7112c60a9bd7a143"
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-arm64.dmg"
   name "Battery"

--- a/Casks/battery.rb
+++ b/Casks/battery.rb
@@ -1,6 +1,6 @@
 cask "battery" do
-  version "1.0.5"
-  sha256 "875369e590ce9ec169f30f7edf3db509223e701af65db8e1a50cb43efae76632"
+  version "1.0.6"
+  sha256 "b41340a7e991b88f2219ce5ec6be2d2c097ca8ae2c0d6460b56f2bd8038fb67c"
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-arm64.dmg"
   name "Battery"


### PR DESCRIPTION
GUI update, plus new discharge feature.

CI will fail due to app being `arm64`.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

N/A