### PR TITLE
ci: add NO_INSTALL_FROM_API env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: pull_request
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_FROM_API: 1
   HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
 
 concurrency:


### PR DESCRIPTION
I believe this should stop the issue we are seeing with audits failing, because the audit is being completed with the version present in the API, not the PR - I am not 100% sure if this is the long-term solution.