### PR TITLE
trader-workstation: fixes uninstall_preflight stanza

### DIFF
--- a/Casks/trader-workstation.rb
+++ b/Casks/trader-workstation.rb
@@ -21,7 +21,11 @@ cask "trader-workstation" do
   }
 
   uninstall_preflight do
+    ohai "Stopping all running instances of Trader Workstation prior to uninstall"
     system_command "/usr/bin/pkill", args: ["-f", "/Applications/Trader Workstation/Trader Workstation.app"]
+
+    rescue RuntimeError
+      ohai "No running instances of Trader Workstation found"
   end
 
   uninstall quit:   "com.install4j.5889-6375-8446-2021",


### PR DESCRIPTION
The trader-workstation cask will currently fail during the `uninstall_preflight` stanza if the application is not running. This is because the system command `pkill` returns a value of `1` if it fails to find a matching process. This update will allow the uninstall to progress if the application is not running, and therefore not forcibly closed prior to uninstall.

Closes #140624
