### PR TITLE
Update macos versinos of Emmetapp

### DIFF
--- a/Casks/emmetapp.rb
+++ b/Casks/emmetapp.rb
@@ -14,10 +14,7 @@ cask "emmetapp" do
   end
 
   auto_updates true
-  depends_on macos: [
-    :catalina,
-    :big_sur,
-  ]
+  depends_on macos: ">= :catalina"
 
   app "emmetapp.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

According to the [homepage](https://emmetapp.com/) of Emmetapp, this app supports all versions beyond macOS Catalina, so I have update this part.
