### PR TITLE
Update battery.rb to v1.0.7

### DIFF
--- a/Casks/battery.rb
+++ b/Casks/battery.rb
@@ -1,6 +1,6 @@
 cask "battery" do
-  version "1.0.6"
-  sha256 "e8df0969017f17f26381b41b47e9af9d5d04f20b197744fa7112c60a9bd7a143"
+  version "1.0.7"
+  sha256 "44aff057583bf976b1ca66aa35723975916ae00f0054626f9b1f0e8b4bed18eb"
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-arm64.dmg"
   name "Battery"


### PR DESCRIPTION
Bump version in accordance with new release.

Brew CI will fail due to app being `arm64` targeted.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

N/A