### PR TITLE
Set `version :latest` on nvidia-geforce-now

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -7,11 +7,6 @@ cask "nvidia-geforce-now" do
   desc "Cloud gaming platform"
   homepage "https://www.nvidia.com/en-us/geforce-now/download/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
-
   depends_on macos: ">= :el_capitan"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,5 +1,5 @@
 cask "nvidia-geforce-now" do
-  version "2.0.48.108"
+  version :latest
   sha256 :no_check
 
   url "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg"

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -1,5 +1,5 @@
 cask "nvidia-geforce-now" do
-  version :latest
+  version "2.0.48.108"
   sha256 :no_check
 
   url "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg"
@@ -7,6 +7,7 @@ cask "nvidia-geforce-now" do
   desc "Cloud gaming platform"
   homepage "https://www.nvidia.com/en-us/geforce-now/download/"
 
+  auto_updates true
   depends_on macos: ">= :el_capitan"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.


### PR DESCRIPTION
URL used for download do not contain version so, how the documentation say, is better to use `version :latest`.


After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

