### PR TITLE
Replaced livecheck strategy from extract_plist to PageMatch on nvidia-geforce-now

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -8,8 +8,8 @@ cask "nvidia-geforce-now" do
   homepage "https://www.nvidia.com/en-us/geforce-now/download/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://ota.nvidia.com/release/available?product=GFN-mac&channel=OFFICIAL&version=#{version.major_minor_patch}"
+    regex(/"version":"(\d+.\d+.\d+.\d+)"/i)
   end
 
   depends_on macos: ">= :el_capitan"

--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -9,7 +9,7 @@ cask "nvidia-geforce-now" do
 
   livecheck do
     url "https://ota.nvidia.com/release/available?product=GFN-mac&channel=OFFICIAL&version=#{version.major_minor_patch}"
-    regex(/"version":"(\d+.\d+.\d+.\d+)"/i)
+    regex(/"version":"v?(\d+(?:\.\d+)+)"/i)
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
Replaced livecheck strategy from extract_plist to PageMatch for better performance. Thanks to @Bo98 https://github.com/Homebrew/homebrew-cask/pull/140737 who discover the OTA URL used from nvidia for push update.

OTA URL called with a previous version it response every time with the latest version available. Called with the current version it response with an empty array so I decided to call the url using `version.major_minor_patch`.

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
