### PR TITLE
Revert "Replaced livecheck strategy from extract_plist to PageMatch on nvidia-geforce-now"

### DIFF
--- a/Casks/nvidia-geforce-now.rb
+++ b/Casks/nvidia-geforce-now.rb
@@ -8,8 +8,8 @@ cask "nvidia-geforce-now" do
   homepage "https://www.nvidia.com/en-us/geforce-now/download/"
 
   livecheck do
-    url "https://ota.nvidia.com/release/available?product=GFN-mac&channel=OFFICIAL&version=#{version.major_minor_patch}"
-    regex(/"version":"v?(\d+(?:\.\d+)+)"/i)
+    url :url
+    strategy :extract_plist
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#140805

Thanks @miccal for picking this up.

The issue with the OTA link @MassimilianoPasquini97 is that it may sometimes provide a URL to `patch` not a full base version of the application.
I don't believe it is safe to assume that the `url` we are using will always distribute the same version as the OTA distribution.