### PR TITLE
mpv: Depends on Monterey as of 0.35.1, add older version

### DIFF
--- a/Casks/mpv.rb
+++ b/Casks/mpv.rb
@@ -1,17 +1,27 @@
 cask "mpv" do
-  version "0.35.1"
-  sha256 "efec391acfb4445f89ab2af2c02199d883d47e7f85013217be158f6b07bbc12c"
+  on_big_sur :or_older do
+    version "0.35.0"
+    sha256 "376415c787aef391a3927cdecd5bb0dac9f21ef9d7742516b8cd8d8ce502e7b6"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_monterey :or_newer do
+    version "0.35.1"
+    sha256 "efec391acfb4445f89ab2af2c02199d883d47e7f85013217be158f6b07bbc12c"
+
+    livecheck do
+      url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
+      regex(/mpv-(\d+(?:\.\d+)+)\.t/i)
+    end
+  end
 
   url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv-#{version}.tar.gz",
       verified: "laboratory.stolendata.net/~djinn/mpv_osx/"
   name "mpv"
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io/"
-
-  livecheck do
-    url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
-    regex(/mpv-(\d+(?:\.\d+)+)\.t/i)
-  end
 
   conflicts_with formula: "mpv"
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.