### PR TITLE
Fix hash of `usbimager` 1.0.9

### DIFF
--- a/Casks/usbimager.rb
+++ b/Casks/usbimager.rb
@@ -1,6 +1,6 @@
 cask "usbimager" do
   version "1.0.9"
-  sha256 "6731d6116468aeb607e82d8560ade2d00ae3f9ae94c33b12a44c9aef68b6e610"
+  sha256 "146e6e78457f28d15840c92952c84578b7e2c934fbba0ce965cee53be7382015"
 
   url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-intel-macosx-cocoa.zip",
       verified: "gitlab.com/bztsrc/usbimager/"


### PR DESCRIPTION
I don't know why, but it seems the `sha256` hash of `usbimager v1.0.9` introduced in https://github.com/Homebrew/homebrew-cask/commit/d683c94cbca2648fcbf97ddfc84d0c51737d9849 does not validates anymore.

See:
```shell-session
$ brew upgrade
==> Downloading https://formulae.brew.sh/api/formula.json
######################################################################## 100.0%
==> Downloading https://formulae.brew.sh/api/cask.json
######################################################################## 100.0%
==> Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them.
==> Upgrading 1 outdated package:
usbimager 1.0.8 -> 1.0.9
==> Upgrading usbimager
==> Downloading https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_1.0.9-intel-macosx-cocoa.zip
Already downloaded: /Users/kde/Library/Caches/Homebrew/downloads/64cc2c352339caf2befd45f90688549570f37bc59e7369a5b9516b233bed9857--usbimager_1.0.9-intel-macosx-cocoa.zip
==> Purging files for version 1.0.9 of Cask usbimager
Error: usbimager: SHA256 mismatch
Expected: 6731d6116468aeb607e82d8560ade2d00ae3f9ae94c33b12a44c9aef68b6e610
  Actual: 146e6e78457f28d15840c92952c84578b7e2c934fbba0ce965cee53be7382015
    File: /Users/kde/Library/Caches/Homebrew/downloads/64cc2c352339caf2befd45f90688549570f37bc59e7369a5b9516b233bed9857--usbimager_1.0.9-intel-macosx-cocoa.zip
To retry an incomplete download, remove the file above.

$ rm -rf /Users/kde/Library/Caches/Homebrew/downloads/64cc2c352339caf2befd45f90688549570f37bc59e7369a5b9516b233bed9857--usbimager_1.0.9-intel-macosx-cocoa.zip

$ brew upgrade
==> Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them.
==> Upgrading 1 outdated package:
usbimager 1.0.8 -> 1.0.9
==> Upgrading usbimager
==> Downloading https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_1.0.9-intel-macosx-cocoa.zip
######################################################################## 100.0%
==> Purging files for version 1.0.9 of Cask usbimager
Error: usbimager: SHA256 mismatch
Expected: 6731d6116468aeb607e82d8560ade2d00ae3f9ae94c33b12a44c9aef68b6e610
  Actual: 146e6e78457f28d15840c92952c84578b7e2c934fbba0ce965cee53be7382015
    File: /Users/kde/Library/Caches/Homebrew/downloads/64cc2c352339caf2befd45f90688549570f37bc59e7369a5b9516b233bed9857--usbimager_1.0.9-intel-macosx-cocoa.zip
To retry an incomplete download, remove the file above.
```

Manually downloading the target file confirms the hash is wrong:
```shell-session
$ wget https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_1.0.9-intel-macosx-cocoa.zip
--2023-02-14 16:59:20--  https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_1.0.9-intel-macosx-cocoa.zip
Resolving gitlab.com (gitlab.com)... 172.65.251.78
(...)

❯ shasum --algorithm 256 ./usbimager_1.0.9-intel-macosx-cocoa.zip
146e6e78457f28d15840c92952c84578b7e2c934fbba0ce965cee53be7382015  ./usbimager_1.0.9-intel-macosx-cocoa.zip
```

This PR fix this issue by updating the SHA hash of the downloaded version.

For the record, here is my Brew version:
```shell-session
$ brew --version
Homebrew 3.6.21-118-ge0ba9a1
Homebrew/homebrew-core (git revision 9b987d9af4b; last commit 2023-02-08)
Homebrew/homebrew-cask (git revision 62abbfc945; last commit 2023-02-08)
```

Checks:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
