### PR TITLE
ci_matrix: add `ci-skip-fetch` label

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -114,6 +114,7 @@ module CiMatrix
 
       audit_exceptions = []
       audit_exceptions << "repository" if labels.include?("ci-skip-repository")
+      audit_exceptions << ["download","signing"] if labels.include?("ci-skip-fetch")
 
       # TODO: Replace with `except`.
       audit_args << if labels.include?("ci-skip-appcast")


### PR DESCRIPTION
This will allow us to skip the fetching (by association the `sha256` check is also skipped). Each URL will still be checked to ensure they do not 404. Perhaps a better approach is to decide whether we test all languages in audit (unless specifically requested with a  flag)? Maybe when there are more than a particular number we choose a set at random?

Could be useful in the instance of Firefox - where the downloads timeout https://github.com/Homebrew/homebrew-cask/pull/141357

CC: @p-linnane