### PR TITLE
Update uninstall files for Jitouch

### DIFF
--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -12,8 +12,14 @@ cask "jitouch" do
 
   pkg "Install-Jitouch.pkg"
 
-  uninstall quit:    "com.jitouch.Jitouch",
-            pkgutil: "com.jitouch.Jitouch"
+  uninstall quit:      "com.jitouch.Jitouch",
+            pkgutil:   "com.jitouch.Jitouch",
+            launchctl: "com.jitouch.Jitouch.agent"
 
-  zap trash: "~/Library/Preferences/com.jitouch.Jitouch.plist"
+  zap trash: [
+    "~/Library/Preferences/com.jitouch.Jitouch.plist",
+    "~/Library/LaunchAgents/com.jitouch.Jitouch.plist",
+    "~/Library/Logs/com.jitouch.Jitouch.log",
+    "~/Library/Logs/com.jitouch.Jitouch.prefpane.log",
+  ]
 end

--- a/Casks/jitouch.rb
+++ b/Casks/jitouch.rb
@@ -17,9 +17,9 @@ cask "jitouch" do
             launchctl: "com.jitouch.Jitouch.agent"
 
   zap trash: [
-    "~/Library/Preferences/com.jitouch.Jitouch.plist",
     "~/Library/LaunchAgents/com.jitouch.Jitouch.plist",
     "~/Library/Logs/com.jitouch.Jitouch.log",
     "~/Library/Logs/com.jitouch.Jitouch.prefpane.log",
+    "~/Library/Preferences/com.jitouch.Jitouch.plist",
   ]
 end


### PR DESCRIPTION
Adds launch agent to uninstall and files to remove with `brew uninstall --zap`.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
