### PR TITLE
fix: command-tab-plus ("source not there" err.)

### DIFF
--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -1,5 +1,5 @@
 cask "command-tab-plus" do
-  version "1.130,380"
+  version "2.6"
   sha256 :no_check
 
   url "https://noteifyapp.com/download/Command-Tab%20Plus.dmg"
@@ -12,11 +12,11 @@ cask "command-tab-plus" do
     strategy :sparkle
   end
 
-  app "Command-Tab Plus.app"
+  app "Command-Tab Plus 2.app"
 
   zap trash: [
-    "/Users/Shared/Command-Tab Plus",
-    "~/Library/Application Support/Command-Tab Plus",
-    "~/Library/Caches/com.sergey-gerasimenko.Command-Tab",
+    "~/Library/Application Support/com.sergey-gerasimenko.Command-Tab-Plus-2",
+    "~/Library/Caches/com.sergey-gerasimenko.Command-Tab-Plus-2",
+    "~/Library/Preferences/com.sergey-gerasimenko.Command-Tab-Plus-2.plist",
   ]
 end

--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -2,21 +2,24 @@ cask "command-tab-plus" do
   version "2.6"
   sha256 :no_check
 
-  url "https://noteifyapp.com/download/Command-Tab%20Plus.dmg"
+  url "https://macplus-software.com/downloads/Command-Tab%20Plus%20#{cersion.major}.zip",
+      verified: "macplus-software.com/downloads/"
   name "Command-Tab Plus"
   desc "Keyboard-centric application and window switcher"
   homepage "https://noteifyapp.com/command-tab-plus/"
 
   livecheck do
-    url "https://macplus-software.com/downloads/Command-Tab.xml"
-    strategy :sparkle
+    url "https://macplus-software.com/downloads/CommandTabPlus#{version.major}.xml"
+    strategy :sparkle, &:short_version
   end
 
-  app "Command-Tab Plus 2.app"
+  depends_on macos: ">= :sierra"
+
+  app "Command-Tab Plus #{version.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/com.sergey-gerasimenko.Command-Tab-Plus-2",
-    "~/Library/Caches/com.sergey-gerasimenko.Command-Tab-Plus-2",
-    "~/Library/Preferences/com.sergey-gerasimenko.Command-Tab-Plus-2.plist",
+    "~/Library/Application Support/com.sergey-gerasimenko.Command-Tab-Plus-#{version.major}",
+    "~/Library/Caches/com.sergey-gerasimenko.Command-Tab-Plus-#{version.major}",
+    "~/Library/Preferences/com.sergey-gerasimenko.Command-Tab-Plus-#{version.major}.plist",
   ]
 end

--- a/Casks/command-tab-plus.rb
+++ b/Casks/command-tab-plus.rb
@@ -2,7 +2,7 @@ cask "command-tab-plus" do
   version "2.6"
   sha256 :no_check
 
-  url "https://macplus-software.com/downloads/Command-Tab%20Plus%20#{cersion.major}.zip",
+  url "https://macplus-software.com/downloads/Command-Tab%20Plus%20#{version.major}.zip",
       verified: "macplus-software.com/downloads/"
   name "Command-Tab Plus"
   desc "Keyboard-centric application and window switcher"


### PR DESCRIPTION
This fixes the `source not there` error due to the app file name having changed since version 2. Also bumped version number and updated `zap` files.

I tried following [the contribution guidelines](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md#getting-set-up-to-contribute), but it seems that since homebrew 4.0 made the casks tap unnecessary, I do not have a `Taps/homebrew/homebrew-cask` directory anymore. Trying `brew tap brew/cask` also was not successful, since it prompts for github username and password which are not supported by github anymore I have setup SSH for github and it works correctly when pushing to my private repos, so I am not sure what the problem here is. 

Due to these troubles, I wasn't able to follow the contribution guide and therefore could not check for `brew audit/style`. Sorry, probably bad timing to make the first contribution right after the 4.0 upgrade 😅 

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
