### PR TITLE
Bump imhex to 1.27.1

### DIFF
--- a/Casks/imhex.rb
+++ b/Casks/imhex.rb
@@ -1,8 +1,8 @@
 cask "imhex" do
-  version "1.26.2"
-  sha256 "1f829950e4dc24041ff171dc2a1d36979edfad3df7c2e78167f10a1eea010a35"
+  version "1.27.1"
+  sha256 "68f3102a93123ed6d4f7226bbbfd7cf239bb3eab2b000475110dd1aad6ca8237"
 
-  url "https://github.com/WerWolv/ImHex/releases/download/v#{version}/imhex-#{version}-macOS.dmg",
+  url "https://github.com/WerWolv/ImHex/releases/download/v#{version}/imhex-#{version}-macOS-x86_64.dmg",
       verified: "github.com/WerWolv/ImHex/"
   name "ImHex"
   desc "Hex editor for reverse engineers"


### PR DESCRIPTION
Update `imhex` cask to 1.27.1.

This was updated manually as the URL has changed (`x86_64` is appended). Should I be doing `arch intel: "x86_64"` instead and using `#{arch}` in the URL, or should I just leave it as is? There is no ARM build at the moment, so would that prevent ARM users from using it with Rosetta 2 (don't have an M1 to test this)? Or does this mean I should add `requires_rosetta`?

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
