### PR TITLE
Link kicad command line tools

### DIFF
--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -16,6 +16,11 @@ cask "kicad" do
   depends_on macos: ">= :catalina"
 
   suite "KiCad"
+  binary "KiCad/KiCad.app/Contents/MacOS/dxf2idf"
+  binary "KiCad/KiCad.app/Contents/MacOS/idf2vrml"
+  binary "KiCad/KiCad.app/Contents/MacOS/idfcyl"
+  binary "KiCad/KiCad.app/Contents/MacOS/idfrect"
+  binary "KiCad/KiCad.app/Contents/MacOS/kicad-cli"
   artifact "demos", target: "/Library/Application Support/kicad/demos"
 
   zap trash: [


### PR DESCRIPTION
This pull request adds `binary` entries for the command-line tools shipped with KiCad. New in KiCad 7 is the `kicad-cli` tool, but I have also included some of the other less noteworthy tools, too.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
