### PR TITLE
triage: add support for `missing zap` label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -44,3 +44,7 @@ jobs:
             - label: appcast migration needed
               path: Casks/.+
               content: \n  appcast .+\n
+
+            - label: missing zap
+              path: Casks/.+
+              missing_content: \n  zap .+\n


### PR DESCRIPTION
Ideally we should add an additional audit to check for a zap stanza when running `brew audit --new-cask` 

But this will help us know when a contributor has added a zap stanza to a new cask