### PR TITLE
Rename mongodb-realm-studio to realm-studio

### DIFF
--- a/Casks/realm-studio.rb
+++ b/Casks/realm-studio.rb
@@ -1,4 +1,4 @@
-cask "mongodb-realm-studio" do
+cask "realm-studio" do
   version "13.0.2"
   sha256 "39f8a9bc620084190e511c86d1f3aafac1abb18234d803b8a6573838a6541b1a"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

As of [this commit](https://github.com/Homebrew/homebrew-cask/pull/91079/commits/ace7943035245b728cad4c3f7c8b4d7ae5c71e60) it was renamed to `mongodb-realm-studio`, but in [version 12](https://github.com/Homebrew/homebrew-cask/commit/13210ab519479f27cdbe28a8203ce24145d19a54) MongoDB is not part of the the app name anymore. And there is no mentioning MongoDB on [the offsite](https://studio-releases.realm.io) for latest versions. One more example of the name [in the offsite](https://www.mongodb.com/docs/realm/studio/).
