### PR TITLE
Update cutter from 2.1.2 to 2.2.0

### DIFF
--- a/Casks/cutter.rb
+++ b/Casks/cutter.rb
@@ -1,9 +1,9 @@
 cask "cutter" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "2.1.2"
-  sha256 arm:   "a261bc89a028f510641535a0463b82cd2e69ede0e828812d6b130318c11ed220",
-         intel: "6d37c18fd91f528c72f92fa7d79a4d0082d377bc02466aa59bf17be155b579c4"
+  version "2.2.0"
+  sha256 arm:   "8077717bc8a35159b1d637ccc7a0c3c5320265458f0a40bc07d9c7a69e5a13e7",
+         intel: "1903c562ad70884a3bc37eee18e37e8ffc9ae417ed4f367ad3d314b3c284cdb5"
 
   url "https://github.com/rizinorg/cutter/releases/download/v#{version}/Cutter-v#{version}-macOS-#{arch}.dmg",
       verified: "github.com/rizinorg/cutter/"


### PR DESCRIPTION
Created with brew `bump-cask-pr`.