### PR TITLE
mia-for-gmail: various updates

### DIFF
--- a/Casks/mia-for-gmail.rb
+++ b/Casks/mia-for-gmail.rb
@@ -1,16 +1,16 @@
 cask "mia-for-gmail" do
-  version "2.4.5,72"
+  version "2.4.5"
   sha256 "31f94c2c5bafc2550adb50ed36919b45c2939bbd691ce1b27b8486d1094600c5"
 
-  url "https://www.sovapps.com/application/notifier-pro-for-gmail/mia.#{version.csv.first}.zip",
+  url "http://www.sovapps.com/application/notifier-pro-for-gmail/mia.#{version}.zip",
       verified: "sovapps.com/application/notifier-pro-for-gmail/"
   name "Mia for Gmail"
   desc "Desktop email client for Gmail"
-  homepage "https://www.miaforgmail.com/"
+  homepage "http://www.miaforgmail.com/"
 
   livecheck do
-    url "https://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml"
-    strategy :sparkle
+    url "http://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
Before:
```
|-> brew fetch mia-for-gmail
==> Downloading https://www.sovapps.com/application/notifier-pro-for-gmail/mia.2.4.5.zip
curl: (60) SSL certificate problem: certificate has expired                   
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

Error: Download failed on Cask 'mia-for-gmail' with message: Download failed: https://www.sovapps.com/application/notifier-pro-for-gmail/mia.2.4.5.zip
```
```
|-> brew livecheck mia-for-gmail --debug
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromDefaultTapPathLoader): loading mia-for-gmail

Cask:             mia-for-gmail
Livecheckable?:   Yes

URL:              https://www.sovapps.com/application/notifier-pro-for-gmail/notifier.xml
Strategy:         Sparkle
curl: (60) SSL certificate problem: certificate has expired
Error: mia-for-gmail: Unable to get versions
```
```
|-> curl https://www.miaforgmail.com/
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```