### PR TITLE
Add fx_cast_bridge 0.3.0

### DIFF
--- a/Casks/fx-cast-bridge.rb
+++ b/Casks/fx-cast-bridge.rb
@@ -25,4 +25,6 @@ cask "fx-cast-bridge" do
   pkg "fx_cast_bridge-#{version}-#{arch}.pkg"
 
   uninstall pkgutil: "tf.matt.fx_cast_bridge"
+
+  # No zap stanza required
 end

--- a/Casks/fx-cast-bridge.rb
+++ b/Casks/fx-cast-bridge.rb
@@ -1,14 +1,14 @@
 cask "fx-cast-bridge" do
-  version "0.3.0"
   arch arm: "arm64", intel: "x64"
+
+  version "0.3.0"
   sha256 intel: "f24e347fd240d5e74b488c83aee8c939b5abf7498dd047b4d3cdb5912a71e8aa",
-         arm: "2e8dd783be80c21b5b25615284046df7ea7322dba80e96f09c93a329f3f6b6fb"
+         arm:   "2e8dd783be80c21b5b25615284046df7ea7322dba80e96f09c93a329f3f6b6fb"
 
   url "https://github.com/hensm/fx_cast/releases/download/v#{version}/fx_cast_bridge-#{version}-#{arch}.pkg",
-    verified: "https://github.com/hensm/fx_cast"
-
+      verified: "https://github.com/hensm/fx_cast"
   name "fx_cast Bridge"
-  desc "The bridge program that helps the fx_cast Firefox extension enable Chromecast support"
+  desc "Bridge helper for fx_cast Firefox extension to enable Chromecast support"
   homepage "https://hensm.github.io/fx_cast/"
 
   livecheck do
@@ -17,8 +17,8 @@ cask "fx-cast-bridge" do
       # look for the latest bridge release since some releases are bridge-only
       # or extension-only, falling back to version if none is found
       found = page.scan(/href=.*?fx_cast_bridge[._-]?(\d{4}.\d{4}.\d{4})[._-]\w{3,5}\.pkg/i)
-        .map { |match| match&.first }
-      !found.empty? ? found : version
+                  .map { |match| match&.first }
+      found.empty? ? version : found
     end
   end
 

--- a/Casks/fx-cast-bridge.rb
+++ b/Casks/fx-cast-bridge.rb
@@ -2,11 +2,11 @@ cask "fx-cast-bridge" do
   arch arm: "arm64", intel: "x64"
 
   version "0.3.0"
-  sha256 intel: "f24e347fd240d5e74b488c83aee8c939b5abf7498dd047b4d3cdb5912a71e8aa",
-         arm:   "2e8dd783be80c21b5b25615284046df7ea7322dba80e96f09c93a329f3f6b6fb"
+  sha256 arm:   "2e8dd783be80c21b5b25615284046df7ea7322dba80e96f09c93a329f3f6b6fb",
+         intel: "f24e347fd240d5e74b488c83aee8c939b5abf7498dd047b4d3cdb5912a71e8aa"
 
   url "https://github.com/hensm/fx_cast/releases/download/v#{version}/fx_cast_bridge-#{version}-#{arch}.pkg",
-      verified: "https://github.com/hensm/fx_cast"
+      verified: "github.com/hensm/fx_cast/"
   name "fx_cast Bridge"
   desc "Bridge helper for fx_cast Firefox extension to enable Chromecast support"
   homepage "https://hensm.github.io/fx_cast/"

--- a/Casks/fx-cast-bridge.rb
+++ b/Casks/fx-cast-bridge.rb
@@ -1,0 +1,28 @@
+cask "fx-cast-bridge" do
+  version "0.3.0"
+  arch arm: "arm64", intel: "x64"
+  sha256 intel: "f24e347fd240d5e74b488c83aee8c939b5abf7498dd047b4d3cdb5912a71e8aa",
+         arm: "2e8dd783be80c21b5b25615284046df7ea7322dba80e96f09c93a329f3f6b6fb"
+
+  url "https://github.com/hensm/fx_cast/releases/download/v#{version}/fx_cast_bridge-#{version}-#{arch}.pkg",
+    verified: "https://github.com/hensm/fx_cast"
+
+  name "fx_cast Bridge"
+  desc "The bridge program that helps the fx_cast Firefox extension enable Chromecast support"
+  homepage "https://hensm.github.io/fx_cast/"
+
+  livecheck do
+    url "https://github.com/hensm/fx_cast/releases"
+    strategy :github_latest do |page|
+      # look for the latest bridge release since some releases are bridge-only
+      # or extension-only, falling back to version if none is found
+      found = page.scan(/href=.*?fx_cast_bridge[._-]?(\d{4}.\d{4}.\d{4})[._-]\w{3,5}\.pkg/i)
+        .map { |match| match&.first }
+      !found.empty? ? found : version
+    end
+  end
+
+  pkg "fx_cast_bridge-#{version}-#{arch}.pkg"
+
+  uninstall pkgutil: "tf.matt.fx_cast_bridge"
+end


### PR DESCRIPTION
This livecheck is flimsy and may not work for subsequent releases. The bridge and its association Firefox extension are released separately but share a pool of version numbers. That is, each tag may have a new bridge, a new extension, or both. Homebrew only cares about the bridge.

I'd love some assistance on producing a livecheck that is more likely to work.

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
