### PR TITLE
Update livecheck blocks to use Json strategy

### DIFF
--- a/Casks/airtable.rb
+++ b/Casks/airtable.rb
@@ -9,8 +9,8 @@ cask "airtable" do
 
   livecheck do
     url "https://airtable.com/desktopAppLatestVersion?version=0.0.0&platform=darwin"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -12,8 +12,8 @@ cask "appcode" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=AC&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["AC"].map do |release|
+    strategy :json do |json|
+      json["AC"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/audiorelay.rb
+++ b/Casks/audiorelay.rb
@@ -9,8 +9,8 @@ cask "audiorelay" do
 
   livecheck do
     url "https://api.audiorelay.net/Downloads"
-    strategy :page_match do |page|
-      JSON.parse(page)["macOs"]["version"]
+    strategy :json do |json|
+      json["macOs"]["version"]
     end
   end
 

--- a/Casks/boop.rb
+++ b/Casks/boop.rb
@@ -10,8 +10,8 @@ cask "boop" do
 
   livecheck do
     url "https://boop.okat.best/version.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["standalone"]["version"]
+    strategy :json do |json|
+      json["standalone"]["version"]
     end
   end
 

--- a/Casks/box-notes.rb
+++ b/Casks/box-notes.rb
@@ -10,8 +10,8 @@ cask "box-notes" do
 
   livecheck do
     url "https://notes.services.box.com/updates/latest?platform=darwin&v=#{version.major}.0.0"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/burp-suite-professional.rb
+++ b/Casks/burp-suite-professional.rb
@@ -12,8 +12,8 @@ cask "burp-suite-professional" do
 
   livecheck do
     url "https://portswigger.net/burp/releases/data"
-    strategy :page_match do |page|
-      all_versions = JSON.parse(page)["ResultSet"]["Results"]
+    strategy :json do |json|
+      all_versions = json["ResultSet"]["Results"]
       next if all_versions.blank?
 
       all_versions.map do |item|

--- a/Casks/burp-suite.rb
+++ b/Casks/burp-suite.rb
@@ -12,8 +12,8 @@ cask "burp-suite" do
 
   livecheck do
     url "https://portswigger.net/burp/releases/data"
-    strategy :page_match do |page|
-      all_versions = JSON.parse(page)["ResultSet"]["Results"]
+    strategy :json do |json|
+      all_versions = json["ResultSet"]["Results"]
       next if all_versions.blank?
 
       all_versions.map do |item|

--- a/Casks/clion.rb
+++ b/Casks/clion.rb
@@ -12,8 +12,8 @@ cask "clion" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=CL&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["CL"].map do |release|
+    strategy :json do |json|
+      json["CL"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/datagrip.rb
+++ b/Casks/datagrip.rb
@@ -12,8 +12,8 @@ cask "datagrip" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["DG"].map do |release|
+    strategy :json do |json|
+      json["DG"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/dataspell.rb
+++ b/Casks/dataspell.rb
@@ -12,8 +12,8 @@ cask "dataspell" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=DS&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["DS"].map do |release|
+    strategy :json do |json|
+      json["DS"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/deepl.rb
+++ b/Casks/deepl.rb
@@ -5,8 +5,8 @@ cask "deepl" do
 
     livecheck do
       url "https://appdownload.deepl.com/macos/update.json"
-      strategy :page_match do |page|
-        JSON.parse(page)["currentRelease"]
+      strategy :json do |json|
+        json["currentRelease"]
       end
     end
   end
@@ -16,8 +16,8 @@ cask "deepl" do
 
     livecheck do
       url "https://appdownload.deepl.com/macos/bigsur/update.json"
-      strategy :page_match do |page|
-        JSON.parse(page)["currentRelease"]
+      strategy :json do |json|
+        json["currentRelease"]
       end
     end
   end

--- a/Casks/fig.rb
+++ b/Casks/fig.rb
@@ -9,8 +9,8 @@ cask "fig" do
 
   livecheck do
     url "https://repo.fig.io/generic/stable/index.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["hints"]["livecheck"]
+    strategy :json do |json|
+      json["hints"]["livecheck"]
     end
   end
 

--- a/Casks/figma.rb
+++ b/Casks/figma.rb
@@ -12,8 +12,8 @@ cask "figma" do
 
   livecheck do
     url "https://desktop.figma.com/#{arch}/RELEASE.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/flipper.rb
+++ b/Casks/flipper.rb
@@ -10,8 +10,8 @@ cask "flipper" do
 
   livecheck do
     url "https://www.facebook.com/fbflipper/public/latest.json?version=0.0.0"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/flomo.rb
+++ b/Casks/flomo.rb
@@ -10,8 +10,8 @@ cask "flomo" do
 
   livecheck do
     url "https://flomoapp.com/api/mac/latest/"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/gitfiend.rb
+++ b/Casks/gitfiend.rb
@@ -9,8 +9,8 @@ cask "gitfiend" do
 
   livecheck do
     url "https://gitfiend.com/app-info"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/goland.rb
+++ b/Casks/goland.rb
@@ -12,8 +12,8 @@ cask "goland" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=GO&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["GO"].map do |release|
+    strategy :json do |json|
+      json["GO"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/grids.rb
+++ b/Casks/grids.rb
@@ -9,8 +9,8 @@ cask "grids" do
 
   livecheck do
     url "https://gridsapp.net/appcast.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]["mac"]
+    strategy :json do |json|
+      json["version"]["mac"]
     end
   end
 

--- a/Casks/hbuilderx.rb
+++ b/Casks/hbuilderx.rb
@@ -10,8 +10,8 @@ cask "hbuilderx" do
 
   livecheck do
     url "https://download1.dcloud.net.cn/hbuilderx/release.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/infra.rb
+++ b/Casks/infra.rb
@@ -9,8 +9,8 @@ cask "infra" do
 
   livecheck do
     url "https://api.infra.app/update/darwin/0.0.1"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/inkdrop.rb
+++ b/Casks/inkdrop.rb
@@ -13,8 +13,8 @@ cask "inkdrop" do
 
   livecheck do
     url "https://api.inkdrop.app/update/links"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/intellij-idea-ce.rb
+++ b/Casks/intellij-idea-ce.rb
@@ -13,8 +13,8 @@ cask "intellij-idea-ce" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["IIC"].map do |release|
+    strategy :json do |json|
+      json["IIC"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/intellij-idea.rb
+++ b/Casks/intellij-idea.rb
@@ -12,8 +12,8 @@ cask "intellij-idea" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["IIU"].map do |release|
+    strategy :json do |json|
+      json["IIU"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/jetbrains-toolbox.rb
+++ b/Casks/jetbrains-toolbox.rb
@@ -12,8 +12,8 @@ cask "jetbrains-toolbox" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["TBA"].map do |release|
+    strategy :json do |json|
+      json["TBA"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/jquake.rb
+++ b/Casks/jquake.rb
@@ -13,8 +13,8 @@ cask "jquake" do
 
   livecheck do
     url "https://fleneindre.github.io/version.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/localxpose.rb
+++ b/Casks/localxpose.rb
@@ -11,8 +11,8 @@ cask "localxpose" do
 
   livecheck do
     url "https://api.localxpose.io/api/v2/downloads/darwin-#{arch}.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["Version"]
+    strategy :json do |json|
+      json["Version"]
     end
   end
 

--- a/Casks/memo.rb
+++ b/Casks/memo.rb
@@ -9,8 +9,8 @@ cask "memo" do
 
   livecheck do
     url "https://raw.githubusercontent.com/btk/memo/master/package.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/mockplus.rb
+++ b/Casks/mockplus.rb
@@ -11,8 +11,8 @@ cask "mockplus" do
 
   livecheck do
     url "https://api.mockplus.com/v6/software/checkNewerVersionForMockupV2?name=MockplusClassic&version=latest&platform=mac"
-    strategy :page_match do |page|
-      JSON.parse(page)["value"]["version"]
+    strategy :json do |json|
+      json["value"]["version"]
     end
   end
 

--- a/Casks/mps.rb
+++ b/Casks/mps.rb
@@ -12,8 +12,8 @@ cask "mps" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=MPS&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["MPS"].map do |release|
+    strategy :json do |json|
+      json["MPS"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/naver-whale.rb
+++ b/Casks/naver-whale.rb
@@ -12,8 +12,8 @@ cask "naver-whale" do
 
   livecheck do
     url "https://cv.whale.naver.com/version/latest_version"
-    strategy :page_match do |page|
-      JSON.parse(page)["message"]["@version"]
+    strategy :json do |json|
+      json["message"]["@version"]
     end
   end
 

--- a/Casks/phpstorm.rb
+++ b/Casks/phpstorm.rb
@@ -12,8 +12,8 @@ cask "phpstorm" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["PS"].map do |release|
+    strategy :json do |json|
+      json["PS"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/postman-cli.rb
+++ b/Casks/postman-cli.rb
@@ -13,8 +13,8 @@ cask "postman-cli" do
 
   livecheck do
     url "https://dl-cli.pstmn.io/api/version/latest"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/postman.rb
+++ b/Casks/postman.rb
@@ -13,8 +13,8 @@ cask "postman" do
 
   livecheck do
     url "https://dl.pstmn.io/api/version/latest"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/purei-play.rb
+++ b/Casks/purei-play.rb
@@ -10,9 +10,8 @@ cask "purei-play" do
 
   livecheck do
     url "https://services.purei.org/api/builds"
-    strategy :page_match do |page|
-      build = JSON.parse(page)
-      "#{build["commitDate"][/^(\d+(?:-\d+)+)T/i, 1]},#{build["commitHash"]}"
+    strategy :json do |json|
+      "#{json["commitDate"][/^(\d+(?:-\d+)+)T/i, 1]},#{json["commitHash"]}"
     end
   end
 

--- a/Casks/pycharm-ce.rb
+++ b/Casks/pycharm-ce.rb
@@ -13,8 +13,8 @@ cask "pycharm-ce" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["PCC"].map do |release|
+    strategy :json do |json|
+      json["PCC"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/pycharm-edu.rb
+++ b/Casks/pycharm-edu.rb
@@ -13,8 +13,8 @@ cask "pycharm-edu" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=PCE&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["PCE"].map do |release|
+    strategy :json do |json|
+      json["PCE"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/pycharm.rb
+++ b/Casks/pycharm.rb
@@ -13,8 +13,8 @@ cask "pycharm" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["PCP"].map do |release|
+    strategy :json do |json|
+      json["PCP"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/rider.rb
+++ b/Casks/rider.rb
@@ -12,8 +12,8 @@ cask "rider" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=RD&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["RD"].map do |release|
+    strategy :json do |json|
+      json["RD"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/rubymine.rb
+++ b/Casks/rubymine.rb
@@ -12,8 +12,8 @@ cask "rubymine" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=RM&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["RM"].map do |release|
+    strategy :json do |json|
+      json["RM"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/shottr.rb
+++ b/Casks/shottr.rb
@@ -15,8 +15,8 @@ cask "shottr" do
   livecheck do
     url "https://shottr.cc/api/version.json"
     regex(/Shottr[._-]v?(\d+(?:\.\d+)+)/i)
-    strategy :page_match do |page, regex|
-      JSON.parse(page)["package"][regex, 1]
+    strategy :json do |json, regex|
+      json["package"][regex, 1]
     end
   end
 

--- a/Casks/soundtoys.rb
+++ b/Casks/soundtoys.rb
@@ -10,8 +10,8 @@ cask "soundtoys" do
 
   livecheck do
     url "https://storage.googleapis.com/soundtoys-download/download.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["Soundtoys5_Mac"]["fullversion"]
+    strategy :json do |json|
+      json["Soundtoys5_Mac"]["fullversion"]
     end
   end
 

--- a/Casks/splice.rb
+++ b/Casks/splice.rb
@@ -10,8 +10,8 @@ cask "splice" do
 
   livecheck do
     url "https://api.splice.com/v2/desktop/darwin/stable/latest?v=0.0.0"
-    strategy :page_match do |page|
-      JSON.parse(page)["name"]
+    strategy :json do |json|
+      json["name"]
     end
   end
 

--- a/Casks/supernotes.rb
+++ b/Casks/supernotes.rb
@@ -9,8 +9,8 @@ cask "supernotes" do
 
   livecheck do
     url "https://api.supernotes.app/v1/"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/temurin.rb
+++ b/Casks/temurin.rb
@@ -13,8 +13,8 @@ cask "temurin" do
 
   livecheck do
     url "https://api.adoptium.net/v3/info/release_versions?release_type=ga&architecture=#{arch}&image_type=jdk&jvm_impl=hotspot&os=mac&page=0&page_size=1&project=jdk&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse"
-    strategy :page_match do |page|
-      JSON.parse(page)["versions"].map do |version|
+    strategy :json do |json|
+      json["versions"].map do |version|
         match = version["openjdk_version"].match(/^(\d+(?:\.\d+)*)\+(\d+(?:\.\d+)*)$/i)
         next if match.blank?
 

--- a/Casks/tidal.rb
+++ b/Casks/tidal.rb
@@ -12,8 +12,8 @@ cask "tidal" do
 
   livecheck do
     url "https://download.tidal.com/desktop/mac/update-#{arch}.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["currentRelease"]
+    strategy :json do |json|
+      json["currentRelease"]
     end
   end
 

--- a/Casks/webstorm.rb
+++ b/Casks/webstorm.rb
@@ -12,8 +12,8 @@ cask "webstorm" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=WS&latest=true&type=release"
-    strategy :page_match do |page|
-      JSON.parse(page)["WS"].map do |release|
+    strategy :json do |json|
+      json["WS"].map do |release|
         "#{release["version"]},#{release["build"]}"
       end
     end

--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -9,8 +9,8 @@ cask "whatsapp" do
 
   livecheck do
     url "https://web.whatsapp.com/desktop/mac/releases"
-    strategy :page_match do |page|
-      JSON.parse(page)["name"]
+    strategy :json do |json|
+      json["name"]
     end
   end
 

--- a/Casks/wow.rb
+++ b/Casks/wow.rb
@@ -10,8 +10,8 @@ cask "wow" do
 
   livecheck do
     url "https://web.static.nowtv.com/watch/player/wowtv/de/latest/update.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["platforms"]["darwin"]["version"]
+    strategy :json do |json|
+      json["platforms"]["darwin"]["version"]
     end
   end
 

--- a/Casks/xlplayer.rb
+++ b/Casks/xlplayer.rb
@@ -11,8 +11,8 @@ cask "xlplayer" do
 
   livecheck do
     url "https://static-xl.a.88cdn.com/json/xunlei_video_version_mac.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

We recently added a generic `Json` strategy to `brew livecheck`, so this PR updates existing `livecheck` blocks that contain a `strategy` block using `Json#parse`. The `Json` strategy takes care of parsing the content and passes it into the `strategy` block, so we can replace that bit of boilerplate.

I did comparative `brew livecheck --json --verbose` runs without/with the changes in this PR and the output remained the same outside of the expected strategy change.

There are 12 other `livecheck` blocks that need to be updated but they weren't 100% straightforward, so I'll be creating separate PRs for those.