### PR TITLE
CI: Support ci-skip-livecheck label

### DIFF
--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -26,6 +26,7 @@ jobs:
         github.event.label.name == 'ci-retry' ||
         github.event.label.name == 'ci-skip-appcast' ||
         github.event.label.name == 'ci-skip-install' ||
+        github.event.label.name == 'ci-skip-livecheck' ||
         github.event.label.name == 'ci-syntax-only' ||
         !github.event.label.name
       )
@@ -37,5 +38,5 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           once-label: ci-requeue
           continuous-label: ci-retry
-          trigger-labels: ci-skip-appcast,ci-skip-install,ci-syntax-only
+          trigger-labels: ci-skip-appcast,ci-skip-install,ci-skip-livecheck,ci-syntax-only
           workflow: ci.yml

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -125,6 +125,10 @@ module CiMatrix
         "--appcast"
       end
 
+      if labels.include?("ci-skip-livecheck")
+        audit_exceptions << ["hosting_with_livecheck", "livecheck_version", "livecheck_min_os"]
+      end
+
       audit_args << "--except" << audit_exceptions.join(",") if audit_exceptions.any?
 
       runners(path).map do |runner|


### PR DESCRIPTION
This adds support for a `ci-skip-livecheck` label to cask repository CI, as a way of skipping livecheck audits when a check works locally and exclusively fails in the CI environment (e.g., https://github.com/Homebrew/homebrew-cask/pull/141821#pullrequestreview-1314545282). This is a rare situation and the label should not be used for any other purpose at this time.

I previously implemented support for this label in homebrew/core (and test-bot) to handle this situation (with the same restrictions on its use), so this commit aligns the core/cask repositories in this regard. The practical effects of the label differ but the fundamental idea remains the same.

My knowledge of cask CI is somewhat limited, so I would appreciate review from anyone with more experience. It seems fairly straightforward from what I've seen in the cask CI workflows and the related `audit` code in Homebrew/brew but it would be good to make sure I haven't overlooked anything.