### PR TITLE
Remove `autoupdates` from `fleet`

### DIFF
--- a/Casks/fleet.rb
+++ b/Casks/fleet.rb
@@ -20,7 +20,6 @@ cask "fleet" do
     end
   end
 
-  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Fleet.app"


### PR DESCRIPTION
I can't seem to find any way of updating the app, possibly due to the only currently supported installation method being through JetBrains toolbox.