### PR TITLE
maintenance: fix URL handling for API installs

### DIFF
--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -50,7 +50,6 @@ cask "maintenance" do
     depends_on macos: :ventura
   end
 
-  url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Maintenance.dmg"
   name "Maintenance"
   desc "Operating system maintenance and cleaning utility"
   homepage "https://www.titanium-software.fr/en/maintenance.html"

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -3,49 +3,49 @@ cask "maintenance" do
 
   on_el_capitan do
     version "2.1.8"
-    sha256 "f27f5d0736e80cd80c85dcc5390dfeb893183424fe65b32b08e280c90b22b24c"
+    url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
 
     depends_on macos: :el_capitan
   end
   on_sierra do
     version "2.3.0"
-    sha256 "8fde91742126d10234451a3c973461f5d84c771e52c6ee14aff93f1d66a0dbca"
+    url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
 
     depends_on macos: :sierra
   end
   on_high_sierra do
     version "2.4.2"
-    sha256 "94c7a322d4d796afc5e52534f3564a562240d9c0ec0a60de210e68372fef2137"
+    url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
 
     depends_on macos: :high_sierra
   end
   on_mojave do
     version "2.5.6"
-    sha256 "d3b0152ce543b84ed597daba3360f74c3f20b4fb2b41d71005f3a7b311d4d681"
+    url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
 
     depends_on macos: :mojave
   end
   on_catalina do
     version "2.7.1"
-    sha256 "833e658f862f0a58dc6a073c70a67bed071b835167f73fc24e80386a36bfd38b"
+    url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
 
     depends_on macos: :catalina
   end
   on_big_sur do
     version "2.8.2"
-    sha256 "e5f35a36eb1fcf46d599719c8ae2123e232f64b23a7741aaa4bf9ca3c78b76f9"
+    url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
 
     depends_on macos: :big_sur
   end
   on_monterey do
     version "2.9.2"
-    sha256 "04a6d9ff584cc7abbffdfa15730de58e1fc18dd76ffc05a099776ae3c56d4c18"
+    url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
 
     depends_on macos: :monterey
   end
   on_ventura do
     version "3.0.0"
-    sha256 "8c124818f9fb36cd221f4b9c28e12ec3241d6d7c6a1ab60cc31e4fa492ad7cf8"
+    url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
 
     depends_on macos: :ventura
   end


### PR DESCRIPTION
It seems the problem is the same as for #140548

Trying to install Maintenance results in SHA256 mismatch
```
==> Downloading https://www.titanium-software.fr/download/13/Maintenance.dmg
Error: SHA256 mismatch
Expected: 99b36dc94c3c3390f66d433c10787473f98b6c600ed75d5a9c5d08bc70eb1e95
  Actual: 8c124818f9fb36cd221f4b9c28e12ec3241d6d7c6a1ab60cc31e4fa492ad7cf8
    File: /Users/User/Library/Caches/Homebrew/downloads/c3d99a8586031be87d26a97b70d43eb4e0f45a2f9bb2a52895f7fa15355f41df--Maintenance.dmg
```