### PR TITLE
xit: Bump to 1.0b17

### DIFF
--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -1,8 +1,11 @@
 cask "xit" do
-  version "1.0b16"
-  sha256 "0e9897d16a5a613a4da9861c907e1f0922df446cc88628e13271793a6c94b229"
+  arch arm: "-arm"
 
-  url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.zip"
+  version "1.0b17"
+  sha256 arm:   "6b44a102747811e0373737e24104902dc1d8aaf8801fc83c0e77622bab1b12fa",
+         intel: "7b25b255a1af84261321b40ac08c31311bbff73a13be2c523862863be0bba620"
+
+  url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit#{arch}.#{version}.zip"
   name "Xit"
   desc "GUI for the git version control system"
   homepage "https://github.com/Uncommon/Xit"
@@ -12,7 +15,7 @@ cask "xit" do
     regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
   end
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :monterey"
 
   app "Xit.app"
 

--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -17,7 +17,7 @@ cask "xit" do
 
   depends_on macos: ">= :monterey"
 
-  app "Xit.app"
+  app "Xit#{arch} #{version}/Xit.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uncommonplace.xit.sfl*",

--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -1,23 +1,40 @@
 cask "xit" do
-  arch arm: "-arm"
+  on_big_sur :or_older do
+    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.zip"
 
-  version "1.0b17"
-  sha256 arm:   "6b44a102747811e0373737e24104902dc1d8aaf8801fc83c0e77622bab1b12fa",
-         intel: "7b25b255a1af84261321b40ac08c31311bbff73a13be2c523862863be0bba620"
+    version "1.0b16"
+    sha256 "0e9897d16a5a613a4da9861c907e1f0922df446cc88628e13271793a6c94b229"
 
-  url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit#{arch}.#{version}.zip"
+    depends_on macos: ">= :mojave"
+
+    app "Xit.app"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_monterey :or_newer do
+    arch arm: "-arm"
+
+    version "1.0b17"
+    sha256 arm:   "6b44a102747811e0373737e24104902dc1d8aaf8801fc83c0e77622bab1b12fa",
+           intel: "7b25b255a1af84261321b40ac08c31311bbff73a13be2c523862863be0bba620"
+
+    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit#{arch}.#{version}.zip"
+
+    depends_on macos: ">= :monterey"
+
+    app "Xit#{arch} #{version}/Xit.app"
+
+    livecheck do
+      url :url
+      regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
+    end
+  end
+
   name "Xit"
   desc "GUI for the git version control system"
   homepage "https://github.com/Uncommon/Xit"
-
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
-  end
-
-  depends_on macos: ">= :monterey"
-
-  app "Xit#{arch} #{version}/Xit.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uncommonplace.xit.sfl*",

--- a/Casks/xit.rb
+++ b/Casks/xit.rb
@@ -1,9 +1,9 @@
 cask "xit" do
   on_big_sur :or_older do
-    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.zip"
-
     version "1.0b16"
     sha256 "0e9897d16a5a613a4da9861c907e1f0922df446cc88628e13271793a6c94b229"
+
+    url "https://github.com/Uncommon/Xit/releases/download/#{version}/Xit.zip"
 
     depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
Now depends on Monterey

 ----

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.