### PR TITLE
ci_matrix: remove unneeded rubocop disable.

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -40,7 +40,7 @@ module CiMatrix
       { versions: [args.first], comparator: "==" }
     elsif /^\s*(?<comparator><|>|[=<>]=)\s*:?(?<version>\S+)\s*$/ =~ args.first
       { versions: [version.to_sym], comparator: comparator }
-    else # rubocop:disable Lint/DuplicateBranch
+    else
       { versions: [args.first], comparator: "==" }
     end
 


### PR DESCRIPTION
Fixes issue revealed in https://github.com/Homebrew/brew/actions/runs/4283441554/jobs/7459055572#step:11:15