### PR TITLE
ci_matrix: add label to skip livecheck_min_os audit

### DIFF
--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -27,6 +27,8 @@ jobs:
         github.event.label.name == 'ci-skip-appcast' ||
         github.event.label.name == 'ci-skip-install' ||
         github.event.label.name == 'ci-skip-livecheck' ||
+        github.event.label.name == 'ci-skip-livecheck-min-os' ||
+        github.event.label.name == 'ci-skip-repository' ||
         github.event.label.name == 'ci-syntax-only' ||
         !github.event.label.name
       )
@@ -38,5 +40,5 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           once-label: ci-requeue
           continuous-label: ci-retry
-          trigger-labels: ci-skip-appcast,ci-skip-install,ci-skip-livecheck,ci-syntax-only
+          trigger-labels: ci-skip-appcast,ci-skip-install,ci-skip-livecheck,ci-syntax-only,ci-skip-repository,ci-skip-livecheck-min-os
           workflow: ci.yml

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -113,10 +113,6 @@ module CiMatrix
       audit_args << "--new-cask" if changed_files[:added_files].include?(path)
 
       audit_exceptions = []
-      if labels.include?("ci-skip-repository")
-        audit_exceptions << ["github_repository", "gitlab_repository",
-                             "bitbucket_repository"]
-      end
 
       # TODO: Replace with `except`.
       audit_args << if labels.include?("ci-skip-appcast")
@@ -127,6 +123,13 @@ module CiMatrix
 
       if labels.include?("ci-skip-livecheck")
         audit_exceptions << ["hosting_with_livecheck", "livecheck_version", "livecheck_min_os"]
+      end
+
+      audit_exceptions << "livecheck_min_os" if labels.include?("ci-skip-livecheck-min-os")
+
+      if labels.include?("ci-skip-repository")
+        audit_exceptions << ["github_repository", "gitlab_repository",
+                             "bitbucket_repository"]
       end
 
       audit_args << "--except" << audit_exceptions.join(",") if audit_exceptions.any?


### PR DESCRIPTION
Adds the ability to skip the `livecheck_min_os` audit when upstream's sparkle feed reports an incorrect minimum OS.
Note that in these cases the issue should also be reported to upstream.

Unblocks: #142063 