### PR TITLE
triage: update missing-zap regex

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -47,4 +47,4 @@ jobs:
 
             - label: missing zap
               path: Casks/.+
-              missing_content: \n  zap .+\n
+              missing_content: zap .+\n


### PR DESCRIPTION
This will prevent the `missing-zap` label from being added to casks that contain the line;

```ruby
  # no zap stanza required
```