### PR TITLE
rubocop: In-line disables for `Style/{Class,Global}Vars`

### DIFF
--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -126,15 +126,15 @@ AFTER_INTERIOR_VERSION_PATS = [
 
 class AppName < String
   def self.remove_trailing_pat
-    @@remove_trailing_pat ||= /(?<=.)(?:#{REMOVE_TRAILING_PATS.join('|')})\Z/i
+    @@remove_trailing_pat ||= /(?<=.)(?:#{REMOVE_TRAILING_PATS.join('|')})\Z/i # rubocop:disable Style/ClassVars
   end
 
   def self.preserve_trailing_pat
-    @@preserve_trailing_pat ||= /(?:#{PRESERVE_TRAILING_PATS.join('|')})\Z/i
+    @@preserve_trailing_pat ||= /(?:#{PRESERVE_TRAILING_PATS.join('|')})\Z/i # rubocop:disable Style/ClassVars
   end
 
   def self.after_interior_version_pat
-    @@after_interior_version_pat ||= /(?:#{AFTER_INTERIOR_VERSION_PATS.join('|')})/i
+    @@after_interior_version_pat ||= /(?:#{AFTER_INTERIOR_VERSION_PATS.join('|')})/i # rubocop:disable Style/ClassVars
   end
 
   def english_from_app_bundle

--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -370,7 +370,7 @@ def warnings
 end
 
 def report
-  puts "Proposed Simplified App name: #{simplified_app_name}" if $debug
+  puts "Proposed Simplified App name: #{simplified_app_name}" if $debug # rubocop:disable Style/GlobalVars
   puts "Proposed token:               #{cask_token}"
   puts "Proposed file name:           #{cask_file_name}"
   puts "Cask Header Line:             cask \"#{cask_token}\" do"
@@ -402,7 +402,7 @@ if /^-+h(elp)?$/i.match?(ARGV.first)
 end
 
 if /^-+debug?$/i.match?(ARGV.first)
-  $debug = 1
+  $debug = 1 # rubocop:disable Style/GlobalVars
   ARGV.shift
 end
 

--- a/developer/bin/list_login_items_for_app
+++ b/developer/bin/list_login_items_for_app
@@ -38,7 +38,7 @@ def process_args
     puts usage
     exit 0
   elsif ARGV.length == 1
-    $app_path = ARGV.first
+    $app_path = ARGV.first # rubocop:disable Style/GlobalVars
   else
     puts usage
     exit 1
@@ -63,4 +63,4 @@ end
 ###
 
 process_args
-list_login_items_for_app $app_path
+list_login_items_for_app $app_path # rubocop:disable Style/GlobalVars

--- a/developer/bin/list_running_app_ids
+++ b/developer/bin/list_running_app_ids
@@ -17,6 +17,7 @@ require "io/console"
 ### globals
 ###
 
+# rubocop:disable Style/GlobalVars
 $opt_test = nil
 $COLUMNS = IO.console.winsize.last
 
@@ -120,3 +121,4 @@ if $opt_test
 else
   report_apps
 end
+# rubocop:enable Style/GlobalVars


### PR DESCRIPTION
- We're working to remove the global `Excludes:` from RuboCop configuration in `Homebrew/brew` (see issue 14685 over there).
- This file in Cask was the only place where class vars weren't already in-line disabled. So, to be able to clean up the configuration stanza in https://github.com/Homebrew/brew/pull/14878, I've added some.
- ~I feel like these scripts are ancient, but I'l leave deciding on cleanup to actual Cask maintainers!~ Nah, these aren't ancient, these are actually used! 😳 It's the ones in `developer/cgi` that looked ancient!

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
