### PR TITLE
The published an update OSX .dmg in January

### DIFF
--- a/Casks/zandronum.rb
+++ b/Casks/zandronum.rb
@@ -1,6 +1,6 @@
 cask "zandronum" do
   version "3.1"
-  sha256 "586dccf52bfb27a6fc019dea99fcd1cce203b85e14ca908268c33a95ae6947ff"
+  sha256 "2adcc9eca3ed7119bb8c28de371318b99ae691a0412f3fcacd4f577955d39933"
 
   url "https://zandronum.com/downloads/zandronum#{version}-macosx.dmg"
   name "Zandronum"

--- a/Casks/zandronum.rb
+++ b/Casks/zandronum.rb
@@ -9,7 +9,7 @@ cask "zandronum" do
 
   livecheck do
     url "https://zandronum.com/downloads/"
-    regex(/href=.*?zandronum[._-]?v?(\d+(?:\.\d+)+)-macosx\.dmg/i)
+    regex(/href=.*?zandronum[._-]?v?(\d+(?:\.\d+)+)[._-]macosx\.dmg/i)
   end
 
   app "Zandronum.app"


### PR DESCRIPTION
On 2023-02-26 21:53 they updated the dmg release for OSX which resulted in a new shasum. Validated new sum from multiple devices.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
