### PR TITLE
Add 115 v2.0.3.6

### DIFF
--- a/Casks/115.rb
+++ b/Casks/115.rb
@@ -23,5 +23,7 @@ cask "115" do
   zap trash: [
     "~/Library/Application Support/115",
     "~/Library/Application Support/115DocViewer",
+    "~/Library/Saved Application State/org.115pc.115Desktop.savedState",
+    "~/Library/Saved Application State/org.115pc.115DocViewer.savedState",
   ]
 end

--- a/Casks/115.rb
+++ b/Casks/115.rb
@@ -1,0 +1,27 @@
+cask "115" do
+  version "2.0.3.6"
+  sha256 "22c605830ec0f45c80d8a84ba0f76dc8335cfdf1844b175e93311de41c5e9ca6"
+
+  url "https://down.115.com/client/115pc/mac/115pc_#{version}.dmg"
+  name "115"
+  name "115电脑版"
+  desc "Client for the 115 cloud storage service"
+  homepage "https://pc.115.com/index.html#mac"
+
+  livecheck do
+    url "https://appversion.115.com/1/web/1.0/api/chrome"
+    strategy :json do |json|
+      json["data"]["mac_115"]["version_code"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "115电脑版.app"
+
+  zap trash: [
+    "~/Library/Application Support/115",
+    "~/Library/Application Support/115DocViewer",
+  ]
+end


### PR DESCRIPTION
This is the client for a Chinese cloud storage service. The app name is literally "115 Desktop" or "115 PC", so I used "115" as the token.

Related casks:
- Removed legacy version: https://github.com/Homebrew/homebrew-cask/commits/master/Casks/115cloud.rb
- Browser variant: https://formulae.brew.sh/cask/115browser

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
