### PR TITLE
Add MFiles v2.4.1

### DIFF
--- a/Casks/mfiles.rb
+++ b/Casks/mfiles.rb
@@ -12,7 +12,7 @@ cask "mfiles" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      match = page.match(/mfiles-helper-([.\d]+)-macos-(\d{8})\.dmg/)
+      match = page.match(/mfiles[._-]helper[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-](\d+)\.dmg/)
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/mfiles.rb
+++ b/Casks/mfiles.rb
@@ -19,7 +19,7 @@ cask "mfiles" do
 
   app "爱传送.app"
 
-  zap trash: [
-    "~/Library/Preferences/com.windtune.itransfer.plist",
-  ]
+  uninstall signal: ["TERM", "com.windtune.itransfer"]
+
+  zap trash: "~/Library/Preferences/com.windtune.itransfer.plist"
 end

--- a/Casks/mfiles.rb
+++ b/Casks/mfiles.rb
@@ -1,0 +1,25 @@
+cask "mfiles" do
+  version "2.4.1,20221127"
+  sha256 "41db127cfba3278215e6f22380d0f8dccb593f98c613c527d433a39721e9a336"
+
+  url "https://mfiles.maokebing.com/mfiles-helper-#{version.csv.first}-macos-#{version.csv.second}.dmg"
+  name "MFiles"
+  name "iTrunSo"
+  name "爱传送"
+  desc "Transfer files over local network"
+  homepage "https://mfiles.maokebing.com/"
+
+  livecheck do
+    url :homepage
+    strategy :page_match do |page|
+      match = page.match(/mfiles-helper-([.\d]+)-macos-(\d{8})\.dmg/)
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  app "爱传送.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.windtune.itransfer.plist",
+  ]
+end

--- a/Casks/mfiles.rb
+++ b/Casks/mfiles.rb
@@ -19,7 +19,7 @@ cask "mfiles" do
 
   app "爱传送.app"
 
-  uninstall signal: ["TERM", "com.windtune.itransfer"]
+  uninstall quit: "com.windtune.itransfer"
 
   zap trash: "~/Library/Preferences/com.windtune.itransfer.plist"
 end


### PR DESCRIPTION
This is a Chinese application to transfer files over your local network. Its original name was "MFiles" and [widely known](https://cn.bing.com/search?q=MFiles). The developer later renamed it to "爱传送" in Chinese. The corresponding English "iTrunSo" (a weird transliteration) is [rarely known](https://www.google.com/search?q=%22iTrunSo%22) except for its [iOS version page](https://apps.apple.com/us/app/id1205826385). Considering that it's mostly used by Chinese (the homepage is completely in Chinese), and the developer didn't rebrand the homepage URL, installers, application project and binary (except for the `Base.lproj` which has "iTrunSo"), I used "mfiles" as the token.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
