### PR TITLE
Allow rerunning CI in debug mode.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
         with:
           test-bot: false
 
+      - name: Enable debug mode
+        run: |
+          echo 'HOMEBREW_DEBUG=1' >> "${GITHUB_ENV}"
+          echo 'HOMEBREW_VERBOSE=1' >> "${GITHUB_ENV}"
+        if: runner.debug
+
       - name: Check out Pull Request
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Set `HOMEBREW_DEBUG` and `HOMEBREW_VERBOSE` when rerunning CI in debug mode.