### PR TITLE
Update Pritunl Client v1.3.3457.61

### DIFF
--- a/Casks/pritunl.rb
+++ b/Casks/pritunl.rb
@@ -1,9 +1,9 @@
 cask "pritunl" do
   arch arm: ".arm64"
 
-  version "1.3.3441.64"
-  sha256 arm:   "3294586767912b9e18a0ac18a5f8de2db01b47ddcbc171d22b2f14dc0473d3ba",
-         intel: "d8d86fd32a2dc9d2c705a4e8f0e05387eef7fd268297d7fcbfd7ae7d29789700"
+  version "1.3.3457.61"
+  sha256 arm:   "4377c126862e543a11d6117c785af5b43cb60c58dea9cd9550eaad8b1ff2cc78",
+         intel: "69ecd51caac1b77398020ac4689031b2037c6610539cdc069726626940c40394"
 
   url "https://github.com/pritunl/pritunl-client-electron/releases/download/#{version}/Pritunl#{arch}.pkg.zip",
       verified: "github.com/pritunl/pritunl-client-electron/"


### PR DESCRIPTION
Changed to recently released stable version of Pritunl Client v1.3.3457.61

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions)
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
