### PR TITLE
Update rawtherapee from 5.8 to 5.9

### DIFF
--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,15 +1,15 @@
 cask "rawtherapee" do
-  version "5.8"
-  sha256 "6fe7cd08bd59b1ca9135e587be0d600d62487d0b9baaa6157972135fe3018f8a"
+  version "5.9"
+  sha256 "d0812e94e8297449ca6bb4136d8a96951540dc14e8e5d98bdac152f7f082d47f"
 
-  url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_#{version}.dmg"
+  url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip"
   name "RawTherapee"
   desc "RAW photo processer"
   homepage "https://rawtherapee.com/"
 
   livecheck do
     url "https://rawtherapee.com/shared/builds/mac/"
-    regex(/href=.*?RawTherapee[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(/href=.*?RawTherapee_\w+[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   app "RawTherapee.app"

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -7,10 +7,7 @@ cask "rawtherapee" do
   desc "RAW photo processer"
   homepage "https://rawtherapee.com/"
 
-  livecheck do
-    url "https://rawtherapee.com/shared/builds/mac/"
-    regex(/href=.*?RawTherapee_\w+[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-  end
+  container nested: "RawTherapee_macOS_11.7_Universal_5.9_folder/RawTherapee_macOS_11.7_Universal_5.9.dmg"
 
   app "RawTherapee.app"
 

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,13 +1,20 @@
 cask "rawtherapee" do
   version "5.9"
-  sha256 :no_check
+  sha256 "d0812e94e8297449ca6bb4136d8a96951540dc14e8e5d98bdac152f7f082d47f"
 
-  url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip"
+  url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_#{version}.zip"
   name "RawTherapee"
   desc "RAW photo processer"
   homepage "https://rawtherapee.com/"
 
-  container nested: "RawTherapee_macOS_11.7_Universal_5.9_folder/RawTherapee_macOS_11.7_Universal_5.9.dmg"
+  livecheck do
+    url "https://rawtherapee.com/shared/builds/mac/"
+    regex(/href=.*?RawTherapee[._-]macOS.+(\d+(?:\.\d+)+)\.zip/i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  container nested: "RawTherapee_macOS_11.7_Universal_#{version}_folder/RawTherapee_macOS_11.7_Universal_#{version}.dmg"
 
   app "RawTherapee.app"
 

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,15 +1,11 @@
 cask "rawtherapee" do
   version "5.9"
-  sha256 "d0812e94e8297449ca6bb4136d8a96951540dc14e8e5d98bdac152f7f082d47f"
+  sha256 :no_check
 
   url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip"
   name "RawTherapee"
   desc "RAW photo processer"
   homepage "https://rawtherapee.com/"
-
-  livecheck do
-    url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip.sha256"
-  end
 
   container nested: "RawTherapee_macOS_11.7_Universal_5.9_folder/RawTherapee_macOS_11.7_Universal_5.9.dmg"
 

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -13,8 +13,8 @@ cask "rawtherapee" do
   end
 
   depends_on macos: ">= :big_sur"
-
   container nested: "RawTherapee_macOS_11.7_Universal_#{version}_folder/RawTherapee_macOS_11.7_Universal_#{version}.dmg"
+
   app "RawTherapee.app"
 
   zap trash: "~/Library/Application Support/RawTherapee"

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,11 +1,15 @@
 cask "rawtherapee" do
   version "5.9"
-  sha256 :no_check
+  sha256 "d0812e94e8297449ca6bb4136d8a96951540dc14e8e5d98bdac152f7f082d47f"
 
   url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip"
   name "RawTherapee"
   desc "RAW photo processer"
   homepage "https://rawtherapee.com/"
+
+  livecheck do
+    url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip.sha256"
+  end
 
   container nested: "RawTherapee_macOS_11.7_Universal_5.9_folder/RawTherapee_macOS_11.7_Universal_5.9.dmg"
 

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -15,7 +15,6 @@ cask "rawtherapee" do
   depends_on macos: ">= :big_sur"
 
   container nested: "RawTherapee_macOS_11.7_Universal_#{version}_folder/RawTherapee_macOS_11.7_Universal_#{version}.dmg"
-
   app "RawTherapee.app"
 
   zap trash: "~/Library/Application Support/RawTherapee"

--- a/Casks/rawtherapee.rb
+++ b/Casks/rawtherapee.rb
@@ -1,6 +1,6 @@
 cask "rawtherapee" do
   version "5.9"
-  sha256 "d0812e94e8297449ca6bb4136d8a96951540dc14e8e5d98bdac152f7f082d47f"
+  sha256 :no_check
 
   url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_11.7_Universal_5.9.zip"
   name "RawTherapee"


### PR DESCRIPTION
On March 03, 2023, Rawtherapee 5.9 for macOS was released in the form of a zip file containing a dmg file.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
