### PR TITLE
Update enclave cask with hotfix for 2023.03.09

### DIFF
--- a/Casks/enclave.rb
+++ b/Casks/enclave.rb
@@ -1,6 +1,6 @@
 cask "enclave" do
-  version "2023.03.09"
-  sha256 "12f2441ebdb36d977b5bd37eae23a259e41a74d7ccc32037379e641daa180dad"
+  version "2023.03.09.hotfix1"
+  sha256 "68aff7b844b4201347ba9e35c34b59d39601aa9dcdb46c4b66a797eac205cc3f"
 
   url "https://release.enclave.io/enclave_osx-installer-x64-stable-#{version}.pkg"
   name "Enclave"


### PR DESCRIPTION
Directly apply a hotfix version to allow a same-day hotfix of Enclave.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
