### PR TITLE
Update perforce from 2022.1,2361553 to 2022.1,2409226

### DIFF
--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,5 +1,5 @@
 cask "perforce" do
-  version "2022.1,2361553"
+  version "2022.1,2409226"
   sha256 "c9da1429c95bba4cd388187559d6b825838e12998e0bb7d206572eca1aa2e317"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"

--- a/Casks/perforce.rb
+++ b/Casks/perforce.rb
@@ -1,6 +1,6 @@
 cask "perforce" do
   version "2022.1,2361553"
-  sha256 "3c763b8f7749d9abc9b55bc39a3ac93b652c6c11c8993eecafa949ee55dd5f64"
+  sha256 "c9da1429c95bba4cd388187559d6b825838e12998e0bb7d206572eca1aa2e317"
 
   url "https://cdist2.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
   name "Perforce Helix Core Server"


### PR DESCRIPTION
Updated sha256 value per: https://cdist2.perforce.com/perforce/r22.1/bin.macosx1015x86_64/SHA256SUMS

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
