### PR TITLE
gather: add livecheck

### DIFF
--- a/Casks/gather.rb
+++ b/Casks/gather.rb
@@ -11,6 +11,11 @@ cask "gather" do
   desc "Virtual video-calling space"
   homepage "https://gather.town/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Gather.app"
 
   zap trash: [


### PR DESCRIPTION
Livecheck is returning a partial commit hash instead of a real version without this.