### PR TITLE
Update idrive.rb

### DIFF
--- a/Casks/idrive.rb
+++ b/Casks/idrive.rb
@@ -1,11 +1,16 @@
 cask "idrive" do
-  version "latest"
+  version "3.5.10.53"
   sha256 :no_check
 
   url "https://www.idrive.com/downloads/IDrive.dmg"
   name "iDrive"
   desc "Cloud backup and storage solution"
   homepage "https://www.idrive.com/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   pkg "IDrive.pkg"
 

--- a/Casks/idrive.rb
+++ b/Casks/idrive.rb
@@ -1,5 +1,5 @@
 cask "idrive" do
-  version "6.7.4.41"
+  version "latest"
   sha256 :no_check
 
   url "https://www.idrive.com/downloads/IDrive.dmg"


### PR DESCRIPTION
Why was this changed to some obscure version number. The string "latest" satisfies it.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
