### PR TITLE
Remove livecheck from discontinued casks

### DIFF
--- a/Casks/appcode.rb
+++ b/Casks/appcode.rb
@@ -10,15 +10,6 @@ cask "appcode" do
   desc "IDE for Swift, Objective-C, C, and C++ development"
   homepage "https://www.jetbrains.com/objc/"
 
-  livecheck do
-    url "https://data.services.jetbrains.com/products/releases?code=AC&latest=true&type=release"
-    strategy :json do |json|
-      json["AC"].map do |release|
-        "#{release["version"]},#{release["build"]}"
-      end
-    end
-  end
-
   auto_updates true
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/encryptr.rb
+++ b/Casks/encryptr.rb
@@ -8,11 +8,6 @@ cask "encryptr" do
   desc "Zero-knowledge cloud-based password manager"
   homepage "https://spideroak.support/hc/en-us/categories/115000424503-Encryptr-Password-Manager"
 
-  livecheck do
-    url :url
-    strategy :header_match
-  end
-
   app "Encryptr.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `appcode` and `encryptr` casks are discontinued, so this PR removes their `livecheck` blocks so they will be automatically skipped as discontinued.