### PR TITLE
Speed up CI.

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -19,10 +19,11 @@ jobs:
     if: startsWith(github.repository, 'Homebrew/')
     strategy:
       matrix:
-        os:
-          - macos-11.0
+        runner:
+          - macos-11
+          - macos-12
           - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -35,8 +36,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
+          key: ${{ matrix.runner }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.runner }}-rubygems-
 
       - name: Install Homebrew Gems
         id: gems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   generate-matrix:
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -79,7 +79,7 @@ jobs:
 
           if ! rm /usr/local/share/man/man1/al.1 || \
              ! sudo rm /etc/paths.d/mono-commands || \
-             ! sudo rm -r /Library/Frameworks/Mono.framework || \
+             ! sudo rm -r /Library/Frameworks/Mono.framework || \
              ! sudo pkgutil --forget com.xamarin.mono-MDK.pkg; then
             echo '::warning::Uninstalling Mono is no longer necessary.'
           fi
@@ -100,39 +100,51 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Cache Homebrew Gems
+        id: cache
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
+          key: ${{ matrix.runner }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.runner }}-rubygems-
 
       - name: Install Homebrew Gems
         id: gems
         run: brew install-bundler-gems
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run brew readall ${{ matrix.tap }}
         id: readall
         run: brew readall '${{ matrix.tap }}'
-        if: always() && steps.gems.outcome == 'success'
+        if: >
+          always() &&
+          contains(fromJSON('["success", "skipped"]'), steps.gems.outcome) &&
+          !matrix.skip_readall
 
       - name: Run brew style ${{ matrix.tap }}
         run: brew style '${{ matrix.tap }}'
-        if: always() && steps.readall.outcome == 'success' && !matrix.cask
+        if: >
+          always() &&
+          contains(fromJSON('["success", "skipped"]'), steps.readall.outcome) &&
+          !matrix.cask
 
       - name: Run brew fetch --cask ${{ matrix.cask.token }}
         id: fetch
         run: |
           brew fetch --cask --retry --force '${{ matrix.cask.path }}'
         timeout-minutes: 30
-        if: always() && steps.readall.outcome == 'success' && matrix.cask
+        if: >
+          always() &&
+          contains(fromJSON('["success", "skipped"]'), steps.readall.outcome) &&
+          matrix.cask
 
       - name: Run brew audit --cask${{ (matrix.cask && ' ') || ' --tap ' }}${{ matrix.cask.token || matrix.tap }}
         id: audit
         run: |
-          brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' --signing ') || ' --tap ' }}'${{ matrix.cask.token || matrix.tap }}'
+          brew audit --cask ${{ join(matrix.audit_args, ' ') }}${{ (matrix.cask && ' ') || ' --tap ' }}'${{ matrix.cask.token || matrix.tap }}'
         timeout-minutes: 30
         if: >
-          always() && steps.readall.outcome == 'success' &&
+          always() &&
+          contains(fromJSON('["success", "skipped"]'), steps.readall.outcome) &&
           (!matrix.cask || steps.fetch.outcome == 'success') &&
           !matrix.skip_audit
 

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -112,6 +112,8 @@ module CiMatrix
       audit_args = ["--online"]
       audit_args << "--new-cask" if changed_files[:added_files].include?(path)
 
+      audit_args << "--signing"
+
       audit_exceptions = []
 
       # TODO: Replace with `except`.
@@ -144,6 +146,7 @@ module CiMatrix
           },
           audit_args:   audit_args,
           skip_install: labels.include?("ci-skip-install"),
+          skip_readall: false,
           runner:       runner[:name],
         }
       end

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -18,9 +18,10 @@ tap = Tap.fetch(ENV.fetch("GITHUB_REPOSITORY"))
 
 runner = CiMatrix.random_runner[:name]
 syntax_job = {
-  name:   "syntax",
-  tap:    tap.name,
-  runner: runner,
+  name:         "syntax",
+  tap:          tap.name,
+  runner:       runner,
+  skip_readall: false,
 }
 
 matrix = [syntax_job]
@@ -32,8 +33,13 @@ unless labels.include?("ci-syntax-only")
     # If casks were changed, skip `audit` for whole tap.
     syntax_job[:skip_audit] = true
 
+    # If casks were cahnged, skip `readall` in the syntax job.
+    syntax_job[:skip_readall] = true
+
     # The syntax job only runs `style` at this point, which should work on Linux.
-    syntax_job[:runner] = "ubuntu-latest"
+    # Running on macOS is currently faster though, since `homebrew/cask` and
+    # `homebrew/core` are already tapped on macOS CI machines.
+    # syntax_job[:runner] = "ubuntu-latest"
   end
 
   matrix += cask_jobs


### PR DESCRIPTION
Two improvements:

- We are populating cache on macOS 11, but running mostly macOS 12, resulting in gems taking ~1m to install even on a cache hit. Fix caching by including the macOS version in the cache key. (~1m improvement)
- Run `generate-matrix` and `syntax` on `macos-latest`, since `homebrew/core` and `homebrew/cask` are already tapped and don't need to be cloned from scratch. (~4m improvement per task, i.e. ~9m improvement overall given they run sequentially).