### PR TITLE
Add Bazecor.app v1.0.0

### DIFF
--- a/Casks/bazecor.rb
+++ b/Casks/bazecor.rb
@@ -1,0 +1,18 @@
+cask "bazecor" do
+  version "1.0.0"
+  sha256 "449ad344e90b2d2f13b1db2a1c417f8739bf5a81d291ea125b50ac17b1501879"
+
+  url "https://github.com/Dygmalab/Bazecor/releases/download/bazecor-#{version}/Bazecor-#{version}.dmg",
+      verified: "github.com/Dygmalab/Bazecor"
+  name "bazecor"
+  desc "Graphical configurator for Dygma Raise"
+  homepage "https://dygma.com/pages/programmable-split-keyboard"
+
+  app "Bazecor.app"
+
+  zap trash: [
+    "~/Library/Application Support/BAZECOR",
+    "~/Library/Preferences/com.dygmalab.bazecor.plist",
+    "~/Library/Saved Application State/com.dygmalab.bazecor.savedState",
+  ]
+end

--- a/Casks/bazecor.rb
+++ b/Casks/bazecor.rb
@@ -4,8 +4,8 @@ cask "bazecor" do
 
   url "https://github.com/Dygmalab/Bazecor/releases/download/bazecor-#{version}/Bazecor-#{version}.dmg",
       verified: "github.com/Dygmalab/Bazecor"
-  name "bazecor"
-  desc "Graphical configurator for Dygma Raise"
+  name "Bazecor"
+  desc "Graphical configurator for Dygma Raise keyboards"
   homepage "https://dygma.com/pages/programmable-split-keyboard"
 
   app "Bazecor.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Please note that `brew audit --new-cask <cask>` fails with the following error:

```
audit for bazecor: failed
 - GitHub fork (not canonical repository)
Error: 1 problem in 1 cask detected
```

which is expected since Bazecor is a fork from Chrysalis, the software for keyboards using the Kaleidoscope firmware, such as the Dygma Raise.

You can read more about Dygma’s decision to maintain Bazecor as their own fork of Chrysalis here: https://dygma.com/pages/programmable-split-keyboard.

>Bazecor is [open-source](https://github.com/Dygmalab/Bazecor) –a fork from Chrysalis, the software for keyboards using the Kaleidoscope firmware, such as the Raise– and it's in continuous development.

My understanding is that the “not canonical repository” can be considered a guideline rather than a hard requirement (so exceptions can be made for cases like this), since Homebrew maintainers can look into a new cask before accepting a PR.

Please note that I don’t work for Dygma, I just use both their product and Homebrew.