### PR TITLE
pagico: Add zap

### DIFF
--- a/Casks/pagico.rb
+++ b/Casks/pagico.rb
@@ -15,4 +15,15 @@ cask "pagico" do
   depends_on macos: ">= :el_capitan"
 
   app "Pagico.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.pagico.mac.Pagico-Extension-for-Safari",
+    "~/Library/Application Support/Pagico",
+    "~/Library/Caches/com.pagico.mac",
+    "~/Library/Containers/com.pagico.mac.Pagico-Extension-for-Safari",
+    "~/Library/HTTPStorages/com.pagico.mac",
+    "~/Library/PagicoHelpers",
+    "~/Library/Preferences/com.pagico.mac.plist",
+    "~/Library/WebKit/com.pagico.mac",
+  ]
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

----

On first run, pagico demands you use an admin account to install a backend thing to `~/Library/PagicoHelpers`.  I didn't add it here, but I think it should be included, right?