### PR TITLE
outline-manager: update livecheck

### DIFF
--- a/Casks/outline-manager.rb
+++ b/Casks/outline-manager.rb
@@ -10,7 +10,8 @@ cask "outline-manager" do
 
   livecheck do
     url :stable
-    regex(/^(?:manager-)?v?(\d+(?:\.\d+)+)$/i)
+    regex(%r{href=["']?[^"' >]*?/tag/(?:manager[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   app "Outline Manager.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #143093, as I wasn't able to review the `livecheck` block change before it was merged. The `livecheck` block was modified in that PR to switch from the `GithubLatest` strategy to the `Git` strategy with a modified regex to match both `v1.2.3` and `manager-v1.2.3` tags. However, the cask URL is a release asset, so the check should be using the `GithubLatest` strategy, otherwise livecheck may surface a new version before the dmg file is available.

This PR returns the `livecheck` block to the `GithubLatest` strategy and adds a modified version of the strategy regex that also handles `manager-v1.2.3` tags. This is the appropriate solution to the previously-described issue.