### PR TITLE
Updates BlueBubbles to v1.6.0

### DIFF
--- a/Casks/bluebubbles.rb
+++ b/Casks/bluebubbles.rb
@@ -1,6 +1,6 @@
 cask "bluebubbles" do
-  version "1.5.5"
-  sha256 "4dbd853a6278e093640cec6fd5022f207d9892d36a13fb6633cccb3bb61fc06b"
+  version "1.6.0"
+  sha256 "d694122adb59c1dcd5f028f00796203143f6224b26d7738fddfc60a86e4f0b86"
 
   url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}.dmg",
       verified: "github.com/BlueBubblesApp/bluebubbles-server"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Outputs:

Audit:

```
==> Downloading https://github.com/BlueBubblesApp/bluebubbles-server/releases/do
==> Downloading from https://objects.githubusercontent.com/github-production-rel
######################################################################## 100.0%
audit for bluebubbles: passed
```

Style:

```
bluebubbles.rb:1:1: C: [Corrected] Magic comments should be in the following order: encoding, typed, warn_indent, frozen_string_literal.
# frozen_string_literal: true
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
bluebubbles.rb:1:1: C: [Corrected] No Sorbet sigil found in file. Try a typed: false to start (you can also use rubocop -a to automatically add this).
cask "bluebubbles" do
^^^^
bluebubbles.rb:1:1: C: [Corrected] Missing frozen string literal comment.
cask "bluebubbles" do
^
bluebubbles.rb:2:1: C: [Corrected] Magic comments should be in the following order: encoding, typed, warn_indent, frozen_string_literal.
# typed: false
^^^^^^^^^^^^^^
bluebubbles.rb:3:1: C: [Corrected] Add an empty line after magic comments.
cask "bluebubbles" do
^
bluebubbles.rb:4:1: C: Block has too many lines. [26/25]
cask "bluebubbles" do ...
^^^^^^^^^^^^^^^^^^^^^
bluebubbles.rb:32:4: C: [Corrected] Final newline missing.
end


1 file inspected, 7 offenses detected, 6 offenses corrected
```

I'm only update the SHA-256 and version number, so im not sure I need to fix the styling issues, but that was my output...