### PR TITLE
rubocop: Autocorrect stanza order for `on_os` and `on_arch` blocks

### DIFF
--- a/Casks/anki.rb
+++ b/Casks/anki.rb
@@ -5,9 +5,6 @@ cask "anki" do
   sha256 arm:   "cbaee7c65b32293d4fb81abc28c87c35ab692d588295a37a04830ca2b6a529d4",
          intel: "0d066c2a427c48c005a59dbf6954408a099bb1d9d6efd8d6ee8b4f39df18feff"
 
-  url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac-#{arch}-qt6.dmg",
-      verified: "github.com/ankitects/anki/"
-
   on_high_sierra :or_older do
     sha256 "9e9fe5ba51a3f6c43a568d15aaa4acb74992f013af17a0211b0447e0742588ec"
 
@@ -15,6 +12,8 @@ cask "anki" do
         verified: "github.com/ankitects/anki/"
   end
 
+  url "https://github.com/ankitects/anki/releases/download/#{version}/anki-#{version}-mac-#{arch}-qt6.dmg",
+      verified: "github.com/ankitects/anki/"
   name "Anki"
   desc "Memory training application"
   homepage "https://apps.ankiweb.net/"

--- a/Casks/avidemux.rb
+++ b/Casks/avidemux.rb
@@ -2,9 +2,6 @@ cask "avidemux" do
   version "2.8.1"
   sha256 "b0b8890114172d531d138f6c1413f0393c0e5a87530168106a12d6b11ae44833"
 
-  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}v2_Monterey_Qt6.dmg",
-      verified: "sourceforge.net/avidemux/"
-
   on_big_sur :or_older do
     version "2.7.4"
     sha256 "a5c5028ecc954b6658b4c0e6b04c1c186c42a12530e66a5379f51fe7a3ebfcd8"
@@ -17,6 +14,8 @@ cask "avidemux" do
     end
   end
 
+  url "https://downloads.sourceforge.net/avidemux/avidemux/#{version}/Avidemux_#{version}v2_Monterey_Qt6.dmg",
+      verified: "sourceforge.net/avidemux/"
   name "Avidemux"
   desc "Video editor"
   homepage "https://www.avidemux.org/"

--- a/Casks/biscuit.rb
+++ b/Casks/biscuit.rb
@@ -1,16 +1,16 @@
 cask "biscuit" do
   version "1.2.27"
 
-  on_intel do
-    sha256 "4eff2c48e3ce24af3ffeb814ed46f5a21406516b0c094763f5896e73bc82bd9b"
-
-    url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}.dmg",
-        verified: "github.com/agata/dl.biscuit/"
-  end
   on_arm do
     sha256 "b2bd9101f9eec59430db3586387cf5bcd077b06115f244ecdff9de1f4f329ac4"
 
     url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}-arm64.dmg",
+        verified: "github.com/agata/dl.biscuit/"
+  end
+  on_intel do
+    sha256 "4eff2c48e3ce24af3ffeb814ed46f5a21406516b0c094763f5896e73bc82bd9b"
+
+    url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}.dmg",
         verified: "github.com/agata/dl.biscuit/"
   end
 

--- a/Casks/blockblock.rb
+++ b/Casks/blockblock.rb
@@ -2,21 +2,6 @@ cask "blockblock" do
   version "2.1.5"
   sha256 "3ee9f1bceec828e91602d7f3d3e516c8aa9cde58e98214065da380b870e92141"
 
-  url "https://github.com/objective-see/BlockBlock/releases/download/v#{version}/BlockBlock_#{version}.zip",
-      verified: "github.com/objective-see/BlockBlock/"
-
-  installer script: {
-    executable: "#{staged_path}/BlockBlock Installer.app/Contents/MacOS/BlockBlock Installer",
-    args:       ["-install"],
-    sudo:       true,
-  }
-
-  uninstall script: {
-    executable: "#{staged_path}/BlockBlock Installer.app/Contents/MacOS/BlockBlock Installer",
-    args:       ["-uninstall"],
-    sudo:       true,
-  }
-
   on_mojave :or_older do
     version "0.9.9.4"
     sha256 "6ab3a8224e8bc77b9abe8d41492c161454c6b0266e60e61b06931fed4b431282"
@@ -37,9 +22,23 @@ cask "blockblock" do
     }
   end
 
+  url "https://github.com/objective-see/BlockBlock/releases/download/v#{version}/BlockBlock_#{version}.zip",
+      verified: "github.com/objective-see/BlockBlock/"
   name "BlockBlock"
   desc "Monitors common persistence locations"
   homepage "https://objective-see.com/products/blockblock.html"
+
+  installer script: {
+    executable: "#{staged_path}/BlockBlock Installer.app/Contents/MacOS/BlockBlock Installer",
+    args:       ["-install"],
+    sudo:       true,
+  }
+
+  uninstall script: {
+    executable: "#{staged_path}/BlockBlock Installer.app/Contents/MacOS/BlockBlock Installer",
+    args:       ["-uninstall"],
+    sudo:       true,
+  }
 
   zap trash: [
     "~/Library/Caches/com.objective-see.blockblock.helper",

--- a/Casks/devbook.rb
+++ b/Casks/devbook.rb
@@ -1,16 +1,16 @@
 cask "devbook" do
   version "0.1.18"
 
-  on_intel do
-    sha256 "1294edfd9ecd586ffb0d1d2cf0247dde8b274b128e7c22c773c8645c8cd8e233"
-
-    url "https://download.todesktop.com/2102273jsy18baz/Devbook%20#{version}.dmg",
-        verified: "download.todesktop.com/"
-  end
   on_arm do
     sha256 "a1e7a0f821bf30dc9bd3b6dd07da8c28af51b415faafb80cc96f4eaed06d37e5"
 
     url "https://download.todesktop.com/2102273jsy18baz/Devbook%20#{version}-arm64.dmg",
+        verified: "download.todesktop.com/"
+  end
+  on_intel do
+    sha256 "1294edfd9ecd586ffb0d1d2cf0247dde8b274b128e7c22c773c8645c8cd8e233"
+
+    url "https://download.todesktop.com/2102273jsy18baz/Devbook%20#{version}.dmg",
         verified: "download.todesktop.com/"
   end
 

--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -3,13 +3,13 @@ cask "dingtalk" do
   folder = on_arch_conditional arm: "M1-Beta/"
   linkid = on_arch_conditional arm: "qd=2022mac-m1"
 
-  on_intel do
-    version "7.0.10.5_28436509"
-    sha256 "8311a41e392f170489a8c58aac3cd0cc555de8912f58108bc1911419ce5f7fe6"
-  end
   on_arm do
     version "7.0.12.5_28488321"
     sha256 "11acb4fc794ee7349d2715681e719ee0f43e9d95658f35b7198ccb90dd59442c"
+  end
+  on_intel do
+    version "7.0.10.5_28436509"
+    sha256 "8311a41e392f170489a8c58aac3cd0cc555de8912f58108bc1911419ce5f7fe6"
   end
 
   url "https://dtapp-pub.dingtalk.com/dingtalk-desktop/mac_dmg/Release/#{folder}DingTalk_v#{version}_#{arch}.dmg"

--- a/Casks/dosbox-x.rb
+++ b/Casks/dosbox-x.rb
@@ -1,13 +1,13 @@
 cask "dosbox-x" do
   arch arm: "arm64", intel: "x86_64"
 
-  on_intel do
-    version "2022.12.26,20221226190321"
-    sha256 "af254d87679beefaf2f30d1f7b3bc1a1f59473e76da9d620c452f0aa1f8db53b"
-  end
   on_arm do
     version "2022.12.26,20221226183221"
     sha256 "ee642043238021e0fdc0874970f431eb218ce02bc0cbf722ddb6f589dd7d2b99"
+  end
+  on_intel do
+    version "2022.12.26,20221226190321"
+    sha256 "af254d87679beefaf2f30d1f7b3bc1a1f59473e76da9d620c452f0aa1f8db53b"
   end
 
   url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.csv.first}/dosbox-x-macosx-#{arch}-#{version.csv.second}.zip",

--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -5,9 +5,6 @@ cask "eddie" do
   sha256 arm:   "04edf9a6aa7311a62eb6827db44c7ed8ee677a0e2581d08a76f2bf004cf3ec0f",
          intel: "9aecfd234ca1b19eee6518b1142643764a503d28b8ee3d873085fda22d25af85"
 
-  url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}",
-      verified: "eddie.website/"
-
   on_mojave :or_older do
     sha256 "a446563a6beb6f91542d6afbd6f90f6745b7a36fef363a13506cff9d8f078c78"
 
@@ -15,6 +12,8 @@ cask "eddie" do
         verified: "eddie.website/"
   end
 
+  url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}",
+      verified: "eddie.website/"
   name "Air VPN"
   name "Eddie"
   desc "OpenVPN UI"

--- a/Casks/feishu.rb
+++ b/Casks/feishu.rb
@@ -1,13 +1,13 @@
 cask "feishu" do
   arch arm: "arm64", intel: "x64"
 
-  on_intel do
-    version "6.0.5,8dde8b15"
-    sha256 "41f5678ec9c60888ba7ffe729fed326170318d40192271f75bd83d6c439488d9"
-  end
   on_arm do
     version "6.0.5,6bd3688a"
     sha256 "62156ddc37e1f8e701fe15ab31645855cb523933bdbc809e5aea45ca7e0b5419"
+  end
+  on_intel do
+    version "6.0.5,8dde8b15"
+    sha256 "41f5678ec9c60888ba7ffe729fed326170318d40192271f75bd83d6c439488d9"
   end
 
   url "https://sf3-cn.feishucdn.com/obj/ee-appcenter/#{version.csv.second}/Feishu-darwin_#{arch}-#{version.csv.first}-signed.dmg",

--- a/Casks/itau.rb
+++ b/Casks/itau.rb
@@ -3,11 +3,11 @@ cask "itau" do
 
   sha256 :no_check
 
-  on_intel do
-    version "2.2.2.12"
-  end
   on_arm do
     version "2.3.2.12"
+  end
+  on_intel do
+    version "2.2.2.12"
   end
 
   url "https://guardiao.itau.com.br/UpdateServer/aplicativoitau#{arch}.dmg"

--- a/Casks/jamulus.rb
+++ b/Casks/jamulus.rb
@@ -2,9 +2,6 @@ cask "jamulus" do
   version "3.9.1"
   sha256 "724f15fd564737fe06c717aa678a8c3817a006f7105bb13b71d5b650ed8c7cc5"
 
-  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac.dmg",
-      verified: "downloads.sourceforge.net/llcon/"
-
   on_mojave :or_older do
     sha256 "6c645ba373205f774a09df59565e39808868b7ef3fb296a56f616ef90e74aefe"
 
@@ -12,6 +9,8 @@ cask "jamulus" do
         verified: "downloads.sourceforge.net/llcon/"
   end
 
+  url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac.dmg",
+      verified: "downloads.sourceforge.net/llcon/"
   name "Jamulus"
   desc "Play music online with friends"
   homepage "https://jamulus.io/"

--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -52,42 +52,6 @@ cask "karabiner-elements" do
 
     pkg "Karabiner-Elements.sparkle_guided.pkg"
   end
-  on_catalina do
-    version "13.7.0"
-    sha256 "9ac5e53a71f3a00d7bdb2f5f5f001f70b6b8b7b2680e10a929e0e4c488c8734b"
-
-    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
-        verified: "github.com/pqrs-org/Karabiner-Elements/"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Karabiner-Elements.pkg"
-  end
-  on_big_sur :or_newer do
-    version "14.11.0"
-    sha256 "227b927d76da498b2772af2354ed792db4260d382e44794e884fcf8f911f5f97"
-
-    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
-        verified: "github.com/pqrs-org/Karabiner-Elements/"
-
-    livecheck do
-      url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
-      strategy :sparkle
-    end
-
-    depends_on macos: ">= :big_sur"
-
-    pkg "Karabiner-Elements.pkg"
-  end
-
-  name "Karabiner Elements"
-  desc "Keyboard customizer"
-  homepage "https://pqrs.org/osx/karabiner/"
-
-  auto_updates true
-
   on_mojave :or_older do
     uninstall signal:    [
                 ["TERM", "org.pqrs.Karabiner-Menu"],
@@ -106,6 +70,19 @@ cask "karabiner-elements" do
                 sudo:       true,
               },
               delete:    "/Library/Application Support/org.pqrs/"
+  end
+  on_catalina do
+    version "13.7.0"
+    sha256 "9ac5e53a71f3a00d7bdb2f5f5f001f70b6b8b7b2680e10a929e0e4c488c8734b"
+
+    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
+        verified: "github.com/pqrs-org/Karabiner-Elements/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    pkg "Karabiner-Elements.pkg"
   end
   on_catalina :or_newer do
     uninstall early_script: {
@@ -133,6 +110,28 @@ cask "karabiner-elements" do
               delete:       "/Library/Application Support/org.pqrs/"
     # The system extension 'org.pqrs.Karabiner-DriverKit-VirtualHIDDevice*' should not be uninstalled by Cask
   end
+  on_big_sur :or_newer do
+    version "14.11.0"
+    sha256 "227b927d76da498b2772af2354ed792db4260d382e44794e884fcf8f911f5f97"
+
+    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
+        verified: "github.com/pqrs-org/Karabiner-Elements/"
+
+    livecheck do
+      url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :big_sur"
+
+    pkg "Karabiner-Elements.pkg"
+  end
+
+  name "Karabiner Elements"
+  desc "Keyboard customizer"
+  homepage "https://pqrs.org/osx/karabiner/"
+
+  auto_updates true
 
   zap trash: [
     "~/.config/karabiner",

--- a/Casks/katrain.rb
+++ b/Casks/katrain.rb
@@ -2,14 +2,14 @@ cask "katrain" do
   version "1.12.3"
   sha256 "7a95ed91970c92c3f0e3c5537d0c8c573f05be56ce18065916369e5aabaa67db"
 
+  on_arm do
+    depends_on formula: "katago"
+  end
+
   url "https://github.com/sanderland/katrain/releases/download/v#{version}/KaTrainOSX.dmg"
   name "KaTrain"
   desc "Tool for analyzing games and playing go with AI feedback from KataGo"
   homepage "https://github.com/sanderland/katrain"
-
-  on_arm do
-    depends_on formula: "katago"
-  end
 
   app "KaTrain.app"
 

--- a/Casks/libreoffice-language-pack.rb
+++ b/Casks/libreoffice-language-pack.rb
@@ -4,400 +4,6 @@ cask "libreoffice-language-pack" do
 
   version "7.5.1"
 
-  on_intel do
-    language "af" do
-      sha256 "0931b515cd55e4e259760ad991026deea6bc07ad20bf0632e75fdd89fe66f30f"
-      "af"
-    end
-    language "am" do
-      sha256 "269933c43488ce9cd8a3e3f085905892a43e807209c2860988602d2b7945e8d1"
-      "am"
-    end
-    language "ar" do
-      sha256 "0cbe5d90c932b864c5d5cec359cf7a74298fc47b820fe7e24c46f4b0938d281a"
-      "ar"
-    end
-    language "as" do
-      sha256 "e32f7ef6228cff6101bd351b233d0b1e3ec5f414eb8698b5f03e9f144a83021c"
-      "as"
-    end
-    language "be" do
-      sha256 "fe22c3b9ad31e4a3d988d0dc2162642abfb1010fb2deb875e26a94c3be11f6fb"
-      "be"
-    end
-    language "bg" do
-      sha256 "bf4b656bb371796bd9ee62015458e7581ecf0439c6785edfccd3dea570dd7ee8"
-      "bg"
-    end
-    language "bn-IN" do
-      sha256 "9bf71c07007fd47c47a08d5d21549a7808d58263f3b26a0f1b93557b84edb781"
-      "bn-IN"
-    end
-    language "bn" do
-      sha256 "c282cb77e814ddb5f08996e2614f4f34a6779fa2becb4ececfdb3aef50f3fcf6"
-      "bn"
-    end
-    language "bo" do
-      sha256 "ed9c851bde7deab68c29ba9946f12fa739b79c25505ffb6a24d773ac7530aa1a"
-      "bo"
-    end
-    language "br" do
-      sha256 "fe481632d05430c20c0353d26daef8ec3eb4e78dd693521beb01420bae864211"
-      "br"
-    end
-    language "bs" do
-      sha256 "fb9a93975252a057a6fd067f8c3c4e146cbffa6ae058a9848d907b9dfc7b75bb"
-      "bs"
-    end
-    language "ca" do
-      sha256 "408b6efbece5d5e631aafbfe4d25925b408be43c76d532cf9c708a7ed66c6b41"
-      "ca"
-    end
-    language "cs" do
-      sha256 "0a12e0445edb119ceb06e70444b7066e7a48f158333891db68f134c8fbb79c49"
-      "cs"
-    end
-    language "cy" do
-      sha256 "55b63023a89d72e4638212b162dfc5d2ec72e8809cb890a04791e248ec2ce313"
-      "cy"
-    end
-    language "da" do
-      sha256 "b00bfa690c243154c03d5fce4d9aa7ff88b86cb7df3792d0415f3d0c15915396"
-      "da"
-    end
-    language "de" do
-      sha256 "87c882916f7944c1b3717b24e5eaec2f596684db2cc07f5744f6fa664a8e6569"
-      "de"
-    end
-    language "dz" do
-      sha256 "be97fd5678c23aa29d2d77e50c2f5f747a62a3046907f446622d95e151981ae2"
-      "dz"
-    end
-    language "el" do
-      sha256 "f7a101fd64296e96f3c622ad7dc7d436c0740be58be6a40a88563b4862b33bb9"
-      "el"
-    end
-    language "en-GB", default: true do
-      sha256 "b14506396b471c65966021eba8fd6966a9a9f7063418999b12b09d806872a735"
-      "en-GB"
-    end
-    language "en-ZA" do
-      sha256 "12dc7038e01f46f73c96af9fb3b364a1c83ed976bb10bc93d6052973cf202caf"
-      "en-ZA"
-    end
-    language "eo" do
-      sha256 "e8153f31753d11ea7fb1a6de7124ba3e41c9ec87f893b177c36df6a44974f7a3"
-      "eo"
-    end
-    language "es" do
-      sha256 "3ec86aef385d3cc86cc96c7f22f431966fde6cae66ab6038dd2045744c85d6ef"
-      "es"
-    end
-    language "et" do
-      sha256 "358f633a9770fb2d559dd2304c2e1b3d3ca62b5273c314b8adbac4146444d7bf"
-      "et"
-    end
-    language "eu" do
-      sha256 "955812af92db06e474f059525dcf0738bd0d80aa8cc771fd63471babc1a916d7"
-      "eu"
-    end
-    language "fa" do
-      sha256 "875a338eb136a82af986d56a8388a430568929d222d4e7cc863be894943196f7"
-      "fa"
-    end
-    language "fi" do
-      sha256 "603d7fceaeb96849f21aafc8bbfea72bbfdeae3cd996341dd10cf7aac5c8df8a"
-      "fi"
-    end
-    language "fr" do
-      sha256 "549a8799cbe3bb6b65ea9fcb19e538154d1cbb28f56cdfa7d9f9f0bf9d389e68"
-      "fr"
-    end
-    language "fy" do
-      sha256 "c6835afc915dc253b7d613c9497c0a846828b2e3e3351efbde13cbc54ea6b75d"
-      "fy"
-    end
-    language "ga" do
-      sha256 "6516a3e89a00bef0bb0bfc807a63f15653a9fd298f9cc6ad02e0600946fe9f65"
-      "ga"
-    end
-    language "gd" do
-      sha256 "c887496916edc10d592434970c5b101b943fdf4bd209053931dd41d72e0a4149"
-      "gd"
-    end
-    language "gl" do
-      sha256 "1c41b708cd4357c9900f175c7afdf6d0bd4240119c7751defdb752f009a3f8c9"
-      "gl"
-    end
-    language "gu" do
-      sha256 "36642bfacaa9c997f77bede46b08f5a4cef3dd89ee5ffff9a2492f6ca75bbdcb"
-      "gu"
-    end
-    language "he" do
-      sha256 "25d58fae4e53f15b3fd72009f469461859ba42af940362cc58a7aabe44afb152"
-      "he"
-    end
-    language "hi" do
-      sha256 "548dadb51d87ac9f53b16a5dd30cd010fdbd8e1909520a4a22963e816b239c1c"
-      "hi"
-    end
-    language "hr" do
-      sha256 "06dbca3ad15a3bedc6a006fae7c5687e57fef56ab0dcf6dcf672d240fe835792"
-      "hr"
-    end
-    language "hu" do
-      sha256 "0b9772d43b7faa4737b5331829bc777afd7671d7bb5419c845fd67a029e649c2"
-      "hu"
-    end
-    language "id" do
-      sha256 "c7d08f7f56728810255dfafe0aa45cb08e5c33f4033e6a6113fb22a426089038"
-      "id"
-    end
-    language "is" do
-      sha256 "5a341278212a7fa1f2356b24ad73c131fc7796a67234d6fdc7daa611eea7e03b"
-      "is"
-    end
-    language "it" do
-      sha256 "33d2b2a69d2ea6768d9180cf957b932308df8ffce515ef466addfd087dc4481d"
-      "it"
-    end
-    language "ja" do
-      sha256 "313cb917b2b5e48883f98ff093b06fb380d4b3684538f4b4f13aa0ef61a1ac0f"
-      "ja"
-    end
-    language "ka" do
-      sha256 "0f652cd5726e9f1264dddeb2cd30dacc5bbb139253485ef2bdfaeb0ded0c6763"
-      "ka"
-    end
-    language "kk" do
-      sha256 "15f5f5423c1b77127da0d865d20fabba32638207d4f9f2ea3056a1ea63569f42"
-      "kk"
-    end
-    language "km" do
-      sha256 "7d8338d5e073840f37598b37a9f97adabc18e45f0160e097254f49104514895f"
-      "km"
-    end
-    language "kn" do
-      sha256 "a747c5754260d877fd9299416529ce0342cefeb8f738336fe7dd74743d0993e2"
-      "kn"
-    end
-    language "ko" do
-      sha256 "f02a1198c8e2841a3578c02604b7b276b2c99b46f074aecf4755a11e9470336e"
-      "ko"
-    end
-    language "ks" do
-      sha256 "f07fbfe1576ca510a0d075b926f0b59ef94734cdd8113bbe4a79d37a09d1717d"
-      "ks"
-    end
-    language "lb" do
-      sha256 "5664278a6ca15e2e2fc73f6bd13b12f8e85a1af8e553cc6e56faa51b554b09d8"
-      "lb"
-    end
-    language "lo" do
-      sha256 "5bc40ac86703079414b6d4561af81eff3731c90c116f61dcdd7fc6681246aebd"
-      "lo"
-    end
-    language "lt" do
-      sha256 "722f42b1a1039cbaf2c18a813a0852b58e2a23fd0c71fdd01e1535db4390184d"
-      "lt"
-    end
-    language "lv" do
-      sha256 "e97cfb436f9b36c3e19d694c7f1dc86e54436c263811122334e3a9742162f5ae"
-      "lv"
-    end
-    language "mk" do
-      sha256 "9df22823e1fed0b89482eabcb0253745d62116f9aab612778afd5848eec5a328"
-      "mk"
-    end
-    language "ml" do
-      sha256 "6757102d6700bd97e038619d5ff491df01585908d43d98d9c4fa2e3bdf7e8cc5"
-      "ml"
-    end
-    language "mn" do
-      sha256 "2ad2a26a2a8b4ce15f67fc2fb936569f299aa91c1dbc0df5d497a68b13948210"
-      "mn"
-    end
-    language "mr" do
-      sha256 "6ef7a48d644a445528a8d316e66c76af62396260725e314d729132e1167d02b2"
-      "mr"
-    end
-    language "my" do
-      sha256 "4474980f3f7baad6bba6d95195cb772ceb12b33ee87e9bf998772f38a1e31a88"
-      "my"
-    end
-    language "nb" do
-      sha256 "17188c9592089b81eabc2de5521de42ca958529fa4fe857ba865a6cf8b4fc5d6"
-      "nb"
-    end
-    language "ne" do
-      sha256 "4aab1245b8aa14c3dde55e00c8412f40450298da8e2c1ec0a3252a0418f9a6db"
-      "ne"
-    end
-    language "nl" do
-      sha256 "b7d379aeb8cb15f834c9e2f2049809bdbdeef9a19c71519eb5205aebc3929575"
-      "nl"
-    end
-    language "nn" do
-      sha256 "553518dbd7748c8c4b048b6275379834bc3bb1b0190d68b74e04dad847a114bb"
-      "nn"
-    end
-    language "nr" do
-      sha256 "cfafedb9ea5ab2b9612b3131ccda3300be55ab91fd5b1ceae0554004d187276b"
-      "nr"
-    end
-    language "oc" do
-      sha256 "3c0d2860460e3ca97ea7168283e5fad6266d087fcdf7c95cb03f7f2d29b9a582"
-      "oc"
-    end
-    language "om" do
-      sha256 "f86c32b2a24fb72c0379057bb2b0046ddee781ba95e6dc48377db7da7084e449"
-      "om"
-    end
-    language "or" do
-      sha256 "2973e6d26b6d2ecca02eea209ce35112a51cef868c66f2ad2996046b6ed50095"
-      "or"
-    end
-    language "pa-IN" do
-      sha256 "9099d1885a869cf540d011f129a3cc1f02e8f89e61c4495704b18555e5f2c604"
-      "pa-IN"
-    end
-    language "pl" do
-      sha256 "a8bf19838d6863fca9e41178e3f7afaa80d404ff96d37dad200a0a6993f51424"
-      "pl"
-    end
-    language "pt-BR" do
-      sha256 "1531ebfaf5cbb2cc58018bb2a262ea9df4625704c90ff689103478ba105b2f86"
-      "pt-BR"
-    end
-    language "pt" do
-      sha256 "9739b8860d0f8313aac05278b3213ac05b0bfe902c78ffccb77b5ad87f4fe8af"
-      "pt"
-    end
-    language "ro" do
-      sha256 "09d91a4e5baf81bbfd7c1c786786e9c1ce6299fa6e02a091e60c2dbb96d89823"
-      "ro"
-    end
-    language "ru" do
-      sha256 "c6e6470fffb88330a2590adbab2521e8a41047da889cc4fffc6093de4b4e7c17"
-      "ru"
-    end
-    language "rw" do
-      sha256 "6d52e957fb92777128fc23adc43de61200a551c6c981ea1bb70ba901651d1482"
-      "rw"
-    end
-    language "sa-IN" do
-      sha256 "8eedd078a3abb3006b165d70e3010f48295dddb93575c2352b9208e91b68f3b9"
-      "sa-IN"
-    end
-    language "sd" do
-      sha256 "286edb579fc010feb41a1d913aadc103a6e350d781e137c22eb5f002540507a6"
-      "sd"
-    end
-    language "si" do
-      sha256 "1d0617dd46aaf1f3c844c6cea336329ffb977df20a313995bdbeaaf6f6a8d8f2"
-      "si"
-    end
-    language "sk" do
-      sha256 "b13f8258279c08d291820cbfea2b271b2002fe94354bb490a590c8f34cf98ded"
-      "sk"
-    end
-    language "sl" do
-      sha256 "99ffafc77fe872137d7e4330628c59616a5d88c8dc98265ca96ed7d12a6206ef"
-      "sl"
-    end
-    language "sq" do
-      sha256 "fa2c179e6faf67a667281ba38747c9795d8ac6b44c2618f5994b8d63dff3be26"
-      "sq"
-    end
-    language "sr" do
-      sha256 "48342cf366738ee616ea30ce398dde3a7ad6d58cda576806b69e304949c4cd11"
-      "sr"
-    end
-    language "ss" do
-      sha256 "4feea4897590ee3e79c07cc0b85d32a9c6d160ac21a8fbefd293ae1f93b56d66"
-      "ss"
-    end
-    language "st" do
-      sha256 "1104f1c5b1e53c61ffbc1927a21175a044019d99039cc5e51a1dda1f936d16eb"
-      "st"
-    end
-    language "sv" do
-      sha256 "3af4dfeb30ea3ebfdcbcb0b76f9fd4c5b84e3800716610d6a450aec954d60db9"
-      "sv"
-    end
-    language "sw-TZ" do
-      sha256 "76a94e86676a4134ec408e6c92925fb6901624cb34ff6ae24c66d21a91f43ade"
-      "sw-TZ"
-    end
-    language "ta" do
-      sha256 "3db2b43d37d4eb775232981e69dac932897ed70fa75c589ed9bc0d79dbb2f7ba"
-      "ta"
-    end
-    language "te" do
-      sha256 "a26dc6636b6ce0d3bab5750a71c0fb7cde47699ee61ca8a62bad2c55b8a039da"
-      "te"
-    end
-    language "tg" do
-      sha256 "9cb2d3afe3735d2a0271ac07ae73cbbb76679328871495e25ce56549f98c13e8"
-      "tg"
-    end
-    language "th" do
-      sha256 "412857e759cde5c2c541566a9378998b83064c6a8884b0da42c8ddc2a4f2dd68"
-      "th"
-    end
-    language "tn" do
-      sha256 "4c6e6e4897f7dd18f0e5fb4a7996120cc1027fc8206d9782096486b5df6f515b"
-      "tn"
-    end
-    language "tr" do
-      sha256 "1593aa2476a991014f6fa9756bbbf57f47a3806adc495a135057b86929d204fb"
-      "tr"
-    end
-    language "ts" do
-      sha256 "aecf759f6000f5bd6ac3221b87c070a632ad18ec614484c42ab2c68d92105285"
-      "ts"
-    end
-    language "tt" do
-      sha256 "df99ab40d6fb12bff8371dde9e2a48683f2517e29b9424fc289b8b885f6da209"
-      "tt"
-    end
-    language "ug" do
-      sha256 "edd7117760fd83ef386b2740824764cf2dcfc509e59c234cf16436265b34c439"
-      "ug"
-    end
-    language "uk" do
-      sha256 "9bacc6c4ea69da0942f9499cb49070f1f1f21588477d9ebc03747aefbe319f5d"
-      "uk"
-    end
-    language "uz" do
-      sha256 "a0cddf36e715cdb92962f72750de3652daf7de6a4d25df231a33872a6df68ccf"
-      "uz"
-    end
-    language "ve" do
-      sha256 "6aec0306f41482a0e8b84e3f6840ac11fc892a44afbadec6445b58f35922e7ff"
-      "ve"
-    end
-    language "vi" do
-      sha256 "c129732e05f163998e7765263775df99b6a7bfefc4586e954f03180b45ad585d"
-      "vi"
-    end
-    language "xh" do
-      sha256 "a14e17c8d239243842c8a8914fec9eb572f9ba81ee16e53e5b0d8bd0bd651ef5"
-      "xh"
-    end
-    language "zh-CN" do
-      sha256 "4809f81bfeb3709b6ffc53ac7c03abaaafd55a19795670d6f0227769d631db51"
-      "zh-CN"
-    end
-    language "zh-TW" do
-      sha256 "c7fb1d2d49ffea299ed5e646195285af6faed11c535035862429bff9fe884a46"
-      "zh-TW"
-    end
-    language "zu" do
-      sha256 "08cb81c06c9884a77f1dcaa6b4d9fcb6aa60e8fad7ad60bb98fc4a47ae6e9932"
-      "zu"
-    end
-  end
   on_arm do
     language "af" do
       sha256 "5d55bcb7d46d02c1f25a4b13a6deaa7bf455005c67417fe18cabf101e1f6b9b6"
@@ -789,6 +395,400 @@ cask "libreoffice-language-pack" do
     end
     language "zu" do
       sha256 "8fcd47fccfb0955b034f8ac20014b89c480f561b0376029b83b3e12de0174ed2"
+      "zu"
+    end
+  end
+  on_intel do
+    language "af" do
+      sha256 "0931b515cd55e4e259760ad991026deea6bc07ad20bf0632e75fdd89fe66f30f"
+      "af"
+    end
+    language "am" do
+      sha256 "269933c43488ce9cd8a3e3f085905892a43e807209c2860988602d2b7945e8d1"
+      "am"
+    end
+    language "ar" do
+      sha256 "0cbe5d90c932b864c5d5cec359cf7a74298fc47b820fe7e24c46f4b0938d281a"
+      "ar"
+    end
+    language "as" do
+      sha256 "e32f7ef6228cff6101bd351b233d0b1e3ec5f414eb8698b5f03e9f144a83021c"
+      "as"
+    end
+    language "be" do
+      sha256 "fe22c3b9ad31e4a3d988d0dc2162642abfb1010fb2deb875e26a94c3be11f6fb"
+      "be"
+    end
+    language "bg" do
+      sha256 "bf4b656bb371796bd9ee62015458e7581ecf0439c6785edfccd3dea570dd7ee8"
+      "bg"
+    end
+    language "bn-IN" do
+      sha256 "9bf71c07007fd47c47a08d5d21549a7808d58263f3b26a0f1b93557b84edb781"
+      "bn-IN"
+    end
+    language "bn" do
+      sha256 "c282cb77e814ddb5f08996e2614f4f34a6779fa2becb4ececfdb3aef50f3fcf6"
+      "bn"
+    end
+    language "bo" do
+      sha256 "ed9c851bde7deab68c29ba9946f12fa739b79c25505ffb6a24d773ac7530aa1a"
+      "bo"
+    end
+    language "br" do
+      sha256 "fe481632d05430c20c0353d26daef8ec3eb4e78dd693521beb01420bae864211"
+      "br"
+    end
+    language "bs" do
+      sha256 "fb9a93975252a057a6fd067f8c3c4e146cbffa6ae058a9848d907b9dfc7b75bb"
+      "bs"
+    end
+    language "ca" do
+      sha256 "408b6efbece5d5e631aafbfe4d25925b408be43c76d532cf9c708a7ed66c6b41"
+      "ca"
+    end
+    language "cs" do
+      sha256 "0a12e0445edb119ceb06e70444b7066e7a48f158333891db68f134c8fbb79c49"
+      "cs"
+    end
+    language "cy" do
+      sha256 "55b63023a89d72e4638212b162dfc5d2ec72e8809cb890a04791e248ec2ce313"
+      "cy"
+    end
+    language "da" do
+      sha256 "b00bfa690c243154c03d5fce4d9aa7ff88b86cb7df3792d0415f3d0c15915396"
+      "da"
+    end
+    language "de" do
+      sha256 "87c882916f7944c1b3717b24e5eaec2f596684db2cc07f5744f6fa664a8e6569"
+      "de"
+    end
+    language "dz" do
+      sha256 "be97fd5678c23aa29d2d77e50c2f5f747a62a3046907f446622d95e151981ae2"
+      "dz"
+    end
+    language "el" do
+      sha256 "f7a101fd64296e96f3c622ad7dc7d436c0740be58be6a40a88563b4862b33bb9"
+      "el"
+    end
+    language "en-GB", default: true do
+      sha256 "b14506396b471c65966021eba8fd6966a9a9f7063418999b12b09d806872a735"
+      "en-GB"
+    end
+    language "en-ZA" do
+      sha256 "12dc7038e01f46f73c96af9fb3b364a1c83ed976bb10bc93d6052973cf202caf"
+      "en-ZA"
+    end
+    language "eo" do
+      sha256 "e8153f31753d11ea7fb1a6de7124ba3e41c9ec87f893b177c36df6a44974f7a3"
+      "eo"
+    end
+    language "es" do
+      sha256 "3ec86aef385d3cc86cc96c7f22f431966fde6cae66ab6038dd2045744c85d6ef"
+      "es"
+    end
+    language "et" do
+      sha256 "358f633a9770fb2d559dd2304c2e1b3d3ca62b5273c314b8adbac4146444d7bf"
+      "et"
+    end
+    language "eu" do
+      sha256 "955812af92db06e474f059525dcf0738bd0d80aa8cc771fd63471babc1a916d7"
+      "eu"
+    end
+    language "fa" do
+      sha256 "875a338eb136a82af986d56a8388a430568929d222d4e7cc863be894943196f7"
+      "fa"
+    end
+    language "fi" do
+      sha256 "603d7fceaeb96849f21aafc8bbfea72bbfdeae3cd996341dd10cf7aac5c8df8a"
+      "fi"
+    end
+    language "fr" do
+      sha256 "549a8799cbe3bb6b65ea9fcb19e538154d1cbb28f56cdfa7d9f9f0bf9d389e68"
+      "fr"
+    end
+    language "fy" do
+      sha256 "c6835afc915dc253b7d613c9497c0a846828b2e3e3351efbde13cbc54ea6b75d"
+      "fy"
+    end
+    language "ga" do
+      sha256 "6516a3e89a00bef0bb0bfc807a63f15653a9fd298f9cc6ad02e0600946fe9f65"
+      "ga"
+    end
+    language "gd" do
+      sha256 "c887496916edc10d592434970c5b101b943fdf4bd209053931dd41d72e0a4149"
+      "gd"
+    end
+    language "gl" do
+      sha256 "1c41b708cd4357c9900f175c7afdf6d0bd4240119c7751defdb752f009a3f8c9"
+      "gl"
+    end
+    language "gu" do
+      sha256 "36642bfacaa9c997f77bede46b08f5a4cef3dd89ee5ffff9a2492f6ca75bbdcb"
+      "gu"
+    end
+    language "he" do
+      sha256 "25d58fae4e53f15b3fd72009f469461859ba42af940362cc58a7aabe44afb152"
+      "he"
+    end
+    language "hi" do
+      sha256 "548dadb51d87ac9f53b16a5dd30cd010fdbd8e1909520a4a22963e816b239c1c"
+      "hi"
+    end
+    language "hr" do
+      sha256 "06dbca3ad15a3bedc6a006fae7c5687e57fef56ab0dcf6dcf672d240fe835792"
+      "hr"
+    end
+    language "hu" do
+      sha256 "0b9772d43b7faa4737b5331829bc777afd7671d7bb5419c845fd67a029e649c2"
+      "hu"
+    end
+    language "id" do
+      sha256 "c7d08f7f56728810255dfafe0aa45cb08e5c33f4033e6a6113fb22a426089038"
+      "id"
+    end
+    language "is" do
+      sha256 "5a341278212a7fa1f2356b24ad73c131fc7796a67234d6fdc7daa611eea7e03b"
+      "is"
+    end
+    language "it" do
+      sha256 "33d2b2a69d2ea6768d9180cf957b932308df8ffce515ef466addfd087dc4481d"
+      "it"
+    end
+    language "ja" do
+      sha256 "313cb917b2b5e48883f98ff093b06fb380d4b3684538f4b4f13aa0ef61a1ac0f"
+      "ja"
+    end
+    language "ka" do
+      sha256 "0f652cd5726e9f1264dddeb2cd30dacc5bbb139253485ef2bdfaeb0ded0c6763"
+      "ka"
+    end
+    language "kk" do
+      sha256 "15f5f5423c1b77127da0d865d20fabba32638207d4f9f2ea3056a1ea63569f42"
+      "kk"
+    end
+    language "km" do
+      sha256 "7d8338d5e073840f37598b37a9f97adabc18e45f0160e097254f49104514895f"
+      "km"
+    end
+    language "kn" do
+      sha256 "a747c5754260d877fd9299416529ce0342cefeb8f738336fe7dd74743d0993e2"
+      "kn"
+    end
+    language "ko" do
+      sha256 "f02a1198c8e2841a3578c02604b7b276b2c99b46f074aecf4755a11e9470336e"
+      "ko"
+    end
+    language "ks" do
+      sha256 "f07fbfe1576ca510a0d075b926f0b59ef94734cdd8113bbe4a79d37a09d1717d"
+      "ks"
+    end
+    language "lb" do
+      sha256 "5664278a6ca15e2e2fc73f6bd13b12f8e85a1af8e553cc6e56faa51b554b09d8"
+      "lb"
+    end
+    language "lo" do
+      sha256 "5bc40ac86703079414b6d4561af81eff3731c90c116f61dcdd7fc6681246aebd"
+      "lo"
+    end
+    language "lt" do
+      sha256 "722f42b1a1039cbaf2c18a813a0852b58e2a23fd0c71fdd01e1535db4390184d"
+      "lt"
+    end
+    language "lv" do
+      sha256 "e97cfb436f9b36c3e19d694c7f1dc86e54436c263811122334e3a9742162f5ae"
+      "lv"
+    end
+    language "mk" do
+      sha256 "9df22823e1fed0b89482eabcb0253745d62116f9aab612778afd5848eec5a328"
+      "mk"
+    end
+    language "ml" do
+      sha256 "6757102d6700bd97e038619d5ff491df01585908d43d98d9c4fa2e3bdf7e8cc5"
+      "ml"
+    end
+    language "mn" do
+      sha256 "2ad2a26a2a8b4ce15f67fc2fb936569f299aa91c1dbc0df5d497a68b13948210"
+      "mn"
+    end
+    language "mr" do
+      sha256 "6ef7a48d644a445528a8d316e66c76af62396260725e314d729132e1167d02b2"
+      "mr"
+    end
+    language "my" do
+      sha256 "4474980f3f7baad6bba6d95195cb772ceb12b33ee87e9bf998772f38a1e31a88"
+      "my"
+    end
+    language "nb" do
+      sha256 "17188c9592089b81eabc2de5521de42ca958529fa4fe857ba865a6cf8b4fc5d6"
+      "nb"
+    end
+    language "ne" do
+      sha256 "4aab1245b8aa14c3dde55e00c8412f40450298da8e2c1ec0a3252a0418f9a6db"
+      "ne"
+    end
+    language "nl" do
+      sha256 "b7d379aeb8cb15f834c9e2f2049809bdbdeef9a19c71519eb5205aebc3929575"
+      "nl"
+    end
+    language "nn" do
+      sha256 "553518dbd7748c8c4b048b6275379834bc3bb1b0190d68b74e04dad847a114bb"
+      "nn"
+    end
+    language "nr" do
+      sha256 "cfafedb9ea5ab2b9612b3131ccda3300be55ab91fd5b1ceae0554004d187276b"
+      "nr"
+    end
+    language "oc" do
+      sha256 "3c0d2860460e3ca97ea7168283e5fad6266d087fcdf7c95cb03f7f2d29b9a582"
+      "oc"
+    end
+    language "om" do
+      sha256 "f86c32b2a24fb72c0379057bb2b0046ddee781ba95e6dc48377db7da7084e449"
+      "om"
+    end
+    language "or" do
+      sha256 "2973e6d26b6d2ecca02eea209ce35112a51cef868c66f2ad2996046b6ed50095"
+      "or"
+    end
+    language "pa-IN" do
+      sha256 "9099d1885a869cf540d011f129a3cc1f02e8f89e61c4495704b18555e5f2c604"
+      "pa-IN"
+    end
+    language "pl" do
+      sha256 "a8bf19838d6863fca9e41178e3f7afaa80d404ff96d37dad200a0a6993f51424"
+      "pl"
+    end
+    language "pt-BR" do
+      sha256 "1531ebfaf5cbb2cc58018bb2a262ea9df4625704c90ff689103478ba105b2f86"
+      "pt-BR"
+    end
+    language "pt" do
+      sha256 "9739b8860d0f8313aac05278b3213ac05b0bfe902c78ffccb77b5ad87f4fe8af"
+      "pt"
+    end
+    language "ro" do
+      sha256 "09d91a4e5baf81bbfd7c1c786786e9c1ce6299fa6e02a091e60c2dbb96d89823"
+      "ro"
+    end
+    language "ru" do
+      sha256 "c6e6470fffb88330a2590adbab2521e8a41047da889cc4fffc6093de4b4e7c17"
+      "ru"
+    end
+    language "rw" do
+      sha256 "6d52e957fb92777128fc23adc43de61200a551c6c981ea1bb70ba901651d1482"
+      "rw"
+    end
+    language "sa-IN" do
+      sha256 "8eedd078a3abb3006b165d70e3010f48295dddb93575c2352b9208e91b68f3b9"
+      "sa-IN"
+    end
+    language "sd" do
+      sha256 "286edb579fc010feb41a1d913aadc103a6e350d781e137c22eb5f002540507a6"
+      "sd"
+    end
+    language "si" do
+      sha256 "1d0617dd46aaf1f3c844c6cea336329ffb977df20a313995bdbeaaf6f6a8d8f2"
+      "si"
+    end
+    language "sk" do
+      sha256 "b13f8258279c08d291820cbfea2b271b2002fe94354bb490a590c8f34cf98ded"
+      "sk"
+    end
+    language "sl" do
+      sha256 "99ffafc77fe872137d7e4330628c59616a5d88c8dc98265ca96ed7d12a6206ef"
+      "sl"
+    end
+    language "sq" do
+      sha256 "fa2c179e6faf67a667281ba38747c9795d8ac6b44c2618f5994b8d63dff3be26"
+      "sq"
+    end
+    language "sr" do
+      sha256 "48342cf366738ee616ea30ce398dde3a7ad6d58cda576806b69e304949c4cd11"
+      "sr"
+    end
+    language "ss" do
+      sha256 "4feea4897590ee3e79c07cc0b85d32a9c6d160ac21a8fbefd293ae1f93b56d66"
+      "ss"
+    end
+    language "st" do
+      sha256 "1104f1c5b1e53c61ffbc1927a21175a044019d99039cc5e51a1dda1f936d16eb"
+      "st"
+    end
+    language "sv" do
+      sha256 "3af4dfeb30ea3ebfdcbcb0b76f9fd4c5b84e3800716610d6a450aec954d60db9"
+      "sv"
+    end
+    language "sw-TZ" do
+      sha256 "76a94e86676a4134ec408e6c92925fb6901624cb34ff6ae24c66d21a91f43ade"
+      "sw-TZ"
+    end
+    language "ta" do
+      sha256 "3db2b43d37d4eb775232981e69dac932897ed70fa75c589ed9bc0d79dbb2f7ba"
+      "ta"
+    end
+    language "te" do
+      sha256 "a26dc6636b6ce0d3bab5750a71c0fb7cde47699ee61ca8a62bad2c55b8a039da"
+      "te"
+    end
+    language "tg" do
+      sha256 "9cb2d3afe3735d2a0271ac07ae73cbbb76679328871495e25ce56549f98c13e8"
+      "tg"
+    end
+    language "th" do
+      sha256 "412857e759cde5c2c541566a9378998b83064c6a8884b0da42c8ddc2a4f2dd68"
+      "th"
+    end
+    language "tn" do
+      sha256 "4c6e6e4897f7dd18f0e5fb4a7996120cc1027fc8206d9782096486b5df6f515b"
+      "tn"
+    end
+    language "tr" do
+      sha256 "1593aa2476a991014f6fa9756bbbf57f47a3806adc495a135057b86929d204fb"
+      "tr"
+    end
+    language "ts" do
+      sha256 "aecf759f6000f5bd6ac3221b87c070a632ad18ec614484c42ab2c68d92105285"
+      "ts"
+    end
+    language "tt" do
+      sha256 "df99ab40d6fb12bff8371dde9e2a48683f2517e29b9424fc289b8b885f6da209"
+      "tt"
+    end
+    language "ug" do
+      sha256 "edd7117760fd83ef386b2740824764cf2dcfc509e59c234cf16436265b34c439"
+      "ug"
+    end
+    language "uk" do
+      sha256 "9bacc6c4ea69da0942f9499cb49070f1f1f21588477d9ebc03747aefbe319f5d"
+      "uk"
+    end
+    language "uz" do
+      sha256 "a0cddf36e715cdb92962f72750de3652daf7de6a4d25df231a33872a6df68ccf"
+      "uz"
+    end
+    language "ve" do
+      sha256 "6aec0306f41482a0e8b84e3f6840ac11fc892a44afbadec6445b58f35922e7ff"
+      "ve"
+    end
+    language "vi" do
+      sha256 "c129732e05f163998e7765263775df99b6a7bfefc4586e954f03180b45ad585d"
+      "vi"
+    end
+    language "xh" do
+      sha256 "a14e17c8d239243842c8a8914fec9eb572f9ba81ee16e53e5b0d8bd0bd651ef5"
+      "xh"
+    end
+    language "zh-CN" do
+      sha256 "4809f81bfeb3709b6ffc53ac7c03abaaafd55a19795670d6f0227769d631db51"
+      "zh-CN"
+    end
+    language "zh-TW" do
+      sha256 "c7fb1d2d49ffea299ed5e646195285af6faed11c535035862429bff9fe884a46"
+      "zh-TW"
+    end
+    language "zu" do
+      sha256 "08cb81c06c9884a77f1dcaa6b4d9fcb6aa60e8fad7ad60bb98fc4a47ae6e9932"
       "zu"
     end
   end

--- a/Casks/librewolf.rb
+++ b/Casks/librewolf.rb
@@ -1,13 +1,13 @@
 cask "librewolf" do
   arch arm: "aarch64", intel: "x86_64"
 
-  on_intel do
-    version "110.0,1,888ba593f6db715c053f5d3247c1b10e"
-    sha256 "93f41c758e5f1918a4061170f689022dfe4bce43420fe402958372892332639e"
-  end
   on_arm do
     version "110.0,1,fc1f7e860eb340beddce51556642a82b"
     sha256 "b9bfee951d72669db40f70f4585774acd884c52c60feb391cdd4072a06d92268"
+  end
+  on_intel do
+    version "110.0,1,888ba593f6db715c053f5d3247c1b10e"
+    sha256 "93f41c758e5f1918a4061170f689022dfe4bce43420fe402958372892332639e"
   end
 
   url "https://gitlab.com/librewolf-community/browser/macos/uploads/#{version.csv.third}/librewolf-#{version.csv.first}-#{version.csv.second}.en-US.mac.#{arch}.dmg",

--- a/Casks/mini-program-studio.rb
+++ b/Casks/mini-program-studio.rb
@@ -1,13 +1,13 @@
 cask "mini-program-studio" do
   arch arm: "-arm64", intel: "-x64"
 
-  on_intel do
-    version "3.3.3,4ddf7f5b-73cd-42dd-806f-5fd90a8327b8"
-    sha256 "539f1f259a1095e1d1639f27db6e7ef218e89a956d1aa394d8c143804b82f965"
-  end
   on_arm do
     version "3.3.3,473624af-67c4-4f44-938a-b84217d1db3b"
     sha256 "9e73204f12cba2657551363669b08194f0060cfeaa456ab987540d1aa3cba790"
+  end
+  on_intel do
+    version "3.3.3,4ddf7f5b-73cd-42dd-806f-5fd90a8327b8"
+    sha256 "539f1f259a1095e1d1639f27db6e7ef218e89a956d1aa394d8c143804b82f965"
   end
 
   url "https://gw.alipayobjects.com/os/volans-demo/#{version.csv.second}/MiniProgramStudio-#{version.csv.first}#{arch}.dmg",

--- a/Casks/motrix.rb
+++ b/Casks/motrix.rb
@@ -1,16 +1,16 @@
 cask "motrix" do
   version "1.6.11"
 
-  on_intel do
-    sha256 "70fa245e44b8e0ec62f50ba5731bc0a876535a51dc0ea318010736d2a6be6dd9"
-
-    url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}.dmg",
-        verified: "github.com/agalwood/Motrix/"
-  end
   on_arm do
     sha256 "1705d6ef4781c17ebf19007dbb2ac52f6227592c783e91ad5b81a1432cf6b668"
 
     url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}-arm64.dmg",
+        verified: "github.com/agalwood/Motrix/"
+  end
+  on_intel do
+    sha256 "70fa245e44b8e0ec62f50ba5731bc0a876535a51dc0ea318010736d2a6be6dd9"
+
+    url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}.dmg",
         verified: "github.com/agalwood/Motrix/"
   end
 

--- a/Casks/ocenaudio.rb
+++ b/Casks/ocenaudio.rb
@@ -2,6 +2,9 @@ cask "ocenaudio" do
   version "3.11.22"
   sha256 :no_check
 
+  on_arm do
+    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_bigsur_arm64.dmg"
+  end
   on_intel do
     on_high_sierra :or_older do
       url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg"
@@ -15,9 +18,6 @@ cask "ocenaudio" do
     on_big_sur :or_newer do
       url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_bigsur.dmg"
     end
-  end
-  on_arm do
-    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_bigsur_arm64.dmg"
   end
 
   name "ocenaudio"

--- a/Casks/oxwu.rb
+++ b/Casks/oxwu.rb
@@ -1,4 +1,14 @@
 cask "oxwu" do
+  on_arm do
+    version "4.1.0"
+    sha256 :no_check
+    url "https://eew.earthquake.tw/releases/mac/arm64/oxwu-mac-arm64.dmg"
+
+    livecheck do
+      url "https://eew.earthquake.tw/releases/mac/arm64/latest-mac.yml"
+      strategy :electron_builder
+    end
+  end
   on_intel do
     version "3.0.0"
     sha256 :no_check
@@ -10,16 +20,6 @@ cask "oxwu" do
       <<~EOS
         Development has ended on the Intel version.
       EOS
-    end
-  end
-  on_arm do
-    version "4.1.0"
-    sha256 :no_check
-    url "https://eew.earthquake.tw/releases/mac/arm64/oxwu-mac-arm64.dmg"
-
-    livecheck do
-      url "https://eew.earthquake.tw/releases/mac/arm64/latest-mac.yml"
-      strategy :electron_builder
     end
   end
 

--- a/Casks/qcad.rb
+++ b/Casks/qcad.rb
@@ -5,14 +5,13 @@ cask "qcad" do
   sha256 arm:   "5f4340e2feb72699b87dbaf8cd8708f54a0cb44874516fdcf21b36fc5a1fb269",
          intel: "cf8578789a17b7f4a550646063e6a12634440b20172f1e21b9cd260b176a4e92"
 
-  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-#{arch}.dmg"
-
   on_high_sierra :or_older do
     sha256 "589a84168c38bf57435441511b19fa081b622e009719c4be7cc1385b7dc55eeb"
 
     url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-10.10-10.13.dmg"
   end
 
+  url "https://www.qcad.org/archives/qcad/qcad-#{version}-trial-macos-#{arch}.dmg"
   name "QCAD"
   desc "Free, open source application for computer aided drafting in 2D"
   homepage "https://www.qcad.org/"

--- a/Casks/r.rb
+++ b/Casks/r.rb
@@ -6,8 +6,6 @@ cask "r" do
   sha256 arm:   "a0fa5cdd3d3e14e0420d9605b5bfbad80267d1805c1f5a92672c157337d739c1",
          intel: "df8db457fcc8aafbe1b084f87ec9fa8763fbcf909f9a252d05c28eb4c2aff0ff"
 
-  url "https://cloud.r-project.org/bin/macosx/#{folder}R-#{version}#{arch}.pkg"
-
   on_sierra :or_older do
     version "3.6.3.nn"
     sha256 "f2b771e94915af0fe0a6f042bc7a04ebc84fb80cb01aad5b7b0341c4636336dd"
@@ -15,6 +13,7 @@ cask "r" do
     url "https://cloud.r-project.org/bin/macosx/R-#{version}.pkg"
   end
 
+  url "https://cloud.r-project.org/bin/macosx/#{folder}R-#{version}#{arch}.pkg"
   name "R"
   desc "Environment for statistical computing and graphics"
   homepage "https://www.r-project.org/"

--- a/Casks/smartgit.rb
+++ b/Casks/smartgit.rb
@@ -5,8 +5,6 @@ cask "smartgit" do
   sha256 arm:   "f921ea2049abbcbc5834dad1e3fd7285a3f34b3aba95a02f0a425ef848d2fa01",
          intel: "2522cd123af57ce9e6b752de357df43c3321792dce45e0c84e1b5f56ab985ee4"
 
-  url "https://www.syntevo.com/downloads/smartgit/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
-
   on_sierra :or_older do
     version "20.2.6"
     sha256 "af5fbf8db26edde3d996d99c6e82287332598359fe63ff2cd97c712a1685a2ea"
@@ -14,6 +12,7 @@ cask "smartgit" do
     url "https://www.syntevo.com/downloads/smartgit/smartgit-macosx-#{version.dots_to_underscores}.dmg"
   end
 
+  url "https://www.syntevo.com/downloads/smartgit/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
   name "SmartGit"
   desc "Git client"
   homepage "https://www.syntevo.com/smartgit/"

--- a/Casks/stack-stack.rb
+++ b/Casks/stack-stack.rb
@@ -1,15 +1,15 @@
 cask "stack-stack" do
   version "3.43.2"
 
-  on_intel do
-    sha256 "5846b9af905bdbaef11f04c099a0d0015ab62077ca4d17f33946ca473ef9dd91"
-
-    url "https://binaries.getstack.app/builds/prod/Stack-#{version}.dmg"
-  end
   on_arm do
     sha256 "2615a79ea08750e3fd4f60b376f8a4e617d578e4c21863a55af0adccc8504dc5"
 
     url "https://binaries.getstack.app/builds/prod/mac/arm64/Stack%20#{version}-arm64.dmg"
+  end
+  on_intel do
+    sha256 "5846b9af905bdbaef11f04c099a0d0015ab62077ca4d17f33946ca473ef9dd91"
+
+    url "https://binaries.getstack.app/builds/prod/Stack-#{version}.dmg"
   end
 
   name "Stack"

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,4 +1,6 @@
 cask "teamviewer" do
+  sha256 :no_check
+
   on_high_sierra :or_older do
     version "15.2.2756"
 
@@ -6,6 +8,9 @@ cask "teamviewer" do
       url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.11.1&type=1&channel=1"
       strategy :sparkle
     end
+  end
+  on_high_sierra :or_older do
+    pkg "Install TeamViewer.pkg"
   end
   on_mojave :or_newer do
     version "15.39.5"
@@ -15,30 +20,7 @@ cask "teamviewer" do
       strategy :sparkle
     end
   end
-
-  sha256 :no_check
-
-  url "https://download.teamviewer.com/download/TeamViewer.dmg"
-  name "TeamViewer"
-  desc "Remote access and connectivity software focused on security"
-  homepage "https://www.teamviewer.com/"
-
-  auto_updates true
-  conflicts_with cask: "teamviewer-host"
-  depends_on macos: ">= :el_capitan"
-
-  on_high_sierra :or_older do
-    pkg "Install TeamViewer.pkg"
-  end
   on_mojave do
-    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
-  end
-  on_catalina do
-    # This Cask should be installed and uninstalled manually on Catalina.
-    # See https://github.com/Homebrew/homebrew-cask/issues/76829
-    installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
-  end
-  on_big_sur :or_newer do
     pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
   end
   on_mojave :or_older do
@@ -76,6 +58,11 @@ cask "teamviewer" do
   on_catalina do
     # This Cask should be installed and uninstalled manually on Catalina.
     # See https://github.com/Homebrew/homebrew-cask/issues/76829
+    installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+  end
+  on_catalina do
+    # This Cask should be installed and uninstalled manually on Catalina.
+    # See https://github.com/Homebrew/homebrew-cask/issues/76829
     uninstall delete: "#{staged_path}/#{token}"
 
     caveats <<~EOS
@@ -84,6 +71,9 @@ cask "teamviewer" do
 
          Preferences → Advanced
     EOS
+  end
+  on_big_sur :or_newer do
+    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
   end
   on_big_sur :or_newer do
     uninstall delete:    [
@@ -117,4 +107,13 @@ cask "teamviewer" do
       "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
     ]
   end
+
+  url "https://download.teamviewer.com/download/TeamViewer.dmg"
+  name "TeamViewer"
+  desc "Remote access and connectivity software focused on security"
+  homepage "https://www.teamviewer.com/"
+
+  auto_updates true
+  conflicts_with cask: "teamviewer-host"
+  depends_on macos: ">= :el_capitan"
 end

--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -6,8 +6,6 @@ cask "transcribe" do
   version "9.21"
   sha256 :no_check
 
-  url "https://www.seventhstring.com/xscribe/transcribe#{arch}.dmg"
-
   on_catalina :or_older do
     version "8.75.2"
     sha256 "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
@@ -17,6 +15,7 @@ cask "transcribe" do
     livecheck_version = "10"
   end
 
+  url "https://www.seventhstring.com/xscribe/transcribe#{arch}.dmg"
   name "Transcribe!"
   desc "Transcribes recorded music"
   homepage "https://www.seventhstring.com/xscribe/overview.html"

--- a/Casks/wechatwork.rb
+++ b/Casks/wechatwork.rb
@@ -1,13 +1,13 @@
 cask "wechatwork" do
   arch arm: "_arm64"
 
-  on_intel do
-    version "4.1.0.90666"
-    sha256 "a39928b787749aac31a34f8147bf54606d6d754d9044c8c907bd2ff83f8061ad"
-  end
   on_arm do
     version "4.1.0.99228"
     sha256 "d45f60521868c43e96bd420361327b43389febbd726184ee9ae305000942634a"
+  end
+  on_intel do
+    version "4.1.0.90666"
+    sha256 "a39928b787749aac31a34f8147bf54606d6d754d9044c8c907bd2ff83f8061ad"
   end
 
   url "https://dldir1.qq.com/foxmail/wecom-mac/update/WeCom_#{version}.dmg"


### PR DESCRIPTION
This is a proof of concept for https://github.com/Homebrew/brew/pull/14976. That PR adds a RuboCop for ensuring a consistent order of `on_#{os_version}` and `on_#{arch}` blocks. In the review for that new feature it was deemed more consistent with current style to have the `on_#{os_version}` in order from oldest to newest.

What do you think?

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
