### PR TITLE
Move strategy after regex in livecheck blocks

### DIFF
--- a/Casks/ampps.rb
+++ b/Casks/ampps.rb
@@ -10,8 +10,8 @@ cask "ampps" do
 
   livecheck do
     url "https://api.ampps.com/download.php?arch=mac64"
-    strategy :header_match
     regex(/AMPPS[._-]v?(\d+(?:\.\d+)+)-x86_64\.dmg/i)
+    strategy :header_match
   end
 
   suite "AMPPS"

--- a/Casks/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/anka-build-cloud-controller-and-registry.rb
@@ -9,8 +9,8 @@ cask "anka-build-cloud-controller-and-registry" do
 
   livecheck do
     url "https://veertu.com/downloads/ankacontroller-registry-mac-latest"
-    strategy :header_match
     regex(/AnkaControllerRegistry[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
+    strategy :header_match
   end
 
   pkg "AnkaControllerRegistry-#{version}.pkg"

--- a/Casks/anka-virtualization.rb
+++ b/Casks/anka-virtualization.rb
@@ -18,8 +18,8 @@ cask "anka-virtualization" do
 
   livecheck do
     url "https://veertu.com/downloads/anka-virtualization-#{livecheck_folder}"
-    strategy :header_match
     regex(/Anka[._-]?v?(\d+(?:\.\d+)+)#{arch}\.pkg/i)
+    strategy :header_match
   end
 
   depends_on macos: ">= :monterey"

--- a/Casks/appgrid.rb
+++ b/Casks/appgrid.rb
@@ -9,8 +9,8 @@ cask "appgrid" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(/href=.*?AppGrid[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    strategy :page_match
   end
 
   app "AppGrid.app"

--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -10,8 +10,8 @@ cask "appium" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   app "Appium Server GUI.app"

--- a/Casks/brl-cad-mged.rb
+++ b/Casks/brl-cad-mged.rb
@@ -5,12 +5,13 @@ cask "brl-cad-mged" do
   url "https://downloads.sourceforge.net/brlcad/BRL-CAD%20for%20Mac%20OS%20X/#{version}/BRL-CAD%20#{version}.dmg",
       verified: "downloads.sourceforge.net/brlcad/"
   name "BRL-CAD"
+  desc "Solid modeling system"
   homepage "https://brlcad.org/"
 
   livecheck do
     url "https://sourceforge.net/projects/brlcad/rss?path=/BRL-CAD%20for%20Mac%20OS%20X"
-    strategy :page_match
     regex(%r{url=.*?/BRL-CAD(?:[._-]|%20)v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match
   end
 
   depends_on cask: "xquartz"

--- a/Casks/cakebrewjs.rb
+++ b/Casks/cakebrewjs.rb
@@ -9,8 +9,8 @@ cask "cakebrewjs" do
 
   livecheck do
     url "https://sourceforge.net/projects/cakebrewjs/rss?"
-    strategy :page_match
     regex(/cakebrewjs-(\d+(?:\.\d+)+)-mac\.zip/i)
+    strategy :page_match
   end
 
   app "cakebrewjs.app"

--- a/Casks/clips-ide.rb
+++ b/Casks/clips-ide.rb
@@ -10,8 +10,8 @@ cask "clips-ide" do
 
   livecheck do
     url "https://sourceforge.net/projects/clipsrules/files/latest/download"
-    strategy :header_match
     regex(%r{/CLIPS/(\d+(?:\.\d+)+)/}i)
+    strategy :header_match
   end
 
   depends_on macos: ">= :el_capitan"

--- a/Casks/clock.rb
+++ b/Casks/clock.rb
@@ -9,8 +9,8 @@ cask "clock" do
 
   livecheck do
     url "https://github.com/zachwaugh/Clock.app"
-    strategy :page_match
     regex(%r{href=.*?/Clock-(\d+(?:\.\d+)+)\.zip}i)
+    strategy :page_match
   end
 
   app "Clock.app"

--- a/Casks/copytranslator.rb
+++ b/Casks/copytranslator.rb
@@ -10,8 +10,8 @@ cask "copytranslator" do
 
   livecheck do
     url "https://github.com/CopyTranslator/copytranslator.github.io/blob/master/docs/.vuepress/public/wiki/mac.md"
-    strategy :page_match
     regex(%r{href=.*?/copytranslator[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/dd-utility.rb
+++ b/Casks/dd-utility.rb
@@ -9,8 +9,8 @@ cask "dd-utility" do
 
   livecheck do
     url "https://github.com/thefanclub/dd-utility/tree/master/DMG"
-    strategy :page_match
     regex(%r{href=.*?/ddUtility[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match
   end
 
   app "dd Utility.app"

--- a/Casks/dingtalk-lite.rb
+++ b/Casks/dingtalk-lite.rb
@@ -10,8 +10,8 @@ cask "dingtalk-lite" do
 
   livecheck do
     url "https://www.dingtalk.com/mac/d/qd=20170420173511985"
-    strategy :header_match
     regex(/DingTalkLite_v(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/dingtalk.rb
+++ b/Casks/dingtalk.rb
@@ -20,8 +20,8 @@ cask "dingtalk" do
 
   livecheck do
     url "https://www.dingtalk.com/mac/d/#{linkid}"
-    strategy :header_match
     regex(/DingTalk[._-]v?(\d+(?:.\d+)+)[._-]#{arch}\.dmg/i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/elk.rb
+++ b/Casks/elk.rb
@@ -12,8 +12,8 @@ cask "elk" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/elk[._-]native[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   app "Elk.app"

--- a/Casks/enzymex.rb
+++ b/Casks/enzymex.rb
@@ -9,8 +9,8 @@ cask "enzymex" do
 
   livecheck do
     url "https://nucleobytes.com/versionEnzymeX.txt"
-    strategy :page_match
     regex(/\d+(?:\.\d+)+/)
+    strategy :page_match
   end
 
   app "EnzymeX.app"

--- a/Casks/fantasy-map-generator.rb
+++ b/Casks/fantasy-map-generator.rb
@@ -10,8 +10,8 @@ cask "fantasy-map-generator" do
 
   livecheck do
     url "https://github.com/Azgaar/Fantasy-Map-Generator/wiki/Q&A#is-there-a-desktop-version"
-    strategy :page_match
     regex(%r{v?(\d+(?:\.\d+)+)/FMG[._-]macos[._-]x64.dmg}i)
+    strategy :page_match
   end
 
   app "Azgaar's Fantasy Map Generator.app"

--- a/Casks/feem.rb
+++ b/Casks/feem.rb
@@ -10,8 +10,8 @@ cask "feem" do
 
   livecheck do
     url "https://feem.link/feem-for-mac"
-    strategy :header_match
     regex(/Feem[._-]Mac[._-]v?(\d+(?:\.\d+)+).*?\.pkg/i)
+    strategy :header_match
   end
 
   pkg "Feem_Mac_#{version}_beta_Installer.pkg"

--- a/Casks/fldigi.rb
+++ b/Casks/fldigi.rb
@@ -9,8 +9,8 @@ cask "fldigi" do
 
   livecheck do
     url "https://sourceforge.net/projects/fldigi/rss?path=/fldigi"
-    strategy :page_match
     regex(/fldigi[._-]v?(\d+(?:\.\d+)+)[._-]u\.dmg/i)
+    strategy :page_match
   end
 
   app "fldigi.app"

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -16,8 +16,8 @@ cask "flrig" do
 
   livecheck do
     url "https://sourceforge.net/projects/fldigi/rss?path=/flrig"
-    strategy :page_match
     regex(/flrig[._-]v?(\d+(?:\.\d+)+)\w*\.dmg/i)
+    strategy :page_match
   end
 
   app "flrig.app"

--- a/Casks/freeplane.rb
+++ b/Casks/freeplane.rb
@@ -13,8 +13,8 @@ cask "freeplane" do
 
   livecheck do
     url "https://sourceforge.net/projects/freeplane/rss?path=/freeplane%20stable"
-    strategy :page_match
     regex(%r{/freeplane%20stable/Freeplane[._-]v?(\d+(?:\.\d+)+)(?:[._-]#{arch})?\.dmg}i)
+    strategy :page_match
   end
 
   app "Freeplane.app"

--- a/Casks/frescobaldi.rb
+++ b/Casks/frescobaldi.rb
@@ -10,8 +10,8 @@ cask "frescobaldi" do
 
   livecheck do
     url "https://github.com/frescobaldi/frescobaldi/releases/"
-    strategy :page_match
     regex(/Frescobaldi[._-]v?(\d+(?:\.\d+)+)[._-]x86[._-]64\.dmg/i)
+    strategy :page_match
   end
 
   app "Frescobaldi.app"

--- a/Casks/fsnotes.rb
+++ b/Casks/fsnotes.rb
@@ -10,8 +10,8 @@ cask "fsnotes" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   app "FSNotes.app"

--- a/Casks/github.rb
+++ b/Casks/github.rb
@@ -14,8 +14,8 @@ cask "github" do
 
   livecheck do
     url "https://central.github.com/deployments/desktop/desktop/latest/#{platform}"
-    strategy :header_match
     regex(%r{(\d+(?:\.\d+)[^/]*)/GitHubDesktop[._-]#{arch}\.zip}i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/gretl.rb
+++ b/Casks/gretl.rb
@@ -10,8 +10,8 @@ cask "gretl" do
 
   livecheck do
     url "https://gretl.sourceforge.net/osx.html"
-    strategy :page_match
     regex(/gretl[._-]v?(\d+\w)[._-]macos[._-]intel\.pkg/i)
+    strategy :page_match
   end
 
   pkg "gretl-#{version}-macos-intel.pkg"

--- a/Casks/hugin.rb
+++ b/Casks/hugin.rb
@@ -9,8 +9,8 @@ cask "hugin" do
 
   livecheck do
     url "https://hugin.sourceforge.net/download/"
-    strategy :page_match
     regex(/Hugin-(\d+(?:\.\d+)*)\.dmg/i)
+    strategy :page_match
   end
 
   suite "Hugin"

--- a/Casks/itunes-volume-control.rb
+++ b/Casks/itunes-volume-control.rb
@@ -10,8 +10,8 @@ cask "itunes-volume-control" do
 
   livecheck do
     url "https://github.com/alberti42/Volume-Control#versions"
-    strategy :page_match
     regex(%r{href=.*?/VolumeControl[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    strategy :page_match
   end
 
   auto_updates true

--- a/Casks/jupyterlab.rb
+++ b/Casks/jupyterlab.rb
@@ -9,8 +9,8 @@ cask "jupyterlab" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   app "JupyterLab.app"

--- a/Casks/keysafe.rb
+++ b/Casks/keysafe.rb
@@ -9,8 +9,8 @@ cask "keysafe" do
 
   livecheck do
     url "https://miln.eu/keysafe/miln-keysafe-darwin-universal.zip"
-    strategy :header_match
     regex(/miln-keysafe[._-]v?(\d+(?:\.\d+)+)-darwin-universal\.zip/i)
+    strategy :header_match
   end
 
   binary "miln-keysafe-v#{version}-darwin-universal/keysafe"

--- a/Casks/knime.rb
+++ b/Casks/knime.rb
@@ -10,8 +10,8 @@ cask "knime" do
 
   livecheck do
     url "https://download.knime.org/analytics-platform/macosx/knime-latest-app.macosx.cocoa.x86_64.dmg"
-    strategy :header_match
     regex(/knime[._-]v?(\d+(?:\.\d+)+).*?\.dmg/i)
+    strategy :header_match
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/lbry.rb
+++ b/Casks/lbry.rb
@@ -10,8 +10,8 @@ cask "lbry" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/lbry-desktop/releases/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   depends_on macos: ">= :mojave"

--- a/Casks/luminance-hdr.rb
+++ b/Casks/luminance-hdr.rb
@@ -10,8 +10,8 @@ cask "luminance-hdr" do
 
   livecheck do
     url "https://qtpfsgui.sourceforge.net/?page_id=10"
-    strategy :page_match
     regex(/LuminanceHDR[._-]?(\d+(?:\.\d+)*)[._-]?-Qt5\.13\.dmg/i)
+    strategy :page_match
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/mambaforge.rb
+++ b/Casks/mambaforge.rb
@@ -12,8 +12,8 @@ cask "mambaforge" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[._-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/manuskript.rb
+++ b/Casks/manuskript.rb
@@ -10,8 +10,8 @@ cask "manuskript" do
 
   livecheck do
     url "https://github.com/olivierkes/manuskript/releases/"
-    strategy :page_match
     regex(/manuskript[._-]?(\d+(?:\.\d+)+)[._-]?osx\.zip/i)
+    strategy :page_match
   end
 
   binary "manuskript/manuskript"

--- a/Casks/microsoft-auto-update.rb
+++ b/Casks/microsoft-auto-update.rb
@@ -15,8 +15,8 @@ cask "microsoft-auto-update" do
 
   livecheck do
     url "https://go.microsoft.com/fwlink/?linkid=830196"
-    strategy :header_match
     regex(/Microsoft[._-]AutoUpdate[._-]v?(\d+(?:\.\d+)+)[._-]Updater\.pkg/i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/miniforge.rb
+++ b/Casks/miniforge.rb
@@ -12,8 +12,8 @@ cask "miniforge" do
 
   livecheck do
     url :homepage
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/mixed-in-key.rb
+++ b/Casks/mixed-in-key.rb
@@ -9,8 +9,8 @@ cask "mixed-in-key" do
 
   livecheck do
     url :url
-    strategy :header_match
     regex(%r{/Mixed%2BIn%2BKey[._-]v?(\d+(?:\.\d+)+)}i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/mtgaprotracker.rb
+++ b/Casks/mtgaprotracker.rb
@@ -10,8 +10,8 @@ cask "mtgaprotracker" do
 
   livecheck do
     url "https://github.com/Razviar/mtgap/"
-    strategy :page_match
     regex(/Mac\sversion.*?(\d+(?:\.\d+)+)/i)
+    strategy :page_match
   end
 
   app "mtgaprotracker.app"

--- a/Casks/n1ghtshade.rb
+++ b/Casks/n1ghtshade.rb
@@ -9,8 +9,8 @@ cask "n1ghtshade" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?([\w._-]+)["' >]}i)
+    strategy :github_latest
   end
 
   depends_on formula: %w[

--- a/Casks/neteasemusic.rb
+++ b/Casks/neteasemusic.rb
@@ -15,8 +15,8 @@ cask "neteasemusic" do
   # from the XML using a regex pattern on the download URLs.
   livecheck do
     url "https://music.163.com/api/osx/download/latest"
-    strategy :header_match
     regex(/NeteaseMusic[._-]v?(\d+(?:[._]\d+)+)_web/i)
+    strategy :header_match
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/nodebox.rb
+++ b/Casks/nodebox.rb
@@ -10,8 +10,8 @@ cask "nodebox" do
 
   livecheck do
     url "https://www.nodebox.net/download"
-    strategy :page_match
     regex(/href=.*?NodeBox[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :page_match
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -14,8 +14,8 @@ cask "notion" do
 
   livecheck do
     url "https://www.notion.so/desktop/#{livecheck_folder}/download"
-    strategy :header_match
     regex(/Notion[._-]v?(\d+(?:\.\d+)*?)[^.]*?\.dmg/i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/obs-ndi.rb
+++ b/Casks/obs-ndi.rb
@@ -9,8 +9,8 @@ cask "obs-ndi" do
 
   livecheck do
     url "https://github.com/Palakis/obs-ndi/releases/"
-    strategy :page_match
     regex(/obs[._-]?ndi[._-]?(\d+(?:\.\d+)*)[._-]?macOS\.pkg/i)
+    strategy :page_match
   end
 
   pkg "obs-ndi-#{version}-macOS.pkg"

--- a/Casks/openmw.rb
+++ b/Casks/openmw.rb
@@ -10,8 +10,8 @@ cask "openmw" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(/openmw[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :github_latest
   end
 
   app "OpenMW.app"

--- a/Casks/oss-browser.rb
+++ b/Casks/oss-browser.rb
@@ -10,8 +10,8 @@ cask "oss-browser" do
 
   livecheck do
     url :homepage
-    strategy :page_match
     regex(%r{href=.*?/(\d+(?:\.\d+)+)/oss-browser-darwin-x64\.zip}i)
+    strategy :page_match
   end
 
   app "oss-browser-darwin-x64/oss-browser.app"

--- a/Casks/pd-extended.rb
+++ b/Casks/pd-extended.rb
@@ -8,8 +8,8 @@ cask "pd-extended" do
 
   livecheck do
     url "https://sourceforge.net/projects/pure-data/rss?path=/pd-extended"
-    strategy :page_match
     regex(%r{/Pd-(\d+(?:\.\d+)*)-extended-macosx105-i386\.dmg}i)
+    strategy :page_match
   end
 
   app "Pd-extended.app"

--- a/Casks/pingnoo.rb
+++ b/Casks/pingnoo.rb
@@ -10,8 +10,8 @@ cask "pingnoo" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+-\w+)["' >]}i)
+    strategy :github_latest
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/plover.rb
+++ b/Casks/plover.rb
@@ -10,8 +10,8 @@ cask "plover" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[\w.]+)["' >]}i)
+    strategy :github_latest
   end
 
   app "Plover.app"

--- a/Casks/qldds.rb
+++ b/Casks/qldds.rb
@@ -4,12 +4,13 @@ cask "qldds" do
 
   url "https://github.com/Marginal/QLdds/releases/download/rel-#{version.no_dots}/QLdds_#{version.no_dots}.pkg"
   name "QuickLook DDS"
+  desc "QuickLook plugin for DirectDraw Surface (DDS) texture files"
   homepage "https://github.com/Marginal/QLdds"
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(/Release\s+(\d+(?:\.\d+)*)/i)
+    strategy :github_latest
   end
 
   pkg "QLdds_#{version.no_dots}.pkg"

--- a/Casks/quodlibet.rb
+++ b/Casks/quodlibet.rb
@@ -10,8 +10,8 @@ cask "quodlibet" do
 
   livecheck do
     url "https://quodlibet.readthedocs.io/en/latest/downloads.html"
-    strategy :page_match
     regex(/QuodLibet[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :page_match
   end
 
   app "QuodLibet.app"

--- a/Casks/ricochet-refresh.rb
+++ b/Casks/ricochet-refresh.rb
@@ -10,8 +10,8 @@ cask "ricochet-refresh" do
 
   livecheck do
     url "https://github.com/blueprint-freespeech/ricochet-refresh/releases"
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)[-"' >]}i)
+    strategy :github_latest
   end
 
   app "Ricochet Refresh.app"

--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -10,8 +10,8 @@ cask "ricochet" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{/ricochet-(\d+(?:\.\d+)*)-macos\.dmg}i)
+    strategy :github_latest
   end
 
   app "Ricochet.app"

--- a/Casks/sizzy.rb
+++ b/Casks/sizzy.rb
@@ -11,8 +11,8 @@ cask "sizzy" do
 
   livecheck do
     url :url
-    strategy :header_match
     regex(/Sizzy[._-]v?(\d+(?:\.\d+)+)(?:[._-]#{arch})?\.dmg/i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/sparkleshare.rb
+++ b/Casks/sparkleshare.rb
@@ -10,8 +10,8 @@ cask "sparkleshare" do
 
   livecheck do
     url "https://github.com/hbons/SparkleShare/releases/"
-    strategy :page_match
     regex(/sparkleshare[._-]?mac[._-]?(\d+(?:\.\d+)*)\.zip/i)
+    strategy :page_match
   end
 
   app "SparkleShare.app"

--- a/Casks/studiolinkstandalone.rb
+++ b/Casks/studiolinkstandalone.rb
@@ -20,7 +20,6 @@ cask "studiolinkstandalone" do
 
   livecheck do
     url "https://gitlab.com/studio.link/app.git"
-    strategy :git
     regex(/^v?(\d+(?:\.\d+)*)[._-]stable$/i)
   end
 

--- a/Casks/sunloginclient.rb
+++ b/Casks/sunloginclient.rb
@@ -10,8 +10,8 @@ cask "sunloginclient" do
 
   livecheck do
     url "https://sunlogin.oray.com/zh_CN/download/download?id=89"
-    strategy :header_match
     regex(/SunloginClient[._-]?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :header_match
   end
 
   pkg "SunloginClient.pkg"

--- a/Casks/sunlogincontrol.rb
+++ b/Casks/sunlogincontrol.rb
@@ -10,8 +10,8 @@ cask "sunlogincontrol" do
 
   livecheck do
     url "https://sunlogin.oray.com/zh_CN/download/download?id=17"
-    strategy :header_match
     regex(/SunloginRemote[._-](\d+(?:\.\d+)+)\.dmg/i)
+    strategy :header_match
   end
 
   pkg "SunloginRemote.pkg"

--- a/Casks/teamviewer-host.rb
+++ b/Casks/teamviewer-host.rb
@@ -9,8 +9,8 @@ cask "teamviewer-host" do
 
   livecheck do
     url "https://dl.teamviewer.com/download/TeamViewerHost.dmg"
-    strategy :header_match
     regex(%r{/version[._-]v?(\d+)x/TeamViewerHost\.dmg}i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/teamviewer-quickjoin.rb
+++ b/Casks/teamviewer-quickjoin.rb
@@ -10,8 +10,8 @@ cask "teamviewer-quickjoin" do
 
   livecheck do
     url "https://dl.teamviewer.com/download/TeamViewerQJ.dmg"
-    strategy :header_match
     regex(%r{/version[._-]v?(\d+)x/TeamViewerQJ\.dmg}i)
+    strategy :header_match
   end
 
   # Renamed for consistency: app name is different in the Finder and in a shell.

--- a/Casks/teamviewer-quicksupport.rb
+++ b/Casks/teamviewer-quicksupport.rb
@@ -10,8 +10,8 @@ cask "teamviewer-quicksupport" do
 
   livecheck do
     url "https://dl.teamviewer.com/download/TeamViewerQS.dmg"
-    strategy :header_match
     regex(%r{/version[._-]v?(\d+)x/TeamViewerQS\.dmg}i)
+    strategy :header_match
   end
 
   # Renamed for consistency: app name is different in the Finder and in a shell.

--- a/Casks/thonny.rb
+++ b/Casks/thonny.rb
@@ -10,8 +10,8 @@ cask "thonny" do
 
   livecheck do
     url "https://github.com/thonny/thonny/releases/"
-    strategy :page_match
     regex(/thonny[._-]?(\d+(?:\.\d+)*)\.pkg/i)
+    strategy :page_match
   end
 
   conflicts_with cask: "thonny-xxl"

--- a/Casks/utc-menu-clock.rb
+++ b/Casks/utc-menu-clock.rb
@@ -9,8 +9,8 @@ cask "utc-menu-clock" do
 
   livecheck do
     url "https://github.com/netik/UTCMenuClock/tree/master/downloads"
-    strategy :page_match
     regex(%r{href=.*?/UTCMenuClock[._-]v?(\d+(?:\.\d+)+)[._-]universal\.zip}i)
+    strategy :page_match
   end
 
   app "UTCMenuClock.app"

--- a/Casks/utm.rb
+++ b/Casks/utm.rb
@@ -10,8 +10,8 @@ cask "utm" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   conflicts_with cask: "homebrew/cask-versions/utm-beta"

--- a/Casks/vidcutter.rb
+++ b/Casks/vidcutter.rb
@@ -9,8 +9,8 @@ cask "vidcutter" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/VidCutter[._-]v?(\d+(?:\.\d+)+)[._-]macOS\.dmg}i)
+    strategy :github_latest
   end
 
   app "VidCutter.app"

--- a/Casks/vimediamanager.rb
+++ b/Casks/vimediamanager.rb
@@ -9,8 +9,8 @@ cask "vimediamanager" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/v?(\d+(?:\.\d+)+[a-z]\d+)["' >]}i)
+    strategy :github_latest
   end
 
   app "ViMediaManager.app"

--- a/Casks/webots.rb
+++ b/Casks/webots.rb
@@ -11,8 +11,8 @@ cask "webots" do
 
   livecheck do
     url :url
-    strategy :github_latest
     regex(%r{href=.*?/tag/([\w._-]+)["' >]}i)
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/webull.rb
+++ b/Casks/webull.rb
@@ -14,8 +14,8 @@ cask "webull" do
 
   livecheck do
     url "https://infoapi.webullfintech.com/api/operation/appver/last?platform=#{livecheck_arch}&osv=10.15"
-    strategy :page_match
     regex(/Webull%20Desktop[._-](\d+(?:\.\d+)+).*?.dmg/i)
+    strategy :page_match
   end
 
   depends_on macos: ">= :mojave"

--- a/Casks/wiznote.rb
+++ b/Casks/wiznote.rb
@@ -12,8 +12,8 @@ cask "wiznote" do
 
   livecheck do
     url "https://url.wiz.cn/u/mac64_new"
-    strategy :header_match
     regex(/wiznote[._-]desktop[._-]?(\d+(?:\.\d+)+).*?\.dmg/i)
+    strategy :header_match
   end
 
   auto_updates true

--- a/Casks/xmind.rb
+++ b/Casks/xmind.rb
@@ -9,8 +9,8 @@ cask "xmind" do
 
   livecheck do
     url "https://www.xmind.net/zen/download/mac/"
-    strategy :header_match
     regex(/XMind[._-]for[._-]macOS[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+    strategy :header_match
   end
 
   conflicts_with cask: "homebrew/cask-versions/xmind8"

--- a/Casks/yacreader.rb
+++ b/Casks/yacreader.rb
@@ -10,8 +10,8 @@ cask "yacreader" do
 
   livecheck do
     url "https://www.yacreader.com/downloads"
-    strategy :page_match
     regex(%r{href=.*?/YACReader[._-]v?(\d+(?:\.\d+)+)[._-]MacOSX[._-]Intel\.Qt6\.dmg}i)
+    strategy :page_match
   end
 
   app "YACReader.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

As the title suggests, this PR modifies existing `livecheck` blocks to ensure that any `#strategy` call comes after `#regex`. I've put this forth as the standard format for years but it's not always adhered to (since we don't enforce the order of `livecheck` blocks programmatically), so this simply brings existing casks up to standard. For a more detailed explanation (motivation, etc.), see: https://github.com/Homebrew/homebrew-core/pull/126007

Besides that, this also adds a `desc` for `brl-cad-mged` and `qldds`. `pd-extended` is still missing a `desc` but I didn't know how to adequately describe that package.

For what it's worth, there are a few related casks that caught my eye which I'll be handling in follow-up PRs instead.