### PR TITLE
Update multiviewer-for-f1 from 1.14.0 to 1.14.2

### DIFF
--- a/Casks/multiviewer-for-f1.rb
+++ b/Casks/multiviewer-for-f1.rb
@@ -2,12 +2,12 @@ cask "multiviewer-for-f1" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.14.0,98081841"
-    sha256 "0af0e0245ef417f0423bb6beba09184a2626d8d83c338f3e7e0419929e19ef9e"
+    version "1.14.2,99811709"
+    sha256 "78c755411457e566d669394b331bc4b6af38eb5a79bf77dcc990f51aa334bb02"
   end
   on_intel do
-    version "1.14.0,98082227"
-    sha256 "1caa2f7e901d20d87b01919b93bdf1c7f45b858b0f57f6d55f567cbfa67ffd04"
+    version "1.14.2,99812219"
+    sha256 "398c92dd7d76f9737409696d67290da77ca26093273c607a648095c84863ce2a"
   end
 
   url "https://releases.multiviewer.app/download/#{version.csv.second}/MultiViewer.for.F1-#{version.csv.first}-#{arch}.dmg"

--- a/Casks/multiviewer-for-f1.rb
+++ b/Casks/multiviewer-for-f1.rb
@@ -34,6 +34,9 @@ cask "multiviewer-for-f1" do
 
   zap trash: [
     "~/Library/Application Support/MultiViewer for F1",
+    "~/Library/Caches/com.electron.multiviewer-for-f1",
+    "~/Library/Caches/com.electron.multiviewer-for-f1.ShipIt",
+    "~/Library/HTTPStorages/com.electron.multiviewer-for-f1",
     "~/Library/Preferences/com.electron.multiviewer-for-f1.plist",
     "~/Library/Saved Application State/com.electron.multiviewer-for-f1.savedState",
   ]


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.