### PR TITLE
Update colour-contrast-analyse from 3.2.0 to 3.2.1

### DIFF
--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -1,8 +1,8 @@
 cask "colour-contrast-analyser" do
-  version "3.2.0"
-  sha256 "2afd22cc174957561d6271810455a7394a9f6ed418c22914ca750ec66849840f"
+  version "3.2.1"
+  sha256 "bc2c4be0c43ad8f41494c4b5ba6621e0e711f7ed0fa40f37844369424e812bc0"
 
-  url "https://github.com/ThePacielloGroup/CCAe/releases/download/v#{version}/CCA-#{version}.dmg",
+  url "https://github.com/ThePacielloGroup/CCAe/releases/download/v#{version}/CCA-x64-#{version}.dmg",
       verified: "github.com/ThePacielloGroup/CCAe/"
   name "Colour Contrast Analyser"
   desc "Color contrast checker"

--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -5,7 +5,7 @@ cask "colour-contrast-analyser" do
   url "https://github.com/ThePacielloGroup/CCAe/releases/download/v#{version}/CCA-x64-#{version}.dmg",
       verified: "github.com/ThePacielloGroup/CCAe/"
   name "Colour Contrast Analyser"
-  desc "Color contrast checker"
+  desc "Colour contrast checker"
   homepage "https://www.tpgi.com/color-contrast-checker/"
 
   livecheck do

--- a/Casks/colour-contrast-analyser.rb
+++ b/Casks/colour-contrast-analyser.rb
@@ -14,4 +14,9 @@ cask "colour-contrast-analyser" do
   end
 
   app "Colour Contrast Analyser.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.electron.cca.plist",
+    "~/Library/Saved Application State/com.electron.cca.savedState",
+  ]
 end


### PR DESCRIPTION
Update version, fix download link and add zap stanza


After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.


