### PR TITLE
Update mactex-no-gui from 2022.0321 to 2023.0314

### DIFF
--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -1,6 +1,6 @@
 cask "mactex-no-gui" do
-  version "2022.0321"
-  sha256 "dc1983c82de2c68f1c434f734d94343959d1338adb6f55132ccce11c787badc1"
+  version "2023.0314"
+  sha256 "57304ece58618f0dfc6a41be39d1d6e8f688d81247c84a89eb1cc788b280050b"
 
   url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"
@@ -23,13 +23,13 @@ cask "mactex-no-gui" do
       choices: [
         {
           # Ghostscript
-          "choiceIdentifier" => "org.tug.mactex.ghostscript9.55",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.00",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },
         {
           # Ghostscript Dynamic Library
-          "choiceIdentifier" => "org.tug.mactex.ghostscript9.55-libgs",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.00-libgs",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
```
 - Version '2023.0314' differs from '' retrieved by livecheck.
 - Version '2023.0314' differs from '' retrieved by livecheck.
```
- [x] `brew style --fix <cask>` reports no offenses.

`brew audit --cask --online`'s output also fails for the old recipe (installation failed due to 404s):

```
audit for mactex-no-gui: failed
 - Version '2022.0321' differs from '' retrieved by livecheck.
 - Version '2022.0321' differs from '' retrieved by livecheck.
 - The binary URL https://mirror.ctan.org/systems/mac/mactex/mactex-20220321.pkg is not reachable (HTTP status code 404)
 - download not possible: Download failed on Cask 'mactex-no-gui' with message: Download failed: https://mirror.ctan.org/systems/mac/mactex/mactex-20220321.pkg
 ```
 
`brew livecheck mactex-no-gui` shows, I am not sure why the audit reports '' as retrieved from livecheck:
```
mactex-no-gui: 2022.0321 ==> 2023.0314
```
