### PR TITLE
Change topcat URL to canonical location

### DIFF
--- a/Casks/topcat.rb
+++ b/Casks/topcat.rb
@@ -2,10 +2,10 @@ cask "topcat" do
   version "4.8-7"
   sha256 :no_check
 
-  url "http://www.star.bris.ac.uk/~mbt/topcat/topcat-full.dmg"
+  url "http://www.starlink.ac.uk/topcat/topcat-full.dmg"
   name "TOPCAT"
   desc "Interactive graphical viewer and editor for tabular data"
-  homepage "http://www.star.bris.ac.uk/~mbt/topcat/"
+  homepage "http://www.starlink.ac.uk/topcat/"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
I (topcat author) have updated the home page and DMG download URLs in the topcat.rb file from http://www.star.bris.ac.uk/~mbt/topcat to http://www.starlink.ac.uk/topcat.

The latter is the canonical URL which should supposedly be more stable than the Bristol one.  At time of writing that's definitely the case, since because of local technical/political issues the www.star.bris.ac.uk server is currently down.  Right now the canonical URL has an HTTP 302 redirect to http://www.g-vo.org/topcat/topcat/, but likely it will change in the near future back to www.star.bristol.ac.uk.

So the above makes sense, and should be put in place ASAP, as long as (possibly multiple) 302 redirects are OK here. I haven't tried it since I don't have a Mac.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
