### PR TITLE
Add Active Trader Pro.app v1.0.49

### DIFF
--- a/Casks/active-trader-pro.rb
+++ b/Casks/active-trader-pro.rb
@@ -1,0 +1,25 @@
+cask "active-trader-pro" do
+  version "1.0.49"
+  sha256 :no_check
+
+  url "https://www.fidelity.com/webcontent/CodeweaverInstaller/ActiveTraderPro.pkg"
+  name "Active Trader Pro"
+  desc "Fidelity's customizable trading platform"
+  homepage "https://www.fidelity.com/trading/advanced-trading-tools/active-trader-pro/overview"
+
+  pkg "ActiveTraderPro.pkg"
+
+  postflight do
+    # The postinstall script automatically opens the app by making a call to
+    # `open -b com.fmr.activetrader`. Therefore, we must suppress this behavior
+    # to make the cask installation non-interactive.
+    retries ||= 3
+    ohai "The Active Trader Pro package postinstall script launches the app" unless retries < 3
+    ohai "Attempting to close Active Trader Pro to avoid unwanted user intervention" unless retries < 3
+    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/Active Trader Pro.app"]
+  end
+
+  uninstall quit:    "com.fmr.activetrader",
+            pkgutil: "com.fmr.activetrader",
+            delete:  "/Applications/Active Trader Pro.app"
+end

--- a/Casks/active-trader-pro.rb
+++ b/Casks/active-trader-pro.rb
@@ -22,4 +22,9 @@ cask "active-trader-pro" do
   uninstall quit:    "com.fmr.activetrader",
             pkgutil: "com.fmr.activetrader",
             delete:  "/Applications/Active Trader Pro.app"
+
+  zap trash: [
+    "~/Library/Application Support/Active Trader Pro/",
+    "~/Library/Preferences/com.fmr.activetrader.plist",
+  ]
 end


### PR DESCRIPTION
Active Trader Pro is an advanced trading platform for customers of Fidelity Investments.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Notes:
`--new-cask` audit fails with 
```
audit for active-trader-pro: failed
 - Signature verification failed:
Processing: /Users/karim/Library/Caches/Homebrew/downloads/03e296f9843d436bdd78ec9a15097d940b14951dec5a0842c9fa65d504d07cfb--ActiveTraderPro.pkg
03e296f9843d436bdd78ec9a15097d940b14951dec5a0842c9fa65d504d07cfb--ActiveTraderPro.pkg does not have a ticket stapled to it.

macOS on ARM requires applications to be signed.
Please contact the upstream developer to let them know they should notarize their package.
Error: 1 problem in 1 cask detected
```
There is no easy way to directly contact the engineering team that is responsible for writing this software; their identities are not published and Fidelity does not give details on how to request that they notarize their Mac packages; furthermore, it's unlikely that customer service representatives will be successful in conveying the request to them and actually having the engineering team choose to do this within the timeframe of this merge request. For reviewers: does the lack of `--new-cask` audit passing without error prevent this formula from being merged entirely?