### PR TITLE
Disable auto update in sqlite studio and add more paths to the trash

### DIFF
--- a/Casks/sqlitestudio.rb
+++ b/Casks/sqlitestudio.rb
@@ -8,12 +8,15 @@ cask "sqlitestudio" do
   desc "Create, edit, browse SQLite databases"
   homepage "https://sqlitestudio.pl/"
 
-  auto_updates true
+  auto_updates false
 
   app "SQLiteStudio.app"
 
   zap trash: [
     "~/.config/sqlitestudio",
     "~/Library/Saved Application State/com.yourcompany.SQLiteStudio.savedState",
+    "~/Library/Saved Application State/pl.com.salsoft.SQLiteStudio.savedState",
+    "~/Library/Preferences/pl.com.salsoft.SQLiteStudio.plist",
+    "~/Library/Preferences/SalSoft/SQLiteStudio/",
   ]
 end

--- a/Casks/sqlitestudio.rb
+++ b/Casks/sqlitestudio.rb
@@ -8,15 +8,13 @@ cask "sqlitestudio" do
   desc "Create, edit, browse SQLite databases"
   homepage "https://sqlitestudio.pl/"
 
-  auto_updates false
-
   app "SQLiteStudio.app"
 
   zap trash: [
     "~/.config/sqlitestudio",
-    "~/Library/Saved Application State/com.yourcompany.SQLiteStudio.savedState",
-    "~/Library/Saved Application State/pl.com.salsoft.SQLiteStudio.savedState",
     "~/Library/Preferences/pl.com.salsoft.SQLiteStudio.plist",
     "~/Library/Preferences/SalSoft/SQLiteStudio/",
+    "~/Library/Saved Application State/com.yourcompany.SQLiteStudio.savedState",
+    "~/Library/Saved Application State/pl.com.salsoft.SQLiteStudio.savedState",
   ]
 end


### PR DESCRIPTION
While it does have update notifications, those just give you a link, you are still required to manually download and install the program itself, which makes brew the easier option. (at least on the version I tried to update)

Not entirely sure if that’s enough of a reason to disable it, but couldn’t hurt to try.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

