### PR TITLE
Update mactex and basictex

### DIFF
--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -1,6 +1,6 @@
 cask "basictex" do
-  version "2022.0314"
-  sha256 "5ef0678318c2b947b78b77c0cddae09e763359596c6c1fd0362f5cdca9714b78"
+  version "2023.0314"
+  sha256 "bee681935e4af6dd3ae79229ccd5437e6a0ced138b530e88fe66a95a13c113b1"
 
   url "https://mirror.ctan.org/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"

--- a/Casks/mactex-no-gui.rb
+++ b/Casks/mactex-no-gui.rb
@@ -1,6 +1,6 @@
 cask "mactex-no-gui" do
-  version "2022.0321"
-  sha256 "dc1983c82de2c68f1c434f734d94343959d1338adb6f55132ccce11c787badc1"
+  version "2023.0314"
+  sha256 "57304ece58618f0dfc6a41be39d1d6e8f688d81247c84a89eb1cc788b280050b"
 
   url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"

--- a/Casks/mactex.rb
+++ b/Casks/mactex.rb
@@ -1,6 +1,6 @@
 cask "mactex" do
-  version "2022.0321"
-  sha256 "dc1983c82de2c68f1c434f734d94343959d1338adb6f55132ccce11c787badc1"
+  version "2023.0314"
+  sha256 "57304ece58618f0dfc6a41be39d1d6e8f688d81247c84a89eb1cc788b280050b"
 
   url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"


### PR DESCRIPTION
Why wasn’t this done automatically? The download didn’t work at all, at least at the mirror that was picked for me. Shouldn’t the live check have caught this?

(edit: I wasn’t paying attention, #143411 exists)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

