### PR TITLE
Specify arm64 and intel arch dmg for whalebird

### DIFF
--- a/Casks/whalebird.rb
+++ b/Casks/whalebird.rb
@@ -1,11 +1,14 @@
 cask "whalebird" do
-  version "5.0.2"
-  sha256 "d7cd43fbeea83f13bba954fafe3aa1b01ed023bdaab29fbd8b1efc2ca6a43794"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://github.com/h3poteto/whalebird-desktop/releases/download/v#{version}/Whalebird-#{version}-darwin-universal.dmg",
+  version "5.0.2"
+  sha256 arm:   "b35f47bb5719b77eabfcba9d1e0af72813a6536cc48fe88b6b533a412c0d0646",
+         intel: "72e0f2a1f9ea7a9e5759237c1b3fe0dd836918187e08054f376da2379bc8957c"
+
+  url "https://github.com/h3poteto/whalebird-desktop/releases/download/v#{version}/Whalebird-#{version}-darwin-#{arch}.dmg",
       verified: "github.com/h3poteto/whalebird-desktop/"
   name "Whalebird"
-  desc "Mastodon, Pleroma and Misskey client"
+  desc "Mastodon, Pleroma, and Misskey client"
   homepage "https://whalebird.social/"
 
   app "Whalebird.app"
@@ -13,7 +16,7 @@ cask "whalebird" do
   zap trash: [
     "~/Library/Application Support/Whalebird",
     "~/Library/Logs/Whalebird",
-    "~/Library/Preferences/org.whalebird.desktop.plist",
-    "~/Library/Saved Application State/org.whalebird.desktop.savedState",
+    "~/Library/Preferences/social.whalebird.app.plist",
+    "~/Library/Saved Application State/social.whalebird.app.savedState",
   ]
 end


### PR DESCRIPTION
I stopped using universal dmg for Whalebird because it has some problems so some users can't launch Whalebird. So, I specify dmg per arch.

And I also added a small fix with the AppID change.


---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
