### PR TITLE
free-gpgmail: update livecheck

### DIFF
--- a/Casks/free-gpgmail.rb
+++ b/Casks/free-gpgmail.rb
@@ -26,11 +26,11 @@ cask "free-gpgmail" do
   # surface a new major version and that will need to be handled manually.
   livecheck do
     url "https://github.com/Free-GPGMail/Free-GPGMail/releases?q=prerelease%3Afalse"
-    regex(/.*?Free-GPGMail[._-]v?(\d+(?:\.\d+)?)[_-](\d+(?:\.\d+)+)([_-][^"' >]+?)?[._-]mailbundle\.zip/i)
+    regex(/.*?Free-GPGMail[._-]v?(\d+(?:\.\d+)*)[_-](\d+(?:\.\d+)+)([_-][^"' >]+?)?[._-]mailbundle\.zip/i)
     strategy :page_match do |page, regex|
       version_suffix = version.csv.third&.sub(/^[_-]/, "")
       page.scan(regex).map do |match|
-        next if match[0] != version.csv.first
+        next if match[0].split(".").first != version.csv.first.split(".").first
         next if match[2]&.sub(/^[_-]/, "") != version_suffix
 
         "#{match[0]},#{match[1]},#{match[2]}"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #143528, where the `livecheck` block regex for `free-gpgmail` was updated to also match a version with more than one part (e.g., `7.1` instead of the usual `7`).

This PR updates the regex to use `\d+(?:\.\d+)*` instead of `\d+(?:\.\d+)?`, as it accomplishes the same goal while also working for versions with more than 1-2 parts (e.g., `1.2.3`). Besides that, this is a more common pattern in our regexes (secondary to the standard `\d+(?:\.\d+)+`).

This also modifies the logic in the `strategy` block that restricts matching to versions with the same main version (e.g., `7`). Since we're now potentially working with versions with more than one part (e.g., `7.1`), I've updated the logic to match based on only the first numeric part (e.g., `7` in `7.1`). This ensures that the restriction continues to relate to the major version, as the existing check was currently only matching 7.1 versions (omitting any 7.x versions before/after it).

With the `strategy` block change, the `livecheck` block is returning all the 7.x versions again, except for `7,2022.2.2,` (since the zip file was named `Free-GPGMail_7_signed.mailbundle.zip` and doesn't include the date-based version). It's probably technically possible to rework the regex to be able to match the versions in that scenario (taking the date-based version from the tag URL and the main version from the filename) but it may be tricky/messy, so I'm going to put it off unless/until it happens again.