### PR TITLE
Fix calcservice livecheck

### DIFF
--- a/Casks/calcservice.rb
+++ b/Casks/calcservice.rb
@@ -9,7 +9,7 @@ cask "calcservice" do
 
   livecheck do
     url "https://www.devontechnologies.com/support/download"
-    regex(%r{<td>CalcService</td><td>(\d+(?:\.\d+)+)</td>}i)
+    regex(/calcservice.*?(\d+(?:\.\d+)+).*?app/i)
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

I've been having issues getting the regex to match. This is the most specific one I've been able to get so far.