### PR TITLE
transcribe: Fix download URLs for working versions per-OS

### DIFF
--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -1,9 +1,5 @@
 cask "transcribe" do
-  arch intel: "intel", arm: "arm"
-
-  livecheck_version = "11"
-
-  sha256 :no_check
+  arch arm: "arm", intel: "intel"
 
   on_catalina :or_older do
     version "8.75.2"
@@ -11,34 +7,63 @@ cask "transcribe" do
 
     url "https://www.seventhstring.com/xscribe/downmo/transcribe#{version.no_dots}.dmg"
 
-    livecheck_version = "10"
+    livecheck do
+      skip "Legacy version"
+    end
   end
-  on_monterey :or_older do
+  on_big_sur do
     version "9.21"
-    url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe#{arch}.dmg"
+    sha256 :no_check
+
+    on_arm do
+      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe_arm.dmg"
+    end
+    on_intel do
+      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe.dmg"
+    end
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_monterey do
+    version "9.21"
+    sha256 :no_check
+
+    on_arm do
+      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe_arm.dmg"
+    end
+    on_intel do
+      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe.dmg"
+    end
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_ventura do
     version "9.25.0"
+    sha256 arm:   "9452c3fd911bd1c1e81f45228233adbd370d4b6cc9d2fb5f3e03c06ce6b392a5",
+           intel: "a01f360c9daeecd8369b89600e4d49175e1961bab50afd79faba32f4ac821af8"
+
     url "https://www.seventhstring.com/xscribe/downmo/transcribe-#{arch}-#{version}.dmg"
 
-    livecheck_version = "13"
+    livecheck do
+      url "https://www.seventhstring.com/xscribe/download_mac.html"
+      regex(/transcribe[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    end
   end
 
   name "Transcribe!"
   desc "Transcribes recorded music"
   homepage "https://www.seventhstring.com/xscribe/overview.html"
 
-  livecheck do
-    url "https://www.seventhstring.com/xscribe/download_mac.html"
-    regex(/version\s*(\d+(?:\.\d+)+)\s*for\s*Mac\s*OS\s*#{livecheck_version}/i)
-  end
-
   app "Transcribe!.app"
 
   uninstall quit: "com.seventhstring.transcribe"
 
   zap trash: [
-    "~/Library/Preferences/Transcribe!7 Preferences",
     "~/Library/Preferences/com.seventhstring.transcribe.plist",
+    "~/Library/Preferences/Transcribe!#{version.major} Preferences",
   ]
 end

--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -13,7 +13,7 @@ cask "transcribe" do
 
     livecheck_version = "10"
   end
-  on_big_sur :or_older do
+  on_monterey :or_older do
     version "9.21"
     url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe#{arch}.dmg"
   end

--- a/Casks/transcribe.rb
+++ b/Casks/transcribe.rb
@@ -1,12 +1,9 @@
 cask "transcribe" do
-  arch arm: "_arm"
+  arch intel: "intel", arm: "arm"
 
   livecheck_version = "11"
 
-  version "9.21"
   sha256 :no_check
-
-  url "https://www.seventhstring.com/xscribe/transcribe#{arch}.dmg"
 
   on_catalina :or_older do
     version "8.75.2"
@@ -15,6 +12,16 @@ cask "transcribe" do
     url "https://www.seventhstring.com/xscribe/downmo/transcribe#{version.no_dots}.dmg"
 
     livecheck_version = "10"
+  end
+  on_big_sur :or_older do
+    version "9.21"
+    url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe#{arch}.dmg"
+  end
+  on_ventura do
+    version "9.25.0"
+    url "https://www.seventhstring.com/xscribe/downmo/transcribe-#{arch}-#{version}.dmg"
+
+    livecheck_version = "13"
   end
 
   name "Transcribe!"


### PR DESCRIPTION
- https://www.seventhstring.com/xscribe/download_mac.html is very complicated, but I noticed this Cask was broken when I looked at CI for https://github.com/Homebrew/homebrew-cask/actions/runs/4501578623/jobs/7931035479?pr=143646.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
