### PR TITLE
Fix workflow name.

### DIFF
--- a/.github/workflows/automerge-review.yml
+++ b/.github/workflows/automerge-review.yml
@@ -3,7 +3,7 @@ name: Enable auto-merge for review
 on:
   workflow_run:
     workflows:
-      - automerge.yml
+      - Enable auto-merge
     types:
       - completed
 


### PR DESCRIPTION
Apparently https://github.com/Homebrew/homebrew-cask/pull/143710 didn't work, so it seems like it needs to be the actual `name` in the workflow file.