### PR TITLE
Fix ableton casks.

### DIFF
--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,17 +1,17 @@
 cask "ableton-live-intro" do
-  arch arm: "universal", intel: "intel"
-
   version "11.2.11"
 
   on_high_sierra :or_older do
     sha256 "68ae4aa7c1a4286f77de340f5e2556442ea17a73976c3f90c9dce1c75dc8234a"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 arm:   "70fb6f33c7e03f7c6290c7f5d5a6bee4454df272527c5fdd5dfd045b7d76f1eb",
-           intel: "ad24ed3cecd392464efd8b6bd3a0b65f8f7b624fdd07b0315e266050d97f77e2"
+    sha256 "ad24ed3cecd392464efd8b6bd3a0b65f8f7b624fdd07b0315e266050d97f77e2"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
   end
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_#{arch}.dmg"
   name "Ableton Live Intro"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -1,16 +1,8 @@
 cask "ableton-live-intro" do
   version "11.2.11"
+  sha256 "70fb6f33c7e03f7c6290c7f5d5a6bee4454df272527c5fdd5dfd045b7d76f1eb"
 
-  on_high_sierra :or_older do
-    sha256 "ad24ed3cecd392464efd8b6bd3a0b65f8f7b624fdd07b0315e266050d97f77e2"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_intel.dmg"
-  end
-  on_mojave :or_newer do
-    sha256 "70fb6f33c7e03f7c6290c7f5d5a6bee4454df272527c5fdd5dfd045b7d76f1eb"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
-  end
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
 
   name "Ableton Live Intro"
   desc "Sound and music editor"

--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -7,7 +7,7 @@ cask "ableton-live-intro" do
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 "ad24ed3cecd392464efd8b6bd3a0b65f8f7b624fdd07b0315e266050d97f77e2"
+    sha256 "70fb6f33c7e03f7c6290c7f5d5a6bee4454df272527c5fdd5dfd045b7d76f1eb"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
   end

--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -2,7 +2,7 @@ cask "ableton-live-intro" do
   version "11.2.11"
 
   on_high_sierra :or_older do
-    sha256 "68ae4aa7c1a4286f77de340f5e2556442ea17a73976c3f90c9dce1c75dc8234a"
+    sha256 "ad24ed3cecd392464efd8b6bd3a0b65f8f7b624fdd07b0315e266050d97f77e2"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_intel.dmg"
   end

--- a/Casks/ableton-live-intro.rb
+++ b/Casks/ableton-live-intro.rb
@@ -3,7 +3,6 @@ cask "ableton-live-intro" do
   sha256 "70fb6f33c7e03f7c6290c7f5d5a6bee4454df272527c5fdd5dfd045b7d76f1eb"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
-
   name "Ableton Live Intro"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -7,7 +7,7 @@ cask "ableton-live-lite" do
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 "44da4a8f4206e2bc76965cda6947e920252e69e53f294ea5d82cae27b05cbe05"
+    sha256 "cc9ae661a0677cb228cfed7eeb685ef1bf74a0b4aacd2c73082cf0756a39e6a3"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
   end

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -2,7 +2,7 @@ cask "ableton-live-lite" do
   version "11.2.11"
 
   on_high_sierra :or_older do
-    sha256 "fefadad3f6cd5d727f897000374d16da9f709f56991f6fcc257bb8b14d76a65d"
+    sha256 "44da4a8f4206e2bc76965cda6947e920252e69e53f294ea5d82cae27b05cbe05"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_intel.dmg"
   end

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,17 +1,17 @@
 cask "ableton-live-lite" do
-  arch arm: "universal", intel: "intel"
-
   version "11.2.11"
 
   on_high_sierra :or_older do
     sha256 "fefadad3f6cd5d727f897000374d16da9f709f56991f6fcc257bb8b14d76a65d"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 arm:   "cc9ae661a0677cb228cfed7eeb685ef1bf74a0b4aacd2c73082cf0756a39e6a3",
-           intel: "44da4a8f4206e2bc76965cda6947e920252e69e53f294ea5d82cae27b05cbe05"
+    sha256 "44da4a8f4206e2bc76965cda6947e920252e69e53f294ea5d82cae27b05cbe05"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
   end
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_#{arch}.dmg"
   name "Ableton Live Lite"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/products/live-lite/"

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -3,7 +3,6 @@ cask "ableton-live-lite" do
   sha256 "cc9ae661a0677cb228cfed7eeb685ef1bf74a0b4aacd2c73082cf0756a39e6a3"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
-
   name "Ableton Live Lite"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/products/live-lite/"

--- a/Casks/ableton-live-lite.rb
+++ b/Casks/ableton-live-lite.rb
@@ -1,16 +1,8 @@
 cask "ableton-live-lite" do
   version "11.2.11"
+  sha256 "cc9ae661a0677cb228cfed7eeb685ef1bf74a0b4aacd2c73082cf0756a39e6a3"
 
-  on_high_sierra :or_older do
-    sha256 "44da4a8f4206e2bc76965cda6947e920252e69e53f294ea5d82cae27b05cbe05"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_intel.dmg"
-  end
-  on_mojave :or_newer do
-    sha256 "cc9ae661a0677cb228cfed7eeb685ef1bf74a0b4aacd2c73082cf0756a39e6a3"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
-  end
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
 
   name "Ableton Live Lite"
   desc "Sound and music editor"

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -2,7 +2,7 @@ cask "ableton-live-standard" do
   version "11.2.11"
 
   on_high_sierra :or_older do
-    sha256 "51bffe5e3ab58c943cabbd605964e74c26535e9b993a3cb76b7a7d230150ec75"
+    sha256 "d72ce86fc89a4857071335d53fa22a355df33690acdac8d0aebed35d6c70b5b0"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_intel.dmg"
   end

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -3,7 +3,6 @@ cask "ableton-live-standard" do
   sha256 "0516a702d0b3c48e8c8a2578717fc74fd411dd77b9f36564f7b50227843d9063"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
-
   name "Ableton Live Standard"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,16 +1,8 @@
 cask "ableton-live-standard" do
   version "11.2.11"
+  sha256 "0516a702d0b3c48e8c8a2578717fc74fd411dd77b9f36564f7b50227843d9063"
 
-  on_high_sierra :or_older do
-    sha256 "d72ce86fc89a4857071335d53fa22a355df33690acdac8d0aebed35d6c70b5b0"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_intel.dmg"
-  end
-  on_mojave :or_newer do
-    sha256 "0516a702d0b3c48e8c8a2578717fc74fd411dd77b9f36564f7b50227843d9063"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
-  end
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
 
   name "Ableton Live Standard"
   desc "Sound and music editor"

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -7,7 +7,7 @@ cask "ableton-live-standard" do
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 "d72ce86fc89a4857071335d53fa22a355df33690acdac8d0aebed35d6c70b5b0"
+    sha256 "0516a702d0b3c48e8c8a2578717fc74fd411dd77b9f36564f7b50227843d9063"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
   end

--- a/Casks/ableton-live-standard.rb
+++ b/Casks/ableton-live-standard.rb
@@ -1,17 +1,17 @@
 cask "ableton-live-standard" do
-  arch arm: "universal", intel: "intel"
-
   version "11.2.11"
 
   on_high_sierra :or_older do
     sha256 "51bffe5e3ab58c943cabbd605964e74c26535e9b993a3cb76b7a7d230150ec75"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 arm:   "0516a702d0b3c48e8c8a2578717fc74fd411dd77b9f36564f7b50227843d9063",
-           intel: "d72ce86fc89a4857071335d53fa22a355df33690acdac8d0aebed35d6c70b5b0"
+    sha256 "d72ce86fc89a4857071335d53fa22a355df33690acdac8d0aebed35d6c70b5b0"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
   end
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_#{arch}.dmg"
   name "Ableton Live Standard"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,17 +1,17 @@
 cask "ableton-live-suite" do
-  arch arm: "universal", intel: "intel"
-
   version "11.2.11"
 
   on_high_sierra :or_older do
     sha256 "ae6f2c978009d7baa86b53d41be8a5eafda27bcb3a0bf102ebff629b4ebe091f"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 arm:   "cbe60f10213e1d73cb1a12b1e3abfc23ead19588d25ec76653734cf81141fbf2",
-           intel: "40484b0508166caf5cdee2edb5557d77173c3ba1a4a326621b386f5d28e099f3"
+    sha256 "40484b0508166caf5cdee2edb5557d77173c3ba1a4a326621b386f5d28e099f3"
+
+    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
   end
 
-  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_#{arch}.dmg"
   name "Ableton Live Suite"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -1,16 +1,8 @@
 cask "ableton-live-suite" do
   version "11.2.11"
+  sha256 "cbe60f10213e1d73cb1a12b1e3abfc23ead19588d25ec76653734cf81141fbf2"
 
-  on_high_sierra :or_older do
-    sha256 "40484b0508166caf5cdee2edb5557d77173c3ba1a4a326621b386f5d28e099f3"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_intel.dmg"
-  end
-  on_mojave :or_newer do
-    sha256 "cbe60f10213e1d73cb1a12b1e3abfc23ead19588d25ec76653734cf81141fbf2"
-
-    url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
-  end
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
 
   name "Ableton Live Suite"
   desc "Sound and music editor"

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -7,7 +7,7 @@ cask "ableton-live-suite" do
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_intel.dmg"
   end
   on_mojave :or_newer do
-    sha256 "40484b0508166caf5cdee2edb5557d77173c3ba1a4a326621b386f5d28e099f3"
+    sha256 "cbe60f10213e1d73cb1a12b1e3abfc23ead19588d25ec76653734cf81141fbf2"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
   end

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -3,7 +3,6 @@ cask "ableton-live-suite" do
   sha256 "cbe60f10213e1d73cb1a12b1e3abfc23ead19588d25ec76653734cf81141fbf2"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
-
   name "Ableton Live Suite"
   desc "Sound and music editor"
   homepage "https://www.ableton.com/en/live/"

--- a/Casks/ableton-live-suite.rb
+++ b/Casks/ableton-live-suite.rb
@@ -2,7 +2,7 @@ cask "ableton-live-suite" do
   version "11.2.11"
 
   on_high_sierra :or_older do
-    sha256 "ae6f2c978009d7baa86b53d41be8a5eafda27bcb3a0bf102ebff629b4ebe091f"
+    sha256 "40484b0508166caf5cdee2edb5557d77173c3ba1a4a326621b386f5d28e099f3"
 
     url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_intel.dmg"
   end


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-cask/pull/143646#issuecomment-1483739028.

This is a weird case: `on_high_sierra` should have the `intel` URL, while later versions can use the `universal` URL for both ARM and Intel.

