### PR TITLE
Fix DBeaver enterprise checksum

### DIFF
--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -3,7 +3,7 @@ cask "dbeaver-enterprise" do
 
   version "23.0.0"
   sha256 arm:   "75ce4e6784dfe76c82f2bf9b6bcd0700189861d455d4e7142e09e5781235898d",
-         intel: "5fb7d8232113c702300f0b9c5969eadf3fa1d664ff492d76f35246b28904ab45"
+         intel: "a642f60bb88c95c6d7709145457b27160605edae764e3c42d87e5e4f63a8516d"
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos-#{arch}.dmg"
   name "DBeaver Enterprise Edition"

--- a/Casks/dbeaver-enterprise.rb
+++ b/Casks/dbeaver-enterprise.rb
@@ -2,7 +2,7 @@ cask "dbeaver-enterprise" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "23.0.0"
-  sha256 arm:   "77607f651df927f642af76c6596f9ea5a4c667c3d1379a2d815c667494850d4e",
+  sha256 arm:   "75ce4e6784dfe76c82f2bf9b6bcd0700189861d455d4e7142e09e5781235898d",
          intel: "5fb7d8232113c702300f0b9c5969eadf3fa1d664ff492d76f35246b28904ab45"
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos-#{arch}.dmg"


### PR DESCRIPTION
Fixed following error:
```
Error: dbeaver-enterprise: SHA256 mismatch
Expected: 77607f651df927f642af76c6596f9ea5a4c667c3d1379a2d815c667494850d4e
  Actual: 75ce4e6784dfe76c82f2bf9b6bcd0700189861d455d4e7142e09e5781235898d
    File: /Users/maverick/Library/Caches/Homebrew/downloads/d3be51e54fce8f3db011d99912618474a2a8cc4d716c0fcb13caf12b2e02b3ea--dbeaver-ee-23.0.0-macos-aarch64.dmg
To retry an incomplete download, remove the file above.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

