### PR TITLE
Update bili-downloader from 1.6.20220723 to 1.7.20230325

### DIFF
--- a/Casks/bili-downloader.rb
+++ b/Casks/bili-downloader.rb
@@ -1,6 +1,6 @@
 cask "bili-downloader" do
-  version "1.6.20220723"
-  sha256 "2e2beae268efb6f601428c0ef745553aefec738d69d04810e4446467498085ed"
+  version "1.7.20230325"
+  sha256 "f081685bef1b1877202a6e182cb78eb8c0049bede1996dc169efc9eae067f8f6"
 
   url "https://github.com/JimmyLiang-lzm/biliDownloader_GUI/releases/download/V#{version}/BiliDownloader_for_MacOS_X.dmg"
   name "BiliDownloader"


### PR DESCRIPTION
Update bili-downloader from 1.6.20220723 to 1.7.20230325

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
