### PR TITLE
rubocop: Fix `Cask/StanzaOrder` offenses for `on_*` blocks

### DIFF
--- a/Casks/karabiner-elements.rb
+++ b/Casks/karabiner-elements.rb
@@ -39,6 +39,25 @@ cask "karabiner-elements" do
 
     pkg "Karabiner-Elements.sparkle_guided.pkg"
   end
+  on_mojave :or_older do
+    uninstall signal:    [
+                ["TERM", "org.pqrs.Karabiner-Menu"],
+                ["TERM", "org.pqrs.Karabiner-NotificationWindow"],
+              ],
+              pkgutil:   "org.pqrs.Karabiner-Elements",
+              launchctl: [
+                "org.pqrs.karabiner.agent.karabiner_grabber",
+                "org.pqrs.karabiner.agent.karabiner_observer",
+                "org.pqrs.karabiner.karabiner_console_user_server",
+                "org.pqrs.karabiner.karabiner_kextd",
+                "org.pqrs.karabiner.karabiner_session_monitor",
+              ],
+              script:    {
+                executable: "/Library/Application Support/org.pqrs/Karabiner-Elements/uninstall_core.sh",
+                sudo:       true,
+              },
+              delete:    "/Library/Application Support/org.pqrs/"
+  end
   on_mojave do
     version "12.10.0"
     sha256 "53252f7d07e44f04972afea2a16ac595552c28715aa65ff4a481a1c18c8be2f4"
@@ -64,48 +83,6 @@ cask "karabiner-elements" do
     end
 
     pkg "Karabiner-Elements.pkg"
-  end
-  on_big_sur :or_newer do
-    version "14.11.0"
-    sha256 "227b927d76da498b2772af2354ed792db4260d382e44794e884fcf8f911f5f97"
-
-    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
-        verified: "github.com/pqrs-org/Karabiner-Elements/"
-
-    livecheck do
-      url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
-      strategy :sparkle
-    end
-
-    depends_on macos: ">= :big_sur"
-
-    pkg "Karabiner-Elements.pkg"
-  end
-
-  name "Karabiner Elements"
-  desc "Keyboard customizer"
-  homepage "https://pqrs.org/osx/karabiner/"
-
-  auto_updates true
-
-  on_mojave :or_older do
-    uninstall signal:    [
-                ["TERM", "org.pqrs.Karabiner-Menu"],
-                ["TERM", "org.pqrs.Karabiner-NotificationWindow"],
-              ],
-              pkgutil:   "org.pqrs.Karabiner-Elements",
-              launchctl: [
-                "org.pqrs.karabiner.agent.karabiner_grabber",
-                "org.pqrs.karabiner.agent.karabiner_observer",
-                "org.pqrs.karabiner.karabiner_console_user_server",
-                "org.pqrs.karabiner.karabiner_kextd",
-                "org.pqrs.karabiner.karabiner_session_monitor",
-              ],
-              script:    {
-                executable: "/Library/Application Support/org.pqrs/Karabiner-Elements/uninstall_core.sh",
-                sudo:       true,
-              },
-              delete:    "/Library/Application Support/org.pqrs/"
   end
   on_catalina :or_newer do
     uninstall early_script: {
@@ -133,6 +110,28 @@ cask "karabiner-elements" do
               delete:       "/Library/Application Support/org.pqrs/"
     # The system extension 'org.pqrs.Karabiner-DriverKit-VirtualHIDDevice*' should not be uninstalled by Cask
   end
+  on_big_sur :or_newer do
+    version "14.11.0"
+    sha256 "227b927d76da498b2772af2354ed792db4260d382e44794e884fcf8f911f5f97"
+
+    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
+        verified: "github.com/pqrs-org/Karabiner-Elements/"
+
+    livecheck do
+      url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :big_sur"
+
+    pkg "Karabiner-Elements.pkg"
+  end
+
+  name "Karabiner Elements"
+  desc "Keyboard customizer"
+  homepage "https://pqrs.org/osx/karabiner/"
+
+  auto_updates true
 
   zap trash: [
     "~/.config/karabiner",

--- a/Casks/katrain.rb
+++ b/Casks/katrain.rb
@@ -2,14 +2,14 @@ cask "katrain" do
   version "1.12.3"
   sha256 "7a95ed91970c92c3f0e3c5537d0c8c573f05be56ce18065916369e5aabaa67db"
 
+  on_arm do
+    depends_on formula: "katago"
+  end
+
   url "https://github.com/sanderland/katrain/releases/download/v#{version}/KaTrainOSX.dmg"
   name "KaTrain"
   desc "Tool for analyzing games and playing go with AI feedback from KataGo"
   homepage "https://github.com/sanderland/katrain"
-
-  on_arm do
-    depends_on formula: "katago"
-  end
 
   app "KaTrain.app"
 

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -69,35 +69,35 @@ cask "teamviewer" do
   on_big_sur :or_newer do
     pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
 
-    uninstall delete: [
-      "/Applications/TeamViewer.app",
-      "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
-    ],
-    pkgutil: [
-      "com.teamviewer.AuthorizationPlugin",
-      "com.teamviewer.remoteaudiodriver",
-      "com.teamviewer.teamviewer.*",
-    ],
-    launchctl: [
-      "com.teamviewer.desktop",
-      "com.teamviewer.Helper",
-      "com.teamviewer.service",
-      "com.teamviewer.teamviewer",
-      "com.teamviewer.teamviewer_desktop",
-      "com.teamviewer.teamviewer_service",
-    ],
-    quit:      "com.teamviewer.TeamViewer"
+    uninstall delete:    [
+                "/Applications/TeamViewer.app",
+                "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+              ],
+              pkgutil:   [
+                "com.teamviewer.AuthorizationPlugin",
+                "com.teamviewer.remoteaudiodriver",
+                "com.teamviewer.teamviewer.*",
+              ],
+              launchctl: [
+                "com.teamviewer.desktop",
+                "com.teamviewer.Helper",
+                "com.teamviewer.service",
+                "com.teamviewer.teamviewer",
+                "com.teamviewer.teamviewer_desktop",
+                "com.teamviewer.teamviewer_service",
+              ],
+              quit:      "com.teamviewer.TeamViewer"
 
     zap trash: [
-    "~/Library/Application Support/TeamViewer",
-    "~/Library/Caches/com.teamviewer.TeamViewer",
-    "~/Library/Caches/TeamViewer",
-    "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
-    "~/Library/Logs/TeamViewer",
-    "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
-    "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
-    "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
-    "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
+      "~/Library/Application Support/TeamViewer",
+      "~/Library/Caches/com.teamviewer.TeamViewer",
+      "~/Library/Caches/TeamViewer",
+      "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
+      "~/Library/Logs/TeamViewer",
+      "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
+      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
+      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+      "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
     ]
   end
 

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,4 +1,6 @@
 cask "teamviewer" do
+  sha256 :no_check
+
   on_high_sierra :or_older do
     version "15.2.2756"
 
@@ -6,40 +8,8 @@ cask "teamviewer" do
       url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.11.1&type=1&channel=1"
       strategy :sparkle
     end
-  end
-  on_mojave :or_newer do
-    version "15.40.8"
 
-    livecheck do
-      url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"
-      strategy :sparkle
-    end
-  end
-
-  sha256 :no_check
-
-  url "https://download.teamviewer.com/download/TeamViewer.dmg"
-  name "TeamViewer"
-  desc "Remote access and connectivity software focused on security"
-  homepage "https://www.teamviewer.com/"
-
-  auto_updates true
-  conflicts_with cask: "teamviewer-host"
-  depends_on macos: ">= :el_capitan"
-
-  on_high_sierra :or_older do
     pkg "Install TeamViewer.pkg"
-  end
-  on_mojave do
-    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
-  end
-  on_catalina do
-    # This Cask should be installed and uninstalled manually on Catalina.
-    # See https://github.com/Homebrew/homebrew-cask/issues/76829
-    installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
-  end
-  on_big_sur :or_newer do
-    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
   end
   on_mojave :or_older do
     uninstall delete:    [
@@ -73,9 +43,20 @@ cask "teamviewer" do
       "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
     ]
   end
+  on_mojave :or_newer do
+    version "15.40.8"
+
+    livecheck do
+      url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.15.1&type=1&channel=1"
+      strategy :sparkle
+    end
+
+    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+  end
   on_catalina do
     # This Cask should be installed and uninstalled manually on Catalina.
     # See https://github.com/Homebrew/homebrew-cask/issues/76829
+    installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
     uninstall delete: "#{staged_path}/#{token}"
 
     caveats <<~EOS
@@ -86,35 +67,46 @@ cask "teamviewer" do
     EOS
   end
   on_big_sur :or_newer do
-    uninstall delete:    [
-                "/Applications/TeamViewer.app",
-                "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
-              ],
-              pkgutil:   [
-                "com.teamviewer.AuthorizationPlugin",
-                "com.teamviewer.remoteaudiodriver",
-                "com.teamviewer.teamviewer.*",
-              ],
-              launchctl: [
-                "com.teamviewer.desktop",
-                "com.teamviewer.Helper",
-                "com.teamviewer.service",
-                "com.teamviewer.teamviewer",
-                "com.teamviewer.teamviewer_desktop",
-                "com.teamviewer.teamviewer_service",
-              ],
-              quit:      "com.teamviewer.TeamViewer"
+    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+
+    uninstall delete: [
+      "/Applications/TeamViewer.app",
+      "/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+    ],
+    pkgutil: [
+      "com.teamviewer.AuthorizationPlugin",
+      "com.teamviewer.remoteaudiodriver",
+      "com.teamviewer.teamviewer.*",
+    ],
+    launchctl: [
+      "com.teamviewer.desktop",
+      "com.teamviewer.Helper",
+      "com.teamviewer.service",
+      "com.teamviewer.teamviewer",
+      "com.teamviewer.teamviewer_desktop",
+      "com.teamviewer.teamviewer_service",
+    ],
+    quit:      "com.teamviewer.TeamViewer"
 
     zap trash: [
-      "~/Library/Application Support/TeamViewer",
-      "~/Library/Caches/com.teamviewer.TeamViewer",
-      "~/Library/Caches/TeamViewer",
-      "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
-      "~/Library/Logs/TeamViewer",
-      "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
-      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
-      "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
-      "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
+    "~/Library/Application Support/TeamViewer",
+    "~/Library/Caches/com.teamviewer.TeamViewer",
+    "~/Library/Caches/TeamViewer",
+    "~/Library/Cookies/com.teamviewer.TeamViewer.binarycookies",
+    "~/Library/Logs/TeamViewer",
+    "~/Library/Preferences/com.teamviewer.TeamViewer.plist",
+    "~/Library/Preferences/com.teamviewer.teamviewer.preferences.Machine.plist",
+    "~/Library/Preferences/com.teamviewer.teamviewer.preferences.plist",
+    "~/Library/Saved Application State/com.teamviewer.TeamViewer.savedState",
     ]
   end
+
+  url "https://download.teamviewer.com/download/TeamViewer.dmg"
+  name "TeamViewer"
+  desc "Remote access and connectivity software focused on security"
+  homepage "https://www.teamviewer.com/"
+
+  auto_updates true
+  conflicts_with cask: "teamviewer-host"
+  depends_on macos: ">= :el_capitan"
 end


### PR DESCRIPTION
This is a proof of concept for https://github.com/Homebrew/brew/pull/14976 that supersedes https://github.com/Homebrew/homebrew-cask/pull/143201.

In it was said that "teamviewer is an absolute mess of a cask and the stanzas were moved for legibility". In this PR that has been undone and I do agree it's now more confusing.

Another way to fix this for the Casks that are exceptions would be to add a `# rubocop:disable Cask/StanzaOrder` comment to the cask, or an excludes list in the main cop config.

What do you think?

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
