### PR TITLE
Add airvpn/hummbingbird-1.2.1

### DIFF
--- a/Casks/hummingbird.rb
+++ b/Casks/hummingbird.rb
@@ -7,7 +7,7 @@ cask "hummingbird" do
 
   url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-#{arch}-notarized-#{version}.zip",
       verified: "eddie.website/repository/hummingbird/"
-  name "hummingbird"
+  name "Hummingbird"
   desc "OpenVPN 3 client"
   homepage "https://airvpn.org/hummingbird"
 

--- a/Casks/hummingbird.rb
+++ b/Casks/hummingbird.rb
@@ -8,7 +8,7 @@ cask "hummingbird" do
   url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-#{arch}-notarized-#{version}.zip",
       verified: "eddie.website/repository/hummingbird/"
   name "hummingbird"
-  desc "OpenVPN 3 client based on AirVPN's OpenVPN 3 library fork"
+  desc "OpenVPN 3 client"
   homepage "https://airvpn.org/hummingbird"
 
   livecheck do

--- a/Casks/hummingbird.rb
+++ b/Casks/hummingbird.rb
@@ -1,0 +1,42 @@
+cask "hummingbird" do
+  version "1.2.1"
+
+  on_intel do
+    sha256 "89be6ad9a198ce8589e19dd236881d24b6a1d415b748c5d4ef768ff94786fe9d"
+
+    url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-x86_64-notarized-#{version}.zip",
+        verified: "eddie.website"
+  end
+  on_arm do
+    sha256 "3ac509d0b8831b827e19f9945b588703c4f107e87e1ad8dbc19421fb2c7683c0"
+
+    url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-arm64-notarized-#{version}.zip",
+        verified: "eddie.website"
+  end
+
+  name "hummingbird"
+  desc "OpenVPN 3 client based on AirVPN's OpenVPN 3 library fork"
+  homepage "https://airvpn.org/hummingbird"
+
+  livecheck do
+    url "https://airvpn.org/macos/hummingbird/"
+    strategy :page_match
+    regex(/eddie_selected_version">(\d+\.\d+\.\d)</i)
+  end
+
+  depends_on arch: [:x86_64, :arm64]
+  depends_on macos: ">= :high_sierra"
+
+  binary "hummingbird-macos-x86_64-#{version}/hummingbird"
+
+  on_intel do
+    postflight do
+      set_ownership("#{HOMEBREW_PREFIX}/Caskroom/airvpn-hummingbird/#{version}/hummingbird-macos-x86_64-#{version}/hummingbird", user: "root")
+    end
+  end
+  on_arm do
+    postflight do
+      set_ownership("#{HOMEBREW_PREFIX}/Caskroom/airvpn-hummingbird/#{version}/hummingbird-macos-arm64-#{version}/hummingbird", user: "root")
+    end
+  end
+end

--- a/Casks/hummingbird.rb
+++ b/Casks/hummingbird.rb
@@ -1,42 +1,26 @@
 cask "hummingbird" do
+  arch arm: "arm64", intel: "x86_64"
+
   version "1.2.1"
+  sha256 arm:   "3ac509d0b8831b827e19f9945b588703c4f107e87e1ad8dbc19421fb2c7683c0",
+         intel: "89be6ad9a198ce8589e19dd236881d24b6a1d415b748c5d4ef768ff94786fe9d"
 
-  on_intel do
-    sha256 "89be6ad9a198ce8589e19dd236881d24b6a1d415b748c5d4ef768ff94786fe9d"
-
-    url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-x86_64-notarized-#{version}.zip",
-        verified: "eddie.website"
-  end
-  on_arm do
-    sha256 "3ac509d0b8831b827e19f9945b588703c4f107e87e1ad8dbc19421fb2c7683c0"
-
-    url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-arm64-notarized-#{version}.zip",
-        verified: "eddie.website"
-  end
-
+  url "https://eddie.website/repository/hummingbird/#{version}/hummingbird-macos-#{arch}-notarized-#{version}.zip",
+      verified: "eddie.website/repository/hummingbird/"
   name "hummingbird"
   desc "OpenVPN 3 client based on AirVPN's OpenVPN 3 library fork"
   homepage "https://airvpn.org/hummingbird"
 
   livecheck do
     url "https://airvpn.org/macos/hummingbird/"
-    strategy :page_match
-    regex(/eddie_selected_version">(\d+\.\d+\.\d)</i)
+    regex(/eddie[._-]selected[._-]version">v?(\d+(?:\.\d+)+)</i)
   end
 
-  depends_on arch: [:x86_64, :arm64]
   depends_on macos: ">= :high_sierra"
 
-  binary "hummingbird-macos-x86_64-#{version}/hummingbird"
+  binary "hummingbird-macos-#{arch}-#{version}/hummingbird"
 
-  on_intel do
-    postflight do
-      set_ownership("#{HOMEBREW_PREFIX}/Caskroom/airvpn-hummingbird/#{version}/hummingbird-macos-x86_64-#{version}/hummingbird", user: "root")
-    end
-  end
-  on_arm do
-    postflight do
-      set_ownership("#{HOMEBREW_PREFIX}/Caskroom/airvpn-hummingbird/#{version}/hummingbird-macos-arm64-#{version}/hummingbird", user: "root")
-    end
+  postflight do
+    set_ownership("#{staged_path}/hummingbird-macos-#{arch}-#{version}/hummingbird", user: "root")
   end
 end

--- a/Casks/hummingbird.rb
+++ b/Casks/hummingbird.rb
@@ -23,4 +23,6 @@ cask "hummingbird" do
   postflight do
     set_ownership("#{staged_path}/hummingbird-macos-#{arch}-#{version}/hummingbird", user: "root")
   end
+
+  # No zap stanza required
 end


### PR DESCRIPTION
This PR adds hummingbird cask, a multiplatform vpn client cli program provided by AirVPN team using openvpn 3.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
