### PR TITLE
ci workflows: disable fail-fast on tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
     needs: generate-matrix
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:


### PR DESCRIPTION
This change disables `fail-fast` on CI test workflows. Would allow for better detection of issues on batch changes.

Currently there are times where maintainers are running consecutive CI jobs with singular changes because CI failures are not collected for the whole batch (the workflow is cancelled on the first failure).

Alternative would be to encourage maintainers to open PRs with less changes, however this may not be an efficient way to move forward.