### PR TITLE
orbstack: Enable auto_updates

### DIFF
--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -16,6 +16,7 @@ cask "orbstack" do
     strategy :header_match
   end
 
+  auto_updates true
   depends_on macos: ">= :monterey"
 
   app "OrbStack.app"


### PR DESCRIPTION
OrbStack includes an auto-updater, which can be triggered from either the GUI (Check for Updates) or CLI (`orb update`). Update notifications are sent automatically.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.