### PR TITLE
orbstack: Add hooks and more complete uninstall/zap

### DIFF
--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -20,5 +20,30 @@ cask "orbstack" do
 
   app "OrbStack.app"
 
-  zap trash: "~/.orbstack"
+  postflight do
+    system_command "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",
+                   args: ["_internal", "brew-postflight"]
+  end
+
+  uninstall script: {
+    executable: "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",
+    args:       ["_internal", "brew-uninstall"],
+  }
+
+  zap script: {
+        executable: "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",
+        args:       ["_internal", "brew-uninstall", "--zap"],
+      },
+      trash:  [
+        "~/.orbstack",
+        "~/Library/Caches/dev.kdrag0n.MacVirt",
+        "~/Library/HTTPStorages/dev.kdrag0n.MacVirt",
+        "~/Library/Preferences/dev.krag0n.MacVirt.plist",
+        "~/Library/WebKit/dev.kdrag0n.MacVirt",
+        "~/Library/Saved Application State/dev.kdrag0n.MacVirt.savedState",
+      ]
+
+  caveats <<~EOS
+    Open the OrbStack app to finish setup.
+  EOS
 end

--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -30,11 +30,7 @@ cask "orbstack" do
     args:       ["_internal", "brew-uninstall"],
   }
 
-  zap script: {
-        executable: "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",
-        args:       ["_internal", "brew-uninstall", "--zap"],
-      },
-      trash:  [
+  zap trash: [
         "~/.orbstack",
         "~/Library/Caches/dev.kdrag0n.MacVirt",
         "~/Library/HTTPStorages/dev.kdrag0n.MacVirt",
@@ -42,7 +38,7 @@ cask "orbstack" do
         "~/Library/WebKit/dev.kdrag0n.MacVirt",
         "~/Library/Saved Application State/dev.kdrag0n.MacVirt.savedState",
       ],
-      rmdir:  [
+      rmdir: [
         "~/OrbStack",
       ]
 

--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -41,6 +41,9 @@ cask "orbstack" do
         "~/Library/Preferences/dev.krag0n.MacVirt.plist",
         "~/Library/WebKit/dev.kdrag0n.MacVirt",
         "~/Library/Saved Application State/dev.kdrag0n.MacVirt.savedState",
+      ],
+      rmdir:  [
+        "~/OrbStack",
       ]
 
   caveats <<~EOS


### PR DESCRIPTION
- Add postflight hook to complete update as discussed in https://github.com/Homebrew/homebrew-cask/pull/143806. Does nothing on first install.
- Add uninstall and zap hooks for VM cleanup (does nothing in v0.5.0 and v0.5.1, but already implemented for future versions)
- Clean up GUI app state in ~/Library on zap. (`macvirt` is the project's codename)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.