### PR TITLE
hstracker: add auto_updates stanza

### DIFF
--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,6 +1,5 @@
 cask "hstracker" do
   version "2.3.12"
-  auto_updates true
   sha256 "272f60424bb44ec1da26845d047f7b9402482814729ae8a0b89beb3f6172e9e5"
 
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip",
@@ -14,6 +13,7 @@ cask "hstracker" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  auto_updates true
   depends_on macos: ">= :sierra"
 
   app "HSTracker.app"

--- a/Casks/hstracker.rb
+++ b/Casks/hstracker.rb
@@ -1,5 +1,6 @@
 cask "hstracker" do
   version "2.3.12"
+  auto_updates true
   sha256 "272f60424bb44ec1da26845d047f7b9402482814729ae8a0b89beb3f6172e9e5"
 
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

