### PR TITLE
Fix SHA256 hash for Retroarch

### DIFF
--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask "retroarch" do
   version "1.15.0"
-  sha256 "b171b3fe6284671a8b9b04cdad82cae6e14eee84faa63be160f754f175fe179c"
+  sha256 "3cc50413cdfabc8f031280c784ea856a8d3e8015b17992a62e026e82e9fdbcf0"
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   name "RetroArch"

--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask "retroarch" do
   version "1.15.0"
-  sha256 "3cc50413cdfabc8f031280c784ea856a8d3e8015b17992a62e026e82e9fdbcf0"
+  sha256 :no_check
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   name "RetroArch"

--- a/Casks/retroarch.rb
+++ b/Casks/retroarch.rb
@@ -1,6 +1,6 @@
 cask "retroarch" do
   version "1.15.0"
-  sha256 :no_check
+  sha256 :no_check # required as upstream package is often updated in place
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg"
   name "RetroArch"


### PR DESCRIPTION
Fixing the hash for RetroArch.

This happens quite often now. I think the person responsible for doing the updates should check their toolchain as I think this is the third time I'm correcting the hash. I don't mind doing it, but I'm worried perhaps the person doing this has a compromised machine, or there is another reason why their hashes are often incorrect.

Verification:

```
❯ wget https://buildbot.libretro.com/stable/1.15.0/apple/osx/x86_64/RetroArch.dmg
--2023-03-27 11:44:36--  https://buildbot.libretro.com/stable/1.15.0/apple/osx/x86_64/RetroArch.dmg
Resolving buildbot.libretro.com (buildbot.libretro.com)... 104.21.6.239, 172.67.135.120
Connecting to buildbot.libretro.com (buildbot.libretro.com)|104.21.6.239|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 174169579 (166M) [application/x-apple-diskimage]
Saving to: ‘RetroArch.dmg’

RetroArch.dmg         100%[=========================>] 166.10M  4.79MB/s    in 33s

2023-03-27 11:45:09 (5.00 MB/s) - ‘RetroArch.dmg’ saved [174169579/174169579]

❯ shasum -a 256 RetroArch.dmg
3cc50413cdfabc8f031280c784ea856a8d3e8015b17992a62e026e82e9fdbcf0  RetroArch.dmg
```

Tagging @razvanazamfirei @p-linnane as co-authors of the last update.



---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
