### PR TITLE
fig: Remove broken zap script

### DIFF
--- a/Casks/fig.rb
+++ b/Casks/fig.rb
@@ -34,21 +34,17 @@ cask "fig" do
               "io.fig.cursor",
             ]
 
-  zap script: {
-        executable: "#{appdir}/Fig.app/Contents/MacOS/fig-darwin-universal",
-        args:       ["_", "brew-uninstall", "--zap"],
-      },
-      trash:  [
-        "~/.fig",
-        "~/.fig.dotfiles.bak",
-        "~/Library/Application Support/com.mschrage.fig",
-        "~/Library/Application Support/fig",
-        "~/Library/Caches/com.mschrage.fig",
-        "~/Library/Caches/fig",
-        "~/Library/HTTPStorages/com.mschrage.fig",
-        "~/Library/Preferences/com.mschrage.fig.*",
-        "~/Library/WebKit/com.mschrage.fig",
-      ]
+  zap trash: [
+    "~/.fig",
+    "~/.fig.dotfiles.bak",
+    "~/Library/Application Support/com.mschrage.fig",
+    "~/Library/Application Support/fig",
+    "~/Library/Caches/com.mschrage.fig",
+    "~/Library/Caches/fig",
+    "~/Library/HTTPStorages/com.mschrage.fig",
+    "~/Library/Preferences/com.mschrage.fig.*",
+    "~/Library/WebKit/com.mschrage.fig",
+  ]
 
   caveats <<~EOS
     Please launch the Fig application to finish setup...


### PR DESCRIPTION
The script is part of the app but runs after the zap, not before, so it no longer exists:

```
==> Running uninstall script /Applications/Fig.app/Contents/MacOS/fig-darwin-universal Error: uninstall script /Applications/Fig.app/Contents/MacOS/fig-darwin-universal does not exist.
```

Zapping implies uninstalling, which happens first, so the script isn't necessary anyway.

Discussed in #143807.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.