### PR TITLE
slicer: update livecheck

### DIFF
--- a/Casks/slicer.rb
+++ b/Casks/slicer.rb
@@ -10,9 +10,10 @@ cask "slicer" do
 
   livecheck do
     url "https://download.slicer.org"
-    strategy :page_match do |page|
-      match = page.scan(%r{href=.*?/bitstream/(\d+\w+).*?\n?.*?version\s*(\d+(?:\.\d+)+)}im)
-      next if match.blank?
+    regex(%r{href=.*?/bitstream/(\h+)["' >].+?["']header["'][^>]*?>\s*v?(\d+(?:\.\d+)+)}im)
+    strategy :page_match do |page, regex|
+      match = page.scan(regex)
+      next unless match.length >= 2
 
       "#{match[1][1]},#{match[1][0]}"
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `slicer` is currently hanging when executed. For whatever reason, calling `#scan` with the existing regex on the current `page` content causes execution to hang (i.e., it never resolves and you simply have to kill the process). I've never seen this happen with a `livecheck` block before but modifying the regex to better target the current text format resolves the issue.

Besides that, this also:

* Updates the `livecheck` block to use `#regex` and pass the regex into the `strategy` block.
* Modifies the `next` condition in the `strategy` block to ensure that `#scan` finds at least two matches (since this targets the second match on the page).

I noticed this while doing a full livecheck run across homebrew/cask, so this fix should allow `brew livecheck --tap homebrew/cask` successfully finish instead of hanging part of the way through (when checking `slicer`).