### PR TITLE
Disable `HOMEBREW_DEBUG` for `install`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,6 @@ jobs:
           fromJSON(steps.info.outputs.macos_requirement_satisfied) &&
           !matrix.skip_install
         timeout-minutes: 30
-        env:
-          HOMEBREW_DEBUG: 1
 
       - name: Run brew uninstall --cask ${{ matrix.cask.token }}
         run: brew uninstall --cask '${{ matrix.cask.path }}'


### PR DESCRIPTION
This can be set by re-running and enabling the runner debugging checkbox, see https://github.com/Homebrew/homebrew-cask/pull/142339.