### PR TITLE
orbstack: Link orb and orbctl CLI binaries

### DIFF
--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -20,6 +20,8 @@ cask "orbstack" do
   depends_on macos: ">= :monterey"
 
   app "OrbStack.app"
+  binary "#{appdir}/OrbStack.app/Contents/MacOS/bin/orb", target: "orb"
+  binary "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl", target: "orbctl"
 
   postflight do
     system_command "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",

--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -20,8 +20,8 @@ cask "orbstack" do
   depends_on macos: ">= :monterey"
 
   app "OrbStack.app"
-  binary "#{appdir}/OrbStack.app/Contents/MacOS/bin/orb", target: "orb"
-  binary "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl", target: "orbctl"
+  binary "#{appdir}/OrbStack.app/Contents/MacOS/bin/orb"
+  binary "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl"
 
   postflight do
     system_command "#{appdir}/OrbStack.app/Contents/MacOS/bin/orbctl",

--- a/Casks/orbstack.rb
+++ b/Casks/orbstack.rb
@@ -1,9 +1,9 @@
 cask "orbstack" do
   arch arm: "arm64", intel: "amd64"
 
-  version "0.5.1_985"
-  sha256 arm:   "4040f4484b9b4991ea20c04cdfd7f6609a35f125f326d527466f8d3517bed603",
-         intel: "3fdb81b1ed9a34ac5d25940217ee991db0c95a92c4cea70dc098a505a85977b2"
+  version "0.5.2_1012"
+  sha256 arm:   "1c37837751d02d411080fafd59ab8529f0afb685d09b5a4adc9c142399405dc0",
+         intel: "65b3ad985515ac8baa18e569ec6c50f78f765e0c150d5f0f87974474a59cdc1d"
 
   url "https://cdn-updates.orbstack.dev/#{arch}/OrbStack_v#{version}_#{arch}.dmg"
   name "OrbStack"


### PR DESCRIPTION
`orbctl` and the shorter `orb` command are CLI tools for using and managing OrbStack and its Linux machines. They're usually symlinked at first launch, but managing them with Homebrew should be better for cask users. The app will detect brew's symlinks and leave them alone.

OrbStack also includes Docker tools similar to Docker Desktop, but it's probably better to let the app decide what it needs to link at launch. There's no requirement to use any particular versions of the Docker tools, so for example, users with Docker installed via Homebrew may want to keep using their existing ones.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
