### PR TITLE
Remove `concurrency` for `automerge` workflow.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,9 +13,6 @@ on:
       - unlabeled
       - ready_for_review
 
-concurrency:
-  group: ${{ github.workflow }}-${ github.head_ref || github.ref }}
-
 permissions: {}
 
 jobs:


### PR DESCRIPTION
The current `group` still doesn't work, so let's just remove it. This workflow only takes a few seconds to run anyways.