### PR TITLE
 Remove auto_update in logseq.rb

### DIFF
--- a/Casks/logseq.rb
+++ b/Casks/logseq.rb
@@ -15,8 +15,6 @@ cask "logseq" do
     strategy :github_latest
   end
 
-  auto_updates true
-
   app "Logseq.app"
 
   zap trash: [


### PR DESCRIPTION
Logseq does not have an automatic update feature. Instead, users must manually check for updates by clicking the "check for updates" button, which will direct them to the GitHub release page where they can download and install any available updates themselves.

![图片](https://user-images.githubusercontent.com/12483662/228750748-3bda6a7f-8cae-41de-ac03-95e6d19c128d.png)

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
