### PR TITLE
Add `org.cocoapods.*` to `list_ids_in_app` script

### DIFF
--- a/developer/bin/list_ids_in_app
+++ b/developer/bin/list_ids_in_app
@@ -91,6 +91,7 @@ clean_sources () {
     /usr/bin/egrep -vi '^net\.wafflesoftware\.ShortcutRecorder\.framework' |                                 \
     /usr/bin/egrep -vi '^org\.AFNetworking\.AFNetworking' |                                                  \
     /usr/bin/egrep -vi '^org\.boredzo\.(LMX|ISO8601DateFormatter)' |                                         \
+    /usr/bin/egrep -vi '^org\.cocoapods\.' |                                                                 \
     /usr/bin/egrep -vi '^org\.dribin\.dave\.DDHidLib' |                                                      \
     /usr/bin/egrep -vi '^org\.linkbackproject\.LinkBack' |                                                   \
     /usr/bin/egrep -vi '^org\.mantle\.Mantle' |                                                              \


### PR DESCRIPTION
Here's a (probably not exhaustive) list of what I found in an app:

```
org.cocoapods.Alamofire
org.cocoapods.CocoaLumberjack
org.cocoapods.PINCache
org.cocoapods.PINOperation
org.cocoapods.ReactiveCocoa
org.cocoapods.ReactiveSwift
org.cocoapods.Result
org.cocoapods.SSZipArchive
org.cocoapods.SnapKit
org.cocoapods.Storm
org.cocoapods.Zip
```