### PR TITLE
Update LibreWolf to v111.0.1-1

### DIFF
--- a/Casks/librewolf.rb
+++ b/Casks/librewolf.rb
@@ -2,12 +2,12 @@ cask "librewolf" do
   arch arm: "aarch64", intel: "x86_64"
 
   on_arm do
-    version "111.0,2,0240b8c0b64aa90c69ba14ecb44b4af0"
-    sha256 "e5a5854914da6ec486105d07c45007d41a1ce0add491765b71837802c2c4adce"
+    version "111.0.1,1,1df5f9939d2c78b3ca0d59948ace0502"
+    sha256 "44819bec19b6b6c9bef5bca0c99ccc482c6adc6a830184f68f904d4d76fbf478"
   end
   on_intel do
-    version "111.0,2,3a4c6f6cc727f4e805166bfaf6439323"
-    sha256 "b14910a74eadecf53aa672795fc7e0a97d9b5b6f77f9b44985bcf0f787e36a4f"
+    version "111.0.1,1,94e569d180182fa68167550cc98a78d5"
+    sha256 "9ae8ee85d5b591d1b03bd7b0b45802af59b4c5a97898e5672fe9322ff4fb6c41"
   end
 
   url "https://gitlab.com/librewolf-community/browser/macos/uploads/#{version.csv.third}/librewolf-#{version.csv.first}-#{version.csv.second}.en-US.mac.#{arch}.dmg",


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.