### PR TITLE
notion: update livecheck, update zap

### DIFF
--- a/Casks/notion.rb
+++ b/Casks/notion.rb
@@ -1,6 +1,6 @@
 cask "notion" do
   arch arm: "-arm64"
-  livecheck_folder = on_arch_conditional arm: "apple-silicon", intel: "mac"
+  livecheck_folder = on_arch_conditional arm: "arm64", intel: "latest"
 
   version "2.1.13"
   sha256 arm:   "658125c5d2df38e82a0b416dd0f0e516efdde85ebda8a103c26665bf87fe5af5",
@@ -13,9 +13,8 @@ cask "notion" do
   homepage "https://www.notion.so/"
 
   livecheck do
-    url "https://www.notion.so/desktop/#{livecheck_folder}/download"
-    regex(/Notion[._-]v?(\d+(?:\.\d+)*?)[^.]*?\.dmg/i)
-    strategy :header_match
+    url "https://desktop-release.notion-static.com/#{livecheck_folder}-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true
@@ -25,8 +24,9 @@ cask "notion" do
   zap trash: [
     "~/Library/Application Support/Caches/notion-updater",
     "~/Library/Application Support/Notion",
-    "~/Library/Caches/notion.id",
+    "~/Library/Caches/notion.id*",
     "~/Library/Logs/Notion",
+    "~/Library/Preferences/ByHost/notion.id.*.plist",
     "~/Library/Preferences/notion.id.helper.plist",
     "~/Library/Preferences/notion.id.plist",
     "~/Library/Saved Application State/notion.id.savedState",


### PR DESCRIPTION
This PR adds missing files to `zap` and aligns `livecheck` with the in-app `:electron_builder` updating strategy.