### PR TITLE
mattermost: fix syntax

### DIFF
--- a/Casks/mattermost.rb
+++ b/Casks/mattermost.rb
@@ -15,7 +15,7 @@ cask "mattermost" do
     strategy :github_latest
   end
 
-  autoupdates true
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Mattermost.app"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/144493 introduced a syntax bug that prints a warning for any user running `brew update`. I will follow up on an audit to catch this moving forward.