### PR TITLE
Update Defold SHA-256

### DIFF
--- a/Casks/defold.rb
+++ b/Casks/defold.rb
@@ -1,6 +1,6 @@
 cask "defold" do
   version "1.4.4"
-  sha256 "81961335ded0113a20ed80477eabf752f444766493d691a87cbf087a077cbb6d"
+  sha256 "c11bd02aebe230338606de6c0cd713ca717cc5f110c32fd01a0472cff120fabf"
 
   url "https://github.com/defold/defold/releases/download/#{version}/Defold-x86_64-macos.dmg",
       verified: "github.com/defold/defold/"


### PR DESCRIPTION
When trying to install Defold 1.4.4, `brew install` reports a mismatching SHA-256 checksum. This PR updates the formula to use the correct one.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
