### PR TITLE
google-cloud-sdk 425.0.0

### DIFF
--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -1,47 +1,71 @@
 cask "google-cloud-sdk" do
-  version :latest # Must remain unversioned, else all installed gcloud components would be lost on upgrade
-  sha256 :no_check
+  arch arm: "arm", intel: "x86_64"
 
-  url "https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz"
+  version "425.0.0"
+  sha256 arm:   "0871269d6f7314b2c8f32afcddcc1054d62a108cb89c80a0cdee9f4542d0cece",
+         intel: "b1f0731482243a08ffc2c362092871ab0fa2bd0db1bc68f12ae0c6bf284a0b1c"
+
+  url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-#{version}-darwin-#{arch}.tar.gz"
   name "Google Cloud SDK"
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
   homepage "https://cloud.google.com/sdk/"
 
+  livecheck do
+    url "https://cloud.google.com/sdk/docs/install-sdk"
+    regex(/google-cloud-cli-(\d+(?:\.\d+)+)/i)
+  end
+
   depends_on formula: "python"
 
+  google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
+
   installer script: {
-    executable: "#{token}/install.sh",
+    executable: "google-cloud-sdk/install.sh",
     args:       [
-      "--usage-reporting", "false", "--bash-completion", "false", "--path-update", "false",
-      "--rc-path", "false", "--quiet",
+      "--quiet",
+      "--usage-reporting", "false",
+      "--bash-completion", "false",
+      "--path-update", "false",
+      "--rc-path", "false",
       "--install-python", "false"
     ],
   }
-  binary "#{token}/bin/anthoscli"
-  binary "#{token}/bin/bq"
-  binary "#{token}/bin/docker-credential-gcloud"
-  binary "#{token}/bin/gcloud"
-  binary "#{token}/bin/git-credential-gcloud.sh", target: "git-credential-gcloud"
-  binary "#{token}/bin/gsutil"
-  binary "#{token}/completion.bash.inc",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/#{token}"
-  binary "#{token}/completion.zsh.inc",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_#{token}"
+  binary "google-cloud-sdk/bin/anthoscli"
+  binary "google-cloud-sdk/bin/bq"
+  binary "google-cloud-sdk/bin/docker-credential-gcloud"
+  binary "google-cloud-sdk/bin/gcloud"
+  binary "google-cloud-sdk/bin/git-credential-gcloud.sh", target: "git-credential-gcloud"
+  binary "google-cloud-sdk/bin/gsutil"
+  binary "google-cloud-sdk/completion.bash.inc",
+         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/google-cloud-sdk"
+  binary "google-cloud-sdk/completion.zsh.inc",
+         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_google-cloud-sdk"
+
+  preflight do
+    FileUtils.cp_r staged_path/"google-cloud-sdk/.", google_cloud_sdk_root, remove_destination: true
+    (staged_path/"google-cloud-sdk").rmtree
+    FileUtils.ln_s google_cloud_sdk_root, (staged_path/"google-cloud-sdk")
+  end
 
   # Not actually necessary, since it would be deleted anyway.
   # It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
-  uninstall delete: "#{staged_path}/#{token}"
+  uninstall delete: "#{staged_path}/google-cloud-sdk"
+
+  zap trash: [
+    google_cloud_sdk_root,
+    "#{google_cloud_sdk_root}.staging",
+  ]
 
   caveats <<~EOS
     To add gcloud components to your PATH, add this to your profile:
 
       for bash users
-        source "#{staged_path}/#{token}/path.bash.inc"
+        source "#{google_cloud_sdk_root}/path.bash.inc"
 
       for zsh users
-        source "#{staged_path}/#{token}/path.zsh.inc"
+        source "#{google_cloud_sdk_root}/path.zsh.inc"
 
       for fish users
-        source "#{staged_path}/#{token}/path.fish.inc"
+        source "#{google_cloud_sdk_root}/path.fish.inc"
   EOS
 end

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -42,6 +42,9 @@ cask "google-cloud-sdk" do
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_google-cloud-sdk"
 
   preflight do
+    # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.
+    FileUtils.ln_s staged_path, (staged_path.dirname/"latest"), force: true
+
     FileUtils.cp_r staged_path/"google-cloud-sdk/.", google_cloud_sdk_root, remove_destination: true
     (staged_path/"google-cloud-sdk").rmtree
     FileUtils.ln_s google_cloud_sdk_root, (staged_path/"google-cloud-sdk")

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -39,7 +39,7 @@ cask "google-cloud-sdk" do
   binary "google-cloud-sdk/completion.bash.inc",
          target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/google-cloud-sdk"
   binary "google-cloud-sdk/completion.zsh.inc",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_google-cloud-sdk"
+         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_google_cloud_sdk"
 
   preflight do
     # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.

--- a/Casks/google-cloud-sdk.rb
+++ b/Casks/google-cloud-sdk.rb
@@ -50,9 +50,7 @@ cask "google-cloud-sdk" do
     FileUtils.ln_s google_cloud_sdk_root, (staged_path/"google-cloud-sdk")
   end
 
-  # Not actually necessary, since it would be deleted anyway.
-  # It is present to make clear an uninstall was not forgotten and that for this cask it is indeed this simple.
-  uninstall delete: "#{staged_path}/google-cloud-sdk"
+  uninstall delete: staged_path.dirname/"latest"
 
   zap trash: [
     google_cloud_sdk_root,


### PR DESCRIPTION
Add a livecheck and make this versioned.

This uses a similar approach as `android-commandlinetools`, installing into `HOMEBREW_PREFIX/"share"` so that the installed components survive updates in the future.

This will nuke components when upgrading from `latest`, but upgrading with `--greedy` would do the same previously.
