### PR TITLE
Update okta-advanced-server-access.rb

### DIFF
--- a/Casks/okta-advanced-server-access.rb
+++ b/Casks/okta-advanced-server-access.rb
@@ -1,17 +1,17 @@
 cask "okta-advanced-server-access" do
   version "1.68.6"
-  sha256 "89fefea34d170fd1bd61a40b2c7c5b63a78c859bd9320c0c448e681b7bdc308f"
+  sha256 "65b292b52433f8d02af4c78a33fbbe7678c344feefa726585090f78fd13c579e"
 
   url "https://dist.scaleft.com/repos/macos/stable/all/macos-client/v#{version}/ScaleFT-#{version}.pkg",
-      verified: "scaleft.com/"
+      verified: "dist.scaleft.com/repos/macos/stable/all/macos-client/"
   name "Okta Advanced Server Access"
   name "ScaleFT"
   desc "Identity and access management"
   homepage "https://help.okta.com/asa/en-us/Content/Topics/Adv_Server_Access/docs/sft-osx.htm"
 
   livecheck do
-    url "https://dist.scaleft.com/client-tools/mac/latest/ScaleFT.pkg"
-    strategy :header_match
+    url "https://dist.scaleft.com/repos/macos/stable/all/macos-client/oktapam-appcast.xml"
+    strategy :sparkle, &:short_version
   end
 
   pkg "ScaleFT-#{version}.pkg"

--- a/Casks/okta-advanced-server-access.rb
+++ b/Casks/okta-advanced-server-access.rb
@@ -1,8 +1,8 @@
 cask "okta-advanced-server-access" do
-  version "1.67.4"
+  version "1.68.6"
   sha256 "89fefea34d170fd1bd61a40b2c7c5b63a78c859bd9320c0c448e681b7bdc308f"
 
-  url "https://dist.scaleft.com/client-tools/mac/v#{version}/ScaleFT-#{version}.pkg",
+  url "https://dist.scaleft.com/repos/macos/stable/all/macos-client/#{version}/ScaleFT-#{version}.pkg",
       verified: "scaleft.com/"
   name "Okta Advanced Server Access"
   name "ScaleFT"

--- a/Casks/okta-advanced-server-access.rb
+++ b/Casks/okta-advanced-server-access.rb
@@ -14,6 +14,8 @@ cask "okta-advanced-server-access" do
     strategy :sparkle, &:short_version
   end
 
+  depends_on macos: ">= :high_sierra"
+
   pkg "ScaleFT-#{version}.pkg"
 
   uninstall pkgutil: "com.scaleft.ScaleFT"

--- a/Casks/okta-advanced-server-access.rb
+++ b/Casks/okta-advanced-server-access.rb
@@ -2,7 +2,7 @@ cask "okta-advanced-server-access" do
   version "1.68.6"
   sha256 "89fefea34d170fd1bd61a40b2c7c5b63a78c859bd9320c0c448e681b7bdc308f"
 
-  url "https://dist.scaleft.com/repos/macos/stable/all/macos-client/#{version}/ScaleFT-#{version}.pkg",
+  url "https://dist.scaleft.com/repos/macos/stable/all/macos-client/v#{version}/ScaleFT-#{version}.pkg",
       verified: "scaleft.com/"
   name "Okta Advanced Server Access"
   name "ScaleFT"


### PR DESCRIPTION
Update okta-advanced-server-access from 1.67.4 to 1.68.6 and changing URL.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
