### PR TITLE
docker 1.8.0 (add caveat)

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -58,14 +58,15 @@ cask "docker" do
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
 
   uninstall delete:    [
+              "/Library/PrivilegedHelperTools/com.docker.socket",
               "/Library/PrivilegedHelperTools/com.docker.vmnetd",
               "/usr/local/bin/com.docker.cli",
-              "/usr/local/bin/docker-compose-v1",
+              "/usr/local/bin/docker",
               "/usr/local/bin/docker-compose",
+              "/usr/local/bin/docker-compose-v1",
               "/usr/local/bin/docker-credential-desktop",
               "/usr/local/bin/docker-credential-ecr-login",
               "/usr/local/bin/docker-credential-osxkeychain",
-              "/usr/local/bin/docker",
               "/usr/local/bin/hub-tool",
               "/usr/local/bin/hyperkit",
               "/usr/local/bin/kubectl.docker",
@@ -91,6 +92,7 @@ cask "docker" do
         "/usr/local/bin/docker.backup",
         "~/.docker",
         "~/Library/Application Scripts/com.docker.helper",
+        "~/Library/Application Scripts/group.com.docker",
         "~/Library/Application Support/com.bugsnag.Bugsnag/com.docker.docker",
         "~/Library/Application Support/Docker Desktop",
         "~/Library/Caches/com.docker.docker",
@@ -99,6 +101,7 @@ cask "docker" do
         "~/Library/Containers/com.docker.docker",
         "~/Library/Containers/com.docker.helper",
         "~/Library/Group Containers/group.com.docker",
+        "~/Library/HTTPStorages/com.docker.docker",
         "~/Library/HTTPStorages/com.docker.docker.binarycookies",
         "~/Library/Logs/Docker Desktop",
         "~/Library/Preferences/com.docker.docker.plist",
@@ -111,4 +114,10 @@ cask "docker" do
         "~/Library/Caches/com.plausiblelabs.crashreporter.data",
         "~/Library/Caches/KSCrashReports",
       ]
+
+  caveats <<~EOS
+    If your CLI tools were symlinked to $HOME/.docker/bin your path should be modified to include:
+
+      $HOME/.docker/bin
+  EOS
 end


### PR DESCRIPTION
Version 1.8.0 CLI tools may not be in `$PATH` by default. Adding caveat.

See https://github.com/Homebrew/homebrew-cask/issues/144587#issuecomment-1499441237
