### PR TITLE
Add TransIP STACK v2.11.1-20220906

### DIFF
--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -9,7 +9,7 @@ cask "stack" do
 
   livecheck do
     url "https://filehosting-client.transip.nl/packages/stack/"
-    regex(%r{href=["'].*?stack/v?((?:2)(?:\.\d+){2}(?:[-_]\d+))["' >]}i)
+    regex(%r{href=["'](?:.*?/)?v?(2(?:[.-]\d+)+)["' >]}i)
   end
 
   app "stack.app"

--- a/Casks/stack.rb
+++ b/Casks/stack.rb
@@ -1,0 +1,25 @@
+cask "stack" do
+  version "2.11.1-20220906"
+  sha256 "d5b92e5f0070fbd1f92c36be58e0c979efcceb79b685dd7e665ebf165d70a82c"
+
+  url "https://filehosting-client.transip.nl/packages/stack/v#{version}/macos/stack-v#{version}.dmg"
+  name "STACK"
+  desc "Personal online hard drive to store, view and share files"
+  homepage "https://www.transip.nl/stack/"
+
+  livecheck do
+    url "https://filehosting-client.transip.nl/packages/stack/"
+    regex(%r{href=["'].*?stack/v?((?:2)(?:\.\d+){2}(?:[-_]\d+))["' >]}i)
+  end
+
+  app "stack.app"
+
+  uninstall login_item: "stack",
+            signal:     ["TERM", "nl.transip.stack"],
+            pkgutil:    "nl.transip.stack"
+
+  zap trash: [
+    "~/Library/Application Support/STACK/",
+    "~/Library/Caches/nl.transip.stack",
+  ]
+end


### PR DESCRIPTION
Although previously removed in 9d975dd, links are available again and do not require login. Livecheck currently narrowed to 2.x.y versions per vendor recommendation.

Checked the basics from contributing instructions (token, both install/uninstall and audit).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
