### PR TITLE
double-commander 1.1.0

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -8,17 +8,20 @@ cask "double-commander" do
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version.csv.first}-#{version.csv.second}.cocoa.#{arch}.dmg",
       verified: "downloads.sourceforge.net/doublecmd/"
   name "Double Commander"
-  desc "File Manager with double panels"
+  desc "File manager with two panels"
   homepage "https://doublecmd.sourceforge.io/"
 
   livecheck do
-    skip "No version information available"
+    url "https://sourceforge.net/projects/doublecmd/rss"
+    regex(/doublecmd[._-](\d+(?:\.\d+)+)[._-](\d+)\.cocoa/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
   app "Double Commander.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Double Commander.app"]
-  end
+  zap trash: [
+    "~/Library/Caches/doublecmd",
+  ]
 end

--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -11,10 +11,14 @@ cask "double-commander" do
   desc "File Manager with double panels"
   homepage "https://doublecmd.sourceforge.io/"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   app "Double Commander.app"
 
   preflight do
     system_command "xattr",
-                   args: ["-d", "com.apple.quarantine", "#{staged_path}/Double Commander.app"]
+                   args: ["-cr", "#{staged_path}/Double Commander.app"]
   end
 end

--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -21,7 +21,5 @@ cask "double-commander" do
 
   app "Double Commander.app"
 
-  zap trash: [
-    "~/Library/Caches/doublecmd",
-  ]
+  zap trash: "~/Library/Caches/doublecmd"
 end

--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -1,16 +1,20 @@
 cask "double-commander" do
-  version "0.9.10-9640"
-  sha256 "1859504e33816db8b19e494dedafa97e3cc90accdb15d9b9ee0c1ad2ba6064d1"
+  arch arm: "aarch64", intel: "x86_64"
 
-  url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version}.qt.x86_64.dmg",
+  version "1.1.0,10668"
+  sha256 arm:   "4727e9a4a75cb6b455d010cbd01bf8b82f1a5557a996774a98ababae3c902d34",
+         intel: "22196b11a5943ad833d5adc6df34deb3a98ea1d1d80138be34bed2ce5bda2300"
+
+  url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version.csv.first}-#{version.csv.second}.cocoa.#{arch}.dmg",
       verified: "downloads.sourceforge.net/doublecmd/"
   name "Double Commander"
-  desc "File manager"
+  desc "File Manager with double panels"
   homepage "https://doublecmd.sourceforge.io/"
 
   app "Double Commander.app"
 
-  caveats do
-    discontinued
+  preflight do
+    system_command "xattr",
+                   args: ["-d", "com.apple.quarantine", "#{staged_path}/Double Commander.app"]
   end
 end


### PR DESCRIPTION
Update Double-Commander to 1.1.0.

1. Double Commander for MacOS has regained official support

2. audit / sytle / install / uninstall have been tested

3. both AArch64 and x86_64 versions have beed inclued in official down page:
https://sourceforge.net/p/doublecmd/wiki/Download/

4. offical homepage:
https://doublecmd.sourceforge.io