### PR TITLE
vym 2.9.0

### DIFF
--- a/Casks/vym.rb
+++ b/Casks/vym.rb
@@ -1,16 +1,15 @@
 cask "vym" do
-  version "2.8.8"
-  sha256 "17587f3ad5550795f6224d09dd1bff659cb525ba77f6482b2d35138a16da1e80"
+  version "2.9.0"
+  sha256 "2243e0d2c89dc9eef53ffac8d4da084650247f025011a522aeba0c19e7857be6"
 
-  url "https://downloads.sourceforge.net/vym/osx11-vym-#{version}-by%20shemeshg.zip"
+  url "https://downloads.sourceforge.net/vym/vym-#{version}.dmg"
   name "VYM (View Your Mind)"
   desc "Generate and manipulate maps which show your thoughts"
   homepage "https://sourceforge.net/projects/vym/"
 
   livecheck do
-    url "https://sourceforge.net/projects/vym/rss"
-    regex(/.*?osx11[._-]vym[._-]v?(\d+(?:\.\d+)+).*?\.zip/i)
-    strategy :page_match
+    url :url
+    regex(%r{url=.*?/vym[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg)}i)
   end
 
   app "vym.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

While doing some other clean-up work, I happened to notice that there's a new version for `vym` (2.9.0) that livecheck misses because the file name and type has changed.

Besides the version bump, this also updates the `livecheck` block to match the version from the current filename format, assuming that they will continue to publish subsequent versions in this manner.

It's worth noting that the existing `livecheck` block URL was identical to the URL generated from the `Sourceforge` strategy, so this should have simply been using `url :url` with no `#strategy` call (instead of manually duplicating the strategy's behavior). We sometimes provide an explicit SourceForge RSS feed URL when we need to specify a path (e.g., `.../rss?path=/something`) but `#strategy` isn't necessary in that situation either.