### PR TITLE
Migrate casks from homebrew/cask-drivers

### DIFF
--- a/Casks/konica-minolta-bizhub-c750i-driver.rb
+++ b/Casks/konica-minolta-bizhub-c750i-driver.rb
@@ -1,0 +1,43 @@
+cask "konica-minolta-bizhub-c750i-driver" do
+  on_catalina :or_older do
+    version "3.0.1,6454ed166639340e7f81bda0dcaeb554,129004"
+    sha256 "4aebd127a1ca363611e04ebb5666efdaf3de2dff1e933bb7ac82f832de878f94"
+
+    pkg "A4/C750i_C650i_C360i_C287i_C286i_C4050i_C4000i_C3320i.pkg"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur :or_newer do
+    version "3.1.3A,55acec5c11f08a2d7a9a06fad48c8949,130158"
+    sha256 "9855a756bf1a1b36a70447232cb98585015dc85a4dfb6ca6e3bd2b10a535610c"
+
+    pkg "C750i_C650i_C360i_C287i_C286i_C4050i_C4000i_C3320i_11.pkg"
+
+    livecheck do
+      url "https://dl.konicaminolta.eu/en?tx_kmdownloadcenter_dlajaxservice[action]=getDocuments&tx_kmdownloadcenter_dlajaxservice[controller]=AjaxService&tx_kmdownloadcenter_dlajaxservice[productId]=103745&tx_kmdownloadcenter_dlajaxservice[system]=KonicaMinolta&cHash=dd72618a38434b6cb3edfc20595d58c5&type=1527583889"
+      strategy :json do |json|
+        items = json.select do |i|
+          i["TypeOfApplicationName_textS"]&.match?(/driver/i) &&
+            i["OperatingSystemsNames_textM"]&.grep(/macOS.*?#{Regexp.escape(MacOS.version.to_s)}/i)&.any?
+        end
+
+        item = items.max_by { |i| i["ReleaseDate_textS"] }
+        files = item["DownloadFiles_textS"].split("\n").map { |file| file.split("|") }
+        dmg = files.find { |f| f.first.end_with?(".dmg") }
+
+        "#{item["Version_textS"]},#{Digest::MD5.hexdigest(dmg[2])},#{item["AnacondaId_textS"]}"
+      end
+    end
+  end
+
+  url "https://dl.konicaminolta.eu/en?tx_kmdownloadcentersite_downloadproxy[fileId]=#{version.csv.second}&tx_kmdownloadcentersite_downloadproxy[documentId]=#{version.csv.third}&tx_kmdownloadcentersite_downloadproxy[system]=KonicaMinolta&tx_kmdownloadcentersite_downloadproxy[language]=EN&type=1558521685"
+  name "Konica Minolta Bizhub C750i/C650i/C360i/C287i/C286i/C4050i/C4000i/C3320i Printer Driver"
+  desc "PostScript printer driver"
+  homepage "https://www.konicaminolta.eu/eu-en/support/download-centre"
+
+  depends_on macos: ">= :sierra"
+
+  uninstall pkgutil: "jp.konicaminolta.print.package.C750i"
+end

--- a/Casks/segger-jlink.rb
+++ b/Casks/segger-jlink.rb
@@ -1,0 +1,47 @@
+cask "segger-jlink" do
+  version "7.86h"
+  sha256 "4022a4351f44f6b07470f818be0a41bf82f8ceea5a35571870e0bfbb1c788207"
+
+  url "https://www.segger.com/downloads/jlink/JLink_MacOSX_V#{version.no_dots}_universal.pkg",
+      using: :post,
+      data:  {
+        "accept_license_agreement" => "accepted",
+        "non_emb_ctr"              => "confirmed",
+        "submit"                   => "Download software",
+      }
+  name "Segger J-Link Command Line Tools"
+  desc "Software and Documentation pack for Segger J-Link debug probes"
+  homepage "https://www.segger.com/downloads/jlink"
+
+  livecheck do
+    url "https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html"
+    regex(/Version\s*V(\d+(?:\.\d+[a-z]?)*)/i)
+  end
+
+  pkg "JLink_MacOSX_V#{version.no_dots}_universal.pkg"
+
+  uninstall quit:    [
+              "com.segger.JFlashLite.*",
+              "com.segger.JLinkGDBServer.*",
+              "com.segger.JLinkLicenseManager.*",
+              "com.segger.JLinkRegistration.*",
+              "com.segger.JLinkRemoteServer.*",
+              "com.segger.JLinkRTTViewer.*",
+            ],
+            pkgutil: "com.segger.pkg.JLink"
+
+  zap trash: [
+    "~/.SEGGER",
+    "~/Library/Application Support/SEGGER",
+    "~/Library/Saved Application State/com.segger.JFlashLite.*savedState",
+    "~/Library/Saved Application State/com.segger.JLinkGDBServer.*savedState",
+    "~/Library/Saved Application State/com.segger.JLinkLicenseManager.*savedState",
+    "~/Library/Saved Application State/com.segger.JLinkRTTViewer.*savedState",
+    "~/Library/Saved Application State/com.segger.JLinkRegistration.*savedState",
+    "~/Library/Saved Application State/com.segger.JLinkRemoteServer.*savedState",
+  ]
+
+  caveats do
+    license @cask.url.to_s
+  end
+end


### PR DESCRIPTION
Merge at the same time as https://github.com/Homebrew/homebrew-cask-drivers/pull/3412.