### PR TITLE
rubocop: Fix `Cask/StanzaGrouping` offenses in `on_*` blocks

### DIFF
--- a/Casks/amethyst.rb
+++ b/Casks/amethyst.rb
@@ -2,6 +2,7 @@ cask "amethyst" do
   on_el_capitan :or_older do
     version "0.10.1"
     sha256 "9fd1ac2cfb8159b2945a4482046ee6d365353df617f4edbabc4e8cadc448c1e7"
+
     url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
 
     livecheck do
@@ -11,6 +12,7 @@ cask "amethyst" do
   on_sierra :or_newer do
     version "0.19.0"
     sha256 "2dd31fc92a0fa58e1f3dc0f21853f9c6fe7fb386b55e895e03b9072a1ca46690"
+
     url "https://github.com/ianyh/Amethyst/releases/download/v#{version}/Amethyst.zip",
         verified: "github.com/ianyh/Amethyst/"
 

--- a/Casks/apparency.rb
+++ b/Casks/apparency.rb
@@ -1,7 +1,9 @@
 cask "apparency" do
   on_mojave do
     version "1.3"
+
     url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
+
     sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
 
     livecheck do
@@ -10,7 +12,9 @@ cask "apparency" do
   end
   on_catalina do
     version "1.4.1"
+
     url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
+
     sha256 "850d19c6d6a86380211d9acdb3d8b0ee3b2a4c8af833126c28141f105823c59a"
 
     livecheck do
@@ -19,7 +23,9 @@ cask "apparency" do
   end
   on_big_sur :or_newer do
     version "1.5.1,285"
+
     url "https://mothersruin.com/software/downloads/Apparency.dmg"
+
     sha256 :no_check
 
     livecheck do

--- a/Casks/apparency.rb
+++ b/Casks/apparency.rb
@@ -1,10 +1,9 @@
 cask "apparency" do
   on_mojave do
     version "1.3"
+    sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
 
     url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
-
-    sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
 
     livecheck do
       skip "Legacy version"
@@ -12,10 +11,9 @@ cask "apparency" do
   end
   on_catalina do
     version "1.4.1"
+    sha256 "850d19c6d6a86380211d9acdb3d8b0ee3b2a4c8af833126c28141f105823c59a"
 
     url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
-
-    sha256 "850d19c6d6a86380211d9acdb3d8b0ee3b2a4c8af833126c28141f105823c59a"
 
     livecheck do
       skip "Legacy version"
@@ -23,10 +21,9 @@ cask "apparency" do
   end
   on_big_sur :or_newer do
     version "1.5.1,285"
+    sha256 :no_check
 
     url "https://mothersruin.com/software/downloads/Apparency.dmg"
-
-    sha256 :no_check
 
     livecheck do
       url "https://www.mothersruin.com/software/Apparency/data/ApparencyVersionInfo.plist"

--- a/Casks/calmly-writer.rb
+++ b/Casks/calmly-writer.rb
@@ -5,10 +5,12 @@ cask "calmly-writer" do
 
   on_arm do
     sha256 "1e7338c2021c8321046f735756c3f745e36cc063b6c4b3f32fa9a01e460c9bfd"
+
     url "https://www.calmlywriter.com/releases/Calmly%20Writer-#{version}-#{arch}.dmg"
   end
   on_intel do
     sha256 "2857f7ba53afb8929ed85d2483faccd28ad9ea309a7752ef738cb9ed91adc878"
+
     url "https://www.calmlywriter.com/releases/Calmly%20Writer-#{version}.dmg"
   end
 

--- a/Casks/deeper.rb
+++ b/Casks/deeper.rb
@@ -3,48 +3,56 @@ cask "deeper" do
 
   on_el_capitan do
     version "2.1.4"
+
     url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
 
     depends_on macos: :el_capitan
   end
   on_sierra do
     version "2.2.3"
+
     url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
 
     depends_on macos: :sierra
   end
   on_high_sierra do
     version "2.3.3"
+
     url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
 
     depends_on macos: :high_sierra
   end
   on_mojave do
     version "2.4.8"
+
     url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
 
     depends_on macos: :mojave
   end
   on_catalina do
     version "2.6.0"
+
     url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
 
     depends_on macos: :catalina
   end
   on_big_sur do
     version "2.7.1"
+
     url "https://www.titanium-software.fr/download/11/Deeper.dmg"
 
     depends_on macos: :big_sur
   end
   on_monterey do
     version "2.8.0"
+
     url "https://www.titanium-software.fr/download/12/Deeper.dmg"
 
     depends_on macos: :monterey
   end
   on_ventura do
     version "2.8.9"
+
     url "https://www.titanium-software.fr/download/13/Deeper.dmg"
 
     depends_on macos: :ventura

--- a/Casks/far2l.rb
+++ b/Casks/far2l.rb
@@ -4,10 +4,12 @@ cask "far2l" do
 
   on_mojave :or_older do
     url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.11.dmg"
+
     sha256 "475f1823652c6e59ff5fe4af448c27b6f88a8f38ac0f358a6620d8aaf5f43c99"
   end
   on_catalina :or_newer do
     url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.15.dmg"
+
     sha256 "9cdde68842f5bfd8e0eda9fdab6507e47eeda2b7a8a6941a8a5966fe89a97435"
   end
 

--- a/Casks/flrig.rb
+++ b/Casks/flrig.rb
@@ -3,10 +3,12 @@ cask "flrig" do
 
   on_sierra :or_older do
     sha256 "03cfdcefe90784f5f6fc643817a22d9590d7508ba03cd5cde0c5168723921f30"
+
     url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version}_LI.dmg"
   end
   on_high_sierra :or_newer do
     sha256 "6ee34eeb589ac00a82d74ac2146fdfbf2295eb24f0b1c9bff96ed1630e086c73"
+
     url "https://downloads.sourceforge.net/fldigi/fldigi/flrig-#{version}_U.dmg"
   end
 

--- a/Casks/gpgfrontend.rb
+++ b/Casks/gpgfrontend.rb
@@ -3,11 +3,13 @@ cask "gpgfrontend" do
 
   on_big_sur do
     sha256 "3558d8786573b8a01dc784465e6dcddba5f58a8b30ce09280a55bdfc29612e6a"
+
     url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-11-x86_64.dmg",
         verified: "github.com/saturneric/GpgFrontend/"
   end
   on_monterey :or_newer do
     sha256 "cd1823c287cfcf550939908938e87aafe0e481fe38edafd3aa79557085b59350"
+
     url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-12-x86_64.dmg",
         verified: "github.com/saturneric/GpgFrontend/"
   end

--- a/Casks/inkstitch.rb
+++ b/Casks/inkstitch.rb
@@ -3,6 +3,7 @@ cask "inkstitch" do
 
   on_high_sierra :or_older do
     sha256 "3d6dfc5539c86840715e8edf03e79dee11fe2a85b91043a81a9c09ea050a75f7"
+
     url "https://github.com/inkstitch/inkstitch/releases/download/v#{version}/inkstitch-v#{version}-sierra-osx.pkg",
         verified: "github.com/inkstitch/inkstitch/"
 
@@ -10,6 +11,7 @@ cask "inkstitch" do
   end
   on_mojave :or_newer do
     sha256 "44706a29277ed14bee11c3bbdae748ac8b97d203b0a1232c278611f918ac1cfb"
+
     url "https://github.com/inkstitch/inkstitch/releases/download/v#{version}/inkstitch-v#{version}-osx.pkg",
         verified: "github.com/inkstitch/inkstitch/"
 

--- a/Casks/maintenance.rb
+++ b/Casks/maintenance.rb
@@ -3,48 +3,56 @@ cask "maintenance" do
 
   on_el_capitan do
     version "2.1.8"
+
     url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
 
     depends_on macos: :el_capitan
   end
   on_sierra do
     version "2.3.0"
+
     url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
 
     depends_on macos: :sierra
   end
   on_high_sierra do
     version "2.4.2"
+
     url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
 
     depends_on macos: :high_sierra
   end
   on_mojave do
     version "2.5.6"
+
     url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
 
     depends_on macos: :mojave
   end
   on_catalina do
     version "2.7.1"
+
     url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
 
     depends_on macos: :catalina
   end
   on_big_sur do
     version "2.8.2"
+
     url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
 
     depends_on macos: :big_sur
   end
   on_monterey do
     version "2.9.2"
+
     url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
 
     depends_on macos: :monterey
   end
   on_ventura do
     version "3.0.1"
+
     url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
 
     depends_on macos: :ventura

--- a/Casks/mysqlworkbench.rb
+++ b/Casks/mysqlworkbench.rb
@@ -2,21 +2,25 @@ cask "mysqlworkbench" do
   on_sierra :or_older do
     version "6.3.10"
     sha256 "29857bf84bebb7c4442ce147e44602d00f8c001e3c09b3a6e3af356767e08d2c"
+
     url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   end
   on_high_sierra do
     version "8.0.16"
     sha256 "3478800290e2797d294e3721fdaea4c41ddc1917f2b59ec94a935e16c18dc5d2"
+
     url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   end
   on_mojave do
     version "8.0.21"
     sha256 "7d812551cc1cc38e1d5f588e6c91b07f1778c78a04bfe94dafac3a23ea425e88"
+
     url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
   end
   on_catalina do
     version "8.0.22"
     sha256 "4e27de82d869043cf80e803f1a57cc041a91cabddf0aa6a6c054d68af1837d48"
+
     url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
 
     livecheck do
@@ -26,6 +30,7 @@ cask "mysqlworkbench" do
   on_big_sur :or_newer do
     version "8.0.32"
     sha256 "746549812eae490c94501de2c4b784c178cd936049e5853bb264fea8b802b081"
+
     url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-x86_64.dmg"
 
     livecheck do

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -3,16 +3,19 @@ cask "natron" do
 
   on_mojave :or_older do
     sha256 "4bf8ce890fe51446c01fc8480e8159cd559cfaac2445eae1699ae1718121fa7a"
+
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-OSX109-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"
   end
   on_catalina do
     sha256 "1c97a1f373c3adcdbb933f20b02d0ebd4d7737d44e5344a372bd7b9e5211860e"
+
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-macOS1015-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"
   end
   on_big_sur :or_newer do
     sha256 "90618183b65cab217b7892d6f0ad3254b7efebc57ef47e77790d8504dbcc7b22"
+
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-macOS12-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"
   end

--- a/Casks/natron.rb
+++ b/Casks/natron.rb
@@ -14,7 +14,7 @@ cask "natron" do
         verified: "github.com/NatronGitHub/Natron/"
   end
   on_big_sur :or_newer do
-    sha256 "90618183b65cab217b7892d6f0ad3254b7efebc57ef47e77790d8504dbcc7b22"
+    sha256 "aa31fb6963344c281b53ca6e93823885e09f7d115ed5cc311abb833de4647537"
 
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-macOS12-x86_64.dmg",
         verified: "github.com/NatronGitHub/Natron/"

--- a/Casks/ncar-ncl.rb
+++ b/Casks/ncar-ncl.rb
@@ -3,11 +3,13 @@ cask "ncar-ncl" do
 
   on_high_sierra :or_older do
     sha256 "4e937a6de4303a4928f0f42390d991b12a37659726d15b9da7e8072db74e1867"
+
     url "https://www.earthsystemgrid.org/api/v1/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.13_64bit_gnu710.tar.gz",
         verified: "earthsystemgrid.org/api/v1/dataset/"
   end
   on_mojave :or_newer do
     sha256 "e2cd644f6b1bb41f55480b8818319e60c450998e31e5e489c69a5e84f3d1f359"
+
     url "https://www.earthsystemgrid.org/api/v1/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.14_64bit_gnu730.tar.gz",
         verified: "earthsystemgrid.org/api/v1/dataset/"
   end

--- a/Casks/omnioutliner.rb
+++ b/Casks/omnioutliner.rb
@@ -2,26 +2,31 @@ cask "omnioutliner" do
   on_el_capitan :or_older do
     version "5.1.4"
     sha256 "91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
   end
   on_sierra do
     version "5.3.4"
     sha256 "dd329a070980ae6fe1aa9c55d398a2ab5b6192082455e7eb3526a9fccb3eaf42"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
   end
   on_high_sierra do
     version "5.4.2"
     sha256 "a9364dcf2ee97a871a881530785fa54d269f5e95298e2e4d2e979c70b6365395"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniOutliner-#{version}(n).dmg"
   end
   on_mojave do
     version "5.8.5"
     sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
   end
   on_catalina :or_newer do
     version "5.11.1"
     sha256 "0117a74bdbca04094931e2c482c80ba3b939f0107d5d2039c6c5ab25ec1e8d9d"
+
     url "https://downloads.omnigroup.com/software/macOS/11/OmniOutliner-#{version}.dmg"
   end
 

--- a/Casks/omniplan.rb
+++ b/Casks/omniplan.rb
@@ -2,26 +2,31 @@ cask "omniplan" do
   on_el_capitan :or_older do
     version "3.7.3"
     sha256 "1a3ab3a1ea22bdbdf9c1afda8cafc9a2fdf60cb4414f142b621c8758f81720bd"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPlan-#{version}.dmg"
   end
   on_sierra do
     version "3.10.4"
     sha256 "a30728e72ae970dbf37b2ef9942a6b54267aa3456288dcc1815f20b44667e9e5"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
   end
   on_high_sierra do
     version "3.13"
     sha256 "82e0d7db2626d751f93f97d80dc032e4bc01bba1e05ea52c553e4771c8cfeec5"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
   end
   on_mojave do
     version "4.2.7"
     sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
   end
   on_catalina :or_newer do
     version "4.5.3"
     sha256 "551e45992f27f907d48d1cf21ce8c19ac7d69c369713f598139e25eee43df126"
+
     url "https://downloads.omnigroup.com/software/macOS/11/OmniPlan-#{version}.dmg"
   end
 

--- a/Casks/omnipresence.rb
+++ b/Casks/omnipresence.rb
@@ -2,31 +2,37 @@ cask "omnipresence" do
   on_el_capitan :or_older do
     version "1.5.2"
     sha256 "82d3c6978e644dc7defafd3706a02d15c500e8254ca22076a5095bdd94b786d1"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPresence-#{version}.dmg"
   end
   on_sierra do
     version "1.6"
     sha256 "48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPresence-#{version}.dmg"
   end
   on_high_sierra do
     version "1.6"
     sha256 "48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPresence-#{version}.dmg"
   end
   on_mojave do
     version "1.9.1"
     sha256 "dfb2d162103b3c23e2225dee2322d006f72be3b99b1283c365f6fdd4d1e047d3"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPresence-#{version}.dmg"
   end
   on_catalina do
     version "1.9.1"
     sha256 "dfb2d162103b3c23e2225dee2322d006f72be3b99b1283c365f6fdd4d1e047d3"
+
     url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPresence-#{version}.dmg"
   end
   on_big_sur :or_newer do
     version "1.9.1"
     sha256 "b20077353ee8815e74770c20c331bb3a23fe8cbd2aa6ef449142fe19a0976002"
+
     url "https://downloads.omnigroup.com/software/macOS/11/OmniPresence-#{version}.dmg"
   end
 

--- a/Casks/onyx.rb
+++ b/Casks/onyx.rb
@@ -3,48 +3,56 @@ cask "onyx" do
 
   on_el_capitan do
     version "3.1.9"
+
     url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
 
     depends_on macos: :el_capitan
   end
   on_sierra do
     version "3.3.1"
+
     url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
 
     depends_on macos: :sierra
   end
   on_high_sierra do
     version "3.4.9"
+
     url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
 
     depends_on macos: :high_sierra
   end
   on_mojave do
     version "3.6.8"
+
     url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
 
     depends_on macos: :mojave
   end
   on_catalina do
     version "3.8.7"
+
     url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
 
     depends_on macos: :catalina
   end
   on_big_sur do
     version "4.0.2"
+
     url "https://www.titanium-software.fr/download/11/OnyX.dmg"
 
     depends_on macos: :big_sur
   end
   on_monterey do
     version "4.2.7"
+
     url "https://www.titanium-software.fr/download/12/OnyX.dmg"
 
     depends_on macos: :monterey
   end
   on_ventura do
     version "4.3.9"
+
     url "https://www.titanium-software.fr/download/13/OnyX.dmg"
 
     depends_on macos: :ventura

--- a/Casks/openrct2.rb
+++ b/Casks/openrct2.rb
@@ -3,18 +3,21 @@ cask "openrct2" do
   on_sierra :or_older do
     version "0.2.6"
     sha256 "0073933b486da10b181bc8a226a140badc64c7cd93f681d769c17b5715221a85"
+
     url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86_64.zip",
         verified: "github.com/OpenRCT2/OpenRCT2/"
   end
   on_high_sierra do
     version "0.3.4.1"
     sha256 "dbe5f13d2ae391160bcf7cfa80d9a8d7fd5937c12f4dd0dea9254f00038e60c7"
+
     url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86-64.zip",
         verified: "github.com/OpenRCT2/OpenRCT2/"
   end
   on_mojave :or_newer do
     version "0.4.4"
     sha256 "13dae6894d2fc639a930be8538fbc996cf4daa1628da514bf47f2b30b9d28854"
+
     url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-universal.zip",
         verified: "github.com/OpenRCT2/OpenRCT2/"
   end

--- a/Casks/reaper.rb
+++ b/Casks/reaper.rb
@@ -3,10 +3,12 @@ cask "reaper" do
 
   on_mojave :or_older do
     sha256 "d1ffb0466ad0f410ea762b7edf68913ccda356070e2613706b753097201f1678"
+
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
   end
   on_catalina :or_newer do
     sha256 "72b3ed954f8c746a4c111b61018b6be7ff40d19ba851d57aae748587fab333fd"
+
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_universal.dmg"
   end
 

--- a/Casks/saoimageds9.rb
+++ b/Casks/saoimageds9.rb
@@ -6,28 +6,33 @@ cask "saoimageds9" do
 
   on_mojave :or_older do
     sha256 "bfe57aa62f1c36ec6ba00e6423bf84b2ce1b34d1af60dffc3adc141caa67d878"
+
     url "https://ds9.si.edu/download/macosmojave/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/"
   end
   on_catalina do
     sha256 "a076aa60f206297ea8f926ba7b267b368ff9e1f0b50f1c7543aa021fc9bfad17"
+
     url "https://ds9.si.edu/download/macoscatalina/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/"
   end
   on_big_sur do
     sha256 "b48565cdaadca1c1363173fac685cd75a68351c914792b2f43c6cb66b3316eed"
+
     url "https://ds9.si.edu/download/macosbigsurx86/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/"
   end
   on_monterey do
     sha256 arm:   "bbee664d4b4c3abab017c7971b92c13071161aa30fff95d2dfa9b1c1f4691a67",
            intel: "32ad574b38e589417cfec7ca34aba52a126d71efd512bcb5145c268aaaa2e4b6"
+
     url "https://ds9.si.edu/download/macosmonterey#{arch}/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/"
   end
   on_ventura do
     sha256 arm:   "ce0a3d3215f21f6203637bf903aac992f44aadd53891e2d067ea102f5b26e5d5",
            intel: "c340891711358110368cb369468c39de925f5e827309786220d84b0ca4595650"
+
     url "https://ds9.si.edu/download/macosventura#{arch}/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/"
   end

--- a/Casks/saoimageds9.rb
+++ b/Casks/saoimageds9.rb
@@ -9,21 +9,21 @@ cask "saoimageds9" do
 
     url "https://ds9.si.edu/download/macosmojave/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/",
-        using: :homebrew_curl
+        using:    :homebrew_curl
   end
   on_catalina do
     sha256 "a076aa60f206297ea8f926ba7b267b368ff9e1f0b50f1c7543aa021fc9bfad17"
 
     url "https://ds9.si.edu/download/macoscatalina/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/",
-        using: :homebrew_curl
+        using:    :homebrew_curl
   end
   on_big_sur do
     sha256 "b48565cdaadca1c1363173fac685cd75a68351c914792b2f43c6cb66b3316eed"
 
     url "https://ds9.si.edu/download/macosbigsurx86/SAOImageDS9%20#{version}.dmg",
         verified: "ds9.si.edu/download/",
-        using: :homebrew_curl
+        using:    :homebrew_curl
   end
   on_monterey do
     sha256 arm:   "bbee664d4b4c3abab017c7971b92c13071161aa30fff95d2dfa9b1c1f4691a67",

--- a/Casks/saoimageds9.rb
+++ b/Casks/saoimageds9.rb
@@ -8,19 +8,22 @@ cask "saoimageds9" do
     sha256 "bfe57aa62f1c36ec6ba00e6423bf84b2ce1b34d1af60dffc3adc141caa67d878"
 
     url "https://ds9.si.edu/download/macosmojave/SAOImageDS9%20#{version}.dmg",
-        verified: "ds9.si.edu/download/"
+        verified: "ds9.si.edu/download/",
+        using: :homebrew_curl
   end
   on_catalina do
     sha256 "a076aa60f206297ea8f926ba7b267b368ff9e1f0b50f1c7543aa021fc9bfad17"
 
     url "https://ds9.si.edu/download/macoscatalina/SAOImageDS9%20#{version}.dmg",
-        verified: "ds9.si.edu/download/"
+        verified: "ds9.si.edu/download/",
+        using: :homebrew_curl
   end
   on_big_sur do
     sha256 "b48565cdaadca1c1363173fac685cd75a68351c914792b2f43c6cb66b3316eed"
 
     url "https://ds9.si.edu/download/macosbigsurx86/SAOImageDS9%20#{version}.dmg",
-        verified: "ds9.si.edu/download/"
+        verified: "ds9.si.edu/download/",
+        using: :homebrew_curl
   end
   on_monterey do
     sha256 arm:   "bbee664d4b4c3abab017c7971b92c13071161aa30fff95d2dfa9b1c1f4691a67",

--- a/Casks/subsurface.rb
+++ b/Casks/subsurface.rb
@@ -3,10 +3,12 @@ cask "subsurface" do
 
   on_mojave :or_older do
     sha256 "b718acc583a986bc36df77b7b076dac0e19f193f6579c55ff802d448cea7c2b3"
+
     url "https://subsurface-divelog.org/downloads/Subsurface-#{version}-10.13+14.dmg"
   end
   on_catalina :or_newer do
     sha256 "c94ae7f1c63e558c6ac7896f4e6ea1514ac65f023ee2246ad69614b8747a9581"
+
     url "https://subsurface-divelog.org/downloads/Subsurface-#{version}-qt6-universal.dmg"
   end
 

--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -57,6 +57,7 @@ cask "teamviewer" do
     # This Cask should be installed and uninstalled manually on Catalina.
     # See https://github.com/Homebrew/homebrew-cask/issues/76829
     installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+
     uninstall delete: "#{staged_path}/#{token}"
 
     caveats <<~EOS

--- a/Casks/tiled.rb
+++ b/Casks/tiled.rb
@@ -3,11 +3,13 @@ cask "tiled" do
 
   on_high_sierra :or_older do
     sha256 "9cd3dae263fd142c72ede7d6b78190860e25580f7ae645145daa39d918aa1ce5"
+
     url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-10.12-10.13.zip",
         verified: "github.com/mapeditor/tiled/"
   end
   on_mojave :or_newer do
     sha256 "75e3d8ccb4fb9a7d5f5fd964cead157b01580f79124e433a4786378114abaeab"
+
     url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-10.14+.zip",
         verified: "github.com/mapeditor/tiled/"
   end

--- a/Casks/vpn-enabler.rb
+++ b/Casks/vpn-enabler.rb
@@ -2,16 +2,19 @@ cask "vpn-enabler" do
   on_el_capitan :or_older do
     version "3.0.6"
     sha256 "fae22c4e3b05c77d3658b45c92398c3a6f7fa7792bc124e1b463efb662519536"
+
     url "https://cutedgesystems.com/downloads/VPNEnablerForElCapitan.zip"
   end
   on_sierra do
     version "4.0"
     sha256 "50e22bcc2e341adff7fc625714c251ac0ac889cfb55983e026cff8478ebd3793"
+
     url "https://cutedgesystems.com/downloads/VPNEnablerForSierra.zip"
   end
   on_high_sierra :or_newer do
     version "5.2"
     sha256 :no_check
+
     url "https://cutedgesystems.com/downloads/VPNEnablerForHighSierra.zip"
   end
 


### PR DESCRIPTION
Companion PR to https://github.com/Homebrew/brew/pull/15211.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
