### PR TITLE
mucommander 1.2.0-2

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,8 +1,8 @@
 cask "mucommander" do
   version "1.2.0-1"
-  sha256 "c77c3d0105de57dcb2e2641a23266aef576b9874a61096935d961427eece636c"
+  sha256 "d5e386d62b01ed7614b15a3fb807b21f8c3e650ddbd2b5b8d08c6949ffcd779d"
 
-  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-#{version}.dmg",
+  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-1.2.0-2.dmg",
       verified: "github.com/mucommander/mucommander/"
   name "muCommander"
   desc "File manager with a dual-pane interface"

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -8,5 +8,15 @@ cask "mucommander" do
   desc "File manager with a dual-pane interface"
   homepage "https://www.mucommander.com/"
 
+  livecheck do
+    url :url
+    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
+    strategy :github_latest
+  end
+
   app "muCommander.app"
+
+  zap trash: [
+    "~/Library/Preferences/muCommander",
+  ]
 end

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,18 +1,12 @@
 cask "mucommander" do
-  version "1.2.0-1"
+  version "1.2.0-2"
   sha256 "d5e386d62b01ed7614b15a3fb807b21f8c3e650ddbd2b5b8d08c6949ffcd779d"
 
-  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-1.2.0-2.dmg",
+  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-#{version}.dmg",
       verified: "github.com/mucommander/mucommander/"
   name "muCommander"
   desc "File manager with a dual-pane interface"
   homepage "https://www.mucommander.com/"
-
-  livecheck do
-    url :url
-    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
-    strategy :github_latest
-  end
 
   app "muCommander.app"
 


### PR DESCRIPTION
Update mucommander from 1.2.0-1 to 1.2.0-2

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
