### PR TITLE
casks-without-zap: remove homebrew-cask-drivers

### DIFF
--- a/developer/bin/casks-without-zap
+++ b/developer/bin/casks-without-zap
@@ -14,7 +14,7 @@ at_exit { TMP_DIR.rmtree }
 
 # Constants
 ONLINE_ISSUE = "https://github.com/Homebrew/homebrew-cask/issues/88469"
-CASK_REPOS = %w[homebrew-cask homebrew-cask-versions homebrew-cask-drivers].freeze
+CASK_REPOS = %w[homebrew-cask homebrew-cask-versions].freeze
 CASK_JSON_URL = "https://formulae.brew.sh/api/analytics/cask-install/365d.json"
 
 # Download the file and save it to the specified directory


### PR DESCRIPTION
If [the repo goes away](https://github.com/Homebrew/homebrew-cask-drivers/issues/3414), the script will need this change.