### PR TITLE
wonderfultools-screensaver: remove livecheck

### DIFF
--- a/Casks/wonderfultools-screensaver.rb
+++ b/Casks/wonderfultools-screensaver.rb
@@ -4,12 +4,8 @@ cask "wonderfultools-screensaver" do
 
   url "https://github.com/aidev1065/Wonderful-Tools-Screensaver/raw/master/WonderfulTools.saver.zip"
   name "Wonderful Tools Screensaver"
+  desc "Screensaver based on opening video from Apple's September 2019 event"
   homepage "https://github.com/aidev1065/Wonderful-Tools-Screensaver/"
-
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
 
   screen_saver "WonderfulTools.saver"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

`wonderfultools-screensaver` was set as `discontinued` in #144398, as it's no longer maintained (according to the [GitHub repository's `README`](https://github.com/heysaik/Wonderful-Tools-Screensaver/blob/master/README.md) which states "WARNING: No Longer Maintained"). A `livecheck` block was added for the cask in the same PR but there's not much benefit to checking for new versions if the project isn't maintained (and the most recent update is from four years ago), especially if it requires the `ExtractPlist` strategy.

With this in mind, this PR removes the `livecheck` block, so the cask will be automatically skipped as discontinued.