### PR TITLE
cask-drivers: migrate casks to homebrew/cask

### DIFF
--- a/Casks/cameracontroller.rb
+++ b/Casks/cameracontroller.rb
@@ -1,0 +1,21 @@
+cask "cameracontroller" do
+  version "1.4.0"
+  sha256 "8a46dcb20a8d8898d4c47540f636e990ca3e3401c0ff062043efe5cc33d39dda"
+
+  url "https://github.com/Itaybre/CameraController/releases/download/v#{version}/CameraController.zip"
+  name "CameraController"
+  desc "Control USB Cameras from an app"
+  homepage "https://github.com/Itaybre/CameraController/"
+
+  depends_on macos: ">= :catalina"
+
+  app "CameraController.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.itaysoft.CameraController",
+    "~/Library/Application Scripts/com.itaysoft.CameraController.Helper",
+    "~/Library/Application Support/CameraController",
+    "~/Library/Containers/CameraController",
+    "~/Library/Preferences/com.itaysoft.CameraController.plist",
+  ]
+end

--- a/Casks/elgato-camera-hub.rb
+++ b/Casks/elgato-camera-hub.rb
@@ -1,0 +1,30 @@
+cask "elgato-camera-hub" do
+  version "1.6.1.999"
+  sha256 "c7f6b71a795d5c4dc3b998c835bb51a1dfbd47443bcb72564b2d13991e3a635f"
+
+  url "https://edge.elgato.com/egc/macos/echm/#{version.major_minor_patch.delete_suffix(".0")}/Camera_Hub_#{version.csv.first}#{version.csv.second.prepend("%23") if version.csv.second}.pkg"
+  name "elgato-camera-hub"
+  desc "Elgato FACECAM configuration tool"
+  homepage "https://www.elgato.com/en/facecam"
+
+  livecheck do
+    url "https://www.elgato.com/sites/default/files/downloads.json"
+    regex(%r{"downloadURL"\s*:\s*"[^"]*?/Camera[._-]Hub[._-]v?(\d+(?:\.\d+)+)(?:%23)?(\d+)?\.pkg"}i)
+    strategy :page_match do |page, regex|
+      match = page.scan(regex).flatten
+      match.second.blank? ? match : "#{match.first},#{match.second}"
+    end
+  end
+
+  pkg "Camera_Hub_#{version.tr(",", "#")}.pkg"
+
+  uninstall signal:    ["TERM", "com.elgato.CameraHub"],
+            launchctl: "com.elgato.CameraHub",
+            pkgutil:   "com.elgato.CameraHub.Installer",
+            delete:    "/Applications/Elgato Camera Hub.app"
+
+  zap trash: [
+    "~/Library/Logs/CameraHub",
+    "~/Library/Preferences/com.elgato.CameraHub.plist",
+  ]
+end

--- a/Casks/elgato-control-center.rb
+++ b/Casks/elgato-control-center.rb
@@ -1,0 +1,29 @@
+cask "elgato-control-center" do
+  version "1.4.1.10463"
+  sha256 "8811db60de8a8865f5253d3c7827a47031616410d92450fb9b6b83deea6dcc0b"
+
+  url "https://edge.elgato.com/egc/macos/eccm/#{version.major_minor_patch.chomp(".0")}/ControlCenterMac-#{version}.app.zip"
+  name "Elgato Control Center"
+  desc "Control your Elgato Key Lights"
+  homepage "https://www.elgato.com/en/gaming/key-light"
+
+  livecheck do
+    url "https://www.elgato.com/sites/default/files/downloads.json"
+    regex(%r{"downloadURL"\s*:\s*"[^"]*?/ControlCenterMac[._-]v?(\d+(?:[._]\d+)+)\.app\.zip"}i)
+  end
+
+  depends_on macos: ">= :mojave"
+
+  app "Elgato Control Center.app"
+
+  uninstall quit: "com.corsair.ControlCenter"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.corsair.ControlCenterLauncher",
+    "~/Library/Application Support/com.corsair.ControlCenter",
+    "~/Library/Caches/com.corsair.ControlCenter",
+    "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.corsair.ControlCenter",
+    "~/Library/Containers/com.corsair.ControlCenterLauncher",
+    "~/Library/Preferences/com.corsair.ControlCenter.plist",
+  ]
+end

--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -1,0 +1,33 @@
+cask "fujitsu-scansnap-home" do
+  version "2.9.0"
+  sha256 "00bde8def991762d6b5bce322b00f54b2da942fe4b9c114d23c11407d8b1eeab"
+
+  url "https://origin.pfultd.com/downloads/ss/sshinst/m-#{version.no_dots}/MacSSHOfflineInstaller_#{version.dots_to_underscores}.dmg",
+      verified: "origin.pfultd.com/"
+  name "ScanSnap Home"
+  desc "Fujitsu ScanSnap Scanner software"
+  homepage "https://www.fujitsu.com/global/products/computing/peripheral/scanners/soho/sshome/"
+
+  # Some of the release titles contain a typo where a space is omitted, so this
+  # regex is a bit extreme about whitespace to ensure we match all the versions.
+  livecheck do
+    url "https://www.pfu.fujitsu.com/imaging/ss_hist/en/mac/index.html"
+    regex(/ScanSnap\s*Home\s*for\s*Mac\s*v?(\d+(?:\.\d+)+)\s*Released/i)
+  end
+
+  depends_on macos: ">= :sierra"
+  container nested: "Download/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"
+
+  pkg "ScanSnap Home.pkg"
+
+  uninstall launchctl: [
+              "com.fujitsu.pfu.SshRegister",
+              "com.fujitsu.pfu.SshResident",
+              "com.fujitsu.pfu.SshSCloudWatch",
+            ],
+            quit:      [
+              "com.fujitsu.pfu.SSMenuBar",
+              "com.fujitsu.pfu.Ssh*",
+            ],
+            pkgutil:   "com.fujitsu.pfu.scansnap.Home.*"
+end

--- a/Casks/garmin-express.rb
+++ b/Casks/garmin-express.rb
@@ -1,0 +1,32 @@
+cask "garmin-express" do
+  version "7.16.1.0,7160100"
+  sha256 :no_check
+
+  url "https://download.garmin.com/omt/express/GarminExpress.dmg"
+  name "Garmin Express"
+  desc "Update maps and software, sync with Garmin Connect and register your device"
+  homepage "https://www.garmin.com/en-US/software/express"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  auto_updates true
+
+  pkg "Install Garmin Express.pkg"
+
+  uninstall quit:    [
+              "com.garmin.renu.client",
+              "com.garmin.renu.service",
+            ],
+            pkgutil: "com.garmin.renu.client"
+
+  zap trash: [
+    "~/Library/Application Support/Garmin/Express",
+    "~/Library/Caches/com.garmin.renu.client",
+    "~/Library/Caches/com.garmin.renu.service",
+    "~/Library/Caches/com.garmin.renu.service.crashreporter",
+    "~/Library/Preferences/com.garmin.renu*",
+  ]
+end

--- a/Casks/logi-options-plus.rb
+++ b/Casks/logi-options-plus.rb
@@ -1,0 +1,62 @@
+cask "logi-options-plus" do
+  version "1.36"
+  sha256 :no_check
+
+  url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip",
+      verified: "download01.logi.com/web/ftp/pub/techsupport/optionsplus/"
+  name "Logitech Options+"
+  desc "Software for Logitech devices"
+  homepage "https://www.logitech.com/en-us/software/logi-options-plus.html"
+
+  livecheck do
+    url "https://support.logi.com/hc/en-gb/articles/1500005516462"
+    strategy :page_match
+    regex(/version\D*?(\d+(?:\.\d+)+)/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  # see https://prosupport.logi.com/hc/en-us/articles/6046882446359
+  installer script: {
+    executable: "logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer",
+    args:       ["--quiet"],
+    sudo:       true,
+  }
+
+  uninstall script:    [
+              executable: "logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer",
+              args:       ["--quiet", "--uninstall"],
+              sudo:       true,
+            ],
+            launchctl: [
+              "com.logi.cp-dev-mgr",
+              "com.logi.optionsplus",
+              "com.logi.optionsplus.agent",
+              "com.logi.optionsplus.updater",
+            ],
+            quit:      [
+              "com.logi.cp-dev-mgr",
+              "com.logi.optionsplus",
+              "com.logi.optionsplus.agent",
+              "com.logi.optionsplus.updater",
+            ],
+            delete:    [
+              "/Applications/logioptionsplus.app",
+              "/Library/LaunchAgents/com.logi.optionsplus.plist",
+              "/Library/LaunchDaemons/com.logi.optionsplus.updater.plist",
+            ]
+
+  zap trash: [
+    "/Users/Shared/LogiOptionsPlus",
+    "~/Library/Application Support/LogiOptionsPlus",
+    "~/Library/Application Support/logioptionsplus",
+    "~/Library/Preferences/com.logi.cp-dev-mgr.plist",
+    "~/Library/Preferences/com.logi.optionsplus.plist",
+    "~/Library/Saved Application State/com.logi.optionsplus.savedState",
+  ]
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/qmk-toolbox.rb
+++ b/Casks/qmk-toolbox.rb
@@ -1,0 +1,19 @@
+cask "qmk-toolbox" do
+  version "0.2.2"
+  sha256 "75f439a9d91630d2310968566bb703306ceba4797f9b5459b1269514be7a62d8"
+
+  url "https://github.com/qmk/qmk_toolbox/releases/download/#{version}/QMK.Toolbox.app.zip",
+      verified: "github.com/qmk/qmk_toolbox/"
+  name "QMK Toolbox"
+  desc "Toolbox companion for QMK Firmware"
+  homepage "https://qmk.fm/"
+
+  app "QMK Toolbox.app"
+
+  uninstall quit: "fm.qmk.toolbox"
+
+  zap trash: [
+    "~/Library/Caches/fm.qmk.toolbox",
+    "~/Library/Saved Application State/fm.qmk.toolbox.savedState",
+  ]
+end

--- a/Casks/sonos.rb
+++ b/Casks/sonos.rb
@@ -1,0 +1,20 @@
+cask "sonos" do
+  version "15.2,72.2.39150"
+  sha256 "cd6ec19343371907e2683aea45b84f9e6b3e4bad7d801f5b4eb2f8663f9fbb0c"
+
+  url "https://update-software.sonos.com/software/vgnciqkn/Sonos_#{version.csv.second.sub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2-\3')}.dmg"
+  name "Sonos"
+  desc "Control your Sonos system"
+  homepage "https://www.sonos.com/"
+
+  livecheck do
+    url "https://www.sonos.com/en/redir/controller_software_mac2"
+    strategy :extract_plist
+  end
+
+  auto_updates true
+
+  app "Sonos.app"
+
+  zap trash: "~/Library/Application Support/SonosV2"
+end

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -1,0 +1,34 @@
+cask "synology-drive" do
+  version "3.2.1,13272"
+  sha256 "a0da3fd858a6eb7c625a256e63df50d7c74738f1f275026bec2f6d89bf0b2ce1"
+
+  url "https://global.download.synology.com/download/Utility/SynologyDriveClient/#{version.csv.first}-#{version.csv.second}/Mac/Installer/synology-drive-client-#{version.csv.second}.dmg"
+  name "Synology Drive"
+  desc "Sync and backup service to Synology NAS drives"
+  homepage "https://www.synology.com/"
+
+  livecheck do
+    url "https://www.synology.com/en-us/releaseNote/SynologyDriveClient"
+    regex(/>\s*Version:\s*(\d+(?:\.\d+)+)-(\d+)\s*</i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
+  end
+
+  auto_updates true
+
+  pkg "Install Synology Drive Client.pkg"
+
+  uninstall quit:      [
+              "io.com.synology.CloudStationUI",
+              "com.synology.CloudStation",
+              "com.synology.CloudStationUI",
+              "com.synology.SynologyDrive.FinderHelper",
+            ],
+            pkgutil:   "com.synology.CloudStation",
+            launchctl: [
+              "com.synology.Synology Cloud Station",
+              "application.com.synology.CloudStationUI*",
+            ],
+            delete:    "/Applications/Synology Drive Client.app"
+end

--- a/Casks/synology-drive.rb
+++ b/Casks/synology-drive.rb
@@ -31,4 +31,17 @@ cask "synology-drive" do
               "application.com.synology.CloudStationUI*",
             ],
             delete:    "/Applications/Synology Drive Client.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.synology.CloudStationUI.FileProvider",
+    "~/Library/Application Scripts/com.synology.SynologyDrive.FinderHelper*",
+    "~/Library/Application Scripts/group.com.synology.CloudStationUI",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.synology.synologydrive.finderhelper.sfl2",
+    "~/Library/Application Support/FileProvider/com.synology.CloudStationUI.FileProvider",
+    "~/Library/Application Support/SynologyDrive",
+    "~/Library/Containers/com.synology.CloudStationUI.FileProvider",
+    "~/Library/Containers/com.synology.SynologyDrive*",
+    "~/Library/Group Containers/group.com.synology.CloudStationUI",
+    "~/Library/Preferences/com.synology.CloudStationUI.plist",
+  ]
 end

--- a/Casks/yubico-authenticator.rb
+++ b/Casks/yubico-authenticator.rb
@@ -1,0 +1,23 @@
+cask "yubico-authenticator" do
+  version "6.1.0"
+  sha256 "9f3eae5d44d7922908a45cd88d70e11975cb2ace2f49d07da7369fb6cbb692d9"
+
+  url "https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-#{version}-mac.dmg"
+  name "Yubico Authenticator"
+  desc "Application for generating TOTP and HOTP codes"
+  homepage "https://developers.yubico.com/yubioath-flutter/"
+
+  livecheck do
+    url "https://developers.yubico.com/yubioath-flutter/Releases/"
+    regex(/href=.*?yubico[._-]authenticator[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Yubico Authenticator.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.yubico.authenticator",
+    "~/Library/Containers/com.yubico.authenticator",
+  ]
+end


### PR DESCRIPTION
Migrating cask-drivers. Merge at the same time as https://github.com/Homebrew/homebrew-cask-drivers/pull/3418