### PR TITLE
rubocop: Fix `Cask/StanzaOrder` offenses in `on_*` blocks

### DIFF
--- a/Casks/choosy.rb
+++ b/Casks/choosy.rb
@@ -53,14 +53,14 @@ cask "choosy" do
     version "2.3"
     sha256 "b4fd6073b43ba7ce8697c6b3f400f2abec9196e10c6488d52970ed989ddb2a76"
 
-    pkg "Choosy.pkg"
+    depends_on macos: ">= :big_sur"
 
     livecheck do
       url "https://www.choosyosx.com/sparkle/feed"
       strategy :sparkle
     end
 
-    depends_on macos: ">= :big_sur"
+    pkg "Choosy.pkg"
   end
 
   url "https://downloads.choosyosx.com/choosy_#{version}.zip"

--- a/Casks/far2l.rb
+++ b/Casks/far2l.rb
@@ -3,14 +3,14 @@ cask "far2l" do
   version "2.5.0"
 
   on_mojave :or_older do
-    url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.11.dmg"
-
     sha256 "475f1823652c6e59ff5fe4af448c27b6f88a8f38ac0f358a6620d8aaf5f43c99"
+
+    url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.11.dmg"
   end
   on_catalina :or_newer do
-    url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.15.dmg"
-
     sha256 "9cdde68842f5bfd8e0eda9fdab6507e47eeda2b7a8a6941a8a5966fe89a97435"
+
+    url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.15.dmg"
   end
 
   name "far2l"


### PR DESCRIPTION
Companion PR to https://github.com/Homebrew/brew/pull/15223.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
