### PR TITLE
Enable 'auto_updates' for 'logseq'

### DIFF
--- a/Casks/logseq.rb
+++ b/Casks/logseq.rb
@@ -15,6 +15,8 @@ cask "logseq" do
     strategy :github_latest
   end
 
+  auto_updates true
+
   app "Logseq.app"
 
   zap trash: [


### PR DESCRIPTION
Enable `auto_updates` for `logseq`

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.