### PR TITLE
citrix-workspace 23.04.0.36 (livecheck)

### DIFF
--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -12,12 +12,7 @@ cask "citrix-workspace" do
 
   livecheck do
     url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos2.xml"
-    strategy :page_match do |page|
-      match = page.match(%r{<Installer platformArchitecture="#{arch}">.*?<Version>([\d.]+)</Version>}m)
-      next if match.blank?
-
-      match[1]
-    end
+    regex(%r{<short\S*?>.*?workspace.*?</short\S*?>.*?<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,8 +1,11 @@
 cask "citrix-workspace" do
-  version "23.04.0.36"
-  sha256 :no_check
+  arch arm: "Universal", intel: "Intel"
 
-  url "https://downloadplugins.citrix.com/Mac/CitrixWorkspaceApp.dmg"
+  version "23.04.0.36"
+  sha256 arm:   "8f24b593d3095464af27ddfc85d7b19d38f48d88f2a8afa31694591b00c3cdcf",
+         intel: "29a6267509af5b3ade006799136829d9ab12c32491a192c1941db290a68e5990"
+
+  url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Mac/CitrixWorkspaceApp#{arch}#{version}.pkg"
   name "Citrix Workspace"
   desc "Managed desktop virtualization solution"
   homepage "https://www.citrix.com/"
@@ -10,7 +13,7 @@ cask "citrix-workspace" do
   livecheck do
     url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos2.xml"
     strategy :page_match do |page|
-      match = page.match(%r{<Installer platformArchitecture="Intel">.*?<Version>([\d.]+)</Version>}m)
+      match = page.match(%r{<Installer platformArchitecture="#{arch}">.*?<Version>([\d.]+)</Version>}m)
       next if match.blank?
 
       match[1]
@@ -19,7 +22,7 @@ cask "citrix-workspace" do
 
   depends_on macos: ">= :catalina"
 
-  pkg "Install Citrix Workspace.pkg"
+  pkg "CitrixWorkspaceApp#{arch}#{version}.pkg"
 
   uninstall launchctl: [
               "com.citrix.AuthManager_Mac",

--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,5 +1,5 @@
 cask "citrix-workspace" do
-  version "23.04.0.36,2304"
+  version "23.04.0.36"
   sha256 :no_check
 
   url "https://downloadplugins.citrix.com/Mac/CitrixWorkspaceApp.dmg"
@@ -8,12 +8,12 @@ cask "citrix-workspace" do
   homepage "https://www.citrix.com/"
 
   livecheck do
-    url "https://www.citrix.com/downloads/workspace-app/mac/workspace-app-for-mac-latest.html"
+    url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos2.xml"
     strategy :page_match do |page|
-      match = page.match(/Version:*\s+(\d+(?:\.\d+)+)\s\((\d+(?:\.\d+)*)\)/i)
+      match = page.match(%r{<Installer platformArchitecture="Intel">.*?<Version>([\d.]+)</Version>}m)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      match[1]
     end
   end
 

--- a/Casks/citrix-workspace.rb
+++ b/Casks/citrix-workspace.rb
@@ -1,23 +1,22 @@
 cask "citrix-workspace" do
-  arch arm: "Universal", intel: "Intel"
-
   version "23.04.0.36"
-  sha256 arm:   "8f24b593d3095464af27ddfc85d7b19d38f48d88f2a8afa31694591b00c3cdcf",
-         intel: "29a6267509af5b3ade006799136829d9ab12c32491a192c1941db290a68e5990"
+  sha256 "8f24b593d3095464af27ddfc85d7b19d38f48d88f2a8afa31694591b00c3cdcf"
 
-  url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Mac/CitrixWorkspaceApp#{arch}#{version}.pkg"
+  url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Mac/CitrixWorkspaceAppUniversal#{version}.pkg"
   name "Citrix Workspace"
   desc "Managed desktop virtualization solution"
   homepage "https://www.citrix.com/"
 
   livecheck do
     url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos2.xml"
-    regex(%r{<short\S*?>.*?workspace.*?</short\S*?>.*?<version>v?(\d+(?:\.\d+)+)</version>}i)
+    strategy :xml do |xml|
+      xml.get_elements("//Installers[@name='WorkspaceApp']/Installer/Version").map(&:text)
+    end
   end
 
   depends_on macos: ">= :catalina"
 
-  pkg "CitrixWorkspaceApp#{arch}#{version}.pkg"
+  pkg "CitrixWorkspaceAppUniversal#{version}.pkg"
 
   uninstall launchctl: [
               "com.citrix.AuthManager_Mac",


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.