### PR TITLE
reminders-menubar 1.17.0 (new cask)

### DIFF
--- a/Casks/reminders-menubar.rb
+++ b/Casks/reminders-menubar.rb
@@ -18,4 +18,11 @@ cask "reminders-menubar" do
       system_command "/usr/bin/open", args: ["-a", application], must_succeed: false
     end
   end
+
+  zap trash: [
+    "~/Library/Application Scripts/br.com.damascenorafael.reminders-menubar",
+    "~/Library/Application Scripts/br.com.damascenorafael.RemindersLauncher",
+    "~/Library/Containers/br.com.damascenorafael.reminders-menubar",
+    "~/Library/Containers/br.com.damascenorafael.RemindersLauncher",
+  ]
 end

--- a/Casks/reminders-menubar.rb
+++ b/Casks/reminders-menubar.rb
@@ -1,0 +1,21 @@
+cask "reminders-menubar" do
+  version "1.17.0"
+  sha256 "e3fdf46b3fc339bde71a14296f544c74ca099058d3845e86aca0d2fdcf8557fe"
+
+  url "https://github.com/DamascenoRafael/reminders-menubar/releases/download/v#{version}/reminders-menubar.zip"
+  name "Reminders MenuBar"
+  desc "Simple menu bar app to view and interact with reminders"
+  homepage "https://github.com/DamascenoRafael/reminders-menubar"
+
+  depends_on macos: ">= :big_sur"
+
+  app "Reminders MenuBar.app"
+
+  postflight do
+    application = "#{appdir}/Reminders MenuBar.app"
+    if system_command("ps", args: ["x"]).stdout.match?(application)
+      system_command "/usr/bin/pkill", args: ["-f", application], must_succeed: false
+      system_command "/usr/bin/open", args: ["-a", application], must_succeed: false
+    end
+  end
+end

--- a/Casks/reminders-menubar.rb
+++ b/Casks/reminders-menubar.rb
@@ -12,7 +12,7 @@ cask "reminders-menubar" do
   app "Reminders MenuBar.app"
 
   postflight do
-    application = "#{appdir}/Reminders MenuBar.app"
+    application = "#{staged_path}/#{token}"
     if system_command("ps", args: ["x"]).stdout.match?(application)
       system_command "/usr/bin/pkill", args: ["-f", application], must_succeed: false
       system_command "/usr/bin/open", args: ["-a", application], must_succeed: false

--- a/Casks/reminders-menubar.rb
+++ b/Casks/reminders-menubar.rb
@@ -11,13 +11,7 @@ cask "reminders-menubar" do
 
   app "Reminders MenuBar.app"
 
-  postflight do
-    application = "#{appdir}/Reminders MenuBar.app"
-    if system_command("ps", args: ["x"]).stdout.match?(application)
-      system_command "/usr/bin/pkill", args: ["-f", application], must_succeed: false
-      system_command "/usr/bin/open", args: ["-a", application], must_succeed: false
-    end
-  end
+  uninstall quit: "br.com.damascenorafael.reminders-menubar"
 
   zap trash: [
     "~/Library/Application Scripts/br.com.damascenorafael.reminders-menubar",

--- a/Casks/reminders-menubar.rb
+++ b/Casks/reminders-menubar.rb
@@ -12,7 +12,7 @@ cask "reminders-menubar" do
   app "Reminders MenuBar.app"
 
   postflight do
-    application = "#{staged_path}/#{token}"
+    application = "#{appdir}/Reminders MenuBar.app"
     if system_command("ps", args: ["x"]).stdout.match?(application)
       system_command "/usr/bin/pkill", args: ["-f", application], must_succeed: false
       system_command "/usr/bin/open", args: ["-a", application], must_succeed: false


### PR DESCRIPTION
Adding [Reminders MenuBar](https://github.com/DamascenoRafael/reminders-menubar) for the first time in homebrew-cask

The cask was available in a personal tap: [DamascenoRafael/homebrew-tap](https://github.com/DamascenoRafael/homebrew-tap)
Here is the PR removing from the previous tap and adding the `tap_migrations.json`:
https://github.com/DamascenoRafael/homebrew-tap/pull/2

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
