### PR TITLE
pulsar 1.104.0

### DIFF
--- a/Casks/pulsar.rb
+++ b/Casks/pulsar.rb
@@ -2,9 +2,9 @@ cask "pulsar" do
   arch arm: "Silicon", intel: "Intel"
   arch_suffix = on_arch_conditional arm: "-arm64"
 
-  version "1.103.0"
-  sha256 arm:   "87d540ee1df71e8763e3c615747cd0ef8810861ed46c93b1605edbae63ec9818",
-         intel: "32285e0622f10ded87b98b2df77cd6f0d20465fbaf5b569b703d0d083370e929"
+  version "1.104.0"
+  sha256 arm:   "65f413d23412f1c55403c0fe81c87c17bd48ee7052ccf34c9e2354c6756c58bb",
+         intel: "05f87ddf0eb1fa2e4ee87688fb54f5b62f3151e381d359b051563bccf16434d8"
 
   url "https://github.com/pulsar-edit/pulsar/releases/download/v#{version}/#{arch}.Mac.Pulsar-#{version}#{arch_suffix}-mac.zip",
       verified: "github.com/pulsar-edit/pulsar/"


### PR DESCRIPTION
- [√] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [√] `brew audit --cask --online <cask>` is error-free.
- [√] `brew style --fix <cask>` reports no offenses.
