### PR TITLE
Revert "Update prerelease allowlist"

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -28,7 +28,6 @@
   "servpane": "all",
   "shadowsocksx-ng-r": "all",
   "splitshow": "all",
-  "standard-notes": "all",
   "steveschow-gfxcardstatus": "all",
   "themeengine": "all",
   "universal-android-debloater": "all",


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#145108

`standard-notes` release behavior is inconsistent. Adding it to the prerelease allowlist leads to audit failures when the website release matches the latest github release.