### PR TITLE
Update raycast.rb depends_on

### DIFF
--- a/Casks/raycast.rb
+++ b/Casks/raycast.rb
@@ -14,7 +14,7 @@ cask "raycast" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Raycast.app"
 


### PR DESCRIPTION
Raycast supports only macOS 11+, macOS 10 is deprecated.

- [x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ x] `brew audit --cask --online <cask>` is error-free.
- [ x] `brew style --fix <cask>` reports no offenses.
