### PR TITLE
raycast 1.49.3 (update url)

### DIFF
--- a/Casks/raycast.rb
+++ b/Casks/raycast.rb
@@ -2,10 +2,10 @@ cask "raycast" do
   version "1.49.3"
   sha256 :no_check
 
-  url "https://api.raycast.app/v2/download"
+  url "https://releases.raycast.com/releases/#{version}/download?build=universal"
   name "Raycast"
   desc "Control your tools with a few keystrokes"
-  homepage "https://raycast.app/"
+  homepage "https://raycast.com/"
 
   livecheck do
     url :url

--- a/Casks/raycast.rb
+++ b/Casks/raycast.rb
@@ -1,6 +1,6 @@
 cask "raycast" do
   version "1.49.3"
-  sha256 :no_check
+  sha256 "22b9fdf7fe3d7d1420ef7717f1a299ef60f5a3e9833e0e38435a5700c757adbd"
 
   url "https://releases.raycast.com/releases/#{version}/download?build=universal"
   name "Raycast"


### PR DESCRIPTION
As discussed in [this issue](https://github.com/Homebrew/homebrew-cask/issues/145362) we added a versioned URL that will allow us to add SHA checks in the future.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

