### PR TITLE
rewind 10161.1 (new cask)

### DIFF
--- a/Casks/rewind.rb
+++ b/Casks/rewind.rb
@@ -1,6 +1,6 @@
 cask "rewind" do
-  version "10056.1,2c3fbe8,20230420"
-  sha256  "5c63ea0e25a24051ff305c7a8aa4782345b714ec909c82cc995a4f92046c7a5e"
+  version "10161.1,ad932b5,20230424"
+  sha256  "8495e608809fb6747bca3da59ff067a10da410e43276fd0992432e38a837a12e"
 
   url "https://updates.rewind.ai/builds/main/b#{version.csv.first}-main-#{version.csv.second}.zip"
   name "Rewind"

--- a/Casks/rewind.rb
+++ b/Casks/rewind.rb
@@ -1,8 +1,8 @@
 cask "rewind" do
-  version "1.0041,20230419"
-  sha256 :no_check
+  version "10056.1,2c3fbe8,20230420"
+  sha256  "5c63ea0e25a24051ff305c7a8aa4782345b714ec909c82cc995a4f92046c7a5e"
 
-  url "https://download.rewind.ai/Rewind.dmg"
+  url "https://updates.rewind.ai/builds/main/b#{version.csv.first}-main-#{version.csv.second}.zip"
   name "Rewind"
   desc "Record and search your screen and audio"
   homepage "https://www.rewind.ai/"
@@ -11,9 +11,9 @@ cask "rewind" do
     url "https://updates.rewind.ai/appcasts/main.xml"
     strategy :sparkle do |item|
       # Throttle updates to one every 3 days.
-      next version if DateTime.parse(version.csv.second) + 3 > Date.today
+      next version if DateTime.parse(version.csv.third) + 3 > Date.today
 
-      "#{item.short_version},#{item.pub_date.strftime("%Y%m%d")}"
+      "#{item.version},#{item.url.match(/[._-](\w+)\.zip/i)[1]},#{item.pub_date.strftime("%Y%m%d")}"
     end
   end
 

--- a/Casks/rewind.rb
+++ b/Casks/rewind.rb
@@ -1,0 +1,42 @@
+cask "rewind" do
+  version "1.0041,20230419"
+  sha256 :no_check
+
+  url "https://download.rewind.ai/Rewind.dmg"
+  name "Rewind"
+  desc "Record and search your screen and audio"
+  homepage "https://www.rewind.ai/"
+
+  livecheck do
+    url "https://updates.rewind.ai/appcasts/main.xml"
+    strategy :xml do |xml|
+      # Throttle updates to one every 3 days.
+      next version if DateTime.parse(version.csv.second) + 3 > Date.today
+
+      item = xml.get_elements("//item")[0]
+      version = item.elements["sparkle:shortVersionString"].text
+      date = DateTime.parse(item.elements["pubDate"].text).strftime("%Y%m%d")
+
+      "#{version},#{date}"
+    end
+  end
+
+  depends_on arch:  :arm64,
+             macos: ">= :monterey"
+
+  app "Rewind.app"
+
+  uninstall quit: "com.memoryvault.MemoryVault"
+
+  zap trash: [
+    "~/Documents/rewind_logs_*.zip",
+    "~/Library/Application Support/com.memoryvault.MemoryVault",
+    "~/Library/Caches/com.memoryvault.MemoryVault",
+    "~/Library/HTTPStorages/com.memoryvault.MemoryVault",
+    "~/Library/LaunchAgents/com.rewind.Rewind.plist",
+    "~/Library/Logs/DiagnosticReports/Rewind_*.diag",
+    "~/Library/Logs/Rewind",
+    "~/Library/Preferences/com.memoryvault.MemoryVault.plist",
+    "~/Library/WebKit/com.memoryvault.MemoryVault",
+  ]
+end

--- a/Casks/rewind.rb
+++ b/Casks/rewind.rb
@@ -21,6 +21,7 @@ cask "rewind" do
     end
   end
 
+  auto_updates true
   depends_on arch:  :arm64,
              macos: ">= :monterey"
 

--- a/Casks/rewind.rb
+++ b/Casks/rewind.rb
@@ -9,15 +9,11 @@ cask "rewind" do
 
   livecheck do
     url "https://updates.rewind.ai/appcasts/main.xml"
-    strategy :xml do |xml|
+    strategy :sparkle do |item|
       # Throttle updates to one every 3 days.
       next version if DateTime.parse(version.csv.second) + 3 > Date.today
 
-      item = xml.get_elements("//item")[0]
-      version = item.elements["sparkle:shortVersionString"].text
-      date = DateTime.parse(item.elements["pubDate"].text).strftime("%Y%m%d")
-
-      "#{version},#{date}"
+      "#{item.short_version},#{item.pub_date.strftime("%Y%m%d")}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This was originally submitted in #143139 by @nihaals. I wrote the livecheck to update every 3 days; it looks like they publish new versions every few hours or so. Would appreciate a second set of eyes on it. I know a versioned url exists, but it includes a random string that isn't found anywhere else in the appcast which is why I opted to use an unversioned link.

Note: This binary is universal, but the app only works on arm. CI skipped the installation process (presumably due to the architecture limitation), but it works locally.