### PR TITLE
xtool-creative-space (new cask)

### DIFF
--- a/Casks/xtool-creative-space.rb
+++ b/Casks/xtool-creative-space.rb
@@ -28,4 +28,11 @@ cask "xtool-creative-space" do
   end
 
   app "xTool Creative Space.app"
+  
+  zap trash: [
+    "~/Library/Application Support/xTool Creative Space",
+    "~/Library/Logs/xTool Creative Space",
+    "~/Library/Preferences/com.makeblock.xcs.plist",
+    "~/Library/Saved Application State/com.makeblock.xcs.savedState",
+  ]  
 end

--- a/Casks/xtool-creative-space.rb
+++ b/Casks/xtool-creative-space.rb
@@ -1,25 +1,30 @@
 cask "xtool-creative-space" do
   arch arm: "arm64", intel: "x64"
 
-  on_intel do  
-    version "16,234,1678158837754,1.2.14-2023-03-06-13-36-37"
-    sha256 "2720a0dfd87cdf73f71831a5335722b5898401173bdb0cf1f406fbb3e92c3164"
-  end
   on_arm do
-    version "28,235,1678160204427,1.2.14-2023-03-06-13-34-59"
+    version "28.235.1678160204427,1.2.14-2023-03-06-13-34-59"
     sha256  "a99e6d8b30d7a17560a7ea2af1d28f5fa8fe382420186d6eba37f1d5a177e3bf"
   end
+  on_intel do
+    version "16.234.1678158837754,1.2.14-2023-03-06-13-36-37"
+    sha256 "2720a0dfd87cdf73f71831a5335722b5898401173bdb0cf1f406fbb3e92c3164"
+  end
 
-  url "https://res-us.makeblock.com/ms/updater/production/packages/#{version.csv.first}/#{version.csv.second}/#{version.csv.third}/xTool%20Creative%20Space-#{version.csv.fourth}-#{arch}.dmg",
+  url "https://res-us.makeblock.com/ms/updater/production/packages/#{version.csv.first.tr(".", "/")}/xTool%20Creative%20Space-#{version.csv.second}-#{arch}.dmg",
       verified: "res-us.makeblock.com/ms/updater/production/packages/"
   name "xTool Creative Space"
   desc "Design and control software for xTool laser machines"
   homepage "https://www.xtool.com/pages/software"
 
   livecheck do
-    # url "https://www.xtool.com/pages/software"
-    # regex(/href=.*\/updater\/production\/packages\/(\d+\/\d+\/\d+\/(?:xTool Creative Space[._-])\d+\.\d+.\d+-\d+-\d+-\d+-\d+-\d+-\d+)-x64.dmg/i)
-    skip "No version information available"
+    url "https://www.xtool.com/pages/software"
+    regex(%r{href=.*?packages/(.*)/xTool\s?Creative\s?Space[._-](.*?)[._-]#{arch}.dmg}i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      "#{match[1].tr("/", ".")},#{match[2]}"
+    end
   end
 
   app "xTool Creative Space.app"

--- a/Casks/xtool-creative-space.rb
+++ b/Casks/xtool-creative-space.rb
@@ -1,0 +1,26 @@
+cask "xtool-creative-space" do
+  arch arm: "arm64", intel: "x64"
+
+  on_intel do  
+    version "16,234,1678158837754,1.2.14-2023-03-06-13-36-37"
+    sha256 "2720a0dfd87cdf73f71831a5335722b5898401173bdb0cf1f406fbb3e92c3164"
+  end
+  on_arm do
+    version "28,235,1678160204427,1.2.14-2023-03-06-13-34-59"
+    sha256  "a99e6d8b30d7a17560a7ea2af1d28f5fa8fe382420186d6eba37f1d5a177e3bf"
+  end
+
+  url "https://res-us.makeblock.com/ms/updater/production/packages/#{version.csv.first}/#{version.csv.second}/#{version.csv.third}/xTool%20Creative%20Space-#{version.csv.fourth}-#{arch}.dmg",
+      verified: "res-us.makeblock.com/ms/updater/production/packages/"
+  name "xTool Creative Space"
+  desc "Design and control software for xTool laser machines"
+  homepage "https://www.xtool.com/pages/software"
+
+  livecheck do
+    # url "https://www.xtool.com/pages/software"
+    # regex(/href=.*\/updater\/production\/packages\/(\d+\/\d+\/\d+\/(?:xTool Creative Space[._-])\d+\.\d+.\d+-\d+-\d+-\d+-\d+-\d+-\d+)-x64.dmg/i)
+    skip "No version information available"
+  end
+
+  app "xTool Creative Space.app"
+end

--- a/Casks/xtool-creative-space.rb
+++ b/Casks/xtool-creative-space.rb
@@ -28,11 +28,11 @@ cask "xtool-creative-space" do
   end
 
   app "xTool Creative Space.app"
-  
+
   zap trash: [
     "~/Library/Application Support/xTool Creative Space",
     "~/Library/Logs/xTool Creative Space",
     "~/Library/Preferences/com.makeblock.xcs.plist",
     "~/Library/Saved Application State/com.makeblock.xcs.savedState",
-  ]  
+  ]
 end


### PR DESCRIPTION
xTool Creative Space is an all-in-one laser cutter software for graphic design, editing, laser processing and machine control for xTool machines.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online xtool-creative-space.rb` is error-free.
- [ ] `brew style --fix xtool-creative-space.rb` reports no offenses.

**Note:** `brew style --fix` does more harm to the files than good?

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask xtool-creative-space.rb` worked successfully.
- [x] `brew install --cask xtool-creative-space.rb` worked successfully.
- [x] `brew uninstall --cask xtool-creative-space.rb` worked successfully.

**Notes:** 
- I am not sure if this is the correct variant to do the versioning, since it has different parts to the path that change.
- Because of this I wasn't sure how to do a livecheck either.