### PR TITLE
CI: add prerelease exceptions to ci-skip-repository

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -141,9 +141,9 @@ module CiMatrix
       audit_exceptions << "livecheck_min_os" if labels.include?("ci-skip-livecheck-min-os")
 
       if labels.include?("ci-skip-repository")
-        audit_exceptions << ["github_repository", "github_prerelease_version",
-                             "gitlab_repository", "gitlab_prerelease_version",
-                             "bitbucket_repository"]
+        audit_exceptions << %w[github_repository github_prerelease_version
+                               gitlab_repository gitlab_prerelease_version
+                               bitbucket_repository]
       end
 
       audit_args << "--except" << audit_exceptions.join(",") if audit_exceptions.any?

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -141,7 +141,8 @@ module CiMatrix
       audit_exceptions << "livecheck_min_os" if labels.include?("ci-skip-livecheck-min-os")
 
       if labels.include?("ci-skip-repository")
-        audit_exceptions << ["github_repository", "gitlab_repository",
+        audit_exceptions << ["github_repository", "github_prerelease_version",
+                             "gitlab_repository", "gitlab_prerelease_version",
                              "bitbucket_repository"]
       end
 


### PR DESCRIPTION
`ci-skip-repository` does not skip all repository checks. There is currently no way to skip checks for pre-release versions without using `ci-syntax-only`. This is an issue when files are served from github, but the labeling of releases does not reflect the version info provided on the upstream website (i.e. stable versions are marked as pre-release on github). Adding the cask to the prerelease allow-list does not work when the github latest version matches the version provided upstream.