### PR TITLE
weka (add zap, depends_on_java)

### DIFF
--- a/Casks/weka.rb
+++ b/Casks/weka.rb
@@ -19,4 +19,13 @@ cask "weka" do
   end
 
   app "weka-#{version}.app"
+
+  zap trash: [
+    "~/Library/Saved Application State/weka.gui.savedState",
+    "~/wekafiles",
+  ]
+
+  caveats do
+    depends_on_java "8+"
+  end
 end


### PR DESCRIPTION
Added missing zap stanza

Added depends_on_java 8+

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.