### PR TITLE
Bump Dangerzone to 0.4.1

### DIFF
--- a/Casks/dangerzone.rb
+++ b/Casks/dangerzone.rb
@@ -1,8 +1,11 @@
 cask "dangerzone" do
-  version "0.4.0"
-  sha256 "552df48cd9ef54345698499419a35bdd74a7397564e244f1364165c7f9ba4b65"
+  arch arm: "arm64", intel: "i686"
 
-  url "https://github.com/freedomofpress/dangerzone/releases/download/v#{version}/Dangerzone-#{version}.dmg",
+  version "0.4.1"
+  sha256 arm:   "ecaa65f030cdf2ecdd422c134b4c5951249dbd85d8a7bcce33ec45838f7fff49",
+         intel: "7fc652c81efd45318e6b07372c6c075c345a55730e0b8b4b30cd8ace8a5fe0a1"
+
+  url "https://github.com/freedomofpress/dangerzone/releases/download/v#{version}/Dangerzone-#{version}-#{arch}.dmg",
       verified: "github.com/freedomofpress/dangerzone/"
   name "Dangerzone"
   desc "Convert potentially dangerous PDFs or Office documents into safe PDFs"


### PR DESCRIPTION
The Dangerzone 0.4.1 release brings support for Apple Silicon chips, meaning that there are now two DMGs that a user can download, depending on their MacOS architecture. This commit adjusts the download link based on the system where Homebrew runs.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
