### PR TITLE
chore: fix autobump repo token naming

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -84,5 +84,5 @@ jobs:
         uses: Homebrew/actions/bump-packages@master
         continue-on-error: true
         with:
-          token: ${{ secrets.HOMEBREW_CASKS_REPO_WORKFLOW_TOKEN }}
+          token: ${{ secrets.HOMEBREW_CASK_REPO_WORKFLOW_TOKEN }}
           casks: ${{ github.event.inputs.casks || env.CASKS }}


### PR DESCRIPTION
@issyl0 correctly pointed out this name was wrong