### PR TITLE
supernotes 2.4.0

### DIFF
--- a/Casks/supernotes.rb
+++ b/Casks/supernotes.rb
@@ -1,6 +1,6 @@
 cask "supernotes" do
-  version "2.3.1"
-  sha256 "767e0a778c0c030dac6783da0481197fca0d595bfd797b4eda01275a7e885c31"
+  version "2.4.0"
+  sha256 "098d7039c5d8116ba6a87a1df7d331fb833d757fb4552f89bd66a428f86556a8"
 
   url "https://download.supernotes.app/Supernotes-#{version}.dmg"
   name "Supernotes"
@@ -15,12 +15,13 @@ cask "supernotes" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "Supernotes.app"
 
   zap trash: [
     "~/Library/Application Support/Supernotes",
+    "~/Library/Logs/Supernotes",
     "~/Library/Preferences/app.supernotes.SupernotesDesktop.plist",
     "~/Library/Saved Application State/app.supernotes.SupernotesDesktop.savedState",
   ]


### PR DESCRIPTION
* Bump from 2.3.1 to 2.4.0

* Update macOS required version from 10.11 to 10.13

* Add additional filepath for logs in zap

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.