### PR TITLE
klokki 1.3.7

### DIFF
--- a/Casks/klokki.rb
+++ b/Casks/klokki.rb
@@ -4,7 +4,7 @@ cask "klokki" do
 
   url "https://klokki.com/download/Klokki.dmg"
   name "Klokki"
-  desc "Automatic time-tracking solution or freelancers and makers"
+  desc "Automatic time-tracking solution"
   homepage "https://klokki.com/"
 
   # The dates in the appcast are sometimes out of order (i.e., a newer version
@@ -30,8 +30,8 @@ cask "klokki" do
 
   zap trash: [
     "~/Library/Application Scripts/com.klokki-launcher",
-    "~/Library/Application Support/Klokki",
     "~/Library/Application Support/com.klokki.macos",
+    "~/Library/Application Support/Klokki",
     "~/Library/Caches/com.klokki.macos",
     "~/Library/Containers/com.klokki-launcher",
     "~/Library/HTTPStorages/com.klokki.macos",

--- a/Casks/klokki.rb
+++ b/Casks/klokki.rb
@@ -1,5 +1,5 @@
 cask "klokki" do
-  version "1.3.6,85"
+  version "1.3.7,91"
   sha256 :no_check
 
   url "https://klokki.com/download/Klokki.dmg"
@@ -24,4 +24,18 @@ cask "klokki" do
   depends_on macos: ">= :high_sierra"
 
   app "Klokki.app"
+
+  uninstall launchctl: "com.klokki-launcher",
+            quit:      "com.klokki-launcher"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.klokki-launcher",
+    "~/Library/Application Support/Klokki",
+    "~/Library/Application Support/com.klokki.macos",
+    "~/Library/Caches/com.klokki.macos",
+    "~/Library/Containers/com.klokki-launcher",
+    "~/Library/HTTPStorages/com.klokki.macos",
+    "~/Library/HTTPStorages/com.klokki.macos.binarycookies",
+    "~/Library/Preferences/com.klokki.macos.plist",
+  ]
 end


### PR DESCRIPTION
* Bump version from 1.3.6 to 1.3.7

* Add uninstall for launchctl

* Add zap


- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.