### PR TITLE
rename hummingbird to airvpn-hummingbird

### DIFF
--- a/Casks/airvpn-hummingbird.rb
+++ b/Casks/airvpn-hummingbird.rb
@@ -1,4 +1,4 @@
-cask "hummingbird" do
+cask "airvpn-hummingbird" do
   arch arm: "arm64", intel: "x86_64"
 
   version "1.2.1"


### PR DESCRIPTION
There is a name conflict with an existing app (that existed before this cask) which led people to unwillingly update to this application. This commit simply adds an "airvpn" prefix to clarify the difference and solve the disambiguity.

See comment [here](https://github.com/Homebrew/homebrew-cask/pull/143791#issuecomment-1521830171) 

Fixes finestructure/Hummingbird#44

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
