### PR TITLE
rekordbox 6.7.1

### DIFF
--- a/Casks/rekordbox.rb
+++ b/Casks/rekordbox.rb
@@ -1,6 +1,6 @@
 cask "rekordbox" do
-  version "6.7.0,20230320142604"
-  sha256 "7482c893b0718522752af93bf4610586d2fa961f6c4b8ca666a9180dd5a74038"
+  version "6.7.1,20230421135130"
+  sha256 "f4b7ea5f36846ec184c628950b2a9471cae72a42fe29f6828877649d7f9f0f6e"
 
   url "https://cdn.rekordbox.com/files/#{version.csv.second}/Install_rekordbox_#{version.csv.first.dots_to_underscores}.pkg_.zip"
   name "rekordbox"
@@ -16,7 +16,7 @@ cask "rekordbox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   pkg "Install_rekordbox_#{version.csv.first.dots_to_underscores}.pkg"
 


### PR DESCRIPTION
* Bump version from 6.7.0 to 6.7.1

* Bump min macOS to Catalina per upstream requirements

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.