### PR TITLE
grisbi: fix checksum

### DIFF
--- a/Casks/grisbi.rb
+++ b/Casks/grisbi.rb
@@ -1,6 +1,6 @@
 cask "grisbi" do
   version "2.0.5"
-  sha256 "75620ff25fd60b9fe8fe3422aed494e23d83a0a6f75d483f6f01f04d183ab21b"
+  sha256 "c927abc191c75b2ac0d622bcb4d9557628ca2cd8e463a000e1a6287a57702a75"
 
   url "https://downloads.sourceforge.net/grisbi/#{version.major_minor}.x/#{version}/Grisbi-#{version}.dmg",
       verified: "downloads.sourceforge.net/grisbi/"

--- a/Casks/grisbi.rb
+++ b/Casks/grisbi.rb
@@ -14,4 +14,10 @@ cask "grisbi" do
   end
 
   app "Grisbi.app"
+
+  zap trash: [
+    "~/Library/Application Support/Grisbi",
+    "~/Library/Preferences/org.grisbi.Grisbi.plist",
+    "~/Library/Saved Application State/org.grisbi.Grisbi.savedState",
+  ]
 end


### PR DESCRIPTION
According to the [README.md](https://sourceforge.net/projects/grisbi/files/grisbi%20stable/2.0.x/2.0.5/) for 2.0.5 from 2023-03-09 the installation image for macOS 11 (Big Sur) and before was renamed to Grisbi-2.0.5-old_macOS.dmg while the installation image for macOS 12 (Monterey) and after was named Grisbi-2.0.5.dmg which caused a new checksum.

This PR updates the checksum to the installer image for macOS 12 (Monterey) and after.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.