### PR TITLE
Easydict 1.3.0

### DIFF
--- a/Casks/easydict.rb
+++ b/Casks/easydict.rb
@@ -1,6 +1,6 @@
 cask "easydict" do
-  version "1.2.3"
-  sha256 "23976414a46a5bc5dae1ac6ae31018559f96ef1722b0162a357312d863c10d27"
+  version "1.3.0"
+  sha256 "bf99ce7f807ca31e38b26d554868db435853075babc999d5bb26c9f2c3201c4f"
 
   url "https://github.com/tisfeng/Easydict/releases/download/#{version}/Easydict.dmg"
   name "Easydict"


### PR DESCRIPTION
### Bump Version
- Cask: Easydict
- Version: `1.2.3` -> `1.3.0`