### PR TITLE
intune-company-portal: Add missing auto_updates flag

### DIFF
--- a/Casks/intune-company-portal.rb
+++ b/Casks/intune-company-portal.rb
@@ -14,6 +14,7 @@ cask "intune-company-portal" do
     end
   end
 
+  auto_updates true
   depends_on cask: "microsoft-auto-update"
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
Like other apps of the Microsoft Office suite, Intune uses Microsoft AutoUpdate to update itself, therefore it shouldn't be updated by brew.

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
