### PR TITLE
appgate-sdp-client: update livecheck

### DIFF
--- a/Casks/appgate-sdp-client.rb
+++ b/Casks/appgate-sdp-client.rb
@@ -36,7 +36,7 @@ cask "appgate-sdp-client" do
         # Check the page for the newest major/minor version, which links to the
         # latest disk image file (containing the full version in the file name)
         version_page = Homebrew::Livecheck::Strategy.page_content(
-          URI.join("https://www.appgate.com/", version_page_path),
+          URI.join("https://www.appgate.com/", version_page_path).to_s,
         )
         next [] if version_page[:content].blank?
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Homebrew/brew#15326 will set `HOMEBREW_SORBET_RUNTIME=1` for dev commands like `brew livecheck`, so I'm working on addressing existing livecheck issues. When doing a run across first-party casks, I noticed a type issue with `appgate-sdp-client`, so this PR preemptively addresses it before Sorbet runtime is used by default (i.e., `Parameter 'url': Expected type String, got type URI::HTTPS` in relation to the secondary `Strategy#page_content` call).