### PR TITLE
grids 8.5.5

### DIFF
--- a/Casks/grids.rb
+++ b/Casks/grids.rb
@@ -1,6 +1,6 @@
 cask "grids" do
-  version "8.5.4"
-  sha256 "29d8fa9e6242e4392c162d731b12ef33f901ca7ae5c59dbc4a102eff1e367c66"
+  version "8.5.5"
+  sha256 "44e3b30ab2a3cd1d1df978f7acae162cd12f33f17a849e6771762e950c2a1aa3"
 
   url "https://gridsapp.net/bin/Grids_#{version}.zip"
   name "Grids"
@@ -15,7 +15,7 @@ cask "grids" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   app "Grids.app"
 
@@ -24,5 +24,6 @@ cask "grids" do
   zap trash: [
     "~/Library/Application Support/ThinkTimeCreations/Grids",
     "~/Library/Preferences/com.thinktimecreations.Grids.plist",
+    "~/Library/Saved Application State/com.thinktimecreations.Grids.savedState",
   ]
 end


### PR DESCRIPTION
* Version bump to 8.5.5

* Update minimum macOS requirement to Mojave

* add savedState file to zap

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
