### PR TITLE
docker: add caveats

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -116,6 +116,11 @@ cask "docker" do
       ]
 
   caveats <<~EOS
+    For CLI tools, you might need to open the Docker app for further instructions. You may use one of the following commands:
+
+      open /Applications/Docker.app
+      open -a Docker
+
     If your CLI tools were symlinked to $HOME/.docker/bin your path should be modified to include:
 
       $HOME/.docker/bin

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -124,6 +124,6 @@ cask "docker" do
 
     If your CLI tools were symlinked to $HOME/.docker/bin your path should be modified to include:
 
-          $HOME/.docker/bin
+        $HOME/.docker/bin
   EOS
 end

--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -116,13 +116,14 @@ cask "docker" do
       ]
 
   caveats <<~EOS
-    For CLI tools, you might need to open the Docker app for further instructions. You may use one of the following commands:
+    CLI tools are installed after launching Docker. They will be symlinked to one of the following
+    based on your preference:
 
-      open /Applications/Docker.app
-      open -a Docker
+        /usr/local/bin
+        $HOME/.docker/bin
 
     If your CLI tools were symlinked to $HOME/.docker/bin your path should be modified to include:
 
-      $HOME/.docker/bin
+          $HOME/.docker/bin
   EOS
 end


### PR DESCRIPTION
The added caveat should clarify how to add the CLI tools after installing the cask.

Fixes [#46078 (comment)](https://github.com/Homebrew/homebrew-cask/issues/146078#issuecomment-1527319437)

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online docker` is error-free.
- [x] `brew style --fix docker` reports no offenses.


Commands log:


  ```
homebrew-cask$ brew audit --cask --online docker
==> Downloading https://desktop.docker.com/mac/main/amd64/106363/Docker.dmg
Already downloaded: /Users/osos/Library/Caches/Homebrew/downloads/a2fa53b312129a06f0f442d39dc52e4aa215dd8202dccd10ade7522d8fdd9584--Docker.dmg
homebrew-cask$ brew style --fix docker

1 file inspected, no offenses detected
homebrew-cask$ git branch
* add-docker-cli-caveat
  master
homebrew-cask$ git status
On branch add-docker-cli-caveat
Your branch is up to date with 'origin/add-docker-cli-caveat'.

nothing to commit, working tree clean
homebrew-cask$ 
  ```
