### PR TITLE
surge-xt.rb to 1.2.2

### DIFF
--- a/Casks/surge-xt.rb
+++ b/Casks/surge-xt.rb
@@ -1,6 +1,6 @@
 cask "surge-xt" do
-  version "1.2.1"
-  sha256 "2b70c036518c1938a122ef07f922c6efbb09c774a450782593fe0d42dd3e1c8d"
+  version "1.2.2"
+  sha256 "ea305bf6697742389fe592aef3e8e55fb9836f56b14b24de4c001218c9ac521f"
 
   url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
       verified: "github.com/surge-synthesizer/releases-xt/"


### PR DESCRIPTION
We had a small error in our 1.2.1 release so have upgraded it this morning.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
