### PR TITLE
cardpresso 1.7.50

### DIFF
--- a/Casks/cardpresso.rb
+++ b/Casks/cardpresso.rb
@@ -1,6 +1,6 @@
 cask "cardpresso" do
-  version "1.7.20"
-  sha256 "94da851ae9c8238f8ad7e4c30abea24d73847996f0717c6b715ef628e0a032da"
+  version "1.7.50"
+  sha256 "c4944229259f5a3402e7f78a6f9018977ed409cb50bf094c5cc9a2856a17b55d"
 
   url "https://www.cardpresso.com/downloads/cardpresso_releases/for_mac_osx/cardPresso#{version}.dmg"
   name "cardpresso"
@@ -10,6 +10,8 @@ cask "cardpresso" do
   livecheck do
     skip "No version information available"
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "cardPresso.app"
 


### PR DESCRIPTION
* Bump version to 1.7.50

* Add minimum macOS requirement of High Sierra

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.