### PR TITLE
microsoft-outlook 16.72.23043001

### DIFF
--- a/Casks/microsoft-outlook.rb
+++ b/Casks/microsoft-outlook.rb
@@ -20,8 +20,8 @@ cask "microsoft-outlook" do
     sha256 "bddede85956713be21fdb5ab72be07ecefd05552752e8e60c649e6a15fd0a2c2"
   end
   on_big_sur :or_newer do
-    version "16.72.23042300"
-    sha256 "5de0ed6207cbb2fbfd2422b3e289d8f6b5438c34d69a019521c229d739621c0a"
+    version "16.72.23043001"
+    sha256 "4b806e34d05b8659d2db82d88cb285f8c762f8581341bb94e8c496ae45e1784b"
   end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg",


### PR DESCRIPTION
* Bump to latest version

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.