### PR TITLE
hiarcs-chess-explorer (rework)

### DIFF
--- a/Casks/hiarcs-chess-explorer.rb
+++ b/Casks/hiarcs-chess-explorer.rb
@@ -17,7 +17,7 @@ cask "hiarcs-chess-explorer" do
   end
   on_mojave :or_newer do
     version "1.12.2a"
-    sha256 "a77ed22e80ef8b85c65e7f74e72876b12b42525b1ae45bcdce656e3f40b1418f"
+    sha256 "fb4569d32e04e4a0434892ad283ccfe97f00ce0525c2851e403f8a13e3cdaaf3"
 
     livecheck do
       url "https://www.hiarcs.com/mac-chess-explorer-download.htm"

--- a/Casks/hiarcs-chess-explorer.rb
+++ b/Casks/hiarcs-chess-explorer.rb
@@ -16,12 +16,12 @@ cask "hiarcs-chess-explorer" do
     end
   end
   on_mojave :or_newer do
-    version "1.12.2"
+    version "1.12.2a"
     sha256 "a77ed22e80ef8b85c65e7f74e72876b12b42525b1ae45bcdce656e3f40b1418f"
 
     livecheck do
       url "https://www.hiarcs.com/mac-chess-explorer-download.htm"
-      regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+)[a-z]?\.pkg}i)
+      regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+[a-z]?)\.pkg}i)
     end
   end
 

--- a/Casks/hiarcs-chess-explorer.rb
+++ b/Casks/hiarcs-chess-explorer.rb
@@ -1,21 +1,40 @@
 cask "hiarcs-chess-explorer" do
-  version "1.12.2"
-  sha256 "a77ed22e80ef8b85c65e7f74e72876b12b42525b1ae45bcdce656e3f40b1418f"
+  on_sierra :or_older do
+    version "1.9.4"
+    sha256 "eaf7627801ca4cc2351fef58bb313353eca2a51d894e28df2b627dd011856a7f"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_high_sierra do
+    version "1.11.1"
+    sha256 "6f188f9c9041ed5667f0398e7b2a9b00d998bd6c77e9391163895bbd746f49ee"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_mojave :or_newer do
+    version "1.12.2"
+    sha256 "a77ed22e80ef8b85c65e7f74e72876b12b42525b1ae45bcdce656e3f40b1418f"
+
+    livecheck do
+      url "https://www.hiarcs.com/mac-chess-explorer-download.htm"
+      regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+)[a-z]?\.pkg}i)
+    end
+  end
 
   url "https://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
   name "(Deep) HIARCS Chess Explorer"
   desc "Chess database, analysis and game playing program"
   homepage "https://www.hiarcs.com/mac-chess-explorer.htm"
 
-  livecheck do
-    url "https://www.hiarcs.com/mac-chess-explorer-download.htm"
-    regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
-  end
-
-  depends_on macos: ">= :high_sierra"
-
   pkg "HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
 
   uninstall signal:  ["TERM", "com.hiarcs.chessexplorer"],
             pkgutil: "com.hiarcs.*"
+
+  zap trash: "~/Library/Preferences/com.hiarcs.Chess Explorer.plist",
+      rmdir: "~/Documents/HIARCS Chess"
 end


### PR DESCRIPTION
* Adjust livecheck url to support optional [a-z] at version end

* Add zap stanza

* Add legacy versions, remove depends_on macOS version

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.