### PR TITLE
intel-power-gadget (fix livecheck)

### DIFF
--- a/Casks/intel-power-gadget.rb
+++ b/Casks/intel-power-gadget.rb
@@ -9,7 +9,7 @@ cask "intel-power-gadget" do
 
   livecheck do
     url :homepage
-    regex(/Intel[._-]Power[._-]Gadget[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+    regex(/href=.*?v?(\d(?:\.\d+)+).*MacOS/i)
   end
 
   auto_updates true


### PR DESCRIPTION
* Fix livecheck

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
