### PR TITLE
fix: teamviewer download URL

### DIFF
--- a/Casks/teamviewer.rb
+++ b/Casks/teamviewer.rb
@@ -1,22 +1,25 @@
+# typed: true
+# frozen_string_literal: true
+
 cask "teamviewer" do
   sha256 :no_check
 
   on_high_sierra :or_older do
     version "15.2.2756"
 
-    pkg "Install TeamViewer.pkg"
+    pkg "TeamViewer.pkg"
   end
   on_mojave do
     version "15.41.9"
 
-    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+    pkg "TeamViewer.pkg"
   end
   on_catalina do
     version "15.41.9"
 
     # This Cask should be installed and uninstalled manually on Catalina.
     # See https://github.com/Homebrew/homebrew-cask/issues/76829
-    installer manual: "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+    installer manual: "TeamViewer.pkg"
 
     caveats <<~EOS
       WARNING: #{token} has a bug in Catalina where it doesn't deal well with being uninstalled by other utilities.
@@ -28,10 +31,10 @@ cask "teamviewer" do
   on_big_sur :or_newer do
     version "15.41.9"
 
-    pkg "Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg"
+    pkg "TeamViewer.pkg"
   end
 
-  url "https://download.teamviewer.com/download/TeamViewer.dmg"
+  url "https://dl.teamviewer.com/download/version_15x/update/#{version}/TeamViewer.pkg"
   name "TeamViewer"
   desc "Remote access and connectivity software focused on security"
   homepage "https://www.teamviewer.com/"


### PR DESCRIPTION
**Use an alternative download URL to avoid downloading the old version from the server cache.**

> The origin download link will result in fetching an older version when installing and running brew upgrade, logs attached below

<details>
    <summary>logs:</summary>

`brew cu -a -y -v`
```
==> Cleaning up old versions
==> Upgrading teamviewer to 15.41.9
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-cask/0c0732d70514127ac279454d829f7637548788c8/Casks/teamviewer.rb
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.0.16-15-gfec24f5\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 13.3.1\)\ curl/7.87.0 --header Accept-Language:\ en --fail --connect-timeout 15 --retry 3 --location --remote-time --output /Users/edward/Library/Caches/Homebrew/downloads/7247ff88d686d416e82bf1b38bf30969f47f13391d54a25ad64e562b612f0436--teamviewer.rb.incomplete https://raw.githubusercontent.com/Homebrew/homebrew-cask/0c0732d70514127ac279454d829f7637548788c8/Casks/teamviewer.rb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2954  100  2954    0     0   6435      0 --:--:-- --:--:-- --:--:--  6520
==> Verifying checksum for '7247ff88d686d416e82bf1b38bf30969f47f13391d54a25ad64e562b612f0436--teamviewer.rb'
==> Downloading https://download.teamviewer.com/download/TeamViewer.dmg
==> Downloading from https://dl.teamviewer.com/download/version_15x/TeamViewer.dmg
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.0.16-15-gfec24f5\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 13.3.1\)\ curl/7.87.0 --header Accept-Language:\ en --fail --retry 3 --location --remote-time --output /Users/edward/Library/Caches/Homebrew/downloads/be05736e528dcf66445ab64fbce55935ab099e89bc1ce99f07b9aa827d3ea6e4--TeamViewer.dmg.incomplete https://dl.teamviewer.com/download/version_15x/TeamViewer.dmg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 75.9M  100 75.9M    0     0  1385k      0  0:00:56  0:00:56 --:--:-- 1445k
Warning: No checksum defined for cask 'teamviewer', skipping verification.
==> Uninstalling Cask teamviewer
==> Removing launchctl service com.teamviewer.desktop
==> Removing launchctl service com.teamviewer.Helper
==> Removing launchctl service com.teamviewer.service
==> Removing launchctl service com.teamviewer.teamviewer
==> Removing launchctl service com.teamviewer.teamviewer_desktop
==> Removing launchctl service com.teamviewer.teamviewer_service
==> Uninstalling packages; your password may be necessary:
com.teamviewer.AuthorizationPlugin
com.teamviewer.remoteaudiodriver
com.teamviewer.teamviewerEnforceUIVersion
com.teamviewer.teamviewer
com.teamviewer.teamviewerPriviledgedHelper
==> Removing files:
/Applications/TeamViewer.app
/Library/Preferences/com.teamviewer.teamviewer.preferences.plist
==> Purging files for version 15.41.8 of Cask teamviewer
==> Installing Cask teamviewer
/usr/bin/env hdiutil attach -plist -nobrowse -readonly -mountrandom /private/tmp/d20230504-26665-6kawvc /Users/edward/Library/Caches/Homebrew/downloads/be05736e528dcf66445ab64fbce55935ab099e89bc1ce99f07b9aa827d3ea6e4--TeamViewer.dmg
/usr/bin/env mkbom -s -i /private/tmp/20230504-26665-1fecvdx.list -- /private/tmp/20230504-26665-y9ixjm.bom
/usr/bin/env ditto --bom /private/tmp/20230504-26665-y9ixjm.bom -- /private/tmp/d20230504-26665-6kawvc/dmg.dc5H96 /private/tmp/d20230504-26665-wmfo1s
/usr/bin/env diskutil info -plist /private/tmp/d20230504-26665-6kawvc/dmg.dc5H96
/usr/bin/env diskutil eject /private/tmp/d20230504-26665-6kawvc/dmg.dc5H96
/usr/bin/env cp -pR /private/tmp/d20230504-26665-wmfo1s/Background.png /opt/homebrew/Caskroom/teamviewer/15.41.9/Background.png
/usr/bin/env cp -pR /private/tmp/d20230504-26665-wmfo1s/Install\ TeamViewer.app/. /opt/homebrew/Caskroom/teamviewer/15.41.9/Install\ TeamViewer.app
==> Running installer for teamviewer; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
installer: Package name is TeamViewer
installer: Installing at base path /
installer:PHASE:Preparing for installation…
installer:PHASE:Preparing the disk…
installer:PHASE:Preparing TeamViewer…
installer:PHASE:Waiting for other installations to complete…
installer:PHASE:Configuring the installation…
installer:STATUS:
installer:%6.350558
installer:PHASE:Writing files…
installer:%26.479098
installer:PHASE:Writing files…
installer:%35.769193
installer:PHASE:Writing files…
installer:%54.349384
installer:PHASE:Writing files…
installer:%65.850411
installer:PHASE:Running package scripts…
installer:%88.698643
installer:PHASE:Running package scripts…
installer:%89.467144
installer:PHASE:Running package scripts…
installer:%90.243296
installer:PHASE:Running package scripts…
installer:%91.019465
installer:PHASE:Running package scripts…
installer:%91.795761
installer:PHASE:Running package scripts…
installer:%92.563871
installer:PHASE:Running package scripts…
installer:%93.058115
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Running package scripts…
installer:PHASE:Validating packages…
installer:%97.262500
installer:PHASE:Registering updated applications…
installer:%97.750000
installer:STATUS:Running installer actions…
installer:STATUS:
installer:PHASE:Finishing the Installation…
installer:STATUS:
installer:%100.000000
installer:PHASE:The software was successfully installed.
installer: The install was successful.
==> The TeamViewer package postinstall script launches the TeamViewer app
==> Attempting to close the TeamViewer app to avoid unwanted user intervention
🍺  teamviewer was successfully installed!
```
**The latest version is 15.41.9, and the installed version using the old download URL is 15.41.8, the installer in Caskroom is also 15.41.8.**
</details>

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
