### PR TITLE
ci-skip-livecheck: skip https availability

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -136,7 +136,8 @@ module CiMatrix
       audit_exceptions = []
 
       if labels.include?("ci-skip-livecheck")
-        audit_exceptions << ["hosting_with_livecheck", "livecheck_version", "livecheck_min_os"]
+        audit_exceptions << %w[hosting_with_livecheck livecheck_version
+                               livecheck_min_os audit_https_availability]
       end
 
       audit_exceptions << "livecheck_min_os" if labels.include?("ci-skip-livecheck-min-os")


### PR DESCRIPTION
`ci-skip-livecheck` does not actually skip checking if the `livecheck` url is available. 

If the URL is not reachable by the CI machines (#146350 #146223 #146330 #146544) there is no way to skip the check besides `ci-syntax-only`.

This adds `audit_https_availability` as one of the checks skipped during `ci-skip-livecheck`. 

Alternatively, it could be integrated into a separate label, but this is where it's come up most.