### PR TITLE
openframeworks (livecheck, zap)

### DIFF
--- a/Casks/openframeworks.rb
+++ b/Casks/openframeworks.rb
@@ -9,8 +9,10 @@ cask "openframeworks" do
 
   livecheck do
     url "https://github.com/openframeworks/openFrameworks"
-    strategy :github_latest
+    regex(/v?(\d+(?:\.\d+)+)/)
   end
 
   suite "of_v#{version}_osx_release"
+
+  # No zap stanza required
 end


### PR DESCRIPTION
* Update livecheck regex to pull stable version number

* Mark as no zap required

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
