### PR TITLE
softube-central-1.9.7

### DIFF
--- a/Casks/softube-central.rb
+++ b/Casks/softube-central.rb
@@ -1,6 +1,6 @@
 cask "softube-central" do
-  version "1.9.0"
-  sha256 "ae3c05350332c638ae566216624f672ab86ad366e88334cba079890e920d8c3f"
+  version "1.9.7"
+  sha256 "0538f8795d8cde686d7f732ce09fff07328d1d2fd85e2b8516b25f122d0b9ae3"
 
   url "https://softubestorage.b-cdn.net/softubecentral/Softube%20Central-#{version}-universal.pkg",
       verified: "softubestorage.b-cdn.net/"
@@ -9,7 +9,8 @@ cask "softube-central" do
   homepage "https://www.softube.com/softube-central/"
 
   livecheck do
-    skip "No version information available"
+    url "https://www.softube.com/installers"
+    regex(/Softube%20Central-v?(\d+(?:\.\d+)+)-universal\.pkg/)
   end
 
   auto_updates true

--- a/Casks/softube-central.rb
+++ b/Casks/softube-central.rb
@@ -10,7 +10,7 @@ cask "softube-central" do
 
   livecheck do
     url "https://www.softube.com/installers"
-    regex(/Softube%20Central-v?(\d+(?:\.\d+)+)-universal\.pkg/)
+    regex(/Softube%20Central[._-]v?(\d+(?:\.\d+)+)[._-]universal\.pkg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
* Version bump to 1.9.7

* Add livecheck information

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
