### PR TITLE
multiviewer-for-f1 1.17.0

### DIFF
--- a/Casks/multiviewer-for-f1.rb
+++ b/Casks/multiviewer-for-f1.rb
@@ -2,7 +2,7 @@ cask "multiviewer-for-f1" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.17.0.2,107017283"
+    version "1.17.0,107017283"
     sha256 "0c650c16ad89432b2b4a800c68c353c33a61390a521bcd35a1ef9e4455efe5b8"
   end
   on_intel do

--- a/Casks/multiviewer-for-f1.rb
+++ b/Casks/multiviewer-for-f1.rb
@@ -2,12 +2,12 @@ cask "multiviewer-for-f1" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.16.2,107000391"
-    sha256 "764728574d085e3f28ea6c840dc69e12f969248a23f2adf523d6f2d93f2779ae"
+    version "1.17.0.2,107017283"
+    sha256 "0c650c16ad89432b2b4a800c68c353c33a61390a521bcd35a1ef9e4455efe5b8"
   end
   on_intel do
-    version "1.16.2,107000843"
-    sha256 "90ed7e559d20b98316ae4f2ed2431a8ef612a6546ba31489710af845dcab35ee"
+    version "1.17.0,107017801"
+    sha256 "e09818b319a5a47ec63a8ab81ce81595fe4e0d2dd9e62d8630fb2090ea46b494"
   end
 
   url "https://releases.multiviewer.app/download/#{version.csv.second}/MultiViewer.for.F1-#{version.csv.first}-#{arch}.dmg"


### PR DESCRIPTION
* Version bump to 1.17.0

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
