### PR TITLE
Don't sync to `homebrew/cask-drivers`.

### DIFF
--- a/.github/workflows/sync-templates-and-ci-config.yml
+++ b/.github/workflows/sync-templates-and-ci-config.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         repo:
-          - Homebrew/homebrew-cask-drivers
           - Homebrew/homebrew-cask-fonts
           - Homebrew/homebrew-cask-versions
     steps:


### PR DESCRIPTION
Tap will be deprecated soon.