### PR TITLE
concept2-utility: migrate from cask-drivers

### DIFF
--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -1,0 +1,32 @@
+cask "concept2-utility" do
+  on_sierra :or_older do
+    version "7.09.02"
+    sha256 "e4ebee8cde57c7ef63c3903285c3fc0ee8f87221e7c5529b9dcf97b3f9ebb57e"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_high_sierra :or_newer do
+    version "7.10.15"
+    sha256 "e92bc06fc75fd08291ed08e8ae726fc7461d4b64c42887641977b5be2817af93"
+
+    livecheck do
+      url :homepage
+      regex(/Concept2\s+Utility\s+(\d+(?:\.\d+)+)/i)
+    end
+  end
+
+  url "https://software.concept2.com/utility/Concept2Utility#{version.no_dots}.dmg"
+  name "Concept2 Utility"
+  desc "Utilities for the Concept2 Performance Monitor"
+  homepage "https://www.concept2.com/service/software/concept2-utility"
+
+  pkg "Concept2 Utility #{version}.pkg"
+
+  uninstall pkgutil: "com.concept2.pkg.Concept2Utility"
+
+  zap trash: [
+    "~/Library/Application Support/Concept2",
+  ]
+end

--- a/Casks/concept2-utility.rb
+++ b/Casks/concept2-utility.rb
@@ -27,6 +27,9 @@ cask "concept2-utility" do
   uninstall pkgutil: "com.concept2.pkg.Concept2Utility"
 
   zap trash: [
+    "~/Documents/Concept2",
     "~/Library/Application Support/Concept2",
+    "~/Library/Preferences/com.concept2.Utility.plist",
+    "~/Library/Saved Application State/com.concept2.lcu.savedState",
   ]
 end


### PR DESCRIPTION
Migrating after https://github.com/Homebrew/homebrew-cask-drivers/pull/3443 - merge with https://github.com/Homebrew/homebrew-cask-drivers/pull/3454

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
