### PR TITLE
caldigit-docking-utility: migrate from cask-drivers

### DIFF
--- a/Casks/caldigit-docking-utility.rb
+++ b/Casks/caldigit-docking-utility.rb
@@ -15,4 +15,9 @@ cask "caldigit-docking-utility" do
 
   uninstall signal:  ["TERM", "CalDigit.CalDigit-Docking-Station-Utility"],
             pkgutil: "com.CalDigit.CDSU.pkg"
+
+  zap trash: [
+    "~/Library/Preferences/CalDigit.CalDigit-Docking-Station-Utility.plist",
+    "~/Library/Saved Application State/CalDigit.CalDigit-Docking-Station-Utility.savedState",
+  ]
 end

--- a/Casks/caldigit-docking-utility.rb
+++ b/Casks/caldigit-docking-utility.rb
@@ -1,0 +1,18 @@
+cask "caldigit-docking-utility" do
+  version "1.9.31"
+  sha256 :no_check
+
+  url "https://downloads.caldigit.com/CalDigit-Docking-Station-Utility.zip"
+  name "CalDigit Thunderbolt Docking Station Utility"
+  desc "Utility to disconnect all drives connected to a Caldigit dock"
+  homepage "https://www.caldigit.com/"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  pkg "CalDigit Docking Station Utility v#{version}.pkg"
+
+  uninstall signal:  ["TERM", "CalDigit.CalDigit-Docking-Station-Utility"],
+            pkgutil: "com.CalDigit.CDSU.pkg"
+end


### PR DESCRIPTION
Similar to #146687, this is a [cask migration from cask-drivers](https://github.com/Homebrew/homebrew-cask-drivers/blob/fe9ec4303b63ca573f6e1229452592e5e5d038b7/Casks/caldigit-docking-utility.rb).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
