### PR TITLE
plex-media-server 1.32.1.6999

### DIFF
--- a/Casks/plex-media-server.rb
+++ b/Casks/plex-media-server.rb
@@ -1,6 +1,6 @@
 cask "plex-media-server" do
-  version "1.32.0.6973,a787c5a8e"
-  sha256 "491274984b54490bfa147e195dac3025eac500ead7e95f2e066341c1fcf059a9"
+  version "1.32.1.6999,91e1e2e2c"
+  sha256 "24d059d37f7f5900df9757a86747f736ec6ed9f0acf1c0ddfb555247ae6e7e4a"
 
   url "https://downloads.plex.tv/plex-media-server-new/#{version.csv.first}-#{version.csv.second}/macos/PlexMediaServer-#{version.csv.first}-#{version.csv.second}-universal.zip"
   name "Plex Media Server"
@@ -16,6 +16,7 @@ cask "plex-media-server" do
   end
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Plex Media Server.app"
   binary "#{appdir}/Plex Media Server.app/Contents/MacOS/Plex Media Scanner", target: "plexms"


### PR DESCRIPTION
* Version bump to 1.32.1.6999

* Add minimum macOS requirement of High Sierra

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
