### PR TITLE
appium: discontinued

### DIFF
--- a/Casks/appium.rb
+++ b/Casks/appium.rb
@@ -8,12 +8,6 @@ cask "appium" do
   desc "Graphical frontend to Appium automation server"
   homepage "https://appium.io/"
 
-  livecheck do
-    url :url
-    regex(%r{href=.*?/tag/v?(\d+(?:[.-]\d+)+)["' >]}i)
-    strategy :github_latest
-  end
-
   app "Appium Server GUI.app"
 
   zap trash: [
@@ -22,4 +16,8 @@ cask "appium" do
     "~/Library/Preferences/io.appium.desktop.plist",
     "~/Library/Saved Application State/io.appium.desktop.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [upstream repository for `appium`](https://github.com/appium/appium-desktop) is archived and the "latest" release (from 2022-05-14) states:

> Appium Desktop is unsupported, no longer maintained, and has known security vulnerabilities. It is advised not to use it at all. See the README for more information. Use at your own risk.

This PR sets the cask as discontinued and removes the `livecheck` block so it will be automatically skipped.