### PR TITLE
brook 20230404.5.1

### DIFF
--- a/Casks/brook.rb
+++ b/Casks/brook.rb
@@ -1,6 +1,6 @@
 cask "brook" do
-  version "20230404"
-  sha256 "72e61121e1c3195b0110f4826334bc08c9494bcd2a727c6414b1a04ca059c316"
+  version "20230404.5.1"
+  sha256 "bcf1375ef6f32343e0619fd5d5bc18917a6c6c4fc0c7be469a4e56d88f07746f"
 
   url "https://github.com/txthinking/brook/releases/download/v#{version}/Brook.dmg"
   name "Brook"
@@ -9,9 +9,11 @@ cask "brook" do
 
   livecheck do
     url :url
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+)["' >]}i)
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
     strategy :github_latest
   end
 
   app "Brook.app"
+
+  zap trash: "~/Library/Saved Application State/com.txthinking.brook.savedState"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates `brook` to the latest release, 20230404.5.1. This also updates the `livecheck` block to fix it for the recent `GithubLatest` changes and to tweak the regex so it will also match versions like `20230404.5.1` (as this version was missed due to the regex).