### PR TITLE
ricochet: update livecheck

### DIFF
--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -2,11 +2,10 @@ cask "ricochet" do
   version "1.1.4.1"
   sha256 "e5fbcbebe51fa52d9443fd2a07714d0e6e087c314a9c3eecf73ed4da8ca9e8aa"
 
-  url "https://github.com/ricochet-im/ricochet/releases/download/v#{version.major_minor_patch}/ricochet-#{version}-macos.dmg",
-      verified: "github.com/ricochet-im/"
+  url "https://github.com/ricochet-im/ricochet/releases/download/v#{version.major_minor_patch}/ricochet-#{version}-macos.dmg"
   name "Ricochet"
   desc "Anonymous peer-to-peer instant messaging"
-  homepage "https://ricochet.im/"
+  homepage "https://github.com/ricochet-im/ricochet"
 
   # Upstream sometimes replaces a release asset and bumps the version, so it
   # doesn't correspond to the tagged version anymore. For example, they may

--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -25,4 +25,9 @@ cask "ricochet" do
   end
 
   app "Ricochet.app"
+
+  zap trash: [
+    "~/Library/Application Support/Ricochet",
+    "~/Library/Saved Application State/im.ricochet.savedState",
+  ]
 end

--- a/Casks/ricochet.rb
+++ b/Casks/ricochet.rb
@@ -8,10 +8,21 @@ cask "ricochet" do
   desc "Anonymous peer-to-peer instant messaging"
   homepage "https://ricochet.im/"
 
+  # Upstream sometimes replaces a release asset and bumps the version, so it
+  # doesn't correspond to the tagged version anymore. For example, they may
+  # publish `ricochet-1.2.3.1-macos.dmg` for a `1.2.3` release, so we have to
+  # check the release assets to guarantee we identify the full version.
   livecheck do
     url :url
-    regex(%r{/ricochet-(\d+(?:\.\d+)*)-macos\.dmg}i)
-    strategy :github_latest
+    regex(/^ricochet[._-]v?(\d+(?:\.\d+)+).*?\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   app "Ricochet.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates the existing `livecheck` block for `ricochet` to fix it in relation to the recent `GithubLatest` changes.

This also updates the `homepage`, as the https://ricochet.im/ SSL certificate expired on 2021-08-07 and hasn't been fixed in the interim time.