### PR TITLE
konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver: migrate from `homebrew/cask-versions`

### DIFF
--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -39,5 +39,19 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
 
   depends_on macos: ">= :sierra"
 
+  uninstall_postflight do
+    set_ownership [
+      "/Library/Printers/KONICAMINOLTA/Preferences",
+    ]
+  end
+
   uninstall pkgutil: "jp.konicaminolta.print.package.C759"
+
+  zap trash: [
+        "/Library/Printers/KONICAMINOLTA/Preferences/jp.konicaminolta.printers.C759",
+        "/Library/Printers/KONICAMINOLTA/Preferences/jp.konicaminolta.printers.C759.plist",
+      ],
+      rmdir: [
+        "/Library/Printers/KONICAMINOLTA",
+      ]
 end

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -1,0 +1,43 @@
+cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
+  on_catalina :or_older do
+    version "11.6.0,08e8308b1e134d6bb6837e3b046b126b,122431"
+    sha256 "8baec3e834f41d4156b3da9ff598171af4182290d7af1183f07df7476158a4b7"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    pkg "C759_C658_C368_C287_C3851_Series_v#{version}_Letter/C759_C658_C368_C287_C3851.pkg"
+  end
+  on_big_sur :or_newer do
+    version "11.8.0A,7228bd01e7674417c6a223ce7a186487,130160"
+    sha256 "0c525868b8f07c257fae3c949fdcfad623edfe7b81d030a771601d2cb88c7796"
+
+    livecheck do
+      url "https://dl.konicaminolta.eu/en?tx_kmdownloadcenter_dlajaxservice[action]=getDocuments&tx_kmdownloadcenter_dlajaxservice[controller]=AjaxService&tx_kmdownloadcenter_dlajaxservice[productId]=102314&tx_kmdownloadcenter_dlajaxservice[system]=KonicaMinolta&cHash=dd72618a38434b6cb3edfc20595d58c5&type=1527583889"
+      strategy :json do |json|
+        items = json.select do |i|
+          i["TypeOfApplicationName_textS"]&.match?(/driver/i) &&
+            i["OperatingSystemsNames_textM"]&.grep(/macOS.*?#{Regexp.escape(MacOS.version.to_s)}/i)&.any?
+        end
+
+        item = items.max_by { |i| i["ReleaseDate_textS"] }
+        files = item["DownloadFiles_textS"].split("\n").map { |file| file.split("|") }
+        dmg = files.find { |f| f.first.end_with?(".dmg") }
+
+        "#{item["Version_textS"]},#{Digest::MD5.hexdigest(dmg[2])},#{item["AnacondaId_textS"]}"
+      end
+    end
+
+    pkg "C759_C658_C368_C287_C3851_#{version.major}.pkg"
+  end
+
+  url "https://dl.konicaminolta.eu/en?tx_kmdownloadcentersite_downloadproxy[fileId]=#{version.csv[1]}&tx_kmdownloadcentersite_downloadproxy[documentId]=#{version.csv[2]}&tx_kmdownloadcentersite_downloadproxy[system]=KonicaMinolta&tx_kmdownloadcentersite_downloadproxy[language]=EN&type=1558521685"
+  name "Konica Minolta Bizhub C759/C658/C368/C287/C3851 Series Printer"
+  desc "Drivers for Konica Monolta Bizhub printers"
+  homepage "https://www.konicaminolta.eu/eu-en/support/download-centre"
+
+  depends_on macos: ">= :sierra"
+
+  uninstall pkgutil: "jp.konicaminolta.print.package.C759"
+end

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -32,7 +32,7 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
     pkg "C759_C658_C368_C287_C3851_#{version.major}.pkg"
   end
 
-  url "https://dl.konicaminolta.eu/en?tx_kmdownloadcentersite_downloadproxy[fileId]=#{version.csv[1]}&tx_kmdownloadcentersite_downloadproxy[documentId]=#{version.csv[2]}&tx_kmdownloadcentersite_downloadproxy[system]=KonicaMinolta&tx_kmdownloadcentersite_downloadproxy[language]=EN&type=1558521685"
+  url "https://dl.konicaminolta.eu/en?tx_kmdownloadcentersite_downloadproxy[fileId]=#{version.csv.second}&tx_kmdownloadcentersite_downloadproxy[documentId]=#{version.csv.third}&tx_kmdownloadcentersite_downloadproxy[system]=KonicaMinolta&tx_kmdownloadcentersite_downloadproxy[language]=EN&type=1558521685"
   name "Konica Minolta Bizhub C759/C658/C368/C287/C3851 Series Printer"
   desc "Drivers for Konica Monolta Bizhub printers"
   homepage "https://www.konicaminolta.eu/eu-en/support/download-centre"

--- a/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -39,7 +39,7 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
 
   depends_on macos: ">= :sierra"
 
-  uninstall_postflight do
+  uninstall_preflight do
     set_ownership [
       "/Library/Printers/KONICAMINOLTA/Preferences",
     ]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

An older implementation kept failing during an audit for an unknown reason. Hopefully, this one will pass the audit. Made based on c751i implementation.

EDIT: Here we are again in the twilight zone. The audit for MacOS 13 passed, while it failed with the same file for MacOS 11 and 12.  🤯🤯🤯

EDIT 2: The strangest thing is that both install and uninstall worked as expected, but only the audit made a problem even though the file was already downloaded?!