### PR TITLE
unison 2.53.3

### DIFF
--- a/Casks/unison.rb
+++ b/Casks/unison.rb
@@ -1,28 +1,23 @@
 cask "unison" do
-  version "2.53.2,4.14.1"
-  sha256 "c73bf7944dee203f1408a08d591d3187a2480ed543007cf1cfe859ce0b22c148"
+  version "2.53.3"
+  sha256 "c389e23927e43117851dd01b6fe681c8fa2f8c21bad599c24e2dfb8639f4100b"
 
-  url "https://github.com/bcpierce00/unison/releases/download/v#{version.csv.first}/Unison-v#{version.csv.first}.ocaml-#{version.csv.second}.macos-10.15.app.tar.gz",
+  url "https://github.com/bcpierce00/unison/releases/download/v#{version}/Unison-#{version}-macos.app.tar.gz",
       verified: "github.com/bcpierce00/unison/"
   name "Unison"
   desc "File synchronizer"
   homepage "https://www.cis.upenn.edu/~bcpierce/unison/"
 
   livecheck do
-    url "https://github.com/bcpierce00/unison/releases/latest"
-    regex(/href=.*?Unison[._-]v?(\d+(?:\.\d+)+)[._-]ocaml[._-]v?(\d+(?:\.\d+)+)[._-]macos/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Unison[._-]v?(\d+(?:\.\d+)+).*?(\d+(?:\.\d+)+)?[._-]macos.*?[._-]app/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates the cask to the latest version, 2.53.3. The "macos-app" tarball previously referenced OCaml in the filename but it doesn't in this newest version. It would be good if someone could confirm that this is an appropriate version with respect to the goals of the cask.

While testing `HeaderMatch` checks recently, I noticed that the `livecheck` block for `unison` was broken due to the recent filename change. This PR also updates the `livecheck` block to be able to match the new filename format. In the process, I migrated the check to `GithubLatest`, since the strategy was recently updated to check the GitHub API instead and the response JSON contains information on release assets, so we can simplify the check and get rid of the secondary request.

To be clear, some of the `livecheck` blocks like this one can be replaced with `GithubLatest` but others will need the forthcoming `GithubReleases` strategy (since some projects don't provide the file the cask uses in every release). I plan to go through the related `livecheck` blocks after `GithubReleases` is available (I'm in the process of reviewing that strategy).