### PR TITLE
added back shureplus-motiv

### DIFF
--- a/Casks/shureplus-motiv.rb
+++ b/Casks/shureplus-motiv.rb
@@ -1,0 +1,24 @@
+cask "shureplus-motiv" do
+  version "1.3.1"
+  sha256 "6ddd8c8fe08ce8136d2c6f3565f6991f34c7b68fe34823db8db7a84907f88d99"
+
+  url "https://content-files.shure.com/Software/shure_plus_motiv_desktop/#{version.dots_to_hyphens}/motiv-mac-#{version}.dmg"
+  name "ShurePlus MOTIV"
+  desc "Additional features and controls for Shure MV7 and MV88+ microphones"
+  homepage "https://www.shure.com/en-US/products/software/shure_plus_motiv_desktop"
+
+  livecheck do
+    url "https://www.shure.com/en-US/support/downloads/software-firmware-archive/shure_plus_motiv_desktop"
+    regex(/<span\sclass="firmware__version">\n?\t+?(\d+(?:\.\d+)+)/i)
+  end
+
+  app "ShurePlus MOTIV.app"
+
+  uninstall quit: "com.shure.motiv.desktop"
+
+  zap trash: [
+    "~/Library/Application Support/ShurePlus MOTIV",
+    "~/Library/Logs/ShurePlus MOTIV",
+    "~/Library/Saved Application State/com.shure.motiv.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
This is just a copy of the cask that was deleted from homebrew-cask-drivers (https://github.com/Homebrew/homebrew-cask-drivers/pull/3443).

Old formula: https://github.com/Homebrew/homebrew-cask-drivers/pull/3443/files#diff-a351b46295b697d813c883996bb61adb1450d451da091a863540780a7ab095a9

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
