### PR TITLE
Migrate bose-updater from homebrew-cask-drivers

### DIFF
--- a/Casks/bose-updater.rb
+++ b/Casks/bose-updater.rb
@@ -1,0 +1,27 @@
+cask "bose-updater" do
+  version "7.1.7.5136"
+  sha256 "80ec0c20b1ed53677999f97acff7a3b4825fea3c300dfd2feba34c0e4890bbd7"
+
+  url "https://downloads.bose.com/ced/boseupdater/mac/BoseUpdater_#{version}.dmg"
+  name "Bose Device Updater"
+  desc "Software updates for Bose products"
+  homepage "https://btu.bose.com/"
+
+  livecheck do
+    url "https://btu.bose.com/data/MUV.xml"
+    regex(/ROOT\sMUV="(\d+(?:.\d+)*)"/i)
+  end
+
+  app "Bose Updater.app"
+
+  uninstall quit: [
+    "com.bose.BoseUpdater",
+    "org.qt-project.Qt.*",
+  ]
+
+  zap trash: "~/Library/Preferences/com.bose.Bose Updater.plist"
+
+  caveats do
+    license "https://btu.bose.com/#section=install"
+  end
+end


### PR DESCRIPTION
Cask copied from [homebrew-cask-drivers](https://github.com/Homebrew/homebrew-cask-drivers/blob/caa3028d12e80d71ea48077970218ca483e09640/Casks/bose-updater.rb).

Merge with https://github.com/Homebrew/homebrew-cask-drivers/pull/3457

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
