### PR TITLE
wondershare-filmora 12.3.2

### DIFF
--- a/Casks/wondershare-filmora.rb
+++ b/Casks/wondershare-filmora.rb
@@ -1,17 +1,20 @@
 cask "wondershare-filmora" do
   arch arm: "arm_"
 
-  version "12.2.11"
-  sha256 :no_check
+  version "12.3.2"
+  sha256 arm:   "d93d535910495653efc177484f7f21dff34d353e46ce5c73fadcb787dd2ccef5",
+         intel: "eaa1f9ba1d53a31d871c6820b1a1632193e290b863e4c89b6fda2a2be8f68192"
 
-  url "https://download.wondershare.com/cbs_down/filmora-mac_#{arch}full718.dmg"
+  url "https://download.wondershare.com/cbs_down/filmora-mac_#{arch}#{version}_gray_full718.dmg"
   name "Wondershare Filmora"
   desc "Video editor"
   homepage "https://filmora.wondershare.com/video-editor-mac/"
 
   livecheck do
-    url "https://cbs.wondershare.com/go.php?m=upgrade_info&pid=718"
-    regex(/<version>(\d+(?:\.\d+)+).*?version>/i)
+    url "https://crm.wondershare.com/api/v1/support/718/release-versions"
+    strategy :json do |json|
+      json["data"].map { |release| release["version_name"] }
+    end
   end
 
   depends_on macos: ">= :mojave"

--- a/Casks/wondershare-filmora.rb
+++ b/Casks/wondershare-filmora.rb
@@ -1,8 +1,10 @@
 cask "wondershare-filmora" do
-  version "12.2.8"
+  arch arm: "_arm_"
+
+  version "12.2.11"
   sha256 :no_check
 
-  url "https://download.wondershare.com/filmora-mac_full718.dmg"
+  url "https://download.wondershare.com/cbs_down/filmora-mac#{arch}full718.dmg"
   name "Wondershare Filmora"
   desc "Video editor"
   homepage "https://filmora.wondershare.com/video-editor-mac/"
@@ -12,9 +14,9 @@ cask "wondershare-filmora" do
     regex(/<version>(\d+(?:\.\d+)+).*?version>/i)
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
-  installer manual: "Wondershare Filmora Installer.app"
+  app "Wondershare Filmora #{version.major}.app"
 
   uninstall delete: "/Applications/Wondershare Filmora #{version.major}.app"
 

--- a/Casks/wondershare-filmora.rb
+++ b/Casks/wondershare-filmora.rb
@@ -1,10 +1,10 @@
 cask "wondershare-filmora" do
-  arch arm: "_arm_"
+  arch arm: "arm_"
 
   version "12.2.11"
   sha256 :no_check
 
-  url "https://download.wondershare.com/cbs_down/filmora-mac#{arch}full718.dmg"
+  url "https://download.wondershare.com/cbs_down/filmora-mac_#{arch}full718.dmg"
   name "Wondershare Filmora"
   desc "Video editor"
   homepage "https://filmora.wondershare.com/video-editor-mac/"

--- a/Casks/wondershare-filmora.rb
+++ b/Casks/wondershare-filmora.rb
@@ -16,9 +16,7 @@ cask "wondershare-filmora" do
 
   depends_on macos: ">= :mojave"
 
-  app "Wondershare Filmora #{version.major}.app"
-
-  uninstall delete: "/Applications/Wondershare Filmora #{version.major}.app"
+  app "Wondershare Filmora X.app"
 
   zap trash: [
     "/Users/Shared/wondershare.plist",


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.