### PR TITLE
fix: texmaker-5.1.4 sha256

### DIFF
--- a/Casks/texmaker.rb
+++ b/Casks/texmaker.rb
@@ -1,6 +1,6 @@
 cask "texmaker" do
   version "5.1.4"
-  sha256 "d28fe0d8dee823ed4d1156e47f9a2b4b5af887464a05e29e9ee5d57c12e1e1fe"
+  sha256 "4fb2896712f3aee93c0aae8f940dafab66c04334a76e055e1366adb21550f1fe"
 
   url "https://www.xm1math.net/texmaker/assets/files/texmaker-#{version}.dmg"
   name "Texmaker"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The previous sha256 did not match that of the file on the distribution site. The[ file on the distribution site](https://www.xm1math.net/texmaker/assets/files/texmaker-5.1.4.dmg) matched the published [MD5sum](https://www.xm1math.net/texmaker/assets/files/md5sum.txt) -- hence this patch. 