### PR TITLE
Use `MacOSVersion` for CI matrix.

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -52,7 +52,7 @@ module CiMatrix
 
     filtered_runners = RUNNERS.select do |runner, _|
       required_macos.any? do |r|
-        MacOS::Version.from_symbol(runner.fetch(:symbol)).public_send(r.fetch(:comparator), r.fetch(:version))
+        MacOSVersion.from_symbol(runner.fetch(:symbol)).compare(r.fetch(:comparator), r.fetch(:version))
       end
     end
     return filtered_runners unless filtered_runners.empty?


### PR DESCRIPTION
Was renamed in https://github.com/Homebrew/brew/pull/15336.