### PR TITLE
zsa-wally 2.1.0 from homebrew-cask-drivers

### DIFF
--- a/Casks/zsa-wally.rb
+++ b/Casks/zsa-wally.rb
@@ -1,0 +1,17 @@
+cask "zsa-wally" do
+  version "2.1.0"
+  sha256 "23f2770744800ba2af2f33caa297c6621a6610c4999ad0d3cf7673a5060c2a44"
+
+  url "https://github.com/zsa/wally/releases/download/#{version}-osx/wally-osx-#{version}.dmg",
+      verified: "github.com/zsa/wally/"
+  name "Wally"
+  desc "Flash tool for ZSA keyboards"
+  homepage "https://ergodox-ez.com/pages/wally"
+
+  livecheck do
+    url "https://configure.ergodox-ez.com/wally/osx"
+    strategy :header_match
+  end
+
+  app "Wally.app"
+end


### PR DESCRIPTION
From https://github.com/homebrew/homebrew-cask-drivers/blob/caa3028d12e80d71ea48077970218ca483e09640/Casks/zsa-wally.rb
With homebrew/homebrew-cask-drivers#3461

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask Casks/zsa-wally.rb` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
