### PR TITLE
hdhomerun: migrate from `homebrew/cask-drivers`

### DIFF
--- a/Casks/hdhomerun.rb
+++ b/Casks/hdhomerun.rb
@@ -1,10 +1,10 @@
 cask "hdhomerun" do
-  version "20230503"
-  sha256 "46db4a8dfa95c9290eddd5513c639b9bdef92cd8dc1ea64f8376d09fc38e4c74"
+  version "20230505"
+  sha256 "a02b78291d87c03ba7c07285dd5e631b0f50d53992435c93c81e64d309fa240b"
 
   url "https://download.silicondust.com/hdhomerun/hdhomerun_mac_#{version}.dmg"
   name "HDHomeRun"
-  desc "Watch, schedule and record terrestrial HDTV"
+  desc "Client for HDHomeRun streamer"
   homepage "https://www.silicondust.com/support/downloads/"
 
   livecheck do

--- a/Casks/hdhomerun.rb
+++ b/Casks/hdhomerun.rb
@@ -1,0 +1,24 @@
+cask "hdhomerun" do
+  version "20230503"
+  sha256 "46db4a8dfa95c9290eddd5513c639b9bdef92cd8dc1ea64f8376d09fc38e4c74"
+
+  url "https://download.silicondust.com/hdhomerun/hdhomerun_mac_#{version}.dmg"
+  name "HDHomeRun"
+  desc "Watch, schedule and record terrestrial HDTV"
+  homepage "https://www.silicondust.com/support/downloads/"
+
+  livecheck do
+    url "https://download.silicondust.com/hdhomerun/hdhomerun_mac.dmg"
+    strategy :header_match
+  end
+
+  pkg "HDHomeRun Installer.pkg"
+
+  uninstall pkgutil: "com.silicondust.*hdhomerun"
+
+  zap trash: [
+    "~/Library/Caches/com.silicondust.hdhomerun",
+    "~/Library/Saved Application State/com.silicondust.hdhomerun.savedState",
+    "~/Library/WebKit/com.silicondust.hdhomerun",
+  ]
+end


### PR DESCRIPTION
Original attempt to add it was in Homebrew/homebrew-cask#56728

It ended up in homebrew-cask-drivers, which recently moved casks back bere, and deleted casks w/ <100 installs:

* Homebrew/homebrew-cask-drivers#3414
* Homebrew/homebrew-cask-drivers#3443