### PR TITLE
Migrated focusrite-control from homebrew-cask-drivers

### DIFF
--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -24,6 +24,6 @@ cask "focusrite-control" do
     "/Library/Logs/Focusrite Control",
     "~/Library/Logs/Focusrite Control",
     "/Library/Logs/Focusrite Control",
-    "/Library/LaunchDaemons/com.focusrite.ControlServer.plist"
+    "/Library/LaunchDaemons/com.focusrite.ControlServer.plist",
   ]
 end

--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -4,8 +4,8 @@ cask "focusrite-control" do
 
   url "https://fael-downloads-prod.focusrite.com/customer/prod/downloads/Focusrite%20Control%20-%20#{version}.dmg"
   name "Focusrite Control"
-  desc "Control your Focusrite interface"
-  homepage "https://focusrite.com/en/focusrite-control"
+  desc "Focusrite interface controller"
+  homepage "https://focusrite.com/en"
 
   livecheck do
     url "https://downloads.focusrite.com/focusrite/scarlett-3rd-gen/scarlett-solo-3rd-gen"

--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -17,13 +17,15 @@ cask "focusrite-control" do
   uninstall pkgutil:   "com.focusrite.FocusriteControl",
             launchctl: "com.focusrite.ControlServer"
 
-  zap trash: [
-    "~/Library/Application Support/Focusrite/Focusrite Control",
-    "/Library/Application Support/Focusrite/Focusrite Control",
-    "~/Library/Logs/Focusrite Control",
-    "/Library/Logs/Focusrite Control",
-    "~/Library/Logs/Focusrite Control",
-    "/Library/Logs/Focusrite Control",
-    "/Library/LaunchDaemons/com.focusrite.ControlServer.plist",
-  ]
+  zap trash:  [
+        "~/Library/Application Support/Focusrite",
+        "~/Library/Caches/com.juce.locks",
+        "~/Library/Logs/Focusrite Control",
+        "~/Library/Saved Application State/com.focusrite.FocusriteControl.savedState",
+      ],
+      delete: [
+        "/Library/Application Support/Focusrite",
+        "/Library/LaunchDaemons/com.focusrite.ControlServer.plist",
+        "/Library/Logs/Focusrite Control",
+      ]
 end

--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -16,4 +16,14 @@ cask "focusrite-control" do
 
   uninstall pkgutil:   "com.focusrite.FocusriteControl",
             launchctl: "com.focusrite.ControlServer"
+
+  zap trash: [
+    "~/Library/Application Support/Focusrite/Focusrite Control",
+    "/Library/Application Support/Focusrite/Focusrite Control",
+    "~/Library/Logs/Focusrite Control",
+    "/Library/Logs/Focusrite Control",
+    "~/Library/Logs/Focusrite Control",
+    "/Library/Logs/Focusrite Control",
+    "/Library/LaunchDaemons/com.focusrite.ControlServer.plist"
+  ]
 end

--- a/Casks/focusrite-control.rb
+++ b/Casks/focusrite-control.rb
@@ -1,0 +1,19 @@
+cask "focusrite-control" do
+  version "3.11.0.1983"
+  sha256 "6563ce66aaec2cb24a31bc8bc91f0d819ecaafc515559f6a692c3c0d766c210c"
+
+  url "https://fael-downloads-prod.focusrite.com/customer/prod/downloads/Focusrite%20Control%20-%20#{version}.dmg"
+  name "Focusrite Control"
+  desc "Control your Focusrite interface"
+  homepage "https://focusrite.com/en/focusrite-control"
+
+  livecheck do
+    url "https://downloads.focusrite.com/focusrite/scarlett-3rd-gen/scarlett-solo-3rd-gen"
+    regex(%r{href=.*?/Focusrite%20Control%20-%20(\d+(?:\.\d+)+)\.dmg}i)
+  end
+
+  pkg "Focusrite Control.pkg"
+
+  uninstall pkgutil:   "com.focusrite.FocusriteControl",
+            launchctl: "com.focusrite.ControlServer"
+end


### PR DESCRIPTION
Migrated `focusrite-control` formula as asked in [this issue](https://github.com/Homebrew/homebrew-cask-drivers/issues/3414). The formula file is identical to the [one that was removed](https://github.com/Homebrew/homebrew-cask-drivers/blob/caa3028d12e80d71ea48077970218ca483e09640/Casks/focusrite-control.rb) from homebrew-cask-dtiver repo.