### PR TITLE
huiontablet: migrate from `homebrew/cask-drivers`

### DIFF
--- a/Casks/huiontablet.rb
+++ b/Casks/huiontablet.rb
@@ -1,0 +1,18 @@
+cask "huiontablet" do
+  version "15.6.4.103"
+  sha256 "444b1779fde66e10f28d136ff633a121cdb5b73e7858059c8325f1407389660c"
+
+  url "https://driverdl.huion.com/driver/Mac/HuionTablet_MacDriver_v#{version}.dmg"
+  name "Huion Tablet"
+  desc "Driver for Huion Tablets"
+  homepage "https://huion.com/"
+
+  livecheck do
+    url "https://huion.com/download/"
+    regex(%r{Mac/HuionTablet_MacDriver_v?(\d+(?:\.\d+)+)\.dmg}i)
+  end
+
+  app "HuionTablet.app"
+
+  zap trash: "~/Library/Saved Application State/com.huion.HuionTablet.savedState"
+end


### PR DESCRIPTION
Migrate a deleted cask from Homebrew/homebrew-cask-drivers#3443.
Should be merged with Homebrew/homebrew-cask-drivers#3472.

Related issue: Homebrew/homebrew-cask-drivers#3414.