### PR TITLE
renamed dbeaverlite and dbeaverultimate for more consistency

### DIFF
--- a/Casks/dbeaver-lite.rb
+++ b/Casks/dbeaver-lite.rb
@@ -1,4 +1,4 @@
-cask "dbeaverlite" do
+cask "dbeaver-lite" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "23.0.0"

--- a/Casks/dbeaver-ultimate.rb
+++ b/Casks/dbeaver-ultimate.rb
@@ -1,4 +1,4 @@
-cask "dbeaverultimate" do
+cask "dbeaver-ultimate" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "23.0.0"


### PR DESCRIPTION
I renamed the casks of 
`dbeaverultimate`  to `dbeaver-ultimate` and 
`dbeaverlite` to `dbeaver-lite`.

DBeaver has 4 versions: lite, community, enterprise and ultimate
If you take a look at the output of `brew search dbeaver --cask` you see, that the naming of these casks are quite inconsistent. Two of these have a dash. Two of these don't.

I'm not sure, if this can be done so easily, because the cask will be removed for some users and they have to reinstall.

Maybe we have to wait for some kind of alias like mentioned in this issue https://github.com/Homebrew/homebrew-cask/issues/111512.

---

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
