### PR TITLE
Revert "renamed dbeaverlite and dbeaverultimate for more consistency"

### DIFF
--- a/Casks/dbeaverlite.rb
+++ b/Casks/dbeaverlite.rb
@@ -1,4 +1,4 @@
-cask "dbeaver-lite" do
+cask "dbeaverlite" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "23.0.0"

--- a/Casks/dbeaverultimate.rb
+++ b/Casks/dbeaverultimate.rb
@@ -1,4 +1,4 @@
-cask "dbeaver-ultimate" do
+cask "dbeaverultimate" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "23.0.0"


### PR DESCRIPTION
Sorry, I didn't mean to merge this one, we should wait until cask-renames are supported in a Homebrew release.

Reverts Homebrew/homebrew-cask#147032