### PR TITLE
Remove `docker-index` symlink

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -67,6 +67,7 @@ cask "docker" do
               "/usr/local/bin/docker-credential-desktop",
               "/usr/local/bin/docker-credential-ecr-login",
               "/usr/local/bin/docker-credential-osxkeychain",
+              "/usr/local/bin/docker-index",
               "/usr/local/bin/hub-tool",
               "/usr/local/bin/hyperkit",
               "/usr/local/bin/kubectl.docker",


### PR DESCRIPTION
This was left behind in `/usr/local/bin` when I removed Docker today

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
