### PR TITLE
Uninstall Docker using their app's CLI

### DIFF
--- a/Casks/docker.rb
+++ b/Casks/docker.rb
@@ -57,22 +57,13 @@ cask "docker" do
   binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
 
-  uninstall delete:    [
+  uninstall script:    {
+              executable: "/Applications/Docker.app/Contents/MacOS/uninstall",
+              sudo:       true,
+            },
+            delete:    [
               "/Library/PrivilegedHelperTools/com.docker.socket",
               "/Library/PrivilegedHelperTools/com.docker.vmnetd",
-              "/usr/local/bin/com.docker.cli",
-              "/usr/local/bin/docker",
-              "/usr/local/bin/docker-compose",
-              "/usr/local/bin/docker-compose-v1",
-              "/usr/local/bin/docker-credential-desktop",
-              "/usr/local/bin/docker-credential-ecr-login",
-              "/usr/local/bin/docker-credential-osxkeychain",
-              "/usr/local/bin/hub-tool",
-              "/usr/local/bin/hyperkit",
-              "/usr/local/bin/kubectl.docker",
-              "/usr/local/bin/kubectl",
-              "/usr/local/bin/notary",
-              "/usr/local/bin/vpnkit",
               "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker",
               "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker_compose",
               "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker.fish",


### PR DESCRIPTION
I noticed the cask doesn't clean up fully. For example if you uninstall and then reinstall you won't be re-prompted to accept the software terms and you won't be prompted to setup the CLI tools again. This leaves you in a broken state - Docker says the CLI tools are installed on the system in `/usr/local/bin` but the symlinks were removed by the uninstall.

I also noticed that `docker-index` was not removed from `/usr/local/bin` but is removed by the uninstall app provided by Docker for Mac.