### PR TITLE
vagrant (update livecheck)

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -10,7 +10,7 @@ cask "vagrant" do
 
   livecheck do
     url "https://github.com/hashicorp/vagrant"
-    strategy :git
+    strategy :github_latest
   end
 
   pkg "vagrant.pkg"


### PR DESCRIPTION
* Update livecheck to :github_latest to avoid pre-releases

I updated the livecheck for Vagrant to use `:github_latest` instead of `:git` as Vagrant has been publishing pre-release versions which have been getting picked up by the livecheck.