### PR TITLE
chessx (update livecheck)

### DIFF
--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -9,8 +9,8 @@ cask "chessx" do
   homepage "https://chessx.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/chessx/files/latest/download"
-    strategy :header_match
+    url "https://sourceforge.net/projects/chessx/rss?path=/chessx"
+    regex(%r{chessx/(\d+(?:\.\d+)+).*?\.dmg}i)
   end
 
   pkg "chessx-installer.mpkg"

--- a/Casks/chessx.rb
+++ b/Casks/chessx.rb
@@ -9,8 +9,8 @@ cask "chessx" do
   homepage "https://chessx.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/chessx/rss?path=/chessx"
-    regex(%r{chessx/(\d+(?:\.\d+)+).*?\.dmg}i)
+    url "https://sourceforge.net/projects/chessx/rss"
+    regex(%r{url=.*?/chessx[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   pkg "chessx-installer.mpkg"


### PR DESCRIPTION
* Update livecheck to use rss feed instead of :header_match

I noticed this cask has been pulling version `1.5.6` for the last couple updates rather than the most recent version despite using `:header_match`.  

This cask has an rss feed for versions, so updated livecheck to check that instead. 