### PR TITLE
kiibohd-configurator: migrate from `homebrew/cask-drivers`

### DIFF
--- a/Casks/kiibohd-configurator.rb
+++ b/Casks/kiibohd-configurator.rb
@@ -1,0 +1,23 @@
+cask "kiibohd-configurator" do
+  version "1.1.0"
+  sha256 "996abcfd4f05420199e0302be50d9e878bd28bb50f541b5f6886a1654862e20f"
+
+  url "https://github.com/kiibohd/configurator/releases/download/v#{version}/kiibohd-configurator-#{version}-mac.dmg",
+      verified: "github.com/kiibohd/configurator/"
+  name "Kiibohd Configurator"
+  desc "Modular community keyboard firmware"
+  homepage "http://kiibohd.com/"
+
+  depends_on formula: "dfu-util"
+
+  app "Kiibohd Configurator.app"
+
+  uninstall quit: "club.input.KiibohdConfigurator"
+
+  zap trash: [
+    "~/Library/Application Support/kiibohd-configurator",
+    "~/Library/Logs/Kiibohd Configurator",
+    "~/Library/Preferences/club.input.KiibohdConfigurator.plist",
+    "~/Library/Saved Application State/club.input.KiibohdConfigurator.savedState",
+  ]
+end


### PR DESCRIPTION
Similar to #147012, this PR migrates a deleted cask from Homebrew/homebrew-cask-drivers#3443.
I realized during setting up a new laptop that I can’t install `kiibohd-configurator`, so hoping it can be re-added, even if it’s not a super popular application.

Related issue: Homebrew/homebrew-cask-drivers#3414.