### PR TITLE
Make Mixxx livecheck regex more robust

### DIFF
--- a/Casks/mixxx.rb
+++ b/Casks/mixxx.rb
@@ -8,7 +8,7 @@ cask "mixxx" do
   homepage "https://www.mixxx.org/"
 
   livecheck do
-    url "https://www.mixxx.org/download/"
+    url "https://mixxx.org/download/"
     regex(%r{href=["']?https://downloads\.mixxx\.org/releases/.*/mixxx[-_.]v?(\d+(?:\.\d+)+)[-_.]macos(?:intel|arm)\.dmg}i)
   end
 

--- a/Casks/mixxx.rb
+++ b/Casks/mixxx.rb
@@ -12,6 +12,8 @@ cask "mixxx" do
     regex(%r{href=.*?/mixxx[._-]v?(\d+(?:\.\d+)+)[._-]macos(?:intel|arm)\.dmg}i)
   end
 
+  conflicts_with cask: "homebrew/cask-versions/mixxx-snapshot"
+
   app "Mixxx.app"
 
   zap trash: [

--- a/Casks/mixxx.rb
+++ b/Casks/mixxx.rb
@@ -9,7 +9,7 @@ cask "mixxx" do
 
   livecheck do
     url "https://mixxx.org/download/"
-    regex(%r{href=["']?https://downloads\.mixxx\.org/releases/.*/mixxx[-_.]v?(\d+(?:\.\d+)+)[-_.]macos(?:intel|arm)\.dmg}i)
+    regex(%r{href=.*?/mixxx[._-]v?(\d+(?:\.\d+)+)[._-]macos(?:intel|arm)\.dmg}i)
   end
 
   app "Mixxx.app"

--- a/Casks/mixxx.rb
+++ b/Casks/mixxx.rb
@@ -9,7 +9,7 @@ cask "mixxx" do
 
   livecheck do
     url "https://www.mixxx.org/download/"
-    regex(%r{href=.*?/mixxx[._-]v?(\d+(?:\.\d+)+)[._-]macosintel\.dmg}i)
+    regex(%r{href=["']?https://downloads\.mixxx\.org/releases/.*/mixxx[-_.]v?(\d+(?:\.\d+)+)[-_.]macos(?:intel|arm)\.dmg}i)
   end
 
   app "Mixxx.app"


### PR DESCRIPTION
This makes the regex less dependent on the order of the links on the website by only considering release download links in the livecheck.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
