### PR TITLE
Revert "kicad 7.0.3-0"

### DIFF
--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -1,6 +1,6 @@
 cask "kicad" do
-  version "7.0.3-0"
-  sha256 "94b3a71584d132abd00f4cc96668acf51b0efc4f39b17177a312ff0a017316fd"
+  version "7.0.2-0"
+  sha256 "bef34c093b3f9e5166961dbc941da74eaad2341e8375b8682791810d848ec0c3"
 
   url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-universal-#{version}.dmg",
       verified: "kicad-downloads.s3.cern.ch/osx/stable/"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#147170

This version was probably pulled.
[Download page](https://www.kicad.org/download/macos/) shows latest as **7.0.2** and there is no 7.0.3 [stable download](https://downloads.kicad.org/kicad/macos/explore/stable).
```sh
brew upgrade kicad
==> Upgrading 1 outdated package:
kicad 7.0.2-0 -> 7.0.3-0
==> Upgrading kicad
==> Purging files for version 7.0.3-0 of Cask kicad
Error: kicad: Download failed on Cask 'kicad' with message: Failure while executing; `/usr/bin/env /usr/local/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.0.18-16-g6c80308\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 13.4\)\ curl/7.88.1 --header Accept-Language:\ en --retry 3 --fail --location --silent --head --request GET https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-universal-7.0.3-0.dmg` exited with 22. Here's the output:
curl: (22) The requested URL returned error: 404
HTTP/2 404 
accept-ranges: bytes
bucket: kicad-downloads
content-type: application/xml
date: Mon, 15 May 2023 05:46:44 GMT
x-amz-request-id: tx000000000000000e1f150-006461c744-3731d7ce-default
content-length: 230
```