### PR TITLE
nightowl 0.4.4.6

### DIFF
--- a/Casks/nightowl.rb
+++ b/Casks/nightowl.rb
@@ -12,7 +12,6 @@ cask "nightowl" do
     strategy :extract_plist
   end
 
-  auto_updates true
   depends_on macos: ">= :mojave"
 
   pkg "nightowl-#{version.csv.first}(release).pkg"

--- a/Casks/nightowl.rb
+++ b/Casks/nightowl.rb
@@ -1,5 +1,5 @@
 cask "nightowl" do
-  version "0.4.4.5,36"
+  version "0.4.4.6,37"
   sha256 :no_check
 
   url "https://nightowlapp.co/files"

--- a/Casks/nightowl.rb
+++ b/Casks/nightowl.rb
@@ -12,6 +12,7 @@ cask "nightowl" do
     strategy :extract_plist
   end
 
+  auto_updates true
   depends_on macos: ">= :mojave"
 
   pkg "nightowl-#{version.csv.first}(release).pkg"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.