### PR TITLE
smooze: corrected to work with "smooze-pro"

### DIFF
--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -12,7 +12,6 @@ cask "smooze" do
   end
 
   auto_updates true
-  conflicts_with cask: "smooze-pro"
   depends_on macos: ">= :sierra"
 
   app "Smooze.app"
@@ -20,8 +19,8 @@ cask "smooze" do
   uninstall quit: "co.smooze.macos"
 
   zap trash: [
-    "~/Library/Application Support/Smooze",
     "~/Library/Application Support/co.smooze.macos",
+    "~/Library/Application Support/Smooze",
     "~/Library/Caches/co.smooze.macos",
     "~/Library/Caches/io.fabric.sdk.mac.data/co.smooze.macos",
     "~/Library/HTTPStorages/co.smooze.macos",
@@ -29,8 +28,7 @@ cask "smooze" do
     "~/Library/Preferences/co.smooze.macos.plist",
   ]
 
-  caveats <<~EOS
-    #{token} is the legacy version of Smooze and is not receiving
-    feature updates. For the latest version, use the "smooze-pro" cask.
-  EOS
+  caveats do
+    discontinued
+  end
 end

--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -1,18 +1,18 @@
 cask "smooze" do
-  version "2.0.0"
+  version "1.9.26"
   sha256 :no_check
 
   url "https://smooze.co/updates/Smooze.dmg"
   name "Smooze"
-  desc "Rediscover your scroll wheel mouse"
+  desc "Animates scrolling and adds functionality to scroll-wheel mice"
   homepage "https://smooze.co/"
 
   livecheck do
-    url "https://smooze.co/updates/update.xml"
-    strategy :sparkle, &:short_version
+    skip "Legacy version"
   end
 
   auto_updates true
+  conflicts_with cask: "smooze-pro"
   depends_on macos: ">= :sierra"
 
   app "Smooze.app"
@@ -20,10 +20,17 @@ cask "smooze" do
   uninstall quit: "co.smooze.macos"
 
   zap trash: [
-    "~/Library/Application Support/co.smooze.macos",
     "~/Library/Application Support/Smooze",
+    "~/Library/Application Support/co.smooze.macos",
     "~/Library/Caches/co.smooze.macos",
     "~/Library/Caches/io.fabric.sdk.mac.data/co.smooze.macos",
+    "~/Library/HTTPStorages/co.smooze.macos",
+    "~/Library/HTTPStorages/co.smooze.macos.binarycookies",
     "~/Library/Preferences/co.smooze.macos.plist",
   ]
+
+  caveats <<~EOS
+    #{token} is the legacy version of Smooze and is not receiving
+    feature updates. For the latest version, use the "smooze-pro" cask.
+  EOS
 end

--- a/Casks/smooze.rb
+++ b/Casks/smooze.rb
@@ -7,10 +7,6 @@ cask "smooze" do
   desc "Animates scrolling and adds functionality to scroll-wheel mice"
   homepage "https://smooze.co/"
 
-  livecheck do
-    skip "Legacy version"
-  end
-
   auto_updates true
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
Updated version back to 1.9.26 and removed the sparkle livecheck because it is being used to redirect users to Smooze Pro.  Added a conflict with Smooze Pro because the developer has stated the two applications cannot work with each other.  Added more directories to the zap list.  Added a caveat that this application is in maintenance mode and pointed users to the "smooze-pro" cask.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.