### PR TITLE
various: relocate livecheck regex

### DIFF
--- a/Casks/abbyy-finereader-pdf.rb
+++ b/Casks/abbyy-finereader-pdf.rb
@@ -9,9 +9,9 @@ cask "abbyy-finereader-pdf" do
 
   livecheck do
     url "https://www.abbyy.com/finereader-pdf-mac-downloads/"
-    strategy :page_match do |page|
-      page.scan(%r{(?:Part #:.*?\n<td>)(\d+(?:[./]\d+)+)}i)
-          .map { |match| match[0].tr("/", ".") }
+    regex(%r{(?:Part #:.*?\n<td>)(\d+(?:[./]\d+)+)}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("/", ".") }
     end
   end
 

--- a/Casks/aether.rb
+++ b/Casks/aether.rb
@@ -9,11 +9,9 @@ cask "aether" do
 
   livecheck do
     url "https://static.getaether.net/WebsiteReleaseLinks/Latest/LatestReleaseLinks.json"
-    strategy :page_match do |page|
-      match = page.match(%r{/Aether-(\d+(?:\.\d+)*-dev\.\d+)%2B(\d+\.[0-9a-f]+)\.dmg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{/Aether-(\d+(?:\.\d+)*-dev\.\d+)%2B(\d+\.[0-9a-f]+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/airmedia.rb
+++ b/Casks/airmedia.rb
@@ -9,9 +9,9 @@ cask "airmedia" do
 
   livecheck do
     url "https://www.crestron.com/Products/Featured-Solutions/AirMedia/Airmedia-Apps"
-    strategy :page_match do |page|
-      v = page[%r{AirMedia[._-]OSx[._-]Guest[._-]Application/v?(\d+(?:-\d+)+)}i, 1]
-      v&.tr("-", ".")
+    regex(%r{AirMedia[._-]OSx[._-]Guest[._-]Application/v?(\d+(?:-\d+)+)}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/alfred.rb
+++ b/Casks/alfred.rb
@@ -9,11 +9,9 @@ cask "alfred" do
 
   livecheck do
     url "https://www.alfredapp.com/app/update#{version.major}/general.xml"
-    strategy :page_match do |page|
-      match = page.match(/Alfred[._-]v?(\d(?:\.\d+)+)[._-](\d+)\.tar\.gz/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(/Alfred[._-]v?(\d(?:\.\d+)+)[._-](\d+)\.tar\.gz/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/algodoo.rb
+++ b/Casks/algodoo.rb
@@ -9,9 +9,9 @@ cask "algodoo" do
 
   livecheck do
     url "http://www.algodoo.com/download/"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/Algodoo_(\d+(?:_\d+)*)-MacOS\.dmg}i, 1]
-      v.tr("_", ".")
+    regex(%r{href=.*?/Algodoo_(\d+(?:_\d+)*)-MacOS\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/aliwangwang.rb
+++ b/Casks/aliwangwang.rb
@@ -10,12 +10,7 @@ cask "aliwangwang" do
 
   livecheck do
     url "https://g.alicdn.com/im/ww-home/0.0.5/detail.min.js"
-    strategy :page_match do |page|
-      match = page.match(/AliWangWang[._-]v?\((\d+(?:\.\d+)+\w+)\)\.dmg/i)
-      next if match.blank?
-
-      (match[1]).to_s
-    end
+    regex(/AliWangWang[._-]v?\((\d+(?:\.\d+)+\w+)\)\.dmg/i)
   end
 
   auto_updates true

--- a/Casks/appzapper.rb
+++ b/Casks/appzapper.rb
@@ -9,11 +9,9 @@ cask "appzapper" do
 
   livecheck do
     url :homepage
+    regex(/href=.*?appzapper(\d+)(\d+)(\d+)\.zip/i)
     strategy :page_match do |page|
-      match = page.match(/href=.*?appzapper(\d+)(\d+)(\d+)\.zip/i)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}.#{match[3]}"
+      page.scan(regex).map { |match| "#{match[0]}.#{match[1]}.#{match[2]}" }
     end
   end
 

--- a/Casks/avtouchbar.rb
+++ b/Casks/avtouchbar.rb
@@ -9,11 +9,9 @@ cask "avtouchbar" do
 
   livecheck do
     url "https://www.avtouchbar.com/downloads/"
-    strategy :page_match do |page|
-      match = page.match(%r{href=.*?/uploads/(\d+)/(\d+)/AVTouchBar[._-]?(\d+(?:\.\d+)+)\.zip}i)
-      next if match.blank?
-
-      "#{match[3]},#{match[1]}.#{match[2]}"
+    regex(%r{href=.*?/uploads/(\d+)/(\d+)/AVTouchBar[._-]?(\d+(?:\.\d+)+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[2]},#{match[0]}.#{match[1]}" }
     end
   end
 

--- a/Casks/basictex.rb
+++ b/Casks/basictex.rb
@@ -10,11 +10,9 @@ cask "basictex" do
 
   livecheck do
     url "https://ctan.org/texarchive/systems/mac/mactex/"
-    strategy :page_match do |page|
-      match = page.match(/href=.*?mactex-basictex-(\d{4})(\d{2})(\d{2})\.pkg/)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}#{match[3]}"
+    regex(/href=.*?mactex-basictex-(\d{4})(\d{2})(\d{2})\.pkg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]}.#{match[1]}#{match[2]}" }
     end
   end
 

--- a/Casks/bean.rb
+++ b/Casks/bean.rb
@@ -9,9 +9,9 @@ cask "bean" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/Bean[._-]Install[._-]v?(\d+(?:-\d+)+)\.zip}i, 1]
-      v.tr("-", ".")
+    regex(%r{href=.*?/Bean[._-]Install[._-]v?(\d+(?:-\d+)+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/beatunes.rb
+++ b/Casks/beatunes.rb
@@ -9,11 +9,9 @@ cask "beatunes" do
 
   livecheck do
     url "https://www.beatunes.com/en/beatunes-download.html"
-    strategy :page_match do |page|
-      match = page[/href=.*?beaTunes[._-]?v?(\d+(?:-\d+)+)\.dmg/i, 1]
-      next if match.blank?
-
-      match.tr("-", ".")
+    regex(/href=.*?beaTunes[._-]?v?(\d+(?:-\d+)+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/bit-fiddle.rb
+++ b/Casks/bit-fiddle.rb
@@ -9,10 +9,9 @@ cask "bit-fiddle" do
 
   livecheck do
     url :homepage
-    strategy :page_match do |page|
-      page.scan(/href=.*?Bit[._-]Fiddle[._-]v?(\d+(?:[._-]\d+)+)\.dmg/i).map do |match|
-        match[0].tr("_", ".")
-      end
+    regex(/href=.*?Bit[._-]Fiddle[._-]v?(\d+(?:[._-]\d+)+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/bluej.rb
+++ b/Casks/bluej.rb
@@ -9,8 +9,9 @@ cask "bluej" do
 
   livecheck do
     url "https://www.bluej.org"
+    regex(%r{href=.*?/BlueJ-mac-(\d+)(\d+)(\d+)(a)?\.zip}i)
     strategy :page_match do |page|
-      match = page.match(%r{href=.*?/BlueJ-mac-(\d+)(\d+)(\d+)(a)?\.zip}i)
+      match = page.match(regex)
       next if match.blank?
 
       "#{match[1]}.#{match[2]}.#{match[3]}" unless match[4]

--- a/Casks/bluos-controller.rb
+++ b/Casks/bluos-controller.rb
@@ -10,11 +10,9 @@ cask "bluos-controller" do
 
   livecheck do
     url "https://www.bluesound.com/downloads"
-    strategy :page_match do |page|
-      match = page.match(%r{uploads/(\d+)/(\d+)/BluOS[._-]Controller[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-      next if match.blank?
-
-      "#{match[3]},#{match[1]},#{match[2]}"
+    regex(%r{uploads/(\d+)/(\d+)/BluOS[._-]Controller[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/cirrus.rb
+++ b/Casks/cirrus.rb
@@ -10,8 +10,9 @@ cask "cirrus" do
 
   livecheck do
     url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    strategy :page_match do |page|
-      match = page.match(%r{/(\d+)/(\d+)/cirrus(\d+)\.zip}i)
+    regex(%r{/(\d+)/(\d+)/cirrus(\d+)\.zip}i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
       next if match.blank?
 
       "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"

--- a/Casks/clipgrab.rb
+++ b/Casks/clipgrab.rb
@@ -11,10 +11,7 @@ cask "clipgrab" do
     url "https://clipgrab.org/"
     regex(%r{href=.*?/ClipGrab[._-]v?(\d+(?:\.\d+)+)-cpython-(\d+)\.dmg}i)
     strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/clock-bar.rb
+++ b/Casks/clock-bar.rb
@@ -9,8 +9,9 @@ cask "clock-bar" do
 
   livecheck do
     url "https://github.com/nihalsharma/Clock-Bar/releases/latest"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/tag/(\d+(?:\.\d+)+)}i, 1]
+    regex(%r{href=.*?/tag/(\d+(?:\.\d+)+)}i)
+    strategy :page_match do |page, regex|
+      v = page[regex, 1]
       id = page[%r{href=.*?/(\d+)/Clock\.Bar\.app\.zip}i, 1]
       "#{v},#{id}"
     end

--- a/Casks/cloudcompare.rb
+++ b/Casks/cloudcompare.rb
@@ -11,9 +11,10 @@ cask "cloudcompare" do
 
   livecheck do
     url "https://www.danielgm.net/cc/release/index.html"
-    strategy :page_match do |page|
+    regex(/CloudCompare[._-](\d+(?:\.\d+)+)[._-][^.]+\.dmg/i)
+    strategy :page_match do |page, regex|
       page = page.split(/stable\s+release/i, 2).second
-      page[/CloudCompare[._-](\d+(?:\.\d+)+)[._-][^.]+\.dmg/i, 1]
+      page[regex, 1]
     end
   end
 

--- a/Casks/codelite.rb
+++ b/Casks/codelite.rb
@@ -12,8 +12,9 @@ cask "codelite" do
 
   livecheck do
     url "https://downloads.codelite.org/"
-    strategy :page_match do |page|
-      match = page.match(/CodeLite\s*(\d+\.\d+)((?:\.\d+)*)\s*-\s*Stable/i)
+    regex(/CodeLite\s*(\d+\.\d+)((?:\.\d+)*)\s*-\s*Stable/i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
       next if match.blank?
 
       "#{match[1]}#{match[2].presence || ".0"}"

--- a/Casks/cr.rb
+++ b/Casks/cr.rb
@@ -9,11 +9,9 @@ cask "cr" do
 
   livecheck do
     url "https://sourceforge.net/projects/crengine/rss?path=/CoolReader#{version.major}/cr#{version.major}-#{version.csv.first}"
-    strategy :page_match do |page|
-      match = page.match(%r{url=.*?/cr(\d+(?:\.\d+)+)-(\d+)\.dmg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{url=.*?/cr(\d+(?:\.\d+)+)-(\d+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/cycling74-max.rb
+++ b/Casks/cycling74-max.rb
@@ -11,9 +11,10 @@ cask "cycling74-max" do
 
   livecheck do
     url "https://auth.cycling74.com/maxversion"
-    strategy :page_match do |page|
+    regex(/^\d{2}(\d{2})[._-](\d{2})[._-](\d{2})/i)
+    strategy :page_match do |page, regex|
       json = JSON.parse(page)
-      match = json["release_date"].match(/^\d{2}(\d{2})[._-](\d{2})[._-](\d{2})/)
+      match = json["release_date"].match(regex)
       next if match.blank?
 
       "#{json["_id"]}_#{match[1]}#{match[2]}#{match[3]}"

--- a/Casks/daedalus-mainnet.rb
+++ b/Casks/daedalus-mainnet.rb
@@ -10,11 +10,9 @@ cask "daedalus-mainnet" do
 
   livecheck do
     url "https://update-cardano-mainnet.iohk.io/daedalus-latest-version.json"
-    strategy :page_match do |page|
-      match = page.match(%r{/daedalus[._-](\d+(?:\.\d+)+)[._-]mainnet[._-](\d+)[._-]x86_64[._-]darwin\.pkg}i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    regex(%r{/daedalus[._-](\d+(?:\.\d+)+)[._-]mainnet[._-](\d+)[._-]x86_64[._-]darwin\.pkg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/daedalus-testnet.rb
+++ b/Casks/daedalus-testnet.rb
@@ -10,12 +10,9 @@ cask "daedalus-testnet" do
 
   livecheck do
     url "https://updates-cardano-testnet.s3.amazonaws.com/daedalus-latest-version.json"
-    strategy :page_match do |page|
-      version = page.match(/"version":"(\d+(?:\.\d+)+)"/)[1]
-      build = page.match(/testnet-(\d+(?:\.\d+)*).*?\.pkg/)[1]
-      next if version.blank? || build.blank?
-
-      "#{version},#{build}"
+    regex(%r{/daedalus[._-](\d+(?:\.\d+)+)[._-]testnet[._-](\d+)[._-]x86_64[._-]darwin\.pkg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/dbschema.rb
+++ b/Casks/dbschema.rb
@@ -9,11 +9,9 @@ cask "dbschema" do
 
   livecheck do
     url "https://www.dbschema.com/download.html"
-    strategy :page_match do |page|
-      v = page[/href=.*?DbSchema[._-]macos[._-]v?(\d+(?:_\d+)+)\.t/i, 1]
-      next if v.blank?
-
-      v.tr("_", ".")
+    regex(/href=.*?DbSchema[._-]macos[._-]v?(\d+(?:_\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/deepgit.rb
+++ b/Casks/deepgit.rb
@@ -12,11 +12,9 @@ cask "deepgit" do
 
   livecheck do
     url "https://syntevo.com/deepgit/download"
-    strategy :page_match do |page|
-      v = page[%r{href=.*?/deepgit-#{arch}-(\d+(?:_\d+)+)\.dmg}i, 1]
-      next if v.blank?
-
-      v.tr("_", ".")
+    regex(%r{href=.*?/deepgit-#{arch}-(\d+(?:_\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/dendroscope.rb
+++ b/Casks/dendroscope.rb
@@ -9,9 +9,9 @@ cask "dendroscope" do
 
   livecheck do
     url "https://software-ab.cs.uni-tuebingen.de/download/dendroscope3/welcome.html"
-    strategy :page_match do |page|
-      v = page[/href=.*?Dendroscope_macos_(\d+(?:_\d+)*)\.dmg/i, 1]
-      v.tr("_", ".")
+    regex(/href=.*?Dendroscope_macos_(\d+(?:_\d+)*)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex)&.map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/dosbox.rb
+++ b/Casks/dosbox.rb
@@ -10,8 +10,9 @@ cask "dosbox" do
 
   livecheck do
     url "https://sourceforge.net/projects/dosbox/rss?path=/dosbox"
-    strategy :page_match do |page|
-      page.scan(%r{<link>.*/DOSBox-(\d+(?:[.-]\d+)*).dmg}i).map do |matches|
+    regex(%r{<link>.*/DOSBox-(\d+(?:[.-]\d+)*).dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |matches|
         versions = matches[0].split("-")
         version = "#{versions[0]}-#{versions[1]},#{versions[2]}" if versions.length == 3
         version = "#{versions[0]}-#{versions[1]}" if versions.length == 2

--- a/Casks/douyin.rb
+++ b/Casks/douyin.rb
@@ -10,11 +10,9 @@ cask "douyin" do
 
   livecheck do
     url "https://www.douyin.com/downloadpage"
-    strategy :page_match do |page|
-      match = page.match(%r{douyin[._-]pc[._-]client/(\d+)/releases/(\d+)/(\d+(?:\.\d+)+)/darwin[._-]universal}i)
-      next if match.blank?
-
-      "#{match[3]},#{match[1]},#{match[2]}"
+    regex(%r{douyin[._-]pc[._-]client/(\d+)/releases/(\d+)/(\d+(?:\.\d+)+)/darwin[._-]universal}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
This PR request:
	* relocates regexes present in the strategy block
	* changes `page.match` to `page.scan` where appropriate