### PR TITLE
Add completions caveat to ngrok

### DIFF
--- a/Casks/ngrok.rb
+++ b/Casks/ngrok.rb
@@ -34,4 +34,11 @@ cask "ngrok" do
     "~/.ngrok#{version.major}",
     "~/Library/Application Support/ngrok",
   ]
+
+  caveats <<~EOS
+    To install shell completions, add this to your profile:
+      if command -v ngrok &>/dev/null; then
+        eval "$(ngrok completion)"
+      fi
+  EOS
 end


### PR DESCRIPTION
Adds a message to the cask's caveats with instructions on enabling completion for `ngrok`

https://ngrok.com/docs/ngrok-agent/ngrok/#ngrok-completion

---------------------------
- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
