### PR TITLE
add arm support to chromium-gost

### DIFF
--- a/Casks/chromium-gost.rb
+++ b/Casks/chromium-gost.rb
@@ -1,8 +1,11 @@
 cask "chromium-gost" do
-  version "113.0.5672.126"
-  sha256 "4566ac26a824746f9d7808f6fa824fa886cd14d561351bcbf7133434f11d06e2"
+  arch arm: "arm64", intel: "amd64"
 
-  url "https://github.com/deemru/Chromium-Gost/releases/download/#{version}/chromium-gost-#{version}-macos-amd64.tar.bz2"
+  version "113.0.5672.126"
+  sha256 arm:   "ea7caa601deae9e5998aa69fb27ce4125575197127504f031abd6e4ad91276b2",
+         intel: "4566ac26a824746f9d7808f6fa824fa886cd14d561351bcbf7133434f11d06e2"
+
+  url "https://github.com/deemru/Chromium-Gost/releases/download/#{version}/chromium-gost-#{version}-macos-#{arch}.tar.bz2"
   name "Chromium-Gost"
   desc "Browser based on Chromium with support for GOST cryptographic algorithms"
   homepage "https://github.com/deemru/Chromium-Gost"


### PR DESCRIPTION
Add support of Apple Silicon besides Intel.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
