### PR TITLE
kicad 7.0.2-0 (downgrade)

### DIFF
--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -1,6 +1,6 @@
 cask "kicad" do
-  version "7.0.4-0"
-  sha256 "874a395b53f37f83b768bec27c28499818938f5af0773a4ffba7293ba3f1bd2a"
+  version "7.0.2-0"
+  sha256 "bef34c093b3f9e5166961dbc941da74eaad2341e8375b8682791810d848ec0c3"
 
   url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-universal-#{version}.dmg",
       verified: "kicad-downloads.s3.cern.ch/osx/stable/"

--- a/Casks/kicad.rb
+++ b/Casks/kicad.rb
@@ -9,7 +9,7 @@ cask "kicad" do
   homepage "https://kicad.org/"
 
   livecheck do
-    url "https://kicad-downloads.s3.cern.ch/?delimiter=/&prefix=osx/stable/"
+    url "https://downloads.kicad.org/kicad/macos/explore/stable"
     regex(/kicad[._-]unified[._-]universal[._-]v?(\d+(?:.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
**We should always wait for official announcement, otherwise this situation will happen!**
See https://forum.kicad.info/t/stable-release-7-0-4/42615/17.

Kicad is not possible to download:
```
Error: kicad: Download failed on Cask 'kicad' with message: Failure while executing; `/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.0.19\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 13.4\)\ curl/7.88.1 --header Accept-Language:\ en --retry 3 --fail --location --silent --head --request GET https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-universal-7.0.4-0.dmg` exited with 22. Here's the output:
curl: (22) The requested URL returned error: 404
HTTP/2 404 
accept-ranges: bytes
bucket: kicad-downloads
content-type: application/xml
date: Wed, 24 May 2023 18:46:08 GMT
x-amz-request-id: tx00000000000007e337142-00646e5b70-30271ed9-default
content-length: 230
```
and not available on the official [URL](https://downloads.kicad.org/kicad/macos/explore/stable).

Reverts Homebrew/homebrew-cask#147753