### PR TITLE
Set auto_updates true (dockmate, gemini, movist-pro)

### DIFF
--- a/Casks/dockmate.rb
+++ b/Casks/dockmate.rb
@@ -13,6 +13,7 @@ cask "dockmate" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: ">= :mojave"
 
   app "DockMate.app"

--- a/Casks/gemini.rb
+++ b/Casks/gemini.rb
@@ -19,6 +19,8 @@ cask "gemini" do
     end
   end
 
+  auto_updates true
+
   app "Gemini #{version.major}.app"
 
   zap trash: [

--- a/Casks/movist-pro.rb
+++ b/Casks/movist-pro.rb
@@ -13,6 +13,7 @@ cask "movist-pro" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Movist Pro.app"


### PR DESCRIPTION
Set `auto_updates true` for
- `dockmate`
- `gemini`
- `movist-pro`

(Source: I have these apps installed and they all auto-update on their own.)

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
