### PR TITLE
workflows/ci: remove Mono and conda cleanup steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,23 +78,12 @@ jobs:
             echo '::warning::Removing Julia is no longer necessary.'
           fi
 
-          if ! rm /usr/local/share/man/man1/al.1 || \
-             ! sudo rm /etc/paths.d/mono-commands || \
-             ! sudo rm -r /Library/Frameworks/Mono.framework || \
-             ! sudo pkgutil --forget com.xamarin.mono-MDK.pkg; then
-            echo '::warning::Uninstalling Mono is no longer necessary.'
-          fi
-
           if ! rm /usr/local/bin/dotnet; then
             echo '::warning::Removing `dotnet` symlink is no longer necessary.'
           fi
 
           if ! rm /usr/local/bin/pod; then
             echo '::warning::Removing `cocoapods` symlink is no longer necessary.'
-          fi
-
-          if ! rm /usr/local/bin/conda; then
-            echo '::warning::Removing `conda` symlink is no longer necessary.'
           fi
 
           brew unlink python && brew link --overwrite python


### PR DESCRIPTION
These are no longer present and all PR's are printing the "no longer necessary" message.