### PR TITLE
Remove sha256 checksum check from OpenLens cask

### DIFF
--- a/Casks/openlens.rb
+++ b/Casks/openlens.rb
@@ -2,8 +2,7 @@ cask "openlens" do
   arch arm: "-arm64"
 
   version "6.5.1"
-  sha256 arm:   "595c2d76f19c98f3d109e6cb89816d3f6510a7abc905c8c7128378483c06854f",
-         intel: "4c2132cb4ee50c145dc4e090ada2e01f57187a879dcbdbd9483d9563413ada41"
+  sha256 :no_check
 
   url "https://github.com/MuhammedKalkan/OpenLens/releases/download/v#{version}/OpenLens-#{version}#{arch}.dmg"
   name "OpenLens"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

OpenLens will produce rebuilds which can cause SHA265 checksum errors. 

https://github.com/MuhammedKalkan/OpenLens/issues/145#issuecomment-1567929643

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
