### PR TITLE
ci/automerge.yml: use `merge` merge-method

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,7 +24,7 @@ jobs:
         uses: reitermarkus/automerge@e0cf02bcf5cbb9f9e9b359cc0ad3d9319bd5f427
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-          merge-method: squash
+          merge-method: merge
           squash-commit-title: ${pull_request.title} (#${pull_request.number})
           squash-commit-message: '\n'
           do-not-merge-labels: automerge-skip,do not merge


### PR DESCRIPTION
After recent changes to `homebrew-cask` we now need to use `merge` as the merge-method.