### PR TITLE
Update LibreWolf to v113.0.2-1

### DIFF
--- a/Casks/librewolf.rb
+++ b/Casks/librewolf.rb
@@ -2,12 +2,12 @@ cask "librewolf" do
   arch arm: "aarch64", intel: "x86_64"
 
   on_arm do
-    version "113.0,1,8f5bbfb22d053a2a682eef9f211be0bd"
-    sha256 "07e1da5acf236e9c291e8b9f56d213cc39ca4ea6105924baafdf92cddc2d81c6"
+    version "113.0.2,1,ee6be51c4b9eee802cd7df889bfcf622"
+    sha256 "42963ef5db33ac14f8814ade0ce20bd790dfa6daee2dbbb2765a4b26ce2b45dc"
   end
   on_intel do
-    version "113.0,1,ee73df7cafc05151e5652553bfc810f8"
-    sha256 "e0872c4d7fe13770a8c4fb236f10fe26773513a01396766497855cbe8dc40ab3"
+    version "113.0.2,1,62a3836df78e94c13455d85abaf521c1"
+    sha256 "1c50ab50f6164fec4547c65d048a44181505417b1dd501f68c47e7eafa76cc6a"
   end
 
   url "https://gitlab.com/librewolf-community/browser/macos/uploads/#{version.csv.third}/librewolf-#{version.csv.first}-#{version.csv.second}.en-US.mac.#{arch}.dmg",


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.