### PR TITLE
loupedeck 5.7.0.16753 (new cask)

### DIFF
--- a/Casks/loupedeck.rb
+++ b/Casks/loupedeck.rb
@@ -1,0 +1,49 @@
+cask "loupedeck" do
+  version "5.7.0.16753"
+  sha256 "d37c3019ed423bc5c6ac8e34f35382d1d173b0a43b7fc7547916a4754b741cdd"
+
+  url "https://5145542.fs1.hubspotusercontent-na1.net/hubfs/5145542/Knowledge%20Base/LD%20Software%20Downloads/#{version.major_minor}/Loupedeck%20#{version}.dmg",
+      verified: "5145542.fs1.hubspotusercontent-na1.net/hubfs/5145542/"
+  name "Loupdeck"
+  desc "Software for Loupedeck consoles"
+  homepage "https://loupedeck.com/"
+
+  livecheck do
+    url "https://loupedeck.com/downloads/"
+    regex(/href=.*?Loupedeck(?:[._\s-]|%20)+v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
+  depends_on macos: ">= :sierra"
+
+  pkg "LoupedeckInstaller.pkg"
+
+  uninstall signal:    [
+              ["TERM", "com.loupedeck.Loupedeck2"],
+              ["QUIT", "com.loupedeck.Loupedeck2"],
+              ["INT", "com.loupedeck.Loupedeck2"],
+              ["HUP", "com.loupedeck.Loupedeck2"],
+              ["KILL", "com.loupedeck.Loupedeck2"],
+            ],
+            launchctl: "com.loupedeck.loupedeck2.launch",
+            pkgutil:   [
+              "com.loupedeck.ImageLibraryInstaller",
+              "com.loupedeck.LibraryInstaller",
+              "com.loupedeck.LoupedeckLibraryPackageManagerMacPackageInstaller",
+              "com.loupedeck.LoupedeckPackageInstaller",
+              "com.loupedeck.LoupedeckServiceToolPackageInstaller",
+              "com.loupedeck.MediaInstaller",
+              "com.loupedeck.OBSClientPluginPackageInstaller",
+              "com.loupedeck.PluginPackageInstaller",
+            ],
+            delete:    "/Applications/Loupedeck.app"
+
+  zap trash: [
+    "~/Library/Application Support/Adobe/CameraRaw/Settings/Loupedeck - Karo Holmberg",
+    "~/Library/Application Support/Adobe/CameraRaw/Settings/Loupedeck - Loke Roos",
+    "~/Library/Application Support/Adobe/Lightroom/Export Presets/Loupedeck Exports",
+    "~/Library/Application Support/Adobe/Lightroom/Modules/loupedeck2.lrplugin",
+    "~/Library/Application Support/Capture One/KeyboardShortcuts/Loupedeck_beta.plist",
+    "~/Library/Application Support/LoupedeckConfig",
+    "~/Library/Logs/LoupedeckConfig",
+  ]
+end


### PR DESCRIPTION
Adding [loupedeck](https://loupedeck.com/).

Formerly in homebrew-cask-drivers, but not included in the migration.
So we updated to the latest version and added a new cask.



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
