### PR TITLE
Mucommander 1.2.0-2

### DIFF
--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -10,7 +10,5 @@ cask "mucommander" do
 
   app "muCommander.app"
 
-  zap trash: [
-    "~/Library/Preferences/muCommander",
-  ]
+  zap trash: "~/Library/Preferences/muCommander"
 end

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -1,12 +1,16 @@
 cask "mucommander" do
-  version "1.2.0-1"
-  sha256 "c77c3d0105de57dcb2e2641a23266aef576b9874a61096935d961427eece636c"
+  version "1.2.0-2"
+  sha256 "d5e386d62b01ed7614b15a3fb807b21f8c3e650ddbd2b5b8d08c6949ffcd779d"
 
-  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-#{version}.dmg",
+  url "https://github.com/mucommander/mucommander/releases/latest/download/muCommander-#{version}.dmg",
       verified: "github.com/mucommander/mucommander/"
   name "muCommander"
   desc "File manager with a dual-pane interface"
   homepage "https://www.mucommander.com/"
 
   app "muCommander.app"
+
+zap trash: [
+  "~/Library/Preferences/muCommander",
+  ]
 end

--- a/Casks/mucommander.rb
+++ b/Casks/mucommander.rb
@@ -10,7 +10,7 @@ cask "mucommander" do
 
   app "muCommander.app"
 
-zap trash: [
-  "~/Library/Preferences/muCommander",
+  zap trash: [
+    "~/Library/Preferences/muCommander",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

The dmg has version 1.2.0-2 instead of 1.2.0-1, resulting in a 404 when trying to download it. Added zap, found the folder with appcleaner

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
