### PR TITLE
cinder: update livecheck

### DIFF
--- a/Casks/cinder.rb
+++ b/Casks/cinder.rb
@@ -4,6 +4,7 @@ cask "cinder" do
 
   url "https://libcinder.org/static/releases/cinder_#{version}_mac.zip"
   name "Cinder"
+  desc "C++ library for creative coding"
   homepage "https://libcinder.org/"
 
   livecheck do

--- a/Casks/cinder.rb
+++ b/Casks/cinder.rb
@@ -7,8 +7,8 @@ cask "cinder" do
   homepage "https://libcinder.org/"
 
   livecheck do
-    url "https://github.com/cinder/cinder"
-    strategy :git
+    url "https://libcinder.org/download"
+    regex(/href=.*?cinder[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i)
   end
 
   suite "cinder_#{version}_mac"

--- a/Casks/cinder.rb
+++ b/Casks/cinder.rb
@@ -13,4 +13,6 @@ cask "cinder" do
   end
 
   suite "cinder_#{version}_mac"
+
+  zap trash: "~/Library/Preferences/org.libcinder.TinderBox.plist"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `cinder` checks the related GitHub repository despite the cask using a zip file from libcinder.org. It also unnecessarily uses `strategy :git` though livecheck already uses the `Git` strategy for this URL.

This PR updates the `livecheck` block to match versions from links on the libcinder.org download page, aligning the check with the cask `url` source. This removes the `#strategy` call in the process, resolving that issue as well.