### PR TITLE
Update karafun.rb 2.3.0,91

### DIFF
--- a/Casks/karafun.rb
+++ b/Casks/karafun.rb
@@ -1,15 +1,23 @@
 cask "karafun" do
-  version "2.3.0,91"
-  sha256 :no_check
+  version "2.3.0.91,8b1dd03e90009107ae99a212322cc03b,fcfd34139c"
+  sha256 "9342909a313edb999a16885963538314f477438bcfb1fb7fd79c36c6b1cbc126"
 
-  url "https://www.karafun.com/download/mac.html"
+  url "https://c20.recis.io/sl/#{version.csv.third}/#{version.csv.second}/KaraFun_#{version.csv.first}.dmg",
+      verified: "c20.recis.io/sl/"
   name "KaraFun"
   desc "Karaoke player software"
   homepage "https://www.karafun.com/"
 
   livecheck do
     url "https://www.karafun.fr/osx/appcast.xml"
-    strategy :sparkle
+    regex(%r{sl/([^/]+)/([^/]+)/v?KaraFun[._-]v?(\d+(?:\.\d+)+)})
+    strategy :sparkle do |item|
+      puts item.url
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{match[3]},#{match[2]},#{match[1]}"
+    end
   end
 
   auto_updates true

--- a/Casks/karafun.rb
+++ b/Casks/karafun.rb
@@ -1,8 +1,8 @@
 cask "karafun" do
-  version "2.3.0.91,8b1dd03e90009107ae99a212322cc03b,fcfd34139c"
+  version "2.3.0,91,8b1dd03e90009107ae99a212322cc03b,fcfd34139c"
   sha256 "9342909a313edb999a16885963538314f477438bcfb1fb7fd79c36c6b1cbc126"
 
-  url "https://c20.recis.io/sl/#{version.csv.third}/#{version.csv.second}/KaraFun_#{version.csv.first}.dmg",
+  url "https://c20.recis.io/sl/#{version.csv.fourth}/#{version.csv.third}/KaraFun_#{version.csv.first}.#{version.csv.second}.dmg",
       verified: "c20.recis.io/sl/"
   name "KaraFun"
   desc "Karaoke player software"
@@ -16,7 +16,7 @@ cask "karafun" do
       match = item.url.match(regex)
       next if match.blank?
 
-      "#{match[3]},#{match[2]},#{match[1]}"
+      "#{item.short_version},#{item.version},#{match[2]},#{match[1]}"
     end
   end
 

--- a/Casks/karafun.rb
+++ b/Casks/karafun.rb
@@ -1,9 +1,8 @@
 cask "karafun" do
-  version "2.2.0,86"
-  sha256 "ca26e741588827b17b8ae4d72d3f713ba8aa029cbddea08eb8403a9bc8151b42"
+  version "2.3.0,91"
+  sha256 :no_check
 
-  url "https://c20.recis.io/sl/75651288c7/63683b44547cfdbafd795b67c7101da5/KaraFun_#{version.csv.first}.#{version.csv.second}.dmg",
-      verified: "c20.recis.io/sl/75651288c7/63683b44547cfdbafd795b67c7101da5/"
+  url "https://www.karafun.com/download/mac.html"
   name "KaraFun"
   desc "Karaoke player software"
   homepage "https://www.karafun.com/"

--- a/Casks/karafun.rb
+++ b/Casks/karafun.rb
@@ -1,15 +1,15 @@
 cask "karafun" do
-  version "2.3.0,91,8b1dd03e90009107ae99a212322cc03b,fcfd34139c"
+  version "2.3.0,91,8b1dd03e90009107ae99a212322cc03b,e8179eab96"
   sha256 "9342909a313edb999a16885963538314f477438bcfb1fb7fd79c36c6b1cbc126"
 
-  url "https://c20.recis.io/sl/#{version.csv.fourth}/#{version.csv.third}/KaraFun_#{version.csv.first}.#{version.csv.second}.dmg",
-      verified: "c20.recis.io/sl/"
+  url "https://c17.recis.io/sl/#{version.csv.fourth}/#{version.csv.third}/KaraFun_#{version.csv.first}.#{version.csv.second}.dmg",
+      verified: "c17.recis.io/sl/"
   name "KaraFun"
   desc "Karaoke player software"
   homepage "https://www.karafun.com/"
 
   livecheck do
-    url "https://www.karafun.fr/osx/appcast.xml"
+    url "https://www.karafun.com/osx/appcast.xml"
     regex(%r{sl/([^/]+)/([^/]+)/v?KaraFun[._-]v?(\d+(?:\.\d+)+)})
     strategy :sparkle do |item|
       puts item.url


### PR DESCRIPTION
`sha256:  9342909a313edb999a16885963538314f477438bcfb1fb7fd79c36c6b1cbc126`

Use `sha256 :no_check` when URL is unversioned
