### PR TITLE
add rode connect v1.3.24

### DIFF
--- a/Casks/rode-connect.rb
+++ b/Casks/rode-connect.rb
@@ -4,8 +4,15 @@ cask "rode-connect" do
 
   url "https://update.rode.com/connect/RODE_Connect_MACOS.zip"
   name "Rode Connect"
-  desc "RØDE Connect is a simple and powerful software solution for podcasting"
+  desc "Podcasting software"
   homepage "https://rode.com/en-us/software/rodeconnect"
+
+  livecheck do
+    url "https://update.rode.com/rode-devices-manifest.json"
+    strategy :json do |json|
+      json["rode-connect-manifest"]["macos"]["main-version"]["update-version"]
+    end
+  end
 
   pkg "RØDE Connect.pkg"
 

--- a/Casks/rode-connect.rb
+++ b/Casks/rode-connect.rb
@@ -1,0 +1,19 @@
+cask "rode-connect" do
+  version "1.3.24"
+  sha256 :no_check
+
+  url "https://update.rode.com/connect/RODE_Connect_MACOS.zip"
+  name "Rode Connect"
+  desc "RØDE Connect is a simple and powerful software solution for podcasting"
+  homepage "https://rode.com/en-us/software/rodeconnect"
+
+  pkg "RØDE Connect.pkg"
+
+  uninstall pkgutil: "com.rodeconnect.installer"
+
+  zap trash: [
+    "~/Library/Cache/com.rode.rodeconnect",
+    "~/Library/HTTPStorages/com.rode.rodeconnect",
+    "~/Library/Preferences/com.rode.rodeconnect.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

There is an error, but I think it is not connected to my cask: 
```
homebrew/core
  * audit_exceptions/versioned_dependencies_conflicts_allowlist.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: predictionio
Error: 1 problem in 1 tap detected.
```
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.

Hitting the error, which I belive is not connected to my cask. 
```
homebrew/core
  * audit_exceptions/versioned_dependencies_conflicts_allowlist.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: predictionio
Error: 1 problem in 1 tap detected.
```
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


This is my first brew PR, please help me figgure out if the error with `Invalid formulae or casks: predictionio` is something I need to fix on my end.

Thanks!