### PR TITLE
vagrant: modify url

### DIFF
--- a/Casks/vagrant.rb
+++ b/Casks/vagrant.rb
@@ -1,8 +1,11 @@
 cask "vagrant" do
-  version "2.3.6"
-  sha256 "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9"
+  arch arm: "arm64", intel: "amd64"
 
-  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_amd64.dmg",
+  version "2.3.6"
+  sha256 arm:   "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9",
+         intel: "4daf4d4c323cce7bf98065ecf5338e9800038a522cd81356c77555d9cd2f0db9"
+
+  url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/vagrant/"
   name "Vagrant"
   desc "Development environment"


### PR DESCRIPTION
Closes #148665.

Vagrant now serves both intel and arm builds (see issue). The builds are identical for now. I'm making this change for when they start diverging.

Thank you, @jmuchovej!