### PR TITLE
createuserpkg: discontinued

### DIFF
--- a/Casks/createuserpkg.rb
+++ b/Casks/createuserpkg.rb
@@ -4,7 +4,7 @@ cask "createuserpkg" do
 
   url "https://magervalp.github.io/CreateUserPkg/Distributions/CreateUserPkg-#{version}.dmg"
   name "CreateUserPkg"
-  desc "Create packages to deploy Mac OS X user accounts"
+  desc "Create packages to deploy user accounts"
   homepage "https://magervalp.github.io/CreateUserPkg/"
 
   app "CreateUserPkg.app"

--- a/Casks/createuserpkg.rb
+++ b/Casks/createuserpkg.rb
@@ -4,12 +4,12 @@ cask "createuserpkg" do
 
   url "https://magervalp.github.io/CreateUserPkg/Distributions/CreateUserPkg-#{version}.dmg"
   name "CreateUserPkg"
+  desc "Create packages to deploy Mac OS X user accounts"
   homepage "https://magervalp.github.io/CreateUserPkg/"
 
-  livecheck do
-    url "https://github.com/MagerValp/CreateUserPkg"
-    strategy :git
-  end
-
   app "CreateUserPkg.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `README` in the [GitHub repository for `CreateUserPkg`](https://github.com/MagerValp/CreateUserPkg) was updated on 2016-12-07 to explain that the project is no longer maintained (later updated to the following message):

> # This project is no longer maintained
>
> Please see the [blog post](https://magervalp.github.io/2016/12/07/createuserpkg-up-for-adoption.html). 10.13 doesn't appear to support SHA1 passwords anymore, and this project needs to be updated to create PBKDF2 passwords (see Security Notes below).

The repository was archived on 2018-01-30, so this PR sets the cask as discontinued and removes the `livecheck` block accordingly. This also adds a `desc` to appease `brew audit`.