### PR TITLE
genymotion: update caveats and dependencies

### DIFF
--- a/Casks/genymotion.rb
+++ b/Casks/genymotion.rb
@@ -12,8 +12,6 @@ cask "genymotion" do
     regex(/Genymotion\s*Desktop\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on cask: "virtualbox"
-
   app "Genymotion.app"
   app "Genymotion Shell.app"
   binary "#{appdir}/Genymotion Shell.app/Contents/MacOS/genyshell"
@@ -26,4 +24,8 @@ cask "genymotion" do
     "~/Library/Saved Application State/com.genymobile.genymotion.savedState",
     "~/Library/Saved Application State/com.genymobile.player.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Removes VirtualBox dependency and adds a rosetta caveat. 
```
The [Latest update of Genymotion](https://www.genymotion.com/blog/genymotion-desktop-3-4-is-released/) has built-in Apple Silicon support under Rosetta 2, and don't need to install virtualbox as a dependency. The cask however, is treating virtualbox as the dependency under all architectures.
```
Closes #148776.