### PR TITLE
dolphin: update livecheck

### DIFF
--- a/Casks/dolphin.rb
+++ b/Casks/dolphin.rb
@@ -8,8 +8,8 @@ cask "dolphin" do
   homepage "https://dolphin-emu.org/"
 
   livecheck do
-    url "https://github.com/dolphin-emu/dolphin"
-    strategy :git
+    url "https://dolphin-emu.org/download/"
+    regex(/href=.*?dolphin[._-]v?(\d+(?:\.\d+)+)(?:[._-]universal)?\.dmg/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `dolphin` checks the [related GitHub repository](https://github.com/dolphin-emu/dolphin) for versions but the cask `url` uses a dmg file from dolphin-emu.org. Besides that, the `livecheck` block unnecessarily uses `strategy :git` when livecheck already uses the `Git` strategy for this URL.

This PR updates the `livecheck` block to check the first-party download page, which links to the cask `url`. This removes the `#strategy` call in the process, resolving that issue as well.