### PR TITLE
double-commander: update livecheck

### DIFF
--- a/Casks/double-commander.rb
+++ b/Casks/double-commander.rb
@@ -12,8 +12,8 @@ cask "double-commander" do
   homepage "https://doublecmd.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/doublecmd/rss"
-    regex(/doublecmd[._-](\d+(?:\.\d+)+)[._-](\d+)\.cocoa/i)
+    url "https://sourceforge.net/projects/doublecmd/rss?path=/macOS"
+    regex(%r{url=.*?/doublecmd[._-](\d+(?:\.\d+)+)[._-](\d+)[^"' ]*?\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `double-commander` uses the same URL that the `Sourceforge` strategy would generated from the cask `url` (i.e., if we wanted to check that URL, it would be more appropriate to use `url :url` in this case). However, we should be checking the `macOS` directory (as there are separate directories for other platforms and those releases may push out the macOS versions from the main RSS feed), so we need to add a `path` query string parameter to the URL.

This PR updates the `livecheck` block `url` and updates the regex to use a pattern that's more typical of `Sourceforge` checks. I've also loosened the suffix part of the regex (e.g., `.cocoa`), so we won't miss a release if that part of the filename changes in the future. That said, if this looseness ends up matching versions that we don't want, we'll have to make it more explicit again.