### PR TITLE
eddie: update livecheck

### DIFF
--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -23,8 +23,8 @@ cask "eddie" do
   homepage "https://airvpn.org/macos/"
 
   livecheck do
-    url "https://github.com/AirVPN/Eddie"
-    strategy :git
+    url "https://eddie.website"
+    regex(/data-version=["']?(\d+(?:\.\d+)+)["' >]/i)
   end
 
   app "Eddie.app"

--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -6,15 +6,13 @@ cask "eddie" do
   on_mojave :or_older do
     sha256 "a446563a6beb6f91542d6afbd6f90f6745b7a36fef363a13506cff9d8f078c78"
 
-    url "https://eddie.website/download/?platform=macos-10.9&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}",
-        verified: "eddie.website/"
+    url "https://eddie.website/download/?platform=macos-10.9&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}"
   end
   on_catalina :or_newer do
     sha256 arm:   "04edf9a6aa7311a62eb6827db44c7ed8ee677a0e2581d08a76f2bf004cf3ec0f",
            intel: "9aecfd234ca1b19eee6518b1142643764a503d28b8ee3d873085fda22d25af85"
 
-    url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}",
-        verified: "eddie.website/"
+    url "https://eddie.website/download/?platform=macos-10.15&arch=#{arch}&ui=ui&format=disk.dmg&version=#{version}"
   end
 
   name "Air VPN"
@@ -30,4 +28,9 @@ cask "eddie" do
   app "Eddie.app"
 
   uninstall quit: "com.eddie.client"
+
+  zap trash: [
+    "~/.config/eddie",
+    "~/Library/Preferences/org.airvpn.eddie.ui.plist",
+  ]
 end

--- a/Casks/eddie.rb
+++ b/Casks/eddie.rb
@@ -20,10 +20,10 @@ cask "eddie" do
   name "Air VPN"
   name "Eddie"
   desc "OpenVPN UI"
-  homepage "https://airvpn.org/macos/"
+  homepage "https://eddie.website/"
 
   livecheck do
-    url "https://eddie.website"
+    url :url
     regex(/data-version=["']?(\d+(?:\.\d+)+)["' >]/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `eddie` checks the related GitHub repository and unnecessarily uses `strategy :git`, even though livecheck uses the `Git` strategy for this URL by default.

This PR indirectly addresses the issue by updating the `livecheck` block to check eddie.website, aligning the check with the source of the cask `url`. The page uses JavaScript to generate the related download URLs, so the regex matches the `data-version` attributes where the version numbers are located.