### PR TITLE
Update nextcloud 3.9.0 and livecheck

### DIFF
--- a/Casks/nextcloud.rb
+++ b/Casks/nextcloud.rb
@@ -7,11 +7,11 @@ cask "nextcloud" do
         verified: "github.com/nextcloud/desktop/"
   end
   on_sierra :or_newer do
-    version "3.8.2"
-    sha256 "3f52186bc3fc54d5592cb3a202a13ef3da95109cd3fb125761243bdc96f1cc75"
+    version "3.9.0"
+    sha256 "2e1f8386462f296061f44ff8f1e705a39789661c3f73aa6093e110ebdff53354"
 
-    url "https://github.com/nextcloud/desktop/releases/download/v#{version}/Nextcloud-#{version}.pkg",
-        verified: "github.com/nextcloud/desktop/"
+    url "https://github.com/nextcloud-releases/desktop/releases/download/v#{version}/Nextcloud-#{version}.pkg",
+        verified: "github.com/nextcloud-releases/desktop/"
   end
 
   name "Nextcloud"
@@ -19,7 +19,7 @@ cask "nextcloud" do
   homepage "https://nextcloud.com/"
 
   livecheck do
-    url "https://github.com/nextcloud/desktop/releases/latest"
+    url "https://github.com/nextcloud-releases/desktop/releases/latest"
     regex(/Nextcloud[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
     strategy :header_match do |headers, regex|
       next if headers["location"].blank?


### PR DESCRIPTION
Nextcloud no longer release their compiled version of desktop app in https://github.com/nextcloud/desktop but uses https://github.com/nextcloud-releases/desktop instead (see https://nextcloud.com/install/#install-clients)