### PR TITLE
xtool-creative-space-1.3.21,28.268.1686756140022

### DIFF
--- a/Casks/xtool-creative-space.rb
+++ b/Casks/xtool-creative-space.rb
@@ -2,12 +2,12 @@ cask "xtool-creative-space" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.3.21,28.265.1685528104377,2023-05-30-15-17-20"
-    sha256  "cf0da60fee213cc0ad8854ab1996389a49fce3864b1ad654025b2eb976abc5f2"
+    version "1.3.21,28.268.1686756140022,2-2023-06-14-22-29-31"
+    sha256  "c629bd7ccb29d119d9d4232968d4bf3e6d4ce6f2f4079d751402ce9baa5f9670"
   end
   on_intel do
-    version "1.3.21,16.264.1685527600463,2023-05-30-15-17-14"
-    sha256 "d4b4604047e459f2c09f8d22902c31a41158f7e9f3b2011cef0bf0156ab24aa1"
+    version "1.3.21,16.267.1686754770561,2-2023-06-14-22-30-04"
+    sha256 "64a695f3de1afd5d0bf439176f9f2347453c9d1c2e8a4718e7eef639cb9cf034"
   end
 
   url "https://res-us.makeblock.com/ms/updater/production/packages/#{version.csv.second.tr(".", "/")}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.third}-#{arch}.dmg",


### PR DESCRIPTION
* Bump to latest versions

I had to bump the ARM and Intel versions individually due to differing version numbers and download paths.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.