### PR TITLE
opencpn 5.8.4

### DIFF
--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -1,19 +1,32 @@
 cask "opencpn" do
-  version "5.6.2"
-  sha256 "dd093babd8b565cced08c0fd6467c70e6af4da707caf5ddc47e64b601944467a"
+  version "5.8.4,0+637.1637c28"
+  sha256 "2c3dc08908c002dcfe61a67b8e594a14d4de7ec486f6e44fc4ddc18219b65b44"
 
-  url "https://github.com/OpenCPN/OpenCPN/releases/download/Release_#{version}/OpenCPN_#{version}.pkg",
+  url "https://github.com/OpenCPN/OpenCPN/releases/download/Release_#{version.csv.first}/OpenCPN_#{version.csv.first}-#{version.csv.second}.pkg",
       verified: "github.com/OpenCPN/OpenCPN/"
   name "OpenCPN"
   desc "Full-featured and concise ChartPlotter/Navigator"
   homepage "https://www.opencpn.org/"
 
   livecheck do
-    url :url
-    regex(/v?(\d+(?:\.\d+)+)$/i)
+    url "https://github.com/OpenCPN/OpenCPN/releases/latest"
+    regex(%r{href=.*?/OpenCPN[._-]?v?(\d+(?:\.+\d+)+)[._-]?([0-9]?[+-]?\d*\.[0-9a-z]*)\.pkg}i)
+    strategy :header_match do |headers, regex|
+      next if headers["location"].blank?
+
+      # Identify the latest tag from the response's `location` header
+      latest_tag = File.basename(headers["location"])
+      next if latest_tag.blank?
+
+      # Fetch the assets list HTML for the latest tag and match within it
+      assets_page = Homebrew::Livecheck::Strategy.page_content(
+        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
+      )
+      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
-  pkg "OpenCPN_#{version}.pkg"
+  pkg "OpenCPN_#{version.csv.first}-#{version.csv.second}.pkg"
 
   uninstall pkgutil: [
     "org.opencpn.pkg.OpenCPN",

--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -9,20 +9,15 @@ cask "opencpn" do
   homepage "https://www.opencpn.org/"
 
   livecheck do
-    url "https://github.com/OpenCPN/OpenCPN/releases/latest"
-    regex(%r{href=.*?/OpenCPN[._-]?v?(\d+(?:\.+\d+)+)[._-]?([0-9]?[+-]?\d*\.[0-9a-z]*)\.pkg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{^OpenCPN[._-]?v?(\d+(?:\.+\d+)+)((?:-\d+)?\+\d+\.\h+)?\.(?:dmg|pkg)$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
     end
   end
 

--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -1,8 +1,8 @@
 cask "opencpn" do
-  version "5.8.4,0+637.1637c28"
+  version "5.8.4,-0+637.1637c28"
   sha256 "2c3dc08908c002dcfe61a67b8e594a14d4de7ec486f6e44fc4ddc18219b65b44"
 
-  url "https://github.com/OpenCPN/OpenCPN/releases/download/Release_#{version.csv.first}/OpenCPN_#{version.csv.first}-#{version.csv.second}.pkg",
+  url "https://github.com/OpenCPN/OpenCPN/releases/download/Release_#{version.csv.first}/OpenCPN_#{version.csv.first}#{version.csv.second}.pkg",
       verified: "github.com/OpenCPN/OpenCPN/"
   name "OpenCPN"
   desc "Full-featured and concise ChartPlotter/Navigator"
@@ -10,7 +10,7 @@ cask "opencpn" do
 
   livecheck do
     url :url
-    regex(%r{^OpenCPN[._-]?v?(\d+(?:\.+\d+)+)((?:-\d+)?\+\d+\.\h+)?\.(?:dmg|pkg)$}i)
+    regex(/^OpenCPN[._-]?v?(\d+(?:\.+\d+)+)((?:-\d+)?\+\d+\.\h+)?\.(?:dmg|pkg)$/i)
     strategy :github_latest do |json, regex|
       json["assets"]&.map do |asset|
         match = asset["name"]&.match(regex)
@@ -21,11 +21,11 @@ cask "opencpn" do
     end
   end
 
-  pkg "OpenCPN_#{version.csv.first}-#{version.csv.second}.pkg"
+  pkg "OpenCPN_#{version.csv.first}#{version.csv.second}.pkg"
 
   uninstall pkgutil: [
-    "org.opencpn.pkg.OpenCPN",
     "org.opencpn",
+    "org.opencpn.pkg.OpenCPN",
   ]
 
   zap trash: [

--- a/Casks/opencpn.rb
+++ b/Casks/opencpn.rb
@@ -32,4 +32,11 @@ cask "opencpn" do
     "org.opencpn.pkg.OpenCPN",
     "org.opencpn",
   ]
+
+  zap trash: [
+    "~/Library/Logs/opencpn.log",
+    "~/Library/Preferences/opencpn",
+    "~/Library/Preferences/org.opencpn.plist",
+    "~/Library/Saved Application State/org.opencpn.savedState",
+  ]
 end


### PR DESCRIPTION
* Update to version 5.8.4

* Update url to latest format

* Update livecheck to parse latest release artifact format

Hi maintainers,

This cask has been reworked for both livecheck and latest version of this cask to bring it up to the latest format.  

Of note for this cask, the `.pkg` artifact naming scheme for downloads has changed some versions back from `OpenCPN_x.y.z` to `OpenCPN_x.y.z-0+build.commithash` (extrapolating a bit from the pkg name).

I've gotten the updates to work, but the url feels a bit fragile. If the format changes or goes to the previous style of `x.y.z`, this will break because of the `-` char in the download url.  I suppose that could be said for any cask, though.  😄 

This can be avoided and both old and new formats can be supported if the second part of the csv starts with a `-` char, as the url string can be updated to `...#{version.csv.first}#{version.csv.second}` in lieu of `...#{version.csv.first}-#{version.csv.second}`, but starting a csv with a `-` seems a bit clunky. 

However, starting with a `-` would also yield being able to install the file with `pkg "OpenCPN_#{version}.pkg"` instead of `pkg "OpenCPN_#{version.first.csv}-#{version.second.csv}"`

I am mentioning this as maybe there is a preferred implementation from your deeper knowledge and style guide.

I intentionally left the `+` in the version number, rather than replacing it with a `,` and therefore leaving the version as 2 csv segments instead of 3.

Livecheck scans the assets in the latest release, as the asset name is different than the release version page.  I borrowed this from another cask and updated accordingly.

Your review and any updates are appreciated.

Thank you for your time!

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.