### PR TITLE
microsoft-defender 101.98.84

### DIFF
--- a/Casks/microsoft-defender.rb
+++ b/Casks/microsoft-defender.rb
@@ -1,5 +1,5 @@
 cask "microsoft-defender" do
-  version "101.98.30"
+  version "101.98.84"
   sha256 :no_check
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft%20Defender.pkg"


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/149202

I added this POS in https://github.com/Homebrew/homebrew-cask/pull/141389 for the sole purpose of removing it via `zap` from my new work machine.

I have no idea what the issue is with this update, and if no-one else can figure it out, I would suggest removing it:
```
==> Analytics
install: 0 (30 days), 0 (90 days), 0 (365 days)
```