### PR TITLE
latexdraw: update livecheck

### DIFF
--- a/Casks/latexdraw.rb
+++ b/Casks/latexdraw.rb
@@ -9,8 +9,8 @@ cask "latexdraw" do
   homepage "https://latexdraw.sourceforge.io/"
 
   livecheck do
-    url "https://github.com/latexdraw/latexdraw"
-    strategy :git
+    url "https://sourceforge.net/projects/latexdraw/rss?path=/latexdraw"
+    regex(%r{url=.*?/LaTeXDraw[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   app "LaTeXDraw.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `latexdraw` checks the related GitHub repository but it unnecessarily uses `strategy :git` (i.e., livecheck already uses the `Git` strategy for this URL).

This PR indirectly addresses the issue by updating the `livecheck` block to check the SourceForge project where the cask `url` comes from. This addresses the unnecessary `#strategy` call while also aligning the check with the cask `url`.

[Just to be clear, I'm using a SourceForge URL in the `livecheck` block instead of `url :url` because we need to specify the `path` query string parameter to restrict the RSS feed to the `latexdraw` directory (excluding the sibling `beta testing` and `releaseNote` directories).]