### PR TITLE
Add GraalVM JDK 20.0.1

### DIFF
--- a/Casks/graalvm-jdk.rb
+++ b/Casks/graalvm-jdk.rb
@@ -13,7 +13,7 @@ cask "graalvm-jdk" do
 
   livecheck do
     url "https://github.com/oracle/graal.git"
-    regex(/jdk-(\d+(?:\.\d+)+)/)
+    regex(/jdk[._-]v?(\d+(?:\.\d+)+)/)
   end
 
   artifact "graalvm-jdk-#{version}+9.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"

--- a/Casks/graalvm-jdk.rb
+++ b/Casks/graalvm-jdk.rb
@@ -1,0 +1,24 @@
+cask "graalvm-jdk" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "20.0.1"
+  sha256 arm:   "b94877df825ccefbe8b6751e087d54aa9b8129f9d2919d29ea18e00900392da1",
+         intel: "b6f14aae4f9d6a1514446f6f2b83685e796ec083a205b613a9873b29454333ef"
+
+  url "https://download.oracle.com/graalvm/#{version.major}/archive/graalvm-jdk-#{version}_macos-#{arch}_bin.tar.gz",
+      verified: "download.oracle.com/"
+  name "GraalVM Java Development Kit"
+  desc "GraalVM from Oracle"
+  homepage "https://www.graalvm.org/"
+
+  livecheck do
+    url "https://github.com/oracle/graal.git"
+    regex(/jdk-(\d+(?:\.\d+)+)/)
+  end
+
+  artifact "graalvm-jdk-#{version}+9.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"
+
+  caveats do
+    license "https://www.oracle.com/downloads/licenses/graal-free-license.html"
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

I know `GraalVM` has been rejected a few times. But since there have been many JDK distributions accepted now, and it just so happens that the latest version of `GraalVM` is now starting to be distributed directly by Oracle as is the regular JDK, I thought it might be worth considering seeing if it could be added as well.
