### PR TITLE
macupdater livecheck

### DIFF
--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,31 +1,26 @@
 cask "macupdater" do
   on_monterey :or_older do
-    version "2.3.5,14289"
+    version "2.3.5"
     sha256 "3270e99cf4bfa95edc674da548a39727976e41882f21ca000f44a78833a84be5"
-
-    livecheck do
-      url "https://www.corecode.io/macupdater/macupdater2.xml"
-      strategy :sparkle
-    end
 
     depends_on macos: ">= :mojave"
   end
   on_ventura :or_newer do
-    version "3.0.4,15817"
+    version "3.0.4"
     sha256 "1ef32a52b8f82305fc2407b9770f0e55e6ee353e0589f4868315717f6f44bf3e"
-
-    livecheck do
-      url "https://www.corecode.io/macupdater/macupdater3.xml"
-      strategy :sparkle
-    end
 
     depends_on macos: ">= :ventura"
   end
 
-  url "https://www.corecode.io/downloads/macupdater_#{version.csv.first}.dmg"
+  url "https://www.corecode.io/downloads/macupdater_#{version}.dmg"
   name "MacUpdater"
   desc "Track and update to the latest versions of installed software"
   homepage "https://www.corecode.io/macupdater/index.html"
+
+  livecheck do
+    url "https://www.corecode.io/macupdater/macupdater#{version.major}.xml"
+    strategy :sparkle, &:short_version
+  end
 
   auto_updates true
 

--- a/Casks/macupdater.rb
+++ b/Casks/macupdater.rb
@@ -1,29 +1,31 @@
 cask "macupdater" do
   on_monterey :or_older do
     version "2.3.5,14289"
-    sha256 :no_check
+    sha256 "3270e99cf4bfa95edc674da548a39727976e41882f21ca000f44a78833a84be5"
 
-    url "https://www.corecode.io/downloads/macupdater_#{version.major}_latest.dmg"
+    livecheck do
+      url "https://www.corecode.io/macupdater/macupdater2.xml"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :mojave"
   end
   on_ventura :or_newer do
     version "3.0.4,15817"
-    sha256 :no_check
+    sha256 "1ef32a52b8f82305fc2407b9770f0e55e6ee353e0589f4868315717f6f44bf3e"
 
-    url "https://www.corecode.io/downloads/macupdater_latest.dmg"
+    livecheck do
+      url "https://www.corecode.io/macupdater/macupdater3.xml"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :ventura"
   end
 
+  url "https://www.corecode.io/downloads/macupdater_#{version.csv.first}.dmg"
   name "MacUpdater"
   desc "Track and update to the latest versions of installed software"
   homepage "https://www.corecode.io/macupdater/index.html"
-
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
 
   auto_updates true
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.