### PR TITLE
quiterss: update livecheck

### DIFF
--- a/Casks/quiterss.rb
+++ b/Casks/quiterss.rb
@@ -8,8 +8,8 @@ cask "quiterss" do
   homepage "https://quiterss.org/"
 
   livecheck do
-    url "https://github.com/QuiteRSS/quiterss"
-    strategy :git
+    url "https://quiterss.org/download"
+    regex(/href=.*?QuiteRSS[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "quiterss.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `quiterss` checks the related GitHub repository but it unnecessarily uses `strategy :git`, even though livecheck already uses the `Git` strategy for this URL.

This PR indirectly addresses this issue by updating the `livecheck` block to check the first-party download page, which links to the cask `url`. This removes the redundant `#strategy` call while also aligning the check with the cask `url` source.