### PR TITLE
qxmledit: update livecheck

### DIFF
--- a/Casks/qxmledit.rb
+++ b/Casks/qxmledit.rb
@@ -9,8 +9,8 @@ cask "qxmledit" do
   homepage "https://qxmledit.org/"
 
   livecheck do
-    url "https://sourceforge.net/projects/qxmledit/rss"
-    regex(/url=.*?QXmlEdit[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
+    url :url
+    regex(%r{url=.*?/QXmlEdit[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   app "QXmlEdit.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `qxmledit` includes the same URL that the `SourceForge` strategy generates from the cask `url`.

This PR addresses this redundancy by updating the `livecheck` block to use `url :url` (i.e., we only use a URL string with the `Sourceforge` strategy when we need to add a `path` query string parameter). Besides that, this also updates the regex to bring it in line with the typical format for SourceForge checks.