### PR TITLE
Upgrade PrusaSlicer to v2.6.0

### DIFF
--- a/Casks/prusaslicer.rb
+++ b/Casks/prusaslicer.rb
@@ -1,6 +1,6 @@
 cask "prusaslicer" do
-  version "2.5.2,202303231232"
-  sha256 "76e780824e5ac5ed16e85bd3cf58ec80a204ec78c3f30dd0bdfc53f8731ce06b"
+  version "2.6.0,202306191415"
+  sha256 "81b90877b9f8ce492ffc3150dc77ce5fffe7f746a137b0810029ef278450d732"
 
   url "https://github.com/prusa3d/PrusaSlicer/releases/download/version_#{version.csv.first}/PrusaSlicer-#{version.csv.first}+MacOS-universal-#{version.csv.second}.dmg",
       verified: "github.com/prusa3d/PrusaSlicer/"


### PR DESCRIPTION
This PR upgrades PrusaSlicer to 2.6.0, which was [just released](https://github.com/prusa3d/PrusaSlicer/releases/tag/version_2.6.0).


## Checklist

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] `brew audit --cask --online <cask>` is NOT error-free.

`brew audit --cask --online prusaslicer` was also failing for 2.5.0, and it continues to give the same failure for 2.6.2:

<details>
<summary>Output</summary>

### For 2.5.0

```
==> Downloading https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.5.0/PrusaSlicer-2.5.0+M
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/52882701
###################################################################################################
  * audit_exceptions/versioned_dependencies_conflicts_allowlist.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: predictionio
  * pypi_formula_mappings.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: rtv
Error: 2 problems in 1 tap detected.
```


### For 2.6.0
```
==> Downloading https://github.com/prusa3d/PrusaSlicer/releases/download/version_2.6.0/PrusaSlicer-2.6.0+M
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/52882701
###################################################################################################
  * audit_exceptions/versioned_dependencies_conflicts_allowlist.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: predictionio
  * pypi_formula_mappings.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: rtv
Error: 2 problems in 1 tap detected.
```
</details>

I don't believe it's related to prusaslicer.