### PR TITLE
marvin: fix cask checksum

### DIFF
--- a/Casks/marvin.rb
+++ b/Casks/marvin.rb
@@ -1,6 +1,6 @@
 cask "marvin" do
   version "1.63.0"
-  sha256 "6fa673b815e3844844fc8ea5e4844997b7e96e54ffb3da0ebc16ad2bf20c2d24"
+  sha256 "8f6c4ca13956c41731086e2112fe79418e00248544e61d713b3ea9ff8d89c77a"
 
   url "https://amazingmarvin.s3.amazonaws.com/Marvin-#{version}.dmg",
       verified: "amazingmarvin.s3.amazonaws.com/"


### PR DESCRIPTION
Silent update/hotfix was released for the Marvin desktop app a few days after the initial 1.63.0 release which is most likely the reason for the wrong sha256 checksum error.

Few Marvin users told us about this problem so this is my attempt at fixing it. I'm not a macOS or Homebrew user (yet) so I sadly couldn't test this on my end. Apologies about that!

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
