### PR TITLE
adobe-creative-cloud: update livecheck

### DIFF
--- a/Casks/adobe-creative-cloud.rb
+++ b/Casks/adobe-creative-cloud.rb
@@ -11,8 +11,8 @@ cask "adobe-creative-cloud" do
   homepage "https://www.adobe.com/creativecloud.html"
 
   livecheck do
-    url "https://helpx.adobe.com/creative-cloud/release-note/cc-release-notes.html"
-    regex(/Version.\s*v?(\d+(?:\.\d+)+)/i)
+    url "https://ffc-static-cdn.oobesaas.adobe.com/features/v3/#{arch}/ccdConfig.xml"
+    regex(/ccd\.fw\.update\.greenline\.latest.*?"version".*?"(\d+(?:\.\d+)+)"/i)
   end
 
   auto_updates true


### PR DESCRIPTION
This is a trial for an updated `livecheck` strategy that should avoid web-only and staggered releases from the online release notes.
