### PR TITLE
sqlexplorer: update livecheck

### DIFF
--- a/Casks/sqlexplorer.rb
+++ b/Casks/sqlexplorer.rb
@@ -9,9 +9,8 @@ cask "sqlexplorer" do
   homepage "https://eclipsesql.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/eclipsesql/rss"
-    regex(/.*?rcp[._-]v?(\d+(?:\.\d+)+)[._-]macosx.*?\.tgz/i)
-    strategy :page_match
+    url "https://sourceforge.net/projects/eclipsesql/rss?path=/SQL%20Explorer%20RCP%20%28exc%20JRE%29"
+    regex(%r{url=.*?/sqlexplorer[._-]rcp[._-]v?(\d+(?:\.\d+)+)[._-]macosx?[^"' ]*?\.(?:t|zip)}i)
   end
 
   app "SQLExplorer/sqlexplorer.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `sqlexplorer` uses a SourceForge RSS feed URL with `strategy :page_match`, when it could technically just use `url :url` with no `#strategy` call to achieve the same thing (as livecheck would use the `Sourceforge` strategy for the cask `url` and generate the same RSS feed URL).

In this case, we need to check the RSS feed for a specific subdirectory in the SourceForge project, so this PR updates the `livecheck` block URL to include an appropriate `path` query string parameter. This also updates the regex to align more with typical `Sourceforge` strategy regexes.