### PR TITLE
gotiengviet 2.4

### DIFF
--- a/Casks/gotiengviet.rb
+++ b/Casks/gotiengviet.rb
@@ -13,4 +13,9 @@ cask "gotiengviet" do
   end
 
   app "GoTiengViet.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.trankynam.GoTiengViet",
+    "~/Library/Containers/com.trankynam.GoTiengViet",
+  ]
 end

--- a/Casks/gotiengviet.rb
+++ b/Casks/gotiengviet.rb
@@ -1,6 +1,6 @@
 cask "gotiengviet" do
-  version "2.4"
-  sha256 "c3be5eb6ad582674489fee63b45bfd97b34bd5501f4c766616a818a002138c18"
+  version "2.4,32"
+  sha256 :no_check
 
   url "https://www.trankynam.com/gotv/downloads/GoTiengViet.dmg"
   name "GoTiengViet"
@@ -8,8 +8,8 @@ cask "gotiengviet" do
   homepage "https://www.trankynam.com/gotv/"
 
   livecheck do
-    url "https://www.trankynam.com/gotv/macos/GoTiengVietMacOSX-Appcast.xml"
-    strategy :sparkle, &:short_version
+    url :url
+    strategy :extract_plist
   end
 
   app "GoTiengViet.app"

--- a/Casks/gotiengviet.rb
+++ b/Casks/gotiengviet.rb
@@ -1,6 +1,6 @@
 cask "gotiengviet" do
-  version "2.3"
-  sha256 :no_check
+  version "2.4"
+  sha256 "c3be5eb6ad582674489fee63b45bfd97b34bd5501f4c766616a818a002138c18"
 
   url "https://www.trankynam.com/gotv/downloads/GoTiengViet.dmg"
   name "GoTiengViet"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.