### PR TITLE
devspace: migrate to cask

### DIFF
--- a/Casks/devspace.rb
+++ b/Casks/devspace.rb
@@ -12,13 +12,11 @@ cask "devspace" do
   homepage "https://devspace.sh/"
 
   livecheck do
-    url :stable
+    url :url
     strategy :github_latest
   end
 
-  auto_updates true
   depends_on formula: "kubernetes-cli"
-  container type: :naked
 
   binary "devspace-darwin-#{arch}", target: "devspace"
 

--- a/Casks/devspace.rb
+++ b/Casks/devspace.rb
@@ -1,0 +1,26 @@
+cask "devspace" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "6.3.2"
+  sha256 arm:   "de09322bd4186192433a0bba3ac2f6284d1e2819b638871011365fbff788b382",
+         intel: "ddb2af8cc6e2b184e643df721e20a47b025aa70861f452f3a6c444de8a23ca89"
+
+  url "https://github.com/devspace-sh/devspace/releases/download/v#{version}/devspace-darwin-#{arch}",
+      verified: "github.com/devspace-sh/devspace/"
+  name "DevSpace"
+  desc "Develop and deploy cloud-native software with Docker and Kubernetes faster"
+  homepage "https://devspace.sh/"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on formula: "kubernetes-cli"
+  container type: :naked
+
+  binary "devspace-darwin-#{arch}", target: "devspace"
+
+  zap trash: "~/.devspace"
+end


### PR DESCRIPTION
Due to DevSpace's build process an encryption key would not be added to the [current formula's](https://github.com/Homebrew/homebrew-core/blob/master/Formula/devspace.rb) resulting binary. This has the side effect of sensitive data getting stored in plaintext on the user's system.

Switching to a cask will use the pre-built binaries that will have the encryption key included.

[Corresponding core PR](https://github.com/Homebrew/homebrew-core/pull/134786)

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
  - failing due to existing formula, [PR](https://github.com/Homebrew/homebrew-core/pull/134786) for it to be removed
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
