### PR TITLE
sonic-robo-blast-2 2.2.11

### DIFF
--- a/Casks/sonic-robo-blast-2.rb
+++ b/Casks/sonic-robo-blast-2.rb
@@ -1,17 +1,17 @@
 cask "sonic-robo-blast-2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  version "2.2.10"
-  sha256 "30bf6a96707c9c824b5fb8a4b2ca43431b2109ae1cb80e9adcbbdf0ef531e5c6"
+  version "2.2.11"
+  sha256 "e072a030cd9680058b73e02be87d44a643480a06224795e2eb8d3d6204809ea0"
 
-  url "https://github.com/STJr/SRB2/releases/download/SRB2_release_#{version}/SRB2-#{version}-macOS-Installer.dmg",
+  url "https://github.com/STJr/SRB2/releases/download/SRB2_release_#{version}/SRB2-#{version}-Darwin.dmg",
       verified: "github.com/STJr/SRB2/"
   name "Sonic Robo Blast 2"
   desc "3D open-source Sonic the Hedgehog fangame built using a Doom Legacy port of Doom"
   homepage "https://www.srb2.org/"
 
   livecheck do
-    url "https://www.srb2.org/download/"
-    regex(%r{href=.*?/SRB2-(\d+(?:\.\d+)*)-macOS-Installer.dmg}i)
+    url "https://github.com/STJr/SRB2/releases"
+    strategy :github_latest
   end
 
   app "Sonic Robo Blast 2.app"


### PR DESCRIPTION
* Update to latest version 2.2.11

* Update url and livecheck

For the latest release, it looks like the naming scheme was changed for the url.  It is not clear if this will remain the case, but seeing as this app has updated very infrequently over the past couple years, it can be adjusted back if it changes in the next iteration.

Switched `livecheck` to use `:github_latest` instead of the website downloads page, which also points to the GitHub artifact.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
