### PR TITLE
hue-topia 4.0.3

### DIFF
--- a/Casks/hue-topia.rb
+++ b/Casks/hue-topia.rb
@@ -9,6 +9,11 @@ cask "hue-topia" do
 
   app "Hue-topia.app"
 
+  zap trash: [
+    "~/Library/Application Scripts/com.peacockmedia.Hue-topia",
+    "~/Library/Containers/com.peacockmedia.Hue-topia",
+  ]
+
   caveats do
     discontinued
   end

--- a/Casks/hue-topia.rb
+++ b/Casks/hue-topia.rb
@@ -1,16 +1,15 @@
 cask "hue-topia" do
-  version "3.4.2,1813"
-  sha256 :no_check
+  version "4.0.3"
+  sha256 "e0a6c4ad5c0574b4ca5cde27fc91c6c6208f215adaf428bdb2495c6c48aeea2e"
 
-  url "https://peacockmedia.software/mac/huetopia/huetopia.dmg"
+  url "https://peacockmedia.software/mac/huetopia/huetopia#{version.no_dots}.dmg"
   name "Hue-topia"
   desc "Manual control over Philips Hue bulbs"
   homepage "https://peacockmedia.software/mac/huetopia/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
-
   app "Hue-topia.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Bumped the application to the latest version 4.0.3, which is the latest version available, even though it is technically marked as "beta".  This version supports both Apple Silicon and Intel.

The application is currently noted as `discontinued` per the upstream comment [here](https://peacockmedia.software/mac/huetopia/).  The previous url for the `3.x` series no longer works, but the versioned url for `4.x` as part of this commit does work.