### PR TITLE
wavesurfer: update livecheck

### DIFF
--- a/Casks/wavesurfer.rb
+++ b/Casks/wavesurfer.rb
@@ -8,8 +8,8 @@ cask "wavesurfer" do
   homepage "https://sourceforge.net/projects/wavesurfer/"
 
   livecheck do
-    url "https://sourceforge.net/projects/wavesurfer/rss"
-    regex(%r{/wavesurfer-(\d+(?:\.\d+)*(?:p\d+(?:\.\d+)*)?)-macos\.dmg}i)
+    url "https://sourceforge.net/projects/wavesurfer/rss?path=/wavesurfer"
+    regex(%r{url=.*?/wavesurfer[._-]v?(\d+(?:\.\d+)+(?:p\d+(?:\.\d+)*)?)[^"' ]*?\.dmg}i)
   end
 
   app "WaveSurfer.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `wavesurfer` uses a SourceForge RSS feed URL, which is the same URL that the `Sourceforge` strategy already uses. The `wavesurfer` files are in a `wavesurfer` subdirectory, so this PR updates the URL to include a `path` query string parameter. [If we didn't need/want to specify a `path`, `url :url` would be more appropriate.]

This also updates the regex to better align with typical `Sourceforge` regexes. Since upstream has used a variety of suffixes over time, I've replaced the `-macos` suffix in the regex with a generic, contextually-appropriate `[^"' ]*?` (which will match `-macos`, `-osx-i386`, etc.).

It's worth mentioning that although upstream has only published stable releases so far, the looseness of this part of the regex could also match something like `wavesurfer-1.2.3-beta.dmg`, so I try to be careful about loose matches like this. That said, I think this is an okay tradeoff in this particular situation and we can always tighten this regex if it surfaces an inappropriate version in the future.