### PR TITLE
fujitsu-scansnap-home: update livecheck

### DIFF
--- a/Casks/fujitsu-scansnap-home.rb
+++ b/Casks/fujitsu-scansnap-home.rb
@@ -8,11 +8,12 @@ cask "fujitsu-scansnap-home" do
   desc "Fujitsu ScanSnap Scanner software"
   homepage "https://www.fujitsu.com/global/products/computing/peripheral/scanners/soho/sshome/"
 
-  # Some of the release titles contain a typo where a space is omitted, so this
-  # regex is a bit extreme about whitespace to ensure we match all the versions.
   livecheck do
-    url "https://www.pfu.fujitsu.com/imaging/ss_hist/en/mac/index.html"
-    regex(/ScanSnap\s*Home\s*for\s*Mac\s*v?(\d+(?:\.\d+)+)\s*Released/i)
+    url "https://www.pfu.ricoh.com/global/scanners/scansnap/dl/mac-sshoffline.html"
+    regex(/m-sshoffline[._-]v?(\d+(?:[._]\d+)+)\.html/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `fujitsu-scansnap-home` returns 2.11.0 as the newest version and, while this is correct, there isn't an offline installer for this version yet. From what I've seen with past versions, it seems commonplace for there to be a notable lag between when a new version is announced on the [release information page](https://www.pfu.ricoh.com/imaging/ss_hist/en/mac/index.html) and when an offline installer becomes available for the version.

This PR updates the `livecheck` block to use the latest offline installer version instead, so we only surface a new version when the cask can be upgraded.