### PR TITLE
Added "PicoScope 7 T&M.app" v7.1.2

### DIFF
--- a/Casks/picoscope.rb
+++ b/Casks/picoscope.rb
@@ -4,16 +4,16 @@ cask "picoscope" do
 
   url "https://www.picotech.com/download/software/sr/PicoScope_#{version}_TnM_Stable.pkg"
   name "PicoScope"
-  desc "Test & Measurement Software for Picotech Oscilloscopes"
+  desc "Test and measurement oscilloscope software for PicoScope oscilloscops"
   homepage "https://www.picotech.com/"
 
   livecheck do
-    url "https://www.picotech.com/downloads/_lightbox/picoscope-7-stable-for-macos"
-    regex(%r{href=.*?/PicoScope_(\d+(?:.\d+)*).*\.pkg}i)
+    url "https://www.picotech.com/downloads/_lightbox/picoscope-#{version.major}-stable-for-macos"
+    regex(%r{href=.*?/PicoScope[._-]v?(\d+(?:.\d+)+)[._-]TnM[._-]Stable\.pkg}i)
   end
 
-  #  app "PicoScope 7 T&M.app" -> "Error: It seems your app is not found in
-  #  /opt/homebrew/Casksroom/..."
+  conflicts_with cask: "homebrew/cask-versions/picoscope-beta"
+
   pkg "PicoScope_#{version}_TnM_Stable.pkg"
 
   uninstall pkgutil: "com.picotech.picoscope#{version.major}tnm"

--- a/Casks/picoscope.rb
+++ b/Casks/picoscope.rb
@@ -1,0 +1,25 @@
+cask "picoscope" do
+  version "7.1.2.15463"
+  sha256 "2c0dbeb737ee0f94eb4dad296da9de808122f468bf2410fceab466a7aa80a34d"
+
+  url "https://www.picotech.com/download/software/sr/PicoScope_#{version}_TnM_Stable.pkg"
+  name "PicoScope"
+  desc "Test & Measurement Software for Picotech Oscilloscopes"
+  homepage "https://www.picotech.com/"
+
+  livecheck do
+    url "https://www.picotech.com/downloads/_lightbox/picoscope-7-stable-for-macos"
+    regex(%r{href=.*?/PicoScope_(\d+(?:.\d+)*).*\.pkg}i)
+  end
+
+  #  app "PicoScope 7 T&M.app" -> "Error: It seems your app is not found in
+  #  /opt/homebrew/Casksroom/..."
+  pkg "PicoScope_#{version}_TnM_Stable.pkg"
+
+  uninstall pkgutil: "com.picotech.picoscope#{version.major}tnm"
+
+  zap trash: [
+    "~/.local/share/Pico Technology",
+    "~/Library/Saved Application State/com.picotech.picoscope#{version.major}.savedState",
+  ]
+end


### PR DESCRIPTION
So far, only the PicoScope Beta software was available. Now, I added the stable version of the software in it's most recent version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).  
  - In my opinion this is misleading in since nobody knows what the "T & M" stands for and might confuse people.
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
