### PR TITLE
update mullvadvpn 2023.4

### DIFF
--- a/Casks/mullvadvpn.rb
+++ b/Casks/mullvadvpn.rb
@@ -1,6 +1,6 @@
 cask "mullvadvpn" do
-  version "2023.3"
-  sha256 "d1d23ea8212c796fdfcd2170e81e995eabf5a3178a018c8cbdf5a091659cef1a"
+  version "2023.4"
+  sha256 "3242edad8edd716109d3bbd0fca3fe09a4293ba047a883e19558b28c9b1cdb6c"
 
   url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg",
       verified: "github.com/mullvad/mullvadvpn-app/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
