### PR TITLE
Update tor-browser version to 12.5.1

### DIFF
--- a/Casks/tor-browser.rb
+++ b/Casks/tor-browser.rb
@@ -1,6 +1,6 @@
 cask "tor-browser" do
-  version "12.5"
-  sha256 "29f5d6402566805030ed948bfe87b1f038a215ffbf4adef8b02ca851eef5f3ec"
+  version "12.5.1"
+  sha256 "9ccf4e212eba72db7be65fc653d75df571ba1fc18d0c2ff683468d094cf1e661"
 
   url "https://dist.torproject.org/torbrowser/#{version}/TorBrowser-#{version}-macos_ALL.dmg"
   name "Tor Browser"


### PR DESCRIPTION
The tow-browser version was bumped to 12.5.1 as can be viewed at https://dist.torproject.org/torbrowser

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.