### PR TITLE
viscosity 1.10.6: update sha256

### DIFF
--- a/Casks/viscosity.rb
+++ b/Casks/viscosity.rb
@@ -1,6 +1,6 @@
 cask "viscosity" do
   version "1.10.6"
-  sha256 "c527879d58021a38850db084564b749777fb58f44684e9adb29840a0d30e66b0"
+  sha256 "fe523f49b301bfe18341fab4243eae98b7a2076a9b362da5d9a314712138629b"
 
   url "https://swupdate.sparklabs.com/download/mac/release/viscosity/Viscosity%20#{version}.dmg"
   name "Viscosity"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

This cask seems to have updated its `sha256` again.  See #150503.  The `sha256` being updated is reflected directly from the applications release notes [here](https://www.sparklabs.com/viscosity/releasenotes/mac).

If this continues to change, we'll have to make further amends.