### PR TITLE
Migrate elektron-overbridge ( Copy direct as per: Homebrew/homebrew-cask-drivers#3414 )

### DIFF
--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -22,6 +22,9 @@ cask "elektron-overbridge" do
 
   uninstall quit:      "se.elektron.OverbridgeEngine",
             pkgutil:   "se.elektron.overbridge.*",
-            launchctl: "se.elektron.overbridge.engine",
+            launchctl: [
+              "se.elektron.overbridge.engine",
+              "asp.se.elektron.overbridge.coreaudio2",
+            ],
             delete:    "/Applications/Elektron"
 end

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -1,6 +1,6 @@
 cask "elektron-overbridge" do
   version "2.5.1"
-  sha256 ""
+  sha256 "a0a32be4cfe38da9c58fbe07c5b67671d97d3a5d0fa01c3b9a5d67f3c855ab1c"
 
   url "https://cdn.www.elektron.se/media/downloads/overbridge/Elektron_Overbridge_#{version.csv.first}.dmg"
   name "Overbridge"

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -1,0 +1,27 @@
+cask "elektron-overbridge" do
+  version "2.1.1.2,7fc48133-4bbc-5e3b-b646-c180686f9c2d"
+  sha256 "b2a7b13a0dd4e971562d7668a9c0783c073c2be20756b762242c5480786c9af9"
+
+  url "https://se-elektron-devops.s3.amazonaws.com/release/#{version.csv.second}/Elektron_Overbridge_#{version.csv.first}.dmg",
+      verified: "se-elektron-devops.s3.amazonaws.com/release/"
+  name "Overbridge"
+  desc "Integrate Elektron hardware into music software"
+  homepage "https://www.elektron.se/overbridge/"
+
+  livecheck do
+    url "https://www.elektron.se/support/?connection=overbridge"
+    regex(%r{href=.*?/(\h+(?:-\h+)*)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    end
+  end
+
+  depends_on macos: ">= :sierra"
+
+  pkg "Elektron Overbridge Installer #{version.before_comma}.pkg"
+
+  uninstall quit:      "se.elektron.OverbridgeEngine",
+            pkgutil:   "se.elektron.overbridge.*",
+            launchctl: "se.elektron.overbridge.engine",
+            delete:    "/Applications/Elektron"
+end

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -1,6 +1,6 @@
 cask "elektron-overbridge" do
-  version "2.1.1.2,7fc48133-4bbc-5e3b-b646-c180686f9c2d"
-  sha256 "b2a7b13a0dd4e971562d7668a9c0783c073c2be20756b762242c5480786c9af9"
+  version "2.5.1"
+  sha256 ""
 
   url "https://cdn.www.elektron.se/media/downloads/overbridge/Elektron_Overbridge_#{version.csv.first}.dmg"
   name "Overbridge"
@@ -9,7 +9,13 @@ cask "elektron-overbridge" do
 
   livecheck do
     url "https://www.elektron.se/us/download-support-overbridge-new"
-    regex(%r{https?:\/\/(cdn\.)?(www\.)?elektron\.se\/(media\/)?(downloads\/)?(overbridge\/)?Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    regex(
+      %r{
+        https?://(cdn\.)?(www\.)?elektron\.se/
+          (media/)?(downloads/)?(overbridge/)?
+            Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg
+      }ix,
+    )
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[5]}," }
     end

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -2,28 +2,19 @@ cask "elektron-overbridge" do
   version "2.5.1"
   sha256 "a0a32be4cfe38da9c58fbe07c5b67671d97d3a5d0fa01c3b9a5d67f3c855ab1c"
 
-  url "https://cdn.www.elektron.se/media/downloads/overbridge/Elektron_Overbridge_#{version.csv.first}.dmg"
+  url "https://cdn.www.elektron.se/media/downloads/overbridge/Elektron_Overbridge_#{version}.dmg"
   name "Overbridge"
   desc "Integrate Elektron hardware into music software"
   homepage "https://www.elektron.se/overbridge/"
 
   livecheck do
     url "https://www.elektron.se/us/download-support-overbridge-new"
-    regex(
-      %r{
-        https?://(cdn\.)?(www\.)?elektron\.se/
-          (media/)?(downloads/)?(overbridge/)?
-            Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg
-      }ix,
-    )
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match[5].to_s }
-    end
+    regex(/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :sierra"
 
-  pkg "Elektron Overbridge Installer #{version.before_comma}.pkg"
+  pkg "Elektron Overbridge Installer #{version}.pkg"
 
   uninstall quit:      "se.elektron.OverbridgeEngine",
             pkgutil:   "se.elektron.overbridge.*",

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -17,7 +17,7 @@ cask "elektron-overbridge" do
       }ix,
     )
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[5]}" }
+      page.scan(regex).map { |match| match[5].to_s }
     end
   end
 

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -17,7 +17,7 @@ cask "elektron-overbridge" do
       }ix,
     )
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[5]}," }
+      page.scan(regex).map { |match| "#{match[5]}" }
     end
   end
 

--- a/Casks/elektron-overbridge.rb
+++ b/Casks/elektron-overbridge.rb
@@ -2,17 +2,16 @@ cask "elektron-overbridge" do
   version "2.1.1.2,7fc48133-4bbc-5e3b-b646-c180686f9c2d"
   sha256 "b2a7b13a0dd4e971562d7668a9c0783c073c2be20756b762242c5480786c9af9"
 
-  url "https://se-elektron-devops.s3.amazonaws.com/release/#{version.csv.second}/Elektron_Overbridge_#{version.csv.first}.dmg",
-      verified: "se-elektron-devops.s3.amazonaws.com/release/"
+  url "https://cdn.www.elektron.se/media/downloads/overbridge/Elektron_Overbridge_#{version.csv.first}.dmg"
   name "Overbridge"
   desc "Integrate Elektron hardware into music software"
   homepage "https://www.elektron.se/overbridge/"
 
   livecheck do
-    url "https://www.elektron.se/support/?connection=overbridge"
-    regex(%r{href=.*?/(\h+(?:-\h+)*)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    url "https://www.elektron.se/us/download-support-overbridge-new"
+    regex(%r{https?:\/\/(cdn\.)?(www\.)?elektron\.se\/(media\/)?(downloads\/)?(overbridge\/)?Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+      page.scan(regex).map { |match| "#{match[5]}," }
     end
   end
 


### PR DESCRIPTION
- Copy & paste from [here](https://github.com/Homebrew/homebrew-cask-drivers/blob/fe9ec4303b63ca573f6e1229452592e5e5d038b7/Casks/elektron-overbridge.rb) via https://github.com/Homebrew/homebrew-cask-drivers/issues/3414.
- Updated `uninstall launchctl` stanza
- Fix outdated livecheck RegExp & URL
- Bump Cask version to 2.5.1