### PR TITLE
Add ente.app v1.6.35

### DIFF
--- a/Casks/ente.rb
+++ b/Casks/ente.rb
@@ -1,0 +1,25 @@
+cask "ente" do
+  version "1.6.35"
+  sha256 "d3f864a1a839f5c09f41f21c830fcbc01c90c96492b7e1d9e0bba4d3720e48ff"
+
+  url "https://github.com/ente-io/photos-desktop/releases/download/v#{version}/ente-#{version}.dmg",
+      verified: "github.com/ente-io/photos-desktop/"
+  name "Ente"
+  desc "Desktop client for Ente"
+  homepage "https://ente.io/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "ente.app"
+
+  zap trash: [
+    "~/Library/Application Support/ente",
+    "~/Library/Logs/ente",
+    "~/Library/Preferences/io.ente.bhari-frame.plist",
+    "~/Library/Preferences/io.ente.bhari-frame.helper.plist",
+    "~/Library/Saved Application State/io.ente.bhari-frame.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


brew audit failed with the following error ` - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)`

I am the maintainer of the desktop App for `ente` (https://github.com/ente-io/photos-desktop) and have been actively maintaining it from the start of the project  (past 2 years).

Is this a hard blocker for us to get added to homebrew?