### PR TITLE
remove tidal from the secure connection skiplist

### DIFF
--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -1,4 +1,3 @@
 {
-  "jaxx-liberty": "https://jaxx.io/",
-  "tidal": "https://tidal.com/"
+  "jaxx-liberty": "https://jaxx.io/"
 }


### PR DESCRIPTION
See #150900 CI checks advising the cask does not need to be on the skiplist any longer.  So, let's remove it and see if that's true.