### PR TITLE
Updated raspberry-pi-imager.rb with universal binary support

### DIFF
--- a/Casks/raspberry-pi-imager.rb
+++ b/Casks/raspberry-pi-imager.rb
@@ -1,15 +1,17 @@
 cask "raspberry-pi-imager" do
-  arch arm: "UNIVERSAL.BUILD.", intel: ""
-
   version "1.7.5"
-  sha256 arm:   "03f73b1402acd52718e27496e8c2a3778f5fc1d6845cd19b04318ffde24d6c4b",
-         intel: "bd690d70253db356965e065a6098170874dfc48f864b0c157c6dda28ac2479f7"
+  sha256 "03f73b1402acd52718e27496e8c2a3778f5fc1d6845cd19b04318ffde24d6c4b"
 
-  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/Raspberry.Pi.Imager.#{version}.#{arch}dmg",
+  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/Raspberry.Pi.Imager.#{version}.UNIVERSAL.BUILD.dmg",
       verified: "github.com/raspberrypi/rpi-imager/"
   name "Raspberry Pi Imager"
   desc "Imaging utility to install operating systems to a microSD card"
   homepage "https://www.raspberrypi.org/downloads/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "Raspberry Pi Imager.app"
 

--- a/Casks/raspberry-pi-imager.rb
+++ b/Casks/raspberry-pi-imager.rb
@@ -1,16 +1,15 @@
 cask "raspberry-pi-imager" do
-  version "1.7.5"
-  sha256 "bd690d70253db356965e065a6098170874dfc48f864b0c157c6dda28ac2479f7"
+  arch arm: "UNIVERSAL.BUILD.", intel: ""
 
-  url "https://downloads.raspberrypi.org/imager/imager_#{version}.dmg"
+  version "1.7.5"
+  sha256 arm:   "03f73b1402acd52718e27496e8c2a3778f5fc1d6845cd19b04318ffde24d6c4b",
+         intel: "bd690d70253db356965e065a6098170874dfc48f864b0c157c6dda28ac2479f7"
+
+  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/Raspberry.Pi.Imager.#{version}.#{arch}dmg",
+      verified: "github.com/raspberrypi/rpi-imager/"
   name "Raspberry Pi Imager"
   desc "Imaging utility to install operating systems to a microSD card"
   homepage "https://www.raspberrypi.org/downloads/"
-
-  livecheck do
-    url "https://downloads.raspberrypi.org/imager/imager_latest.dmg"
-    strategy :header_match
-  end
 
   app "Raspberry Pi Imager.app"
 


### PR DESCRIPTION
- Changed download url from raspberrypi site to github page.
- Added universal binary for arm maintaining old intel binary for x86_64 machine.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
