### PR TITLE
go2shell: fix curl issue

### DIFF
--- a/Casks/go2shell.rb
+++ b/Casks/go2shell.rb
@@ -2,8 +2,7 @@ cask "go2shell" do
   version "2.5"
   sha256 :no_check
 
-  url "https://zipzapmac.com/download/Go2Shell",
-      using: :homebrew_curl
+  url "https://zipzapmac.com/DMGs/Go2Shell.dmg"
   name "Go2Shell"
   desc "Opens a terminal window to the current directory in Finder"
   homepage "https://zipzapmac.com/go2shell"
@@ -14,4 +13,6 @@ cask "go2shell" do
   end
 
   app "Go2Shell.app"
+
+  zap trash: "~/Library/Preferences/com.zipzapmac.Go2Shell.plist"
 end

--- a/Casks/go2shell.rb
+++ b/Casks/go2shell.rb
@@ -2,7 +2,8 @@ cask "go2shell" do
   version "2.5"
   sha256 :no_check
 
-  url "https://zipzapmac.com/download/Go2Shell"
+  url "https://zipzapmac.com/download/Go2Shell",
+      using: :homebrew_curl
   name "Go2Shell"
   desc "Opens a terminal window to the current directory in Finder"
   homepage "https://zipzapmac.com/go2shell"


### PR DESCRIPTION
This pull request uses the Homebrew `curl` instead of the system `curl`.

On macOS 13.4.1 (22F82), `curl` version 7.88.1 results in errors. There are different errors depending on which version of `curl` is used, looking at the `--trace` dump from the various versions it wasn't immediately clear what the exact server response issue is.

Here are the `curl` versions and corresponding errors if available:

7.35.0: Ubuntu 14.04.6
curl: (60) SSL certificate problem: certificate has expired

7.79.1: macOS 12.5 (21G72)

7.88.1: macOS 13.4.1 (22F82)
curl: (1) Received HTTP/0.9 when not allowed

8.1.2: Homebrew

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The `brew audit` was run initially with Homebrew version 4.0.22, under version 4.0.28 it doesn't appear to work.