### PR TITLE
libreoffice: specify/differentiate description

### DIFF
--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -9,7 +9,7 @@ cask "libreoffice" do
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice"
-  desc "Office suite"
+  desc "Free cross-platform office suite, fresh version recommended for technology enthusiasts"
   homepage "https://www.libreoffice.org/"
 
   livecheck do

--- a/Casks/libreoffice.rb
+++ b/Casks/libreoffice.rb
@@ -9,7 +9,7 @@ cask "libreoffice" do
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice"
-  desc "Free cross-platform office suite, fresh version recommended for technology enthusiasts"
+  desc "Free cross-platform office suite, fresh version"
   homepage "https://www.libreoffice.org/"
 
   livecheck do


### PR DESCRIPTION
Specifies description to expand on what kind of office suite LibreOffice offers. Differentiates description from [libreoffice-still.rb in homebrew-cask-versions](https://github.com/Homebrew/homebrew-cask-versions/blob/master/Casks/libreoffice-still.rb), adding information from https://www.libreoffice.org/download/release-notes/#Fresh.

`Office suite` -> `Free cross-platform office suite, fresh version recommended for technology enthusiasts`

The wording "fresh version recommended for technology enthusiasts" comes from (bolding added for emphasis):
> "The latest "**fresh**" version of LibreOffice, **recommended for technology enthusiasts**, which contains new features and program enhancements. This version may contain a few annoying bugs which will be fixed in the next bugfix versions to come."–https://www.libreoffice.org/download/release-notes/#Fresh

This differentiation is improved by https://github.com/Homebrew/homebrew-cask-versions/pull/17143

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
