### PR TITLE
one-switch: update url to use universal dmg

### DIFF
--- a/Casks/one-switch.rb
+++ b/Casks/one-switch.rb
@@ -1,8 +1,8 @@
 cask "one-switch" do
   version "1.31,392"
-  sha256 "f7ce936a1ff37403226deac19dc65d82369ff24442f616e1b2ac468be74f3fd7"
+  sha256 "ba090841303e008c499b4d2ec91854d42f01245becb6e4a1bbec23be7d353c1f"
 
-  url "https://fireball.studio/api/release_manager/downloads/studio.fireball.OneSwitch/#{version.csv.second}.zip"
+  url "https://fireball.studio/media/uploads/files/OneSwitchOfficial-#{version.csv.second}.dmg"
   name "One Switch"
   desc "All system and utility switches in one place"
   homepage "https://fireball.studio/oneswitch"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

This should close #151074.  Investigating the downloads provided by upstream, the `sparkle` file being used for `livecheck` references a `.zip` file which was being used as the download link.  This was only providing an `x86_64` compatible binary.

The `.dmg` file updated here provides a universal binary.