### PR TITLE
Update ytmdesktop from 1.13.0 to 1.14.2

### DIFF
--- a/Casks/ytmdesktop-youtube-music.rb
+++ b/Casks/ytmdesktop-youtube-music.rb
@@ -8,6 +8,8 @@ cask "ytmdesktop-youtube-music" do
   desc "YouTube music client"
   homepage "https://ytmdesktop.app/"
 
+  container nested: "YouTube Music Desktop App-#{version}.dmg"
+
   app "YouTube Music Desktop App.app"
 
   zap trash: [

--- a/Casks/ytmdesktop-youtube-music.rb
+++ b/Casks/ytmdesktop-youtube-music.rb
@@ -8,11 +8,6 @@ cask "ytmdesktop-youtube-music" do
   desc "YouTube music client"
   homepage "https://ytmdesktop.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   container nested: "YouTube Music Desktop App-#{version}.dmg"
 
   app "YouTube Music Desktop App.app"

--- a/Casks/ytmdesktop-youtube-music.rb
+++ b/Casks/ytmdesktop-youtube-music.rb
@@ -2,7 +2,7 @@ cask "ytmdesktop-youtube-music" do
   version "1.14.2"
   sha256 "d7fb0b2dbe54469b39fc1c2daf0f17e65b0d84d4a2c171998c41c7691a378f0d"
 
-  url "https://github.com/ytmdesktop/ytmdesktop/releases/download/#{version}/ytm-desktop_macos-#{version.gsub(".", "_")}.zip",
+  url "https://github.com/ytmdesktop/ytmdesktop/releases/download/#{version}/ytm-desktop_macos-#{version.tr(".", "_")}.zip",
       verified: "github.com/ytmdesktop/"
   name "YouTube Music Desktop App"
   desc "YouTube music client"
@@ -12,6 +12,8 @@ cask "ytmdesktop-youtube-music" do
     url :url
     strategy :github_latest
   end
+
+  container nested: "YouTube Music Desktop App-#{version}.dmg"
 
   app "YouTube Music Desktop App.app"
 

--- a/Casks/ytmdesktop-youtube-music.rb
+++ b/Casks/ytmdesktop-youtube-music.rb
@@ -8,8 +8,6 @@ cask "ytmdesktop-youtube-music" do
   desc "YouTube music client"
   homepage "https://ytmdesktop.app/"
 
-  container nested: "YouTube Music Desktop App-#{version}.dmg"
-
   app "YouTube Music Desktop App.app"
 
   zap trash: [

--- a/Casks/ytmdesktop-youtube-music.rb
+++ b/Casks/ytmdesktop-youtube-music.rb
@@ -1,8 +1,8 @@
 cask "ytmdesktop-youtube-music" do
-  version "1.13.0"
-  sha256 "074e95032a51d7787eed8c4ee2b19046676d72e0cba5cca59af7cc6f79d3887e"
+  version "1.14.2"
+  sha256 "d7fb0b2dbe54469b39fc1c2daf0f17e65b0d84d4a2c171998c41c7691a378f0d"
 
-  url "https://github.com/ytmdesktop/ytmdesktop/releases/download/v#{version}/YouTube-Music-Desktop-App-#{version}.dmg",
+  url "https://github.com/ytmdesktop/ytmdesktop/releases/download/#{version}/ytm-desktop_macos-#{version.gsub(".", "_")}.zip",
       verified: "github.com/ytmdesktop/"
   name "YouTube Music Desktop App"
   desc "YouTube music client"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -31,5 +31,6 @@
   "themeengine": "all",
   "universal-android-debloater": "all",
   "virtualbuddy": "all",
-  "xit": "all"
+  "xit": "all",
+  "ytmdesktop-youtube-music": "all"
 }


### PR DESCRIPTION
This is my first PR to brew so be gentle. I'm neither a ruby developer. :)

Waiting on confirmation that the version is a stable version. Last stable version was released in 2020 and the repo seems inactive.
https://github.com/ytmdesktop/ytmdesktop/issues/205#issuecomment-1427877690
https://github.com/ytmdesktop/ytmdesktop/issues/1092

Is there any guide on how to test locally?
EDIT: When I did than it was working and I got the latest version. I'm not sure if I miss something though. Happily taking feedback.

```
brew edit ytmdesktop-youtube-music
HOMEBREW_NO_INSTALL_FROM_API=1 brew install ytmdesktop-youtube-music
```
**Important:** _Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process._

In the following questions `<cask>` is the token of the cask you're submitting.

After making all changes to a cask, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [ ]  Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.