### PR TITLE
opensesame 4.0.1

### DIFF
--- a/Casks/opensesame.rb
+++ b/Casks/opensesame.rb
@@ -1,8 +1,8 @@
 cask "opensesame" do
-  version "3.3.14"
-  sha256 "36f7dfc092a8a6531ca4b94f979a581ffbeb83bc007cb8cf0d9dd3aa280a6ff3"
+  version "4.0.1"
+  sha256 "8912e2f77d8fa58b2f91958aa7139d733334f7b16f96b75db88f9f5df8a05eec"
 
-  url "https://github.com/open-cogsci/OpenSesame/releases/download/release%2F#{version}/opensesame_#{version}-py37-macos-x64-1.dmg",
+  url "https://github.com/open-cogsci/OpenSesame/releases/download/release%2F#{version}/opensesame_#{version}-py311-macos-x64-1.dmg",
       verified: "github.com/open-cogsci/OpenSesame/"
   name "OpenSesame"
   desc "Graphical experiment builder for the social sciences"
@@ -10,8 +10,13 @@ cask "opensesame" do
 
   livecheck do
     url :url
-    regex(%r{^release[/._-]v?(\d+(?:\.\d+)+)$}i)
+    strategy :github_latest
   end
 
   app "OpenSesame.app"
+
+  zap trash: [
+    "~/.opensesame",
+    "~/Library/Preferences/com.cogscinl.default.plist",
+  ]
 end


### PR DESCRIPTION
* Update to version 4.0.1

* Update url to latest format

* Update livecheck to use `:github_latest` to avoid pulling in patch updates which are source only and downloaded through the application

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.