### PR TITLE
Fix checksum in Tunnelbear 5.1.0 cask

### DIFF
--- a/Casks/tunnelbear.rb
+++ b/Casks/tunnelbear.rb
@@ -5,7 +5,7 @@ cask "tunnelbear" do
   end
   on_big_sur :or_newer do
     version "5.1.0"
-    sha256 "818456b86fb0aaf9a1a0855990a2b5575a5f70ecb1ec344062c5ba423003f31f"
+    sha256 "80b7ddebacb08de0c29e4beffae70ba1c536056f6ec6d668e7845ddd8b3105e2"
   end
 
   url "https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-#{version}.zip",


### PR DESCRIPTION
This PR fixes the `Error: SHA256 mismatch` error for Tunnelbear 5.1.0 cask:

<img width="815" alt="Screenshot 2023-07-15 at 15 52 38" src="https://github.com/Homebrew/homebrew-cask/assets/1451690/dc90778b-a0f9-4467-9e46-df63cbf4ad88">

It turns out the sha256 sum currently specified for the 5.1.0 version of the cask in question – `818456b86fb0aaf9a1a0855990a2b5575a5f70ecb1ec344062c5ba423003f31f` – is for the unversioned url: `https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear.zip`, while the versioned one `https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-5.1.0.zip` has the sha256 sum specified in this PR. I double-checked both sums using the `shasum -a 256 ~/Downloads/TunnelBear{,-5.1.0}.zip` command.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.