### PR TITLE
singularity: use https:// schema

### DIFF
--- a/Casks/singularity.rb
+++ b/Casks/singularity.rb
@@ -6,10 +6,10 @@ cask "singularity" do
       verified: "bitbucket.org/router_gray/singularityviewer/"
   name "Singularity Viewer"
   desc "Client for Second Life and OpenSim"
-  homepage "http://www.singularityviewer.org/"
+  homepage "https://www.singularityviewer.org/"
 
   livecheck do
-    url "http://www.singularityviewer.org/downloads"
+    url "https://www.singularityviewer.org/downloads"
     strategy :page_match do |page|
       v = page[/Singularity[._-]?Alpha[._-]?(\d+(?:_\d+)*)[._-]?x86_64\.dmg/i, 1]
       v.tr("_", ".")


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---

> Homepage link http://www.singularityviewer.org/ is a permanent redirect to its HTTPS counterpart https://www.singularityviewer.org/ and should be updated.

As recommended by repology in https://repology.org/repository/homebrew_casks/problems

