### PR TITLE
time-lapse-assembler. use https:// schema

### DIFF
--- a/Casks/time-lapse-assembler.rb
+++ b/Casks/time-lapse-assembler.rb
@@ -2,10 +2,10 @@ cask "time-lapse-assembler" do
   version "1.5.3"
   sha256 :no_check
 
-  url "http://www.dayofthenewdan.com/TimeLapseAssembler.dmg"
+  url "https://www.dayofthenewdan.com/TimeLapseAssembler.dmg"
   name "Time Lapse Assembler"
   desc "Tool to create movies from a sequence of images"
-  homepage "http://www.dayofthenewdan.com/projects/time-lapse-assembler-1/"
+  homepage "https://www.dayofthenewdan.com/projects/time-lapse-assembler-1/"
 
   livecheck do
     url :url


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---

> Homepage link http://www.dayofthenewdan.com/projects/time-lapse-assembler-1/ is a permanent redirect to its HTTPS counterpart https://www.dayofthenewdan.com/projects/time-lapse-assembler-1/ and should be updated. 
> Download link http://www.dayofthenewdan.com/TimeLapseAssembler.dmg is a permanent redirect to its HTTPS counterpart https://www.dayofthenewdan.com/TimeLapseAssembler.dmg and should be updated. 

As recommended by repology in https://repology.org/repository/homebrew_casks/problems