### PR TITLE
Add GSteamer Framework version 1.22.4

### DIFF
--- a/Casks/gstreamer.rb
+++ b/Casks/gstreamer.rb
@@ -1,0 +1,41 @@
+cask "gstreamer" do
+  version "1.22.4"
+  sha256 "739da4bcb2994e441a1efb8a647e32ce0fd9322a2b99f15ccf3b0fb139a836e2"
+
+  url "https://gstreamer.freedesktop.org/data/pkg/osx/#{version}/gstreamer-1.0-#{version}-universal.pkg"
+  name "GStreamer"
+  desc "Open Source Multimedia Framework"
+  homepage "https://gstreamer.freedesktop.org/"
+
+  livecheck do
+    url "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tags?format=atom"
+    regex(%r{<title>(\d+(?:\.\d+)+)</title>}i)
+  end
+
+  pkg "gstreamer-1.0-#{version}-universal.pkg"
+
+  uninstall pkgutil: [
+    "org.freedesktop.gstreamer.universal.base-crypto",
+    "org.freedesktop.gstreamer.universal.base-system-1.0",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-capture",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-codecs-gpl",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-codecs-restricted",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-codecs",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-core",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-devtools",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-dvd",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-editing",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-effects",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-encoding",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-libav",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-net-restricted",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-net",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-playback",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-qt5",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-system",
+    "org.freedesktop.gstreamer.universal.gstreamer-1.0-visualizers",
+    "org.freedesktop.gstreamer.universal.GStreamer",
+  ]
+
+  caveats "This cask installs GStreamer.framework into /Library/Frameworks/"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


`brew audit --new-cask`complains about a possible duplication/conflict. The cask installs GStreamer to `/Library/Frameworks/GStreamer.framework`, though. So, both can live side by side.