### PR TITLE
Update MacMediaKeyForwarder sha256

### DIFF
--- a/Casks/macmediakeyforwarder.rb
+++ b/Casks/macmediakeyforwarder.rb
@@ -1,6 +1,6 @@
 cask "macmediakeyforwarder" do
   version "3.1.2"
-  sha256 "ae6a593a4e3f8e28351911e12df208275f14f781e9c3e0c11f9ba33105415751"
+  sha256 "3e2c8ae7fbc9190e9c7528a3c4799ae42e6a33ddaf27f5cf01e141a0b9d6cd04"
 
   url "https://github.com/quentinlesceller/macmediakeyforwarder/releases/download/v#{version}/MacMediaKeyForwarder.zip"
   name "Mac Media Key Forwarder"


### PR DESCRIPTION
I've changed the binary and thus the formula is now broken. This SHA256 is the correct one.