### PR TITLE
Fix izotope-product-portal 1.4.8's checksum

### DIFF
--- a/Casks/izotope-product-portal.rb
+++ b/Casks/izotope-product-portal.rb
@@ -1,6 +1,6 @@
 cask "izotope-product-portal" do
   version "1.4.8"
-  sha256 "e8163cd61a4cb5280cf8e6a31ee67807c5f5a751971d804c0011efb3d66b07cd"
+  sha256 "5f4ea1f17723630b3512598da86086a661a05880cdd9a33aad1b0f2aafc402ff"
 
   url "https://s3.amazonaws.com/izotopedownloads/product_download/iZotope_Product_Portal_v#{version.dots_to_underscores}.dmg",
       verified: "s3.amazonaws.com/izotopedownloads/"


### PR DESCRIPTION
They must have replaced the file for a patch release

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
