### PR TITLE
ci_matrix: convert version symbols to MacOSVersion

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -52,7 +52,10 @@ module CiMatrix
 
     filtered_runners = RUNNERS.select do |runner, _|
       required_macos.any? do |r|
-        MacOSVersion.from_symbol(runner.fetch(:symbol)).compare(r.fetch(:comparator), r.fetch(:version))
+        MacOSVersion.from_symbol(runner.fetch(:symbol)).compare(
+          r.fetch(:comparator),
+          MacOSVersion.from_symbol(r.fetch(:version)),
+        )
       end
     end
     return filtered_runners unless filtered_runners.empty?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Recent PRs are failing (e.g., #151427) with Sorbet errors due to the `version` symbols in `ci_matrix.rb`'s `#filter_runners` method being a symbol instead of a `Version` object. This PR attempts to resolve the error by converting the version symbols to `MacOSVersion` objects (which inherits from `Version` and _should_ work with the existing type signature).

I will be away for the next few hours but feel free to test this with affected PRs, make any necessary changes, etc. in the interim time.