### PR TITLE
Bump 'Bluesnooze' cask from v1.1 to v1.2

### DIFF
--- a/Casks/bluesnooze.rb
+++ b/Casks/bluesnooze.rb
@@ -1,13 +1,13 @@
 cask "bluesnooze" do
-  version "1.1"
-  sha256 "377badb146885f71eb3aeae25036c4ef00b0a6c2a1627b575f54dfbc4569bfb1"
+  version "1.2"
+  sha256 "075a8b7cf8f66d4f4002c62a1985a5d3fb043e3df09e7fd405e88ce24a96feb0"
 
   url "https://github.com/odlp/bluesnooze/releases/download/v#{version}/Bluesnooze.zip"
   name "Bluesnooze"
   desc "Prevents your sleeping computer from connecting to Bluetooth accessories"
   homepage "https://github.com/odlp/bluesnooze"
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :monterey"
 
   app "Bluesnooze.app"
 


### PR DESCRIPTION
Hello,

I'm the author of Bluesnooze and would like to bump the Homebrew version from v1.1 to v1.2:

https://github.com/odlp/bluesnooze/releases/tag/v1.2

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
  - Expected failure? `Version '1.1' differs from '1.2' retrieved by livecheck`
- [x] `brew style --fix <cask>` reports no offenses.
