### PR TITLE
Fix displaylink license url

### DIFF
--- a/Casks/displaylink.rb
+++ b/Casks/displaylink.rb
@@ -77,6 +77,6 @@ cask "displaylink" do
 
   caveats do
     reboot
-    license "https://www.synaptics.com/products/displaylink-graphics/downloads/macos-#{version.csv.first}"
+    license "https://www.synaptics.com/products/displaylink-graphics/downloads/macos-connectivity-#{version.csv.first}"
   end
 end


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.