### PR TITLE
Update chromedriver to v115

### DIFF
--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -21,7 +21,7 @@ cask "chromedriver" do
 
   conflicts_with cask: "homebrew/cask-versions/chromedriver-beta"
 
-  binary "chromedriver"
+  binary "chromedriver-mac-#{arch}/chromedriver"
 
   # No zap stanza required
 end

--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -1,19 +1,22 @@
 cask "chromedriver" do
-  arch arm: "mac_arm64", intel: "mac64"
+  arch arm: "arm64", intel: "x64"
 
-  version "114.0.5735.90"
-  sha256 arm:   "14eb3a1642a829fcbc11ef22e113b2f6a2340c4f4e235e5494b414c4834fa47c",
-         intel: "6abdc9d358c2bc4668bef7b23048de2a9dbd3ad82cfbc6dfe322e74d4cff1650"
+  version "115.0.5790.102"
+  sha256 arm:   "9badcef71d8b4ffdd286b5be7088372a50f0168488ff714335a05110c99986b1",
+         intel: "47410a535ab6f8ba170026fd4fd3059d44b6685843792692832cd94abf4846e0"
 
-  url "https://chromedriver.storage.googleapis.com/#{version}/chromedriver_#{arch}.zip",
-      verified: "chromedriver.storage.googleapis.com/"
+  url "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/#{version}/mac-#{arch}/chromedriver-mac-#{arch}.zip",
+      verified: "edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/"
   name "ChromeDriver"
   desc "Automated testing of webapps for Google Chrome"
-  homepage "https://sites.google.com/chromium.org/driver/"
+  homepage "https://chromedriver.chromium.org/"
 
   livecheck do
-    url "https://chromedriver.storage.googleapis.com/LATEST_RELEASE"
+    url "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
     regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :json do |json, regex|
+      json["channels"]["stable"]["version"]&.scan(regex) { |match| match[0] }
+    end
   end
 
   conflicts_with cask: "homebrew/cask-versions/chromedriver-beta"

--- a/Casks/chromedriver.rb
+++ b/Casks/chromedriver.rb
@@ -15,7 +15,7 @@ cask "chromedriver" do
     url "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
     regex(/v?(\d+(?:\.\d+)+)/i)
     strategy :json do |json, regex|
-      json["channels"]["stable"]["version"]&.scan(regex) { |match| match[0] }
+      json["channels"]["Stable"]["version"]&.scan(regex) { |match| match[0] }
     end
   end
 


### PR DESCRIPTION
According to the information on the [official homepage](https://chromedriver.chromium.org/), starting from version 115 ChromeDriver is provided on the new endpoints. Also new method should be used to check for the latest version. This PR updates ChromeDriver to the latest version and changes endpoints for downloading and version checking.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.