### PR TITLE
Housekeeping: various qlplugin updates (add no zap, add desc)

### DIFF
--- a/Casks/avifquicklook.rb
+++ b/Casks/avifquicklook.rb
@@ -8,4 +8,6 @@ cask "avifquicklook" do
   homepage "https://github.com/dreampiggy/AVIFQuickLook"
 
   qlplugin "AVIFQuickLook.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/inloop-qlplayground.rb
+++ b/Casks/inloop-qlplayground.rb
@@ -4,7 +4,10 @@ cask "inloop-qlplayground" do
 
   url "https://github.com/inloop/qlplayground/releases/download/v#{version}/inloop-qlplayground.v#{version}.zip"
   name "inloop-qlplayground"
+  desc "QuickLook generator for Xcode Playgrounds"
   homepage "https://github.com/inloop/qlplayground"
 
   qlplugin "inloop-qlplayground.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/jupyter-notebook-ql.rb
+++ b/Casks/jupyter-notebook-ql.rb
@@ -4,9 +4,12 @@ cask "jupyter-notebook-ql" do
 
   url "https://github.com/jendas1/jupyter-notebook-quick-look/releases/download/v#{version}/jupyter-notebook-quick-look.qlgenerator.zip"
   name "Jupyter Notebook Quick Look"
+  desc "QuickLook plugin for Jupyter notebooks"
   homepage "https://github.com/jendas1/jupyter-notebook-quick-look"
 
   qlplugin "jupyter-notebook-quick-look.qlgenerator"
+
+  # No zap stanza required
 
   caveats <<~EOS
     You need python 3 and the nbconvert module to use this plugin.

--- a/Casks/qladdict.rb
+++ b/Casks/qladdict.rb
@@ -4,7 +4,10 @@ cask "qladdict" do
 
   url "https://github.com/tattali/QLAddict/releases/download/#{version}/QLAddict.qlgenerator.#{version}.zip"
   name "QLAddict"
+  desc "QuickLook plugin for subtitle (.srt) files"
   homepage "https://github.com/tattali/QLAddict/"
 
   qlplugin "QLAddict.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/qlcommonmark.rb
+++ b/Casks/qlcommonmark.rb
@@ -4,7 +4,10 @@ cask "qlcommonmark" do
 
   url "https://github.com/digitalmoksha/QLCommonMark/releases/download/v#{version}/QLCommonMark.qlgenerator.zip"
   name "QLCommonMark"
+  desc "QuickLook plugin for CommonMark and Markdown"
   homepage "https://github.com/digitalmoksha/QLCommonMark/"
 
   qlplugin "QLCommonMark.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/qlfits.rb
+++ b/Casks/qlfits.rb
@@ -4,6 +4,7 @@ cask "qlfits" do
 
   url "https://github.com/onekiloparsec/QLFits/releases/download/#{version}/QLFits#{version.major}.qlgenerator.zip"
   name "QLFits"
+  desc "QuickLook plugin to view FITS files"
   homepage "https://github.com/onekiloparsec/QLFits"
 
   qlplugin "QLFits#{version.major}.qlgenerator"

--- a/Casks/qlgradle.rb
+++ b/Casks/qlgradle.rb
@@ -4,7 +4,10 @@ cask "qlgradle" do
 
   url "https://github.com/Urucas/QLGradle/releases/download/#{version}/QLGradle.qlgenerator.zip"
   name "qlgradle"
+  desc "QuickLook plugin for viewing gradle files"
   homepage "https://github.com/Urucas/QLGradle"
 
   qlplugin "QLGradle.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/qlmobi.rb
+++ b/Casks/qlmobi.rb
@@ -8,4 +8,6 @@ cask "qlmobi" do
   homepage "https://github.com/bfabiszewski/QLMobi"
 
   qlplugin "QLMobi.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/qlnetcdf.rb
+++ b/Casks/qlnetcdf.rb
@@ -4,7 +4,10 @@ cask "qlnetcdf" do
 
   url "https://github.com/tobeycarman/QLNetcdf/releases/download/v#{version}/QLNetcdf.qlgenerator.zip"
   name "QLNetcdf"
+  desc "QuickLook plugin for viewing NetCDF files"
   homepage "https://github.com/tobeycarman/QLNetcdf/"
 
   qlplugin "QLNetcdf.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/qlplayground.rb
+++ b/Casks/qlplayground.rb
@@ -4,7 +4,10 @@ cask "qlplayground" do
 
   url "https://github.com/norio-nomura/qlplayground/releases/download/#{version}/qlplayground.qlgenerator-#{version}.zip"
   name "qlplayground"
+  desc "QuickLook plugin for Swift files"
   homepage "https://github.com/norio-nomura/qlplayground"
 
   qlplugin "qlplayground.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/qlprettypatch.rb
+++ b/Casks/qlprettypatch.rb
@@ -4,6 +4,7 @@ cask "qlprettypatch" do
 
   url "https://github.com/atnan/QLPrettyPatch/releases/download/v#{version}/QLPrettyPatch.qlgenerator.zip"
   name "QLPrettyPatch"
+  desc "QuickLook plugin to view patch files"
   homepage "https://github.com/atnan/QLPrettyPatch"
 
   qlplugin "QLPrettyPatch.qlgenerator"

--- a/Casks/qlswift.rb
+++ b/Casks/qlswift.rb
@@ -4,7 +4,10 @@ cask "qlswift" do
 
   url "https://github.com/lexrus/QLSwift/releases/download/#{version}/QLSwift.qlgenerator.zip"
   name "QLSwift"
+  desc "QuickLook plugin for Swift files"
   homepage "https://github.com/lexrus/QLSwift"
 
   qlplugin "QLSwift.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/quickgeojson.rb
+++ b/Casks/quickgeojson.rb
@@ -4,7 +4,10 @@ cask "quickgeojson" do
 
   url "https://github.com/irees/quickgeojson/releases/download/v#{version}/quickgeojson.qlgenerator.zip"
   name "quickgeojson"
+  desc "QuickLook plugin for GeoJSON and TopoJSON"
   homepage "https://github.com/irees/quickgeojson"
 
   qlplugin "quickgeojson.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/quickjson.rb
+++ b/Casks/quickjson.rb
@@ -4,7 +4,10 @@ cask "quickjson" do
 
   url "https://github.com/johan/QuickJSON/releases/download/v#{version}/QuickJSON.qlgenerator.zip"
   name "QuickJSON"
+  desc "QuickLook plugin to pretty-print JSON"
   homepage "https://github.com/johan/QuickJSON"
 
   qlplugin "QuickJSON.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/quicknfo.rb
+++ b/Casks/quicknfo.rb
@@ -4,7 +4,10 @@ cask "quicknfo" do
 
   url "https://github.com/The-Master777/QuickNFO/releases/download/v#{version}/QuickNFO.qlgenerator.zip"
   name "QuickNFO"
+  desc "QuickLook plugin for viewing NFO files"
   homepage "https://github.com/planbnet/QuickNFO"
 
   qlplugin "QuickNFO.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/receiptquicklook.rb
+++ b/Casks/receiptquicklook.rb
@@ -4,7 +4,10 @@ cask "receiptquicklook" do
 
   url "https://github.com/letiemble/ReceiptQuickLook/releases/download/#{version}/ReceiptQuickLook.qlgenerator.zip"
   name "ReceiptQuickLook"
+  desc "QuickLook plugin to visualize App Store cryptographic receipts"
   homepage "https://github.com/letiemble/ReceiptQuickLook"
 
   qlplugin "ReceiptQuickLook.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/scriptql.rb
+++ b/Casks/scriptql.rb
@@ -13,4 +13,6 @@ cask "scriptql" do
   end
 
   qlplugin "ScriptQL.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/stringsfile.rb
+++ b/Casks/stringsfile.rb
@@ -4,6 +4,7 @@ cask "stringsfile" do
 
   url "https://blog.timac.org/2014/0325-quicklook-plugin-to-preview-strings-files/StringsFile.qlgenerator.zip"
   name "StringsFile QuickLook plugin"
+  desc "QuickLook plugin to preview .strings files"
   homepage "https://blog.timac.org/?p=933"
 
   livecheck do
@@ -12,4 +13,6 @@ cask "stringsfile" do
   end
 
   qlplugin "StringsFile.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/toland-qlmarkdown.rb
+++ b/Casks/toland-qlmarkdown.rb
@@ -9,6 +9,8 @@ cask "toland-qlmarkdown" do
 
   qlplugin "QLMarkdown.qlgenerator"
 
+  # No zap stanza required
+
   caveats do
     discontinued
   end

--- a/Casks/ttscoff-mmd-quicklook.rb
+++ b/Casks/ttscoff-mmd-quicklook.rb
@@ -4,7 +4,10 @@ cask "ttscoff-mmd-quicklook" do
 
   url "https://github.com/ttscoff/MMD-QuickLook/releases/download/#{version}/MMD-QuickLook#{version}.zip"
   name "MMD-QuickLook"
+  desc "QuickLook plugin for viewing MultiMarkdown"
   homepage "https://github.com/ttscoff/mmd-quicklook"
 
   qlplugin "MultiMarkdown QuickLook.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/voxql.rb
+++ b/Casks/voxql.rb
@@ -4,6 +4,7 @@ cask "voxql" do
 
   url "https://github.com/heptal/VoxQL/releases/download/#{version}/VoxQL.qlgenerator.zip"
   name "voxql"
+  desc "QuickLook generator for MagicaVoxel files"
   homepage "https://github.com/heptal/VoxQL"
 
   qlplugin "VoxQL.qlgenerator"

--- a/Casks/voxql.rb
+++ b/Casks/voxql.rb
@@ -7,4 +7,6 @@ cask "voxql" do
   homepage "https://github.com/heptal/VoxQL"
 
   qlplugin "VoxQL.qlgenerator"
+
+  # No zap stanza required
 end

--- a/Casks/webpquicklook.rb
+++ b/Casks/webpquicklook.rb
@@ -5,6 +5,7 @@ cask "webpquicklook" do
   url "https://raw.githubusercontent.com/emin/WebPQuickLook/master/WebpQuickLook.tar.gz",
       verified: "raw.githubusercontent.com/emin/WebPQuickLook/"
   name "WebPQuickLook"
+  desc "QuickLook plugin for webp files"
   homepage "https://github.com/emin/WebPQuickLook"
 
   livecheck do


### PR DESCRIPTION
Doing some housekeeping, and found there are a good number of `casks` that are `qlplugins` without a `zap` stanza and do not need one.

This submission is only for casks that can be marked `no zap stanza required` and are a `qlplugin` to help get them off the `missing zap` list.

Some of these due to their age may also not have a `desc` block, so that will be added as needed.

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
