### PR TITLE
case-sensitive battery.rb

### DIFF
--- a/Casks/battery.rb
+++ b/Casks/battery.rb
@@ -9,7 +9,7 @@ cask "battery" do
 
   depends_on arch: :arm64
 
-  app "Battery.app"
+  app "battery.app"
 
   uninstall delete: "/usr/local/bin/smc"
 


### PR DESCRIPTION
Although this cask specifies an upper-case `Battery.app`, the project releases it as `battery.app` (or has since at least 1.1.3).

For systems with case-sensitive filesystems, this matters.

Since this does not bump the version but merely changes the case of the app bundle to match the origin project, I've been pretty casual about validation. Without this change, `brew install --cask battery` fails with:
```
Error: It seems the App source '/opt/homebrew/Caskroom/battery/1.1.5/Battery.app' is not there.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
