### PR TITLE
Update checksum for Screens 4.12.10b1689789098

### DIFF
--- a/Casks/screens.rb
+++ b/Casks/screens.rb
@@ -1,6 +1,6 @@
 cask "screens" do
   version "4.12.10,1689789098"
-  sha256 "edf188f25384d7c39857fec9ce491aedf7176bd6b52ea5b41c5e433285cdfe8c"
+  sha256 "2b971afaa18076d46eee213b432ad86beb429c64eb97a76a9074c9751ab0887b"
 
   url "https://updates.edovia.com/com.edovia.screens#{version.major}.mac/Screens_#{version.csv.first}b#{version.csv.second}.zip"
   name "Screens"


### PR DESCRIPTION
Checksum has changed without a change of version number (confirmed at https://edovia.com/en/screens-mac/)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
