### PR TITLE
Add cask for google-chrome-for-testing

### DIFF
--- a/Casks/google-chrome-for-testing.rb
+++ b/Casks/google-chrome-for-testing.rb
@@ -22,4 +22,5 @@ cask "google-chrome-for-testing" do
   depends_on macos: ">= :high_sierra"
 
   app "chrome-mac-#{arch}/Google Chrome for Testing.app"
+  binary "#{appdir}/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
 end

--- a/Casks/google-chrome-for-testing.rb
+++ b/Casks/google-chrome-for-testing.rb
@@ -1,0 +1,25 @@
+cask "google-chrome-for-testing" do
+  arch arm: "arm64", intel: "x64"
+
+  version "115.0.5790.102"
+  sha256 arm:   "ceaf0b0140520a9f931185a44411b8aa8b88d03dcbc4e54b098ffaf028f6bf84",
+         intel: "76e2fbb782e195259e7e7873ffca0e7270d52066af79a0d401c92d66382420ec"
+
+  url "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/#{version}/mac-#{arch}/chrome-mac-#{arch}.zip",
+      verified: "edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/"
+  name "Google Chrome for Testing"
+  desc "Web browser for testing and automation use cases"
+  homepage "https://developer.chrome.com/blog/chrome-for-testing/"
+
+  livecheck do
+    url "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+    regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :json do |json, regex|
+      json["channels"]["Stable"]["version"]&.scan(regex) { |match| match[0] }
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "chrome-mac-#{arch}/Google Chrome for Testing.app"
+end


### PR DESCRIPTION
[Chrome for Testing](https://developer.chrome.com/blog/chrome-for-testing/) is a new Chrome flavor that specifically targets web app testing and automation use cases. It's stable and required for the latest version of chromedriver.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
