### PR TITLE
cakebrewjs: avoid js redirect of homepage url

### DIFF
--- a/Casks/cakebrewjs.rb
+++ b/Casks/cakebrewjs.rb
@@ -5,7 +5,7 @@ cask "cakebrewjs" do
   url "https://downloads.sourceforge.net/cakebrewjs/v#{version}/cakebrewjs-#{version}-mac.zip"
   name "cakebrewjs"
   desc "Homebrew GUI app written in electron"
-  homepage "https://sourceforge.net/projects/cakebrewjs"
+  homepage "https://sourceforge.net/projects/cakebrewjs/"
 
   livecheck do
     url "https://sourceforge.net/projects/cakebrewjs/rss?"


### PR DESCRIPTION
Fix a repology report per https://repology.org/repository/homebrew_casks/problems

> Homepage link https://sourceforge.net/projects/cakebrewjs needs a trailing slash added, otherwise there's a javascript redirect.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.