### PR TITLE
idisplay: add https:// schema

### DIFF
--- a/Casks/idisplay.rb
+++ b/Casks/idisplay.rb
@@ -4,7 +4,7 @@ cask "idisplay" do
 
   url "https://getidisplay.com/downloads/iDisplayMac.dmg"
   name "iDisplay"
-  homepage "http://getidisplay.com/"
+  homepage "https://getidisplay.com/"
 
   livecheck do
     url :url


### PR DESCRIPTION
Fix repology report per https://repology.org/repository/homebrew_casks/problems 

> Homepage link http://getidisplay.com/ is a permanent redirect to its HTTPS counterpart https://getidisplay.com/ and should be updated.

---- 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.