### PR TITLE
idisplay: add desc

### DIFF
--- a/Casks/idisplay.rb
+++ b/Casks/idisplay.rb
@@ -4,6 +4,7 @@ cask "idisplay" do
 
   url "https://getidisplay.com/downloads/iDisplayMac.dmg"
   name "iDisplay"
+  desc "Use a tablet as an extra screen"
   homepage "https://getidisplay.com/"
 
   livecheck do


### PR DESCRIPTION
Adding the missing `desc` field

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
