### PR TITLE
fix: Add missing Cask rename: sublime-text3 -> sublime-text

### DIFF
--- a/cask_renames.json
+++ b/cask_renames.json
@@ -1,4 +1,5 @@
 {
   "ankerslicer": "ankermake",
-  "cloudapp": "zight"
+  "cloudapp": "zight",
+  "sublime-text3": "sublime-text"
 }


### PR DESCRIPTION
It looks like this was missed, and I'm sure I'm not alone with having run into upgrade problems on old macOS systems.  I have a few macbooks that are still apparently stuck on this old version. (I'm not using them as a daily driver, but this was preventing them from a clean upgrade via automation / config management tools).

Refs:

- Cask removed in: Homebrew/homebrew-cask-versions@8d7ef627f6889b3ceabe0a7c4ad2ea9c1f2992b5
- Tap Migration PR: Homebrew/homebrew-cask-versions#17278
- Fixes: LyraPhase/sprout-wrap#196

This PR should be merged with its companion: Homebrew/homebrew-cask-versions#17278

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: <kbd>N/A</kbd>

- [N/A] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [N/A] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [N/A] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [N/A] `brew audit --new-cask <cask>` worked successfully.
- [N/A] `brew install --cask <cask>` worked successfully.
- [N/A] `brew uninstall --cask <cask>` worked successfully.
