### PR TITLE
Latest emacs 29.1 cask updated

### DIFF
--- a/Casks/emacs.rb
+++ b/Casks/emacs.rb
@@ -1,8 +1,8 @@
 cask "emacs" do
   arch arm: "arm64-11", intel: "x86_64-10_11"
 
-  version "28.2"
-  sha256 "b2bd1f0dcdc8e5be37f613310572b23e022cc42b950cb3860a9f4aaad1fd426a"
+  version "29.1"
+  sha256 "a2e9e1c4b11c326434535762d1523c56d7c8d509a005069cc94e20e6d4c86353"
 
   url "https://emacsformacosx.com/emacs-builds/Emacs-#{version}-universal.dmg"
   name "Emacs"


### PR DESCRIPTION
Updated the cask to latest emacs 29.1 version which includes eglot.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ X] `brew audit --cask --online <cask>` is error-free.
- [ X] `brew style --fix <cask>` reports no offenses.