### PR TITLE
Fix wrong sha256 hash from visualboyadvance-m 2.1.6

### DIFF
--- a/Casks/visualboyadvance-m.rb
+++ b/Casks/visualboyadvance-m.rb
@@ -1,6 +1,6 @@
 cask "visualboyadvance-m" do
   version "2.1.6"
-  sha256 "ab45eb8a3ed9b263c44e1f05dcef794c676b5fce0adbf693587a1f7fc2004c70"
+  sha256 "d9d13debc6f19eeba7cb729de75389e4e2f45bdf56bd68035c05fe3eb75abf2e"
 
   url "https://github.com/visualboyadvance-m/visualboyadvance-m/releases/download/v#{version}/visualboyadvance-m-Mac-x86_64.zip",
       verified: "github.com/visualboyadvance-m/visualboyadvance-m/"


### PR DESCRIPTION
Fixed the SHA256 error in the visualboyadvance-m cask.

VBA-M Team said
> The initial git tag for this release was wrong, please update your clone if you pulled it.

https://github.com/visualboyadvance-m/visualboyadvance-m/releases/tag/v2.1.6
So I think that the files were rewritten due to a mistake in the release.

I double-checked both sums using the,
`shasum -a 256 visualboyadvance-m-Mac-x86_64.zip`
`d9d13debc6f19eeba7cb729de75389e4e2f45bdf56bd68035c05fe3eb75abf2e  visualboyadvance-m-Mac-x86_64.zip`
