### PR TITLE
Stats requires MacOS 10.15 starting with v2.9

### DIFF
--- a/Casks/stats.rb
+++ b/Casks/stats.rb
@@ -18,7 +18,6 @@ cask "stats" do
   homepage "https://github.com/exelban/stats"
 
   auto_updates true
-
   depends_on macos: ">= :mojave"
 
   app "Stats.app"

--- a/Casks/stats.rb
+++ b/Casks/stats.rb
@@ -1,6 +1,16 @@
 cask "stats" do
-  version "2.9.3"
-  sha256 "b70d0b9caa09c7fe8eeadfe8022a40af87f32eec662401f002af14ecc979f8d0"
+  on_mojave :or_older do
+    version "2.8.26"
+    sha256 "1a4b44ba02520683b0a6c192388f593c36dde4d15c784a22dccf0caefe81e8b7"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_catalina :or_newer do
+    version "2.9.3"
+    sha256 "b70d0b9caa09c7fe8eeadfe8022a40af87f32eec662401f002af14ecc979f8d0"
+  end
 
   url "https://github.com/exelban/stats/releases/download/v#{version}/Stats.dmg"
   name "Stats"
@@ -8,7 +18,8 @@ cask "stats" do
   homepage "https://github.com/exelban/stats"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+
+  depends_on macos: ">= :mojave"
 
   app "Stats.app"
 

--- a/Casks/stats.rb
+++ b/Casks/stats.rb
@@ -8,7 +8,7 @@ cask "stats" do
   homepage "https://github.com/exelban/stats"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :catalina"
 
   app "Stats.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Hopefully, changing the OSX version doesn't trigger errors.