### PR TITLE
freecad 0.21.0

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -1,31 +1,47 @@
-cask "freecad" do
-  version "0.20.2,2022-12-27"
-  sha256 "3808bdf0751a70770b1d561269d9d014f9c486eb49bc4e187d106d3d2664d347"
+cask("freecad") do
+  version("0.21.0")
 
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version.csv.first.hyphens_to_dots}/FreeCAD_#{version.csv.first}-#{version.csv.second}-conda-macOS-x86_64-py310.dmg",
-      verified: "github.com/FreeCAD/FreeCAD/"
-  name "FreeCAD"
-  desc "3D parametric modeler"
-  homepage "https://www.freecadweb.org/"
+  on_arm do
+    sha256("e12232d2f3411966f25837a4d5f2c14b72ea700b2a4dbb0a7b88f6b1da3044fb")
+
+    url(
+      "https://github.com/FreeCAD/FreeCAD/releases/download/#{version}/FreeCAD-#{version}-mac-arm64.dmg",
+      verified: "github.com/FreeCAD/FreeCAD/",
+    )
+  end
+  on_intel do
+    sha256("271a3785a0ca68fab94ef6a7397ca9ed39cafbdce5bea19755b835462d8bceb0")
+
+    url(
+      "https://github.com/FreeCAD/FreeCAD/releases/download/#{version}/FreeCAD-#{version}-mac-intel_x86.dmg",
+      verified: "github.com/FreeCAD/FreeCAD/",
+    )
+  end
+
+  name("FreeCAD")
+  desc("3D parametric modeler")
+  homepage("https://www.freecadweb.org/")
 
   livecheck do
-    url "https://www.freecadweb.org/downloads.php"
-    strategy :page_match do |page|
-      match = page.match(/href=.*?FreeCAD[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:-\d+)+).*?\.dmg/i)
+    url("https://www.freecadweb.org/downloads.php")
+    strategy(:page_match) do |page|
+      match = page.match(/href=.*?FreeCAD[._-]?(\d+(?:\.\d+)+)[._-].*?\.dmg/i)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      match[1].to_s
     end
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on(macos: ">= :sierra")
 
-  app "FreeCAD.app"
+  app("FreeCAD.app")
 
-  zap trash: [
-    "~/Library/Application Support/FreeCAD",
-    "~/Library/Caches/FreeCAD",
-    "~/Library/Preferences/FreeCAD",
-    "~/Library/Preferences/com.freecad.FreeCAD.plist",
-  ]
+  zap(
+    trash: [
+      "~/Library/Application Support/FreeCAD",
+      "~/Library/Caches/FreeCAD",
+      "~/Library/Preferences/FreeCAD",
+      "~/Library/Preferences/com.freecad.FreeCAD.plist",
+    ],
+  )
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

**NOTES**:

Did **not** use `brew bump-cask-pr`. Latest release of FreeCAD has builds for both x86 and arm64 and simplifies the name of the binary release artifacts (removes the date string) so I manually extended the formula to account for these changes.

I expect `brew bump-cask-pr` will be able to be used for future updates.

**TODO**: I forgot to also test on an x86 machine. Will do that now.