### PR TITLE
Upgrade Headlamp version to 0.19.0

### DIFF
--- a/Casks/headlamp.rb
+++ b/Casks/headlamp.rb
@@ -1,9 +1,9 @@
 cask "headlamp" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.18.0"
-  sha256 arm:   "872972d38c6080fc940ee28d3e41d46358ab32878664adb4eee580f92324eeb8",
-         intel: "bea70e42c788c8edcfc4c504ad8a77b6e0133aa2d28fe0a2e246a2efb80fa95f"
+  version "0.19.0"
+  sha256 arm:   "726ae4d45245697063ea1b13b5f8e689cc77809f8468a87567fb0cf958daa895",
+         intel: "6dc6cd1b7b74da00e08b51e3ab2f54eb414f43ab6d15c060ef50fa0d33ac7cb0"
 
   url "https://github.com/kinvolk/headlamp/releases/download/v#{version}/Headlamp-#{version}-mac-#{arch}.dmg",
       verified: "github.com/kinvolk/headlamp/"


### PR DESCRIPTION
Upgrade Headlamp version to 0.19.0
  cc: @joaquimrocha