### PR TITLE
streamlink-twitch-gui 2.3.0

### DIFF
--- a/Casks/streamlink-twitch-gui.rb
+++ b/Casks/streamlink-twitch-gui.rb
@@ -12,8 +12,8 @@ cask "streamlink-twitch-gui" do
   app "Streamlink Twitch GUI.app"
 
   zap trash: [
-    "~/Library/Caches/streamlink-twitch-gui/",
-    "~/Library/Application Support/streamlink-twitch-gui/",
-    "~/Library/Logs/streamlink-twitch-gui/",
+    "~/Library/Application Support/streamlink-twitch-gui",
+    "~/Library/Caches/streamlink-twitch-gui",
+    "~/Library/Logs/streamlink-twitch-gui",
   ]
 end

--- a/Casks/streamlink-twitch-gui.rb
+++ b/Casks/streamlink-twitch-gui.rb
@@ -1,6 +1,6 @@
 cask "streamlink-twitch-gui" do
-  version "2.2.0"
-  sha256 "1101b5dd4076277dce55be0d86741f4e6a28af472c5498d26e6477c2c608502b"
+  version "2.3.0"
+  sha256 "57692ebb08968c7846490fa3fa2a9aab87400e9fc1f32003cd3ac308236eec14"
 
   url "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v#{version}/streamlink-twitch-gui-v#{version}-macOS.tar.gz"
   name "Streamlink Twitch GUI"
@@ -10,4 +10,10 @@ cask "streamlink-twitch-gui" do
   depends_on formula: "streamlink"
 
   app "Streamlink Twitch GUI.app"
+
+  zap trash: [
+    "~/Library/Caches/streamlink-twitch-gui/",
+    "~/Library/Application Support/streamlink-twitch-gui/",
+    "~/Library/Logs/streamlink-twitch-gui/",
+  ]
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

----

How do I check locally modified cask files if brew doesn't allow specifying a local path to the cask file anymore? This has been changed since I last updated the cask...

```
$ brew audit --cask --online Casks/streamlink-twitch-gui.rb
Error: Calling brew audit [path ...] is disabled! Use brew audit [name ...] instead.

$ brew audit --cask --online streamlink-twitch-gui
==> Downloading https://github.com/streamlink/streamlink-twitch-gui/releases/download/v2.2.0/streamlink-twitch-gui-v2.2.0-macOS.tar.gz
Already downloaded: /Users/basti/Library/Caches/Homebrew/downloads/beb7a78283f8bcf488603f621e8dac871bc3fbe8e45889a3b4d19079f0e8664f--streamlink-twitch-gui-v2.2.0-macOS.tar.gz
audit for streamlink-twitch-gui: failed
 - Version '2.2.0' differs from '2.3.0' retrieved by livecheck.
 - Version '2.2.0' differs from '2.3.0' retrieved by livecheck.
streamlink-twitch-gui
  * Version '2.2.0' differs from '2.3.0' retrieved by livecheck.
Error: 1 problem in 1 cask detected.
```

Submitting anyway, since it's just a regular version bump and checksum change.