### PR TITLE
freecad: fix superfluous forward slash in homepage URL

### DIFF
--- a/Casks/freecad.rb
+++ b/Casks/freecad.rb
@@ -9,7 +9,7 @@ cask "freecad" do
       verified: "github.com/FreeCAD/FreeCAD/"
   name "FreeCAD"
   desc "3D parametric modeler"
-  homepage "https://www.freecad.org//"
+  homepage "https://www.freecad.org/"
 
   livecheck do
     url "https://www.freecad.org/downloads.php"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
