### PR TITLE
Casks/sublime-text.rb: fix sha265sum

### DIFF
--- a/Casks/sublime-text.rb
+++ b/Casks/sublime-text.rb
@@ -1,7 +1,7 @@
 cask "sublime-text" do
   # NOTE: The first digit of the build number is the major version.
   version "4152"
-  sha256 "80b56346818bc36d2c852b10fb1fc1c4f5ade655ae491d1f2adc8c49369a5a76"
+  sha256 "8ac68a1a9a7b6e733df491acf7958b3575b97ad1da0bd48a85d53cabcb88abd6"
 
   url "https://download.sublimetext.com/sublime_text_build_#{version}_mac.zip"
   name "Sublime Text"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

# Description
Since commit [66911a0](https://github.com/Homebrew/homebrew-cask/commit/66911a029ae948467d665bf3a5395c12cc0a9cf7), it's impossible to upgrade Sublime Text due to a sha256 mismatch:
```bash
nilho@M09  brew update; brew upgrade; brew upgrade --cask --greedy
Installing from the API is now the default behaviour!
You can save space and time by running:
  brew untap homebrew/core
  brew untap homebrew/cask
Already up-to-date.
==> `brew cleanup` has not been run in the last 30 days, running now...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Error: Permission denied @ apply2files - /usr/local/lib/docker/cli-plugins
==> Upgrading 1 outdated package:
sublime-text 4143 -> 4152
==> Upgrading sublime-text
==> Downloading https://download.sublimetext.com/sublime_text_build_4152_mac.zip
################################################################################################################################################# 100.0%
==> Purging files for version 4152 of Cask sublime-text
Error: sublime-text: SHA256 mismatch
Expected: 80b56346818bc36d2c852b10fb1fc1c4f5ade655ae491d1f2adc8c49369a5a76
  Actual: 8ac68a1a9a7b6e733df491acf7958b3575b97ad1da0bd48a85d53cabcb88abd6
```

Sublime Text v4152 has been downloaded manually to do a sha256sum to verify the actual checksum:
```bash
nilho@M09  wget https://download.sublimetext.com/sublime_text_build_4152_mac.zip
--2023-08-04 10:47:16--  https://download.sublimetext.com/sublime_text_build_4152_mac.zip
Résolution de download.sublimetext.com (download.sublimetext.com)… 104.236.0.104
Connexion à download.sublimetext.com (download.sublimetext.com)|104.236.0.104|:443… connecté.
requête HTTP transmise, en attente de la réponse… 200 OK
Taille : 39712633 (38M) [application/zip]
Sauvegarde en : « sublime_text_build_4152_mac.zip »

sublime_text_build_4152_mac.zip       100%[=========================================================================>]  37,87M  2,10MB/s    ds 17s

2023-08-04 10:47:34 (2,22 MB/s) — « sublime_text_build_4152_mac.zip » sauvegardé [39712633/39712633]


nilho@M09  sha256sum sublime_text_build_4152_mac.zip
8ac68a1a9a7b6e733df491acf7958b3575b97ad1da0bd48a85d53cabcb88abd6  sublime_text_build_4152_mac.zip
```