### PR TITLE
jamf-migrator: add zap

### DIFF
--- a/Casks/jamf-migrator.rb
+++ b/Casks/jamf-migrator.rb
@@ -10,4 +10,10 @@ cask "jamf-migrator" do
   depends_on macos: ">= :high_sierra"
 
   app "jamf-migrator.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.jamf.jamf-migrator",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.jamf.jamf-migrator.sfl*",
+    "~/Library/Containers/com.jamf.jamf-migrator",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.