### PR TITLE
klogg: add zap

### DIFF
--- a/Casks/klogg.rb
+++ b/Casks/klogg.rb
@@ -36,4 +36,11 @@ cask "klogg" do
       exec '#{appdir}/klogg.app/Contents/MacOS/klogg' "$@"
     EOS
   end
+
+  zap trash: [
+    "~/Library/Application Support/klogg",
+    "~/Library/Preferences/com.klogg.klogg.plist",
+    "~/Library/Preferences/com.klogg.klogg_session.plist",
+    "~/Library/Saved Application State/com.github.variar.klogg.savedState",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
