### PR TITLE
soundflower: add desc

### DIFF
--- a/Casks/soundflower.rb
+++ b/Casks/soundflower.rb
@@ -4,6 +4,7 @@ cask "soundflower" do
 
   url "https://github.com/mattingalls/Soundflower/releases/download/#{version}/Soundflower-#{version}.dmg"
   name "Soundflower"
+  desc "Allow applications to pass audio to other applications"
   homepage "https://github.com/mattingalls/Soundflower"
 
   pkg "Soundflower.pkg"


### PR DESCRIPTION
* Added missing `desc`

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.