### PR TITLE
pomotroid: add zap

### DIFF
--- a/Casks/pomotroid.rb
+++ b/Casks/pomotroid.rb
@@ -8,4 +8,10 @@ cask "pomotroid" do
   homepage "https://github.com/Splode/pomotroid"
 
   app "Pomotroid.app"
+
+  zap trash: [
+    "~/Library/Application Support/pomotroid",
+    "~/Library/Preferences/com.splode.pomotroid.plist",
+    "~/Library/Saved Application State/com.splode.pomotroid.savedState",
+  ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.