### PR TITLE
Casks/openshift-client.rb: fix sha256sum

### DIFF
--- a/Casks/openshift-client.rb
+++ b/Casks/openshift-client.rb
@@ -2,7 +2,7 @@ cask "openshift-client" do
   arch arm: "-arm64"
 
   version "4.13.8"
-  sha256 arm:   "f4d50a90d2f965e8bd94658e9bb85917c8a63782975cfe8ee7a7cd312aee1265",
+  sha256 arm:   "da24f03a41e9d305f28490633a401ccf3e961d2873bdcb7c07580541d304a151",
          intel: "6d2b1c337f4524bede2b35b1cf217cc2fb6753298fd2191cc90114290455ee23"
 
   url "https://mirror.openshift.com/pub/openshift-v#{version.major}/clients/ocp/#{version}/openshift-client-mac#{arch}.tar.gz"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


---

```
$ brew upgrade --greedy
==> Upgrading 1 outdated package:
openshift-client 4.13.7 -> 4.13.8
==> Upgrading openshift-client
==> Downloading https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.13.8/openshift-client-mac-arm64.tar.gz
Already downloaded: /Users/qcu/Library/Caches/Homebrew/downloads/94716d3c61b740a6f7277df5e60feff68a7fa83d298b73ff0dcfad0ead9bed1c--openshift-client-mac-arm64.tar.gz
==> Purging files for version 4.13.8 of Cask openshift-client
Error: openshift-client: SHA256 mismatch
Expected: f4d50a90d2f965e8bd94658e9bb85917c8a63782975cfe8ee7a7cd312aee1265
  Actual: da24f03a41e9d305f28490633a401ccf3e961d2873bdcb7c07580541d304a151
    File: /Users/qcu/Library/Caches/Homebrew/downloads/94716d3c61b740a6f7277df5e60feff68a7fa83d298b73ff0dcfad0ead9bed1c--openshift-client-mac-arm64.tar.gz
To retry an incomplete download, remove the file above.
```

it's seems the vendor updates the app in-place：
https://[mirror.openshift.com/pub/openshift-v4/clients/ocp/4.13.8/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.13.8/)

<img width="1845" alt="image" src="https://github.com/Homebrew/homebrew-cask/assets/11624864/a81243bc-a506-400f-b62f-0f68af42b5d5">


