### PR TITLE
goldencheetah: update to 3.6

### DIFF
--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -1,8 +1,8 @@
 cask "goldencheetah" do
-  version "3.5"
-  sha256 "02518bee5427ec126aa2fdb3d3c6d236c03dd25a78623c36e8f3d27080028f2a"
+  version "3.6"
+  sha256 "3cc4540d0490c5b1026c5f523cea34dede17c63d4eb582403d710ccb2cba1156"
 
-  url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V#{version}/GoldenCheetah_v#{version}_64bit_MacOS.dmg",
+  url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V#{version}/GoldenCheetah_v#{version}_x64.dmg",
       verified: "github.com/GoldenCheetah/GoldenCheetah/"
   name "GoldenCheetah"
   desc "Performance software for cyclists, runners and triathletes"

--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -2,7 +2,7 @@ cask "goldencheetah" do
   version "3.6"
   sha256 "3cc4540d0490c5b1026c5f523cea34dede17c63d4eb582403d710ccb2cba1156"
 
-  url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/V#{version}/GoldenCheetah_v#{version}_x64.dmg",
+  url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/v#{version}/GoldenCheetah_v#{version}_x64.dmg",
       verified: "github.com/GoldenCheetah/GoldenCheetah/"
   name "GoldenCheetah"
   desc "Performance software for cyclists, runners and triathletes"

--- a/Casks/goldencheetah.rb
+++ b/Casks/goldencheetah.rb
@@ -1,6 +1,6 @@
 cask "goldencheetah" do
   version "3.6"
-  sha256 "3cc4540d0490c5b1026c5f523cea34dede17c63d4eb582403d710ccb2cba1156"
+  sha256 "7d3d8f5682f664b030af61b6988b94a333526dbc686cc7d1f94b6f37889cdb50"
 
   url "https://github.com/GoldenCheetah/GoldenCheetah/releases/download/v#{version}/GoldenCheetah_v#{version}_x64.dmg",
       verified: "github.com/GoldenCheetah/GoldenCheetah/"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

--- 

Along with version bump this commit also includes URL tweak since upstream changed name of file slightly.
From `..._64bit_MacOS.dmg` to `..._x64.dmg`

ref: https://github.com/GoldenCheetah/GoldenCheetah/releases/tag/v3.6

