### PR TITLE
synology-photo-station-uploader: add zap

### DIFF
--- a/Casks/synology-photo-station-uploader.rb
+++ b/Casks/synology-photo-station-uploader.rb
@@ -29,4 +29,14 @@ cask "synology-photo-station-uploader" do
               "com.synology.PhotoUploaderUninstaller",
               "com.synology.SynoSIMBL_RefreshFinder",
             ]
+
+  zap trash: [
+        "~/Library/Application Support/Synology/Photo Station Uploader",
+        "~/Library/Application Scripts/com.synology.PhotoUploaderShellApp.PhotoUploaderFinderSync",
+        "~/Library/Application Scripts/group.com.synology.PhotoUploader",
+        "~/Library/Containers/com.synology.PhotoUploaderShellApp.PhotoUploaderFinderSync",
+        "~/Library/Group Containers/group.com.synology.PhotoUploader",
+        "~/Library/Saved Application State/com.synology.PhotoStationUploader.savedState",
+      ],
+      rmdir: "~/Library/Application Support/Synology"
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
