### PR TITLE
Add git-credential-manager v2.3.0

### DIFF
--- a/Casks/g/git-credential-manager.rb
+++ b/Casks/g/git-credential-manager.rb
@@ -1,0 +1,26 @@
+cask "git-credential-manager" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.3.0"
+  sha256 arm:   "8acfa913307140c06ec9b2692f9abfef32ecde4c83634d728597a94d34e0e773",
+         intel: "2c835e24eb5223ef190c528f12a7d7054b8ca143f7399ab23f61c68c0b8e029b"
+
+  url "https://github.com/git-ecosystem/git-credential-manager/releases/download/v#{version.major_minor_patch}/gcm-osx-#{arch}-#{version.major_minor_patch}.pkg",
+      verified: "github.com/git-ecosystem/git-credential-manager/"
+  name "Git Credential Manager"
+  desc "Cross-platform Git credential storage for multiple hosting providers"
+  homepage "https://aka.ms/gcm"
+
+  pkg "gcm-osx-#{arch}-#{version}.pkg"
+
+  uninstall script:  {
+              executable: "/usr/local/share/gcm-core/uninstall.sh",
+              sudo:       true,
+            },
+            pkgutil: "com.microsoft.GitCredentialManager"
+
+  zap trash: [
+    "~/Library/Preferences/git-credential-manager-ui.plist",
+    "~/Library/Preferences/git-credential-manager.plist",
+  ]
+end


### PR DESCRIPTION
Add cask for the Git Credential Manager cross-platform Git credential helper.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
     - See my comment below regarding this.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
     - See my comment below regarding this.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
