### PR TITLE
android-ndk: update livecheck

### DIFF
--- a/Casks/a/android-ndk.rb
+++ b/Casks/a/android-ndk.rb
@@ -10,7 +10,7 @@ cask "android-ndk" do
 
   livecheck do
     url "https://developer.android.com/ndk/downloads"
-    regex(/Latest.*?r(\d+[a-z]?)\b(?!\s+Preview)/i)
+    regex(/Latest.*?r(\d+[a-z]?)\b(?!\s+Beta)/i)
   end
 
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
Upstream is now using "Beta" instead of "Preview".