### PR TITLE
Bump Maltego cask to version 4.5.0

### DIFF
--- a/Casks/m/maltego.rb
+++ b/Casks/m/maltego.rb
@@ -2,13 +2,13 @@ cask "maltego" do
   version "4.5.0"
   sha256 "d2ad23677000da380e9ef7b3ee71d3ca8f42d436fb9f37c3cee2bb30f67c434d"
 
-  url "https://downloads.maltego.com/maltego-v4/mac/Maltego.v#{version}.dmg"
+  url "https://downloads.maltego.com/maltego-v#{version.major}/mac/Maltego.v#{version}.dmg"
   name "Maltego"
   desc "Open source intelligence and graphical link analysis tool"
   homepage "https://www.maltego.com/pricing-plans/"
 
   livecheck do
-    url "https://downloads.maltego.com/maltego-v4/info.json"
+    url "https://downloads.maltego.com/maltego-v#{version.major}/info.json"
     regex(/Maltego[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/m/maltego.rb
+++ b/Casks/m/maltego.rb
@@ -1,15 +1,14 @@
 cask "maltego" do
-  version "4.3.1"
-  sha256 "d6303d29a5725b3c48e870e5b272ff895bed71d8e913fa39cadd3be3afac14d0"
+  version "4.5.0"
+  sha256 "d2ad23677000da380e9ef7b3ee71d3ca8f42d436fb9f37c3cee2bb30f67c434d"
 
-  url "https://maltego-downloads.s3.us-east-2.amazonaws.com/mac/Maltego.v#{version}.dmg",
-      verified: "maltego-downloads.s3.us-east-2.amazonaws.com/"
+  url "https://downloads.maltego.com/maltego-v4/mac/Maltego.v#{version}.dmg"
   name "Maltego"
   desc "Open source intelligence and graphical link analysis tool"
   homepage "https://www.maltego.com/pricing-plans/"
 
   livecheck do
-    url "https://maltego-downloads.s3.us-east-2.amazonaws.com/info.json"
+    url "https://downloads.maltego.com/maltego-v4/info.json"
     regex(/Maltego[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online maltego` is error-free.
- [x] `brew style --fix maltego` reports no offenses.

Verified all of the above and used `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall maltego` to install the new version.

I also verified on [the changelog page](https://www.maltego.com/changelog/) and [the downloads page](https://www.maltego.com/downloads/) that version 4.5.0 is the latest stable release.