### PR TITLE
ticktick 4.5.61, 270

### DIFF
--- a/Casks/t/ticktick.rb
+++ b/Casks/t/ticktick.rb
@@ -1,8 +1,8 @@
 cask "ticktick" do
-  version "4.5.61,270"
+  version "4.5.61, 270"
   sha256 "c40fde50e2e489ba696eee04b1c611df3f4a20f838084adebee63cf4c01ab8ed"
 
-  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_%20#{version.csv.second}.dmg",
+  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second.gsub!(' ', '%20')}.dmg",
       verified: "ticktick-download-mac.s3.amazonaws.com/"
   name "TickTick"
   desc "To-do & task list manager"
@@ -11,7 +11,7 @@ cask "ticktick" do
   livecheck do
     url "https://www.ticktick.com/static/getApp/download?type=mac"
     strategy :header_match do |headers|
-      match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-] (\d+)\.dmg/i)
+      match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-](\s?\d+)\.dmg/i)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"

--- a/Casks/t/ticktick.rb
+++ b/Casks/t/ticktick.rb
@@ -1,9 +1,9 @@
 cask "ticktick" do
-  version "4.5.60,260"
-  sha256 "78b3d04c6150837463029039404ad122a1a57b6980edb6710780d016150429fd"
+  version "4.5.61,270"
+  sha256 "c40fde50e2e489ba696eee04b1c611df3f4a20f838084adebee63cf4c01ab8ed"
 
-  url "https://appest-public.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second}.dmg",
-      verified: "appest-public.s3.amazonaws.com/"
+  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_%20#{version.csv.second}.dmg",
+      verified: "ticktick-download-mac.s3.amazonaws.com/"
   name "TickTick"
   desc "To-do & task list manager"
   homepage "https://www.ticktick.com/home"
@@ -11,7 +11,7 @@ cask "ticktick" do
   livecheck do
     url "https://www.ticktick.com/static/getApp/download?type=mac"
     strategy :header_match do |headers|
-      match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-](\d+)\.dmg/i)
+      match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-] (\d+)\.dmg/i)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"

--- a/Casks/t/ticktick.rb
+++ b/Casks/t/ticktick.rb
@@ -2,12 +2,16 @@ cask "ticktick" do
   version "4.5.61, 270"
   sha256 "c40fde50e2e489ba696eee04b1c611df3f4a20f838084adebee63cf4c01ab8ed"
 
-  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second.gsub!(' ', '%20')}.dmg",
+  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second.gsub!(" ", "%20")}.dmg",
       verified: "ticktick-download-mac.s3.amazonaws.com/"
   name "TickTick"
   desc "To-do & task list manager"
   homepage "https://www.ticktick.com/home"
 
+  # The livecheck block retrieves a version that optionally includes a space character.
+  # This is done intentionally as the url can contain the charcther. Once this is
+  # resolved upstream, edit the livecheck block and remove gsub from the url.
+  # See: https://github.com/Homebrew/homebrew-cask/pull/152705
   livecheck do
     url "https://www.ticktick.com/static/getApp/download?type=mac"
     strategy :header_match do |headers|


### PR DESCRIPTION
Their url changed, inlcuding inserting a space, so tweak url and livecheck.  I would think it's unlikely to be permanent, so maybe this isn't the best way?  But 🤷‍♀️ 

----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
