### PR TITLE
internxt-drive: add livecheck

### DIFF
--- a/Casks/i/internxt-drive.rb
+++ b/Casks/i/internxt-drive.rb
@@ -8,6 +8,11 @@ cask "internxt-drive" do
   desc "Client for Internxt file storage service"
   homepage "https://internxt.com/drive"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   auto_updates true
 
   app "Internxt Drive.app"


### PR DESCRIPTION
Added livecheck to pin to `:github_latest`

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.