### PR TITLE
miniconda.rb: add manual initialization method

### DIFF
--- a/Casks/m/miniconda.rb
+++ b/Casks/m/miniconda.rb
@@ -40,5 +40,8 @@ cask "miniconda" do
   caveats <<~EOS
     Please run the following to setup your shell:
       conda init "$(basename "${SHELL}")"
+
+    Alternatively, manually add the following to your shell init:
+      eval "$(conda "shell.$(basename "${SHELL}")" hook)"
   EOS
 end


### PR DESCRIPTION
Needed for nix/home-manager users where conda init fails to modify the shell init scripts.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
