### PR TITLE
threads 2.3.0

### DIFF
--- a/Casks/t/threads.rb
+++ b/Casks/t/threads.rb
@@ -1,6 +1,6 @@
 cask "threads" do
-  version "2.2.7"
-  sha256 "1608918f028433e5d547d3b629996655841086dcfd42e338026c18f97eff8eb1"
+  version "2.3.0"
+  sha256 "f8601416f6160d73cb5c685df2419933dadea12f15404e52426edd1b02a7b790"
 
   url "https://starupdate.threads.com/download/version/#{version}/Threads-darwin-#{version}.zip"
   name "Threads"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.