### PR TITLE
tdr-nova: remove suffix from homepage and add zap

### DIFF
--- a/Casks/t/tdr-nova.rb
+++ b/Casks/t/tdr-nova.rb
@@ -9,19 +9,17 @@ cask "tdr-nova" do
 
   livecheck do
     url :homepage
-    regex(%r{Latest\sversion:\s<strong>(\d+(?:\.\d+)+)</strong>}i)
+    regex(%r{latest\sversion:\s<strong>(\d+(?:\.\d+)+)</strong>}i)
   end
 
   pkg "TDR Nova.pkg"
 
   uninstall pkgutil: [
-    "com.TokyoDawnLabs.TDRNova.VST",
     "com.TokyoDawnLabs.TDRNova.AAX",
     "com.TokyoDawnLabs.TDRNova.AU",
+    "com.TokyoDawnLabs.TDRNova.VST",
     "com.TokyoDawnLabs.TDRNova.VST3",
   ]
 
-  zap trash: [
-    "~/Library/Tokyo Dawn Labs/TDR Nova.conf",
-  ]
+  zap trash: "~/Library/Tokyo Dawn Labs/TDR Nova.conf"
 end

--- a/Casks/t/tdr-nova.rb
+++ b/Casks/t/tdr-nova.rb
@@ -5,7 +5,7 @@ cask "tdr-nova" do
   url "https://www.tokyodawn.net/labs/Nova/#{version}/TDR%20Nova.zip?x24775"
   name "TDR Nova"
   desc "Parallel dynamic equalizer"
-  homepage "https://www.tokyodawn.net/tdr-nova/5/"
+  homepage "https://www.tokyodawn.net/tdr-nova/"
 
   livecheck do
     url :homepage

--- a/Casks/t/tdr-nova.rb
+++ b/Casks/t/tdr-nova.rb
@@ -20,4 +20,8 @@ cask "tdr-nova" do
     "com.TokyoDawnLabs.TDRNova.AU",
     "com.TokyoDawnLabs.TDRNova.VST3",
   ]
+
+  zap trash: [
+    "~/Library/Tokyo Dawn Labs/TDR Nova.conf",
+  ]
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

From what I know, that suffix at the end of the homepage is not relevant and can be removed.