### PR TITLE
dictunifier: add zap

### DIFF
--- a/Casks/d/dictunifier.rb
+++ b/Casks/d/dictunifier.rb
@@ -8,4 +8,6 @@ cask "dictunifier" do
   homepage "https://github.com/jjgod/mac-dictionary-kit/"
 
   app "DictUnifier.app"
+
+  zap trash: "~/Library/Saved Application State/org.jjgod.DictUnifier.savedState"
 end


### PR DESCRIPTION
Add missing zap

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.