### PR TITLE
ipepresenter: remove incorrect `zap`

### DIFF
--- a/Casks/i/ipepresenter.rb
+++ b/Casks/i/ipepresenter.rb
@@ -17,6 +17,4 @@ cask "ipepresenter" do
   end
 
   app "IpePresenter.app"
-
-  zap trash: "~/Library/Caches/com.apple.python/Applications/Présentation.app"
 end


### PR DESCRIPTION
Incorrectly closed https://github.com/Homebrew/homebrew-cask/pull/152979 and added the `zap` here by mistake.

Apologies @krehel.