### PR TITLE
git-credential-manager: add livecheck

### DIFF
--- a/Casks/g/git-credential-manager.rb
+++ b/Casks/g/git-credential-manager.rb
@@ -11,6 +11,11 @@ cask "git-credential-manager" do
   desc "Cross-platform Git credential storage for multiple hosting providers"
   homepage "https://aka.ms/gcm"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   pkg "gcm-osx-#{arch}-#{version}.pkg"
 
   uninstall script:  {


### PR DESCRIPTION
* Add livecheck to avoid pre-releases by using `:github_latest`

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
