### PR TITLE
iem-plugin-suite: update livecheck

### DIFF
--- a/Casks/i/iem-plugin-suite.rb
+++ b/Casks/i/iem-plugin-suite.rb
@@ -8,8 +8,8 @@ cask "iem-plugin-suite" do
   homepage "https://plugins.iem.at/"
 
   livecheck do
-    url "https://git.iem.at/audioplugins/IEMPluginSuite.git"
-    strategy :git
+    url "https://plugins.iem.at/download/"
+    regex(/href=.*?IEMPluginSuite[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg)/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `iem-plugin-suite` checks the related Git repository and includes a redundant `#strategy` call (i.e., we only use it when we need to override livecheck's strategy selection or if we're using a `strategy` block).

That said, this should be checking the first-party download page, which links to the cask `url`. When comparing sources of version information, it's preferable to check one that's closest to the cask `url` as possible (unless there are issues that force us to use a different source, etc.).

This PR updates the `livecheck` block to check the aforementioned download page, removing the redundant `#strategy` call in the process.