### PR TITLE
Fix url for modern-csv 2.0.2

### DIFF
--- a/Casks/m/modern-csv.rb
+++ b/Casks/m/modern-csv.rb
@@ -2,8 +2,7 @@ cask "modern-csv" do
   version "2.0.2"
   sha256 "7a87b7902d2bbd9f7ba1e9d0ddf7ad171070cd79cc20a45604d65aef05de7908"
 
-  url "https://t6a3m9g6.rocketcdn.me/release/ModernCSV-Mac-v#{version}.dmg",
-      verified: "t6a3m9g6.rocketcdn.me/"
+  url "https://www.moderncsv.com/release/ModernCSV-Mac-v#{version}.dmg"
   name "Modern CSV"
   desc "CSV editor"
   homepage "https://www.moderncsv.com/"


### PR DESCRIPTION
* The t6a3m9g6.rocketcdn.me domain is no longer resolvable from anywhere in the world as far as I can see.
* We no longer need the `verified` option, because the url and the homepage domains now match.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
