### PR TITLE
Enforce sha256 on Packages

### DIFF
--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -1,6 +1,7 @@
 cask "packages" do
   version "1.2.10"
-  sha256 :no_check
+  # required as the host has HTTP (insecure) transport only, see PR for details
+  sha256 "6afdd25386295974dad8f078b8f1e41cabebd08e72d970bf92f707c7e48b16c9"
 
   url "http://s.sudre.free.fr/Software/files/Packages.dmg"
   name "Packages"


### PR DESCRIPTION
Currently _Packages_ is hosted on free.fr (HTTP) and no shasum checking is enforced. Add the sha256 for the current version, to add integrity verification.

I also got in touch with the developer to move it to secure host with versioning.