### PR TITLE
sync/templates: add `automerge`, remove old workflows

### DIFF
--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -19,7 +19,7 @@ puts 'Detecting changes…'
   '.github/*.md',
   '.github/*.yml',
   '.github/ISSUE_TEMPLATE/*.{md,yml}',
-  '.github/workflows/{autopublish,cache,ci,dispatch-command,publish-commit-casks,rebase,rerun-workflow,review,triage}.yml',
+  '.github/workflows/{automerge,autopublish,cache,ci,dispatch-command,publish-commit-casks,rebase,rerun-workflow,review,triage}.yml',
   '.gitignore',
   '.travis.yml',
   'Casks/.rubocop.yml',

--- a/.github/actions/sync/templates.rb
+++ b/.github/actions/sync/templates.rb
@@ -19,10 +19,8 @@ puts 'Detecting changes…'
   '.github/*.md',
   '.github/*.yml',
   '.github/ISSUE_TEMPLATE/*.{md,yml}',
-  '.github/workflows/{automerge,autopublish,cache,ci,dispatch-command,publish-commit-casks,rebase,rerun-workflow,review,triage}.yml',
+  '.github/workflows/{automerge,cache,ci,dispatch-command,rebase,rerun-workflow,triage}.yml',
   '.gitignore',
-  '.travis.yml',
-  'Casks/.rubocop.yml',
 ].each do |glob|
   src_paths = Pathname.glob(glob)
   dst_paths = Pathname.glob(repo_dir.join(glob))


### PR DESCRIPTION
This PR adds the `automerge` workflow to the sync workflow. It also removes workflows that no longer exist.