### PR TITLE
multipass: fixes

### DIFF
--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -15,6 +15,8 @@ cask "multipass" do
   depends_on macos: ">= :mojave"
 
   pkg "multipass-#{version}+mac-Darwin.pkg"
+  binary "/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
+         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass"
 
   uninstall launchctl: "com.canonical.multipassd",
             pkgutil:   "com.canonical.multipass.*",
@@ -23,7 +25,7 @@ cask "multipass" do
               "/Library/Application Support/com.canonical.multipass",
               "/Library/Logs/Multipass",
               "/usr/local/bin/multipass",
-              "/usr/local/etc/bash_completion.d/multipass",
+              "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass",
             ]
 
   zap trash: [

--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -15,8 +15,13 @@ cask "multipass" do
   depends_on macos: ">= :mojave"
 
   pkg "multipass-#{version}+mac-Darwin.pkg"
-  binary "/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass"
+
+  postflight do
+    if Hardware::CPU.arm?
+      File.symlink("/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
+                   "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass")
+    end
+  end
 
   uninstall launchctl: "com.canonical.multipassd",
             pkgutil:   "com.canonical.multipass.*",

--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -21,11 +21,12 @@ cask "multipass" do
   uninstall launchctl: "com.canonical.multipassd",
             pkgutil:   "com.canonical.multipass.*",
             delete:    [
+              "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass",
               "/Applications/Multipass.app",
               "/Library/Application Support/com.canonical.multipass",
               "/Library/Logs/Multipass",
               "/usr/local/bin/multipass",
-              "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass",
+              "/usr/local/etc/bash_completion.d/multipass",
             ]
 
   zap trash: [

--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -16,8 +16,8 @@ cask "multipass" do
 
   pkg "multipass-#{version}+mac-Darwin.pkg"
 
-  postflight do
-    if Hardware::CPU.arm?
+  on_arm do
+    postflight do
       File.symlink("/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
                    "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass")
     end

--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -2,6 +2,13 @@ cask "multipass" do
   version "1.12.2"
   sha256 "c2994476746369935ff54258a2c764cb6e344f77f64cf09688d55a86245bcbf4"
 
+  on_arm do
+    postflight do
+      File.symlink("/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
+                   "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass")
+    end
+  end
+
   url "https://github.com/canonical/multipass/releases/download/v#{version}/multipass-#{version}+mac-Darwin.pkg"
   name "Multipass"
   desc "Orchestrates virtual Ubuntu instances"
@@ -15,13 +22,6 @@ cask "multipass" do
   depends_on macos: ">= :mojave"
 
   pkg "multipass-#{version}+mac-Darwin.pkg"
-
-  on_arm do
-    postflight do
-      File.symlink("/Library/Application Support/com.canonical.multipass/Resources/completions/bash/multipass",
-                   "#{HOMEBREW_PREFIX}/etc/bash_completion.d/multipass")
-    end
-  end
 
   uninstall launchctl: "com.canonical.multipassd",
             pkgutil:   "com.canonical.multipass.*",


### PR DESCRIPTION
* Add `bash` completion for ARM

* Update uninstall to remove `bash` completion

@Homebrew/cask - please see issue #153333 for the details on this PR.  Feedback welcomed.

The install from upstream only looks for Homebrew installed in `/usr/local`, which means the install for autocompletion doesn't work on ARM.  Ultimately, a fix should be made upstream IMHO.  This PR should fix the issue as a workaround by linking the binary to the appropriate prefix regardless of ARM or Intel.  Likewise, I removed the hard-coded `/usr/local` in the `uninstall delete` for this completion file and replaced it with `#{HOMEBREW_PREFIX}` to ensure cleanup works correctly.

I am not sure if this is something we want to support as a (even temporary) workaround, so please feel free to comment or reject this PR if deemed otherwise out of line.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
