### PR TITLE
virtualbox: handle binary rebuilds from upstream

### DIFF
--- a/Casks/v/virtualbox.rb
+++ b/Casks/v/virtualbox.rb
@@ -1,8 +1,8 @@
 cask "virtualbox" do
-  version "7.0.10,158379"
-  sha256 "de2a77c9154e90e6715573cf3fc140d56d582cba56072a06231a625cecc892bc"
+  version "7.0.10,a,158379"
+  sha256 "f3f25870bc7988c35f77eb370402623a1facf7405128fe86f0583fa07a5fff1b"
 
-  url "https://download.virtualbox.org/virtualbox/#{version.csv.first}/VirtualBox-#{version.csv.first}-#{version.csv.second}-OSX.dmg"
+  url "https://download.virtualbox.org/virtualbox/#{version.csv.first}/VirtualBox-#{version.csv.first}#{version.csv.second}-#{version.csv.third}-OSX.dmg"
   name "Oracle VirtualBox"
   desc "Virtualizer for x86 hardware"
   homepage "https://www.virtualbox.org/"
@@ -10,10 +10,10 @@ cask "virtualbox" do
   livecheck do
     url "https://www.virtualbox.org/wiki/Downloads"
     strategy :page_match do |page|
-      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)+)-(\d+)-OSX.dmg/)
+      match = page.match(/href=.*?VirtualBox-(\d+(?:\.\d+)+)([a-z]+)[._-](\d+)[._-]OSX.dmg/)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      "#{match[1]},#{match[2]},#{match[3]}"
     end
   end
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Upstream published binaries with an additional alphanumerical character without changing main version, probably to account for a binary rebuild.

Updated livecheck regex, version format, download url, version and checksum.