### PR TITLE
Update xtool-creative-space to 1.4.13

### DIFF
--- a/Casks/x/xtool-creative-space.rb
+++ b/Casks/x/xtool-creative-space.rb
@@ -2,29 +2,31 @@ cask "xtool-creative-space" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.3.21,28.268.1686756140022,2-2023-06-14-22-29-31"
-    sha256  "c629bd7ccb29d119d9d4232968d4bf3e6d4ce6f2f4079d751402ce9baa5f9670"
+    version "1.4.13,28.ca6e5be6-e891-425b-91f9-76905be4c2c6,2023-08-01-20-46-35"
+    sha256  "a9fcc73f25c65221d82c3c623c44058844574963152b678817f1ae52e2f311c4"
   end
   on_intel do
-    version "1.3.21,16.267.1686754770561,2-2023-06-14-22-30-04"
-    sha256 "64a695f3de1afd5d0bf439176f9f2347453c9d1c2e8a4718e7eef639cb9cf034"
+    version "1.4.13,16.006c4bfc-da2b-4f3b-9bc0-a8b9f9facfe2,2023-08-01-20-47-35"
+    sha256 "267eed57a83300c78116560733ad1d3c9b3af62ed242740801735fb26bd49558"
   end
 
-  url "https://res-us.makeblock.com/ms/updater/production/packages/#{version.csv.second.tr(".", "/")}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.third}-#{arch}.dmg",
-      verified: "res-us.makeblock.com/ms/updater/production/packages/"
+  url "https://res-us.makeblock.com/efficacy/xcs/production/packages/#{version.csv.second.tr(".", "/")}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.third}-#{arch}.dmg",
+      verified: "res-us.makeblock.com/efficacy/xcs/production/packages/"
   name "xTool Creative Space"
   desc "Design and control software for xTool laser machines"
   homepage "https://www.xtool.com/pages/software"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?packages/(.*)/xTool\s?Creative\s?Space[._-](\d+(?:\.\d+)+)-(\d+(?:-\d+)+)-#{arch}\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[1]},#{match[0].tr("/", ".")},#{match[2]}"
-      end
-    end
-  end
+## Disabling livecheck because homepage does not have version information anymore
+## instead links redirect to the latest release
+#  livecheck do
+#    url :homepage
+#    regex(%r{href=.*?packages/(.*)/xTool\s?Creative\s?Space[._-](\d+(?:\.\d+)+)-(\d+(?:-\d+)+)-#{arch}\.dmg}i)
+#    strategy :page_match do |page, regex|
+#      page.scan(regex).map do |match|
+#        "#{match[1]},#{match[0].tr("/", ".")},#{match[2]}"
+#      end
+#    end
+#  end
 
   app "xTool Creative Space.app"
 

--- a/Casks/x/xtool-creative-space.rb
+++ b/Casks/x/xtool-creative-space.rb
@@ -1,32 +1,32 @@
 cask "xtool-creative-space" do
   arch arm: "arm64", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "apple", intel: "intel"
 
   on_arm do
-    version "1.4.13,28.ca6e5be6-e891-425b-91f9-76905be4c2c6,2023-08-01-20-46-35"
+    version "1.4.13,28,ca6e5be6-e891-425b-91f9-76905be4c2c6,2023-08-01-20-46-35"
     sha256  "a9fcc73f25c65221d82c3c623c44058844574963152b678817f1ae52e2f311c4"
   end
   on_intel do
-    version "1.4.13,16.006c4bfc-da2b-4f3b-9bc0-a8b9f9facfe2,2023-08-01-20-47-35"
+    version "1.4.13,16,006c4bfc-da2b-4f3b-9bc0-a8b9f9facfe2,2023-08-01-20-47-35"
     sha256 "267eed57a83300c78116560733ad1d3c9b3af62ed242740801735fb26bd49558"
   end
 
-  url "https://res-us.makeblock.com/efficacy/xcs/production/packages/#{version.csv.second.tr(".", "/")}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.third}-#{arch}.dmg",
+  url "https://res-us.makeblock.com/efficacy/xcs/production/packages/#{version.csv.second}/#{version.csv.third}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.fourth}-#{arch}.dmg",
       verified: "res-us.makeblock.com/efficacy/xcs/production/packages/"
   name "xTool Creative Space"
   desc "Design and control software for xTool laser machines"
   homepage "https://www.xtool.com/pages/software"
 
-## Disabling livecheck because homepage does not have version information anymore
-## instead links redirect to the latest release
-#  livecheck do
-#    url :homepage
-#    regex(%r{href=.*?packages/(.*)/xTool\s?Creative\s?Space[._-](\d+(?:\.\d+)+)-(\d+(?:-\d+)+)-#{arch}\.dmg}i)
-#    strategy :page_match do |page, regex|
-#      page.scan(regex).map do |match|
-#        "#{match[1]},#{match[0].tr("/", ".")},#{match[2]}"
-#      end
-#    end
-#  end
+  livecheck do
+    url "https://s.xtool.com/software/download/macos-#{livecheck_arch}-chip"
+    regex(%r{/([^/]+)/([^/]+)/xTool.*Creative.*Space[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:-\d+)+)[._-]#{arch}\.dmg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[3]},#{match[1]},#{match[2]},#{match[4]}"
+    end
+  end
 
   app "xTool Creative Space.app"
 


### PR DESCRIPTION
I have disabled livecheck because the homepage does not have version information in the links anymore, instead they redirect to the latest release.

I am not sure how to do the livecheck in that case.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.