### PR TITLE
inkscape: update url and version

### DIFF
--- a/Casks/i/inkscape.rb
+++ b/Casks/i/inkscape.rb
@@ -1,18 +1,26 @@
 cask "inkscape" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "1.3.0"
-  sha256 arm:   "e37b5f8b8995a0ecc41ca7fcae90d79bcd652b7a25d2f6e52c4e2e79aef7fec1",
-         intel: "e97de6804d8811dd2f1bc45d709d87fb6fe45963aae710c24a4ed655ecd8eb8a"
+  on_arm do
+    version "1.3.0,42339"
+    sha256 "e37b5f8b8995a0ecc41ca7fcae90d79bcd652b7a25d2f6e52c4e2e79aef7fec1"
+  end
+  on_intel do
+    version "1.3.0,42338"
+    sha256 "e97de6804d8811dd2f1bc45d709d87fb6fe45963aae710c24a4ed655ecd8eb8a"
+  end
 
-  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}_#{arch}.dmg"
+  url "https://inkscape.org/gallery/item/#{version.csv.second}/Inkscape-#{version.csv.first}_#{arch}.dmg"
   name "Inkscape"
   desc "Vector graphics editor"
   homepage "https://inkscape.org/"
 
   livecheck do
     url "https://inkscape.org/release/all/mac-os-x/"
-    regex(/href=.*?Inkscape[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
+    regex(%r{href=.*?item/(\d+)/Inkscape[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    end
   end
 
   app "Inkscape.app"


### PR DESCRIPTION
See:
https://gitlab.com/inkscape/inkscape-web/-/issues/647#note_1523592178
https://discourse.nixos.org/t/inkscape-possible-domain-compromise/32008/8

Changed cask to use the release page url.