### PR TITLE
Update playdate-simulator to 2.0.3 and improve uninstall

### DIFF
--- a/Casks/p/playdate-simulator.rb
+++ b/Casks/p/playdate-simulator.rb
@@ -22,12 +22,10 @@ cask "playdate-simulator" do
       exec.unlink if exec.exist? && exec.readlink.to_s.include?("playdate")
     end
   end
-  
+
   uninstall pkgutil: "date.play.sdk",
-            trash:   [
-              "~/Developer/PlaydateSDK",
-              "/usr/local/playdate"
-            ],
+            trash:   "~/Developer/PlaydateSDK",
+            delete:  "/usr/local/playdate",
             rmdir:   "~/Developer"
 
   zap trash: "~/.Playdate"

--- a/Casks/p/playdate-simulator.rb
+++ b/Casks/p/playdate-simulator.rb
@@ -1,6 +1,6 @@
 cask "playdate-simulator" do
-  version "2.0.1"
-  sha256 "04c53f03f6b01da0b5bfcf902649225136f04d838693ad4f219dcb041eb2d1c1"
+  version "2.0.3"
+  sha256 "603e0d71d95d44e0e0f49cf3d1d71b86fcc1b586fbee4f46777ffca63c9dd243"
 
   url "https://download-keycdn.panic.com/playdate_sdk/PlaydateSDK-#{version}.zip",
       verified: "download-keycdn.panic.com/playdate_sdk/"
@@ -17,8 +17,17 @@ cask "playdate-simulator" do
 
   pkg "PlaydateSDK.pkg"
 
+  uninstall_preflight do
+    Pathname("/usr/local/bin").glob("arm-*").each do |exec|
+      exec.unlink if exec.exist? && exec.readlink.to_s.include?("playdate")
+    end
+  end
+  
   uninstall pkgutil: "date.play.sdk",
-            trash:   "~/Developer/PlaydateSDK",
+            trash:   [
+              "~/Developer/PlaydateSDK",
+              "/usr/local/playdate"
+            ],
             rmdir:   "~/Developer"
 
   zap trash: "~/.Playdate"


### PR DESCRIPTION
Remove the cross compiling toolchain installed by the Playdate SDK that is not currently removed by the uninstall stanza.

https://devforum.play.date/t/how-can-i-safely-delete-the-command-line-tools-from-my-disk/11318/2

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
