### PR TITLE
battery: add auto_update

### DIFF
--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -7,6 +7,7 @@ cask "battery" do
   desc "CLI for managing the battery charging status"
   homepage "https://github.com/actuallymentor/battery/"
 
+  auto_updates true
   depends_on arch: :arm64
 
   app "battery.app"


### PR DESCRIPTION
Battery has it's [own update mechanism](https://github.com/actuallymentor/battery).

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
