### PR TITLE
sonic-pi 4.4.0, now with Apple Silicon builds

### DIFF
--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -48,19 +48,19 @@ cask "sonic-pi" do
            intel: "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
 
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for#{arch_bonus}-Mac-#{arch}-v#{version.dots_to_hyphens}.dmg"
+
+    livecheck do
+      url :homepage
+      regex(/href=.*?Sonic-Pi[^"' >]*?[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| match[0].tr("-", ".") }
+      end
+    end
   end
 
   name "Sonic Pi"
   desc "Code-based music creation and performance tool"
   homepage "https://sonic-pi.net/"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?Sonic-Pi[^"' >]*?[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match[0].tr("-", ".") }
-    end
-  end
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -1,6 +1,6 @@
 cask "sonic-pi" do
   arch arm: "arm64", intel: "x64"
-  
+
   on_mojave :or_older do
     version "3.3.1"
     sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -25,7 +25,7 @@ cask "sonic-pi" do
     version "4.3.0"
     sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -25,7 +25,7 @@ cask "sonic-pi" do
     version "4.4.0"
     sha256 "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
 
     livecheck do
       skip "Legacy version"
@@ -35,7 +35,7 @@ cask "sonic-pi" do
     version "4.4.0"
     sha256 "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -1,8 +1,26 @@
 cask "sonic-pi" do
-  version "4.3.0"
-  sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+  if MacOS.version <= :mojave
+    version "3.3.1"
+    sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+  elsif MacOS.version <= :catalina
+    version "4.3.0"
+    sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+  elsif MacOS.version <= :monterey
+    version "4.4.0"
+    sha256 "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+  else
+    version "4.4.0"
+    sha256 arm:   "fa4020ac4c3259bbed6d456c4b0e13126fe404c1b474654bffd583335f5d0ab5",
+           intel: "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
+    arch_bonus = Hardware::CPU.intel? ? "-Intel" : ""
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for#{arch_bonus}-Mac-#{arch}-v#{version.dots_to_hyphens}.dmg"
+  end
+
   name "Sonic Pi"
   desc "Code-based music creation and performance tool"
   homepage "https://sonic-pi.net/"
@@ -14,6 +32,8 @@ cask "sonic-pi" do
       page.scan(regex).map { |match| match[0].tr("-", ".") }
     end
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "Sonic Pi.app"
 end

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -6,24 +6,40 @@ cask "sonic-pi" do
     sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
 
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_catalina do
     version "4.3.0"
     sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
 
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_big_sur do
     version "4.3.0"
     sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
 
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_monterey do
     version "4.4.0"
     sha256 "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
 
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_ventura :or_newer do
     arch_bonus = on_arch_conditional intel: "-Intel"

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -1,23 +1,36 @@
 cask "sonic-pi" do
   arch arm: "arm64", intel: "x64"
 
-  if MacOS.version <= :mojave
+  on_mojave :or_older do
     version "3.3.1"
     sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
+
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-  elsif MacOS.version <= :catalina
+  end
+  on_catalina do
     version "4.3.0"
     sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
+
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-  elsif MacOS.version <= :monterey
+  end
+  on_big_sur do
+    version "4.3.0"
+    sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
+
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+  end
+  on_monterey do
     version "4.4.0"
     sha256 "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
+
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-  else
+  end
+  on_ventura :or_newer do
+    arch_bonus = on_arch_conditional intel: "-Intel"
     version "4.4.0"
     sha256 arm:   "fa4020ac4c3259bbed6d456c4b0e13126fe404c1b474654bffd583335f5d0ab5",
            intel: "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
-    arch_bonus = Hardware::CPU.intel? ? "-Intel" : ""
+
     url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for#{arch_bonus}-Mac-#{arch}-v#{version.dots_to_hyphens}.dmg"
   end
 

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -1,6 +1,6 @@
 cask "sonic-pi" do
   arch arm: "arm64", intel: "x64"
-
+  
   on_mojave :or_older do
     version "3.3.1"
     sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
@@ -22,10 +22,10 @@ cask "sonic-pi" do
     end
   end
   on_big_sur do
-    version "4.3.0"
-    sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
+    version "4.4.0"
+    sha256 "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -65,4 +65,11 @@ cask "sonic-pi" do
   depends_on macos: ">= :high_sierra"
 
   app "Sonic Pi.app"
+
+  zap trash: [
+    "~/.config/sonic-pi.net",
+    "~/.sonic-pi",
+    "~/Library/Preferences/net.sonic-pi.app.plist",
+    "~/Library/Saved Application State/net.sonic-pi.app.savedState",
+  ]
 end

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -1,5 +1,5 @@
 cask "sonic-pi" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "Mac-arm64", intel: "Intel-Mac-x64"
 
   on_mojave :or_older do
     version "3.3.1"
@@ -42,16 +42,15 @@ cask "sonic-pi" do
     end
   end
   on_ventura :or_newer do
-    arch_bonus = on_arch_conditional intel: "-Intel"
     version "4.4.0"
     sha256 arm:   "fa4020ac4c3259bbed6d456c4b0e13126fe404c1b474654bffd583335f5d0ab5",
            intel: "7ed0e94cf92fdf2e8d51ee42c5f7c3478fbcef9630eb12dccf203f5e72bb517f"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for#{arch_bonus}-Mac-#{arch}-v#{version.dots_to_hyphens}.dmg"
+    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-#{arch}-v#{version.dots_to_hyphens}.dmg"
 
     livecheck do
       url :homepage
-      regex(/href=.*?Sonic-Pi[^"' >]*?[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+      regex(/href=.*?Sonic[._-]Pi[._-]for[._-]#{arch}[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
       strategy :page_match do |page, regex|
         page.scan(regex).map { |match| match[0].tr("-", ".") }
       end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
   (as well as `brew audit --strict --online sonic-pi` as per your [PR docs](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request).
- [ ] `brew style --fix <cask>` reports no offenses.
   😕 I'm confused, as `Don't use if MacOS.version <= :catalina` style warnings contradicts https://docs.brew.sh/Cask-Cookbook#version-comparisons. I did have to scribble notes to get these right, so I'm optimistic the style warnings hint at a better future. 😄

I can't check all the boxes. This is my first go, so without docs coverage of the new `version` and `arch`-related style, I'll have to leave further improvements to those who are more experienced with this. I must've picked bad example casks to learn those parts from. 😨 