### PR TITLE
anka-build-cloud-controller-and-registry support two arch pkgs

### DIFF
--- a/Casks/a/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/a/anka-build-cloud-controller-and-registry.rb
@@ -11,8 +11,8 @@ cask "anka-build-cloud-controller-and-registry" do
   homepage "https://veertu.com/"
 
   livecheck do
-    url "https://veertu.com/downloads/anka-build-cloud-controller-registry-darwin-amd64-latest"
-    regex(/AnkaControllerRegistryAmd64[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
+    url "https://veertu.com/downloads/anka-build-cloud-controller-registry-darwin-#{arch.downcase}-latest"
+    regex(/AnkaControllerRegistry#{arch}[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
     strategy :header_match
   end
 

--- a/Casks/a/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/a/anka-build-cloud-controller-and-registry.rb
@@ -1,19 +1,22 @@
 cask "anka-build-cloud-controller-and-registry" do
-  version "1.36.1-efbe0727"
-  sha256 "0baafc3a688846c1b21234c71f5e55c96fad8bfb217af5c4d225ba6f2bdd2381"
+  arch arm: "Arm64", intel: "Amd64"
 
-  url "https://downloads.veertu.com/anka/AnkaControllerRegistry-#{version}.pkg"
+  version "1.37.0-4e3ffe71"
+  sha256 arm:   "6bb8cd1cbc19db88e8970dbbf74cc9e9e080729ec286df41e0ef3a2588201f17",
+         intel: "5e450ff8bc1ab0ee6360326587b990fd0e7a798b40eb3130dced7d5a24c40371"
+
+  url "https://downloads.veertu.com/anka/AnkaControllerRegistry#{arch}-#{version}.pkg"
   name "Anka Build Cloud Controller & Registry"
   desc "Virtual machine management GUI/API and registry"
   homepage "https://veertu.com/"
 
   livecheck do
-    url "https://veertu.com/downloads/ankacontroller-registry-mac-latest"
-    regex(/AnkaControllerRegistry[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
+    url "https://veertu.com/downloads/anka-build-cloud-controller-registry-darwin-amd64-latest"
+    regex(/AnkaControllerRegistryAmd64[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
     strategy :header_match
   end
 
-  pkg "AnkaControllerRegistry-#{version}.pkg"
+  pkg "AnkaControllerRegistry#{arch}-#{version}.pkg"
 
   uninstall script: {
     executable: "/Library/Application Support/Veertu/Anka/tools/controller/uninstall.sh",


### PR DESCRIPTION
Changes to support two separate architecture packages for anka-build-cloud-controller-and-registry
