### PR TITLE
Update WhatsApp to 2.23.17.79 (first stable native release)

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,16 +1,17 @@
 cask "whatsapp" do
-  version "2.2335.9"
-  sha256 "0ad4f59a11bb6e40156596833e7f7298f27566d402252013433ef4b0226adc23"
+  version "2.23.17.79"
+  sha256 "64f6e30430fbcf60dfc4845d5e6913a1782cc5670bdc61839169eebe71e52d51"
 
-  url "https://web.whatsapp.com/desktop/mac/files/release-#{version}.zip"
+  url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&branch=relbranch"
   name "WhatsApp"
-  desc "Desktop client for WhatsApp"
+  desc "Native desktop client for WhatsApp"
   homepage "https://www.whatsapp.com/"
 
   livecheck do
-    url "https://web.whatsapp.com/desktop/mac/releases"
-    strategy :json do |json|
-      json["name"]
+    url "https://web.whatsapp.com/desktop/mac_native/updates/?branch=relbranch"
+    regex(/version=v?(\d+(?:\.\d+)+)/i)
+    strategy :sparkle do |item, regex|
+      item.url.scan(regex).map(&:first)
     end
   end
 
@@ -19,17 +20,24 @@ cask "whatsapp" do
     "homebrew/cask-versions/whatsapp-alpha",
     "homebrew/cask-versions/whatsapp-beta",
   ]
+  depends_on macos: ">= :big_sur"
 
   app "WhatsApp.app"
 
   zap trash: [
-    "~/Library/Application Support/WhatsApp",
-    "~/Library/Application Support/WhatsApp.ShipIt",
-    "~/Library/Caches/WhatsApp",
-    "~/Library/Caches/WhatsApp.ShipIt",
-    "~/Library/Preferences/ByHost/WhatsApp.ShipIt.*.plist",
-    "~/Library/Preferences/WhatsApp.plist",
-    "~/Library/Preferences/WhatsApp-Helper.plist",
-    "~/Library/Saved Application State/WhatsApp.savedState",
+    "~/Library/Application Scripts/net.whatsapp.WhatsApp",
+    "~/Library/Application Scripts/net.whatsapp.WhatsApp.Intents",
+    "~/Library/Application Scripts/net.whatsapp.WhatsApp.IntentsUI",
+    "~/Library/Application Scripts/net.whatsapp.WhatsApp.ServiceExtension",
+    "~/Library/Caches/net.whatsapp.WhatsApp",
+    "~/Library/Containers/net.whatsapp.WhatsApp",
+    "~/Library/Containers/net.whatsapp.WhatsApp.Intents",
+    "~/Library/Containers/net.whatsapp.WhatsApp.ServiceExtension",
+    "~/Library/Group Containers/group.com.facebook.family",
+    "~/Library/Group Containers/group.net.whatsapp.family",
+    "~/Library/Group Containers/group.net.whatsapp.WhatsApp.private",
+    "~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared",
+    "~/Library/Group Containers/group.net.whatsapp.WhatsAppSMB.shared",
+    "~/Library/Saved Application State/net.whatsapp.WhatsApp.savedState",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

As per the [FAQ page](https://faq.whatsapp.com/451924530376167/?cms_platform=mac-desktop&helpref=platform_switcher) for the new native desktop client:

> The new WhatsApp desktop app for Mac users is now live

The cask implementation (including the version prefix) comes from https://github.com/Homebrew/homebrew-cask-versions/blob/master/Casks/whatsapp-alpha.rb.