### PR TITLE
whatsapp: fix native download url

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,14 +1,14 @@
 cask "whatsapp" do
   version "2.23.17.79"
-  sha256 "64f6e30430fbcf60dfc4845d5e6913a1782cc5670bdc61839169eebe71e52d51"
+  sha256 "9f19eba79472e0ec43b5c60a624ed0e54860ab94e9becfc87956d06d57807df7"
 
-  url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&branch=relbranch"
+  url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&configuration=Release&branch=relbranch"
   name "WhatsApp"
   desc "Native desktop client for WhatsApp"
   homepage "https://www.whatsapp.com/"
 
   livecheck do
-    url "https://web.whatsapp.com/desktop/mac_native/updates/?branch=relbranch"
+    url "https://web.whatsapp.com/desktop/mac_native/updates/?configuration=Release&branch=relbranch"
     regex(/version=v?(\d+(?:\.\d+)+)/i)
     strategy :sparkle do |item, regex|
       item.url.scan(regex).map(&:first)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Fixes #154030. The download URL defaults to `configuration=Beta` apparently, and happily downloads an app with the stable version string but beta branding.