### PR TITLE
Updating `rstudio` checksum

### DIFF
--- a/Casks/r/rstudio.rb
+++ b/Casks/r/rstudio.rb
@@ -1,6 +1,6 @@
 cask "rstudio" do
   version "2023.06.2,561"
-  sha256 "9ecc49ce31948f2746de6987c797e7fff16528aa97bb3a4a4b59351557006f7d"
+  sha256 "eba48a6092736dafc6eab67017275d57d42d8b36b1039f32b5acf2a2d03a2a9f"
 
   url "https://download1.rstudio.org/electron/macos/RStudio-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "download1.rstudio.org/electron/macos/"


### PR DESCRIPTION
Attempting to install `rstudio` outputs an "Error: SHA256 mismatch" message.

Version 2023.06.2-561 appears to have been retagged upstream. The new checksum can be seen in the project's [download page](https://posit.co/download/rstudio-desktop/).

----
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
