### PR TITLE
sdm 21.22.0

### DIFF
--- a/Casks/s/sdm.rb
+++ b/Casks/s/sdm.rb
@@ -1,14 +1,14 @@
 cask "sdm" do
-  version "15.58.0,9CEBD65A85DBAD91F1D6296C4122894DC7A91E0D"
-  sha256 "27767acb103a90170d8c0b0102f6936e82dde5ba83835ad3b9037ce888b4c937"
+  version "21.22.0,40F5C99A830E0A821C057A5D19F08A7C2B4DE556"
+  sha256 "E5A6F1B0732737DB140D2639E2D4B747FDA88DC0C507E1AE9B0D54A841F9554C"
 
-  url "https://downloads.strongdm.com/builds/sdm-gui/#{version.csv.first}/darwin/universal/#{version.csv.second}/SDM-#{version.csv.first}.universal.zip"
+  url "https://downloads.strongdm.com/builds/desktop/#{version.csv.first}/darwin/universal/#{version.csv.second}/SDM-#{version.csv.first}.universal.zip"
   name "sdm"
-  desc "Strongdm client"
+  desc "StrongDM client"
   homepage "https://www.strongdm.com/"
 
   livecheck do
-    url "https://app.strongdm.com/releases/client/darwin/0.0.0"
+    url "https://app.strongdm.com/releases/desktop/darwin/0.0.0"
     regex(%r{https:.*?/(\h+)/SDM[._-]v?(\d+(?:\.\d+)+)\.universal\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }


### PR DESCRIPTION
Change the binary from legacy sdm-gui to new desktop client

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
