### PR TITLE
joplin 2.12.15

### DIFF
--- a/Casks/j/joplin.rb
+++ b/Casks/j/joplin.rb
@@ -1,9 +1,16 @@
 cask "joplin" do
-  version "2.11.11"
-  sha256 "fddbda6076bb3d3e8503ade49ad8eb12b25923d3be84894abc79dfe519df7998"
-
-  url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg",
-      verified: "github.com/laurent22/joplin/"
+  arch arm: "arm64", intel: "x86_64"
+  version "2.12.15"
+  on_arm do
+    sha256 "1bd09fb676914f0ab72beb4165d193e0739d4d7470fdd5a72cd9b77fd08e9c7a"
+    url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}-arm64.DMG",
+        verified: "github.com/laurent22/joplin/"
+  end
+  on_intel do
+    sha256 "8b7c6a3147d426901c2737598b4170b0c48530f3a51ac6261ad4666c29fd51e4"
+    url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg",
+        verified: "github.com/laurent22/joplin/"
+  end
   name "Joplin"
   desc "Note taking and to-do application with synchronization capabilities"
   homepage "https://joplinapp.org/"

--- a/Casks/j/joplin.rb
+++ b/Casks/j/joplin.rb
@@ -1,16 +1,12 @@
 cask "joplin" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "-arm64"
+
   version "2.12.15"
-  on_arm do
-    sha256 "1bd09fb676914f0ab72beb4165d193e0739d4d7470fdd5a72cd9b77fd08e9c7a"
-    url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}-arm64.DMG",
-        verified: "github.com/laurent22/joplin/"
-  end
-  on_intel do
-    sha256 "8b7c6a3147d426901c2737598b4170b0c48530f3a51ac6261ad4666c29fd51e4"
-    url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}.dmg",
-        verified: "github.com/laurent22/joplin/"
-  end
+  sha256 arm:   "1bd09fb676914f0ab72beb4165d193e0739d4d7470fdd5a72cd9b77fd08e9c7a",
+         intel: "8b7c6a3147d426901c2737598b4170b0c48530f3a51ac6261ad4666c29fd51e4"
+
+  url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}#{arch}.DMG",
+      verified: "github.com/laurent22/joplin/"
   name "Joplin"
   desc "Note taking and to-do application with synchronization capabilities"
   homepage "https://joplinapp.org/"


### PR DESCRIPTION
The new Joplin release has placed the Arm and Intel versions in separate URLs and even extension names are different (one with capital letter), necessitating a change in the casting code.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
