### PR TITLE
hashbackup 3075

### DIFF
--- a/Casks/h/hashbackup.rb
+++ b/Casks/h/hashbackup.rb
@@ -12,7 +12,7 @@ cask "hashbackup" do
     regex(/>\s*#(\d+)\s+[a-z]+\s*\d{1,2},\s*\d{4}\s*</i)
   end
 
-  binary "hb.r#{version}.Darwin.x86_64", target: "hb"
+  binary "hb"
 
   zap trash: "~/hashbackup"
 end

--- a/Casks/h/hashbackup.rb
+++ b/Casks/h/hashbackup.rb
@@ -1,5 +1,5 @@
 cask "hashbackup" do
-  version "3075"
+  version "3068"
   sha256 :no_check
 
   url "https://www.hashbackup.com/download/hb-mac-64bit.tar.gz"
@@ -8,8 +8,8 @@ cask "hashbackup" do
   homepage "https://www.hashbackup.com/hashbackup/index.html"
 
   livecheck do
-    url "https://www.hashbackup.com/hashbackup/releases.html"
-    regex(/>\s*#(\d+)\s+[a-z]+\s*\d{1,2},\s*\d{4}\s*</i)
+    url "http://upgrade.hashbackup.com/release/latest.txt"
+    regex(/^(\d+)$/i)
   end
 
   binary "hb"

--- a/Casks/h/hashbackup.rb
+++ b/Casks/h/hashbackup.rb
@@ -1,8 +1,8 @@
 cask "hashbackup" do
-  version "3068"
-  sha256 "c7eb5b117b7083d7c0e4b74c4aeae1922963d5243748d08883b54139ef5dd2e5"
+  version "3075"
+  sha256 :no_check
 
-  url "http://upgrade.hashbackup.com/#{version}/hb.r#{version}.Darwin.x86_64.bz2"
+  url "https://www.hashbackup.com/download/hb-mac-64bit.tar.gz"
   name "HashBackup"
   desc "Command-line backup program"
   homepage "https://www.hashbackup.com/hashbackup/index.html"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

