### PR TITLE
ubiquiti-unifi-controller 7.5.174

### DIFF
--- a/Casks/u/ubiquiti-unifi-controller.rb
+++ b/Casks/u/ubiquiti-unifi-controller.rb
@@ -13,22 +13,7 @@ cask "ubiquiti-unifi-controller" do
     regex(/"version"\s*:\s*"v?(\d+(?:\.\d+)+)/i)
   end
 
-  pkg "UniFi.pkg"
-
-  postflight do
-    set_ownership "~/Library/Application Support/UniFi"
-  end
-
-  uninstall quit:    [
-              "com.oracle.java.*.jre",
-              "com.ubnt.UniFi-Discover",
-            ],
-            signal:  ["TERM", "com.ubnt.UniFi"],
-            pkgutil: "com.ubnt.UniFi",
-            delete:  [
-              "/Applications/UniFi-Discover.app",
-              "/Applications/UniFi.app",
-            ]
+  app "UniFi.app"
 
   zap trash: [
     "~/Library/Application Support/UniFi",
@@ -39,5 +24,6 @@ cask "ubiquiti-unifi-controller" do
   caveats do
     depends_on_java "8"
     license "https://www.ui.com/eula/"
+    requires_rosetta
   end
 end

--- a/Casks/u/ubiquiti-unifi-controller.rb
+++ b/Casks/u/ubiquiti-unifi-controller.rb
@@ -3,7 +3,7 @@ cask "ubiquiti-unifi-controller" do
   sha256 "c086c23f3da18d286d859ca202d705a51733c625bdbaae301a53aecfe4a71103"
 
   url "https://fw-download.ubnt.com/data/unifi-controller/5c14-macos-#{version}-05bb1ef6-1356-4888-af43-620e8c19643a.dmg",
-      verified: "dl.ubnt.com/"
+      verified: "fw-download.ubnt.com/"
   name "Ubiquiti UniFi Network Controller"
   desc "Set up, configure, manage and analyze your UniFi network"
   homepage "https://ui.com/consoles"

--- a/Casks/u/ubiquiti-unifi-controller.rb
+++ b/Casks/u/ubiquiti-unifi-controller.rb
@@ -1,12 +1,12 @@
 cask "ubiquiti-unifi-controller" do
-  version "7.4.162"
-  sha256 "444409c1c8fb162a1f32e5c31ec86951737318a8aad5378705f69d616005b0eb"
+  version "7.5.174"
+  sha256 "c086c23f3da18d286d859ca202d705a51733c625bdbaae301a53aecfe4a71103"
 
-  url "https://dl.ubnt.com/unifi/#{version}/UniFi.pkg",
+  url "https://fw-download.ubnt.com/data/unifi-controller/5c14-macos-#{version}-05bb1ef6-1356-4888-af43-620e8c19643a.dmg",
       verified: "dl.ubnt.com/"
   name "Ubiquiti UniFi Network Controller"
   desc "Set up, configure, manage and analyze your UniFi network"
-  homepage "https://unifi-sdn.ui.com/"
+  homepage "https://ui.com/consoles"
 
   livecheck do
     url "https://fw-update.ubnt.com/api/firmware-latest?filter=eq~~product~~unifi-controller&filter=eq~~channel~~release&filter=eq~~platform~~macos"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

