### PR TITLE
poe 1.1.2

### DIFF
--- a/Casks/p/poe.rb
+++ b/Casks/p/poe.rb
@@ -12,8 +12,7 @@ cask "poe" do
   homepage "https://poe.com/"
 
   livecheck do
-    url "https://updater.poe.com/darwin_#{arch}/0.0"
-    regex(/updates.*?(\d+(?:\.+\d+)+)\.zip/i)
+    skip "No version information available"
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/p/poe.rb
+++ b/Casks/p/poe.rb
@@ -1,9 +1,9 @@
 cask "poe" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.1.1"
-  sha256 arm:   "0ef78ba048be820939188d10fc1025a66727fd4a7983bd45762c4781c46854e5",
-         intel: "71f8be93c8d6f91b0c60c089884f334422ce20000c96dc0e1ae8674b2ced33e3"
+  version "1.1.2"
+  sha256 arm:   "7627a824501b97494ec3318223e624f4557e438e41b8c356da56eccd703cbe39",
+         intel: "c55396820209f69f7d1c0ac019bce5677902247f3d592534c391f818229f4ae0"
 
   url "https://desktop-app.poecdn.net/updates/darwin_#{arch}/#{version}.zip",
       verified: "desktop-app.poecdn.net/updates/"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

