### PR TITLE
eddie: add livecheck

### DIFF
--- a/Casks/e/eddie.rb
+++ b/Casks/e/eddie.rb
@@ -21,8 +21,8 @@ cask "eddie" do
   homepage "https://eddie.website/"
 
   livecheck do
-    url :url
-    regex(/data-version=["']?(\d+(?:\.\d+)+)["' >]/i)
+    url "https://github.com/AirVPN/Eddie"
+    strategy :github_latest
   end
 
   app "Eddie.app"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---------

```diff
- Error: eddie: Timeout::Error
+ eddie: 2.21.8 ==> 2.21.8
```