### PR TITLE
cleanshot: update livecheck

### DIFF
--- a/Casks/c/cleanshot.rb
+++ b/Casks/c/cleanshot.rb
@@ -9,7 +9,7 @@ cask "cleanshot" do
 
   livecheck do
     url "https://cleanshot.com/changelog"
-    regex(/class="number">(\d+(?:\.\d+)+)/i)
+    regex(/class="number"[^>]*?>(\d+(?:\.\d+)+)</i)
   end
 
   auto_updates true


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---------

```diff
- Error: cleanshot: Unable to get versions
+ cleanshot: 4.5.1 ==> 4.5.1
```