### PR TITLE
utc-menu-clock: update livecheck

### DIFF
--- a/Casks/u/utc-menu-clock.rb
+++ b/Casks/u/utc-menu-clock.rb
@@ -9,7 +9,7 @@ cask "utc-menu-clock" do
 
   livecheck do
     url "https://github.com/netik/UTCMenuClock/tree/master/downloads"
-    regex(%r{href=.*?/UTCMenuClock[._-]v?(\d+(?:\.\d+)+)[._-]universal\.zip}i)
+    regex(/UTCMenuClock[._-]v?(\d+(?:\.\d+)+)[._-]universal\.zip/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---------

```diff
- Error: utc-menu-clock: Unable to get versions
+ utc-menu-clock: 1.3 ==> 1.3
```