### PR TITLE
dd-utility: update livecheck

### DIFF
--- a/Casks/d/dd-utility.rb
+++ b/Casks/d/dd-utility.rb
@@ -9,7 +9,7 @@ cask "dd-utility" do
 
   livecheck do
     url "https://github.com/thefanclub/dd-utility/tree/master/DMG"
-    regex(%r{href=.*?/ddUtility[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    regex(/ddUtility[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---------

```diff
- Error: dd-utility: Unable to get versions
+ dd-utility: 1.11 ==> 1.11
```