### PR TITLE
Add the Threema 2.0 Desktop client and Threema 2.0 Work Desktop as se…

### DIFF
--- a/Casks/t/threema-2.rb
+++ b/Casks/t/threema-2.rb
@@ -1,0 +1,25 @@
+cask "threema-2" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.0-beta20"
+  sha256 arm:   "5926e2537a1e7c4b71a3ffbf4f0910450e22f91db3558e8614071143858cd55e",
+         intel: "d7f79a7bb625a197e7a54165cacffbe50372c2ffb308dadea9d70cdb1f3f836f"
+
+  url "https://releases.threema.ch/desktop/#{version}/threema-desktop-v#{version}-macos-#{arch}.dmg"
+  name "Threema Desktop Beta"
+  desc "End-to-end encrypted instant messaging (Currently only usable with iOS Beta)"
+  homepage "https://threema.ch/en/download-md"
+
+  livecheck do
+    url "https://releases.threema.ch/desktop/latest-version-consumer-macos.json"
+    strategy :json do |json|
+      json["latestVersion"]["version"]
+    end
+  end
+
+  app "Threema Beta.app"
+
+  zap trash: [
+    "~/Library/Application Support/ThreemaDesktop/consumer-live-default/",
+  ]
+end

--- a/Casks/t/threema-work-2.rb
+++ b/Casks/t/threema-work-2.rb
@@ -1,0 +1,25 @@
+cask "threema-work-2" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.0-beta20"
+  sha256 arm:   "f42360bef5a4e6ef3dca494f73a9ce8c36d6a84792f1cf571dc2c098ef8e0e01",
+         intel: "a5fa9d954a80af48b6e639106c18a39edeb1ae3ba2fb3704aedff0184b9311a0"
+
+  url "https://releases.threema.ch/desktop/#{version}/threema-work-desktop-v#{version}-macos-#{arch}.dmg"
+  name "Threema Work Beta"
+  desc "End-to-end encrypted instant messaging (currently only available in iOS)"
+  homepage "https://threema.ch/en/work/download-mdw"
+
+  livecheck do
+    url "https://releases.threema.ch/desktop/latest-version-work-macos.json"
+    strategy :json do |json|
+      json["latestVersion"]["version"]
+    end
+  end
+
+  app "Threema Work Beta.app"
+
+  zap trash: [
+    "~/Library/Application Support/ThreemaDesktop/work-live-default/",
+  ]
+end


### PR DESCRIPTION
Add the Threema 2.0 Desktop client and Threema 2.0 Work Desktop as separate cask, as it is only available in beta at the moment. It is fundamentally different to the existing Threema Desktop app, as it works standalone.

As soon as it is available for all Threema Users, it will replace the `threema` and `threema-work` cask. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully. 
(Not sure how to test this locally, I am getting this error `Calling brew audit [path ...] is disabled! Use brew audit [name ...] instead.`)
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
