### PR TITLE
ticktick: bump to 4.5.61,279

### DIFF
--- a/Casks/t/ticktick.rb
+++ b/Casks/t/ticktick.rb
@@ -1,21 +1,17 @@
 cask "ticktick" do
-  version "4.5.61, 270"
-  sha256 "c40fde50e2e489ba696eee04b1c611df3f4a20f838084adebee63cf4c01ab8ed"
+  version "4.5.65,279"
+  sha256 "86891a48f66128721285a79e0a6441884656250b4d098d3d5c9017ef14f8acfe"
 
-  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second.gsub!(" ", "%20")}.dmg",
+  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second}.dmg",
       verified: "ticktick-download-mac.s3.amazonaws.com/"
   name "TickTick"
   desc "To-do & task list manager"
   homepage "https://www.ticktick.com/home"
 
-  # The livecheck block retrieves a version that optionally includes a space character.
-  # This is done intentionally as the url can contain the charcther. Once this is
-  # resolved upstream, edit the livecheck block and remove gsub from the url.
-  # See: https://github.com/Homebrew/homebrew-cask/pull/152705
   livecheck do
     url "https://www.ticktick.com/static/getApp/download?type=mac"
     strategy :header_match do |headers|
-      match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-](\s?\d+)\.dmg/i)
+      match = headers["location"].match(/TickTick[._-]v?(\d+(?:\.\d+)+)[_-](\d+)\.dmg/i)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"


### PR DESCRIPTION
Undo the temporary hotfix for the erroneous space added in #152705

----

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free. (`brew audit` currently broken, see other commits/prs (` undefined method 'parse_curl_response' for Utils::Curl:Module Did you mean?  parse_curl_output`))
- [X] `brew style --fix <cask>` reports no offenses.