### PR TITLE
calhash: use static URLs for each system block

### DIFF
--- a/Casks/c/calhash.rb
+++ b/Casks/c/calhash.rb
@@ -1,30 +1,38 @@
 cask "calhash" do
+  sha256 :no_check
+
+  on_mojave :or_older do
+    depends_on macos: ">= :catalina"
+  end
   on_catalina do
     version "1.0.5"
-    sha256 "bb15c18839837bdeda203a8a916b09b4f2b971e5bba10b603f290130939d3bf7"
+
+    url "https://www.titanium-software.fr/download/1015/CalHash.dmg"
 
     depends_on macos: :catalina
   end
   on_big_sur do
     version "1.1.1"
-    sha256 "66b2de6f514119b3ddf915310b94486d24d3cc6733c74af97e367b76cb2d7478"
+
+    url "https://www.titanium-software.fr/download/11/CalHash.dmg"
 
     depends_on macos: :big_sur
   end
   on_monterey do
     version "1.1.9"
-    sha256 "6a8b9ddd3ed4acf4e8a84c8fe78a6ed783c526d84d38bf00acaf1b37311bf223"
+
+    url "https://www.titanium-software.fr/download/12/CalHash.dmg"
 
     depends_on macos: :monterey
   end
-  on_ventura do
+  on_ventura :or_newer do
     version "1.2.1"
-    sha256 "5372c281ab6edbd10f4a6a237a7e9afb529222b62f39c3b0357d779672cbaa6d"
 
-    depends_on macos: :ventura
+    url "https://www.titanium-software.fr/download/13/CalHash.dmg"
+
+    depends_on macos: "<= :ventura"
   end
 
-  url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/CalHash.dmg"
   name "CalHash"
   desc "Calculate and compare file checksums"
   homepage "https://www.titanium-software.fr/en/calhash.html"


### PR DESCRIPTION
Match style of other titanium-software.fr casks - see https://github.com/Homebrew/brew/pull/15956#issuecomment-1706959261

Also adds extra system blocks so that each macOS release gets either a URL or a `depends_on` stanza - see https://github.com/Homebrew/brew/pull/15956#issuecomment-1707579462