### PR TITLE
mblock: update livecheck

### DIFF
--- a/Casks/m/mblock.rb
+++ b/Casks/m/mblock.rb
@@ -9,8 +9,8 @@ cask "mblock" do
   homepage "https://www.mblock.cc/"
 
   livecheck do
-    url "https://mblock.makeblock.com/en-us/download/"
-    regex(/href=.*?V?(\d+(?:\.\d+)+)\.pkg/i)
+    url "https://www.mblock.cc/en/download/"
+    regex(/<span>Version: V?(\d+(?:\.\d+)+)</i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/m/mblock.rb
+++ b/Casks/m/mblock.rb
@@ -9,8 +9,8 @@ cask "mblock" do
   homepage "https://www.mblock.cc/"
 
   livecheck do
-    url "https://www.mblock.cc/en/download/"
-    regex(/<span>Version: V?(\d+(?:\.\d+)+)</i)
+    url "https://s.mblock.cc/download/pc-mac"
+    strategy :header_match
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---------

```diff
- Error: mblock: Unable to get versions
+ mblock: 5.4.0 ==> 5.4.0
```