### PR TITLE
calhash, deeper, maintenance, onyx: use array for allowed macOS releases

### DIFF
--- a/Casks/c/calhash.rb
+++ b/Casks/c/calhash.rb
@@ -1,36 +1,25 @@
 cask "calhash" do
   sha256 :no_check
 
-  on_mojave :or_older do
-    depends_on macos: ">= :catalina"
-  end
   on_catalina do
     version "1.0.5"
 
     url "https://www.titanium-software.fr/download/1015/CalHash.dmg"
-
-    depends_on macos: :catalina
   end
   on_big_sur do
     version "1.1.1"
 
     url "https://www.titanium-software.fr/download/11/CalHash.dmg"
-
-    depends_on macos: :big_sur
   end
   on_monterey do
     version "1.1.9"
 
     url "https://www.titanium-software.fr/download/12/CalHash.dmg"
-
-    depends_on macos: :monterey
   end
   on_ventura :or_newer do
     version "1.2.1"
 
     url "https://www.titanium-software.fr/download/13/CalHash.dmg"
-
-    depends_on macos: "<= :ventura"
   end
 
   name "CalHash"
@@ -41,6 +30,13 @@ cask "calhash" do
     url :homepage
     regex(/>\s*CalHash\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s.-]*\s+#{MacOS.version}\s*</i)
   end
+
+  depends_on macos: [
+    :catalina,
+    :big_sur,
+    :monterey,
+    :ventura,
+  ]
 
   app "CalHash.app"
 

--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -5,57 +5,41 @@ cask "deeper" do
     version "2.1.4"
 
     url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
-
-    depends_on macos: :el_capitan
   end
   on_sierra do
     version "2.2.3"
 
     url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
-
-    depends_on macos: :sierra
   end
   on_high_sierra do
     version "2.3.3"
 
     url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
-
-    depends_on macos: :high_sierra
   end
   on_mojave do
     version "2.4.8"
 
     url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
-
-    depends_on macos: :mojave
   end
   on_catalina do
     version "2.6.0"
 
     url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
-
-    depends_on macos: :catalina
   end
   on_big_sur do
     version "2.7.1"
 
     url "https://www.titanium-software.fr/download/11/Deeper.dmg"
-
-    depends_on macos: :big_sur
   end
   on_monterey do
     version "2.8.0"
 
     url "https://www.titanium-software.fr/download/12/Deeper.dmg"
-
-    depends_on macos: :monterey
   end
   on_ventura :or_newer do
     version "2.9.0"
 
     url "https://www.titanium-software.fr/download/13/Deeper.dmg"
-
-    depends_on macos: "<= :ventura"
   end
 
   name "Deeper"
@@ -66,6 +50,17 @@ cask "deeper" do
     url :homepage
     regex(/>\s*Deeper\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s.-]*\s+#{MacOS.version}\s*</i)
   end
+
+  depends_on macos: [
+    :el_capitan,
+    :sierra,
+    :high_sierra,
+    :mojave,
+    :catalina,
+    :big_sur,
+    :monterey,
+    :ventura,
+  ]
 
   app "Deeper.app"
 

--- a/Casks/m/maintenance.rb
+++ b/Casks/m/maintenance.rb
@@ -5,57 +5,41 @@ cask "maintenance" do
     version "2.1.8"
 
     url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
-
-    depends_on macos: :el_capitan
   end
   on_sierra do
     version "2.3.0"
 
     url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
-
-    depends_on macos: :sierra
   end
   on_high_sierra do
     version "2.4.2"
 
     url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
-
-    depends_on macos: :high_sierra
   end
   on_mojave do
     version "2.5.6"
 
     url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
-
-    depends_on macos: :mojave
   end
   on_catalina do
     version "2.7.1"
 
     url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
-
-    depends_on macos: :catalina
   end
   on_big_sur do
     version "2.8.2"
 
     url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
-
-    depends_on macos: :big_sur
   end
   on_monterey do
     version "2.9.2"
 
     url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
-
-    depends_on macos: :monterey
   end
   on_ventura :or_newer do
     version "3.0.2"
 
     url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
-
-    depends_on macos: "<= :ventura"
   end
 
   name "Maintenance"
@@ -66,6 +50,17 @@ cask "maintenance" do
     url :homepage
     regex(/>\s*Maintenance\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s.-]*\s+#{MacOS.version}\s*</i)
   end
+
+  depends_on macos: [
+    :el_capitan,
+    :sierra,
+    :high_sierra,
+    :mojave,
+    :catalina,
+    :big_sur,
+    :monterey,
+    :ventura,
+  ]
 
   app "Maintenance.app"
 

--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -5,57 +5,41 @@ cask "onyx" do
     version "3.1.9"
 
     url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
-
-    depends_on macos: :el_capitan
   end
   on_sierra do
     version "3.3.1"
 
     url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
-
-    depends_on macos: :sierra
   end
   on_high_sierra do
     version "3.4.9"
 
     url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
-
-    depends_on macos: :high_sierra
   end
   on_mojave do
     version "3.6.8"
 
     url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
-
-    depends_on macos: :mojave
   end
   on_catalina do
     version "3.8.7"
 
     url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
-
-    depends_on macos: :catalina
   end
   on_big_sur do
     version "4.0.2"
 
     url "https://www.titanium-software.fr/download/11/OnyX.dmg"
-
-    depends_on macos: :big_sur
   end
   on_monterey do
     version "4.2.7"
 
     url "https://www.titanium-software.fr/download/12/OnyX.dmg"
-
-    depends_on macos: :monterey
   end
   on_ventura :or_newer do
     version "4.4.2"
 
     url "https://www.titanium-software.fr/download/13/OnyX.dmg"
-
-    depends_on macos: "<= :ventura"
   end
 
   name "OnyX"
@@ -66,6 +50,17 @@ cask "onyx" do
     url :homepage
     regex(/>\s*OnyX\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s.-]*\s+#{MacOS.version}\s*</i)
   end
+
+  depends_on macos: [
+    :el_capitan,
+    :sierra,
+    :high_sierra,
+    :mojave,
+    :catalina,
+    :big_sur,
+    :monterey,
+    :ventura,
+  ]
 
   app "OnyX.app"
 


### PR DESCRIPTION
An improved take on the issue addressed in #154503, relying on brew changes made in Homebrew/brew#15977. Applies the same changes to all apps from the same vendor, using [syntax](https://docs.brew.sh/Cask-Cookbook#requiring-an-exact-macos-release) that [wasn't originally available](https://github.com/Homebrew/homebrew-cask/pull/154503#issuecomment-1707621049) to define an exact list of allowed macOS releases. Each retains the Ventura block's `:or_newer` to avoid issues with CI once macOS Sonoma testing starts, or once `brew audit` is updated to [fully support SimulateSystem](https://github.com/Homebrew/brew/pull/15977).