### PR TITLE
Replace Remotion with Multiapp in autobump

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -72,7 +72,7 @@ env:
     puzzles
     readdle-spark
     rewind
-    remotion
+    multiapp
     rive
     qownnotes
     quarto


### PR DESCRIPTION
When I renamed Remotion to Multiapp in #153968 I didn't know about the auto bump script. (Looking back I should have done a search for Remotion in the repo. 🙄)