### PR TITLE
1password-cli cask doesn't ask for root password anymore

### DIFF
--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -8,7 +8,7 @@ cask "1password-cli" do
   url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_darwin_#{arch}_v#{version}.zip"
       verified: "cache.agilebits.com/dist/1P/op2/pkg/"
   name "1Password CLI"
-  desc "Command-line helper for the 1Password password manager"
+  desc "Command-line interface for 1Password"
   homepage "https://developer.1password.com/docs/cli"
 
   livecheck do

--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -1,8 +1,11 @@
 cask "1password-cli" do
-  version "2.21.0"
-  sha256 "015891e77ab5fe366dce9159ec5681c286401ae5ec1877d42c422e22b4ea812b"
+  arch arm: "arm64", intel: "amd64"
 
-  url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_apple_universal_v#{version}.pkg",
+  version "2.21.0"
+  sha256 arm:   "1de120081d7a7d278fdc6c619a4ce15d691bc535c2d2aa494d975bc3463c6a33",
+         intel: "6e81ac0d9f7f2dbc4dc1e3ed71c02790a7b874ceb36e79432a03ea084b291820"
+
+  url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_darwin_#{arch}_v#{version}.zip"
       verified: "cache.agilebits.com/dist/1P/op2/pkg/"
   name "1Password CLI"
   desc "Command-line helper for the 1Password password manager"
@@ -15,9 +18,7 @@ cask "1password-cli" do
 
   conflicts_with cask: "1password-cli1"
 
-  pkg "op_apple_universal_v#{version}.pkg"
-
-  uninstall pkgutil: "com.1password.op"
+  binary "op"
 
   zap trash: "~/.op"
 end

--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -5,7 +5,7 @@ cask "1password-cli" do
   sha256 arm:   "1de120081d7a7d278fdc6c619a4ce15d691bc535c2d2aa494d975bc3463c6a33",
          intel: "6e81ac0d9f7f2dbc4dc1e3ed71c02790a7b874ceb36e79432a03ea084b291820"
 
-  url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_darwin_#{arch}_v#{version}.zip"
+  url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_darwin_#{arch}_v#{version}.zip",
       verified: "cache.agilebits.com/dist/1P/op2/pkg/"
   name "1Password CLI"
   desc "Command-line interface for 1Password"


### PR DESCRIPTION
## Context
Since the latest desktop app version, the CLI can now be installed outside of `/usr/local/bin`. 

## Problem
Our brew cask requires the root password because it's using the pkg installer and places the binary in `/usr/local/bin`

## Solution
This MR changes our cask formula to download the `op` Darwin zip for latest version, for either arm64 or amd64, and place it in the mainstream `/opt/homebrew/bin` dir.

## Thought process
**architecture:** On MacOS, only 2 architectures are supported: arm64 or amd64 (x86_64). 

**install location:** `/opt/homebrew/bin` has been chosen because that's where `brew` installs its packages and it requires no permission to be granted in the process. CLI can now be installed in this path.

**livecheck:** keep the same live check as before as it's a good indicator of whether new packages are available for download

**uninstall:** no uninstall stanza is needed anymore. The zap stanza is kept as before.



## How to test
You can test that this runs okay by uninstalling your `op`, checking out this branch and running:  `HOMEBREW_NO_AUTO_UPDATE=1 brew install -v --build-from-source --HEAD Casks/1password-cli.rb`. 

Then run `which op` to check that it's in `/opt/homebrew/bin/op`.