### PR TITLE
updated Mochi Cards checksums

### DIFF
--- a/Casks/m/mochi.rb
+++ b/Casks/m/mochi.rb
@@ -2,8 +2,8 @@ cask "mochi" do
   arch arm: "-arm64"
 
   version "1.15.27"
-  sha256 arm:   "476882901079984ca243b800e65dde9eaf2850fe2d190454c11be37fb80b4e7b",
-         intel: "42c65adf1d93e386865fe87411c3cf535acb943a92ae88d342ce89c6a29d7b85"
+  sha256 arm:   "6fb776c5165e7534c60279c488ff49b84116315652aca61923bc3081f6a22656",
+         intel: "cd36fd8ad2961c2d1e1de3b1a074f3ef97bd15775dfea12f08e390ddf6ad0393"
 
   url "https://mochi.cards/releases/Mochi-#{version}#{arch}.dmg"
   name "Mochi"


### PR DESCRIPTION
updated outdated checksums of latest Mochi version available on the website for both Intel and M1 version, which caused SHA256 mismatch errors during update attempts.

`shasum -a 256 Mochi-1.15.27-arm64.dmg`
6fb776c5165e7534c60279c488ff49b84116315652aca61923bc3081f6a22656  Mochi-1.15.27-arm64.dmg

`shasum -a 256 Mochi-1.15.27.dmg`
cd36fd8ad2961c2d1e1de3b1a074f3ef97bd15775dfea12f08e390ddf6ad0393  Mochi-1.15.27.dmg

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
