### PR TITLE
updated latest box-drive version number

### DIFF
--- a/Casks/b/box-drive.rb
+++ b/Casks/b/box-drive.rb
@@ -1,5 +1,5 @@
 cask "box-drive" do
-  version "2.34.84"
+  version "2.35.95"
   sha256 :no_check
 
   url "https://e3.boxcdn.net/desktop/releases/mac/BoxDrive.pkg",


### PR DESCRIPTION
in case sha256 checksum is also required (but only one version exists covering both, Intel and M1):

`shasum -a 256 BoxDrive.pkg`
`561f976d3e97f966f5cbd24ee69da2b31b995cd8bcb24e2c5b09b126196f135b`  BoxDrive.pkg

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
