### PR TITLE
openlp: update livecheck to ignore rc release

### DIFF
--- a/Casks/o/openlp.rb
+++ b/Casks/o/openlp.rb
@@ -9,7 +9,7 @@ cask "openlp" do
 
   livecheck do
     url "https://get.openlp.org"
-    regex(/href=['"]?(\d+(?:\.\d+)+)['"]?/i)
+    regex(%r{href=['"]?(\d+(?:\.\d+)+)(?!rc\d+)/['"]?}i)
   end
 
   app "OpenLP.app"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
