### PR TITLE
iridium: fix livecheck

### DIFF
--- a/Casks/i/iridium.rb
+++ b/Casks/i/iridium.rb
@@ -9,7 +9,7 @@ cask "iridium" do
 
   livecheck do
     url "https://iridiumbrowser.de/downloads/macos"
-    regex(/iridium-browser[._-]?v?(\d+(?:\.\d+)+)[._-]?macos\.dmg/i)
+    regex(/iridium-browser[._-]?v?(\d+(?:\.\d+)+)[._-]?macos_universal\.dmg/i)
   end
 
   app "Iridium.app"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
