### PR TITLE
cookie: update url

### DIFF
--- a/Casks/c/cookie.rb
+++ b/Casks/c/cookie.rb
@@ -2,7 +2,7 @@ cask "cookie" do
   version "7.0.1"
   sha256 :no_check
 
-  url "https://sweetpproductions.com/products/cookieapp/Cookie.dmg"
+  url "https://sweetpproductions.com/products/cookie7/Cookie.dmg"
   name "Cookie"
   desc "Protection from tracking and online profiling"
   homepage "https://sweetpproductions.com/"
@@ -13,7 +13,7 @@ cask "cookie" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :monterey"
 
   app "Cookie.app"
 


### PR DESCRIPTION
The download URL has changed for Cookie 7, so has the minimum macOS version supported.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
