### PR TITLE
Autocompile Ghidra decompiler on AppleSilicon

### DIFF
--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -2,6 +2,15 @@ cask "ghidra" do
   version "10.3.3,20230829"
   sha256 "63833361bea8ef5ada1bc28cd2aa2ae4ab43204d2672b595500372582152eebe"
 
+  on_arm do
+    depends_on formula: "gradle"
+    postflight do
+      ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin:" + ENV.fetch("PATH", nil)
+      puts "Compiling Ghidra native decompiler"
+      system_command "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/support/buildNatives"
+    end
+  end
+
   url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.csv.first}_build/ghidra_#{version.csv.first}_PUBLIC_#{version.csv.second}.zip",
       verified: "github.com/NationalSecurityAgency/ghidra/"
   name "Ghidra"
@@ -31,15 +40,6 @@ cask "ghidra" do
   preflight do
     # Log4j misinterprets comma in staged_path as alternative delimiter
     FileUtils.mv(staged_path, "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}")
-  end
-
-  on_arm do
-    depends_on formula: "gradle"
-    postflight do
-      ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin:" + ENV.fetch("PATH", nil)
-      puts "Compiling Ghidra native decompiler"
-      system_command "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/support/buildNatives"
-    end
   end
 
   uninstall_preflight do

--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -33,6 +33,15 @@ cask "ghidra" do
     FileUtils.mv(staged_path, "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}")
   end
 
+  on_arm do
+    depends_on formula: "gradle"
+    postflight do
+      ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin:" + ENV.fetch("PATH", nil)
+      puts "Compiling Ghidra native decompiler"
+      system_command "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/support/buildNatives"
+    end
+  end
+
   uninstall_preflight do
     FileUtils.mv("#{caskroom_path}/#{version.csv.first}-#{version.csv.second}", staged_path)
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

(`brew style` report an offense about `on_arm` stanza being out of order, but for developer sanity I think it's better the current position instead of the one suggested by `brew style`)

----

**Pull Request Rationale**

Installing the Ghidra Cask on M1/M2/AppleSilicon devices ends up in a Gatekeeper error because the following binary[1] file is not codesigned.
This PR adds a new `on_arm`/`postflight` stanza that will compile locally the binary file using gradle from brew itself.
In this way the compiled binary file will not trigger the Gatekeeper error when the application is started.
More info is available at the following link: https://lachy.io/articles/properly-installing-ghidra-on-an-m1-mac


- [1] `/opt/homebrew/Caskroom/ghidra/10.3.3-20230829/ghidra_10.3.3_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/decompile`
