### PR TITLE
Mark `elgato-stream-deck` as `auto_update`-able

### DIFF
--- a/Casks/e/elgato-stream-deck.rb
+++ b/Casks/e/elgato-stream-deck.rb
@@ -12,6 +12,7 @@ cask "elgato-stream-deck" do
     regex(/Stream[._-]Deck[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
+  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   pkg "Stream_Deck_#{version}.pkg"


### PR DESCRIPTION
<img width="469" alt="CleanShot 2023-09-14 at 09 46 21@2x" src="https://github.com/Homebrew/homebrew-cask/assets/11512/d3b741e9-1f4f-4f1f-b6a4-100b0b55dbbe">

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - (see below)
- [x] `brew style --fix <cask>` reports no offenses.

---

Even without modifications, `brew audit` fails for me:
```
brew audit --cask --online elgato-stream-deck

Error: no implicit conversion of nil into String
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:85:in `initialize'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:85:in `Pathname'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:85:in `can_load?'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:176:in `can_load?'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:421:in `block in for'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:420:in `each'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:420:in `for'
/opt/homebrew/Library/Homebrew/cask/cask_loader.rb:407:in `load'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:250:in `block (3 levels) in audit'
/opt/homebrew/Library/Homebrew/simulate_system.rb:29:in `with'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:157:in `call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:157:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:246:in `block (2 levels) in audit'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:243:in `each'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:243:in `flat_map'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:243:in `block in audit'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:240:in `each'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:240:in `each_with_object'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:240:in `audit'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:157:in `call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:157:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```