### PR TITLE
bookmacster 3.0.12

### DIFF
--- a/Casks/b/bookmacster.rb
+++ b/Casks/b/bookmacster.rb
@@ -13,6 +13,7 @@ cask "bookmacster" do
     url "https://sheepsystems.com/bookmacster/appcast.xml"
     strategy :sparkle do |items|
       items.map(&:short_version)
+    end
   end
 
   auto_updates true

--- a/Casks/b/bookmacster.rb
+++ b/Casks/b/bookmacster.rb
@@ -1,15 +1,18 @@
 cask "bookmacster" do
-  version "3.0.8"
-  sha256 "b743b550c4fa3d7667823bfad5052dc636ec0e3cf2ac49f334d8ce26c0bb0cb6"
+  version "3.0.12"
+  sha256 "0b79ed601d82648ce212166e7cda278d54a1914058ed81ad465bd47a8d47f485"
 
   url "https://sheepsystems.com/bookmacster/BookMacster_#{version}.zip"
   name "BookMacster"
   desc "Bookmarks manager"
   homepage "https://sheepsystems.com/products/bookmacster.html"
 
+  # Older items in the Sparkle feed may have a newer pubDate, so it's necessary
+  # to work with all of the items in the feed (not just the newest one).
   livecheck do
     url "https://sheepsystems.com/bookmacster/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle do |items|
+      items.map(&:short_version)
   end
 
   auto_updates true


### PR DESCRIPTION
update bookmacster to 3.0.12 and update livecheck to use a strategy block with the magic items argument to work with all of the appcast items in such a way that it ignores the strategy's default pubDate sorting.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
