### PR TITLE
Migrate playdate-mirror from cask-drivers

### DIFF
--- a/Casks/p/playdate-mirror.rb
+++ b/Casks/p/playdate-mirror.rb
@@ -1,0 +1,28 @@
+cask "playdate-mirror" do
+  version "1.0.0"
+  sha256 "690137066bd7059b55b7e5717994569e64814dbd5b06e7f19a181f59e0268a0b"
+
+  url "https://download-keycdn.panic.com/mirror/Mirror-#{version}.zip",
+      verified: "download-keycdn.panic.com/mirror/"
+  name "Playdate Mirror"
+  desc "Application that streams gameplay audio and video from your Playdate"
+  homepage "https://play.date/mirror"
+
+  livecheck do
+    url "https://download.panic.com/mirror/Mirror-latest.zip"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Mirror.app"
+
+  uninstall quit: "com.panic.Mirror"
+
+  zap trash: [
+    "~/Library/Saved Application State/com.panic.Mirror.savedState",
+    "~/Library/Preferences/com.panic.Mirror.plist",
+    "~/Library/Preferences/Mirror Preferences",
+  ]
+end


### PR DESCRIPTION
Linked cask-drivers PR https://github.com/Homebrew/homebrew-cask-drivers/pull/3481

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
