### PR TITLE
applite: add dependency and bump to 1.2

### DIFF
--- a/Casks/a/applite.rb
+++ b/Casks/a/applite.rb
@@ -1,6 +1,6 @@
 cask "applite" do
-  version "1.1"
-  sha256 "47748d5e7c09e70147f88592073f85c7dfa5ceef4db405507e5f12951398eda5"
+  version "1.2"
+  sha256 "0ed96bb654108b4f448e421fdbd695ba8e2da348c4a33075ac195b8222e42e45"
 
   url "https://github.com/milanvarady/Applite/releases/download/v#{version}/Applite.dmg",
       verified: "github.com/milanvarady/Applite/"

--- a/Casks/a/applite.rb
+++ b/Casks/a/applite.rb
@@ -15,6 +15,7 @@ cask "applite" do
 
   auto_updates true
   depends_on macos: ">= :ventura"
+  depends_on formula: "pinentry-mac"
 
   app "Applite.app"
 


### PR DESCRIPTION

Add `pinentry-mac` formula as a dependency to cask `applite`. It is used by the application to safely retrieve user password.