### PR TITLE
Add os/arch options to readall command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run brew readall ${{ matrix.tap }}
         id: readall
-        run: brew readall '${{ matrix.tap }}'
+        run: brew readall --os=all --arch=all '${{ matrix.tap }}'
         if: >
           always() &&
           contains(fromJSON('["success", "skipped"]'), steps.gems.outcome) &&


### PR DESCRIPTION
This is a follow-up to changes that added os/arch combinations a few months ago. They were made the default temporarily until the references to `brew readall` in the other Homebrew repos were updated as well.

- https://github.com/Homebrew/brew/pull/15470
- https://github.com/Homebrew/brew/pull/15937#discussion_r1313889254