### PR TITLE
soduto: replace with more recent fork

### DIFF
--- a/Casks/s/soduto.rb
+++ b/Casks/s/soduto.rb
@@ -1,16 +1,12 @@
 cask "soduto" do
-  version "1.0.1"
-  sha256 "ccd412fce497bb9b7822fc702c65792b5354711b6dfc1e028fb12cd7f202931f"
+  version "2.0.3-nightly"
+  sha256 "d0e7350b14e87253f93be36b6a04ee80831d8636b60a74fbf1d6ac0e455a6392"
 
-  url "https://soduto.com/downloads/Soduto_v#{version}.dmg"
+  url "https://github.com/sannidhyaroy/Soduto/releases/download/v#{version}/Soduto.Nightly.dmg",
+      verified: "github.com/sannidhyaroy/Soduto/"
   name "Soduto"
   desc "Communicate and share information between devices"
-  homepage "https://soduto.com/"
-
-  livecheck do
-    url "https://soduto.com/downloads/"
-    regex(%r{href=.*?/Soduto_v?(\d+(?:\.\d+)*)\.dmg}i)
-  end
+  homepage "https://soduto.thenoton.com/"
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
Work in [original repository 
](https://github.com/soduto/Soduto) stalled more then a year ago. [Fork](https://github.com/sannidhyaroy/Soduto) is very much alive and adding new features. Might be better to create a separate cask for it, I'm not too sure.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
