### PR TITLE
Remove ARM requirement from `rewind`

### DIFF
--- a/Casks/r/rewind.rb
+++ b/Casks/r/rewind.rb
@@ -18,8 +18,7 @@ cask "rewind" do
   end
 
   auto_updates true
-  depends_on arch:  :arm64,
-             macos: ">= :monterey"
+  depends_on macos: ">= :monterey"
 
   app "Rewind.app"
 


### PR DESCRIPTION
Rewind [now supports Intel](https://help.rewind.ai/en/articles/6705951-what-hardware-is-required-to-run-rewind).