### PR TITLE
Add CLINQ.app latest

### DIFF
--- a/Casks/c/clinq.rb
+++ b/Casks/c/clinq.rb
@@ -1,11 +1,16 @@
 cask "clinq" do
-  version :latest
+  version "1.6.13"
   sha256 :no_check
 
   url "https://desktop.download.clinq.com/clinq-desktop.dmg"
-  name "Clinq"
-  desc "Softphone"
-  homepage "https://clinq.com/"
+  name "CLINQ"
+  desc "softphone for making telephone calls over the internet"
+  homepage "https://clinq.com/download/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/c/clinq.rb
+++ b/Casks/c/clinq.rb
@@ -4,7 +4,7 @@ cask "clinq" do
 
   url "https://desktop.download.clinq.com/clinq-desktop.dmg"
   name "CLINQ"
-  desc "softphone for making telephone calls over the internet"
+  desc "Softphone for making telephone calls over the internet"
   homepage "https://clinq.com/download/"
 
   livecheck do

--- a/Casks/c/clinq.rb
+++ b/Casks/c/clinq.rb
@@ -1,0 +1,18 @@
+cask "clinq" do
+  version :latest
+  sha256 :no_check
+
+  url "https://desktop.download.clinq.com/clinq-desktop.dmg"
+  name "Clinq"
+  desc "Softphone"
+  homepage "https://clinq.com/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "CLINQ.app"
+
+  zap trash: [
+    "~/Library/Application Support/clinq-desktop/",
+    "~/Library/Saved Application State/com.clinq.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
I followed https://docs.brew.sh/Adding-Software-to-Homebrew#casks and https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#cask-related-pull-request 

The download page is https://clinq.com/download/ which somehow isn't linked anywhere on the homepage. I couldn't find a version or hash on the homepage, so left that blank. The current version is `1.6.13` and from the log the hash of the download seems to be `149dbf8c75002a2c5e901287fcca6a3c9786169c1c3c0da99478fa52b010729d`.

Feel free to edit if it can be improved.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
