### PR TITLE
gossip 0.8.0 (new cask)

### DIFF
--- a/Casks/g/gossip.rb
+++ b/Casks/g/gossip.rb
@@ -1,0 +1,35 @@
+cask "gossip" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "0.8.0"
+  sha256 arm:   "3b589bbf7357904142922270991748c10e380335124df31434058c416cfc168c",
+         intel: "f661810442773c816f2eb1d05ec276a3e443a3d0f4e459d9d7715b88d75f8f41"
+
+  url "https://github.com/mikedilger/gossip/releases/download/v#{version}/gossip-#{version}-Darwin-#{arch}.dmg"
+  name "Gossip"
+  desc "Desktop client for Nostr written in Rust"
+  homepage "https://github.com/mikedilger/gossip"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Gossip.app"
+
+  zap trash: [
+    "~/Library/Application Support/gossip",
+    "~/Library/Saved Application State/com.mikedilger.gossip.savedState",
+  ]
+
+  caveats <<~EOS
+    This app may not run with quarantine attributes typically applied by macOS
+    security policy. If you're sure you want to trust the app, you can reinstall
+    without quarantine attributes:
+
+      brew reinstall --cask --no-quarantine #{token}
+
+    https://docs.brew.sh/FAQ#why-cant-i-open-a-mac-app-from-an-unidentified-developer
+    https://github.com/mikedilger/gossip/blob/master/packaging/macos/README.macos.txt
+  EOS
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

`brew audit --new-cask` option does not exist (?) but succeeds on my system. `brew audit --new --cask` fails however due to a codesigning issue which there is precedent for accepting (https://github.com/Homebrew/homebrew-cask/pull/127827). This issue potentially exists in other existing casks but only appears to get caught for new ones, e.g. `brew audit --new --cask bloodhound` fails for the same reason.

```
❯ brew audit --new --cask gossip
==> Downloading https://github.com/mikedilger/gossip/releases/download/v0.8.0/gossip-0.8.0-Darwin-arm64.dmg
Already downloaded: /Users/me/Library/Caches/Homebrew/downloads/47753c8aa684a088f56e0a664224865c424cd58bd2453c1e4b2055245ed0e9fb--gossip-0.8.0-Darwin-arm64.dmg
==> Downloading https://github.com/mikedilger/gossip/releases/download/v0.8.0/gossip-0.8.0-Darwin-arm64.dmg
Already downloaded: /Users/me/Library/Caches/Homebrew/downloads/47753c8aa684a088f56e0a664224865c424cd58bd2453c1e4b2055245ed0e9fb--gossip-0.8.0-Darwin-arm64.dmg
audit for gossip: failed
 - Signature verification failed:
/private/tmp/d20230920-58675-sm6ue2/Gossip.app: code has no resources but signature indicates they must be present

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
gossip
  * line 8, col 2: Signature verification failed:
    /private/tmp/d20230920-58675-sm6ue2/Gossip.app: code has no resources but signature indicates they must be present

    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 1 problem in 1 cask detected.
```

I have added an appropriate caveat to guide the user to reinstall without quarantine attributes, if they are sure they want to trust the app, as documented in the [Homebrew FAQ](https://docs.brew.sh/FAQ#why-cant-i-open-a-mac-app-from-an-unidentified-developer).