### PR TITLE
apidog: various updates

### DIFF
--- a/Casks/a/apidog.rb
+++ b/Casks/a/apidog.rb
@@ -1,6 +1,6 @@
 cask "apidog" do
   arch arm: "-macOS-arm64"
-  livecheck_folder = on_arch_conditional arm: "mac-arm64", intel: "mac"
+  livecheck_folder = on_arch_conditional arm: "-arm64"
 
   version "2.3.16"
   sha256 arm:   "c9d5dbcf5726733eeb94226cea15197d5a9d20004695033b2de424761c97c35b",
@@ -12,11 +12,12 @@ cask "apidog" do
   homepage "https://apidog.com/"
 
   livecheck do
-    url "https://api.apidog.com/api/v1/configs/client-updates/#{version}/#{livecheck_folder}/latest-mac.yml"
+    url "https://api.apidog.com/api/v1/configs/client-updates/latest/mac#{livecheck_folder}/latest-mac.yml"
     strategy :electron_builder
   end
 
   auto_updates true
+  depends_on macos: ">= :el_capitan"
 
   app "Apidog.app"
 


### PR DESCRIPTION
A `livecheck` `url` containing `#{version}` is useless.