### PR TITLE
caprine: remove empty intel arch

### DIFF
--- a/Casks/c/caprine.rb
+++ b/Casks/c/caprine.rb
@@ -1,5 +1,5 @@
 cask "caprine" do
-  arch arm: "-arm64", intel: ""
+  arch arm: "-arm64"
 
   version "2.58.2"
   sha256 arm:   "1b8f5d19ed75cff49fdb4ba87bba4eebf2d50f9876ee9445f03a7095156791e5",


### PR DESCRIPTION
There was an empty intel arch flag which was not needed.  Removing as a cleanup fix.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
