### PR TITLE
xca 2.5.0

### DIFF
--- a/Casks/x/xca.rb
+++ b/Casks/x/xca.rb
@@ -1,8 +1,8 @@
 cask "xca" do
-  version "2.4.0"
-  sha256 "1fb5fa69759f9bfd15e0a8ddabc6b9e2cf52e9c41ad2346b2f4c293d950c6bc4"
+  version "2.5.0"
+  sha256 "0042758b99d09aa254d721e1e94fd97adfc186727891093e9eeec4d18e9d734f"
 
-  url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}.dmg",
+  url "https://github.com/chris2511/xca/releases/download/RELEASE.#{version}/xca-#{version}-Darwin.dmg",
       verified: "github.com/chris2511/xca/"
   name "XCA"
   desc "X Certificate and Key management"
@@ -14,4 +14,9 @@ cask "xca" do
   end
 
   app "xca.app"
+
+  zap trash: [
+    "~/Library/Application Support/xca",
+    "~/Library/Saved Application State/de.hohnstaedt.xca.savedState",
+  ]
 end


### PR DESCRIPTION
* Bump to version 2.5.0

* Update url

* Add zap

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
