### PR TITLE
Fix cask for packages: the pkg installer name was incorrect

### DIFF
--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -14,7 +14,7 @@ cask "packages" do
 
   auto_updates true
 
-  pkg "packages/Packages.pkg"
+  pkg "packages/Install Packages.pkg"
 
   uninstall script: { executable: "Extras/uninstall.sh", sudo: true }
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free. 
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

These changes fix the [packages](http://s.sudre.free.fr/Software/Packages/about.html) cask, which was failing because the name of the pkg installer run in the cask was incorrect.