### PR TITLE
time-to-leave 3.0.0

### DIFF
--- a/Casks/t/time-to-leave.rb
+++ b/Casks/t/time-to-leave.rb
@@ -1,8 +1,8 @@
 cask "time-to-leave" do
-  version "2.0.1"
-  sha256 "645026480b04cec15dce96b0dbd361565f6647fcb9ab79df457ea5f1fa75f02f"
+  version "3.0.0"
+  sha256 "25fef73ac373e37ba8c0363e25e7e0996afb048466698777e9f0a0e5bb8876a0"
 
-  url "https://github.com/thamara/time-to-leave/releases/download/v#{version}/time-to-leave.dmg"
+  url "https://github.com/thamara/time-to-leave/releases/download/#{version}/time-to-leave-#{version}.dmg"
   name "Time To Leave"
   desc "Log work hours and get notified when it's time to leave the office"
   homepage "https://github.com/thamara/time-to-leave"

--- a/Casks/t/time-to-leave.rb
+++ b/Casks/t/time-to-leave.rb
@@ -16,4 +16,9 @@ cask "time-to-leave" do
   end
 
   app "Time To Leave.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.electron.time-to-leave.plist",
+    "~/Library/Saved Application State/com.electron.time-to-leave.savedState",
+  ]
 end


### PR DESCRIPTION
* Update version to 3.0.0

* Update url for latest release

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
