### PR TITLE
vallum 4.1

### DIFF
--- a/Casks/v/vallum.rb
+++ b/Casks/v/vallum.rb
@@ -1,8 +1,8 @@
 cask "vallum" do
-  version "4.0.14"
-  sha256 "d737bf85cd7cd1c28a0a15110b3695ef1b32f012e691e98636080a966bac8251"
+  version "4.1"
+  sha256 "6ae54ce248aeb06c2efd44bdd57433d771a693395904afdec577d0741fc3fd9d"
 
-  url "https://github.com/TheMurusTeam/Vallum/releases/download/v#{version}/vallum-#{version}.zip",
+  url "https://github.com/TheMurusTeam/Vallum/releases/download/v#{version}/vallum.#{version}.zip",
       verified: "github.com/TheMurusTeam/Vallum/"
   name "Vallum"
   desc "Application firewall"


### PR DESCRIPTION
* Update to version 4.1

* Update download url

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
