### PR TITLE
sf: add cask

### DIFF
--- a/Casks/s/sf.rb
+++ b/Casks/s/sf.rb
@@ -3,7 +3,7 @@ cask "sf" do
 
   version "2.10.2,1c35561"
   sha256 intel: "0b54d605dee853abe4c575f549271141ee1647532d2345b51cd1f2045fff3a87",
-         arm: "020d85b97be4834441b477efb3f801705eda7d44eed9ab4ef1a9ac43ae64f699"
+         arm:   "020d85b97be4834441b477efb3f801705eda7d44eed9ab4ef1a9ac43ae64f699"
 
   url "https://developer.salesforce.com/media/salesforce-cli/sf/versions/#{version.csv.first}/#{version.csv.second}/sf-v#{version.csv.first}-#{version.csv.second}-#{arch}.pkg"
   name "Salesforce CLI"

--- a/Casks/s/sf.rb
+++ b/Casks/s/sf.rb
@@ -1,20 +1,23 @@
 cask "sf" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.9.8"
-  sha256 :no_check
+  version "2.10.2,1c35561"
+  sha256 intel: "0b54d605dee853abe4c575f549271141ee1647532d2345b51cd1f2045fff3a87",
+         arm: "020d85b97be4834441b477efb3f801705eda7d44eed9ab4ef1a9ac43ae64f699"
 
-  url "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-#{arch}.pkg"
+  url "https://developer.salesforce.com/media/salesforce-cli/sf/versions/#{version.csv.first}/#{version.csv.second}/sf-v#{version.csv.first}-#{version.csv.second}-#{arch}.pkg"
   name "Salesforce CLI"
   desc "Salesforce CLI tools"
   homepage "https://developer.salesforce.com/tools/salesforcecli"
 
   livecheck do
-    url "https://raw.githubusercontent.com/forcedotcom/cli/main/releasenotes/README.md"
-    regex(/(\d+(?:\.\d+)+)\s+\(.*?\)\s+\[stable\]/i)
+    url "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-darwin-#{arch}-buildmanifest"
+    strategy :json do |json|
+      "#{json["version"]},#{json["sha"]}"
+    end
   end
 
-  pkg "sf-#{arch}.pkg"
+  pkg "sf-v#{version.csv.first}-#{version.csv.second}-#{arch}.pkg"
 
   uninstall pkgutil: "com.salesforce.cli",
             delete:  [

--- a/Casks/s/sf.rb
+++ b/Casks/s/sf.rb
@@ -1,0 +1,31 @@
+cask "sf" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.9.8"
+  sha256 :no_check
+
+  url "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-#{arch}.pkg"
+  name "Salesforce CLI"
+  desc "Salesforce CLI tools"
+  homepage "https://developer.salesforce.com/tools/salesforcecli"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/forcedotcom/cli/main/releasenotes/README.md"
+    regex(/(\d+(?:\.\d+)+)\s+\(.*?\)\s+(?:\[stable\])/i)
+  end
+
+  pkg "sf-#{arch}.pkg"
+
+  uninstall pkgutil: "com.salesforce.cli",
+            delete:  [
+              "/usr/local/bin/sf",
+              "/usr/local/bin/sfdx",
+            ]
+
+  zap trash: [
+    "~/.cache/sf",
+    "~/.config/sf",
+    "~/.local/share/sf",
+    "~/.sf",
+  ]
+end

--- a/Casks/s/sf.rb
+++ b/Casks/s/sf.rb
@@ -11,7 +11,7 @@ cask "sf" do
 
   livecheck do
     url "https://raw.githubusercontent.com/forcedotcom/cli/main/releasenotes/README.md"
-    regex(/(\d+(?:\.\d+)+)\s+\(.*?\)\s+(?:\[stable\])/i)
+    regex(/(\d+(?:\.\d+)+)\s+\(.*?\)\s+\[stable\]/i)
   end
 
   pkg "sf-#{arch}.pkg"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


Salesforce has released a `v2` of their CLI, simply named `sf` which replaces the now obsolete `sfdx` (another PR to be submitted to end-of-life that Cask, and add a caveat to point to `sf`).

Details can be found here => https://github.com/forcedotcom/cli/tree/main/releasenotes

```
IMPORTANT: Are you still using sfdx (v7)? If so, we recommend that you move to sf (v2). It's easy: simply uninstall sfdx and then install sf. 
```