### PR TITLE
sfdx: mark discontinued

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -84,7 +84,7 @@ env:
     rewind
     rive
     setapp
-    sfdx
+    sf
     shapr3d
     sigmaos
     signal

--- a/Casks/s/sfdx.rb
+++ b/Casks/s/sfdx.rb
@@ -1,19 +1,13 @@
 cask "sfdx" do
   arch arm: "arm64", intel: "x64"
 
-  version "58.0"
+  version "7.209.6"
   sha256 :no_check
 
   url "https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-#{arch}.pkg"
   name "Salesforce DX CLI"
   desc "SalesForce CLI tools"
   homepage "https://developer.salesforce.com/tools/sfdxcli"
-
-  livecheck do
-    url "https://github.com/forcedotcom/cli/blob/main/releasenotes/sfdx/README.md"
-    regex(/(\d+(?:\.\d+)+).*?[stable]\]/i)
-    strategy :page_match
-  end
 
   pkg "sfdx-#{arch}.pkg"
 
@@ -27,6 +21,15 @@ cask "sfdx" do
     "~/.cache/sfdx",
     "~/.config/sfdx",
     "~/.local/share/sfdx",
-    "~/.sf",
   ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      `sf` is the official successor to this software
+
+        brew install --cask sf
+    EOS
+  end
 end


### PR DESCRIPTION
`sfdx` is deprecated per upstream, and is replaced by `sf`.

This PR sets the final version of the software, adds a `caveat` recommending to use `sf` instead, and changes the `autobump.yml` to replace `sfdx` with `sf` 

```
IMPORTANT: Are you still using sfdx (v7)? If so, we recommend that you move to sf (v2). It's easy: simply uninstall sfdx and then install sf.
```

Additionally, from their documents [here](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_move_to_sf_v2.htm)

Do not merge until #156346 is completed.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
