### PR TITLE
Update AlDente sources and improve uninstall routine

### DIFF
--- a/Casks/a/aldente.rb
+++ b/Casks/a/aldente.rb
@@ -1,15 +1,15 @@
 cask "aldente" do
   version "1.22.2"
-  sha256 :no_check
+  sha256 "6d1108d114b8c6f11c732c37c9e779683f281b9c260f98721bcdaa5b6b6a9440"
 
-  url "https://apphousekitchen.com/aldente/AlDente-Pro.dmg"
+  url "https://apphousekitchen.com/aldente/AlDente#{version}.dmg"
   name "AlDente"
   desc "Menu bar tool to limit maximum charging percentage"
   homepage "https://apphousekitchen.com/"
 
   livecheck do
-    url "https://github.com/AppHouseKitchen/AlDente-Charge-Limiter"
-    strategy :github_latest
+    url "https://apphousekitchen.com/aldente/aldenteproappcast.xml"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/a/aldente.rb
+++ b/Casks/a/aldente.rb
@@ -1,15 +1,15 @@
 cask "aldente" do
-  version "1.22.2"
+  version "1.22.2,42"
   sha256 "6d1108d114b8c6f11c732c37c9e779683f281b9c260f98721bcdaa5b6b6a9440"
 
-  url "https://apphousekitchen.com/aldente/AlDente#{version}.dmg"
+  url "https://apphousekitchen.com/aldente/AlDente#{version.csv.first}.dmg"
   name "AlDente"
   desc "Menu bar tool to limit maximum charging percentage"
   homepage "https://apphousekitchen.com/"
 
   livecheck do
-    url "https://apphousekitchen.com/aldente/aldenteproappcast.xml"
-    strategy :sparkle, &:short_version
+    url "https://apphousekitchen.com/aldente/AlDente-Pro.dmg"
+    strategy :extract_plist
   end
 
   auto_updates true

--- a/Casks/a/aldente.rb
+++ b/Casks/a/aldente.rb
@@ -1,14 +1,14 @@
 cask "aldente" do
   version "1.22.2"
-  sha256 "6d1108d114b8c6f11c732c37c9e779683f281b9c260f98721bcdaa5b6b6a9440"
+  sha256 :no_check
 
-  url "https://github.com/davidwernhart/AlDente/releases/download/#{version}/AlDente.dmg"
+  url "https://apphousekitchen.com/aldente/AlDente-Pro.dmg"
   name "AlDente"
   desc "Menu bar tool to limit maximum charging percentage"
-  homepage "https://github.com/davidwernhart/AlDente"
+  homepage "https://apphousekitchen.com/"
 
   livecheck do
-    url :url
+    url "https://github.com/AppHouseKitchen/AlDente-Charge-Limiter"
     strategy :github_latest
   end
 
@@ -17,15 +17,16 @@ cask "aldente" do
 
   app "AlDente.app"
 
-  uninstall quit:   "com.davidwernhart.Helper",
-            delete: [
-              "/Library/LaunchDaemons/com.apphousekitchen.aldente-pro.helper.plist",
-              "/Library/PrivilegedHelperTools/com.apphousekitchen.aldente-pro.helper",
-            ]
+  uninstall quit:       "com.apphousekitchen.aldente-pro",
+            launchctl:  "com.apphousekitchen.aldente-pro.helper",
+            login_item: "AlDente",
+            delete:     "/Library/PrivilegedHelperTools/com.apphousekitchen.aldente-pro.helper"
 
   zap trash: [
     "~/Library/Application Support/AlDente",
     "~/Library/Caches/com.apphousekitchen.aldente-pro",
     "~/Library/HTTPStorages/com.apphousekitchen.aldente-pro.binarycookies",
+    "~/Library/Preferences/com.apphousekitchen.aldente-pro_backup.plist",
+    "~/Library/Preferences/com.apphousekitchen.aldente-pro.plist",
   ]
 end


### PR DESCRIPTION
The developers do not use the davidwernhart identifiers any longer. The github repo _davidwernhart/AlDente_ does not exist anymore and points to _AppHouseKitchen/AlDente-Charge-Limiter_.

The paid features are of course not available on github. The now used sources from the developers' website include the free version as well as the premium features unlock-able by license key.

Additionally I improved the uninstall routine a bit. Some preference files have not been removed and the quit command ran into empty space.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
