### PR TITLE
orion 0.99.125 sonoma 14.0

### DIFF
--- a/Casks/o/orion.rb
+++ b/Casks/o/orion.rb
@@ -49,7 +49,7 @@ cask "orion" do
 
     depends_on macos: :monterey
   end
-  on_ventura :or_newer do
+  on_ventura do
     sha256 "905787264208ec31ce912a1630e8051606fb8aaceb52b93b1a9a83d3bd134705"
 
     url "https://browser.kagi.com/updates/13_0/#{version.csv.second}.zip"
@@ -59,7 +59,19 @@ cask "orion" do
       strategy :sparkle
     end
 
-    depends_on macos: "<= :ventura"
+    depends_on macos: :ventura
+  end
+  on_sonoma :or_newer do
+    sha256 "20c78c54fb661f2d1509d53bdf71cf9a2142f15a19193f4cface48d971e1d59f"
+
+    url "https://browser.kagi.com/updates/14_0/#{version.csv.second}.zip"
+
+    livecheck do
+      url "https://cdn.kagi.com/updates/14_0/appcast.xml"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :sonoma"
   end
 
   name "Orion Browser"


### PR DESCRIPTION
- Fixes https://github.com/Homebrew/homebrew-cask/issues/150646

macOS 14.0 Sonoma is now live and this cask fails to install with the following error:

> `Error: This cask does not run on macOS versions newer than Ventura.`

![Screenshot 2023-09-28 at 7 44 33 PM](https://github.com/Homebrew/homebrew-cask/assets/9257785/ee048309-4155-4265-81c7-9cd594b64f4b)