### PR TITLE
virtualbuddy: update livecheck

### DIFF
--- a/Casks/v/virtualbuddy.rb
+++ b/Casks/v/virtualbuddy.rb
@@ -8,20 +8,15 @@ cask "virtualbuddy" do
   homepage "https://github.com/insidegui/VirtualBuddy"
 
   livecheck do
-    url "https://github.com/insidegui/VirtualBuddy/releases/latest"
-    regex(/href=.*VirtualBuddy[._-]v?(\d+(?:\.\d+)+)[._-]((\d+))\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^VirtualBuddy[._-]v?(\d+(?:[.-]\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        match[1].tr("-", ",")
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #156512, to replace the older GitHub asset-checking approach that we used before the `GithubLatest` strategy was modified to use the JSON API (I wasn't able to catch that PR before it was merged). Nowadays, `GithubLatest` can pass the release JSON data to a `strategy` block, so we can easily iterate through the assets [without having to make multiple requests].

Besides the refactoring related to the strategy, this simplifies the regex and modifies how we handle the match, so it will continue to return a version if there is ever a dmg file that doesn't include a numeric suffix (e.g., `1.2.3` instead of the usual `1.2.3-4`).