### PR TITLE
Patch kong insomnia

### DIFF
--- a/Casks/i/inso.rb
+++ b/Casks/i/inso.rb
@@ -9,7 +9,7 @@ cask "inso" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    regex(/lib@v?(\d+(?:\.\d+)+)(?!.)/i)
+    regex(/lib@v?(\d{1,3}(?:\.\d+)+)(?!.)/i)
   end
 
   conflicts_with cask: "homebrew/cask-versions/inso-beta"

--- a/Casks/i/inso.rb
+++ b/Casks/i/inso.rb
@@ -1,6 +1,6 @@
 cask "inso" do
-  version "2023.5.8"
-  sha256 "2ab577f3b3e0e0afc7080b24908c248a31863a7ae1d6d81595e5d16d0238ec58"
+  version "8.1.0"
+  sha256 "b1fc1c0e4156e20d92d433ce545be0886d07f8e735a789319e1cb3962af94db5"
 
   url "https://github.com/Kong/insomnia/releases/download/lib%40#{version}/inso-macos-#{version}.zip",
       verified: "github.com/Kong/insomnia/"

--- a/Casks/i/inso.rb
+++ b/Casks/i/inso.rb
@@ -8,8 +8,12 @@ cask "inso" do
   desc "CLI HTTP and GraphQL Client"
   homepage "https://insomnia.rest/products/inso"
 
+  # Upstream previously used a date-based version scheme (e.g., `2023.5.8`)
+  # before switching to a typical `8.1.0` format. The date-based versions are
+  # numerically higher, so we have to avoid matching them.
   livecheck do
-    regex(/lib@v?(\d{1,3}(?:\.\d+)+)(?!.)/i)
+    url :url
+    regex(/^lib@v?(\d{1,3}(?:\.\d+)+)$/i)
   end
 
   conflicts_with cask: "homebrew/cask-versions/inso-beta"

--- a/Casks/i/insomnia.rb
+++ b/Casks/i/insomnia.rb
@@ -8,8 +8,12 @@ cask "insomnia" do
   desc "HTTP and GraphQL Client"
   homepage "https://insomnia.rest/"
 
+  # Upstream previously used a date-based version scheme (e.g., `2023.5.8`)
+  # before switching to a typical `8.1.0` format. The date-based versions are
+  # numerically higher, so we have to avoid matching them.
   livecheck do
-    regex(/core@v?(\d{1,3}(?:\.\d+)+)(?!.)/i)
+    url :url
+    regex(/^core@v?(\d{1,3}(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/i/insomnia.rb
+++ b/Casks/i/insomnia.rb
@@ -1,5 +1,5 @@
 cask "insomnia" do
-  version "8.1.0"
+  version "2023.5.8"
   sha256 "40c640dcb17bc9d3a66e2afc82c28fac4c78f92aaccf72c4aea14fdfd984847f"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",

--- a/Casks/i/insomnia.rb
+++ b/Casks/i/insomnia.rb
@@ -1,5 +1,5 @@
 cask "insomnia" do
-  version "2023.5.8"
+  version "8.1.0"
   sha256 "40c640dcb17bc9d3a66e2afc82c28fac4c78f92aaccf72c4aea14fdfd984847f"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",
@@ -9,7 +9,7 @@ cask "insomnia" do
   homepage "https://insomnia.rest/"
 
   livecheck do
-    regex(/core@v?(\d+(?:\.\d+)+)(?!.)/i)
+    regex(/core@v?(\d{1,3}(?:\.\d+)+)(?!.)/i)
   end
 
   auto_updates true

--- a/Casks/i/insomnia.rb
+++ b/Casks/i/insomnia.rb
@@ -1,6 +1,6 @@
 cask "insomnia" do
-  version "2023.5.8"
-  sha256 "40c640dcb17bc9d3a66e2afc82c28fac4c78f92aaccf72c4aea14fdfd984847f"
+  version "8.1.0"
+  sha256 "f011d0bead17b5784a915873d9ba4513fcb4a1ed07cfc9e43af459b5dcc10b39"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",
       verified: "github.com/Kong/insomnia/"


### PR DESCRIPTION
The versioning scheme of insomnia and inso has changed from 2023.5.8 to 8.x.x
see https://insomnia.rest/changelog#8.0.0


---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
