### PR TITLE
Add ecoDMS 23.01

### DIFF
--- a/Casks/e/ecodms-client.rb
+++ b/Casks/e/ecodms-client.rb
@@ -1,18 +1,17 @@
-cask "ecodms" do
+cask "ecodms-client" do
   version "23.01"
-  sha256 "1bc94d3bc28a3b17fa525d8f9c5151450606a166bbb3752f3b2c19cdc9ed9226"
+  sha256 :no_check
 
   url "https://www.ecodms.de/index.php/de/component/jdownloads/?task=download.send&id=413&catid=162&m=0&Itemid=661"
-  name "ecoDMS"
+  name "ecoDMS Client"
   desc "Document Management System"
   homepage "https://www.ecodms.de/"
 
   livecheck do
-    url "https://www.ecodms.de/index.php/en/download/ecodms-archiv/ecodms-burns"
-    # TODO: define regex pattern and strategy
+    url :url
+    strategy :header_match
   end
 
-  auto_updates false
   depends_on macos: ">= :ventura"
 
   pkg "ecoDMS Clients_#{version}.pkg"
@@ -30,7 +29,5 @@ cask "ecodms" do
     "~/Library/Preferences/com.ecodms-gmbh.ecodmsclientarchivesettings.plist",
     "~/Library/Preferences/de.applord.ecoDMS-Client.plist",
     "~/Library/Saved Application State/de.applord.ecoDMS-Client.savedState",
-    "/private/var/folders/j3/zpp4m98n2pl8c12vbyrgcyhw0000gn/C/de.applord.ecoDMS-Client",
-    "/private/var/folders/j3/zpp4m98n2pl8c12vbyrgcyhw0000gn/C/de.applord.ecoDMS-Connection-Manager",
   ]
 end

--- a/Casks/e/ecodms.rb
+++ b/Casks/e/ecodms.rb
@@ -1,0 +1,36 @@
+cask "ecodms" do
+  version "23.01"
+  sha256 "1bc94d3bc28a3b17fa525d8f9c5151450606a166bbb3752f3b2c19cdc9ed9226"
+
+  url "https://www.ecodms.de/index.php/de/component/jdownloads/?task=download.send&id=413&catid=162&m=0&Itemid=661"
+  name "ecoDMS"
+  desc "Document Management System"
+  homepage "https://www.ecodms.de/"
+
+  livecheck do
+    url "https://www.ecodms.de/index.php/en/download/ecodms-archiv/ecodms-burns"
+    # TODO: define regex pattern and strategy
+  end
+
+  auto_updates false
+  depends_on macos: ">= :ventura"
+
+  pkg "ecoDMS Clients_#{version}.pkg"
+
+  uninstall pkgutil: "de.applord.pkg.ecodms",
+            quit:    [
+              "de.applord.ecoDMS-Client",
+              "de.applord.ecoDMS-Connection-Manager",
+            ]
+
+  zap trash: [
+    "~/Library/Preferences/com.applord-gmbh.ecoDMS - Profilemanager.plist",
+    "~/Library/Preferences/com.applord-gmbh.ecodmsclient.plist",
+    "~/Library/Preferences/com.applord-gmbh.ecodmsclient_*.plist",
+    "~/Library/Preferences/com.ecodms-gmbh.ecodmsclientarchivesettings.plist",
+    "~/Library/Preferences/de.applord.ecoDMS-Client.plist",
+    "~/Library/Saved Application State/de.applord.ecoDMS-Client.savedState",
+    "/private/var/folders/j3/zpp4m98n2pl8c12vbyrgcyhw0000gn/C/de.applord.ecoDMS-Client",
+    "/private/var/folders/j3/zpp4m98n2pl8c12vbyrgcyhw0000gn/C/de.applord.ecoDMS-Connection-Manager",
+  ]
+end


### PR DESCRIPTION
Add the current version of the document management system ecoDMS. Livecheck does not work so far, which causes the audits to fail.

I need assistance with implementing the livecheck. The only download page by the vendor seems to be https://www.ecodms.de/index.php/en/download/ecodms-archiv/ecodms-burns. There the URLs are formatted quite unfortunate. I see two approaches but have problems with the implementation:
1. Search for the link pattern `regex(href="\/index.php\/en\/component\/jdownloads\/\?task=download\.send&.*?")`, follow all these links and look for `headers["content-disposition"][ecoDMS[._-\s]?Clients([._-\s]?OSX)?[._-\s]?\d{2}\.\d{2}([._-]\d{1})?\.pkg]` to filter the relevant macOS package. Unfortunately the file naming is not consistent across different versions. So I suggest to make the regex query as flexible and resilient as possible. Example: the current file is named _ecoDMS Clients_23.01.pkg,_ the previous version was named _ecoDMS-Clients-OSX-22.08-1.pkg._ Who knows what notation they'll come up with next?
2. Look on the downloads page for an a.jd_download_url element with value _ecoDMS Client (macOS)_ and take its href attribute as download url. Assume the contents of the following div.eco-dl-details as the current version number.

Maybe the pkg attribute of the cask could be made more resilient. Currently it would not find an install package named _ecoDMS-Clients-OSX-22.08-1.pkg._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
