### PR TITLE
Update GithubLatest livecheck blocks

### DIFF
--- a/Casks/8/86box.rb
+++ b/Casks/8/86box.rb
@@ -9,20 +9,15 @@ cask "86box" do
   homepage "https://86box.net/"
 
   livecheck do
-    url "https://github.com/86Box/86Box/releases/latest"
-    regex(%r{href=.*?/download/v?(\d+(?:\.\d+)*)/86Box[._-]macOS.*?[._-]b(\d+).zip}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)*)/86Box[._-]macOS.*?[._-]b(\d+)\.zip$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/c/cockatrice.rb
+++ b/Casks/c/cockatrice.rb
@@ -26,20 +26,15 @@ cask "cockatrice" do
   homepage "https://cockatrice.github.io/"
 
   livecheck do
-    url "https://github.com/Cockatrice/Cockatrice/releases/latest/"
-    regex(%r{href=".*?/(\d+(?:-\d+)+)-Release-(\d+(?:\.\d+)+)/Cockatrice-([^/]+)-\2-macOS-[.\w]*\.dmg"}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/(\d+(?:-\d+)+)-Release-(\d+(?:\.\d+)+)/Cockatrice-([^/]+)-\2-macOS-[.\w]*\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[1]},#{match[0]},#{match[2]}" }
+        "#{match[2]},#{match[1]},#{match[3]}"
+      end
     end
   end
 

--- a/Casks/c/codeedit.rb
+++ b/Casks/c/codeedit.rb
@@ -9,20 +9,15 @@ cask "codeedit" do
   homepage "https://www.codeedit.app/"
 
   livecheck do
-    url "https://github.com/CodeEditApp/CodeEdit/releases/latest"
-    regex(%r{href=.*?/download/\D*?([^/]+?)/CodeEdit[._-]([a-f0-9]+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/\D*?([^/]+?)/CodeEdit[._-]([a-f0-9]+)\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/c/codeexpander.rb
+++ b/Casks/c/codeexpander.rb
@@ -8,20 +8,15 @@ cask "codeexpander" do
   homepage "https://github.com/oncework/codeexpander"
 
   livecheck do
-    url "https://github.com/oncework/codeexpander/releases/latest"
-    regex(%r{href=.*?/CodeExpander-(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^CodeExpander[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/d/devcleaner.rb
+++ b/Casks/d/devcleaner.rb
@@ -8,20 +8,15 @@ cask "devcleaner" do
   homepage "https://github.com/vashpan/xcode-dev-cleaner"
 
   livecheck do
-    url "https://github.com/vashpan/xcode-dev-cleaner/releases/latest"
-    regex(/DevCleaner[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^DevCleaner[._-]v?(\d+(?:[.-]\d+)+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/d/dosbox-x.rb
+++ b/Casks/d/dosbox-x.rb
@@ -17,20 +17,15 @@ cask "dosbox-x" do
   homepage "https://dosbox-x.com/"
 
   livecheck do
-    url "https://github.com/joncampbell123/dosbox-x/releases/latest"
-    regex(%r{href=".*?/dosbox-x-v?(\d+(?:\.\d+)+)/dosbox-x-macosx-#{arch}-([^/]+)\.zip"}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/dosbox-x-v?(\d+(?:\.\d+)+)/dosbox-x-macosx-#{arch}-([^/]+)\.zip$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/d/dynobase.rb
+++ b/Casks/d/dynobase.rb
@@ -12,20 +12,15 @@ cask "dynobase" do
   homepage "https://dynobase.dev/"
 
   livecheck do
-    url "https://github.com/Dynobase/dynobase/releases/latest"
-    regex(%r{(\d+(?:\.\d+)+)/Dynobase[._-](\d+(?:\.\d+)+)[._-]+Build[._-](\S+)[._-]#{arch}\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/Dynobase[._-](\d+(?:\.\d+)+)[._-]+Build[._-](\S+)[._-]#{arch}\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[1]},#{match[2]},#{match[0]}" }
+        "#{match[2]},#{match[3]},#{match[1]}"
+      end
     end
   end
 

--- a/Casks/f/fontforge.rb
+++ b/Casks/f/fontforge.rb
@@ -9,20 +9,15 @@ cask "fontforge" do
   homepage "https://fontforge.github.io/en-US/"
 
   livecheck do
-    url "https://github.com/fontforge/fontforge/releases/latest"
-    regex(%r{href=.*?/FontForge-(\d+(?:-\d+)*)-([0-9a-f]+)\.app\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^FontForge[._-]v?(\d+(?:-\d+)+)-([0-9a-f]+)\.app\.dmg/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/g/ganttproject.rb
+++ b/Casks/g/ganttproject.rb
@@ -9,20 +9,15 @@ cask "ganttproject" do
   homepage "https://www.ganttproject.biz/"
 
   livecheck do
-    url "https://github.com/bardsoftware/ganttproject/releases/latest"
-    regex(%r{href=.*ganttproject[._-]v?(\d+(?:\.\d+)+)/ganttproject[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/ganttproject[._-]v?(\d+(?:\.\d+)+)/ganttproject[._-]v?(\d+(?:\.\d+)+)\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/g/get-iplayer-automator.rb
+++ b/Casks/g/get-iplayer-automator.rb
@@ -8,20 +8,15 @@ cask "get-iplayer-automator" do
   homepage "https://github.com/Ascoware/get-iplayer-automator"
 
   livecheck do
-    url "https://github.com/Ascoware/get-iplayer-automator/releases/latest"
-    regex(%r{href=.*?/Get\.?iPlayer\.?Automator\.?v?(\d+(?:.\d+)*).b(\d+)\.zip}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Get\.?iPlayer\.?Automator\.?v?(\d+(?:.\d+)*)\.b(\d+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -9,20 +9,15 @@ cask "ghidra" do
   homepage "https://www.ghidra-sre.org/"
 
   livecheck do
-    url "https://github.com/NationalSecurityAgency/ghidra/releases/latest"
-    regex(/href=.*?ghidra[._-]v?(\d+(?:\.\d+)+)[._-]PUBLIC[._-](\d+)\.zip/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^ghidra[._-]v?(\d+(?:\.\d+)+)[._-]PUBLIC[._-](\d+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/g/gittyup.rb
+++ b/Casks/g/gittyup.rb
@@ -9,20 +9,15 @@ cask "gittyup" do
   homepage "https://murmele.github.io/Gittyup/"
 
   livecheck do
-    url "https://github.com/Murmele/Gittyup/releases/latest"
-    regex(%r{href=.*?/Gittyup-(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Gittyup[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/g/gnucash.rb
+++ b/Casks/g/gnucash.rb
@@ -9,20 +9,15 @@ cask "gnucash" do
   homepage "https://www.gnucash.org/"
 
   livecheck do
-    url "https://github.com/Gnucash/gnucash/releases/latest"
-    regex(%r{href=.*/Gnucash-Intel-v?(\d+\.\d+-\d+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Gnucash-Intel[._-]v?(\d+(?:[.-]\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/g/gramps.rb
+++ b/Casks/g/gramps.rb
@@ -12,20 +12,15 @@ cask "gramps" do
   homepage "https://gramps-project.org/blog/"
 
   livecheck do
-    url "https://github.com/gramps-project/gramps/releases/latest"
-    regex(/Gramps[._-]#{arch}[._-]v?(\d+(?:.\d+)+)[._-](\d+)\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Gramps[._-]#{arch}[._-]v?(\d+(?:.\d+)+)[._-](\d+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/i/iconchanger.rb
+++ b/Casks/i/iconchanger.rb
@@ -8,20 +8,15 @@ cask "iconchanger" do
   homepage "https://github.com/underthestars-zhy/IconChanger"
 
   livecheck do
-    url "https://github.com/underthestars-zhy/IconChanger/releases/latest"
-    regex(%r{href=.*?download/v?(\d+(?:\.\d+)*)/IconChanger[._-](\d+(?:-\d+)*)[._-](\d+(?:-\d+)*).zip}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/IconChanger[._-](\d+(?:-\d+)+)[._-](\d+(?:-\d+)+)\.zip$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
+        "#{match[1]},#{match[2]},#{match[3]}"
+      end
     end
   end
 

--- a/Casks/i/inform.rb
+++ b/Casks/i/inform.rb
@@ -9,20 +9,15 @@ cask "inform" do
   homepage "https://ganelson.github.io/inform-website"
 
   livecheck do
-    url "https://github.com/ganelson/inform/releases/latest"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/.*?macOS[._-](\d+(?:_\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/.*?macOS[._-]v?(\d+(?:_\d+)+)\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/j/jmc.rb
+++ b/Casks/j/jmc.rb
@@ -7,9 +7,13 @@ cask "jmc" do
   desc "Media organizer"
   homepage "https://github.com/jcm93/jmc"
 
+  # This regex should be removed or tightened (/^v?(\d+(?:\.\d+)+)$/i) when
+  # upstream starts publishing stable versions. Until then, it has to be loose
+  # enough to match unstable versions like `0.2-beta.6`, etc.).
   livecheck do
-    url "https://github.com/jcm93/jmc/releases/latest"
-    regex(%r{releases/tag/v?(\d+(?:\.\d+)*((?:-beta)?)*(\d+)?)}i)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+.+)$/i)
+    strategy :github_latest
   end
 
   app "jmc.app"

--- a/Casks/k/kapitainsky-rclone-browser.rb
+++ b/Casks/k/kapitainsky-rclone-browser.rb
@@ -8,20 +8,15 @@ cask "kapitainsky-rclone-browser" do
   homepage "https://github.com/kapitainsky/RcloneBrowser"
 
   livecheck do
-    url "https://github.com/kapitainsky/RcloneBrowser/releases/latest"
-    regex(%r{href=.*?/rclone-browser-(\d+(?:.\d+)*)-([0-9a-f]+)-macos\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^rclone-browser[._-]v?(\d+(?:\.\d+)+)-([0-9a-f]+)-macos\.dmg/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/k/klogg.rb
+++ b/Casks/k/klogg.rb
@@ -8,20 +8,15 @@ cask "klogg" do
   homepage "https://github.com/variar/klogg"
 
   livecheck do
-    url "https://github.com/variar/klogg/releases/latest"
-    regex(%r{href=.*?/klogg-(\d+(?:\.\d+)*)-OSX-Qt5\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^klogg[._-]v?(\d+(?:\.\d+)+)-OSX-Qt5\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/l/lyricsx.rb
+++ b/Casks/l/lyricsx.rb
@@ -8,20 +8,15 @@ cask "lyricsx" do
   homepage "https://github.com/ddddxxx/LyricsX"
 
   livecheck do
-    url "https://github.com/ddddxxx/LyricsX/releases/latest"
-    regex(%r{href=.*?/LyricsX_(\d+(?:\.\d+)*)\+(\d+)\.zip}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^LyricsX[._-]v?(\d+(?:\.\d+)+)\+(\d+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/m/mediaelch.rb
+++ b/Casks/m/mediaelch.rb
@@ -9,20 +9,15 @@ cask "mediaelch" do
   homepage "https://www.kvibes.de/en/mediaelch/"
 
   livecheck do
-    url "https://github.com/Komet/MediaElch/releases/latest"
-    regex(%r{href=.*?/MediaElch_macOS_.*?[._-](\d+(?:\.\d+)*)_(\d+(?:.\d+)*)_git-([^/]*?)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^MediaElch_macOS_.*?[._-]v?(\d+(?:\.\d+)+)_(\d+(?:.\d+)*)_git-(.+?)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
+        "#{match[1]},#{match[2]},#{match[3]}"
+      end
     end
   end
 

--- a/Casks/m/mindforger.rb
+++ b/Casks/m/mindforger.rb
@@ -9,20 +9,15 @@ cask "mindforger" do
   homepage "https://www.mindforger.com/"
 
   livecheck do
-    url "https://github.com/dvorka/mindforger/releases/latest"
-    regex(/href=.*?mindforger[._-]v?(\d+(?:[.-]\d+)+)-intel\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^mindforger[._-]v?(\d+(?:[.-]\d+)+)-intel\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/m/munki.rb
+++ b/Casks/m/munki.rb
@@ -9,20 +9,15 @@ cask "munki" do
   homepage "https://www.munki.org/munki/"
 
   livecheck do
-    url "https://github.com/munki/munki/releases/latest"
-    regex(%r{href=.*?/munkitools[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^munkitools[._-]v?(\d+(?:\.\d+)+)\.pkg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/m/musescore.rb
+++ b/Casks/m/musescore.rb
@@ -9,20 +9,15 @@ cask "musescore" do
   homepage "https://musescore.org/"
 
   livecheck do
-    url "https://github.com/musescore/MuseScore/releases/latest"
-    regex(%r{href=.*?/MuseScore[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^MuseScore[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/n/nextcloud.rb
+++ b/Casks/n/nextcloud.rb
@@ -19,20 +19,15 @@ cask "nextcloud" do
   homepage "https://nextcloud.com/"
 
   livecheck do
-    url "https://github.com/nextcloud-releases/desktop/releases/latest"
-    regex(/Nextcloud[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Nextcloud[._-]v?(\d+(?:\.\d+)+)\.pkg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/n/nightingale.rb
+++ b/Casks/n/nightingale.rb
@@ -9,20 +9,15 @@ cask "nightingale" do
   homepage "https://getnightingale.com/"
 
   livecheck do
-    url "https://github.com/nightingale-media-player/nightingale-hacking/releases/latest"
-    regex(%r{href=.*?/Nightingale_(\d+(?:\.\d+)*)-(\d+)_macosx-i686\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Nightingale[._-]v?(\d+(?:\.\d+)+)-(\d+)_macosx-i686\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/o/openbci.rb
+++ b/Casks/o/openbci.rb
@@ -9,20 +9,15 @@ cask "openbci" do
   homepage "https://openbci.com/"
 
   livecheck do
-    url "https://github.com/OpenBCI/OpenBCI_GUI/releases/latest"
-    regex(/openbcigui[._-]v?(\d+(?:\.\d+)+)[._-](.+)[._-]macosx\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^openbcigui[._-]v?(\d+(?:\.\d+)+)[._-](.+)[._-]macosx\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/o/otx.rb
+++ b/Casks/o/otx.rb
@@ -8,20 +8,15 @@ cask "otx" do
   homepage "https://github.com/x43x61x69/otx"
 
   livecheck do
-    url "https://github.com/x43x61x69/otx/releases/latest"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/otx[._-](\h+)\.zip}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/otx[._-](\h+)\.zip$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/p/postgres-unofficial.rb
+++ b/Casks/p/postgres-unofficial.rb
@@ -9,20 +9,15 @@ cask "postgres-unofficial" do
   homepage "https://postgresapp.com/"
 
   livecheck do
-    url "https://github.com/PostgresApp/PostgresApp/releases/latest"
-    regex(/href=.*?Postgres[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:-\d+)+)\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Postgres[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:-\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/p/praat.rb
+++ b/Casks/p/praat.rb
@@ -9,20 +9,15 @@ cask "praat" do
   homepage "https://www.fon.hum.uva.nl/praat/"
 
   livecheck do
-    url "https://github.com/praat/praat/releases/latest"
-    regex(%r{href=.*?(\d+(?:\.\d+)+)/praat(\d+)[._-]mac\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/praat(\d+)[._-]mac\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/p/pronterface.rb
+++ b/Casks/p/pronterface.rb
@@ -17,10 +17,15 @@ cask "pronterface" do
   homepage "https://github.com/kliment/Printrun"
 
   livecheck do
-    url "https://api.github.com/repos/kliment/Printrun/releases/latest"
-    regex(/printrun[._-]v?(\d+(?:\.\d+)+)[._-]macos(?:.+)[._-]py(\d+(?:\.\d+)+)\.zip/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    url :url
+    regex(/^printrun[._-]v?(\d+(?:\.\d+)+)[._-]macos(?:.+)[._-]py(\d+(?:\.\d+)+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/p/pure-writer.rb
+++ b/Casks/p/pure-writer.rb
@@ -9,20 +9,15 @@ cask "pure-writer" do
   homepage "https://writer.drakeet.com/desktop"
 
   livecheck do
-    url "https://github.com/PureWriter/desktop/releases/latest"
-    regex(%r{href=.*?([^/]+)/PureWriter[._-]v?(\d+(?:\.\d+)+)-macOS\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/PureWriter[._-]v?(\d+(?:\.\d+)+)-macOS\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/q/qlvideo.rb
+++ b/Casks/q/qlvideo.rb
@@ -8,12 +8,15 @@ cask "qlvideo" do
   homepage "https://github.com/Marginal/QLVideo"
 
   livecheck do
-    url "https://api.github.com/repos/Marginal/QLVideo/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(/QLVideo[._-]v?(\d+?)(\d+)\.dmg/i)
-      next if match.blank?
+    url :url
+    regex(/^QLVideo[._-]v?(\d+?)(\d+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      "#{match[1]}.#{match[2]}"
+        "#{match[1]}.#{match[2]}"
+      end
     end
   end
 

--- a/Casks/q/quaternion.rb
+++ b/Casks/q/quaternion.rb
@@ -8,20 +8,15 @@ cask "quaternion" do
   homepage "https://github.com/quotient-im/Quaternion"
 
   livecheck do
-    url "https://github.com/quotient-im/Quaternion/releases/latest"
-    regex(/href=.*?quaternion[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^quaternion[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/r/raze.rb
+++ b/Casks/r/raze.rb
@@ -8,20 +8,15 @@ cask "raze" do
   homepage "https://github.com/coelckers/Raze"
 
   livecheck do
-    url "https://github.com/coelckers/Raze/releases/latest"
-    regex(/raze[._-]macos[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^raze[._-]macos[._-]v?(\d+(?:\.\d+)+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/s/sage.rb
+++ b/Casks/s/sage.rb
@@ -12,20 +12,15 @@ cask "sage" do
   homepage "https://www.sagemath.org/"
 
   livecheck do
-    url "https://github.com/3-manifolds/Sage_macOS/releases/latest"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/SageMath[._-]v?(\d+(?:\.\d+)+)[._-].*?#{arch}\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/SageMath[._-]v?(\d+(?:\.\d+)+)[._-].*?#{arch}\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[1]},#{match[0]}" }
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 

--- a/Casks/s/schildichat.rb
+++ b/Casks/s/schildichat.rb
@@ -9,8 +9,9 @@ cask "schildichat" do
   homepage "https://schildi.chat/desktop/"
 
   livecheck do
-    url "https://github.com/SchildiChat/schildichat-desktop/releases/latest"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+-\w*?\.?\d*?)["' >]}i)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:-sc\.?\d+)?)$/i)
+    strategy :github_latest
   end
 
   app "SchildiChat.app"

--- a/Casks/s/solar2d.rb
+++ b/Casks/s/solar2d.rb
@@ -9,20 +9,15 @@ cask "solar2d" do
   homepage "https://solar2d.com/"
 
   livecheck do
-    url "https://github.com/coronalabs/corona/releases/latest"
-    regex(%r{href=.*?/Solar2D[._-]macOS[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^Solar2D[._-]macOS[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/s/stoplight-studio.rb
+++ b/Casks/s/stoplight-studio.rb
@@ -12,10 +12,15 @@ cask "stoplight-studio" do
   homepage "https://stoplight.io/studio/"
 
   livecheck do
-    url "https://github.com/stoplightio/studio/releases/latest"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)[._-]stable[._-]([^/]+)/stoplight[._-]studio[._-]#{arch}\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)[._-]stable[._-]([^/]+)/stoplight[._-]studio[._-]#{arch}\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/s/switchhosts.rb
+++ b/Casks/s/switchhosts.rb
@@ -12,20 +12,15 @@ cask "switchhosts" do
   homepage "https://oldj.github.io/SwitchHosts/"
 
   livecheck do
-    url "https://github.com/oldj/SwitchHosts/releases/latest"
-    regex(%r{/SwitchHosts_mac_#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^SwitchHosts_mac_#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 

--- a/Casks/t/tabby.rb
+++ b/Casks/t/tabby.rb
@@ -13,8 +13,8 @@ cask "tabby" do
   homepage "https://eugeny.github.io/tabby/"
 
   livecheck do
-    url "https://github.com/Eugeny/tabby/releases/latest"
-    strategy :header_match
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/t/texworks.rb
+++ b/Casks/t/texworks.rb
@@ -9,20 +9,15 @@ cask "texworks" do
   homepage "https://www.tug.org/texworks/"
 
   livecheck do
-    url "https://github.com/TeXworks/texworks/releases/latest"
-    regex(%r{href=.*?/TeXworks-macos10.15-(\d+(?:\.\d+)*)-(\d+)-git_(.*?)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^TeXworks-macos10.15[._-]v?(\d+(?:\.\d+)+)-(\d+)-git_(.*?)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
+        "#{match[1]},#{match[2]},#{match[3]}"
+      end
     end
   end
 

--- a/Casks/t/toolreleases.rb
+++ b/Casks/t/toolreleases.rb
@@ -8,20 +8,15 @@ cask "toolreleases" do
   homepage "https://github.com/DeveloperMaris/ToolReleases"
 
   livecheck do
-    url "https://github.com/DeveloperMaris/ToolReleases/releases/latest"
-    regex(%r{href=.*?/ToolReleases_v?(\d+(?:\.\d+)*)\.b(\d+)\.zip}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^ToolReleases[._-]v?(\d+(?:\.\d+)+)[._-]b(\d+)\.zip$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/u/uhk-agent.rb
+++ b/Casks/u/uhk-agent.rb
@@ -9,8 +9,8 @@ cask "uhk-agent" do
   homepage "https://github.com/UltimateHackingKeyboard/agent"
 
   livecheck do
-    url "https://github.com/UltimateHackingKeyboard/agent/releases/latest"
-    strategy :header_match
+    url :url
+    strategy :github_latest
   end
 
   app "UHK Agent.app"

--- a/Casks/v/vimr.rb
+++ b/Casks/v/vimr.rb
@@ -9,9 +9,10 @@ cask "vimr" do
   homepage "http://vimr.org/"
 
   livecheck do
-    url "https://github.com/qvacua/vimr/releases/latest"
-    strategy :page_match do |page|
-      match = page.match(/v?(\d+(?:\.\d+)+)[._-](\d+(?:\.\d+)+)/i)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)[._-](\d+(?:\.\d+)+)$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
       next if match.blank?
 
       "#{match[1]},#{match[2]}"

--- a/Casks/w/wwdc.rb
+++ b/Casks/w/wwdc.rb
@@ -9,20 +9,15 @@ cask "wwdc" do
   homepage "https://wwdc.io/"
 
   livecheck do
-    url "https://github.com/insidegui/WWDC/releases/latest"
-    regex(%r{href=.*?/WWDC[._-]v?(\d+(?:[.-]\d+)+)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^WWDC[._-]v?(\d+(?:[.-]\d+)+)\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0].tr("-", ",").to_s }
+        match[1].tr("-", ",")
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates existing `livecheck` blocks that check the "latest" release on GitHub to use the `GithubLatest` strategy now that it uses the JSON API.

`livecheck` blocks using a regex that only matches the filename can check the asset `name` value. `livecheck` blocks using a regex that also matches the tag in the full release asset download URL have to check the asset `browser_download_url` value instead.

Outside of the necessary changes to adapt the regexes to the context of the `GithubLatest` strategy, I've made a few small tweaks to some of these regexes but I tried to keep it minimal. There's plenty of room for improvement in these `livecheck` blocks but it's beyond the scope of this bulk PR.

-----

I've omitted `synfigstudio` and `veusz` (in favor of separate PRs), since they will fail audits here:

```
audit for synfigstudio: failed
 - Version '1.5.1,2021.10.21,2cb6c' differs from '1.4.4,2022.12.25,b8d62' retrieved by livecheck.
```

```
audit for veusz: failed
 - Version '3.6' differs from '3.6.2' retrieved by livecheck.
```