### PR TITLE
maria: discontinued

### DIFF
--- a/Casks/m/maria.rb
+++ b/Casks/m/maria.rb
@@ -7,23 +7,9 @@ cask "maria" do
   desc "App/widget for aria2 download tool"
   homepage "https://github.com/shincurry/Maria"
 
-  livecheck do
-    url "https://github.com/shincurry/Maria/releases/latest"
-    regex(%r{href=.*?/Maria_v?(\d+(?:\.\d+)*)_build(.*?)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
-
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }
-    end
-  end
-
   app "Maria.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The GitHub repository for `maria` was archived on 2023-04-13, so this sets the cask as discontinued. The most recent release was on 2017-01-21 (though there were a couple of subsequent version tags in 2017/2018 that didn't get a release), so it's fair to say this probably isn't being developed anymore.