### PR TITLE
veusz 3.6.2

### DIFF
--- a/Casks/v/veusz.rb
+++ b/Casks/v/veusz.rb
@@ -1,28 +1,23 @@
 cask "veusz" do
-  version "3.6"
-  sha256 "c23d7593724f5398747c6858bc99fdc950633631dfc8d9224730eed682ada8f6"
+  version "3.6.2"
+  sha256 "cc09d7491c64259b5b4e06004719c350f7e9a5a472173cf293c8ad067056c002"
 
-  url "https://github.com/veusz/veusz/releases/download/veusz-#{version.major_minor}/veusz-#{version}-AppleOSX.dmg",
+  url "https://github.com/veusz/veusz/releases/download/veusz-#{version}/veusz-#{version}-AppleOSX.dmg",
       verified: "github.com/veusz/veusz/"
   name "Veusz"
   desc "Scientific plotting application"
   homepage "https://veusz.github.io/"
 
   livecheck do
-    url "https://github.com/veusz/veusz/releases/latest"
-    regex(/href=.*?veusz[._-]v?(\d+(?:\.\d+)+)(?:[._-][^"' >]+)?\.dmg/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :url
+    regex(/^veusz[._-]v?(\d+(?:\.\d+)+)(?:[._-].+)?\.dmg$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `veusz` to the latest release, 3.6.2.

Besides that, this updates the `livecheck` block to use the `GithubLatest` strategy (instead of our previous approach). This was originally part of #156596 but was failing an audit because the cask version (3.6) didn't match the `livecheck` version (3.6.2).