### PR TITLE
dropbox-dash 2.77.1 (new cask)

### DIFF
--- a/Casks/d/dropbox-dash.rb
+++ b/Casks/d/dropbox-dash.rb
@@ -1,0 +1,26 @@
+cask "dropbox-dash" do
+  version "2.77.1"
+  sha256 "e148468fbae575d0934f7fab29bfa5abde3f1f37990dc1816c65e122b2fb0c88"
+
+  url "https://dash-releases.s3.amazonaws.com/Dropbox%20Dash-#{version}.dmg",
+      verified: "dash-releases.s3.amazonaws.com/"
+  name "Dropbox Dash"
+  desc "Search all your apps. All your tabs. All in one place"
+  homepage "https://www.dropbox.com/dash"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Dropbox Dash.app"
+
+  uninstall quit: "io.hypertools.Dropbox-Dash"
+
+  zap trash: [
+    "~/Library/Preferences/io.hypertools.Dropbox-Dash.plist",
+    "~/Library/Application Support/Dropbox Dash",
+  ]
+end

--- a/Casks/d/dropbox-dash.rb
+++ b/Casks/d/dropbox-dash.rb
@@ -9,8 +9,9 @@ cask "dropbox-dash" do
   homepage "https://www.dropbox.com/dash"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://dash-releases.s3.amazonaws.com/latest-mac.yml"
+    regex(/version.*?(\d+(?:\.\d+)*)/i)
+    strategy :page_match
   end
 
   depends_on macos: ">= :catalina"
@@ -20,7 +21,8 @@ cask "dropbox-dash" do
   uninstall quit: "io.hypertools.Dropbox-Dash"
 
   zap trash: [
-    "~/Library/Preferences/io.hypertools.Dropbox-Dash.plist",
     "~/Library/Application Support/Dropbox Dash",
+    "~/Library/Group Containers/com.dash",
+    "~/Library/Preferences/io.hypertools.Dropbox-Dash.plist",
   ]
 end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
