### PR TITLE
vertcoin-core 23.2

### DIFF
--- a/Casks/v/vertcoin-core.rb
+++ b/Casks/v/vertcoin-core.rb
@@ -1,8 +1,11 @@
 cask "vertcoin-core" do
-  version "22.1"
-  sha256 "50b485cf60d4f778bf4dedda1189cb83988fd814af93da8734568f79784e542c"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://github.com/vertcoin-project/vertcoin-core/releases/download/v#{version}/vertcoin-#{version}-osx-signed.dmg",
+  version "23.2"
+  sha256 arm:   "c83810e10bccfb5af29d8209a15a2b28e901834ba86366bece2994c89db733ad",
+         intel: "38ae781c773ddefe0f91ac7a5474ebe8feb3ef095780da8776fc79b4f5918170"
+
+  url "https://github.com/vertcoin-project/vertcoin-core/releases/download/v#{version}/vertcoin-#{version}-#{arch}-apple-darwin.dmg",
       verified: "github.com/vertcoin-project/vertcoin-core/"
   name "Vertcoin Core"
   desc "Vertcoin client and wallet"
@@ -12,6 +15,8 @@ cask "vertcoin-core" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :catalina"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "Vertcoin-Qt.app", target: "Vertcoin Core.app"


### PR DESCRIPTION
This PR updates the `vertcoin-core` cask to 23.2, adds the ARM build and sets a minimum version.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.