### PR TITLE
meshlab: add zap

### DIFF
--- a/Casks/m/meshlab.rb
+++ b/Casks/m/meshlab.rb
@@ -23,6 +23,7 @@ cask "meshlab" do
   end
 
   zap trash: [
+    "~/Library/Application Support/VCG/MeshLab_64bit_fp",
     "~/Library/Preferences/com.vcg.MeshLab_64bit_fp.plist",
     "~/Library/Saved Application State/com.vcg.meshlab.savedState",
   ]

--- a/Casks/m/meshlab.rb
+++ b/Casks/m/meshlab.rb
@@ -21,4 +21,9 @@ cask "meshlab" do
       File.symlink("meshlab", "MeshLab") unless File.exist? "MeshLab"
     end
   end
+
+  zap trash: [
+    "~/Library/Preferences/com.vcg.MeshLab_64bit_fp.plist",
+    "~/Library/Saved Application State/com.vcg.meshlab.savedState",
+  ]
 end


### PR DESCRIPTION
Add zap for `meshlab`

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
