### PR TITLE
ipremoteutility: add zap

### DIFF
--- a/Casks/i/ipremoteutility.rb
+++ b/Casks/i/ipremoteutility.rb
@@ -16,4 +16,10 @@ cask "ipremoteutility" do
   container nested: "IPRemoteUtility-#{version}-macOSX/IPRemoteUtility-#{version}.dmg"
 
   app "IPRemoteUtility.app"
+
+  zap trash: [
+    "~/Library/Application Support/FlandersScientific/IPRemoteUtility",
+    "~/Library/Caches/FlandersScientific/IPRemoteUtility",
+    "~/Library/Preferences/com.flandersscientific.IPRemoteUtility.plist",
+  ]
 end


### PR DESCRIPTION
Added missing zap stanza

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.