### PR TITLE
creality-slicer: update livecheck

### DIFF
--- a/Casks/c/creality-slicer.rb
+++ b/Casks/c/creality-slicer.rb
@@ -1,22 +1,17 @@
 cask "creality-slicer" do
-  version "4.8.2,172"
-  sha256 "3767c53efa588daab001cc680b5a5527f19ab64e7c718ebbefbcfc02dd5d7296"
+  version "4.8.2"
+  sha256 "7c9588826a8358c6e9cfecc33d3e325b4ad0826729e0d07144037c15628a10dd"
 
-  url "https://file2-cdn.creality.com/file/6c68eac01dc22f26448a50f3ee8618c2/Creality_Slicer-#{version.csv.first}-build-#{version.csv.second}-Darwin.dmg"
+  url "https://file-cdn.creality.com/CrealitySlicer/darwin/Creality_Slicer-#{version}-Darwin.dmg"
   name "Creality Slicer"
   desc "Slicer for all Creality FDM 3D printers"
   homepage "https://www.creality.com/download/"
 
-  # A product must be selected to download software for,
-  # so we use an arbitrary product for livecheck
   livecheck do
-    url "https://www.creality.com/pages/download-ender-5-s1"
-    regex(/Creality[._-]Slicer[._-](\d+(?:\.\d+)+)[._-]build[._-](\d+)[._-]Darwin\.dmg/i)
-    strategy :page_match do |page|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    url "https://file-cdn.creality.com/ota-sz/crealityslicer/last.json"
+    strategy :json do |json|
+      v = json["cura"]["Darwin"]
+      "#{v["major"]}.#{v["minor"]}.#{v["revision"]}"
     end
   end
 


### PR DESCRIPTION
This updates the `livecheck` to use the same location as the in-app updater which should be more resilient than the current check.