### PR TITLE
Add structuredlogviewer (new cask)

### DIFF
--- a/Casks/s/structuredlogviewer.rb
+++ b/Casks/s/structuredlogviewer.rb
@@ -1,30 +1,29 @@
 cask "structuredlogviewer" do
   arch arm: "Arm", intel: "Intel"
-
   artifact_arch = on_arch_conditional arm: "arm64", intel: "x64"
-  appBundle = "StructuredLogViewer.app"
+
+  app_bundle = "StructuredLogViewer.app"
 
   version "2.1.858"
+  sha256  arm:   "c3491fd31fe2916c9373524fee1a04ae331c04ea253ef571d34e2352f7911489",
+          intel: "42ad96cbbacebc9a3756cd82fb9b5877c578da9b8d7a4f0437456d1707f1937c"
 
   url "https://github.com/KirillOsenkov/MSBuildStructuredLog/releases/download/v#{version}/StructuredLogViewer-#{artifact_arch}.zip",
-      verified: "https://github.com/KirillOsenkov/MSBuildStructuredLog/"
+      verified: "github.com/KirillOsenkov/MSBuildStructuredLog/"
   name "StructuredLogViewer"
-  desc "A rich interactive log viewer for MSBuild structured logs (*.binlog)"
+  desc "Rich interactive log viewer for MSBuild structured logs (*.binlog)"
   homepage "https://msbuildlog.com/"
-
-  depends_on macos: ">= :big_sur"
 
   livecheck do
     url :url
     strategy :github_latest
   end
 
-  sha256  arm: "c3491fd31fe2916c9373524fee1a04ae331c04ea253ef571d34e2352f7911489",
-          intel: "42ad96cbbacebc9a3756cd82fb9b5877c578da9b8d7a4f0437456d1707f1937c"
+  depends_on macos: ">= :big_sur"
 
-  app appBundle
+  app app_bundle
 
   preflight do
-    set_permissions "#{staged_path}/#{appBundle}/Contents/MacOS/StructuredLogViewer.Avalonia", "a+x"
+    set_permissions "#{staged_path}/#{app_bundle}/Contents/MacOS/StructuredLogViewer.Avalonia", "a+x"
   end
 end

--- a/Casks/s/structuredlogviewer.rb
+++ b/Casks/s/structuredlogviewer.rb
@@ -1,0 +1,30 @@
+cask "structuredlogviewer" do
+  arch arm: "Arm", intel: "Intel"
+
+  artifact_arch = on_arch_conditional arm: "arm64", intel: "x64"
+  appBundle = "StructuredLogViewer.app"
+
+  version "2.1.858"
+
+  url "https://github.com/KirillOsenkov/MSBuildStructuredLog/releases/download/v#{version}/StructuredLogViewer-#{artifact_arch}.zip",
+      verified: "https://github.com/KirillOsenkov/MSBuildStructuredLog/"
+  name "StructuredLogViewer"
+  desc "A rich interactive log viewer for MSBuild structured logs (*.binlog)"
+  homepage "https://msbuildlog.com/"
+
+  depends_on macos: ">= :big_sur"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  sha256  arm: "c3491fd31fe2916c9373524fee1a04ae331c04ea253ef571d34e2352f7911489",
+          intel: "42ad96cbbacebc9a3756cd82fb9b5877c578da9b8d7a4f0437456d1707f1937c"
+
+  app appBundle
+
+  preflight do
+    set_permissions "#{staged_path}/#{appBundle}/Contents/MacOS/StructuredLogViewer.Avalonia", "a+x"
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Audit fails with a signature error because the author hasn't signed the app (see https://github.com/KirillOsenkov/MSBuildStructuredLog/issues/686). There are no other errors.

```
audit for structuredlogviewer: failed
 - Signature verification failed:
/private/tmp/d20231004-26997-fa6qjl/StructuredLogViewer.app: rejected

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
structuredlogviewer
  * line 9, col 2: Signature verification failed:
    /private/tmp/d20231004-26997-fa6qjl/StructuredLogViewer.app: rejected
    
    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 1 problem in 1 cask detected.
```
