### PR TITLE
marked 2.6.26,1047

### DIFF
--- a/Casks/m/marked.rb
+++ b/Casks/m/marked.rb
@@ -1,5 +1,5 @@
 cask "marked" do
-  version "2.6.256,1047"
+  version "2.6.26,1047"
   sha256 "69ab296f94fa265e44521455ed7454887c6ab94b0e6bf552af514256b790db85"
 
   url "https://updates.marked2app.com/Marked#{version.csv.first}#{version.csv.second}.dmg"

--- a/Casks/m/marked.rb
+++ b/Casks/m/marked.rb
@@ -1,6 +1,6 @@
 cask "marked" do
-  version "2.6.25,1046"
-  sha256 "c9960b6977a4dca091870ac365feb5fd98ea6533cf0394e10c7de431b6956004"
+  version "2.6.256,1047"
+  sha256 "69ab296f94fa265e44521455ed7454887c6ab94b0e6bf552af514256b790db85"
 
   url "https://updates.marked2app.com/Marked#{version.csv.first}#{version.csv.second}.dmg"
   name "Marked"
@@ -13,7 +13,7 @@ cask "marked" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :ventura"
 
   app "Marked #{version.major}.app"
 


### PR DESCRIPTION
bump-cask marked to 2.6.26,1047
and update depends_on from sierra to ventura

Shall we add a fallback for older macOS versions? Is there a minimal macOS version homebrew-casks want to support?

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
