### PR TITLE
lightkey: add legacy version, update livecheck

### DIFF
--- a/Casks/l/lightkey.rb
+++ b/Casks/l/lightkey.rb
@@ -1,24 +1,32 @@
 cask "lightkey" do
-  version "4.5.1,0a7389d85e-1696487850"
-  sha256 "40dd3cff27680c5f0202d81c0b61d49ef24c5033e96618c7f29008d6937bd365"
+  on_monterey :or_older do
+    version "4.4.4"
+    sha256 "d560c897b76f4b3aba1ec41fc3ccd21c3e4f9739fde7140f3fa01a6b621a1eff"
 
-  url "https://lightkeyapp.com/media/pages/download/Lightkey-#{version.csv.first.dots_to_hyphens}/#{version.csv.second}/LightkeyInstaller.zip"
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :big_sur"
+  end
+  on_ventura :or_newer do
+    version "4.5.1"
+    sha256 "40dd3cff27680c5f0202d81c0b61d49ef24c5033e96618c7f29008d6937bd365"
+
+    livecheck do
+      url "https://lightkeyapp.com/en/update"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :ventura"
+  end
+
+  url "https://lightkeyapp.com/download/Lightkey-#{version.dots_to_hyphens}/LightkeyInstaller.zip"
   name "Lightkey"
   desc "DMX lighting control"
   homepage "https://lightkeyapp.com/"
 
-  livecheck do
-    url "https://lightkeyapp.com/en/download"
-    regex(%r{/Lightkey[._-]v?(\d+(?:-\d+)+)/([^/]+)/LightkeyInstaller\.zip}i)
-    strategy :header_match do |headers, regex|
-      headers["location"].scan(regex).map do |match|
-        "#{match[0].tr("-", ".")},#{match[1]}"
-      end
-    end
-  end
-
   auto_updates true
-  depends_on macos: ">= :ventura"
 
   pkg "LightkeyInstaller.pkg"
 


### PR DESCRIPTION
This PR simplifies the `livecheck` to use the Sparkle feed, and adds a legacy version for pre-Ventura.