### PR TITLE
Bump Xpra 5.0.3,0; add arm64 reference

### DIFF
--- a/Casks/x/xpra.rb
+++ b/Casks/x/xpra.rb
@@ -1,15 +1,23 @@
 cask "xpra" do
-  version "5.0.2,3"
-  sha256 "4fce517e0547dc5cd6b26c08df9f42c4ad30bdfe7eebc9e0d0f4f4c6f280de9a"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64-#{version.csv.first}-r#{version.csv.second}.pkg"
+  on_arm do
+    version "5.0.3,0"
+    sha256 "34a6b8c831b5a31a87dbd93898c3afb415ab2096faccea0c4530ada4ccbef9f1"
+  end
+  on_intel do
+    version "5.0.2,3"
+    sha256 "4fce517e0547dc5cd6b26c08df9f42c4ad30bdfe7eebc9e0d0f4f4c6f280de9a"
+  end
+
+  url "https://www.xpra.org/dists/osx/#{arch}/Xpra-#{arch}-#{version.csv.first}-r#{version.csv.second}.pkg"
   name "Xpra"
   desc "Screen and application forwarding system"
   homepage "https://www.xpra.org/"
 
   livecheck do
-    url "https://www.xpra.org/dists/osx/x86_64/Xpra-x86_64.pkg.sha1"
-    regex(/x86_64[._-]v?(\d+(?:\.\d+)+)[._-]r(\d+)\.pkg/i)
+    url "https://www.xpra.org/dists/osx/#{arch}/Xpra-#{arch}.pkg.sha1"
+    regex(/#{arch}[._-]v?(\d+(?:\.\d+)+)[._-]r(\d+)\.pkg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
@@ -17,7 +25,7 @@ cask "xpra" do
 
   depends_on macos: ">= :sierra"
 
-  pkg "Xpra-x86_64-#{version.csv.first}-r#{version.csv.second}.pkg"
+  pkg "Xpra-#{arch}-#{version.csv.first}-r#{version.csv.second}.pkg"
 
   uninstall pkgutil: "org.xpra.pkg",
             delete:  [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This PR;
- Adds downloads to the arm64 releases
- Bumps the version for the arm release to `5.0.3,0`

This PR *does not* bump the intel release, as [the maintainer forgot to build and upload a build](https://www.xpra.org/dists/osx/x86_64/) for that version. This may be due to manually building and releasing, but this is also possibly due to the fact that the author does not wish to go forward with intel releases anymore (if this is the case, i have not seen any statement about it).