### PR TITLE
dosbox-x: use sdl2 version instead of the outdated sdl1 version

### DIFF
--- a/Casks/d/dosbox-x.rb
+++ b/Casks/d/dosbox-x.rb
@@ -29,7 +29,7 @@ cask "dosbox-x" do
     end
   end
 
-  app "dosbox-x/dosbox-x.app"
+  app "dosbox-x-sdl2/dosbox-x.app"
 
   zap trash: [
     "~/Library/Preferences/com.dosbox-x.plist",


### PR DESCRIPTION
As SDL1 is in maintainance mode, SDL2 version [is more actively tested and bug free](https://github.com/joncampbell123/dosbox-x/issues/4515).

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
