### PR TITLE
mark auto_updates of eudic to false

### DIFF
--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -15,8 +15,6 @@ cask "eudic" do
     strategy :extract_plist
   end
 
-  auto_updates false
-
   app "Eudic.app"
 
   uninstall quit: [

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -15,7 +15,7 @@ cask "eudic" do
     strategy :extract_plist
   end
 
-  auto_updates true
+  auto_updates false
 
   app "Eudic.app"
 


### PR DESCRIPTION
Mark the auto_updates of `eudic` to false. The software has a menu item called upgrade, however, it simply opens the official website and prompts the user to download the latest version. Therefore, the software should not be regarded as having built-in update functionality.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

