### PR TITLE
defold: update livecheck

### DIFF
--- a/Casks/d/defold.rb
+++ b/Casks/d/defold.rb
@@ -10,12 +10,13 @@ cask "defold" do
   desc "Game engine for development of desktop, mobile and web games"
   homepage "https://defold.com/"
 
-  # Alpha releases are labeled as "pre-release" but beta releases aren't, so we
-  # can't use the `GithubLatest` strategy here.
+  # Upstream only marks alpha releases as "pre-release", so the "latest" GitHub
+  # release is sometimes a beta version. As such, it's necessary to check
+  # multiple recent releases to identify the latest stable version.
   livecheck do
-    url "https://github.com/defold/defold/releases?q=prerelease%3Afalse"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

We are updating the `livecheck` blocks for `defold-alpha` and `defold-beta` (in the homebrew/cask-versions tap) to use the `GithubReleases` strategy, so this PR brings the main `defold` check in line.

[For what it's worth, the `livecheck` blocks for the unstable casks are a bit more involved since they have to use a `strategy` block to be able to also match releases marked as "pre-release". This cask is only concerned with stable versions, so the `livecheck` block is pretty simple.]