### PR TITLE
kuaitie 3.5.0,1691639687

### DIFF
--- a/Casks/k/kuaitie.rb
+++ b/Casks/k/kuaitie.rb
@@ -1,20 +1,16 @@
 cask "kuaitie" do
-  version "3.5.0"
-  sha256 "9c7b01e911c4aacd841a1962d8ff677bec48d377759d79c03111c0ff354fd122"
+  version "3.5.0,1691639687"
+  sha256 "134c51c7dcef59ad51f2df4dcdaf9541b9df4247f4a362bae5f3be50167e85b6"
 
-  url "https://dl.clipber.com/mac/copies_#{version.dots_to_underscores}.dmg"
+  url "https://clipweb.oss-cn-qingdao.aliyuncs.com/release/macos/packages/kuaitie-#{version.csv.first.no_dots}_#{version.csv.second}.zip",
+      verified: "clipweb.oss-cn-qingdao.aliyuncs.com/release/macos/packages/"
   name "kuaitie"
   desc "Cross-platform cloud clipboard synchronization tool"
   homepage "https://home.clipber.com/"
 
   livecheck do
-    url "https://clipber.com/getmac"
-    regex(/copies[._-]v?(\d+(?:_\d+)+)\.dmg/i)
-    strategy :header_match do |headers, regex|
-      headers["location"].scan(regex).map do |match|
-        match[0].tr("_", ".").to_s
-      end
-    end
+    url "https://clipweb.oss-cn-qingdao.aliyuncs.com/release/macos/update.xml"
+    strategy :sparkle
   end
 
   auto_updates true


### PR DESCRIPTION
Changes `livecheck` strategy to follow the Sparkle feed from the in-app updater.