### PR TITLE
mission-control-plus: fix hash

### DIFF
--- a/Casks/m/mission-control-plus.rb
+++ b/Casks/m/mission-control-plus.rb
@@ -11,4 +11,6 @@ cask "mission-control-plus" do
   depends_on macos: ">= :high_sierra"
 
   app "Mission Control Plus.app"
+
+  # No zap stanza required
 end

--- a/Casks/m/mission-control-plus.rb
+++ b/Casks/m/mission-control-plus.rb
@@ -1,6 +1,6 @@
 cask "mission-control-plus" do
   version "1.23"
-  sha256 "6f91e918d6a6b1456c03de0e6d946b8f313e7a239c7dc4254dffc68a694961b3"
+  sha256 "58ffd154bad723dbd413bb793b389c81e60f5a57611dae32e87c2fea65f2597b"
 
   url "https://github.com/ronyfadel/MissionControlPlusReleases/releases/download/v#{version}/Mission.Control.Plus.tgz",
       verified: "github.com/ronyfadel/MissionControlPlusReleases/"


### PR DESCRIPTION
Upgrading fails due to a hash mismatch. This is the hash of the file upstream is currently serving.