### PR TITLE
Update the download URL for "Kobo"

### DIFF
--- a/Casks/k/kobo.rb
+++ b/Casks/k/kobo.rb
@@ -2,9 +2,9 @@ cask "kobo" do
   version :latest
   sha256 :no_check
 
-  url "https://cdn.kobo.com/downloads/desktop/kobodesktop/kobosetup.dmg",
-      verified: "cdn.kobo.com"
+  url "https://cdn.kobo.com/downloads/desktop/kobodesktop/kobosetup.dmg"
   name "Kobo"
+  desc "Desktop reader for Kobo eBooks"
   homepage "https://www.kobo.com/desktop"
 
   livecheck do

--- a/Casks/k/kobo.rb
+++ b/Casks/k/kobo.rb
@@ -2,8 +2,8 @@ cask "kobo" do
   version :latest
   sha256 :no_check
 
-  url "https://kbdownload1-a.akamaihd.net/desktop/kobodesktop/kobosetup.dmg",
-      verified: "kbdownload1-a.akamaihd.net/"
+  url "https://cdn.kobo.com/downloads/desktop/kobodesktop/kobosetup.dmg",
+      verified: "cdn.kobo.com"
   name "Kobo"
   homepage "https://www.kobo.com/desktop"
 


### PR DESCRIPTION
With the previous URL, `brew outdated --cask --greedy` would always fail with this message:

```
Error: Download failed on Cask 'kobo' with message: Download failed: https://kbdownload1-a.akamaihd.net/desktop/kobodesktop/kobosetup.dmg
```

The new URL is taken from the homepage. This should fix the `brew outdated` error.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
