### PR TITLE
free-podcast-transcription 0.0.4 (new cask)

### DIFF
--- a/Casks/f/free-podcast-transcription.rb
+++ b/Casks/f/free-podcast-transcription.rb
@@ -1,22 +1,32 @@
 cask "free-podcast-transcription" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "0.0.4"
-  sha256 arm:   "bd9177f88e23a179776d416e2d5912f9c5dc9b3979f796ed708522944ce2f81d",
-         intel: "e2605d7110c0a1951664a1e3fd0624d843b89869673a5eecae2a47e8c0ca9391"
+  on_arm do
+    version "0.0.4,20230417.152948"
+    sha256 "bd9177f88e23a179776d416e2d5912f9c5dc9b3979f796ed708522944ce2f81d"
+  end
+  on_intel do
+    version "0.0.4,20230417.153610"
+    sha256 "e2605d7110c0a1951664a1e3fd0624d843b89869673a5eecae2a47e8c0ca9391"
+  end
 
   url "https://freepodcasttranscription.com/desktop-builds/darwin/#{arch}/Free%20Podcast%20Transcription.dmg"
   name "Free Podcast Transcription"
   desc "Transcribe Your Podcast"
   homepage "https://freepodcasttranscription.com/"
 
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
   app "Free Podcast Transcription.app"
 
   zap trash: [
+    "~/Library/Application Support/com.spreaker.freepodcasttranscription/",
     "~/Library/Caches/com.spreaker.freepodcasttranscription/",
     "~/Library/Preferences/com.spreaker.freepodcasttranscription.plist",
-    "~/Library/WebKit/com.spreaker.freepodcasttranscription/",
     "~/Library/Saved Application State/com.spreaker.freepodcasttranscription.savedState/",
-    "~/Library/Application Support/com.spreaker.freepodcasttranscription/",
+    "~/Library/WebKit/com.spreaker.freepodcasttranscription/",
   ]
 end

--- a/Casks/f/free-podcast-transcription.rb
+++ b/Casks/f/free-podcast-transcription.rb
@@ -1,0 +1,22 @@
+cask "free-podcast-transcription" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "0.0.4"
+  sha256 arm:   "bd9177f88e23a179776d416e2d5912f9c5dc9b3979f796ed708522944ce2f81d",
+         intel: "e2605d7110c0a1951664a1e3fd0624d843b89869673a5eecae2a47e8c0ca9391"
+
+  url "https://freepodcasttranscription.com/desktop-builds/darwin/#{arch}/Free%20Podcast%20Transcription.dmg"
+  name "Free Podcast Transcription"
+  desc "Transcribe Your Podcast"
+  homepage "https://freepodcasttranscription.com/"
+
+  app "Free Podcast Transcription.app"
+
+  zap trash: [
+    "~/Library/Caches/com.spreaker.freepodcasttranscription/",
+    "~/Library/Preferences/com.spreaker.freepodcasttranscription.plist",
+    "~/Library/WebKit/com.spreaker.freepodcasttranscription/",
+    "~/Library/Saved Application State/com.spreaker.freepodcasttranscription.savedState/",
+    "~/Library/Application Support/com.spreaker.freepodcasttranscription/",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


---

needs some help on livecheck



```
$ brew audit --cask --online free-podcast-transcription
==> Downloading https://freepodcasttranscription.com/desktop-builds/darwin/aarch64/Free%20Podcast%20Transcription.dmg
############################################################################################################################################################## 100.0%
audit for free-podcast-transcription: failed
 - Version '0.0.4' differs from '' retrieved by livecheck.
 - Version '0.0.4' differs from '' retrieved by livecheck.
free-podcast-transcription
  * Version '0.0.4' differs from '' retrieved by livecheck.
Error: 1 problem in 1 cask detected.
```