### PR TITLE
manuskript 0.15.0

### DIFF
--- a/Casks/m/manuskript.rb
+++ b/Casks/m/manuskript.rb
@@ -1,18 +1,38 @@
 cask "manuskript" do
-  version "0.10.0"
-  sha256 "f48f9c96af19b42c61a1ab6119e581e9398c33a8795ba5051cc0d44add1d2d7f"
+  version "0.15.0"
+  sha256 "59cd751d2010e661e4b3fc38bbbf49801dcf9b9317d7a62aff0826f8bcbac085"
 
-  url "https://github.com/olivierkes/manuskript/releases/download/#{version.major_minor_patch}/manuskript-#{version}-osx.zip",
+  url "https://github.com/olivierkes/manuskript/releases/download/#{version.major_minor_patch}/manuskript-#{version}-osx.dmg",
       verified: "github.com/olivierkes/manuskript/"
   name "Manuskript"
   desc "Tool for writers"
   homepage "https://www.theologeek.ch/manuskript/"
 
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
-    url "https://github.com/olivierkes/manuskript/releases/"
-    regex(/manuskript[._-]?(\d+(?:\.\d+)+)[._-]?osx\.zip/i)
-    strategy :page_match
+    url :url
+    regex(/^manuskript[._-]v?(\d+(?:\.\d+)+)[._-]osx\.(?:dmg|pkg|zip)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
 
-  binary "manuskript/manuskript"
+  app "manuskript.app"
+
+  zap trash: [
+    "~/Library/Application Support/manuskript",
+    "~/Library/Preferences/ch.theologeek.www.manuskript.plist",
+    "~/Library/Preferences/com.manuskript.manuskript.plist",
+    "~/Library/Saved Application State/ch.theologeek.manuskript.savedState",
+  ]
 end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -14,7 +14,6 @@
   "irccloud": "all",
   "jenkins-menu": "all",
   "majsoul-plus": "all",
-  "manuskript": "all",
   "messenger-native": "all",
   "mongotron": "all",
   "my-budget": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates `manuskript` to the latest release, 0.15.0.

This also updates the `livecheck` block to use the `GithubReleases` strategy and make the regex match additional file types beyond zip (as the 0.15.0 release uses a dmg instead of a zip file).

Currently, the `livecheck` block is checking the GitHub releases page and relying on the fact that release descriptions contain a link to the macOS release asset, as the release asset HTML is now fetched asynchronously on load (and when opening the assets list). Switching to the `GithubReleases` strategy allows us to check the release assets for recent releases instead of hoping that upstream always includes a link in the release description text.

To be clear, I'm using the `GithubReleases` strategy here because not every release contains an asset for macOS. If upstream becomes consistent about providing macOS files on every release, then we could switch to the `GithubLatest` strategy (though we would need to modify the `strategy` block in the process).