### PR TITLE
obs-ndi 4.11.1

### DIFF
--- a/Casks/o/obs-ndi.rb
+++ b/Casks/o/obs-ndi.rb
@@ -1,19 +1,18 @@
 cask "obs-ndi" do
-  version "4.9.0"
-  sha256 "b70b379fb34321188d5eca3bd36784aed4659eacad839af56cf0fe30acf88976"
+  version "4.11.1"
+  sha256 "e2008e9ce970fdb5edeb6f24c50526eef1e383776ffcc52f7bb6ee8ea1116ea2"
 
-  url "https://github.com/Palakis/obs-ndi/releases/download/#{version}/obs-ndi-#{version}-macOS.pkg"
+  url "https://github.com/obs-ndi/obs-ndi/releases/download/#{version}/obs-ndi-#{version}-macos-universal.pkg"
   name "obs-ndi"
   desc "NewTek NDI integration for OBS Studio"
-  homepage "https://github.com/Palakis/obs-ndi"
+  homepage "https://github.com/obs-ndi/obs-ndi"
 
   livecheck do
-    url "https://github.com/Palakis/obs-ndi/releases/"
-    regex(/obs[._-]?ndi[._-]?(\d+(?:\.\d+)*)[._-]?macOS\.pkg/i)
-    strategy :page_match
+    url :url
+    strategy :github_latest
   end
 
-  pkg "obs-ndi-#{version}-macOS.pkg"
+  pkg "obs-ndi-#{version}-macOS-universal.pkg"
 
   uninstall pkgutil: [
     "com.newtek.ndi.runtime",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `obs-ndi` to the latest release, 4.11.1. In the process, this updates the URLs to use the obs-ndi/obs-ndi repository, as the previous Palakis/obs-ndi repository now automatically redirects to it.

-----

Past that, this updates the `livecheck` block to simply use the `GithubLatest` strategy, as all of the releases provide a file for macOS and we don't need to specifically match the release asset (unless/until this becomes a problem).

The existing `livecheck` block may have been added when the GitHub releases page HTML also contained the release assets (they're now fetched asynchronously after load, for individual releases). The existing check continued to work after release asset HTML was removed from releases pages because the release descriptions usually contained the macOS filename.

However, 1) the 4.9.1 and 4.10.0 release descriptions didn't contain any filenames, 2) the macOS file for 4.10.0 switched to a `-Qt6-macOS` suffix (instead of the previous`-macOS`), and 3) the 4.11.0 release switched to a `-macos-universal` suffix. Due to these changes, the existing check erroneously reports 4.9.0 as the newest version instead of 4.11.1. Using the `GithubLatest` strategy without checking release asset names avoids these issues and should be more reliable going forward.