### PR TITLE
rustdesk: Fix shasum

### DIFF
--- a/Casks/r/rustdesk.rb
+++ b/Casks/r/rustdesk.rb
@@ -3,7 +3,7 @@ cask "rustdesk" do
 
   version "1.2.3"
   sha256 arm:   "647bc014238086d7a73a3d8f1543a1a559b5240f1796e1311a2142be0b57152e",
-         intel: "dafdbbaa0d8d60e5928df0b7523ac9a6c7d156dbe20c72068b2f46fbbbdba162"
+         intel: "63f1f5bbe2a308495be039604886adc83937bc36e97b09d4fd9b675ee108ee09"
 
   url "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-#{arch}.dmg",
       verified: "github.com/rustdesk/rustdesk/"


### PR DESCRIPTION
Follow-up of https://github.com/Homebrew/homebrew-cask/pull/157576, because it looks like Rustdesk changed their DMG for Intel again.
Also discovered in https://github.com/Homebrew/homebrew-cask/commit/71ea181bdebc4bf3dab6658e62795fc16474332c#commitcomment-130174470.