### PR TITLE
mysql-connector-python: discontinued

### DIFF
--- a/Casks/m/mysql-connector-python.rb
+++ b/Casks/m/mysql-connector-python.rb
@@ -10,11 +10,6 @@ cask "mysql-connector-python" do
   desc "Self-contained Python driver for communicating with MySQL servers"
   homepage "https://dev.mysql.com/downloads/connector/python/"
 
-  livecheck do
-    url "https://dev.mysql.com/downloads/connector/python/?tpl=files&os=33"
-    regex(/href=.*?mysql[._-]connector[._-]python[._-]v?(\d+(?:\.\d+)+)[._-]macos13[._-]#{arch}\.dmg/i)
-  end
-
   depends_on macos: ">= :monterey"
 
   pkg "mysql-connector-python-#{version}-macos13-#{arch}.pkg"
@@ -29,4 +24,8 @@ cask "mysql-connector-python" do
   ]
 
   # No zap stanza required
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [download page for `mysql-connector-python`](https://dev.mysql.com/downloads/connector/python/) no longer provides a file for macOS as of version 8.1 (see the "Functionality Added or Changed" section of the [8.1 release notes](https://dev.mysql.com/doc/relnotes/connector-python/en/news-8-1-0.html)). This discontinues the cask and removes the `livecheck` block (so it will be automatically skipped).