### PR TITLE
reactotron: update livecheck

### DIFF
--- a/Casks/r/reactotron.rb
+++ b/Casks/r/reactotron.rb
@@ -7,9 +7,15 @@ cask "reactotron" do
   desc "Desktop app for inspecting React JS and React Native projects"
   homepage "https://github.com/infinitered/reactotron"
 
+  # Upstream publishes multiple packages in the same repository, so we can't
+  # rely on the "latest" release being for the application and we can't even
+  # guarantee that the most recent releases will contain a release of the app
+  # (as of writing, the `GithubReleases` strategy doesn't work for this reason).
+  # For the time being, we check the "Quick Installation Guide" file that's
+  # linked in the README.
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://raw.githubusercontent.com/infinitered/reactotron/master/docs/installing.md"
+    regex(%r{releases/tag/v?(\d+(?:\.\d+)+)\)}i)
   end
 
   auto_updates true
@@ -18,6 +24,7 @@ cask "reactotron" do
 
   zap trash: [
     "~/Library/Application Support/Reactotron",
+    "~/Library/Logs/Reactotron",
     "~/Library/Preferences/com.reactotron.app.helper.plist",
     "~/Library/Preferences/com.reactotron.app.plist",
     "~/Library/Saved Application State/com.reactotron.app.savedState",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `reactotron` uses the `GithubLatest` strategy but upstream now publishes releases for various packages, so the "latest" release isn't for an app release. Currently, livecheck reports 0.1.4 as the newest version (instead of 2.17.1), from the `reactotron-react-native-mmkv@0.1.4` release that's currently "latest".

Unfortunately, we can't even use the `GithubReleases` strategy here because there have been so many unrelated releases since the most recent app release (v2.17.1) that it's not found in the most recent releases from the GitHub API (i.e., it returns an `Unable to get versions` error when used with an appropriate regex).

The [Installation Guide](https://github.com/infinitered/reactotron/blob/master/docs/installing.md) suggests that the app will alert the user when there is a new version but I didn't observe the app making any network requests and only saw a link in the app to the repository's releases (which doesn't help us).

Since we can't rely on the `GithubLatest` and `GithubReleases` strategies and the homepage doesn't provide any version information, it seems like our only recourse for now is to check the release URL in the installation guide. This updates the `livecheck` block accordingly.