### PR TITLE
kicad: update `url`

### DIFF
--- a/Casks/k/kicad.rb
+++ b/Casks/k/kicad.rb
@@ -8,6 +8,11 @@ cask "kicad" do
   desc "Electronics design automation suite"
   homepage "https://kicad.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :big_sur"
 
   suite "KiCad"

--- a/Casks/k/kicad.rb
+++ b/Casks/k/kicad.rb
@@ -2,18 +2,13 @@ cask "kicad" do
   version "7.0.8"
   sha256 "abef169617a7d4bc76d65e5212f0405bd0f2b20aa19c6bffd105e0e815a38c85"
 
-  url "https://kicad-downloads.s3.cern.ch/osx/stable/kicad-unified-universal-#{version}.dmg",
-      verified: "kicad-downloads.s3.cern.ch/osx/stable/"
+  url "https://github.com/KiCad/kicad-source-mirror/releases/download/#{version}/kicad-unified-universal-#{version}.dmg",
+      verified: "github.com/KiCad/kicad-source-mirror/"
   name "KiCad"
   desc "Electronics design automation suite"
   homepage "https://kicad.org/"
 
-  livecheck do
-    url "https://downloads.kicad.org/kicad/macos/explore/stable"
-    regex(/kicad[._-]unified[._-]universal[._-]v?(\d+(?:.\d+)+)\.dmg/i)
-  end
-
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   suite "KiCad"
   binary "KiCad/KiCad.app/Contents/MacOS/dxf2idf"


### PR DESCRIPTION
This is the recommended `url` for worldwide according to https://www.kicad.org/download/macos/