### PR TITLE
wpsoffice-cn 6.2.2,8394

### DIFF
--- a/Casks/w/wpsoffice-cn.rb
+++ b/Casks/w/wpsoffice-cn.rb
@@ -1,9 +1,9 @@
 cask "wpsoffice-cn" do
   arch arm: "arm64", intel: "x64"
 
-  version "6.2.1,8344"
-  sha256 arm:   "2ac4db60ce7f5ab50d15c1bc0abf23b40ee0bc9a351f6a39a7057abc3bee2636",
-         intel: "210d3c0308fdc36f09c35a3a1372bd18057b52de07730aa7a0daf4c0c87185ab"
+  version "6.2.2,8394"
+  sha256 arm:   "f6363f1d9f45708e91d3612320e3f74612c0241d923bac58ae4cba6cd9d32f77",
+         intel: "d9174cdc8a9bde01278ca2279662ff78823ce58d5d2434e5ce916ac9f8deaac9"
 
   url "https://package.mac.wpscdn.cn/mac_wps_pkg/#{version.csv.first}/WPS_Office_#{version.csv.first}(#{version.csv.second})_#{arch}.dmg",
       verified: "package.mac.wpscdn.cn/mac_wps_pkg/"
@@ -13,7 +13,7 @@ cask "wpsoffice-cn" do
 
   livecheck do
     url :homepage
-    regex(%r{>\s+(\d+(?:\.\d+)+)[_(](\d+)[_)]/[\d.]+\s+<}i)
+    regex(%r{>\s*v?(\d+(?:\.\d+)+)\s*[_\uff08(](\d+)[_\uff09)]\s*/\s*\d+(?:\.\d+)*\s*<}im)
     strategy :page_match do |page|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates `wpsoffice-cn` to the latest version, 6.2.2 (8394).

This also updates the `livecheck` block regex to match the current version on the homepage, as the existing regex is leading to an `Unable to get versions` error. The regex is intended to match text in the homepage HTML like:

```
<p class="banner_txt">
    6.2.2（8394）/2023.10.11
</p>
```

The regex matches normal opening and closing parentheses but it fails to match the current homepage text because the parentheses are full width instead (i.e., U+FF08 and U+FF09 instead of U+0028 and U+0029).

This updates the regex to also match full width parentheses in addition to some tweaks to hopefully make this a little more resilient to whitespace variations.