### PR TITLE
Update cinebench from 23 to 2024

### DIFF
--- a/Casks/c/cinebench.rb
+++ b/Casks/c/cinebench.rb
@@ -2,7 +2,8 @@ cask "cinebench" do
   version "2024"
   sha256 "dcc840852c85c2f9ea39f55e78b23efbb59a27960555c0fb319d5bce7f51fdb6"
 
-  url "https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/cinebench/Cinebench#{version}_macOS.dmg"
+  url "https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/cinebench/Cinebench#{version}_macOS.dmg",
+      referer: "https://www.maxon.net/en/downloads/cinebench-#{version}-downloads"
   name "Cinebench"
   desc "Hardware benchmarking utility"
   homepage "https://www.maxon.net/products/cinebench/"

--- a/Casks/c/cinebench.rb
+++ b/Casks/c/cinebench.rb
@@ -1,18 +1,18 @@
 cask "cinebench" do
-  version "23"
-  sha256 "c8826647af0c7c8cc9bfa2533b254a37deb9852caeea1a47cbacec5e577cdda9"
+  version "2024"
+  sha256 "dcc840852c85c2f9ea39f55e78b23efbb59a27960555c0fb319d5bce7f51fdb6"
 
-  url "https://http.maxon.net/pub/cinebench/CinebenchR#{version}.dmg"
+  url "https://mx-app-blob-prod.maxon.net/mx-package-production/website/macos/maxon/cinebench/Cinebench#{version}_macOS.dmg"
   name "Cinebench"
   desc "Hardware benchmarking utility"
   homepage "https://www.maxon.net/products/cinebench/"
 
   livecheck do
-    url "https://www.maxon.net/_nuxt/static/1661539108/en/downloads/payload.js"
-    regex(/href=.*?cinebench-r(\d+(?:\.\d+)*)-downloads/i)
+    url "https://www.maxon.net/_nuxt/static/1697633267/en/downloads/cinebench-2024-downloads/payload.js"
+    regex(/Cinebench(\d+(?:\.\d+)*)(?:_macOS\.dmg)/i)
   end
 
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :big_sur"
 
   app "Cinebench.app"
 

--- a/Casks/c/cinebench.rb
+++ b/Casks/c/cinebench.rb
@@ -7,9 +7,27 @@ cask "cinebench" do
   desc "Hardware benchmarking utility"
   homepage "https://www.maxon.net/products/cinebench/"
 
+  # The content of the Downloads page is kept in a `payload.js` file but the
+  # URL contains a numeric identifier that changes when the website is updated.
+  # As such, we have to identify the JS file URL from the Downloads page HTML
+  # before fetching and checking the JS file for version information.
   livecheck do
-    url "https://www.maxon.net/_nuxt/static/1697633267/en/downloads/cinebench-2024-downloads/payload.js"
-    regex(/Cinebench(\d+(?:\.\d+)*)(?:_macOS\.dmg)/i)
+    url "https://www.maxon.net/en/downloads"
+    regex(/cinebench-?[rv]?(\d+(?:\.\d+)*)-downloads/i)
+    strategy :page_match do |page, regex|
+      # Find the current JS file URL on the Downloads page
+      js_match = page.match(%r{href=["']?([^"' >]+?/en/downloads/payload.js[^"' >]*?)}i)
+      next if js_match.blank?
+
+      # Fetch the JS file (using the absolute URL)
+      js_response = Homebrew::Livecheck::Strategy.page_content(
+        URI.join(@url, js_match[1]).to_s,
+      )
+      next if (js_content = js_response[:content]).blank?
+
+      # Identify the version from the versioned downloads page URL
+      js_content.scan(regex).map { |match| match[0] }
+    end
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

I can't fix `livecheck` and it seems like download from CLI ends with `403`.