### PR TITLE
tor-browser: update download url to archive.torproject.org

### DIFF
--- a/Casks/t/tor-browser.rb
+++ b/Casks/t/tor-browser.rb
@@ -2,7 +2,7 @@ cask "tor-browser" do
   version "13.0"
   sha256 "fff8c29768a40b9c911f717274900746f9887e4506d642a4a3a12633d57da0dd"
 
-  url "https://dist.torproject.org/torbrowser/#{version}/tor-browser-macos-#{version}.dmg"
+  url "https://archive.torproject.org/tor-package-archive/torbrowser/#{version}/tor-browser-macos-#{version}.dmg"
   name "Tor Browser"
   desc "Web browser focusing on security"
   homepage "https://www.torproject.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

So the general flow of our release process for Tor Browser is:

- build+package+sign
- deploy to https://dist.torproject.org, https://archive.torproject.org
- enable updates (for the self/autoupdater)
- update our blog+website to point to newest version
- remove previous version from dist.torproject.org

Therefore, if the homebrew casks is not updated promptly, there will be a window during which users attempting to download the tor-browser package will (presumably?) fail since the dmg pointed to by the package definition no longer exists.

This patch updates the Cask defintion to point to archive.torproject.org which has all of our releases going back to the start and will always have the requested dmg.

Thanks!