### PR TITLE
Update blink1control.rb

### DIFF
--- a/Casks/b/blink1control.rb
+++ b/Casks/b/blink1control.rb
@@ -5,7 +5,7 @@ cask "blink1control" do
   version "2.2.9"
   sha256 arm:   "5201cc77aa1b51b927d90e59f6221ff55f147f5910f6e75b6acd0966b3f4c099",
          intel: "fa4a8457f905b6e7ef288c621fed646305ac31408932a9cfa7181fde41499ec2"
-         
+
   url "https://github.com/todbot/Blink1Control2/releases/download/v#{version}/Blink1Control#{version.major}-#{version}-mac-#{arch}.dmg",
       verified: "github.com/todbot/Blink1Control2/"
   name "Blink1Control"

--- a/Casks/b/blink1control.rb
+++ b/Casks/b/blink1control.rb
@@ -1,10 +1,10 @@
 cask "blink1control" do
+  # NOTE: "1" is not a version number, but an intrinsic part of the product name
+  arch arm: "arm64", intel: "x64"
+
   version "2.2.9"
-  arch arm: "arm64"
-  arch intel: "x64"
-  sha512
-   sha512 arm:   "FJsSMLEhw15CauZ1gM/ALsJDqDMQxZZCeOjSIuhuiswR+pi63+NrVlsp2C5MBESEEFnr0vD4rek8k7Ufd9SW0Q=="
-   sha512 intel: "MxBa22/EdYaptnj/0pRc+x6gMdRtE7MApvU+zOK7AAIHy0TpLBnnDpCHzkuZpTWoInzojSuaD+2/XxCLiy72eg=="
+  sha256 arm:   "5201cc77aa1b51b927d90e59f6221ff55f147f5910f6e75b6acd0966b3f4c099",
+         intel: "fa4a8457f905b6e7ef288c621fed646305ac31408932a9cfa7181fde41499ec2"
          
   url "https://github.com/todbot/Blink1Control2/releases/download/v#{version}/Blink1Control#{version.major}-#{version}-mac-#{arch}.dmg",
       verified: "github.com/todbot/Blink1Control2/"
@@ -12,10 +12,7 @@ cask "blink1control" do
   desc "Utility to control blink(1) USB RGB LED devices"
   homepage "https://blink1.thingm.com/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  depends_on macos: ">= :el_capitan"
 
   app "Blink1Control#{version.major}.app"
 end

--- a/Casks/b/blink1control.rb
+++ b/Casks/b/blink1control.rb
@@ -1,8 +1,12 @@
 cask "blink1control" do
   version "2.2.9"
-  sha256 "fa4a8457f905b6e7ef288c621fed646305ac31408932a9cfa7181fde41499ec2"
-
-  url "https://github.com/todbot/Blink1Control2/releases/download/v#{version}/Blink1Control#{version.major}-#{version}-mac-x64.dmg",
+  arch arm: "arm64"
+  arch intel: "x64"
+  sha512
+   sha512 arm:   "FJsSMLEhw15CauZ1gM/ALsJDqDMQxZZCeOjSIuhuiswR+pi63+NrVlsp2C5MBESEEFnr0vD4rek8k7Ufd9SW0Q=="
+   sha512 intel: "MxBa22/EdYaptnj/0pRc+x6gMdRtE7MApvU+zOK7AAIHy0TpLBnnDpCHzkuZpTWoInzojSuaD+2/XxCLiy72eg=="
+         
+  url "https://github.com/todbot/Blink1Control2/releases/download/v#{version}/Blink1Control#{version.major}-#{version}-mac-#{arch}.dmg",
       verified: "github.com/todbot/Blink1Control2/"
   name "Blink1Control"
   desc "Utility to control blink(1) USB RGB LED devices"


### PR DESCRIPTION
added support for x64 and arm64 binaries and switched to sha512

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
