### PR TITLE
Update raspberry-pi-imager to 1.8.1

### DIFF
--- a/Casks/r/raspberry-pi-imager.rb
+++ b/Casks/r/raspberry-pi-imager.rb
@@ -1,8 +1,8 @@
 cask "raspberry-pi-imager" do
-  version "1.7.5"
-  sha256 "03f73b1402acd52718e27496e8c2a3778f5fc1d6845cd19b04318ffde24d6c4b"
+  version "1.8.1"
+  sha256 "8b9e154d4b40475abd1184157a5bbedd9dfcb01781056b69f03801e6a4356b19"
 
-  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/Raspberry.Pi.Imager.#{version}.UNIVERSAL.BUILD.dmg",
+  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/Raspberry.Pi.Imager.#{version}-UNIVERSAL-BUILD.dmg",
       verified: "github.com/raspberrypi/rpi-imager/"
   name "Raspberry Pi Imager"
   desc "Imaging utility to install operating systems to a microSD card"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.