### PR TITLE
altserver: update livecheck

### DIFF
--- a/Casks/a/altserver.rb
+++ b/Casks/a/altserver.rb
@@ -7,9 +7,13 @@ cask "altserver" do
   desc "iOS App Store alternative"
   homepage "https://altstore.io/"
 
+  # Older items in the Sparkle feed may have a newer pubDate, so it's necessary
+  # to work with all of the items in the feed (not just the newest one).
   livecheck do
     url "https://altstore.io/altserver/sparkle-macos.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle do |items|
+      items.map(&:short_version)
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `altserver` is erroneously returning 1.6.2 as the newest version instead of 1.7. This is happening because the [Sparkle feed](https://altstore.io/altserver/sparkle-macos.xml) item for 1.6.2 has a newer `pubDate` (`Thu, 28 Sep 2023 13:00:00 -0005`) than the item for 1.7 (`Mon, 18 Sep 2023 12:00:00 -0005`).

This resolves the issue by updating the `livecheck` block to use a `strategy` block that returns all versions in the feed instead of only the first one sorted by `pubDate`/`bundle_version`.