### PR TITLE
oracle-jdk-javadoc: update to 21.0.1,12,415e3f918a1f4062a0074a2794853d0d and fix installation target

### DIFF
--- a/Casks/o/oracle-jdk-javadoc.rb
+++ b/Casks/o/oracle-jdk-javadoc.rb
@@ -18,9 +18,9 @@ cask "oracle-jdk-javadoc" do
     end
   end
 
-  artifact "docs", target: "/Library/Java/JavaVirtualMachines/jdk-#{version.csv.first}.jdk/Contents/Home/docs"
+  artifact "docs", target: "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk/Contents/Home/docs"
 
-  uninstall rmdir: "/Library/Java/JavaVirtualMachines/jdk-#{version.csv.first}.jdk"
+  uninstall rmdir: "/Library/Java/JavaVirtualMachines/jdk-#{version.major}.jdk"
 
   # No zap stanza required
 

--- a/Casks/o/oracle-jdk-javadoc.rb
+++ b/Casks/o/oracle-jdk-javadoc.rb
@@ -1,6 +1,6 @@
 cask "oracle-jdk-javadoc" do
-  version "20.0.2,9,6e380f22cbe7469fa75fb448bd903d8e"
-  sha256 "7d41ca5845dd71d20ae95968773bed4c1f652880d11048aef1f482e7b69cfc8c"
+  version "21.0.1,12,415e3f918a1f4062a0074a2794853d0d"
+  sha256 "ef02d2707c1e2a24dc8de84e6252f5f6563c569f4e41999718956561e229f477"
 
   url "https://download.oracle.com/otn_software/java/jdk/#{version.csv.first}+#{version.csv.second}/#{version.csv.third}/jdk-#{version.csv.first}_doc-all.zip",
       cookies: {


### PR DESCRIPTION
Oracle seems to have ceased including the minor and patch numbers in the installed directory name, starting with JDK 19.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
