### PR TITLE
intel-power-gadget: discontinued

### DIFF
--- a/Casks/i/intel-power-gadget.rb
+++ b/Casks/i/intel-power-gadget.rb
@@ -7,22 +7,22 @@ cask "intel-power-gadget" do
   desc "Power usage monitoring tool enabled for Intel Core processors"
   homepage "https://www.intel.com/content/www/us/en/developer/articles/tool/power-gadget.html"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?v?(\d(?:\.\d+)+).*MacOS/i)
-  end
-
   auto_updates true
   depends_on arch: :x86_64
   depends_on macos: ">= :el_capitan"
 
   pkg "Install Intel Power Gadget.pkg"
 
-  uninstall pkgutil: "com.intel.pkg.PowerGadget.*",
-            kext:    "com.intel.driver.EnergyDriver"
+  uninstall pkgutil:   "com.intel.pkg.PowerGadget.*",
+            kext:      "com.intel.driver.EnergyDriver",
+            launchctl: "com.microsoft.EdgeUpdater.wake.system"
 
   zap trash: [
     "~/Library/Caches/com.intel.PowerGadget",
     "~/Library/Preferences/com.intel.PowerGadget.plist",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

According to the [`intel-power-gadget` homepage](https://www.intel.com/content/www/us/en/developer/articles/tool/power-gadget.html), it will no longer be updated as of 2023-10-09:

> As of October 9, 2023, no functional, security, or other updates will be provided for Intel® Power Gadget. Intel® Power Gadget will no longer be available after October 13, 2023. All versions are provided as is. Intel recommends that users of Intel® Power Gadget uninstall and discontinue use as soon as possible and use Intel® Performance Counter Monitor (Intel® PCM),  an application programming interface (API) and a set of tools based on the API to monitor performance and energy metrics of Intel® Core™, Xeon®, Atom® and Xeon® Phi™ processors. PCM works on Linux, Windows, Mac OS X, FreeBSD, DragonFlyBSD and ChromeOS operating systems.
>
> Visit https://github.com/intel/pcm to learn more and download Intel® PCM.

This sets the cask as discontinued and removes the `livecheck` block, so it will be automatically skipped.