### PR TITLE
Cask USBImager - add support for MacOS ARM

### DIFF
--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -1,7 +1,7 @@
 cask "usbimager" do
-  version "1.0.10"
   arch arm: "arm", intel: "intel"
-
+  
+  version "1.0.10"
   on_arm do
     sha256 "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d"
   end

--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -1,7 +1,9 @@
 cask "usbimager" do
   arch arm: "arm", intel: "intel"
-  sha256 arm: "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d", intel: "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
+
   version "1.0.10"
+  sha256 arm: "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d", 
+         intel: "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
 
   url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-#{arch}-macosx-cocoa.zip",
       verified: "gitlab.com/bztsrc/usbimager/"

--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -2,7 +2,7 @@ cask "usbimager" do
   arch arm: "arm", intel: "intel"
 
   version "1.0.10"
-  sha256 arm: "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d", 
+  sha256 arm:   "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d", 
          intel: "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
 
   url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-#{arch}-macosx-cocoa.zip",

--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -1,8 +1,15 @@
 cask "usbimager" do
   version "1.0.10"
-  sha256 "08c49d21c624d1ac75c12af3fea2d804d14bc57052b196e96adcf0eb2e4824f8"
+  arch arm: "arm", intel: "intel"
 
-  url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-intel-macosx-cocoa.zip",
+  on_arm do
+    sha256 "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d"
+  end
+  on_intel do
+    sha256 "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
+  end
+
+  url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-#{arch}-macosx-cocoa.zip",
       verified: "gitlab.com/bztsrc/usbimager/"
   name "USBImager"
   desc "Very minimal GUI app that can write/read to disk images and USB drives"

--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -2,7 +2,7 @@ cask "usbimager" do
   arch arm: "arm", intel: "intel"
 
   version "1.0.10"
-  sha256 arm:   "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d", 
+  sha256 arm:   "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d",
          intel: "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
 
   url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-#{arch}-macosx-cocoa.zip",

--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -1,10 +1,13 @@
 cask "usbimager" do
+
   arch arm: "arm", intel: "intel"
-  
+
   version "1.0.10"
+
   on_arm do
     sha256 "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d"
   end
+
   on_intel do
     sha256 "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
   end

--- a/Casks/u/usbimager.rb
+++ b/Casks/u/usbimager.rb
@@ -1,16 +1,7 @@
 cask "usbimager" do
-
   arch arm: "arm", intel: "intel"
-
+  sha256 arm: "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d", intel: "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
   version "1.0.10"
-
-  on_arm do
-    sha256 "54fb7b909009acca97f8ae42939d53e5a70c1030c001a024a0531173001e908d"
-  end
-
-  on_intel do
-    sha256 "85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a"
-  end
 
   url "https://gitlab.com/bztsrc/usbimager/raw/binaries/usbimager_#{version}-#{arch}-macosx-cocoa.zip",
       verified: "gitlab.com/bztsrc/usbimager/"


### PR DESCRIPTION
- added support for Apple Silicon
- also fix the sha256 for intel, see below
```sh
> brew audit --cask --online usbimager
audit for usbimager: failed
 - download not possible: SHA256 mismatch
Expected: 08c49d21c624d1ac75c12af3fea2d804d14bc57052b196e96adcf0eb2e4824f8
  Actual: 85081cde8626b3714b77244de85d38830e89f0d1af7341514ad93077c7ba826a
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
