### PR TITLE
3dgenceslicer 3.4.0,4.0

### DIFF
--- a/Casks/3/3dgenceslicer.rb
+++ b/Casks/3/3dgenceslicer.rb
@@ -1,6 +1,6 @@
 cask "3dgenceslicer" do
-  version "3.3.0,4.0"
-  sha256 "b1b34d7582950a288e6ce4d216d7383cea4b4d71962817d632d8be6d1253871a"
+  version "3.4.0,4.0"
+  sha256 "3fc0b3b4aac1b05e54d80e66640fda1ae5ec498596bef8568a140be46ab62c45"
 
   url "https://cloud.3dgence.com/downloads/slicer/3DGenceSlicer-#{version.csv.second}-(v#{version.csv.first}).dmg"
   name "3DGence Slicer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `3dgenceslicer` to the latest version, 3.4.0,4.0.

livecheck is only able to return an older version at the moment (2.5.0,4.0) because the `href` attribute for the macOS file on the [support page](https://support.3dgence.com/software.html) is unexpectedly blank. The dmg file exists, so it may have been an accident when upstream updated the page.

The check will work again if/when upstream updates the macOS link (hopefully with the next release), so I've added the `ci-skip-livecheck` label for now. If this remains a persistent issue across releases, then we can update the `livecheck` block regex to match the version from something else on the page (e.g., the Windows file).