### PR TITLE
guitar-pro: update livecheck

### DIFF
--- a/Casks/g/guitar-pro.rb
+++ b/Casks/g/guitar-pro.rb
@@ -8,8 +8,8 @@ cask "guitar-pro" do
   homepage "https://www.guitar-pro.com/"
 
   livecheck do
-    url :homepage
-    regex(/Guitar\s*Pro\s*(\d+(?:\.\d+)*)/i)
+    url "https://www.guitar-pro.com/blog/c/2163-guitar-pro-news-tips"
+    regex(/Guitar\s+Pro\s+v?(\d+(?:\.\d+)*)/i)
   end
 
   pkg "guitar-pro-#{version.major}-setup.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `guitar-pro` checks the homepage but only returns 8 as the version instead of 8.1. This is because the homepage only includes text with the major version (e.g., "Guitar Pro 8").

Upstream only seems to list new versions on their blog, so this PR updates the `livecheck` block to check the related section. The blog post title format varies (and there are other posts that aren't related to new versions) but they at least all include text like "Guitar Pro 8.1", "Guitar Pro 7.5.5", etc., so this check works for now.