### PR TITLE
Adds fossa v3.8.18

### DIFF
--- a/Casks/f/fossa.rb
+++ b/Casks/f/fossa.rb
@@ -8,59 +8,10 @@ cask "fossa" do
   desc "Zero-configuration polyglot dependency analysis tool"
   homepage "https://fossa.com/"
 
-  # Uses github api to retrieve latest release.
-  # > brew livecheck --debug fossa
-  # Ref: https://docs.brew.sh/Brew-Livecheck#githublatest-strategy-block
-  livecheck do
-    url :stable
-    strategy :github_latest do |json, regex|
-      match = json["tag_name"]&.match(regex)
-      next if match.blank?
-
-      match[1]
-    end
-  end
-
-  auto_updates false
-
   binary "fossa"
-
-  # Verify that binary can be execuated!
-  postflight do
-    # If the cmd does not return exit 0, it will
-    # not perform installation.
-    cmd = "#{staged_path}/fossa --version"
-    raise "Could run command: `#{cmd}`." unless system cmd
-  end
 
   caveats do
     # fossa-cli requires Rosetta 2 for it to run on Apple Silicon.
     requires_rosetta
-
-    <<~EOS
-      **********************************************************************
-
-        You can find more information about fossa-cli at:
-          https://github.com/fossas/fossa-cli/tree/master/docs#user-manual
-
-        To use fossa-cli you will FOSSA API KEY:
-          >> export FOSSA_API_KEY=<FOSSA-API-KEY>
-
-        Learn more on how to generate api key:
-          https://docs.fossa.com/docs/api-reference
-
-        After which, you can use fossa-cli:
-          >> cd $MY_PROJECT_DIR # Use your actual project location here.
-          >> fossa analyze
-          >> fossa test
-
-        To run fossa analysis without without API key in output only mode:
-          >> fossa analyze --output
-
-        If you are running into issues, contact support at:
-          https://support.fossa.com/
-
-      **********************************************************************
-    EOS
   end
 end

--- a/Casks/f/fossa.rb
+++ b/Casks/f/fossa.rb
@@ -11,7 +11,8 @@ cask "fossa" do
   binary "fossa"
 
   caveats do
-    # fossa-cli requires Rosetta 2 for it to run on Apple Silicon.
     requires_rosetta
   end
+
+  # No zap stanza required
 end

--- a/Casks/f/fossa.rb
+++ b/Casks/f/fossa.rb
@@ -1,0 +1,66 @@
+cask "fossa" do
+  version "3.8.18"
+  sha256 "8fba90188752cea2c35a764f3b2308adc71058d7984cd761dd447a1c8359444f"
+
+  url "https://github.com/fossas/fossa-cli/releases/download/v#{version}/fossa_#{version}_darwin_amd64.zip",
+      verified: "github.com/fossas/fossa-cli/"
+  name "fossa"
+  desc "Zero-configuration polyglot dependency analysis tool"
+  homepage "https://fossa.com/"
+
+  # Uses github api to retrieve latest release.
+  # > brew livecheck --debug fossa
+  # Ref: https://docs.brew.sh/Brew-Livecheck#githublatest-strategy-block
+  livecheck do
+    url :stable
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
+  end
+
+  auto_updates false
+
+  binary "fossa"
+
+  # Verify that binary can be execuated!
+  postflight do
+    # If the cmd does not return exit 0, it will
+    # not perform installation.
+    cmd = "#{staged_path}/fossa --version"
+    raise "Could run command: `#{cmd}`." unless system cmd
+  end
+
+  caveats do
+    # fossa-cli requires Rosetta 2 for it to run on Apple Silicon.
+    requires_rosetta
+
+    <<~EOS
+      **********************************************************************
+
+        You can find more information about fossa-cli at:
+          https://github.com/fossas/fossa-cli/tree/master/docs#user-manual
+
+        To use fossa-cli you will FOSSA API KEY:
+          >> export FOSSA_API_KEY=<FOSSA-API-KEY>
+
+        Learn more on how to generate api key:
+          https://docs.fossa.com/docs/api-reference
+
+        After which, you can use fossa-cli:
+          >> cd $MY_PROJECT_DIR # Use your actual project location here.
+          >> fossa analyze
+          >> fossa test
+
+        To run fossa analysis without without API key in output only mode:
+          >> fossa analyze --output
+
+        If you are running into issues, contact support at:
+          https://support.fossa.com/
+
+      **********************************************************************
+    EOS
+  end
+end

--- a/Casks/f/fossa.rb
+++ b/Casks/f/fossa.rb
@@ -14,5 +14,5 @@ cask "fossa" do
 
   caveats do
     requires_rosetta
-  end  
+  end
 end

--- a/Casks/f/fossa.rb
+++ b/Casks/f/fossa.rb
@@ -10,9 +10,9 @@ cask "fossa" do
 
   binary "fossa"
 
+  # No zap stanza required
+
   caveats do
     requires_rosetta
-  end
-
-  # No zap stanza required
+  end  
 end


### PR DESCRIPTION
This PR, 

- Adds new cask: `fossa` with `v3.8.18`

_In the following questions `<cask>` is the token of the cask you're submitting._
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

### Why is it a cask but not formulae

fossa-cli is [MPL-2](https://github.com/fossas/fossa-cli/blob/master/LICENSE), but the built and distributed binary (via github releases) also includes propriety executables as embedded in fossa-executable (which are not open source) - so it simply is not possible to make this into formulae. Let me know if there are alternatives. I was recommended to make this into cask (from discussion section in github for homebrew) - since the reproducible build process is closed-source.