### PR TITLE
timing 2023.5.4

### DIFF
--- a/Casks/t/timing.rb
+++ b/Casks/t/timing.rb
@@ -1,6 +1,6 @@
 cask "timing" do
-  version "2023.5"
-  sha256 "4d00a27159521fa7d65e8d31fe71387cc23efabae5bfa2256207a31e29c29083"
+  version "2023.5.4"
+  sha256 "f1f064d54873a83e1256635a898467bcd652a757a24b2eccaf65910dc2ffd27e"
 
   url "https://updates.timingapp.com/download/Timing-#{version}.dmg"
   name "Timing"
@@ -8,9 +8,13 @@ cask "timing" do
   desc "Automatic time and productivity tracking app"
   homepage "https://timingapp.com/"
 
+  # Some items in the Sparkle feed may not have a pubDate, so it's necessary to
+  # work with all of the items in the feed (not just the newest one).
   livecheck do
     url "https://updates.timingapp.com/updates/timing2.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle do |items|
+      items.map(&:short_version)
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `timing` to the latest version. 2023.5.4.

The existing` livecheck` block is returning 2023.4.4 instead of 2023.5.4. The latter item doesn't have a `pubDate` value, so it isn't the newest item after the `Sparkle` strategy's internal sorting. With this in mind, I've updated the `livecheck` block to work with all the items (allowing livecheck to use all the item versions instead of only the newest after sorting).