### PR TITLE
pdfify 3.8.1,274

### DIFF
--- a/Casks/p/pdfify.rb
+++ b/Casks/p/pdfify.rb
@@ -1,15 +1,17 @@
 cask "pdfify" do
-  version "3.8-260"
-  sha256 "54636e971244e33776464c4bad116a4ee98f50a30d365600a62798932c94f8d6"
+  version "3.8.1,274"
+  sha256 "a7d6d71b1927d7899f088f5fa6ad851e8fe28e187ab84f8f37cb1ba00f9fb3da"
 
-  url "https://pdfify.app/get/cask/download/macos/PDFify-#{version}.zip"
+  url "https://pdfify.app/get/cask/download/macos/PDFify-#{version.csv.first}-#{version.csv.second}.zip"
   name "PDFify"
   desc "Create searchable and smaller PDF"
   homepage "https://pdfify.app/"
 
   livecheck do
     url "https://pdfify.app/updater-macos"
-    regex(/PDFify[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version}"
+    end
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `pdfify` to the latest version, 3.8.1-274.

This also updates the version scheme to `3.8.1,274`, as the version from livecheck (3.8.1-274) was being treated as older than the cask version (3.8-260). This happens because livecheck uses `Version` comparison, which effectively ignores delimiters, so 260 is compared against 1 and seen as higher. Using a CSV version format (3.8.1,274) ensures that the main version and the suffix are compared separately.

The existing `livecheck` block is also checking a Sparkle feed but isn't using the `Sparkle` strategy, so this modifies the `livecheck` block to address this and update the logic to correspond with the new version scheme.