### PR TITLE
flomo: discontinued

### DIFF
--- a/Casks/f/flomo.rb
+++ b/Casks/f/flomo.rb
@@ -8,13 +8,6 @@ cask "flomo" do
   desc "Memo note taking and management app"
   homepage "https://flomoapp.com/"
 
-  livecheck do
-    url "https://flomoapp.com/api/mac/latest/"
-    strategy :json do |json|
-      json["version"]
-    end
-  end
-
   depends_on macos: ">= :catalina"
 
   app "flomo.app"
@@ -23,4 +16,17 @@ cask "flomo" do
     "~/Library/Application Scripts/com.flomoapp.mac",
     "~/Library/Containers/com.flomoapp.mac",
   ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      Flomo versions prior to 2.0 are no longer supported and newer versions
+      are hosted on third-party file uploading sites that we can't use in the
+      cask or check for new versions.
+
+      See the homepage for alternative installation methods (Mac App Store,
+      etc.).
+    EOS
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `flomo` is giving a `Content could not be parsed as JSON` error, as the URL now returns an HTML page that redirects to https://help.flomoapp.com/community/update-new-version.html using JavaScript only (there's no `Location` header in the response).

I ran that page through a translator and it basically says that pre-2.0 versions aren't supported (as of 2023-07-14) and users should update to newer versions. However, upstream now hosts standalone dmg files on third-party services that I don't think we can reasonably download from or identify new versions (see: https://help.flomoapp.com/basic/app.html#mac-版本). Besides that, the current standalone dmg version is 3.23.92 (uploaded 2023-09-15) but the version on the Mac App Store is 3.23.387 (from a month ago), so I'm not sure how up-to-date the standalone dmg is.

With that in mind, I don't think we can update this cask and, even if we can, it's probably not worthwhile if the standalone dmg file isn't kept up to date. At this point, we're better off setting this as discontinued and users can install the app from the Mac App Store.