### PR TITLE
mmhmm-studio 2.6.0

### DIFF
--- a/Casks/m/mmhmm-studio.rb
+++ b/Casks/m/mmhmm-studio.rb
@@ -1,24 +1,37 @@
 cask "mmhmm-studio" do
-  version "2.5.2,1687464000"
-  sha256 "49ddb6c2b02050386f7786a619a5d2e87eea130f5b68fcd03ebb2ac4dfb8986f"
+  on_monterey :or_older do
+    version "2.5.2,1687464000"
+    sha256 "49ddb6c2b02050386f7786a619a5d2e87eea130f5b68fcd03ebb2ac4dfb8986f"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :big_sur"
+  end
+  on_ventura :or_newer do
+    version "2.6.0,1697775000"
+    sha256 "613e356605b9ca7e5eac9eed2c7cc80e5336804dca50b008a842126672cf8209"
+
+    # This appcast sometimes uses a newer pubDate for an older version, so we
+    # have to ignore the default `Sparkle` strategy sorting (which involves the
+    # pubDate) and simply work with the version numbers.
+    livecheck do
+      url "https://updates.mmhmm.app/mac/production/sparkle.xml"
+      strategy :sparkle do |items|
+        items.map(&:nice_version)
+      end
+    end
+
+    depends_on macos: ">= :ventura"
+  end
 
   url "https://updates.mmhmm.app/mac/production/mmhmmStudio_#{version.csv.first}.zip"
   name "mmhmm Studio"
   desc "Virtual video presentation software"
   homepage "https://www.mmhmm.app/product"
 
-  # This appcast sometimes uses a newer pubDate for an older version, so we
-  # have to ignore the default `Sparkle` strategy sorting (which involves the
-  # pubDate) and simply work with the version numbers.
-  livecheck do
-    url "https://updates.mmhmm.app/mac/production/sparkle.xml"
-    strategy :sparkle do |items|
-      items.map(&:nice_version)
-    end
-  end
-
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "mmhmm Studio.app"
 


### PR DESCRIPTION
The latest version only appears to support Ventura and newer.  

Updates to keep the previous version which have a minimum requirement of Big Sur and include the newest version.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
