### PR TITLE
Revert 158332 nordvpn 8.11.1

### DIFF
--- a/Casks/n/nordvpn.rb
+++ b/Casks/n/nordvpn.rb
@@ -1,6 +1,6 @@
 cask "nordvpn" do
-  version "8.11.1"
-  sha256 "ab6d7f6441ef51e96d3a432055f7f8a10c0a4234371980e57646d6d9d80cd623"
+  version "8.10.4"
+  sha256 "4a2d051646fd4fdd9eb87213dc7d3ebd13eb2501b51d8f497b3e7e80fa165f0b"
 
   url "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/#{version}/NordVPN.pkg",
       verified: "downloads.nordcdn.com/apps/macos/generic/"


### PR DESCRIPTION
This reverts commit #158332 as the files do not seem to be available at current time, and livecheck is also reporting the previous `8.10.4` version as current.

This update may have been an unreleased version and due to timing issues was picked up.
