### PR TITLE
Devtunnel update

### DIFF
--- a/Casks/d/devtunnel.rb
+++ b/Casks/d/devtunnel.rb
@@ -2,8 +2,8 @@ cask "devtunnel" do
   arch arm: "arm64", intel: "x64"
 
   version "1.0.964+9595af4514"
-  sha256 arm:   "065e86312e3513aa2a5bd6ea2f0822ca3a50ad6981e497043ded6b1630044737",
-         intel: "d9875469d96c563302cb68d1bd6834bde6ba949ace57714a86ecd0108073da1e"
+  sha256 arm:   "3d81eaa2bd1d5be99489ac378c2925f2076f01d1a505044b0e51902ce052a868",
+         intel: "c48f72ec265cf152929143672ccc090ff9739b925bbf56e54621ea55657e8f54"
 
   url "https://tunnelsassetsprod.blob.core.windows.net/cli/#{version}/osx-#{arch}-devtunnel-zip",
       verified: "tunnelsassetsprod.blob.core.windows.net/cli/"
@@ -19,6 +19,6 @@ cask "devtunnel" do
   end
 
   binary "devtunnel"
-
+  
   # No zap stanza required
 end

--- a/Casks/d/devtunnel.rb
+++ b/Casks/d/devtunnel.rb
@@ -19,6 +19,6 @@ cask "devtunnel" do
   end
 
   binary "devtunnel"
-  
+
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


**== PLEASE DO NOT CLOSE THE PR AND SEE BELOW SCREEN SHOTS==**

- We inserted dev tunnel with this initial Pr  here :  https://github.com/Homebrew/homebrew-cask/pull/156889
- In the first insertion it was pointing to non-versioned generic url.  
- The devtunnel version for that generic url was : **1.0.922+fa34179138**
- We set up versioned urls and sent the second Pr to update to the new version of dev tunnel which is:  **1.0.964+9595af4514**. PR : https://github.com/Homebrew/homebrew-cask/pull/156998
- The second Pr is closed by saying sha numbers supposed to be the same in the first pr. I believe it is not possible cause the version numbers of these 2 are different and they cannot have the same she numbers. 
- Pr is merged by maintainers  with old sha numbers now when you download devtunnel it points to old version. (1.0.922+fa34179138)  . It supposed to point to the new version (1.0.964+9595af4514) with new sha numbers.
 
**I need help to fix this and understand what is missing and why Pr tests are failing. Please see the screen shots from my local terminal.**

The result indicates the sha  numbers I sent this pr is correct. 

Here is the result for "brew audit --strict  --online homebrew/cask/devtunnel" 

![Screen Shot 2023-10-17 at 3 58 38 PM](https://github.com/Homebrew/homebrew-cask/assets/37163639/525d96bf-4fbc-49b4-97b9-4235faa2882a)

When I calculate the sea number with "shamus --algorithm 256 dev tunnel" it shows the sea number I have is correct. Please see the results below : 
![Screen Shot 2023-10-11 at 4 50 52 PM](https://github.com/Homebrew/homebrew-cask/assets/37163639/fe52c735-0137-46d7-b73b-51bdd05daa3d)

