### PR TITLE
karabiner-elements: update urls

### DIFF
--- a/Casks/k/karabiner-elements.rb
+++ b/Casks/k/karabiner-elements.rb
@@ -3,7 +3,8 @@ cask "karabiner-elements" do
     version "11.6.0"
     sha256 "c1b06252ecc42cdd8051eb3d606050ee47b04532629293245ffdfa01bbc2430d"
 
-    url "https://pqrs.org/osx/karabiner/files/Karabiner-Elements-#{version}.dmg"
+    url "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v#{version}/Karabiner-Elements-#{version}.dmg",
+        verified: "github.com/pqrs-org/Karabiner-Elements/"
 
     livecheck do
       skip "Legacy version"
@@ -118,7 +119,7 @@ cask "karabiner-elements" do
         verified: "github.com/pqrs-org/Karabiner-Elements/"
 
     livecheck do
-      url "https://pqrs.org/osx/karabiner/files/karabiner-elements-appcast.xml"
+      url "https://appcast.pqrs.org/karabiner-elements-appcast.xml"
       strategy :sparkle
     end
 
@@ -129,7 +130,7 @@ cask "karabiner-elements" do
 
   name "Karabiner Elements"
   desc "Keyboard customizer"
-  homepage "https://pqrs.org/osx/karabiner/"
+  homepage "https://karabiner-elements.pqrs.org/"
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `karabiner-elements` to also use the dmg from GitHub in the `on_el_capitan :or_older` block (aligning with the related URL on the homepage).

This also updates other URLs in the cask to resolve redirections:

* The existing `homepage` URL redirects to https://karabiner-elements.pqrs.org
* The existing `livecheck` block URL redirects to https://appcast.pqrs.org/karabiner-elements-appcast.xml