### PR TITLE
Genymotion only installs 3.5.1+ on Ventura & newer

### DIFF
--- a/Casks/g/genymotion.rb
+++ b/Casks/g/genymotion.rb
@@ -1,6 +1,12 @@
 cask "genymotion" do
-  version "3.5.1"
-  sha256 "cc4bc949b8e5744272dbb77c798035ff009740d0eb8bd251b2b5d82daa2113fb"
+  on_monterey :or_older do
+    version "3.5.0"
+    sha256 "c4be3f53a85908027340b7529dcdc79e7a6b19572056b354fc94d9688c0c10f7"
+  end
+  on_ventura :or_newer do
+    version "3.5.1"
+    sha256 "cc4bc949b8e5744272dbb77c798035ff009740d0eb8bd251b2b5d82daa2113fb"
+  end
 
   url "https://dl.genymotion.com/releases/genymotion-#{version}/genymotion-#{version}.dmg"
   name "Genymotion"
@@ -11,8 +17,6 @@ cask "genymotion" do
     url "https://www.genymotion.com/download/"
     regex(/href=.*?Genymotion[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg)/i)
   end
-
-  depends_on macos: ">= :ventura"
 
   app "Genymotion.app"
   app "Genymotion Shell.app"


### PR DESCRIPTION
Genymotion only installs 3.5.1+ on Ventura & newer

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
