### PR TITLE
avogadro: reorder zap

### DIFF
--- a/Casks/a/avogadro.rb
+++ b/Casks/a/avogadro.rb
@@ -14,8 +14,8 @@ cask "avogadro" do
   app "Avogadro2.app"
 
   zap trash: [
+    "~/Library/Application Support/OpenChemistry/Avogadro",
     "~/Library/Preferences/org.openchemistry.Avogadro.plist",
     "~/Library/Saved Application State/cc.avogadro.savedState",
-    "~/Library/Application Support/OpenChemistry/Avogadro",
   ]
 end


### PR DESCRIPTION
Reordering the zap to be in alphabetical order.  No other changes.