### PR TITLE
lulu: remove auto update stanza

### DIFF
--- a/Casks/l/lulu.rb
+++ b/Casks/l/lulu.rb
@@ -13,7 +13,6 @@ cask "lulu" do
     strategy :github_latest
   end
 
-  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "LuLu.app"


### PR DESCRIPTION
Lulu doesn't auto update in its current state, so not sure why this stanza is there. When using the built-in updater, Lulu redirects to the website to download a disk image file.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
