### PR TITLE
Adds fossa to bump-cask github action workflow

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -120,6 +120,7 @@ env:
     zed
     zoom
     zoom-for-it-admins
+    fossa
 
 permissions:
   contents: read

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -47,6 +47,7 @@ env:
     firefox
     flipper
     fmail2
+    fossa
     foxglove-studio
     gather
     glyphs
@@ -120,7 +121,6 @@ env:
     zed
     zoom
     zoom-for-it-admins
-    fossa
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR, 
- adds `fossa` to `autobump` github action workflow, that automatically bumps version of the cask

This is continuation from: https://github.com/Homebrew/homebrew-cask/pull/158367#issuecomment-1783586611 

------------------------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] ~The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).~
- [ ] ~`brew audit --cask --online <cask>` is error-free.~
- [ ] ~`brew style --fix <cask>` reports no offenses.~

Additionally, **if adding a new cask**:

- [ ] ~Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).~
- [ ] ~Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).~
- [ ] ~Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).~
- [ ] ~`brew audit --new-cask <cask>` worked successfully.~
- [ ] ~`brew install --cask <cask>` worked successfully.~
- [ ] ~`brew uninstall --cask <cask>` worked successfully.~
