### PR TITLE
clone-hero: use `github_latest` livecheck strategy

### DIFF
--- a/Casks/c/clone-hero.rb
+++ b/Casks/c/clone-hero.rb
@@ -8,6 +8,11 @@ cask "clone-hero" do
   desc "Guitar Hero clone"
   homepage "https://clonehero.net/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :high_sierra"
 
   app "Clone Hero.app"


### PR DESCRIPTION
The GitHub repository now includes pre-releases, so use `github_latest` livecheck strategy.