### PR TITLE
data-integration 9.4.0.0-343

### DIFF
--- a/Casks/d/data-integration.rb
+++ b/Casks/d/data-integration.rb
@@ -1,15 +1,16 @@
 cask "data-integration" do
-  version "9.3.0.0-428"
-  sha256 "5c7a453ec448d4b8a568e445b119bcf4f0f41517b42e3626bc437f882c9f46c1"
+  version "9.4.0.0-343"
+  sha256 "e6804fae1a9aa66b92e781e9b2e835d72d56a6adc53dc03e429a847991a334e8"
 
-  url "https://downloads.sourceforge.net/pentaho/pdi-ce-#{version}.zip"
+  url "https://privatefilesbucket-community-edition.s3.us-west-2.amazonaws.com/#{version}/ce/client-tools/pdi-ce-#{version}.zip",
+      verified: "privatefilesbucket-community-edition.s3.us-west-2.amazonaws.com/"
   name "Pentaho Data Integration"
   desc "End to end data integration and analytics platform"
-  homepage "https://sourceforge.net/projects/pentaho/"
+  homepage "https://www.hitachivantara.com/en-us/products/pentaho-platform/data-integration-analytics/pentaho-community-edition.html"
 
   livecheck do
-    url :url
-    regex(%r{url=.*?/pdi-ce[._-]v?(\d+(?:[.-]\d+)+)\.zip}i)
+    url :homepage
+    regex(/href=.*?pdi-ce[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
   end
 
   app "data-integration/Data Integration.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `data-integration` to the newest version, 9.4.0.0-343.

Pentaho Community Edition has moved from SourceForge to https://www.hitachivantara.com/en-us/products/pentaho-platform/data-integration-analytics/pentaho-community-edition.html, so this updates the cask URLs accordingly.

The existing `livecheck` block gives an `Unable to get versions` error because the SourceForge project was emptied except for a PDF file. This PR updates the `livecheck` block to match the new source, so it returns 9.4.0.0-343 as the latest version.