### PR TITLE
new cask `crunchy-labs/crunchy-cli`

### DIFF
--- a/Casks/c/crunchy-cli.rb
+++ b/Casks/c/crunchy-cli.rb
@@ -20,4 +20,6 @@ cask "crunchy-cli" do
   postflight do
     set_permissions "#{staged_path}/crunchy-cli", "0755"
   end
+
+  # No zap stanza required
 end

--- a/Casks/c/crunchy-cli.rb
+++ b/Casks/c/crunchy-cli.rb
@@ -1,0 +1,23 @@
+cask "crunchy-cli" do
+  version "3.0.3"
+  sha256 "0a7a1a7fc17472f39576b4cf7d37e1e69fe0af5fa22b487f2c8992e320e7a058"
+
+  url "https://github.com/crunchy-labs/crunchy-cli/releases/download/v#{version}/crunchy-cli-v#{version}-darwin-x86_64"
+  name "crunchy-cli"
+  desc "Command-line downloader for Crunchyroll"
+  homepage "https://github.com/crunchy-labs/crunchy-cli"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on formula: "ffmpeg"
+  container type: :naked
+
+  binary "crunchy-cli-v#{version}-darwin-x86_64", target: "crunchy-cli"
+
+  postflight do
+    set_permissions "#{staged_path}/crunchy-cli", "0755"
+  end
+end


### PR DESCRIPTION
Command-line downloader for Crunchyroll

depends on `ffmpeg`

Requires CrunchyRoll Premium Subscription membership

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
```
brew audit --cask --online crunchy-cli
==> Downloading https://github.com/crunchy-labs/crunchy-cli/releases/download/v3.0.3/crunchy-cli-v3.0.3-darwin-x86_64
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/394457250/2b838a4c-6ed1-4b5a-92c4-d88c4740c66e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAI
...####### 100.0%
```
- [x] `brew style --fix <cask>` reports no offenses.
```
brew style --fix crunchy-cli

1 file inspected, no offenses detected
```

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
```
brew audit --new-cask crunchy-cli
==> Downloading https://github.com/crunchy-labs/crunchy-cli/releases/download/v3.0.3/crunchy-cli-v3.0.3-darwin-x86_64
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/394457250/2b838a4c-6ed1-4b5a-92c4-d88c4740c66e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAI
################################################################################################################################################################################################# 100.0%
==> Downloading https://github.com/crunchy-labs/crunchy-cli/releases/download/v3.0.3/crunchy-cli-v3.0.3-darwin-x86_64
Already downloaded: /Users/.../Library/Caches/Homebrew/downloads/9a28940f37a5a79ed7d1f18ec06af382054893889f2e1aa77340f97422dc7706--crunchy-cli-v3.0.3-darwin-x86_64
```
- [x] `brew install --cask <cask>` worked successfully.
```
brew install --cask crunchy-cli
==> Downloading https://github.com/crunchy-labs/crunchy-cli/releases/download/v3.0.3/crunchy-cli-v3.0.3-darwin-x86_64
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/394457250/2b838a4c-6ed1-4b5a-92c4-d88c4740c66e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAI
################################################################################################################################################################################################# 100.0%
All formula dependencies satisfied.
==> Installing Cask crunchy-cli
==> Linking Binary 'crunchy-cli-v3.0.3-darwin-x86_64' to '/opt/homebrew/bin/crunchy-cli'
🍺  crunchy-cli was successfully installed!
```
- [x] `brew uninstall --cask <cask>` worked successfully.
```
brew uninstall --cask crunchy-cli
==> Uninstalling Cask crunchy-cli
==> Unlinking Binary '/opt/homebrew/bin/crunchy-cli'
==> Purging files for version 3.0.3 of Cask crunchy-cli
```

NOTE: Above were tested with my own tap with the same manifest, I was getting this error with my local `homebrew/cask` tap. Not sure why. 
```
brew install --cask crunchy-cli
Warning: Cask 'crunchy-cli' is unavailable: No Cask with this name exists.
==> Searching for similarly named casks...
==> Casks
crunch

To install crunch, run:
  brew install --cask crunch
```


