### PR TITLE
luminance-hdr: update livecheck

### DIFF
--- a/Casks/l/luminance-hdr.rb
+++ b/Casks/l/luminance-hdr.rb
@@ -9,9 +9,8 @@ cask "luminance-hdr" do
   homepage "https://qtpfsgui.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/p/qtpfsgui/activity"
-    regex(/LuminanceHDR[._-]?(\d+(?:\.\d+)*)[._-]?-Qt5\.13\.dmg/i)
-    strategy :page_match
+    url "https://sourceforge.net/projects/qtpfsgui/rss?path=/luminance"
+    regex(%r{url=.*?/Luminance[_-]?HDR[._-]v?(\d+(?:\.\d+)+)[^"' ]*?\.dmg}i)
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Prior to #158828, the existing `livecheck` block for `luminance-hdr` was giving an `Unable to get versions` error, as it was checking a page that no longer exists (and now simply redirects to the SourceForge project page).

This PR is an alternative fix for this issue, using the `Sourceforge` strategy to check the RSS feed for the `luminance` subdirectory, as this is the typical check for this scenario.

@bevanjkay Was there any particular reason for checking the project activity page that I'm missing? We don't have any other SourceForge formulae/casks using this type of check and it doesn't seem necessary here (not to mention that the activity page contains quite a bit of extraneous information like notifications for tickets, comments, blog posts, etc.).