### PR TITLE
ibabel: update `livecheck`

### DIFF
--- a/Casks/i/ibabel.rb
+++ b/Casks/i/ibabel.rb
@@ -14,7 +14,7 @@ cask "ibabel" do
       match = page.match(regex)
 
       cask = CaskLoader.load("ibabel")
-      download_url = "https://macinchem.co.uk/wp-content/uploads/#{match[1]}/#{match[2]}/iBabel.zip"
+      download_url = "https://macinchem.org/wp-content/uploads/#{match[1]}/#{match[2]}/iBabel.zip"
       app_version = Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask: cask,
                                                                               url:  download_url)[:matches].values.max
       next if app_version.blank?


### PR DESCRIPTION
```
|-> curl -sLI https://macinchem.co.uk/wp-content/uploads/2023/02/iBabel.zip
HTTP/2 307 
location: https://macinchem.org/wp-content/uploads/2023/02/iBabel.zip
content-type: text/plain; charset=utf-8
content-length: 18
date: Mon, 30 Oct 2023 09:27:34 GMT

HTTP/2 200 
accept-ranges: bytes
content-type: application/zip
date: Mon, 30 Oct 2023 09:27:35 GMT
etag: "379616-5f4d6a1796ac4"
last-modified: Thu, 16 Feb 2023 19:59:12 GMT
server: Apache/2.4.56 (Debian)
content-length: 3642902
```