### PR TITLE
gcc-arm-embedded: various updates

### DIFF
--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -19,43 +19,44 @@ cask "gcc-arm-embedded" do
   end
 
   pkg "arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-addr2line"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ar"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-as"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-c++"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-c++filt"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-cpp"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-elfedit"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-g++"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-#{gcc_version}"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-ar"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-nm"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcc-ranlib"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcov"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcov-dump"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gcov-tool"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gdb"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gdb-add-index"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gfortran"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-gprof"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ld"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ld.bfd"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-lto-dump"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-nm"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-objcopy"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-objdump"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-ranlib"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-readelf"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-size"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-strings"
-  binary "#{appdir}/ArmGNUToolchain/#{version}/arm-none-eabi/bin/arm-none-eabi-strip"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-addr2line"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-as"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-c++"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-c++filt"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-cpp"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-elfedit"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-g++"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-#{gcc_version}"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcov"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcov-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcov-tool"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gdb"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gdb-add-index"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gfortran"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gprof"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ld"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ld.bfd"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-lto-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-objcopy"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-objdump"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-readelf"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-size"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-strings"
+  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-strip"
 
   uninstall pkgutil: "arm-gnu-toolchain-#{version.major_minor}*-darwin-#{arch}-arm-none-eabi",
-            delete:  "/Applications/ArmGNUToolchain/#{version}/arm-none-eabi",
+            delete:  "/Applications/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi",
             rmdir:   [
-              "/Applications/ArmGNUToolchain/#{version}",
+              "/Applications/ArmGNUToolchain/#{version.major_minor}*",
               "/Applications/ArmGNUToolchain",
             ]
+
   # No zap stanza required
 end

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -4,6 +4,7 @@ cask "gcc-arm-embedded" do
   arch arm: "arm64", intel: "x86_64"
 
   version "13.2.rel1"
+  pkg_version = "13.2.Rel1"
   gcc_version = "13.2.1"
   sha256 arm:   "57343df9a2d7c5c587b59ad011bf516ca286f6f9d0ef5957a3ad251f5579fd16",
          intel: "cba310dcd5e5b7f443ffea3ae4d6e00d757a616eb824ace6158c7473a8e2b33c"
@@ -19,42 +20,42 @@ cask "gcc-arm-embedded" do
   end
 
   pkg "arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-addr2line"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ar"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-as"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-c++"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-c++filt"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-cpp"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-elfedit"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-g++"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-#{gcc_version}"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-ar"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-nm"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcc-ranlib"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcov"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcov-dump"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gcov-tool"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gdb"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gdb-add-index"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gfortran"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-gprof"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ld"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ld.bfd"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-lto-dump"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-nm"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-objcopy"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-objdump"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-ranlib"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-readelf"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-size"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-strings"
-  binary "#{appdir}/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi/bin/arm-none-eabi-strip"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-addr2line"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-as"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-c++"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-c++filt"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-cpp"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-elfedit"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-g++"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcc"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcc-#{gcc_version}"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcc-ar"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcc-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcc-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcov"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcov-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gcov-tool"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gdb"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gdb-add-index"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gfortran"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gprof"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ld"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ld.bfd"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-lto-dump"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-nm"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-objcopy"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-objdump"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ranlib"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-readelf"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-size"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strings"
+  binary "#{appdir}/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "arm-gnu-toolchain-#{version.major_minor}*-darwin-#{arch}-arm-none-eabi",
-            delete:  "/Applications/ArmGNUToolchain/#{version.major_minor}*/arm-none-eabi",
+  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{arch}-arm-none-eabi",
+            delete:  "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi",
             rmdir:   [
-              "/Applications/ArmGNUToolchain/#{version.major_minor}*",
+              "/Applications/ArmGNUToolchain/#{pkg_version}",
               "/Applications/ArmGNUToolchain",
             ]
 


### PR DESCRIPTION
Version inside the `ArmGNUToolchain` folder is listed as `13.2.Rel1` instead of `13.2.rel1`, which will cause problems on case-sensitive file systems.