### PR TITLE
data-rescue 6.0.8

### DIFF
--- a/Casks/d/data-rescue.rb
+++ b/Casks/d/data-rescue.rb
@@ -1,15 +1,15 @@
 cask "data-rescue" do
-  version "6.0.7"
-  sha256 "45ba579f20251bbe4c7d8cd52a31da210abbb15428c4d42d6c617ac40ce3fd69"
+  version "6.0.8"
+  sha256 "74526630976a9973905936766e6aff8d90f7ed9910014ba154849da7da6b3ad2"
 
   url "https://downloads.prosofteng.com/dr/Data_Rescue_#{version}.dmg"
   name "Data Rescue #{version.major}"
   desc "Data recovery software"
-  homepage "https://www.prosofteng.com/data-rescue-recovery-software/"
+  homepage "https://www.prosofteng.com/mac-data-recovery"
 
   livecheck do
-    url "https://www.prosofteng.com/resources/dr#{version.major}/dr#{version.major}_updates_mac.xml"
-    strategy :sparkle, &:short_version
+    url "https://www.prosofteng.com/downloads"
+    regex(/>\s*Data\s+Rescue(?:\s+\d+)?\s+\(Mac\)\s*<.+?v?(\d+(?:\.\d+)+)/im)
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `data-rescue` to the latest version, 6.0.8.

The existing `livecheck` block was checking a Sparkle feed but this now returns a 404 (Not Found) response with an HTML body (instead of XML), which the `Sparkle` strategy predictably can't handle:

```
Error: data-rescue: Missing end tag for 'link' (got 'head')
Line: 1
Position: 27311
Last 80 unconsumed characters:
<body><div class="max-w-screen-lg pt-5 mx-auto px-4"><input id="hamburger" type="
```

This PR updates the `livecheck` block to check the [first-party download page](https://www.prosofteng.com/downloads) instead, as this was the only unversioned source of version information I could readily find. The regex to match the Mac versions on the page is a bit gnarly but this is necessary unless there's a better source available.