### PR TITLE
Update app-tamer.rb to fix the sha256

### DIFF
--- a/Casks/a/app-tamer.rb
+++ b/Casks/a/app-tamer.rb
@@ -1,6 +1,6 @@
 cask "app-tamer" do
   version "2.8.2"
-  sha256 "92dfaf11623e3b1b86c132752e2932ccc940cc87e38d92434f7d04344413e01e"
+  sha256 "f289ddc261a7b29c9d3c3116dd459b94d44fa10501f5bac02d2fb503976ee995"
 
   url "https://www.stclairsoft.com/download/AppTamer-#{version}.dmg"
   name "AppTamer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

```
Error: app-tamer: SHA256 mismatch
Expected: 92dfaf11623e3b1b86c132752e2932ccc940cc87e38d92434f7d04344413e01e
  Actual: f289ddc261a7b29c9d3c3116dd459b94d44fa10501f5bac02d2fb503976ee995
```