### PR TITLE
imageoptim: bump to 1.9.3

### DIFF
--- a/Casks/i/imageoptim.rb
+++ b/Casks/i/imageoptim.rb
@@ -1,8 +1,8 @@
 cask "imageoptim" do
-  version "1.8.8"
-  sha256 "f48ce652b8cbf0186e3a550d1dcd0ab81366d0662a3f01621d4cadd4af23cce3"
+  version "1.9.3"
+  sha256 "d4e453bbb55b6491d519a30e0e6de5beb7ce1a929e8f835767b638ef6ffd371d"
 
-  url "https://imageoptim.com/ImageOptim#{version}.tar.bz2"
+  url "https://imageoptim.com/ImageOptim#{version}.tar.xz"
   name "ImageOptim"
   desc "Tool to optimize images to a smaller size"
   homepage "https://imageoptim.com/mac"
@@ -13,6 +13,7 @@ cask "imageoptim" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "ImageOptim.app"
 


### PR DESCRIPTION
New download `url` and `depends_on`

----

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.