### PR TITLE
Add missing files to be zapped for the new Microsoft Teams client

### DIFF
--- a/Casks/m/microsoft-teams.rb
+++ b/Casks/m/microsoft-teams.rb
@@ -46,21 +46,31 @@ cask "microsoft-teams" do
             quit:      "com.microsoft.autoupdate2",
             delete:    [
               "/Applications/Microsoft Teams (work or school).app",
+              "/Library/Application Support/Microsoft/TeamsUpdaterDaemon",
               "/Library/Logs/Microsoft/Teams",
+              "/Library/Logs/Microsoft/MSTeams",
               "/Library/Preferences/com.microsoft.teams.plist",
             ]
 
   zap trash: [
+        "~/Library/Application Scripts/com.microsoft.teams2",
+        "~/Library/Application Scripts/com.microsoft.teams2.launcher",
+        "~/Library/Application Scripts/com.microsoft.teams2.notificationcenter",
         "~/Library/Application Support/com.microsoft.teams",
         "~/Library/Application Support/Microsoft/Teams",
         "~/Library/Application Support/Teams",
         "~/Library/Caches/com.microsoft.teams",
+        "~/Library/Containers/com.microsoft.teams2",
+        "~/Library/Containers/com.microsoft.teams2.launcher",
+        "~/Library/Containers/com.microsoft.teams2.notificationcenter",
         "~/Library/Cookies/com.microsoft.teams.binarycookies",
         "~/Library/HTTPStorages/com.microsoft.teams",
         "~/Library/HTTPStorages/com.microsoft.teams.binarycookies",
         "~/Library/Logs/Microsoft Teams",
+        "~/Library/Logs/Microsoft Teams Helper (Renderer)",
         "~/Library/Preferences/com.microsoft.teams.plist",
         "~/Library/Saved Application State/com.microsoft.teams.savedState",
+        "~/Library/Saved Application State/com.microsoft.teams2.savedState",
         "~/Library/WebKit/com.microsoft.teams",
       ],
       rmdir: "~/Library/Application Support/Microsoft"


### PR DESCRIPTION
The microsoft-teams cask was not removing files used by the new Microsoft Teams client when running `brew uninstall` or `brew uninstall --zap`.
I've found those leftovers by running `find ~/Library -iname "*teams*"` and `sudo find /Library -iname "*teams*"`.

By looking at other casks, it seems that `--zap` should remove user-related leftovers, while system-level ones should always be removed upon uninstallation, is that correct? 

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
