### PR TITLE
Fix Docker cask for macOS Big Sur

### DIFF
--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -16,7 +16,18 @@ cask "docker" do
 
     depends_on macos: ">= :catalina"
   end
-  on_big_sur :or_newer do
+  on_big_sur do
+    version "4.24.2,124339"
+    sha256 arm:   "fec5b7f8f38b7cbec3a654b01fcc1828b4dbaa3875033adab20a88fa9ad4c7c4",
+           intel: "0bedaa13c4e8870b55250162def44cafba65d857c265f1f7488d8326ec386f71"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: :big_sur
+  end
+  on_monterey :or_newer do
     version "4.25.0,126437"
     sha256 arm:   "7ff7c3a5a1a4e582f610cd713aa3ee69fae669bbb8345601e892f05a33fb87b3",
            intel: "1786b2f47127dd30674aaf8dfa491d9c614cbf260ae03c8f699abe36578713dd"
@@ -26,7 +37,7 @@ cask "docker" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :big_sur"
+    depends_on macos: ">= :monterey"
   end
 
   url "https://desktop.docker.com/mac/main/#{arch}/#{version.csv.second}/Docker.dmg"


### PR DESCRIPTION
This PR fixes the Docker cask to restore compatibility with macOS Big Sur broken as of https://github.com/Homebrew/homebrew-cask/commit/42480777c570371e7ca1dedd5a5381aac0d3958d.

Starting with version `4.25.0`, Docker no longer supports macOS Big Sur (`11.7.10`) and produces the following error when trying to open the app:

![Screenshot 2023-10-31 at 16 29 28](https://github.com/Homebrew/homebrew-cask/assets/1451690/ad623c46-c84f-4a30-92a1-09832a800c92)

As per https://docs.docker.com/desktop/install/mac-install/:

> Docker supports Docker Desktop on the most recent versions of macOS. That is, the current release of macOS and the previous two releases. As new major versions of macOS are made generally available, Docker stops supporting the oldest version and supports the newest version of macOS (in addition to the previous two releases).

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online docker` is error-free.
- [x] `brew style --fix docker` reports no offenses.