### PR TITLE
privatevpn 3.3.2

### DIFF
--- a/Casks/p/privatevpn.rb
+++ b/Casks/p/privatevpn.rb
@@ -1,5 +1,5 @@
 cask "privatevpn" do
-  version "3.2.1"
+  version "3.3.2"
   sha256 :no_check
 
   url "https://privatevpn.com/client/PrivateVPN.dmg"
@@ -8,8 +8,8 @@ cask "privatevpn" do
   homepage "https://privatevpn.com/"
 
   livecheck do
-    url "https://xu515.pvdatanet.com/v3/mac/appcast.xml"
-    strategy :sparkle, &:short_version
+    url "https://privatevpn.com/why-privatevpn/view-our-software/"
+    regex(/Mac\s*OS(?:\s+X)?\s+VPN\s+App\s+(?:Version\s+)?v?(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `privatevpn` to the latest version, 3.3.2.

The existing `livecheck` block was using the `Sparkle` strategy to check an appcast XML file but the URL now returns a 403 (Forbidden) response. This updates the `livecheck` block to match the version from text like "Download our Mac OS X VPN App Version 3.3.2", as the dmg URL is unversioned. The regex is a little gnarly, since I wanted it to be able to adapt to conceivable text changes in the future. [I'm not fond of matching loose text like this but hopefully this will hold up better than a more explicit regex.]