### PR TITLE
Set auto_updates true for Reflect

### DIFF
--- a/Casks/r/reflect.rb
+++ b/Casks/r/reflect.rb
@@ -11,6 +11,8 @@ cask "reflect" do
   desc "Note taking app for meetings, ideas, journalling, and research"
   homepage "https://reflect.app/"
 
+  auto_updates true
+
   app "Reflect.app"
 
   zap trash: [


### PR DESCRIPTION
Reflect always automatically installs updates and has no way of opting out.

Additionally, in order to pass `brew audit`, I also did the following:
- updated the formula to Reflect 2.1.2
- moved the formula to `./r/reflect.rb`.

Note: `brew oudated` still lists `reflect (2.0.9) != 2.1.2` for me — I'm assuming it's not using the formula in `/opt/homebrew/` that I just edited and submitted?

***

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.