### PR TITLE
xiv-on-mac: Update supported macOS version from Big Sur to Monterey

### DIFF
--- a/Casks/x/xiv-on-mac.rb
+++ b/Casks/x/xiv-on-mac.rb
@@ -13,7 +13,7 @@ cask "xiv-on-mac" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "XIV on Mac.app"
 


### PR DESCRIPTION
Since version 4.10, macOS Big Sur is no longer supported. The software only works on macOS Monterey and newer now.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
