### PR TITLE
Add mitmproxy cask

### DIFF
--- a/Casks/m/mitmproxy.rb
+++ b/Casks/m/mitmproxy.rb
@@ -1,0 +1,25 @@
+cask "mitmproxy" do
+  version "10.1.2"
+  sha256 "57f1d07809b712e9014305c2efad31fcb3de7e3dabd321cdfa8f79e971f8ae02"
+
+  url "https://downloads.mitmproxy.org/#{version}/mitmproxy-#{version}-macos-x86_64.tar.gz"
+  name "mitmproxy"
+  desc "Intercept, modify, replay, save HTTP/S traffic"
+  homepage "https://mitmproxy.org/"
+
+  livecheck do
+    url "https://github.com/mitmproxy/mitmproxy"
+    strategy :git
+    regex(/^(\d+(?:\.\d+)+)$/i)
+  end
+
+  binary "mitmproxy.app/Contents/MacOS/mitmproxy"
+  binary "mitmproxy.app/Contents/MacOS/mitmdump"
+  binary "mitmproxy.app/Contents/MacOS/mitmweb"
+
+  zap trash: "~/.mitmproxy"
+
+  caveats do
+    requires_rosetta
+  end
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -27,7 +27,6 @@
   "lunchy": "homebrew/core",
   "micromamba": "homebrew/core",
   "minikube": "homebrew/core",
-  "mitmproxy": "homebrew/core",
   "mosh": "homebrew/core",
   "nmap": "homebrew/core",
   "node": "homebrew/core",


### PR DESCRIPTION
Hi all! 

Following up on https://github.com/Homebrew/homebrew-core/pull/145547, this PR adds a cask for mitmproxy. To recap, we need to transition mitmproxy from formula to a cask because we are including an (open source) macOS System Network Extension in mitmproxy, which needs to be signed & notarized for distribution. This requires us to precompile, which makes it ineligible for a formula.

This is my first time authoring a Cask, so any additional hints/tips is appreciated. All checks below are passing, with the exception of `brew audit --new-cask` which complains about a formula with the same name. The necessary changes for homebrew-core are [here](https://github.com/Homebrew/homebrew-core/compare/master...mhils:homebrew-core:mitmproxy-cask?expand=1), let me know what the blessed order of operations is.

We plan on shipping arm64 binaries once GitHub Actions figures out M1 runners for FOSS projects, for now I've added a rosetta caveat. I've intentionally not added an app stanza because mitmproxy is CLI-only.

--------------------

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.

    > [!WARNING]  
    > 
    > audit for mitmproxy: failed
    >  - possible duplicate, cask token conflicts with Homebrew core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula//Formula/m/mitmproxy.rb
    > mitmproxy

- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
