### PR TITLE
remote-desktop-manager-free 2023.3.7.0

### DIFF
--- a/Casks/r/remote-desktop-manager-free.rb
+++ b/Casks/r/remote-desktop-manager-free.rb
@@ -1,17 +1,12 @@
 cask "remote-desktop-manager-free" do
-  version "2023.3.7.0"
-  sha256 "0159f5721c9612347c616629e4ad5190e3449cd378ff1beabb7019761fc53cce"
+  version "2022.2.16.0"
+  sha256 "26545b52627f780fc3618f62649ff58589adfd1409d72f5b84f50be11b218879"
 
-  url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg",
+  url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg",
       verified: "devolutions.net/"
   name "Remote Desktop Manager Free"
   desc "Centralizes all remote connections on a single platform"
   homepage "https://mac.remotedesktopmanager.com/"
-
-  livecheck do
-    url "https://devolutions.net/products.htm"
-    regex(/RDMMacFreeWeb\.Version=(\d+(?:\.\d+)+)/i)
-  end
 
   depends_on macos: ">= :sierra"
 
@@ -21,4 +16,15 @@ cask "remote-desktop-manager-free" do
     "~/Library/Application Support/com.devolutions.remotedesktopmanager.free",
     "~/Library/Preferences/com.devolutions.remotedesktopmanager.free",
   ]
+
+  caveats do
+    discontinued
+    <<~EOS
+      TO install the free version run:
+
+        brew install --cask remote-desktop-manager
+
+      and when launched you can choose to use the free version.
+    EOS
+  end
 end

--- a/Casks/r/remote-desktop-manager-free.rb
+++ b/Casks/r/remote-desktop-manager-free.rb
@@ -1,16 +1,16 @@
 cask "remote-desktop-manager-free" do
-  version "2022.2.16.0"
-  sha256 "26545b52627f780fc3618f62649ff58589adfd1409d72f5b84f50be11b218879"
-
-  url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Free.Mac.#{version}.dmg",
+  version "2023.3.6.3"
+  sha256 "e16436e8c061f691ce7752d487bca7702ca85cc67d5b4399c580e7153721d59f"
+ 
+  url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg",
       verified: "devolutions.net/"
   name "Remote Desktop Manager Free"
   desc "Centralizes all remote connections on a single platform"
   homepage "https://mac.remotedesktopmanager.com/"
 
   livecheck do
-    url "https://cdn.devolutions.net/download/Mac/RemoteDesktopManagerFree.xml"
-    strategy :sparkle
+    url "https://devolutions.net/products.htm"
+    regex(/RDMMacFreeWeb\.Version=(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/r/remote-desktop-manager-free.rb
+++ b/Casks/r/remote-desktop-manager-free.rb
@@ -1,7 +1,7 @@
 cask "remote-desktop-manager-free" do
-  version "2023.3.6.3"
-  sha256 "e16436e8c061f691ce7752d487bca7702ca85cc67d5b4399c580e7153721d59f"
- 
+  version "2023.3.7.0"
+  sha256 "0159f5721c9612347c616629e4ad5190e3449cd378ff1beabb7019761fc53cce"
+
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg",
       verified: "devolutions.net/"
   name "Remote Desktop Manager Free"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


Also updates livecheck as old url seems outdated. New url is taked from rdm updaters latest version.
