### PR TITLE
autodesk-fusion360: fix install and uninstall

### DIFF
--- a/Casks/a/autodesk-fusion360.rb
+++ b/Casks/a/autodesk-fusion360.rb
@@ -10,9 +10,7 @@ cask "autodesk-fusion360" do
 
   installer script: {
     executable: "#{staged_path}/Install Autodesk Fusion 360.app/Contents/MacOS/Fusion 360 Client Downloader",
-    args:       [
-      "--quiet",
-    ],
+    args:       ["--quiet"],
   }
 
   uninstall quit:   [

--- a/Casks/a/autodesk-fusion360.rb
+++ b/Casks/a/autodesk-fusion360.rb
@@ -22,7 +22,9 @@ cask "autodesk-fusion360" do
                 "--process", "uninstall",
                 "--appid", "73e72ada57b7480280f7a6f4a289729f",
                 "--stream", "production",
-                "--quiet"
+                "--quiet",
+                "--silent",
+                "--purge-incomplete"
               ],
             },
             delete: [

--- a/Casks/a/autodesk-fusion360.rb
+++ b/Casks/a/autodesk-fusion360.rb
@@ -10,6 +10,9 @@ cask "autodesk-fusion360" do
 
   installer script: {
     executable: "#{staged_path}/Install Autodesk Fusion 360.app/Contents/MacOS/Fusion 360 Client Downloader",
+    args:       [
+      "--quiet",
+    ],
   }
 
   uninstall quit:   [
@@ -20,8 +23,6 @@ cask "autodesk-fusion360" do
               executable: "#{staged_path}/Install Autodesk Fusion 360.app/Contents/MacOS/streamer",
               args:       [
                 "--process", "uninstall",
-                "--appid", "73e72ada57b7480280f7a6f4a289729f",
-                "--stream", "production",
                 "--quiet",
                 "--silent",
                 "--purge-incomplete"

--- a/Casks/a/autodesk-fusion360.rb
+++ b/Casks/a/autodesk-fusion360.rb
@@ -30,6 +30,7 @@ cask "autodesk-fusion360" do
             },
             delete: [
               "~/Applications/Autodesk Fusion 360.app",
+              "~/Applications/Autodesk Fusion 360 Service Utility.app",
               "~/Applications/Remove Autodesk Fusion 360.app",
             ]
 


### PR DESCRIPTION
This PR fixes the install stanza by making it truly unattended with no GUI, and also fixes the uninstall to completely uninstall the app.