### PR TITLE
tunnelbear 5.1.1

### DIFF
--- a/Casks/t/tunnelbear.rb
+++ b/Casks/t/tunnelbear.rb
@@ -2,14 +2,18 @@ cask "tunnelbear" do
   on_catalina :or_older do
     version "4.1.8"
     sha256 "60c332511b91b794405249132ceb0c88e999b070c087b5f70f1cf09a84e5e5e9"
+
+    url "https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-#{version}.zip",
+        verified: "s3.amazonaws.com/tunnelbear/downloads/mac/"
   end
   on_big_sur :or_newer do
     version "5.1.1"
-    sha256 "80b7ddebacb08de0c29e4beffae70ba1c536056f6ec6d668e7845ddd8b3105e2"
+    sha256 :no_check
+
+    url "https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear.zip",
+        verified: "s3.amazonaws.com/tunnelbear/downloads/mac/"
   end
 
-  url "https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-#{version}.zip",
-      verified: "s3.amazonaws.com/tunnelbear/downloads/mac/"
   name "TunnelBear"
   desc "VPN client for secure internet access and private browsing"
   homepage "https://www.tunnelbear.com/"

--- a/Casks/t/tunnelbear.rb
+++ b/Casks/t/tunnelbear.rb
@@ -4,7 +4,7 @@ cask "tunnelbear" do
     sha256 "60c332511b91b794405249132ceb0c88e999b070c087b5f70f1cf09a84e5e5e9"
   end
   on_big_sur :or_newer do
-    version "5.1.0"
+    version "5.1.1"
     sha256 "80b7ddebacb08de0c29e4beffae70ba1c536056f6ec6d668e7845ddd8b3105e2"
   end
 
@@ -14,9 +14,13 @@ cask "tunnelbear" do
   desc "VPN client for secure internet access and private browsing"
   homepage "https://www.tunnelbear.com/"
 
+  # Older versions may have a more recent `pubDate` than newer versions, so we
+  # have to check all the items in the appcast.
   livecheck do
     url "https://tunnelbear.s3.amazonaws.com/downloads/mac/appcast.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle do |items|
+      items.map(&:short_version)
+    end
   end
 
   auto_updates true

--- a/Casks/t/tunnelbear.rb
+++ b/Casks/t/tunnelbear.rb
@@ -5,6 +5,8 @@ cask "tunnelbear" do
 
     url "https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear-#{version}.zip",
         verified: "s3.amazonaws.com/tunnelbear/downloads/mac/"
+
+    depends_on macos: ">= :sierra"
   end
   on_big_sur :or_newer do
     version "5.1.1"
@@ -12,6 +14,8 @@ cask "tunnelbear" do
 
     url "https://s3.amazonaws.com/tunnelbear/downloads/mac/TunnelBear.zip",
         verified: "s3.amazonaws.com/tunnelbear/downloads/mac/"
+
+    depends_on macos: ">= :big_sur"
   end
 
   name "TunnelBear"
@@ -28,7 +32,6 @@ cask "tunnelbear" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TunnelBear.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `tunnelbear` to the latest version, 5.1.1.

The existing `livecheck` block was returning the older version as newest because the 4.1.8 item has a newer `pubDate` than the 5.1.1 item. This adds a `strategy` block that returns the `shortVersion` for all items in the appcast, effectively ignoring the `pubDate`.