### PR TITLE
Update URLs to resolve unnecessary redirections

### DIFF
--- a/Casks/8/8x8-work.rb
+++ b/Casks/8/8x8-work.rb
@@ -8,7 +8,7 @@ cask "8x8-work" do
   homepage "https://www.8x8.com/products/apps"
 
   livecheck do
-    url "https://support.8x8.com/cloud-phone-service/voice/work-desktop/download-8x8-work-for-desktop#Download_for_Mac"
+    url "https://support.8x8.com/business-phone/voice/work-desktop/download-8x8-work-for-desktop"
     regex(/work[._-]dmg[._-]v(\d+(?:.\d+)*)\.dmg/i)
   end
 

--- a/Casks/a/adium.rb
+++ b/Casks/a/adium.rb
@@ -9,7 +9,7 @@ cask "adium" do
   homepage "https://www.adium.im/"
 
   livecheck do
-    url "https://www.adium.im/sparkle/appcast-release.xml"
+    url "https://sparkle.adium.im/appcast-release.xml"
     strategy :sparkle
   end
 

--- a/Casks/a/atext.rb
+++ b/Casks/a/atext.rb
@@ -8,7 +8,7 @@ cask "atext" do
   homepage "https://www.trankynam.com/atext/"
 
   livecheck do
-    url "https://www.trankynam.com/atext/changelog.mac.html"
+    url "https://www.trankynam.com/atext/changelog.mac"
     regex(/aText\s*v?(\d+(?:\.\d+)+)["< ]/i)
   end
 

--- a/Casks/a/avitools.rb
+++ b/Casks/a/avitools.rb
@@ -8,7 +8,7 @@ cask "avitools" do
   homepage "https://www.emmgunn.com/avitools-home/"
 
   livecheck do
-    url "https://www.emmgunn.com/avitools-home/avitools-downloads/"
+    url "https://emmgunn.com/avitools-home/avitools-downloads/"
     regex(%r{href=.*?/avitools(\d+(?:\.\d+)+)\.zip}i)
   end
 

--- a/Casks/b/bluos-controller.rb
+++ b/Casks/b/bluos-controller.rb
@@ -9,7 +9,7 @@ cask "bluos-controller" do
   homepage "https://www.bluesound.com/"
 
   livecheck do
-    url "https://www.bluesound.com/downloads"
+    url "https://www.bluesound.com/downloads/"
     regex(%r{uploads/(\d+)/(\d+)/BluOS[._-]Controller[._-]v?(\d+(?:\.\d+)+)[._-]MacOS\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }

--- a/Casks/b/boxy-suite.rb
+++ b/Casks/b/boxy-suite.rb
@@ -9,7 +9,7 @@ cask "boxy-suite" do
   homepage "https://www.boxysuite.com/"
 
   livecheck do
-    url "https://www.boxysuite.com/updates"
+    url "https://www.boxysuite.com/updates/"
     regex(/Version\s+(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/b/bricklink-partdesigner.rb
+++ b/Casks/b/bricklink-partdesigner.rb
@@ -6,7 +6,7 @@ cask "bricklink-partdesigner" do
       verified: "dzncyaxjqx7p3.cloudfront.net/PartDesigner/"
   name "PartDesigner"
   desc "Design your own LEGO parts"
-  homepage "https://bricklink.com/v3/studio/partdesigner.page"
+  homepage "https://www.bricklink.com/v3/studio/partdesigner.page"
 
   livecheck do
     url :homepage

--- a/Casks/c/cheatsheet.rb
+++ b/Casks/c/cheatsheet.rb
@@ -8,7 +8,7 @@ cask "cheatsheet" do
   homepage "https://www.mediaatelier.com/CheatSheet/"
 
   livecheck do
-    url "https://mediaatelier.com/CheatSheet/feed.php"
+    url "https://www.mediaatelier.com/CheatSheet/feed.php"
     strategy :sparkle
   end
 

--- a/Casks/c/coinomi-wallet.rb
+++ b/Casks/c/coinomi-wallet.rb
@@ -6,10 +6,10 @@ cask "coinomi-wallet" do
       user_agent: :fake
   name "Coinomi Wallet"
   desc "Securely store, manage and exchange many blockchain assets"
-  homepage "https://coinomi.com/"
+  homepage "https://www.coinomi.com/en/"
 
   livecheck do
-    url "https://coinomi.com/downloads"
+    url "https://www.coinomi.com/downloads/"
     regex(/href=.*?coinomi[._-]wallet[._-]v?(\d+(?:\.\d+)+)[._-]macos\.dmg/i)
   end
 

--- a/Casks/c/connectmenow.rb
+++ b/Casks/c/connectmenow.rb
@@ -8,7 +8,7 @@ cask "connectmenow" do
   homepage "https://www.tweaking4all.com/os-tips-and-tricks/macosx-tips-and-tricks/connectmenow-v#{version.major}/"
 
   livecheck do
-    url "https://www.tweaking4all.com/os-tips-and-tricks/macosx-tips-and-tricks/connectmenow-v#{version.major}"
+    url "https://www.tweaking4all.com/os-tips-and-tricks/macosx-tips-and-tricks/connectmenow-v#{version.major}/"
     regex(%r{href=.*?/ConnectMeNow[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]64bit\.dmg}i)
   end
 

--- a/Casks/c/couchbase-server-community.rb
+++ b/Casks/c/couchbase-server-community.rb
@@ -8,7 +8,7 @@ cask "couchbase-server-community" do
   homepage "https://www.couchbase.com/"
 
   livecheck do
-    url "https://www.couchbase.com/downloads"
+    url "https://www.couchbase.com/downloads/"
     regex(/couchbase[._-]server[._-]community[._-]v?(\d+(:?\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg/i)
   end
 

--- a/Casks/c/couchbase-server-enterprise.rb
+++ b/Casks/c/couchbase-server-enterprise.rb
@@ -18,7 +18,7 @@ cask "couchbase-server-enterprise" do
     url "https://packages.couchbase.com/releases/#{version}/couchbase-server-enterprise_#{version}-macos_x86_64.dmg"
 
     livecheck do
-      url "https://www.couchbase.com/downloads"
+      url "https://www.couchbase.com/downloads/"
       regex(/couchbase[._-]server[._-]enterprise[._-]v?(\d+(:?\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg/i)
     end
 

--- a/Casks/d/darwindumper.rb
+++ b/Casks/d/darwindumper.rb
@@ -8,7 +8,7 @@ cask "darwindumper" do
   homepage "https://bitbucket.org/blackosx/darwindumper"
 
   livecheck do
-    url "https://bitbucket.org/blackosx/darwindumper/wiki/DD_AppCast.xml"
+    url "https://bytebucket.org/blackosx/darwindumper/wiki/DD_AppCast.xml"
     strategy :sparkle do |item|
       item.short_version.delete_prefix("r").to_s
     end

--- a/Casks/d/dbvisualizer.rb
+++ b/Casks/d/dbvisualizer.rb
@@ -11,7 +11,7 @@ cask "dbvisualizer" do
   homepage "https://www.dbvis.com/"
 
   livecheck do
-    url "https://www.dbvis.com/download"
+    url "https://www.dbvis.com/download/"
     regex(/href=.*?dbvis[._-](\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/d/deepgit.rb
+++ b/Casks/d/deepgit.rb
@@ -11,7 +11,7 @@ cask "deepgit" do
   homepage "https://www.syntevo.com/deepgit/"
 
   livecheck do
-    url "https://syntevo.com/deepgit/download"
+    url "https://www.syntevo.com/deepgit/download/"
     regex(%r{href=.*?/deepgit-#{arch}-(\d+(?:_\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex)&.map { |match| match[0].tr("_", ".") }

--- a/Casks/d/devolo-cockpit.rb
+++ b/Casks/d/devolo-cockpit.rb
@@ -8,7 +8,7 @@ cask "devolo-cockpit" do
   homepage "https://www.devolo.global/devolo-cockpit"
 
   livecheck do
-    url "https://www.devolo.global/support/downloads/download/devolo-cockpit"
+    url "https://www.devolo.global/support/download/download/devolo-cockpit"
     strategy :page_match do |page|
       match = page[%r{href=.*?/devolo-cockpit-v?(\d+(?:-\d+)*).dmg}i, 1]
       match.tr("-", ".")

--- a/Casks/d/disk-expert.rb
+++ b/Casks/d/disk-expert.rb
@@ -8,7 +8,7 @@ cask "disk-expert" do
   homepage "https://nektony.com/disk-expert"
 
   livecheck do
-    url "https://nektony.com/pro-support/disk-expert/update/update.xml"
+    url "https://download.nektony.com/pro-support/disk-expert/update/update.xml"
     strategy :sparkle
   end
 

--- a/Casks/d/duplicate-file-finder.rb
+++ b/Casks/d/duplicate-file-finder.rb
@@ -8,7 +8,7 @@ cask "duplicate-file-finder" do
   homepage "https://nektony.com/duplicate-finder-free"
 
   livecheck do
-    url "https://nektony.com/pro-support/duplicates-finder-site/update/update.xml"
+    url "https://download.nektony.com/pro-support/duplicates-finder-site/update/update.xml"
     strategy :sparkle
   end
 

--- a/Casks/e/elasticwolf.rb
+++ b/Casks/e/elasticwolf.rb
@@ -6,7 +6,7 @@ cask "elasticwolf" do
       verified: "s3-us-gov-west-1.amazonaws.com/elasticwolf/"
   name "AWS ElasticWolf Client Console"
   desc "Manage Amazon Web Services (AWS) cloud resources"
-  homepage "https://aws.amazon.com/tools/aws-elasticwolf-client-console/"
+  homepage "https://aws.amazon.com/developer/tools/AWS-ElasticWolf-Client-Console/"
 
   livecheck do
     url :homepage

--- a/Casks/e/emailchemy.rb
+++ b/Casks/e/emailchemy.rb
@@ -9,7 +9,7 @@ cask "emailchemy" do
   homepage "https://weirdkid.com/emailchemy/"
 
   livecheck do
-    url "https://weirdkid.com/emailchemyversionhistory"
+    url "https://weirdkid.com/emailchemyversionhistory/"
     regex(/version\s*(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/f/flic.rb
+++ b/Casks/f/flic.rb
@@ -6,7 +6,7 @@ cask "flic" do
       verified: "misc-scl-cdn.s3.amazonaws.com/"
   name "Flic"
   desc "Driver for the Flic bluetooth button"
-  homepage "https://flic.io/mac-app"
+  homepage "https://flic.io/applications/mac-app"
 
   livecheck do
     url :homepage

--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -15,7 +15,7 @@ cask "gcc-aarch64-embedded" do
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
   livecheck do
-    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
+    url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
     regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-aarch64-none-elf.pkg/i)
   end
 

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -15,7 +15,7 @@ cask "gcc-arm-embedded" do
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
   livecheck do
-    url "https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/downloads"
+    url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
     regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-arm-none-eabi.pkg/i)
   end
 

--- a/Casks/g/geph.rb
+++ b/Casks/g/geph.rb
@@ -6,7 +6,7 @@ cask "geph" do
       verified: "sos-ch-dk-2.exo.io/utopia/geph-releases/"
   name "Geph"
   desc "Modular Internet censorship circumvention system"
-  homepage "https://geph.io/en/"
+  homepage "https://geph.io/en"
 
   livecheck do
     url :homepage

--- a/Casks/g/gutenprint.rb
+++ b/Casks/g/gutenprint.rb
@@ -2,13 +2,14 @@ cask "gutenprint" do
   version "5.3.3"
   sha256 "6dd810482845604a1e17fc3aef48a03d178798c14fe6f106a443f5af14022519"
 
-  url "https://downloads.sourceforge.net/gimp-print/gutenprint-#{version.major_minor}/#{version}/gutenprint-#{version}.dmg"
+  url "https://downloads.sourceforge.net/gimp-print/gutenprint-#{version.major_minor}/#{version}/gutenprint-#{version}.dmg",
+      verified: "downloads.sourceforge.net/gimp-print/"
   name "Gutenprint"
   desc "Drivers for various printers for use with CUPS and GIMP"
-  homepage "https://gimp-print.sourceforge.net/"
+  homepage "https://gimp-print.sourceforge.io/"
 
   livecheck do
-    url "https://gimp-print.sourceforge.net/MacOSX.php"
+    url "https://gimp-print.sourceforge.io/MacOSX.php"
     regex(/gutenprint[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :page_match
   end

--- a/Casks/h/hiarcs-chess-explorer.rb
+++ b/Casks/h/hiarcs-chess-explorer.rb
@@ -20,7 +20,7 @@ cask "hiarcs-chess-explorer" do
     sha256 "fb4569d32e04e4a0434892ad283ccfe97f00ce0525c2851e403f8a13e3cdaaf3"
 
     livecheck do
-      url "https://www.hiarcs.com/mac-chess-explorer-download.htm"
+      url "https://www.hiarcs.com/mac-chess-explorer-download.html"
       regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+[a-z]?)\.pkg}i)
     end
   end
@@ -28,7 +28,7 @@ cask "hiarcs-chess-explorer" do
   url "https://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
   name "(Deep) HIARCS Chess Explorer"
   desc "Chess database, analysis and game playing program"
-  homepage "https://www.hiarcs.com/mac-chess-explorer.htm"
+  homepage "https://www.hiarcs.com/mac-chess-explorer.html"
 
   pkg "HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
 

--- a/Casks/h/houdahspot.rb
+++ b/Casks/h/houdahspot.rb
@@ -8,7 +8,7 @@ cask "houdahspot" do
   homepage "https://www.houdah.com/houdahSpot/"
 
   livecheck do
-    url "https://www.houdah.com/houdahSpot/updates/cast#{version.major}.xml"
+    url "https://www.houdah.com/houdahSpot/updates/cast#{version.major}.php"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/h/hugin.rb
+++ b/Casks/h/hugin.rb
@@ -2,13 +2,14 @@ cask "hugin" do
   version "2019.2.0"
   sha256 "00caa732134c3b4dedd04f3605a4a1660e6baa49f54b6bb45eb25387dbe1e419"
 
-  url "https://downloads.sourceforge.net/hugin/Hugin-#{version}.dmg"
+  url "https://downloads.sourceforge.net/hugin/Hugin-#{version}.dmg",
+      verified: "downloads.sourceforge.net/hugin/"
   name "Hugin"
   desc "Panorama photo stitcher"
-  homepage "https://hugin.sourceforge.net/"
+  homepage "https://hugin.sourceforge.io/"
 
   livecheck do
-    url "https://hugin.sourceforge.net/download/"
+    url "https://hugin.sourceforge.io/download/"
     regex(/Hugin-(\d+(?:\.\d+)*)\.dmg/i)
     strategy :page_match
   end

--- a/Casks/i/iconscout.rb
+++ b/Casks/i/iconscout.rb
@@ -8,7 +8,7 @@ cask "iconscout" do
   homepage "https://iconscout.com/"
 
   livecheck do
-    url "https://iconscout.com/download"
+    url "https://iconscout.com/desktop-app/for-mac"
     regex(/Iconscout[._-]v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/j/jdk-mission-control.rb
+++ b/Casks/j/jdk-mission-control.rb
@@ -8,7 +8,7 @@ cask "jdk-mission-control" do
   url "https://download.java.net/java/GA/jmc#{version.major}/#{version.csv.second}/binaries/jmc-#{version.csv.first}_macos-#{arch}.tar.gz"
   name "JDK Mission Control"
   desc "Tools to manage, monitor, profile and troubleshoot Java applications"
-  homepage "https://jdk.java.net/jmc/8"
+  homepage "https://jdk.java.net/jmc/#{version.major}/"
 
   livecheck do
     url :homepage

--- a/Casks/j/jump.rb
+++ b/Casks/j/jump.rb
@@ -8,7 +8,7 @@ cask "jump" do
   homepage "https://jumpdesktop.com/#jdmac"
 
   livecheck do
-    url "https://jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml"
+    url "https://mirror.jumpdesktop.com/downloads/viewer/jdmac-web-appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/k/keka.rb
+++ b/Casks/k/keka.rb
@@ -9,7 +9,7 @@ cask "keka" do
   homepage "https://www.keka.io/"
 
   livecheck do
-    url "https://u.keka.io"
+    url "https://u.keka.io/keka.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/k/keyman.rb
+++ b/Casks/k/keyman.rb
@@ -8,7 +8,7 @@ cask "keyman" do
   homepage "https://keyman.com/"
 
   livecheck do
-    url "https://downloads.keyman.com/mac/stable"
+    url "https://downloads.keyman.com/mac/stable/"
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 

--- a/Casks/k/keyshot.rb
+++ b/Casks/k/keyshot.rb
@@ -8,7 +8,7 @@ cask "keyshot" do
   homepage "https://www.keyshot.com/"
 
   livecheck do
-    url "https://www.keyshot.com/dd/"
+    url "https://www.keyshot.com/direct-downloads/"
     regex(/href=.*?keyshot[._-]mac64[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 

--- a/Casks/k/kvirc.rb
+++ b/Casks/k/kvirc.rb
@@ -5,10 +5,10 @@ cask "kvirc" do
   url "ftp://ftp.kvirc.net/pub/kvirc/#{version}/binary/macosx/KVIrc-#{version}.dmg"
   name "KVIrc"
   desc "IRC Client"
-  homepage "http://kvirc.net/"
+  homepage "https://www.kvirc.net/"
 
   livecheck do
-    url "http://kvirc.net/?id=releases&platform=macosx"
+    url "https://www.kvirc.net/?id=releases&platform=macosx"
     regex(/href=.*?version=(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/l/lunacy.rb
+++ b/Casks/l/lunacy.rb
@@ -8,7 +8,7 @@ cask "lunacy" do
   homepage "https://icons8.com/lunacy"
 
   livecheck do
-    url "https://docs.icons8.com/release-notes/"
+    url "https://lunacy.docs.icons8.com/release-notes/"
     regex(/Lunacy[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/m/maccleaner-pro.rb
+++ b/Casks/m/maccleaner-pro.rb
@@ -8,7 +8,7 @@ cask "maccleaner-pro" do
   homepage "https://nektony.com/mac-cleaner-pro"
 
   livecheck do
-    url "https://nektony.com/pro-support/mac-cleaner-pro/update/update.xml"
+    url "https://download.nektony.com/pro-support/mac-cleaner-pro/update/update.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/m/master-pdf-editor.rb
+++ b/Casks/m/master-pdf-editor.rb
@@ -8,7 +8,7 @@ cask "master-pdf-editor" do
   homepage "https://code-industry.net/masterpdfeditor/"
 
   livecheck do
-    url "https://code-industry.net/get-masterpdfeditor"
+    url "https://code-industry.net/get-masterpdfeditor/"
     regex(%r{>Version\s(\d+(?:\.\d+)+).*?macOS.*?</h}i)
   end
 

--- a/Casks/m/mat.rb
+++ b/Casks/m/mat.rb
@@ -5,13 +5,14 @@ cask "mat" do
   sha256 arm:   "4fff45cd2518348eaed38522d5a58ad6e4cc4515c08cd89144944c83db52a7f6",
          intel: "236175bc2f306ec963b708b3b765c1684a018d30da4d38c52c9774b80133ddfb"
 
-  url "https://download.eclipse.org/mat/#{version.major_minor_patch}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.#{arch}.dmg"
+  url "https://download.eclipse.org/mat/#{version.major_minor_patch}/rcp/MemoryAnalyzer-#{version}-macosx.cocoa.#{arch}.dmg",
+      verified: "download.eclipse.org/mat/"
   name "Eclipse Memory Analyzer"
   desc "Java heap analyzer"
-  homepage "https://www.eclipse.org/mat/"
+  homepage "https://eclipse.dev/mat/"
 
   livecheck do
-    url "https://www.eclipse.org/mat/downloads.php"
+    url "https://eclipse.dev/mat/downloads.php"
     regex(/href=.*?MemoryAnalyzer-(\d+(?:\.\d+)*).*?\.dmg/i)
   end
 

--- a/Casks/m/mcreator.rb
+++ b/Casks/m/mcreator.rb
@@ -9,7 +9,7 @@ cask "mcreator" do
   homepage "https://mcreator.net/"
 
   livecheck do
-    url "https://mcreator.net/changelog/"
+    url "https://mcreator.net/changelog"
     regex(/>v?(\d+(?:\.\d+)+)</i)
   end
 

--- a/Casks/m/mds.rb
+++ b/Casks/m/mds.rb
@@ -6,10 +6,10 @@ cask "mds" do
       verified: "twocanoes-software-updates.s3.amazonaws.com/"
   name "MDS"
   desc "Deploy Intel and Apple Silicon Macs in Seconds"
-  homepage "https://twocanoes.com/products/mac/mac-deploy-stick/"
+  homepage "https://twocanoes.com/products/mac/mds/"
 
   livecheck do
-    url "https://twocanoes.com/products/mac/mac-deploy-stick/history/"
+    url "https://twocanoes.com/products/mac/mds/history/"
     regex(%r{/MDS_Build-(\d+)_Version-(\d+(?:[._-]\d+)*)\.dmg}i)
     strategy :page_match do |page, regex|
       match = page.match(regex)

--- a/Casks/m/millie.rb
+++ b/Casks/m/millie.rb
@@ -8,7 +8,7 @@ cask "millie" do
   homepage "https://www.millie.co.kr/"
 
   livecheck do
-    url "https://apis.millie.co.kr/v1/download/installer/mac/latest-mac.yml"
+    url "https://install.millie.co.kr/mac/latest-mac.yml"
     strategy :electron_builder
   end
 

--- a/Casks/m/minecraft-server.rb
+++ b/Casks/m/minecraft-server.rb
@@ -9,7 +9,7 @@ cask "minecraft-server" do
   homepage "https://www.minecraft.net/en-us/"
 
   livecheck do
-    url "https://www.minecraft.net/en-us/download/server/"
+    url "https://www.minecraft.net/en-us/download/server"
     strategy :page_match do |page|
       page.scan(%r{href=.*?/objects/(\h+)/server\.jar[^>]*>minecraft[_-]server[._-]v?(\d+(?:\.\d+)*)\.jar}i)
           .map { |match| "#{match[1]},#{match[0]}" }

--- a/Casks/m/mkvtools.rb
+++ b/Casks/m/mkvtools.rb
@@ -8,7 +8,7 @@ cask "mkvtools" do
   homepage "https://www.emmgunn.com/mkvtools-home/"
 
   livecheck do
-    url "https://www.emmgunn.com/mkvtools-home/mkvtools-downloads/"
+    url "https://emmgunn.com/mkvtools-home/mkvtools-downloads/"
     regex(%r{href=.*?/mkvtools(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/m/mp4tools.rb
+++ b/Casks/m/mp4tools.rb
@@ -8,7 +8,7 @@ cask "mp4tools" do
   homepage "https://www.emmgunn.com/mp4tools-home/"
 
   livecheck do
-    url "https://www.emmgunn.com/mp4tools-home/mp4tools-downloads/"
+    url "https://emmgunn.com/mp4tools-home/mp4tools-downloads/"
     regex(%r{href=.*?/mp4tools(\d+(?:\.\d+)*)\.zip}i)
   end
 

--- a/Casks/m/mplabx-ide.rb
+++ b/Casks/m/mplabx-ide.rb
@@ -5,7 +5,7 @@ cask "mplabx-ide" do
   url "https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/MPLABX-v#{version}-osx-installer.dmg"
   name "MPLab X IDE"
   desc "IDE for Microchip's microcontrollers and digital signal controllers"
-  homepage "https://www.microchip.com/en-us/development-tools-tools-and-software/mplab-x-ide"
+  homepage "https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide"
 
   livecheck do
     url :homepage

--- a/Casks/n/neo4j.rb
+++ b/Casks/n/neo4j.rb
@@ -10,7 +10,7 @@ cask "neo4j" do
   homepage "https://neo4j.com/download/"
 
   livecheck do
-    url "https://neo4j.com/download-center/#desktop"
+    url "https://neo4j.com/deployment-center/"
     regex(%r{href=.*?/neo4j-desktop/.*?flavour=osx.*?release=(\d+(?:\.\d+)+)}i)
   end
 

--- a/Casks/n/netxms-console.rb
+++ b/Casks/n/netxms-console.rb
@@ -11,7 +11,7 @@ cask "netxms-console" do
   homepage "https://netxms.org/"
 
   livecheck do
-    url "https://netxms.org/download"
+    url "https://netxms.com/downloads/"
     regex(/href=.*?nxmc[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/n/nitro-pdf-pro.rb
+++ b/Casks/n/nitro-pdf-pro.rb
@@ -2,14 +2,13 @@ cask "nitro-pdf-pro" do
   version "13.3.1"
   sha256 "f8838b72ae3821466d2f5a2cdd27c71305ecb3cf35dcfa13d52f6de954c24e69"
 
-  url "https://downloads.gonitro.com/macos/Nitro%20PDF%20Pro%20Retail_#{version}.dmg",
-      verified: "downloads.gonitro.com/macos/"
+  url "https://downloads.gonitro.com/macos/Nitro%20PDF%20Pro%20Retail_#{version}.dmg"
   name "Nitro PDF Pro"
   desc "PDF editing software"
-  homepage "https://pdfpen.com/"
+  homepage "https://www.gonitro.com/pdfpen"
 
   livecheck do
-    url "https://pdfpen.com/pdfpenpro/download_thanks/"
+    url "https://www.gonitro.com/pro/try/mac/download/thanks"
     regex(/href=.*?Retail[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/n/nodebox.rb
+++ b/Casks/n/nodebox.rb
@@ -9,7 +9,7 @@ cask "nodebox" do
   homepage "https://www.nodebox.net/node/"
 
   livecheck do
-    url "https://www.nodebox.net/download"
+    url "https://www.nodebox.net/download/"
     regex(/href=.*?NodeBox[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/n/nomachine-enterprise-client.rb
+++ b/Casks/n/nomachine-enterprise-client.rb
@@ -8,7 +8,7 @@ cask "nomachine-enterprise-client" do
   homepage "https://www.nomachine.com/"
 
   livecheck do
-    url "https://nomachine.com/support&destination=downloads&callback=L2Rvd25sb2FkLz9pZD0xNi"
+    url "https://www.nomachine.com/support&destination=downloads&callback=L2Rvd25sb2FkLz9pZD0xNi"
     regex(/nomachine-enterprise-client[._-]v?(\d+(?:\.\d+)*_\d+)\.dmg/i)
   end
 

--- a/Casks/n/nomachine.rb
+++ b/Casks/n/nomachine.rb
@@ -8,7 +8,7 @@ cask "nomachine" do
   homepage "https://www.nomachine.com/"
 
   livecheck do
-    url "https://nomachine.com/support&destination=downloads&callback=L2Rvd25sb2FkLz9pZD03"
+    url "https://www.nomachine.com/support&destination=downloads&callback=L2Rvd25sb2FkLz9pZD03"
     regex(/nomachine[._-]v?(\d+(?:\.\d+)+_\d+)\.dmg/i)
   end
 

--- a/Casks/o/onecast.rb
+++ b/Casks/o/onecast.rb
@@ -5,10 +5,10 @@ cask "onecast" do
   url "https://onecast.me/downloads/OneCast.dmg"
   name "OneCast"
   desc "Xbox remote play"
-  homepage "https://onecast.me/"
+  homepage "https://www.onecast.me/"
 
   livecheck do
-    url "https://onecast.me/download/"
+    url "https://www.onecast.me/download/"
     regex(/>v(\d+(?:\.\d+)+)</i)
   end
 

--- a/Casks/o/openttd.rb
+++ b/Casks/o/openttd.rb
@@ -12,7 +12,7 @@ cask "openttd" do
     sha256 "085cdb35867dca1dcfb8a1748417e7ba6431551ebc33df290a4e48b244d8d376"
 
     livecheck do
-      url "https://www.openttd.org/downloads/openttd-releases/latest.html"
+      url "https://www.openttd.org/downloads/openttd-releases/latest"
       regex(%r{href=.*?/openttd-(\d+(?:\.\d+)*)-macos-universal\.zip}i)
     end
   end

--- a/Casks/p/papyrus.rb
+++ b/Casks/p/papyrus.rb
@@ -8,7 +8,7 @@ cask "papyrus" do
   homepage "https://eclipse.org/papyrus/"
 
   livecheck do
-    url "https://www.eclipse.org/papyrus/download.html"
+    url "https://eclipse.dev/papyrus/download.html"
     regex(%r{href=.*?/papyrus-(\d+(?:-\d+)*)-(\d+(?:\.\d+)*)-macosx64\.tar\.gz}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }

--- a/Casks/p/pdfkey-pro.rb
+++ b/Casks/p/pdfkey-pro.rb
@@ -4,7 +4,8 @@ cask "pdfkey-pro" do
 
   url "https://pdfkey.com/PDFKeyPro.dmg"
   name "PDFKey Pro"
-  homepage "https://pdfkey.com/"
+  desc "Utility to unlock password-protected PDFs"
+  homepage "https://pdfkey.com/en/"
 
   livecheck do
     url :homepage

--- a/Casks/p/perimeter81.rb
+++ b/Casks/p/perimeter81.rb
@@ -9,7 +9,7 @@ cask "perimeter81" do
   homepage "https://perimeter81.com/"
 
   livecheck do
-    url "https://support.perimeter81.com/v1/docs/en/downloading-the-agent/"
+    url "https://support.perimeter81.com/v1/docs/en/downloading-the-agent"
     regex(/href=.*?Perimeter81[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 

--- a/Casks/p/picfindr.rb
+++ b/Casks/p/picfindr.rb
@@ -8,7 +8,7 @@ cask "picfindr" do
   homepage "https://softorino.com/picfindr/"
 
   livecheck do
-    url "https://api.softorino.com/live/app-manager/v3/pfm/mac/updates"
+    url "https://ushining.softorino.com/appcast.php?abbr=pfm"
     strategy :sparkle
   end
 

--- a/Casks/p/pingplotter.rb
+++ b/Casks/p/pingplotter.rb
@@ -8,7 +8,7 @@ cask "pingplotter" do
   homepage "https://www.pingplotter.com/"
 
   livecheck do
-    url "https://www.pingplotter.com/download/release-notes"
+    url "https://www.pingplotter.com/download/release-notes/"
     regex(/(\d+(?:\.\d+)+).*?h2/i)
   end
 

--- a/Casks/p/pocket-casts.rb
+++ b/Casks/p/pocket-casts.rb
@@ -8,7 +8,7 @@ cask "pocket-casts" do
   homepage "https://play.pocketcasts.com/"
 
   livecheck do
-    url "https://static2.pocketcasts.com/mac/appcast.xml"
+    url "https://static.pocketcasts.com/mac/appcast.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/q/qgis.rb
+++ b/Casks/q/qgis.rb
@@ -8,7 +8,7 @@ cask "qgis" do
   homepage "https://www.qgis.org/"
 
   livecheck do
-    url "https://qgis.org/downloads/macos/qgis-macos-pr.sha256sum"
+    url "https://download.qgis.org/downloads/macos/qgis-macos-pr.sha256sum"
     strategy :page_match do |page|
       match = page.match(/qgis_pr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
       next if match.blank?

--- a/Casks/r/r.rb
+++ b/Casks/r/r.rb
@@ -62,7 +62,7 @@ cask "r" do
     url "https://cloud.r-project.org/bin/macosx/big-sur-#{arch}/base/R-#{version}-#{arch}.pkg"
 
     livecheck do
-      url "https://cloud.r-project.org/bin/macosx"
+      url "https://cloud.r-project.org/bin/macosx/"
       regex(/href=.*?R[._-]v?(\d+(?:\.\d+)*)([._-]#{arch})?\.pkg/i)
     end
 

--- a/Casks/r/realforce.rb
+++ b/Casks/r/realforce.rb
@@ -8,7 +8,7 @@ cask "realforce" do
   homepage "https://www.realforce.co.jp/"
 
   livecheck do
-    url "https://www.realforce.co.jp/support/download/software"
+    url "https://www.realforce.co.jp/support/download/software/"
     regex(%r{href=.*?/REALFORCE\s*?CONNECT\s*?Software[._-](\d+(?:-\d+)+)\.pkg})
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match[0].tr("-", ".").to_s }

--- a/Casks/r/retro-virtual-machine.rb
+++ b/Casks/r/retro-virtual-machine.rb
@@ -6,10 +6,10 @@ cask "retro-virtual-machine" do
       verified: "static.retrovm.org/release/"
   name "Retro Virtual Machine"
   desc "ZX Spectrum and Amstrad CPC emulator"
-  homepage "https://www.retrovirtualmachine.org/en/"
+  homepage "https://www.retrovirtualmachine.org/"
 
   livecheck do
-    url "https://www.retrovirtualmachine.org/download"
+    url "https://www.retrovirtualmachine.org/download/"
     regex(/RetroVirtualMachine[._-](\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/r/rstudio.rb
+++ b/Casks/r/rstudio.rb
@@ -6,10 +6,10 @@ cask "rstudio" do
       verified: "download1.rstudio.org/electron/macos/"
   name "RStudio"
   desc "Data science software focusing on R and Python"
-  homepage "https://www.rstudio.com/"
+  homepage "https://posit.co/products/open-source/rstudio/"
 
   livecheck do
-    url "https://www.rstudio.com/products/rstudio/download/"
+    url "https://posit.co/download/rstudio-desktop/"
     strategy :page_match do |page|
       match = page.match(/RStudio-(\d+(?:\.\d+)+)-(\d+)\.dmg/i)
       next if match.blank?

--- a/Casks/s/samsung-portable-ssd-t7.rb
+++ b/Casks/s/samsung-portable-ssd-t7.rb
@@ -5,7 +5,7 @@ cask "samsung-portable-ssd-t7" do
   url "https://semiconductor.samsung.com/resources/software-resources/SamsungPortableSSD_Setup_Mac_#{version.csv.second}.zip"
   name "Samsung Portable SSD Software for T7"
   desc "Software for Samsung external storage drives (T7 series)"
-  homepage "https://www.samsung.com/semiconductor/minisite/ssd/download/portable/"
+  homepage "https://semiconductor.samsung.com/consumer-storage/support/tools/"
 
   livecheck do
     url :homepage

--- a/Casks/s/singularity.rb
+++ b/Casks/s/singularity.rb
@@ -9,7 +9,7 @@ cask "singularity" do
   homepage "https://www.singularityviewer.org/"
 
   livecheck do
-    url "https://www.singularityviewer.org/downloads"
+    url "https://www.singularityviewer.org/downloads/"
     strategy :page_match do |page|
       v = page[/Singularity[._-]?Alpha[._-]?(\d+(?:_\d+)*)[._-]?x86_64\.dmg/i, 1]
       v.tr("_", ".")

--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -9,7 +9,7 @@ cask "slack-cli" do
   homepage "https://api.slack.com/future/tools/cli"
 
   livecheck do
-    url "https://api.slack.com/future/changelog"
+    url "https://api.slack.com/automation/changelog"
     regex(%r{h2.*?v?(\d+(?:\.\d+)+).*?/h2}i)
   end
 

--- a/Casks/s/softorino-youtube-converter.rb
+++ b/Casks/s/softorino-youtube-converter.rb
@@ -8,7 +8,7 @@ cask "softorino-youtube-converter" do
   homepage "https://softorino.com/youtube-converter/"
 
   livecheck do
-    url "https://api.softorino.com/live/app-manager/v3/syc2/mac/updates"
+    url "https://ushining.softorino.com/appcast.php?abbr=syc2m"
     strategy :sparkle
   end
 

--- a/Casks/s/sourcenote.rb
+++ b/Casks/s/sourcenote.rb
@@ -4,10 +4,11 @@ cask "sourcenote" do
 
   url "https://www.sourcenoteapp.com/releases/SourceNote_#{version}.dmg"
   name "SourceNote"
+  desc "Text snippet app"
   homepage "https://www.sourcenoteapp.com/"
 
   livecheck do
-    url "https://sourcenoteapp.com/releases/appcast.xml"
+    url "https://www.sourcenoteapp.com/releases/appcast.xml"
     strategy :sparkle
   end
 

--- a/Casks/s/springtoolsuite.rb
+++ b/Casks/s/springtoolsuite.rb
@@ -9,7 +9,7 @@ cask "springtoolsuite" do
       verified: "download.springsource.com/release/"
   name "Spring Tool Suite"
   desc "Next generation tooling for Spring Boot"
-  homepage "https://spring.io/tools"
+  homepage "https://spring.io/tools/"
 
   livecheck do
     url :homepage

--- a/Casks/s/sqlcl.rb
+++ b/Casks/s/sqlcl.rb
@@ -8,7 +8,7 @@ cask "sqlcl" do
   homepage "https://www.oracle.com/sqlcl"
 
   livecheck do
-    url "https://www.oracle.com/tools/downloads/sqlcl-downloads.html"
+    url "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/"
     regex(/p>Version.*?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/s/staruml.rb
+++ b/Casks/s/staruml.rb
@@ -11,7 +11,7 @@ cask "staruml" do
   homepage "https://staruml.io/"
 
   livecheck do
-    url "https://staruml.io/download"
+    url "https://staruml.io/download/"
     regex(%r{href=.*?/StarUML[._-]v?(\d+(?:\.\d+)*)#{arch}\.dmg}i)
   end
 

--- a/Casks/s/supernotes.rb
+++ b/Casks/s/supernotes.rb
@@ -8,7 +8,7 @@ cask "supernotes" do
   homepage "https://supernotes.app/"
 
   livecheck do
-    url "https://api.supernotes.app/v1/"
+    url "https://api.supernotes.app/v1"
     strategy :json do |json|
       json["version"]
     end

--- a/Casks/t/textexpander.rb
+++ b/Casks/t/textexpander.rb
@@ -9,7 +9,7 @@ cask "textexpander" do
   homepage "https://smilesoftware.com/TextExpander"
 
   livecheck do
-    url "https://textexpander.com/appcast/TextExpander-macOS.xml"
+    url "https://cgi.textexpander.com/appcast/TextExpander-macOS.xml"
     strategy :sparkle
   end
 

--- a/Casks/t/the-battle-for-wesnoth.rb
+++ b/Casks/t/the-battle-for-wesnoth.rb
@@ -6,7 +6,7 @@ cask "the-battle-for-wesnoth" do
       verified: "sourceforge.net/wesnoth/"
   name "The Battle for Wesnoth"
   desc "Fantasy-themed turn-based strategy game"
-  homepage "https://wesnoth.org/"
+  homepage "https://www.wesnoth.org/"
 
   livecheck do
     url :homepage

--- a/Casks/t/thinlinc-client.rb
+++ b/Casks/t/thinlinc-client.rb
@@ -5,10 +5,10 @@ cask "thinlinc-client" do
   url "https://www.cendio.com/downloads/clients/tl-#{version}-client-macos.iso"
   name "ThinLinc"
   desc "Linux remote desktop server"
-  homepage "https://www.cendio.com/thinlinc"
+  homepage "https://www.cendio.com/thinlinc/what-is-thinlinc/"
 
   livecheck do
-    url "https://www.cendio.com/thinlinc/download"
+    url "https://www.cendio.com/thinlinc/download/"
     regex(/tl[._-]v?(\d+(?:[._]\d+)+)[._-]client[._-]macos\.iso/i)
   end
 

--- a/Casks/t/toshiba-color-mfp.rb
+++ b/Casks/t/toshiba-color-mfp.rb
@@ -8,7 +8,7 @@ cask "toshiba-color-mfp" do
   homepage "https://business.toshiba.com/support"
 
   livecheck do
-    url "http://business.toshiba.com/support/downloads/GetDownloads.jsp?model=e-STUDIO3515AC"
+    url "https://business.toshiba.com/support/downloads/GetDownloads.jsp?model=e-STUDIO3515AC"
     strategy :page_match do |page|
       match = page.match(/"MacDC",.*?"id":"(\d+)",.*?"versionName":"(\d+(?:\.\d+)+)",/)
       next if match.blank?

--- a/Casks/t/transmit.rb
+++ b/Casks/t/transmit.rb
@@ -8,7 +8,7 @@ cask "transmit" do
   homepage "https://panic.com/transmit/"
 
   livecheck do
-    url "https://library.panic.com/transmit/transmit5/release-integrity/"
+    url "https://help.panic.com/transmit/transmit#{version.major}/release-integrity/"
     regex(/href=.*?Transmit[\s._-]?v?(\d+(?:\.\d+)+)\.zip/i)
   end
 

--- a/Casks/t/tuxera-ntfs.rb
+++ b/Casks/t/tuxera-ntfs.rb
@@ -8,7 +8,7 @@ cask "tuxera-ntfs" do
   homepage "https://ntfsformac.tuxera.com/"
 
   livecheck do
-    url "https://ntfsformac.tuxera.com/support"
+    url "https://ntfsformac.tuxera.com/support/"
     regex(/Release\s*?v?(\d+(?:\.\d+)*)/i)
   end
 

--- a/Casks/v/vsdx-annotator.rb
+++ b/Casks/v/vsdx-annotator.rb
@@ -8,7 +8,7 @@ cask "vsdx-annotator" do
   homepage "https://nektony.com/products/vsdx-annotator-mac"
 
   livecheck do
-    url "https://nektony.com/promo/vsdx-annotator/update/update.xml"
+    url "https://download.nektony.com/promo/vsdx-annotator/update/update.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/w/waltr.rb
+++ b/Casks/w/waltr.rb
@@ -8,7 +8,7 @@ cask "waltr" do
   homepage "https://softorino.com/w#{version.major}/"
 
   livecheck do
-    url "https://api.softorino.com/v1/app-manager/waltr#{version.major}/mac/updates"
+    url "https://shining.softorino.com/appcast.php?abbr=w#{version.major}m"
     strategy :sparkle
   end
 

--- a/Casks/w/witch.rb
+++ b/Casks/w/witch.rb
@@ -8,7 +8,7 @@ cask "witch" do
   homepage "https://manytricks.com/witch/"
 
   livecheck do
-    url "https://manytricks.com/witch/appcast.xml"
+    url "https://manytricks.com/witch/appcast/"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/x/xamarin-profiler.rb
+++ b/Casks/x/xamarin-profiler.rb
@@ -6,7 +6,7 @@ cask "xamarin-profiler" do
       verified: "dl.xamarin.com/profiler/"
   name "Xamarin Profiler"
   desc "Mono log profiler graphical interface"
-  homepage "https://docs.microsoft.com/en-us/xamarin/tools/profiler/?tabs=macos"
+  homepage "https://learn.microsoft.com/en-us/xamarin/tools/profiler/?tabs=macos"
 
   livecheck do
     url :homepage

--- a/Casks/x/xonotic.rb
+++ b/Casks/x/xonotic.rb
@@ -5,10 +5,10 @@ cask "xonotic" do
   url "https://dl.xonotic.org/xonotic-#{version}.zip"
   name "Xonotic"
   desc "Arena-style first person shooter"
-  homepage "https://www.xonotic.org/"
+  homepage "https://xonotic.org/"
 
   livecheck do
-    url "https://www.xonotic.org/download/"
+    url "https://xonotic.org/download/"
     regex(%r{href=.*?/xonotic[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 

--- a/Casks/x/xrg.rb
+++ b/Casks/x/xrg.rb
@@ -2,10 +2,11 @@ cask "xrg" do
   version "3.2.1"
   sha256 "26892490b0b67c2baf6286e6360a7a88236fe16e4d94708ba8722037431a1de4"
 
-  url "https://download.gauchosoft.com/xrg/XRG-release-#{version}.zip"
+  url "https://download.gauchosoft.com/xrg/XRG-release-#{version}.zip",
+      verified: "download.gauchosoft.com/xrg/"
   name "XRG"
   desc "System monitor"
-  homepage "https://gauchosoft.com/Products/XRG/"
+  homepage "https://gaucho.software/Products/XRG/"
 
   livecheck do
     url :homepage

--- a/Casks/y/youtype.rb
+++ b/Casks/y/youtype.rb
@@ -8,7 +8,7 @@ cask "youtype" do
   homepage "https://github.com/freefelt/YouType"
 
   livecheck do
-    url "https://github.com/freefelt/YouType/raw/main/appcast.xml"
+    url "https://raw.githubusercontent.com/freefelt/YouType/main/appcast.xml"
     strategy :sparkle
   end
 

--- a/Casks/z/zed.rb
+++ b/Casks/z/zed.rb
@@ -8,7 +8,7 @@ cask "zed" do
   homepage "https://zed.dev/"
 
   livecheck do
-    url "https://zed.dev/releases"
+    url "https://zed.dev/releases/stable"
     regex(%r{href=.*?/stable/(\d+(?:\.\d+)+)/Zed.dmg}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates various casks' `homepage` and/or `livecheck` block URLs to avoid unnecessary redirections. This is focused on resolving `livecheck` block redirections and the `homepage` changes are secondary in some cases.

These are redirections where it makes sense to update the URL (i.e., relatively minor changes to the domain or path) but I've left the redirections that go from a first-party URL to a third-party provider (e.g., AWS, Dropbox, etc.). The latter redirections are useful because they involve a fixed URL that we can reliably check, even if upstream switches between third-party file hosts.

Past that, I've added descriptions for `pdfkey-pro` and `sourcenote`, to address the related audit.

-----

There are around 14 others that involve changes to the cask `url` and I will be handling those in a follow-up PR (#159370). This allows us to reduce the CI burden by running this PR as syntax-only and we can do full CI runs for the others separately.

I've tested these URLs and `livecheck` blocks locally and the only check that doesn't work as expected is `bricklink-partdesigner`, as the website is temporarily undergoing maintenance (i.e., it should work once the expected page is available again).

It's also worth noting that the `nomachine` and `nomachine-enterprise-client` `livecheck` block URLs still redirect. If you try to update them to the final URL (https://downloads.nomachine.com/download/?id=7 and https://downloads.nomachine.com/download/?id=16 respectively), they will redirect back to the current URLs and end up in a redirection loop. Unfortunately, we can't avoid the redirections in those instances.