### PR TITLE
xscreensaver: add uninstall_postflight and zap

### DIFF
--- a/Casks/x/xscreensaver.rb
+++ b/Casks/x/xscreensaver.rb
@@ -14,9 +14,30 @@ cask "xscreensaver" do
 
   pkg "Install Everything.pkg"
 
+  # There is no uninstall script for this Cask, so a manual uninstall is performed
+  # Loop through all screensaver plist files, looking for "org,jwz" in the bundle identifier
+  # Then remove the screensaver if the bundle identifier matches
+  uninstall_postflight do
+    Pathname.glob("/Library/Screen Savers/*.saver/Contents/Info.plist").each do |plist|
+      bundle_id = `/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "#{plist}"`
+      next unless bundle_id.start_with?("org.jwz")
+
+      screensaver_name = `/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "#{plist}"`.delete(" ").strip
+      screensaver = Pathname.new("/Library/Screen Savers/#{screensaver_name}.saver")
+      Utils.gain_permissions_remove(screensaver) if screensaver.directory?
+    end
+  end
+
   uninstall pkgutil: "org.jwz.xscreensaver",
             delete:  [
               "/Applications/Apple2.app",
               "/Applications/Phosphor.app",
+              "/Library/Screen Savers/XScreenSaverUpdater.app",
             ]
+
+  zap trash: [
+    "~/Library/HTTPStorages/org.jwz.xscreensaver.XScreenSaverUpdater",
+    "~/Library/Preferences/org.jwz.xscreensaver.*.plist",
+    "~/Library/Saved Application State/org.jwz.xscreensaver.*.savedState",
+  ]
 end


### PR DESCRIPTION
Background: 

The `pkg` that installs `xscreensaver` does not contain an uninstall script nor does it appear to keep receipts of the installed artifacts.  As a consequence, running a `brew uninstall` does not remove the actual screensaver artifacts stored in `/Library/Screen Savers` as of this commit.

This commit introduces a brief `uninstall_postflight` to look through all screensavers in `/Library/Screen Savers` and identify the bundle identifier associated with the screensavers in this package (`org.jwz`), gather the `CFBundleExecutable` name, and remove any whitespace so it can be used as the identified artifact for removal.  

As of this commit there are 252 screensavers, so while it's not particularly effective to add each one to `zap trash`, it can be done and would require ongoing maintenance with each release.

Certainly welcome to changes or a better way to do this.  Thanks!

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
