### PR TITLE
various: add no zap required

### DIFF
--- a/Casks/i/ilya-birman-typography-layout.rb
+++ b/Casks/i/ilya-birman-typography-layout.rb
@@ -15,6 +15,8 @@ cask "ilya-birman-typography-layout" do
   keyboard_layout \
     "Install Ilya Birman Typography Layout.app/Contents/Resources/Layout/Ilya Birman Typography Layout.bundle"
 
+  # No zap stanza required
+
   caveats do
     reboot
   end

--- a/Casks/p/programmer-dvorak.rb
+++ b/Casks/p/programmer-dvorak.rb
@@ -19,6 +19,8 @@ cask "programmer-dvorak" do
 
   keyboard_layout "Library/Keyboard Layouts/Programmer Dvorak.bundle"
 
+  # No zap stanza required
+
   caveats do
     reboot
   end

--- a/Casks/q/qwerty-fr.rb
+++ b/Casks/q/qwerty-fr.rb
@@ -16,6 +16,8 @@ cask "qwerty-fr" do
 
   keyboard_layout "qwerty-fr.bundle"
 
+  # No zap stanza required
+
   caveats do
     reboot
   end

--- a/Casks/u/ukrainian-typographic-keyboard.rb
+++ b/Casks/u/ukrainian-typographic-keyboard.rb
@@ -10,6 +10,8 @@ cask "ukrainian-typographic-keyboard" do
 
   keyboard_layout "ukrainian-typographic-keyboard-#{version}/ukrainian-typographic-keyboard.bundle"
 
+  # No zap stanza required
+
   caveats do
     reboot
   end

--- a/Casks/u/ukrainian-unicode-layout.rb
+++ b/Casks/u/ukrainian-unicode-layout.rb
@@ -9,6 +9,8 @@ cask "ukrainian-unicode-layout" do
 
   keyboard_layout "macOS-Ukrainian-Unicode-Layout-#{version}"
 
+  # No zap stanza required
+
   caveats do
     reboot
   end

--- a/Casks/w/workman.rb
+++ b/Casks/w/workman.rb
@@ -15,6 +15,8 @@ cask "workman" do
 
   keyboard_layout "Workman-master/mac/Workman.bundle"
 
+  # No zap stanza required
+
   caveats do
     reboot
   end


### PR DESCRIPTION
There are a handful of keyboard layouts that do not require any zap stanza, as the uninstall process removes all installed files.  

This just adds a `# No zap stanza required` comment to them.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.