### PR TITLE
fix the wrong eudic version

### DIFF
--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -1,6 +1,6 @@
 cask "eudic" do
   version "4.5.3,1117"
-  sha256 "1234" # Fix after CI run
+  sha256 "9d50c6df0e1c98de06f8579aba6fefcaa037b51cf1f9fe0b66d2398970a7ca6b"
 
   url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.csv.second}",
       verified:   "static.frdic.com/",

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -1,8 +1,8 @@
 cask "eudic" do
   version "4.5.3,1117"
-  sha256 :no_check
+  sha256 "1234" # Fix after CI run
 
-  url "https://static.frdic.com/pkg/eudicmac.dmg?v=1117",
+  url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.csv.second}",
       verified:   "static.frdic.com/",
       user_agent: :fake
   name "Eudic"
@@ -11,8 +11,8 @@ cask "eudic" do
   homepage "https://www.eudic.net/v4/en/app/eudic"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://www.eudic.net/update/eudic_mac.xml"
+    strategy :sparkle
   end
 
   app "Eudic.app"

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -14,7 +14,7 @@ cask "eudic" do
     url "https://www.eudic.net/update/eudic_mac.xml"
     strategy :sparkle
   end
-  
+
   depends_on macos: ">= :high_sierra"
 
   app "Eudic.app"

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -2,7 +2,7 @@ cask "eudic" do
   version "4.5.3,1117"
   sha256 :no_check
 
-  url "https://static.frdic.com/pkg/eudicmac.dmg",
+  url "https://static.frdic.com/pkg/eudicmac.dmg?v=1117",
       verified:   "static.frdic.com/",
       user_agent: :fake
   name "Eudic"

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -14,6 +14,8 @@ cask "eudic" do
     url "https://www.eudic.net/update/eudic_mac.xml"
     strategy :sparkle
   end
+  
+  depends_on macos: ">= :high_sierra"
 
   app "Eudic.app"
 


### PR DESCRIPTION
The current url will download 4.4.9 (1109), I find the right url should add v=1117. 

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.