### PR TITLE
mitmproxy: update livecheck

### DIFF
--- a/Casks/m/mitmproxy.rb
+++ b/Casks/m/mitmproxy.rb
@@ -7,10 +7,15 @@ cask "mitmproxy" do
   desc "Intercept, modify, replay, save HTTP/S traffic"
   homepage "https://mitmproxy.org/"
 
+  # The downloads page (https://mitmproxy.org/downloads/) uses an XML file to
+  # dynamically generate the list of version directories on load.
   livecheck do
-    url "https://github.com/mitmproxy/mitmproxy"
-    strategy :git
-    regex(/^(\d+(?:\.\d+)+)$/i)
+    url "https://downloads.mitmproxy.org/list"
+    strategy :xml do |xml|
+      xml.get_elements("//ListBucketResult//CommonPrefixes//Prefix").map do |item|
+        item.text&.strip&.delete_suffix("/")
+      end
+    end
   end
 
   binary "mitmproxy.app/Contents/MacOS/mitmproxy"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `mitmproxy` checks the Git repository but the tarball used in the cask comes from the first-party website. This PR updates the `livecheck` block to check the XML file that's used to populate the list of versions on the [downloads page](https://mitmproxy.org/downloads/), so the check aligns with the cask URL source.

As a side effect, this resolves issues with the existing `livecheck` block:

* `strategy :git` was redundant, as livecheck already used the `Git` strategy for the GitHub URL
* The `#strategy` call should come after the `#regex` call (i.e., we sometimes pass the `regex` into a `strategy` block, so this arrangement makes it easy to add a `strategy` block in the future)