### PR TITLE
Remove redundant livecheck strategy calls

### DIFF
--- a/Casks/c/codux.rb
+++ b/Casks/c/codux.rb
@@ -14,7 +14,6 @@ cask "codux" do
   livecheck do
     url "https://www.codux.com/download"
     regex(/href=.*?Codux[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
-    strategy :page_match
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/g/gutenprint.rb
+++ b/Casks/g/gutenprint.rb
@@ -11,7 +11,6 @@ cask "gutenprint" do
   livecheck do
     url "https://gimp-print.sourceforge.io/MacOSX.php"
     regex(/gutenprint[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
-    strategy :page_match
   end
 
   pkg "gutenprint-#{version}.pkg"

--- a/Casks/h/hugin.rb
+++ b/Casks/h/hugin.rb
@@ -11,7 +11,6 @@ cask "hugin" do
   livecheck do
     url "https://hugin.sourceforge.io/download/"
     regex(/Hugin-(\d+(?:\.\d+)*)\.dmg/i)
-    strategy :page_match
   end
 
   suite "Hugin"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` blocks for `codux`, `gutenprint`, and `hugin` use redundant `strategy :page_match` calls, as livecheck already uses the `PageMatch` strategy for these by default. This PR removes the redundant `strategy` calls accordingly.

For what it's worth, there are other `livecheck` blocks with redundant elements but they involve less-straightforward changes, so I'll be handling them separately.