### PR TITLE
alex313031-thorium: update livecheck

### DIFF
--- a/Casks/a/alex313031-thorium.rb
+++ b/Casks/a/alex313031-thorium.rb
@@ -12,8 +12,9 @@ cask "alex313031-thorium" do
   homepage "https://thorium.rocks/"
 
   livecheck do
-    strategy :git
-    regex(/^(M\d+(?:\.\d+)+)/i)
+    url :url
+    regex(/^(M?\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   conflicts_with cask: "thorium"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `alex313031-thorium`:

* Doesn't contain a `url` call (this should be present for all strategies except `ExtractPlist`)
* Contains a redundant `#strategy` call (i.e., livecheck already uses the `Git` strategy for the cask `url`)
* Should have the `#regex` call before the `#strategy` call
* Should use the `GithubLatest` strategy, as the cask `url` is a release asset

This PR modifies the `livecheck` block to resolve these issues.