### PR TITLE
electrumsv 1.3.16

### DIFF
--- a/Casks/e/electrumsv.rb
+++ b/Casks/e/electrumsv.rb
@@ -1,6 +1,6 @@
 cask "electrumsv" do
-  version "1.4.0b1"
-  sha256 "816bf0cdcbd26edeb7854c636401874352798a9a6f5f631d72f547f474ddb0dc"
+  version "1.3.16"
+  sha256 "d1910e583813bfc8cbe5d815d0df1059a1d144df6d96fc6bc6c0ae3dccc4bc7e"
 
   url "https://s3.us-east-2.amazonaws.com/electrumsv-downloads/releases/#{version}/ElectrumSV-#{version}.dmg",
       verified: "s3.us-east-2.amazonaws.com/electrumsv-downloads/"
@@ -9,8 +9,8 @@ cask "electrumsv" do
   homepage "https://electrumsv.io/"
 
   livecheck do
-    url "https://github.com/electrumsv/electrumsv"
-    strategy :git
+    url "https://electrumsv.io/download.html"
+    regex(/href=.*?ElectrumSV[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "ElectrumSV.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `electrumsv` cask was updated to 1.4.0b1 in #109953 but this doesn't appear to be a stable version. The latest stable version is currently 1.3.16, released on 2023-05-23. This PR updates `electrumsv` to the latest stable version, 1.3.16.

This also updates the `livecheck` block to check the [first-party download page](https://electrumsv.io/download.html), so it will align with the cask `url` source and correctly return 1.3.16 as the latest stable version. [In the process, this addresses the redundant `#strategy` call (i.e., livecheck was already using the `Git` strategy for the previous GitHub URL).]

I'm creating this as a draft until @bevanjkay has a chance to review, in case there was any specific reason for updating this to a seemingly-unstable version.