### PR TITLE
multipatch: update url, livecheck

### DIFF
--- a/Casks/m/multipatch.rb
+++ b/Casks/m/multipatch.rb
@@ -2,14 +2,15 @@ cask "multipatch" do
   version "2.0"
   sha256 "92d4077bc10802c7b4395d6716afc5c23bbdb34788be4a672fd5fef807a2072b"
 
-  url "https://projects.sappharad.com/multipatch/multipatch#{version.no_dots}.zip"
+  url "https://github.com/Sappharad/MultiPatch/releases/download/#{version}/multipatch#{version.no_dots}.zip",
+      verified: "github.com/Sappharad/MultiPatch/"
   name "MultiPatch"
   desc "File patching utility"
   homepage "https://projects.sappharad.com/multipatch/"
 
   livecheck do
-    url "https://github.com/Sappharad/MultiPatch"
-    strategy :git
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `multipatch` checks the [related GitHub repository](https://github.com/Sappharad/MultiPatch) (as linked from the [homepage](https://projects.sappharad.com/multipatch/)) and uses a redundant `strategy :git` call (i.e., livecheck already uses the `Git` strategy for the GitHub URL). This PR addresses the issue by simply updating the cask `url` to use the zip file from the 2.0 release on GitHub.

The zip file doesn't use a version delimiter in the filename (i.e., `multipatch20.zip`), so we would otherwise have to match loose "Version 2.0" text on the homepage to identify new versions. I'm not particularly fond of vague/loose checks when we can reasonably avoid them, so it's easier to simply update the zip source in the cask and use `url :url`/`strategy :github_latest` in the `livecheck` block.

Alternatively, if we prefer to continue using the zip file from the first-party website, I can update the `livecheck` block to check the homepage instead. Either way, the `livecheck` block should align with the cask `url` source.