### PR TITLE
skitch: update livecheck

### DIFF
--- a/Casks/s/skitch.rb
+++ b/Casks/s/skitch.rb
@@ -8,8 +8,7 @@ cask "skitch" do
   homepage "https://evernote.com/products/skitch"
 
   livecheck do
-    url "https://evernote.s3.amazonaws.com/skitch/mac/release/skitch-appcast.xml"
-    strategy :sparkle, &:short_version
+    skip "No version information available"
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `livecheck` block for `skitch` checks an appcast but this now returns a 403 (Forbidden) response. The [homepage](https://evernote.com/products/skitch) simply contains a "Download for Mac" button that points to the app on the Mac App Store. I don't see another way of checking for new versions, so this updates the `livecheck` block to skip the cask.

Removal of the appcast may be a signal that they're moving towards getting rid of the non-MAS version of Skitch (or getting rid of Skitch altogether) but the zip file still resolves for now. The MAS version hasn't been updated in three years and other platforms were deprecated at the end of 2015, so it's probably only a matter of time.