### PR TITLE
gitfiend: revert to 0.42.1

### DIFF
--- a/Casks/g/gitfiend.rb
+++ b/Casks/g/gitfiend.rb
@@ -1,6 +1,6 @@
 cask "gitfiend" do
-  version "0.43.6"
-  sha256 "a08d70fd1e45c8b4b4c7395c53b10004a98d4048e8a93512ef4f394bc7d3a887"
+  version "0.42.1"
+  sha256 "5d8e61da86afe65093cce79112029ed6f2facba7f60a794f7305e8e3f242969b"
 
   url "https://gitfiend.com/resources/GitFiend-#{version}.dmg"
   name "GitFiend"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `gitfiend` cask was updated to 0.43.6 in #158791 but this is listed as a beta version on the [upstream downloads page](https://gitfiend.com/all-downloads). This PR reverts the cask to the latest stable version, 0.42.1.

The `livecheck` block returns 0.42.1 as the latest version, so it is currently working as expected.