### PR TITLE
pdf-squeezer: update livecheck

### DIFF
--- a/Casks/p/pdf-squeezer.rb
+++ b/Casks/p/pdf-squeezer.rb
@@ -9,7 +9,11 @@ cask "pdf-squeezer" do
 
   livecheck do
     url "https://www.witt-software.com/downloads/pdfsqueezer/pdfsq#{version.major}-appcast.xml"
-    strategy :sparkle, &:short_version
+    regex(/^(\d+(?:\.\d+)+)$/i)
+    strategy :sparkle do |items, regex|
+      items.select { |item| item.short_version.match(regex) }
+           .map(&:short_version)
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
Upstream has added a "BETA" release to the Sparkle feed without marking it with a different channel. This PR updates the livecheck block to only return items with the standard version scheme for PDF Squeezer.