### PR TITLE
vorta: use `github_releases` livecheck strategy

### DIFF
--- a/Casks/v/vorta.rb
+++ b/Casks/v/vorta.rb
@@ -7,9 +7,23 @@ cask "vorta" do
   desc "Desktop Backup Client for Borg"
   homepage "https://github.com/borgbase/vorta"
 
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^vorta[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg|zip)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
The latest release does not have a MacOS binary, so use the `github_releases` strategy to check for the latest release with a suitable binary.