### PR TITLE
hdfview: fix url and livecheck

### DIFF
--- a/Casks/h/hdfview.rb
+++ b/Casks/h/hdfview.rb
@@ -5,11 +5,11 @@ cask "hdfview" do
   url "https://support.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/hdfview-#{version}/bin/HDFView-#{version}-macos11_64.tar.gz"
   name "HDFView"
   desc "Tool for browsing and editing HDF files"
-  homepage "https://confluence.hdfgroup.org/display/support"
+  homepage "https://www.hdfgroup.org/downloads/hdfview/"
 
   livecheck do
-    url "https://confluence.hdfgroup.org/display/support/Download+HDFView"
-    regex(/HDFView\+(\d+(?:\.\d+)+)/i)
+    url :homepage
+    regex(/href=.*?HDFView[._-]v?(\d+(?:\.\d+)+)[._-]macos11_64\.(?:t|zip)/i)
   end
 
   depends_on macos: ">= :el_capitan"
@@ -18,7 +18,7 @@ cask "hdfview" do
   app "HDFView.app"
 
   zap trash: [
-    "~/.hdfview#{version}",
+    "~/.hdfview*",
     "~/Library/Preferences/HDFView.hdfgroup.org.plist",
     "~/Library/Saved Application State/hdf.view.savedState",
   ]

--- a/Casks/h/hdfview.rb
+++ b/Casks/h/hdfview.rb
@@ -9,7 +9,7 @@ cask "hdfview" do
 
   livecheck do
     url :homepage
-    regex(/href=.*?HDFView[._-]v?(\d+(?:\.\d+)+)[._-]macos11_64\.(?:t|zip)/i)
+    regex(/href=.*?HDFView[._-]v?(\d+(?:\.\d+)+)[._-]macos[^"' >]*?\.(?:t|zip)/i)
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
Fixes broken `url` and additionally the `livecheck` block.