### PR TITLE
fontbase 2.19.1

### DIFF
--- a/Casks/f/fontbase.rb
+++ b/Casks/f/fontbase.rb
@@ -1,6 +1,6 @@
 cask "fontbase" do
-  version "2.18.1"
-  sha256 "813a8819af04382afb6a4f9d2ea0886bf73d83975688fe6c25043e6b2dab710a"
+  version "2.19.1"
+  sha256 "d1b744be2c3481247682e2b09e8d7e78bad1cac73c9969704b5e15b1f2f90505"
 
   url "https://releases.fontba.se/mac/FontBase-#{version}.dmg"
   name "FontBase"


### PR DESCRIPTION
Upstream website is running quite slow at the moment, so this will likely timeout for now.