### PR TITLE
keymapp: add cask

### DIFF
--- a/Casks/k/keymapp.rb
+++ b/Casks/k/keymapp.rb
@@ -1,5 +1,5 @@
 cask "keymapp" do
-  version "0.0.6"
+  version "1.0.4"
   sha256 :no_check
 
   url "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-latest.dmg",
@@ -9,9 +9,9 @@ cask "keymapp" do
   homepage "https://www.zsa.io/flash"
 
   livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.zsa.io.Keymapp"].short_version
+    url "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-macos.json
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/k/keymapp.rb
+++ b/Casks/k/keymapp.rb
@@ -1,0 +1,28 @@
+cask "keymapp" do
+  version "0.0.6"
+  sha256 :no_check
+
+  url "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-latest.dmg",
+      verified: "oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/"
+  name "Keymapp"
+  desc "ZSA keyboard firmware flasher"
+  homepage "https://www.zsa.io/flash"
+
+  livecheck do
+    url :url
+    strategy :extract_plist do |items|
+      items["com.zsa.io.Keymapp"].short_version
+    end
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "Keymapp.app"
+
+  zap trash: [
+    "~/Library/Application Support/.keymapp",
+    "~/Library/Caches/com.zsa.io.Keymapp",
+    "~/Library/Preferences/com.zsa.io.Keymapp.plist",
+    "~/Library/WebKit/com.zsa.io.Keymapp",
+  ]
+end

--- a/Casks/k/keymapp.rb
+++ b/Casks/k/keymapp.rb
@@ -9,7 +9,7 @@ cask "keymapp" do
   homepage "https://www.zsa.io/flash"
 
   livecheck do
-    url "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-macos.json
+    url "https://oryx.nyc3.cdn.digitaloceanspaces.com/keymapp/keymapp-macos.json"
     strategy :json do |json|
       json["version"]
     end


### PR DESCRIPTION
This PR adds [Keymapp](https://www.zsa.io/flash), a utility used for flashing ZSA keyboards.

The previous software used for this, [Wally](https://github.com/Homebrew/homebrew-cask/blob/ce18b837e26451bcab0657522910123c8cbb1ca0/Casks/z/zsa-wally.rb), is now being superseded by Keymapp.  A separate PR will be opened to mark as `discontinued` after this is merged.

Information from ZSA about the above can be found [here](https://blog.zsa.io/keymapp/)

----

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.