### PR TITLE
zsa-wally: mark discontinued

### DIFF
--- a/Casks/z/zsa-wally.rb
+++ b/Casks/z/zsa-wally.rb
@@ -8,15 +8,20 @@ cask "zsa-wally" do
   desc "Flash tool for ZSA keyboards"
   homepage "https://ergodox-ez.com/pages/wally"
 
-  livecheck do
-    url "https://configure.ergodox-ez.com/wally/osx"
-    strategy :header_match
-  end
-
   app "Wally.app"
 
   zap trash: [
     "~/Library/Preferences/com.zsa.wally.plist",
     "~/Library/Saved Application State/com.zsa.wally.savedState",
   ]
+
+  caveats do
+    discontinued
+
+    <<~EOS
+      Keymapp is the official successor to this software:
+
+        brew install --cask keymapp
+    EOS
+  end
 end


### PR DESCRIPTION
This is a follow-up to #159623, which adds the Keymapp application that is the successor to `zsa-wally`.  This is noted in an official [ZSA blog post.](https://blog.zsa.io/keymapp/)

Accordingly, `zsa-wally` is being marked as formally discontinued.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.