### PR TITLE
various: update `CaskLoader.load()` reference

### DIFF
--- a/Casks/i/ibabel.rb
+++ b/Casks/i/ibabel.rb
@@ -13,7 +13,7 @@ cask "ibabel" do
     strategy :page_match do |page, regex|
       match = page.match(regex)
 
-      cask = CaskLoader.load("ibabel")
+      cask = CaskLoader.load(__FILE__)
       download_url = "https://macinchem.org/wp-content/uploads/#{match[1]}/#{match[2]}/iBabel.zip"
       app_version = Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask: cask,
                                                                               url:  download_url)[:matches].values.max

--- a/Casks/r/redquits.rb
+++ b/Casks/r/redquits.rb
@@ -15,7 +15,7 @@ cask "redquits" do
       major_version = page[regex, 1]
       next if major_version.blank?
 
-      cask = CaskLoader.load("redquits")
+      cask = CaskLoader.load(__FILE__)
       download_url = "http://redquits.s3.amazonaws.com/RedQuits_v#{major_version}.pkg"
       Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask: cask, url: download_url)[:matches].values
     end

--- a/Casks/s/smultron.rb
+++ b/Casks/s/smultron.rb
@@ -14,7 +14,7 @@ cask "smultron" do
       major_version = page[regex, 1]
       next if major_version.blank?
 
-      cask = CaskLoader.load("smultron")
+      cask = CaskLoader.load(__FILE__)
       download_url = "https://www.peterborgapps.com/downloads/Smultron#{major_version}.zip"
       Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask: cask, url: download_url)[:matches].values
     end


### PR DESCRIPTION
This updates the remaining casks calling `CaskLoader.load()` directly to reference `__FILE__` to ensure that the local file is always reloaded, and not loaded from the API.
Ideally this situation will not occur, this change is less likely to break in the interim while `livecheck` API changes are being discussed - https://github.com/Homebrew/brew/issues/16194

Also see discussion in - https://github.com/Homebrew/homebrew-cask/pull/159614