### PR TITLE
mater: add desc and zap stanza

### DIFF
--- a/Casks/m/mater.rb
+++ b/Casks/m/mater.rb
@@ -4,7 +4,14 @@ cask "mater" do
 
   url "https://github.com/jasonlong/mater/releases/download/#{version}/Mater-darwin-x64.zip"
   name "Mater"
+  desc "Menubar pomodoro app"
   homepage "https://github.com/jasonlong/mater"
 
   app "Mater-darwin-x64/Mater.app"
+
+  zap trash: [
+    "~/Library/Application Support/mater",
+    "~/Library/Preferences/com.electron.mater.plist",
+    "~/Library/Saved Application State/com.electron.mater.savedState",
+  ]
 end


### PR DESCRIPTION
Adding the missing `desc` and `zap` stanzas

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
