### PR TITLE
Remote Desktop Manager Cask has built in auto-updates

### DIFF
--- a/Casks/r/remote-desktop-manager.rb
+++ b/Casks/r/remote-desktop-manager.rb
@@ -13,6 +13,7 @@ cask "remote-desktop-manager" do
     strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: ">= :sierra"
 
   app "Remote Desktop Manager.app"


### PR DESCRIPTION
The cask `remote-desktop-manager` has a built-in update mechanism, which is enabled by default.

By default, it checks on every startup + once a month. (I disabled the check at startup)

![image](https://github.com/Homebrew/homebrew-cask/assets/24353767/2c05cab6-10cf-4e81-9202-742e42a93933)

_In the following questions `remote-desktop-manager` is the token of the cask you're submitting._

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online remote-desktop-manager` is error-free.
- [X] `brew style --fix remote-desktop-manager` reports no offenses.
