### PR TITLE
add deskpad cask

### DIFF
--- a/Casks/d/deskpad.rb
+++ b/Casks/d/deskpad.rb
@@ -1,0 +1,16 @@
+cask "deskpad" do
+  version "1.1"
+  sha256 "6c9a3ee8b58249e5c2e9d0a9009d450cfc6132ed87c8b65ce93c97823c9cc0aa"
+
+  url "https://github.com/Stengo/DeskPad/releases/download/v#{version}/DeskPad.app.zip"
+  name "DeskPad"
+  desc "Virtual monitor for screen sharing"
+  homepage "https://github.com/Stengo/DeskPad"
+
+  app "DeskPad.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.stengo.DeskPad",
+    "~/Library/Containers/com.stengo.DeskPad",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully. (**_see below)_**
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


`brew audit --new-cask deskpad` fails with:
```shell
audit for deskpad: failed
 - Signature verification failed:
/private/tmp/d20231109-7846-1mz7mon/DeskPad.app: rejected

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
deskpad
  * line 5, col 2: Signature verification failed:
    /private/tmp/d20231109-7846-1mz7mon/DeskPad.app: rejected

    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 1 problem in 1 cask detected.
```
I've raised the topic of signing and notarized the app with the developer at Stengo/DeskPad#17 but I'm not sure if this will be resolved timely or at all. Considering that not all casks available in Homebrew are signed and notarized - is this a blocker for integration?

Resolves Stengo/DeskPad#15
