### PR TITLE
meteorologist: update livecheck

### DIFF
--- a/Casks/m/meteorologist.rb
+++ b/Casks/m/meteorologist.rb
@@ -9,9 +9,11 @@ cask "meteorologist" do
   homepage "https://heat-meteo.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/heat-meteo/rss"
-    regex(/Meteorologist[._-](\d+(?:\.\d+)+)(?![._-]b\d)\.dmg/i)
+    url "https://sourceforge.net/projects/heat-meteo/rss?path=/Meteo"
+    regex(%r{url=.*?/Meteorologist[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
+
+  depends_on macos: ">= :ventura"
 
   app "Meteorologist.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `meteorologist` has a URL that is the same as the default URL from the `Sourceforge` strategy. This could use `url :url` but we only want to check the `Meteo` directory, so this PR updates the URL to use the `?path=/Meteo` query string parameter.

Besides that, the regex includes a negative lookahead `(?![._-]b\d)`, that doesn't appear to be necessary. The usual `Meteorologist[._-]v?(\d+(?:\.\d+)+)\.dmg` will match files for stable versions (e.g., `Meteorologist-4.0.2.dmg`) while avoiding unstable versions like `Meteorologist-4.0.3.b4.dmg`. This also updates the regex to use the typical pattern for SourceForge `livecheck` blocks.

This also adds `depends_on macos: ">= :ventura"`, to resolve the following audit failure: `Upstream defined :ventura as the minimum OS version and the cask defined no minimum OS version`.