### PR TITLE
Update official repository location for cask musicbrainz-picard

### DIFF
--- a/Casks/m/musicbrainz-picard.rb
+++ b/Casks/m/musicbrainz-picard.rb
@@ -2,8 +2,7 @@ cask "musicbrainz-picard" do
   version "2.10"
   sha256 "183d145dd37ae042c2c76b962ed5887846c70d2981fe1cb89149bf9988554ab0"
 
-  url "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}-macOS-10.14.dmg",
-      verified: "musicbrainz.osuosl.org/pub/"
+  url "https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-#{version}-macOS-10.14.dmg"
   name "MusicBrainz Picard"
   desc "Music tagger"
   homepage "https://picard.musicbrainz.org/"


### PR DESCRIPTION
The official repository for MusicBrainz Picard seems to have moved from `https://musicbrainz.osuosl.org/` to `https://data.musicbrainz.org/`. When (re-)installing or upgrading using the existing cask, the following error is generated:

```
$ brew reinstall musicbrainz-picard
==> Downloading https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.10-macOS-10.14.dmg
curl: (22) The requested URL returned error: 404

Error: Download failed on Cask 'musicbrainz-picard' with message: Download failed: https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.10-macOS-10.14.dmg
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
