### PR TITLE
Bump OBS to 30.0.0 

### DIFF
--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -9,7 +9,7 @@ cask "obs" do
   url "https://cdn-fastly.obsproject.com/downloads/obs-studio-#{version}-macos-#{arch}.dmg"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
-  homepage "https://obsproject.com/forum/list/test-builds.20/"
+  homepage "https://obsproject.com/"
 
   livecheck do
     url "https://obsproject.com/osx_update/updates_#{livecheck_folder}_v2.xml"

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -6,7 +6,7 @@ cask "obs" do
   sha256 arm:   "a4bd98bc5bf224ef545f264188969a3d39a3e5e275686b8447e8ad7cc704aafc",
          intel: "367b12299a7c226b8017108bd251093af50dfe2d86a6b0aaa54180a1da63f657"
 
-  url "https://cdn-fastly.obsproject.com/downloads/OBSs-Studio-#{version}-macos-#{arch}.dmg"
+  url "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-#{version}-macos-#{arch}.dmg"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -6,7 +6,7 @@ cask "obs" do
   sha256 arm:   "a4bd98bc5bf224ef545f264188969a3d39a3e5e275686b8447e8ad7cc704aafc",
          intel: "367b12299a7c226b8017108bd251093af50dfe2d86a6b0aaa54180a1da63f657"
 
-  url "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-#{version}-macos-#{arch}.dmg"
+  url "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-#{version}-macOS-#{arch}.dmg"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -1,17 +1,18 @@
 cask "obs" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "Apple", intel: "Intel"
+  arch_2 = on_arch_conditional arm: "arm64", intel: "x86_64"
 
-  version "29.1.3"
-  sha256 arm:   "ad8586d6af8dd4a0039e6074cf92213340f3d2408cf87e3593fa0822cbc8a73a",
-         intel: "0e87051cd5ee50f9efb9c9052d79a3d598761b154308213c40accacc3c9d0895"
+  version "30.0.0"
+  sha256 arm:   "a4bd98bc5bf224ef545f264188969a3d39a3e5e275686b8447e8ad7cc704aafc",
+         intel: "367b12299a7c226b8017108bd251093af50dfe2d86a6b0aaa54180a1da63f657"
 
-  url "https://cdn-fastly.obsproject.com/downloads/obs-studio-#{version}-macos-#{arch}.dmg"
+  url "https://cdn-fastly.obsproject.com/downloads/OBSs-Studio-#{version}-macos-#{arch}.dmg"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"
 
   livecheck do
-    url "https://obsproject.com/osx_update/stable/updates_#{arch}.xml"
+    url "https://obsproject.com/osx_update/stable/updates_#{arch_2}.xml"
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -13,7 +13,7 @@ cask "obs" do
 
   livecheck do
     url "https://obsproject.com/osx_update/updates_#{livecheck_folder}_v2.xml"
-    regex(/obs[._-]studio[._-](\d+(?:[.-]\d+)+(?:(?:-beta)|(?:-rc))\d+)[._-]macos/i)
+    regex(/obs[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
     strategy :sparkle do |items, regex|
       items.find { |item| item.channel == "stable" }&.url&.scan(regex)&.flatten
     end

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -1,19 +1,22 @@
 cask "obs" do
-  arch arm: "Apple", intel: "Intel"
-  arch_2 = on_arch_conditional arm: "arm64", intel: "x86_64"
+  arch arm: "apple", intel: "intel"
+  livecheck_folder = on_arch_conditional arm: "arm64", intel: "x86_64"
 
   version "30.0.0"
   sha256 arm:   "a4bd98bc5bf224ef545f264188969a3d39a3e5e275686b8447e8ad7cc704aafc",
          intel: "367b12299a7c226b8017108bd251093af50dfe2d86a6b0aaa54180a1da63f657"
 
-  url "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-#{version}-macOS-#{arch}.dmg"
+  url "https://cdn-fastly.obsproject.com/downloads/obs-studio-#{version}-macos-#{arch}.dmg"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
-  homepage "https://obsproject.com/"
+  homepage "https://obsproject.com/forum/list/test-builds.20/"
 
   livecheck do
-    url "https://obsproject.com/osx_update/stable/updates_#{arch_2}.xml"
-    strategy :sparkle, &:short_version
+    url "https://obsproject.com/osx_update/updates_#{livecheck_folder}_v2.xml"
+    regex(/obs[._-]studio[._-](\d+(?:[.-]\d+)+(?:(?:-beta)|(?:-rc))\d+)[._-]macos/i)
+    strategy :sparkle do |items, regex|
+      items.find { |item| item.channel == "stable" }&.url&.scan(regex)&.flatten
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
It should be an easy bump but OBS now uses "Intel" and "Apple" as architecture names in the download link. The architecture names in the livecheck URL remain the same.

The livecheck still returns 29.1.3 as the latest version, even though the latest stable version on the OBS website is 30.0.0, so I cannot check checkbox 2.

No offense detected by brew style --fix, checking checkbox 3.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
