### PR TITLE
daedalus-testnet 5.3.0

### DIFF
--- a/Casks/d/daedalus-testnet.rb
+++ b/Casks/d/daedalus-testnet.rb
@@ -1,25 +1,25 @@
 cask "daedalus-testnet" do
-  version "4.12.1,22105"
-  sha256 "2a7d3c2ee346157445d9e4a4eccc76c303fbf78cf1fe4460a63438626592c1d2"
+  version "5.3.0,59334,44942bd51"
+  sha256 "930c3156a56221b4af294361c76691a0f693edeeef6d16c9ffd7a506928dfd79"
 
-  url "https://updates-cardano-testnet.s3.amazonaws.com/daedalus-#{version.csv.first}-testnet-#{version.csv.second}-x86_64-darwin.pkg",
-      verified: "updates-cardano-testnet.s3.amazonaws.com/"
+  url "https://lace-daedalus-preview.s3.amazonaws.com/daedalus-#{version.csv.first}-#{version.csv.second}-preview-#{version.csv.third}-x86_64-darwin.pkg",
+      verified: "lace-daedalus-preview.s3.amazonaws.com/"
   name "Daedalus Testnet"
   desc "Cryptocurrency wallet for test ada on the Cardano Testnet blockchain"
   homepage "https://developers.cardano.org/en/testnets/cardano/get-started/wallet/"
 
   livecheck do
-    url "https://updates-cardano-testnet.s3.amazonaws.com/daedalus-latest-version.json"
-    regex(%r{/daedalus[._-](\d+(?:\.\d+)+)[._-]testnet[._-](\d+)[._-]x86_64[._-]darwin\.pkg}i)
+    url "https://lace-daedalus-preview.s3.amazonaws.com/daedalus-latest-version.json"
+    regex(%r{/daedalus[._-](\d+(?:\.\d+)+)[._-](\d+)[._-]preview[._-]([\da-f]+)[._-]x86_64[._-]darwin\.pkg}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
     end
   end
 
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
-  pkg "daedalus-#{version.csv.first}-testnet-#{version.csv.second}-x86_64-darwin.pkg"
+  pkg "daedalus-#{version.csv.first}-#{version.csv.second}-preview-#{version.csv.third}-x86_64-darwin.pkg"
 
   uninstall pkgutil: "org.Daedalustestnet.pkg"
 


### PR DESCRIPTION
The previous `url` is returning 404.
The only links available on the `homepage` are for a "preview" or "pre-prod" release. This uses the "preview" release as the application is only for testing purposes.

---

Alternative would be to consider removal.