### PR TITLE
raze: use `github_releases` livecheck strategy

### DIFF
--- a/Casks/r/raze.rb
+++ b/Casks/r/raze.rb
@@ -7,6 +7,8 @@ cask "raze" do
   desc "Build engine port backed by GZDoom tech"
   homepage "https://github.com/coelckers/Raze"
 
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
     url :url
     regex(/^raze[._-]macos[._-]v?(\d+(?:\.\d+)+)\.zip$/i)

--- a/Casks/r/raze.rb
+++ b/Casks/r/raze.rb
@@ -10,13 +10,17 @@ cask "raze" do
   livecheck do
     url :url
     regex(/^raze[._-]macos[._-]v?(\d+(?:\.\d+)+)\.zip$/i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
 
-        match[1]
-      end
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
     end
   end
 


### PR DESCRIPTION
Use `github_releases` livecheck strategy to find the latest version that includes a suitable binary.