### PR TITLE
whatsapp 2.23.23.81

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,6 +1,6 @@
 cask "whatsapp" do
-  version "2.23.21.79"
-  sha256 "aa089eb81089ffd68c1c96a4d4a4ec66bb754814f70cf0f8ca38f1b93b096ef2"
+  version "2.23.23.81"
+  sha256 "bf20f79471920b87e987f9cb9fdea48362e9986100024ef71c08bd2ad12480a4"
 
   url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&configuration=Release&branch=relbranch"
   name "WhatsApp"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


## Logs

```
 $ brew audit --cask --online whatsapp   
...
audit for whatsapp: failed
 - Version '2.2302.8' differs from '2.2349.51' retrieved by livecheck.
 - Version '2.2302.8' differs from '2.2349.51' retrieved by livecheck.
 - Cask should be located in '/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/w/whatsapp.rb'
whatsapp
  * Version '2.2302.8' differs from '2.2349.51' retrieved by livecheck.
  * Cask should be located in '/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/w/whatsapp.rb'
Error: 2 problems in 1 cask detected.

$ brew livecheck --cask whatsapp     
whatsapp: 2.2302.8 ==> 2.2349.51

$ brew style --fix ./Casks/w/whatsapp.rb 
1 file inspected, no offenses detected
```