### PR TITLE
sf: updates for `sha256` issues

### DIFF
--- a/Casks/s/sf.rb
+++ b/Casks/s/sf.rb
@@ -1,25 +1,22 @@
 cask "sf" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.16.10,38f3e4f"
-  sha256 arm:   "f6845bb2d329bdae9ed835f53390b8ad60e335f0cc15cd368cef63803e09b93a",
-         intel: "18d09197e7cd31519589d7f8117a369b1b0ffb26cc921ce53a9e17ac1165b454"
+  version "2.16.7"
+  sha256 :no_check
 
-  url "https://developer.salesforce.com/media/salesforce-cli/sf/versions/#{version.csv.first}/#{version.csv.second}/sf-v#{version.csv.first}-#{version.csv.second}-#{arch}.pkg"
+  url "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-#{arch}.pkg"
   name "Salesforce CLI"
   desc "Salesforce CLI tools"
   homepage "https://developer.salesforce.com/tools/salesforcecli"
 
   livecheck do
-    url "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-darwin-#{arch}-buildmanifest"
-    strategy :json do |json|
-      "#{json["version"]},#{json["sha"]}"
-    end
+    url "https://raw.githubusercontent.com/forcedotcom/cli/main/releasenotes/README.md"
+    regex(/(\d+(?:\.\d+)+)\s+\(.*?\)\s+\[stable\]/i)
   end
 
   depends_on macos: ">= :el_capitan"
 
-  pkg "sf-v#{version.csv.first}-#{version.csv.second}-#{arch}.pkg"
+  pkg "sf-#{arch}.pkg"
 
   uninstall pkgutil: "com.salesforce.cli",
             delete:  [


### PR DESCRIPTION
* Revert to `sha256 :no_check` to avoid in place update hash issues

* Parse `README.md` on GitHub for [stable] version

This cask has been having some issues with `sha256` mismatches (#159993, #158514, #156404, #156385).  There have also been several updates to this Cask, sometimes on a daily basis, when this should be updating once per week as a `stable` release from Salesforce on Wednesdays, US time.  Since these incremental updates are being pulled in, it seems as a regression and not providing an actual `stable` version as intended.

This PR switches to a method that was used in its predecessor cask, `sfdx`, by parsing the authoritative source of updates from the Salesforce repository [`README.md`](https://raw.githubusercontent.com/forcedotcom/cli/main/releasenotes/README.md) and extracting the update beside the `[stable]` tag.  This also pulls the latest official `stable` download from Salesforce directly for install.  Unfortunately, this is not a versioned `url` so dropping the `sha256` will be needed, but should help improve overall stability.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
