### PR TITLE
gifrocket: depends_on intel architecture

### DIFF
--- a/Casks/g/gifrocket.rb
+++ b/Casks/g/gifrocket.rb
@@ -12,5 +12,7 @@ cask "gifrocket" do
     regex(/href=.*?Gifrocket.v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
+  depends_on arch: :x86_64
+
   app "Gifrocket.app"
 end


### PR DESCRIPTION
Does not run on `arm` architecture. Is a node-based app that only runs on intel.