### PR TITLE
cask_renames.json: remove `sublime-text3`

### DIFF
--- a/cask_renames.json
+++ b/cask_renames.json
@@ -9,6 +9,5 @@
   "opal": "opal-composer",
   "owasp-zap": "zap",
   "remotion": "multiapp",
-  "streamlabs-obs": "streamlabs",
-  "sublime-text3": "sublime-text"
+  "streamlabs-obs": "streamlabs"
 }


### PR DESCRIPTION
Needed for https://github.com/Homebrew/homebrew-cask-versions/pull/18384