### PR TITLE
kindle: mark discontinued

### DIFF
--- a/Casks/k/kindle.rb
+++ b/Casks/k/kindle.rb
@@ -28,7 +28,7 @@ cask "kindle" do
     discontinued
     requires_rosetta
     <<~EOS
-      Please see https://www.amazon.com/kindle-dbs/arp/B0C9PRPV28 for regarding application end of life.
+      Please see https://www.amazon.com/kindle-dbs/arp/B0C9PRPV28 for information regarding application end of life.
     EOS
   end
 end

--- a/Casks/k/kindle.rb
+++ b/Casks/k/kindle.rb
@@ -8,12 +8,8 @@ cask "kindle" do
   desc "Interface for reading and syncing eBooks"
   homepage "https://www.amazon.com/gp/digital/fiona/kcp-landing-page"
 
-  livecheck do
-    url "https://www.amazon.com/kindlemacdownload/ref=klp_hz_mac"
-    strategy :header_match
-  end
-
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   app "Kindle.app"
 
@@ -27,4 +23,12 @@ cask "kindle" do
     "~/Library/Preferences/com.amazon.Kindle.plist",
     "~/Library/Saved Application State/com.amazon.Kindle.savedState",
   ]
+
+  caveats do
+    discontinued
+    requires_rosetta
+    <<~EOS
+      Please see https://www.amazon.com/kindle-dbs/arp/B0C9PRPV28 for regarding application end of life.
+    EOS
+  end
 end


### PR DESCRIPTION
Follow on to #160186

This application is being formally discontinued by upstream, with information found [here](https://www.amazon.com/kindle-dbs/arp/B0C9PRPV28).

This application is rather popular, so opt for discontinue over removal as the download is still available.  It can be revisited for removal in the future.

```
30 days: 412 (#420)
90 days: 1,455 (#351)
365 days: 4,073 (#305)
```