### PR TITLE
lulu: fix uninstall

### DIFF
--- a/Casks/l/lulu.rb
+++ b/Casks/l/lulu.rb
@@ -17,11 +17,7 @@ cask "lulu" do
 
   app "LuLu.app"
 
-  uninstall script: {
-    executable: "#{staged_path}/LuLu.app/Contents/Resources/LuLu Uninstaller.app/Contents/MacOS/LuLu Uninstaller",
-    args:       ["-uninstall"],
-    sudo:       true,
-  }
+  # Lulu's uninstaller removes all preference files breaking brew upgrade
 
   zap trash: [
     "~/Library/Caches/com.objective-see.lulu",


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/158764

Lulu's uninstaller removes all preference files, so we need to avoid using it to prevent `brew upgrade` from resetting the app.