### PR TITLE
Fix Calibre version compatibility

### DIFF
--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -23,7 +23,23 @@ cask "calibre" do
       skip "Legacy version"
     end
   end
-  on_big_sur :or_newer do
+  on_big_sur do
+    version "6.29.0"
+    sha256 "2f76428ae19617875c5725cd892751a80eb2acdda76e06cd19c2f21a63966998"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_monterey do
+    version "6.29.0"
+    sha256 "2f76428ae19617875c5725cd892751a80eb2acdda76e06cd19c2f21a63966998"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_ventura :or_newer do
     version "7.0.0"
     sha256 "884061bce0df80085b4a9ce60da1f63530040f615804eb8cf499718a2e314a8e"
 


### PR DESCRIPTION
Calibre 7.0 is not compatible with older MacOS releases. See https://calibre-ebook.com/download_osx
Note: I wasn't able to verify the changes with `brew audit --cask --online calibre`. It failes with `No Cask with this name exists`. Providing a path to my updated formula, instead of the cask token, fails with `Calling brew audit [path ...] is disabled!`. I read the docs and found them to be unclear about what command I'm supposed to execute. In any case, I tested that (un)installing this formula works on BigSur.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
