### PR TITLE
MarkText cask: Update ARM warning with more helpful link to issue

### DIFF
--- a/Casks/m/mark-text.rb
+++ b/Casks/m/mark-text.rb
@@ -25,6 +25,6 @@ cask "mark-text" do
     The Apple Silicon (ARM) version of #{token} is not signed. It will display an error stating it is damaged and can't
     be opened. Please see https://github.com/marktext/marktext/issues/2983 for details and workarounds.
 
-    This is something only the package maintainer, not Homebrew, can fix.
+    This is something only the developer, not Homebrew, can fix.
   EOS
 end

--- a/Casks/m/mark-text.rb
+++ b/Casks/m/mark-text.rb
@@ -22,9 +22,8 @@ cask "mark-text" do
   ]
 
   caveats <<~EOS
-    The Apple Silicon (ARM) version of #{token} is not signed. It will display an error stating it is damaged and can't be opened.
-  
-    Please see https://github.com/marktext/marktext/issues/2983 for details and workarounds.
+    The Apple Silicon (ARM) version of #{token} is not signed. It will display an error stating it is damaged and can't
+    be opened. Please see https://github.com/marktext/marktext/issues/2983 for details and workarounds.
 
     This is something only the package maintainer, not Homebrew, can fix.
   EOS

--- a/Casks/m/mark-text.rb
+++ b/Casks/m/mark-text.rb
@@ -22,7 +22,10 @@ cask "mark-text" do
   ]
 
   caveats <<~EOS
-    The Apple Silicon (arm) version of #{token} is not signed, and
-    will display an error stating it is damaged and can't be opened.
+    The Apple Silicon (ARM) version of #{token} is not signed. It will display an error stating it is damaged and can't be opened.
+  
+    Please see https://github.com/marktext/marktext/issues/2983 for details and workarounds.
+
+    This is something only the package maintainer, not Homebrew, can fix.
   EOS
 end


### PR DESCRIPTION
This just changes the warning text for the `mark-text` ARM64 package to be more helpful. It now provides a link to the maintainer's issue page discussing the problem, along with community-provided workarounds. It stops short of recommending any particular security bypass, allowing the installer to decide for themselves if they want to try any of the ones listed in the issue.

See https://github.com/Homebrew/homebrew-cask/issues/159554 for details.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

(Not adding a new cask)