### PR TITLE
lightkey: update livecheck

### DIFF
--- a/Casks/l/lightkey.rb
+++ b/Casks/l/lightkey.rb
@@ -3,8 +3,21 @@ cask "lightkey" do
     version "4.4.5"
     sha256 "457df4bb2d2f21a52eec9b9b05830eb082014ce66fd79f91544a0838d54a3241"
 
+    # This check should only return legacy versions and the conditions may need
+    # to be updated as the minimum system version of releases changes. If/when
+    # upstream stops publishing new legacy versions, this should be updated to
+    # use `skip` instead.
     livecheck do
-      skip "Legacy version"
+      url "https://lightkeyapp.com/en/update"
+      strategy :sparkle do |items|
+        items.map do |item|
+          next unless item.minimum_system_version
+          next if item.minimum_system_version < :big_sur ||
+                  item.minimum_system_version >= :ventura
+
+          item.version
+        end
+      end
     end
 
     depends_on macos: ">= :big_sur"
@@ -13,8 +26,10 @@ cask "lightkey" do
     version "4.6"
     sha256 "fccd39bd1cde1ff01a04194643bd8d17fc593e4c6b82a058e22e41471fed41a9"
 
-    # Updates for legacy versions are included so sorting by release date
-    # return false positives, pass all version numbers to livecheck instead
+    # Upstream also publishes legacy versions (with a lower minor version) in
+    # the appcast, so the first `item` after sorting by `pubDate`/`version` may
+    # not be the highest version. This `strategy` block collects the `version`
+    # from all `items`, ignoring the `Sparkle` strategy's `pubDate` sorting.
     livecheck do
       url "https://lightkeyapp.com/en/update"
       strategy :sparkle do |items|


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

As proposed in https://github.com/Homebrew/homebrew-cask/pull/158044, this updates the `livecheck` block for the legacy version of `lightkey` to match items based on their `minimumSystemVersion`. This wasn't previously possible but I recently modified the `Sparkle` strategy to surface more `item` values (see https://github.com/Homebrew/brew/pull/16158 and https://github.com/Homebrew/brew/pull/16196), so we can now use `item.minimum_system_version` to filter `items` in a `strategy` block.

This type of approach should only be used when upstream is actively releasing new legacy versions (alongside the newer, primary version). This isn't appropriate for when upstream simply bumps the `minimumSystemVersion` going forward and does not publish new versions with a lower major/minor/etc. version.

With that in mind, this should probably switch back to using `skip "Legacy version"` if/when upstream stops publishing new legacy versions. I didn't see any clear guidance around how long legacy versions will be maintained but I added a comment about this (to keep it in mind).

One caveat about this approach is that the conditions in the `strategy` block may need to be updated as the minimum system version of releases changes (though only as needed to correctly match legacy versions).

The other caveat is that this will omit any item without a `minimumSystemVersion` value. Since we need this information to restrict matching to certain macOS versions, omitting those items is more reasonable than naively including them (potentially leading to an inappropriate version being reported as newest).