### PR TITLE
tunnelblick: update url, livecheck

### DIFF
--- a/Casks/t/tunnelblick.rb
+++ b/Casks/t/tunnelblick.rb
@@ -1,22 +1,26 @@
 cask "tunnelblick" do
-  version "3.8.8e,5779"
+  version "3.8.8e,5779.1"
   sha256 "6eeecb9184c7587363bbd16032e9f1d17385f5da6cea9d6229c8127812783493"
 
-  url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.csv.first}/Tunnelblick_#{version.csv.first}_build_#{version.csv.second}.1.dmg",
+  url "https://github.com/Tunnelblick/Tunnelblick/releases/download/v#{version.csv.first}/Tunnelblick_#{version.csv.first}_build_#{version.csv.second}.dmg",
       verified: "github.com/Tunnelblick/Tunnelblick/"
   name "Tunnelblick"
   desc "Free and open-source OpenVPN client"
   homepage "https://www.tunnelblick.net/"
 
   livecheck do
-    url "https://github.com/Tunnelblick/Tunnelblick/releases"
-    regex(/Tunnelblick\s+?(\d+(?:\.\d+)*[a-z]?)\s+?\(build\s+?(\d+)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    url :url
+    regex(/Tunnelblick\s+v?(\d+(?:\.\d+)+[a-z]?)\s+\(build\s+(\d+(?:\.\d+)*)\)/i)
+    strategy :github_latest do |json, regex|
+      match = json["name"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Tunnelblick.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates the `livecheck` block for `tunnelblick` to use the `GithubLatest` strategy, as releases seem to reliably provide dmg files since upstream started doing that. This also modifies the `livecheck` block regex to capture full build numbers like `5779.1`, instead of truncating it to the first number (`5779`). Most releases use a simple `5779` format but this change ensures we properly handle build numbers like `5779.1` when they do appear.

Similarly, this updates the cask to include the full build number in the version, instead of hardcoding `.1` in the `url`. With livecheck surfacing the full build number, this setup will make it easier to update the cask going forward.

Lastly, this adds `depends_on macos: ">= :high_sierra"`, to resolve the related audit error.