### PR TITLE
Update `livecheck` blocks to use GithubReleases strategy

### DIFF
--- a/Casks/e/eloston-chromium.rb
+++ b/Casks/e/eloston-chromium.rb
@@ -16,12 +16,19 @@ cask "eloston-chromium" do
   desc "Google Chromium, sans integration with Google"
   homepage "https://ungoogled-software.github.io/ungoogled-chromium-binaries/"
 
+  # Releases are separated by architecture, so we have to check multiple recent
+  # releases instead of only the "latest" release.
   livecheck do
-    url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tree/v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?["' >]}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        (match.length > 1) ? "#{match[0]},#{match[1]}" : match[0]
+    url :url
+    regex(/^v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        (match.length >= 2) ? "#{match[1]},#{match[2]}" : match[1]
       end
     end
   end

--- a/Casks/e/extraterm.rb
+++ b/Casks/e/extraterm.rb
@@ -12,9 +12,20 @@ cask "extraterm" do
   # This should be updated to use the `GithubLatest` strategy if/when stable
   # versions become available.
   livecheck do
-    url "https://github.com/sedwards2009/extraterm/releases"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        # This omits the usual `release["prerelease"]` early return condition,
+        # as we need to work with pre-release versions for now.
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   app "ExtratermQt.app"

--- a/Casks/f/forkgram-telegram.rb
+++ b/Casks/f/forkgram-telegram.rb
@@ -10,28 +10,22 @@ cask "forkgram-telegram" do
   desc "Fork of Telegram Desktop"
   homepage "https://github.com/Forkgram/"
 
-  # NOTE: This approach involves multiple requests and should be avoided
-  # whenever possible. If upstream starts reliably providing the macOS zip
-  # files in every release, we should switch to `url :url` with
-  # `strategy :github_latest`.
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
-    url "https://github.com/Forkgram/tdesktop/releases?q=prerelease%3Afalse"
-    regex(%r{/v?(\d+(?:\.\d+)+)/Forkgram[._-]macOS[._-][^"' >]*?#{arch}\.zip}i)
-    strategy :page_match do |page, regex|
-      # Collect the release tags on the page
-      tags = page.scan(%r{href=["']?[^"' >]*?/releases/tag/([^"' >]*?)["' >]}i)&.flatten&.uniq
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      file_regex = /^Forkgram[._-]macOS[._-].*?#{arch}\.zip$/i
 
-      max_reqs = 4
-      tags.each_with_index do |tag, i|
-        break if i >= max_reqs
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+        next unless release["assets"]&.any? { |asset| asset["name"]&.match?(file_regex) }
 
-        # Fetch the assets list HTML for the tag and match within it
-        assets_page = Homebrew::Livecheck::Strategy.page_content(
-          @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{tag}"),
-        )
-        matches = assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match = release["tag_name"].match(regex)
+        next if match.blank?
 
-        break matches if matches.present?
+        match[1]
       end
     end
   end

--- a/Casks/o/obs-websocket.rb
+++ b/Casks/o/obs-websocket.rb
@@ -11,9 +11,8 @@ cask "obs-websocket" do
   # "latest" release may be for an older major version. Unless/until this is
   # resolved, we have to check more than just the "latest" release.
   livecheck do
-    url "https://github.com/obsproject/obs-websocket/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)[^"' >]*?["' >]}i)
-    strategy :page_match
+    url :url
+    strategy :github_releases
   end
 
   pkg "obs-websocket-#{version}-macOS.pkg"

--- a/Casks/w/wine-stable.rb
+++ b/Casks/w/wine-stable.rb
@@ -11,28 +11,22 @@ cask "wine-stable" do
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
 
-  # NOTE: This approach involves multiple requests and should be avoided
-  # whenever possible. If upstream starts reliably providing `wine-stable` zip
-  # files in every release, we should switch to `url :url` with
-  # `strategy :github_latest`.
+  # Not every GitHub release provides a `wine-stable` file, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
-    url "https://github.com/Gcenx/macOS_Wine_builds/releases?q=prerelease%3Afalse"
-    regex(%r{/v?(\d+(?:\.\d+)+)/wine-stable[._-][^"' >]*?\.t}i)
-    strategy :page_match do |page, regex|
-      # Collect the release tags on the page
-      tags = page.scan(%r{href=["']?[^"' >]*?/releases/tag/([^"' >]*?)["' >]}i)&.flatten&.uniq
+    url :url
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      file_regex = /^wine-stable[._-].*?$/i
 
-      max_reqs = 6
-      tags.each_with_index do |tag, i|
-        break if i >= max_reqs
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+        next unless release["assets"]&.any? { |asset| asset["name"]&.match?(file_regex) }
 
-        # Fetch the assets list HTML for the tag and match within it
-        assets_page = Homebrew::Livecheck::Strategy.page_content(
-          @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{tag}"),
-        )
-        matches = assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match = release["tag_name"].match(regex)
+        next if match.blank?
 
-        break matches if matches.present?
+        match[1]
       end
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `livecheck` blocks that 1) check a GitHub releases page, 2) need to check multiple releases (i.e., `GithubLatest` isn't sufficient), and 3) can be migrated to the `GithubReleases` strategy. Among other things, this gets rid of the remaining instances of my gnarly `strategy` block that was used to check release assets after GitHub removed asset HTML from the releases page.