### PR TITLE
motrix: update url, livecheck

### DIFF
--- a/Casks/m/motrix.rb
+++ b/Casks/m/motrix.rb
@@ -5,18 +5,18 @@ cask "motrix" do
   sha256 arm:   "d73f4d69f3597ad8f98b821aa0fb58ba964bf85061b4a13f00edcb3618001c0e",
          intel: "b644cc83aa98224147ef2942fd49ecfc8cdcebfce9616550fa35caa6850c4178"
 
-  url "https://dl.moapp.me/https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}#{arch}.dmg",
-      verified: "dl.moapp.me/"
+  url "https://github.com/agalwood/Motrix/releases/download/v#{version}/Motrix-#{version}#{arch}.dmg",
+      verified: "github.com/agalwood/Motrix/"
   name "Motrix"
   desc "Open-source download manager"
   homepage "https://motrix.app/"
 
-  # A tag using the stable version format is sometimes marked as "Pre-release"
-  # on the GitHub releases page, so we have to use the `GithubLatest` strategy.
   livecheck do
-    url "https://github.com/agalwood/Motrix/releases"
+    url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "Motrix.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `motrix` to simply use the dmg file from GitHub releases, as we were already using the `GithubLatest` strategy to check for version information in the `livecheck` block.

With that change, we can simply use `url :url` in the `livecheck` block instead of the GitHub releases page URL string. I've removed the preceding comment about "pre-release" versions, as we should be using the `GithubLatest` (or `GithubReleases`) strategy anyway when the `url` is a GitHub release asset.

If we would prefer to stick with the first-party dmg URL, I can update it to the current URLs (https://dl.motrix.app/release/Motrix-1.8.19-arm64.dmg, https://dl.motrix.app/release/Motrix-1.8.19.dmg) and update the `livecheck` block to match the version from the GitHub tag link on the [download page](https://motrix.app/download). [The download page uses client-side rendering and the version information is in one of the JavaScript files with a hash for a filename (currently https://motrix.app/_nuxt/213316c.js), so that's the only reliable way of getting the version from that page.]

Besides that, this adds ` depends_on macos: ">= :high_sierra"`, to resolve the related audit error.