### PR TITLE
Update certain `GithubLatest` checks

### DIFF
--- a/Casks/f/far2l.rb
+++ b/Casks/f/far2l.rb
@@ -25,9 +25,9 @@ cask "far2l" do
   # This check should be updated to avoid unstable versions if/when stable
   # versions become available in the future.
   livecheck do
-    url "https://github.com/elfmz/far2l/releases"
-    regex(%r{href=["']?[^"' >]*?/tree/[^"' >]*?(\d+(?:\.\d+)+)(?:[._-]?(?:alpha|beta))?["' >]}i)
-    strategy :page_match
+    url :url
+    regex(/^\D*?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   depends_on macos: ">= :el_capitan"

--- a/Casks/r/ricochet-refresh.rb
+++ b/Casks/r/ricochet-refresh.rb
@@ -12,8 +12,8 @@ cask "ricochet-refresh" do
   homepage "https://www.ricochetrefresh.net/"
 
   livecheck do
-    url "https://github.com/blueprint-freespeech/ricochet-refresh/releases"
-    regex(/v?(\d+(?:\.\d+)+)/i)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+[a-z]?)(?:[._-]release)?$/i)
     strategy :github_latest
   end
 

--- a/Casks/s/sonic-robo-blast-2-kart.rb
+++ b/Casks/s/sonic-robo-blast-2-kart.rb
@@ -9,6 +9,11 @@ cask "sonic-robo-blast-2-kart" do
   desc "Classic styled kart racer, complete with beautiful courses, and wacky items"
   homepage "https://mb.srb2.org/addons/srb2kart.2435/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Sonic Robo Blast 2 Kart.app"
 
   zap trash: "~/srb2kart"

--- a/Casks/s/sonic-robo-blast-2.rb
+++ b/Casks/s/sonic-robo-blast-2.rb
@@ -10,7 +10,7 @@ cask "sonic-robo-blast-2" do
   homepage "https://www.srb2.org/"
 
   livecheck do
-    url "https://github.com/STJr/SRB2/releases"
+    url :url
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR adds/updates a handful of `livecheck` blocks that are related to `GithubLatest`:

* `far2l`: Use `GithubLatest` instead of checking the GitHub releases page; update regex to only match stable versions
* `ricochet-refresh`: use `url :url` instead of a GitHub releases page URL string; update the regex to properly match existing tag formats
* `sonic-robo-blast-2`: use `url :url` instead of a GitHub releases page URL string
* `sonic-robo-blast-2-kart`: use `GithubLatest`, like `sonic-robo-blast-2`