### PR TITLE
lantern: update livecheck

### DIFF
--- a/Casks/l/lantern.rb
+++ b/Casks/l/lantern.rb
@@ -8,9 +8,14 @@ cask "lantern" do
   desc "Open Internet For All"
   homepage "https://lantern.io/"
 
+  # The first-party download page (https://lantern.io/download?os=mac) only
+  # links to an unversioned file, with no version information on the page. We
+  # check GitHub releases as a best guess of when a new version is released.
+  # Upstream has not marked recent releases as "latest", so we have to check
+  # multiple releases until upstream reliably marks releases as "latest" again.
   livecheck do
-    url "https://github.com/getlantern/lantern/releases"
-    strategy :github_latest
+    url "https://github.com/getlantern/lantern"
+    strategy :github_releases
   end
 
   app "Lantern.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to #160540, as `lantern` also needs to use the `GithubReleases` strategy for now. Upstream hasn't marked recent versions as "latest" on GitHub, so the `GithubLatest` strategy returns 7.6.2 as the newest version but the newest GitHub release is 7.6.15 (which the cask is currently using).

This can return to using `GithubLatest` if/when upstream starts reliably marking releases as "latest" again but this is necessary for the moment.

Fwiw, since this isn't actually checking the GitHub releases page (`GithubReleases` uses the GitHub API), removing `/releases` from the `livecheck` block URL is just a stylistic change. So long as the URL is for the GitHub repository, anything beyond that in the path is meaningless to the `GithubLatest` and `GithubReleases` strategy, so there's no point in including it (and it may mislead users as to how this works).