### PR TITLE
kodi: update livecheck

### DIFF
--- a/Casks/k/kodi.rb
+++ b/Casks/k/kodi.rb
@@ -7,9 +7,11 @@ cask "kodi" do
   desc "Free and open-source media player"
   homepage "https://kodi.tv/"
 
+  # The regex below assumes that the release name will always be one word
+  # (e.g., Leia, Matrix, Nexus, etc.).
   livecheck do
-    url "https://github.com/xbmc/xbmc/releases"
-    regex(/^(\d+(?:\.\d+)*-[a-z]+)$/i)
+    url "https://kodi.tv/download/macos/"
+    regex(/href=.*?kodi[._-]v?(\d+(?:\.\d+)+[._-][^-]+?)[._-][^-]+?\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates the existing `livecheck` block for `kodi` to check the first-party download page for macOS instead of the tags from GitHub (despite the URL, this doesn't actually check releases). This aligns the check with the source of the cask `url`.