### PR TITLE
standard-notes: update livecheck

### DIFF
--- a/Casks/s/standard-notes.rb
+++ b/Casks/s/standard-notes.rb
@@ -11,16 +11,21 @@ cask "standard-notes" do
   desc "Free, open-source, and completely encrypted notes app"
   homepage "https://standardnotes.org/"
 
-  # Using only desktop releases that are not marked as pre-release to align
-  # with the auto-updater strategy used by the app.
+  # The app's auto-updater avoids versions marked as "pre-release" on GitHub,
+  # so we do the same thing in this check.
   # See: https://github.com/Homebrew/homebrew-cask/pull/145753#issuecomment-1521465815
+  # We specifically check the GitHub releases page with the `prerelease:false`
+  # query (instead of using the `GithubReleases` strategy) because upstream
+  # publishes a lot of pre-release versions and they may push the most recent
+  # stable desktop release out of the most recent info from the GitHub API.
   livecheck do
     url "https://github.com/standardnotes/app/releases?q=prerelease%3Afalse"
-    regex(%r{href=["'].*?tags/@standardnotes/desktop@(\d+(?:\.\d+)+).*?["']}i)
+    regex(%r{href=["']?[^"' >]*?/tag/%40standardnotes%2Fdesktop%40(\d+(?:\.\d+)+)["' >]}i)
     strategy :page_match
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Standard Notes.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates the `livecheck` block for `standard-notes` to use the typical regex for matching tags on the GitHub releases page. We've mostly migrated to use the `GithubLatest` and `GithubReleases` strategy instead but this one makes sense to continue checking the releases page with the `prerelease:false` query.

Basically, upstream creates a lot of pre-release versions but GitHub doesn't provide a way to omit them from the API results, so there's a real chance that the newest stable release for desktop will be pushed out of the most recent API data (as it's limited to 30 recent releases by default). Until the GitHub API provides this functionality, we're better off maintaining the existing check.

That said, the existing check isn't perfect, as there's a chance that non-desktop releases could push the latest desktop release beyond the first page of results (limited to 10 recent releases). However, this is arguably less likely to occur than the previously-described situation with the GitHub API.

Past that, this adds `depends_on macos: ">= :catalina"`, to address the related audit error.