### PR TITLE
foxitreader: fix download url

### DIFF
--- a/Casks/f/foxitreader.rb
+++ b/Casks/f/foxitreader.rb
@@ -2,8 +2,8 @@ cask "foxitreader" do
   version "2023.2"
   sha256 "62adc1436d16fb6263375cee6b43e6936d11c98fd97c7bab1ca842873e3022f0"
 
-  url "https://cdn78.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/#{version}/FoxitPDFReader#{version.no_dots}.L10N.Setup.pkg",
-      verified: "cdn78.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/"
+  url "https://cdn01.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/#{version}/FoxitPDFReader#{version.no_dots}.L10N.Setup.pkg",
+      verified: "cdn01.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/"
   name "Foxit Reader"
   desc "PDF reader"
   homepage "https://www.foxit.com/pdf-reader/"


### PR DESCRIPTION
The original download link https://cdn78.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/2023.2/FoxitPDFReader20232.L10N.Setup.pkg will report 403 Forbidden error.

Change it to https://cdn01.foxitsoftware.com/pub/foxit/phantomPDF/desktop/mac/2023.2/FoxitPDFReader20232.L10N.Setup.pkg and works well. (with the same SHA-256 checksum)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
