### PR TITLE
artisan: use `github_latest` livecheck strategy

### DIFF
--- a/Casks/a/artisan.rb
+++ b/Casks/a/artisan.rb
@@ -8,6 +8,11 @@ cask "artisan" do
   desc "Visual scope for coffee roasters"
   homepage "https://artisan-scope.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :catalina"
 
   app "Artisan.app"


### PR DESCRIPTION
Upstream have started utilise pre-releases, so therefore we should move to the `github_latest` livecheck strategy to return the correct version.