### PR TITLE
bdash: use `github_latest` livecheck strategy

### DIFF
--- a/Casks/b/bdash.rb
+++ b/Casks/b/bdash.rb
@@ -7,6 +7,11 @@ cask "bdash" do
   desc "Simple SQL Client for lightweight data analysis"
   homepage "https://github.com/bdash-app/bdash"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Bdash.app"
 
   zap trash: [


### PR DESCRIPTION
Upstream are using a tag that does not have a corresponding release, `github_latest` livecheck strategy returns the correct version.