### PR TITLE
Update some livecheck blocks to use :url

### DIFF
--- a/Casks/c/cellprofiler.rb
+++ b/Casks/c/cellprofiler.rb
@@ -9,7 +9,7 @@ cask "cellprofiler" do
   homepage "https://cellprofiler.org/"
 
   livecheck do
-    url "https://github.com/CellProfiler/CellProfiler"
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/d/dhs.rb
+++ b/Casks/d/dhs.rb
@@ -9,7 +9,7 @@ cask "dhs" do
   homepage "https://objective-see.com/products/dhs.html"
 
   livecheck do
-    url "https://github.com/objective-see/DylibHijackScanner"
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/o/openrefine.rb
+++ b/Casks/o/openrefine.rb
@@ -9,7 +9,7 @@ cask "openrefine" do
   homepage "https://openrefine.org/"
 
   livecheck do
-    url "https://github.com/OpenRefine/OpenRefine"
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/u/universal-gcode-platform.rb
+++ b/Casks/u/universal-gcode-platform.rb
@@ -12,7 +12,7 @@ cask "universal-gcode-platform" do
   homepage "https://winder.github.io/ugs_website/"
 
   livecheck do
-    url "https://github.com/winder/Universal-G-Code-Sender"
+    url :url
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The casks in this PR use a GitHub release asset and have a `livecheck` block that uses a GitHub URL string. This updates these `livecheck` blocks to simply use `url :url` instead.

We only use a GitHub URL string in a `livecheck` block when the cask `url` is not a GitHub URL. In those cases, we should add a comment before the `livecheck` block to explain why we can't create a check that aligns with the cask `url` source and have to check GitHub instead. [I'm working through GitHub-related `livecheck` blocks and will be adding comments for existing exceptions in a later PR.]