### PR TITLE
ibm-cloud-cli: add arm64 pkg, update livecheck

### DIFF
--- a/Casks/i/ibm-cloud-cli.rb
+++ b/Casks/i/ibm-cloud-cli.rb
@@ -1,14 +1,25 @@
 cask "ibm-cloud-cli" do
-  version "2.21.0"
-  sha256 "5809f1f96a5d8cb85084d858bf3378581c6f9df5166864534e1193a4b1516083"
+  arch arm: "_arm64"
 
-  url "https://download.clis.cloud.ibm.com/ibm-cloud-cli/#{version}/IBM_Cloud_CLI_#{version}.pkg"
+  version "2.21.0"
+  sha256 arm:   "7c0ba063e899069f55178f72370789f665a8f2d704a5b601b3d0de98dc52cafe",
+         intel: "5809f1f96a5d8cb85084d858bf3378581c6f9df5166864534e1193a4b1516083"
+
+  url "https://download.clis.cloud.ibm.com/ibm-cloud-cli/#{version}/IBM_Cloud_CLI_#{version}#{arch}.pkg"
   name "IBM Cloud CLI"
   desc "Command-line API client"
   homepage "https://cloud.ibm.com/docs/cli/index.html"
 
+  # Upstream publishes file links in the description of GitHub releases.
   livecheck do
     url "https://github.com/IBM-Cloud/ibm-cloud-cli-release"
+    regex(/IBM[._-]Cloud[._-]CLI[._-]v?(\d+(?:\.\d+)+)#{arch}\.(?:dmg|pkg)/i)
+    strategy :github_latest do |json, regex|
+      match = json["body"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
   end
 
   pkg "IBM_Cloud_CLI_#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates the `livecheck` block for `ibm-cloud-cli` to document why we're checking GitHub releases instead of something that aligns with the cask `url` source. I've also added a `strategy` block that matches versions from the links in the release description (i.e., these are the links that point to the cask `url` files).

Past that, I saw that there's also an ARM64 pkg, so I added it to the cask.