### PR TITLE
Openzfs: replaced intel sonoma 2.2.0 build

### DIFF
--- a/Casks/o/openzfs.rb
+++ b/Casks/o/openzfs.rb
@@ -58,9 +58,9 @@ cask "openzfs" do
       sha256 "8818bb186c610e9d51b8e48ff4ad545794c835b0df246ff22b3e0dce37d74aba"
     end
     on_sonoma :or_newer do
-      arch intel: "Sonoma-14"
-      version "2.2.0,497"
-      sha256 "c030556ac295c787a95c78cbd76b4a83db69bc119bec7fc2feb018938921c395"
+      arch intel: "Sonoma-14.REPACK"
+      version "2.2.0,499"
+      sha256 "1223d8694b3ff585608655ed98cd6f479c645f6945fc8129aeb4ca3e7a52a7f2"
     end
   end
 


### PR DESCRIPTION
See https://openzfsonosx.org/wiki/Downloads#2.2.0
"Sorry about the REPACK thing, the Sonoma-x86_64.pkg build was incorrect. OpenZFS_on_OS_X_2.2.0.REPACK.dmg 2023-11-17"

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version]
- [ x] `brew audit --cask --online <cask>` is error-free.
- [x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
