### PR TITLE
Add livecheck comment to document GitHub exceptions

### DIFF
--- a/Casks/b/blackhole-16ch.rb
+++ b/Casks/b/blackhole-16ch.rb
@@ -7,6 +7,8 @@ cask "blackhole-16ch" do
   desc "Virtual Audio Driver"
   homepage "https://existential.audio/blackhole/"
 
+  # The upstream website doesn't provide version information. We check GitHub
+  # releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/ExistentialAudio/BlackHole"
     strategy :github_latest

--- a/Casks/b/blackhole-2ch.rb
+++ b/Casks/b/blackhole-2ch.rb
@@ -7,6 +7,8 @@ cask "blackhole-2ch" do
   desc "Virtual Audio Driver"
   homepage "https://existential.audio/blackhole/"
 
+  # The upstream website doesn't provide version information. We check GitHub
+  # releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/ExistentialAudio/BlackHole"
     strategy :github_latest

--- a/Casks/b/blackhole-64ch.rb
+++ b/Casks/b/blackhole-64ch.rb
@@ -7,6 +7,8 @@ cask "blackhole-64ch" do
   desc "Virtual Audio Driver"
   homepage "https://existential.audio/blackhole/"
 
+  # The upstream website doesn't provide version information. We check GitHub
+  # releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/ExistentialAudio/BlackHole"
     strategy :github_latest

--- a/Casks/d/drata-agent.rb
+++ b/Casks/d/drata-agent.rb
@@ -7,8 +7,11 @@ cask "drata-agent" do
   desc "Security audit software"
   homepage "https://drata.com/"
 
+  # Upstream doesn't appear to publish any public version information. We check
+  # GitHub releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/drata/drata-agent"
+    strategy :github_latest
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/e/eddie.rb
+++ b/Casks/e/eddie.rb
@@ -20,6 +20,8 @@ cask "eddie" do
   desc "OpenVPN UI"
   homepage "https://eddie.website/"
 
+  # The homepage provides version information but it will frequently timeout.
+  # We check GitHub releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/AirVPN/Eddie"
     strategy :github_latest

--- a/Casks/e/element.rb
+++ b/Casks/e/element.rb
@@ -7,6 +7,8 @@ cask "element" do
   desc "Matrix collaboration client"
   homepage "https://element.io/get-started"
 
+  # The upstream website doesn't appear to provide version information. We check
+  # GitHub releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/vector-im/element-desktop"
     strategy :github_latest

--- a/Casks/e/entry.rb
+++ b/Casks/e/entry.rb
@@ -7,8 +7,12 @@ cask "entry" do
   desc "Block-based coding platform"
   homepage "https://playentry.org/"
 
+  # The download page (https://playentry.org/download/offline) fetches the
+  # version information from https://playentry.org/graphql using a `POST`
+  # request but livecheck can't do that yet. We check GitHub releases as a best
+  # guess of when a new version is released.
   livecheck do
-    url "https://github.com/entrylabs/entry-offline/"
+    url "https://github.com/entrylabs/entry-offline"
     strategy :github_latest
   end
 

--- a/Casks/m/mattermost.rb
+++ b/Casks/m/mattermost.rb
@@ -10,8 +10,9 @@ cask "mattermost" do
   desc "Open-source, self-hosted Slack-alternative"
   homepage "https://mattermost.com/"
 
+  # Upstream publishes file links in the description of GitHub releases.
   livecheck do
-    url "https://github.com/mattermost/desktop/"
+    url "https://github.com/mattermost/desktop"
     strategy :github_latest
   end
 

--- a/Casks/m/megacmd.rb
+++ b/Casks/m/megacmd.rb
@@ -7,9 +7,12 @@ cask "megacmd" do
   desc "Command-line access to MEGA services"
   homepage "https://mega.nz/cmd"
 
+  # The upstream website doesn't appear to provide version information. We check
+  # GitHub tags as a best guess of when a new version is released (upstream
+  # doesn't use GitHub releases).
   livecheck do
     url "https://github.com/meganz/MEGAcmd"
-    regex(/(\d+(?:\.\d+)+)[._-]macOS/i)
+    regex(/^v?(\d+(?:\.\d+)+)[._-]macOS$/i)
   end
 
   app "MEGAcmd.app"

--- a/Casks/r/redisinsight.rb
+++ b/Casks/r/redisinsight.rb
@@ -9,9 +9,12 @@ cask "redisinsight" do
   desc "GUI for streamlined Redis application development"
   homepage "https://redis.com/redis-enterprise/redis-insight/"
 
+  # The first-party site doesn't publish public version information (the page
+  # requires users to submit contact information to download files). We check
+  # GitHub releases as a best guess of when a new version is released.
   livecheck do
-    url "https://github.com/RedisInsight/RedisInsight.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://github.com/RedisInsight/RedisInsight"
+    strategy :github_latest
   end
 
   app "RedisInsight-v#{version.major}.app", target: "RedisInsight.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The casks in this PR have a `livecheck` block that checks GitHub for version information but the cask `url` comes from a different source. Of the GitHub-related checks I've been through recently, these are the only instances where there is a reason for checking a different source (`ibm-cloud-cli` and `lantern` are also exceptions but I've handled them in separate PRs). In these cases, we should make sure to add a comment before the `livecheck` block to explain why we can't check a source that aligns with the cask `url`. This PR adds these comments.

Besides that, this also changes the following:

* Update GitHub URLs in `livecheck` blocks to use simply use the repository URL, without any trailing slash.
* `drata-agent`, `redisinsight`: Use `GithubLatest` to check releases (instead of Git tags).
* `megacmd`: Update the regex to use a more explicit approach