### PR TITLE
dbeaver*: update livecheck

### DIFF
--- a/Casks/d/dbeaver-community.rb
+++ b/Casks/d/dbeaver-community.rb
@@ -11,8 +11,10 @@ cask "dbeaver-community" do
   homepage "https://dbeaver.io/"
 
   livecheck do
-    url "https://github.com/dbeaver/dbeaver"
-    strategy :github_latest
+    url "https://dbeaver.io/product/dbeaver-ce-version.xml"
+    strategy :xml do |xml|
+      xml.get_elements("version/number").first&.text&.strip
+    end
   end
 
   auto_updates true

--- a/Casks/d/dbeaver-enterprise.rb
+++ b/Casks/d/dbeaver-enterprise.rb
@@ -11,8 +11,10 @@ cask "dbeaver-enterprise" do
   homepage "https://dbeaver.com/"
 
   livecheck do
-    url "https://dbeaver.com/product/version.xml"
-    regex(%r{<number[^>]*?>v?(\d+(?:\.\d+)+)</number>}i)
+    url "https://dbeaver.com/product/dbeaver-ee-version.xml"
+    strategy :xml do |xml|
+      xml.get_elements("version/number").first&.text&.strip
+    end
   end
 
   app "DBeaverEE.app"

--- a/Casks/d/dbeaverlite.rb
+++ b/Casks/d/dbeaverlite.rb
@@ -12,7 +12,9 @@ cask "dbeaverlite" do
 
   livecheck do
     url "https://dbeaver.com/product/dbeaver-le-version.xml"
-    regex(%r{<number[^>]*?>v?(\d+(?:\.\d+)+)</number>}i)
+    strategy :xml do |xml|
+      xml.get_elements("version/number").first&.text&.strip
+    end
   end
 
   app "DBeaverLite.app"

--- a/Casks/d/dbeaverultimate.rb
+++ b/Casks/d/dbeaverultimate.rb
@@ -12,7 +12,9 @@ cask "dbeaverultimate" do
 
   livecheck do
     url "https://dbeaver.com/product/dbeaver-ue-version.xml"
-    regex(%r{<number[^>]*?>v?(\d+(?:\.\d+)+)</number>}i)
+    strategy :xml do |xml|
+      xml.get_elements("version/number").first&.text&.strip
+    end
   end
 
   app "DBeaverUltimate.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates the `livecheck` blocks for the various DBeaver casks to improve uniformity and to use the `Xml` strategy (instead of matching XML text with a regex).

The main impetus of this PR is to update the `dbeaver-community` `livecheck` block to check a source that aligns with the cask `url` source (as there's no reason for it to check GitHub versions). While I was at it, I saw the other related casks and figured I would tidy them up.

-----

For what it's worth, the download pages for the various DBeaver flavors ([Community](https://dbeaver.io/download/), [Enterprise](https://dbeaver.com/download/enterprise/), [Lite](https://dbeaver.com/download/lite/), [Ultimate](https://dbeaver.com/download/ultimate/)) all contain a dmg file link that redirects to the latest versioned dmg file. We could technically update these `livecheck` blocks to check the redirecting dmg URLs using the `HeaderMatch` strategy (identifying the version from the filename in the `Location` header URL) but there are two redirections before fetching the final URL, so that's three requests in total. These XML files only involve one request, so that's preferable until we can specify in a `livecheck` block that `HeaderMatch` doesn't need to follow redirections. [That will eventually be a feature but I need to lay some groundwork first.]