### PR TITLE
godot*: update url, livecheck

### DIFF
--- a/Casks/g/godot-mono.rb
+++ b/Casks/g/godot-mono.rb
@@ -2,18 +2,20 @@ cask "godot-mono" do
   version "4.1.3"
   sha256 "5c827410d71b429207d4da836c8ff8b0b59bd06b28856468a092867f3365885a"
 
-  url "https://downloads.tuxfamily.org/godotengine/#{version}/mono/Godot_v#{version}-stable_mono_macos.universal.zip",
-      verified: "downloads.tuxfamily.org/godotengine/"
+  url "https://github.com/godotengine/godot/releases/download/#{version}-stable/Godot_v#{version}-stable_mono_macos.universal.zip",
+      verified: "github.com/godotengine/godot/"
   name "Godot Engine"
   desc "C# scripting capable version of Godot game engine"
   homepage "https://godotengine.org/"
 
   livecheck do
-    url "https://github.com/godotengine/godot"
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)[._-]stable$/i)
+    strategy :github_latest
   end
 
   depends_on cask: "dotnet-sdk"
+  depends_on macos: ">= :sierra"
 
   app "Godot_mono.app"
 

--- a/Casks/g/godot.rb
+++ b/Casks/g/godot.rb
@@ -2,18 +2,20 @@ cask "godot" do
   version "4.1.3"
   sha256 "a6c8e41b7eea4b02c2d27bc2d1e3246189a86081a7ef4cd65443ac01d922e785"
 
-  url "https://downloads.tuxfamily.org/godotengine/#{version}/Godot_v#{version}-stable_macos.universal.zip",
-      verified: "downloads.tuxfamily.org/godotengine/"
+  url "https://github.com/godotengine/godot/releases/download/#{version}-stable/Godot_v#{version}-stable_macos.universal.zip",
+      verified: "github.com/godotengine/godot/"
   name "Godot Engine"
   desc "Game development engine"
   homepage "https://godotengine.org/"
 
   livecheck do
-    url "https://github.com/godotengine/godot"
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)[._-]stable$/i)
+    strategy :github_latest
   end
 
   conflicts_with cask: "homebrew/cask-versions/godot3"
+  depends_on macos: ">= :sierra"
 
   app "Godot.app"
   binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `godot` and `godot-mono` casks have used a downloads.tuxfamily.org artifact URL since the 2.0.3 PR (#21192) but the `livecheck` block identifies versions from the GitHub repository and the [Godot download page](https://godotengine.org/download/macos/) links to GitHub release artifacts. This PR updates the Godot casks to use GitHub release artifacts and updates the `livecheck` blocks to use the `GithubLatest` strategy (which is more appropriate here).

This adds `depends_on macos: ">= :sierra"` to both, to resolve the related audit error.