### PR TITLE
osquery: update url, livecheck

### DIFF
--- a/Casks/o/osquery.rb
+++ b/Casks/o/osquery.rb
@@ -2,13 +2,14 @@ cask "osquery" do
   version "5.10.2"
   sha256 "a01d1f7da016f1e6bed54955e97982d491b7e55311433ff0fc985269160633af"
 
-  url "https://pkg.osquery.io/darwin/osquery-#{version}.pkg"
+  url "https://github.com/osquery/osquery/releases/download/#{version}/osquery-#{version}.pkg",
+      verified: "github.com/osquery/osquery/"
   name "osquery"
   desc "SQL powered operating system instrumentation and analytics"
   homepage "https://osquery.io/"
 
   livecheck do
-    url "https://github.com/osquery/osquery"
+    url :url
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The website for `osquery` (https://osquery.io) is rendered client-side and the version information is found in a 2 MB JavaScript file (~1.73 MB compressed). As such, the `livecheck` block checks the "latest" GitHub release instead.

Since we're already checking GitHub releases for version information and they provide the same pkg file that we're currently using from pkg.osquery.io, this PR simply updates the cask to use the GitHub release asset instead. This aligns the `livecheck` block with the cask `url` source.

-----

If we would prefer to continue using the first-party pkg file, I can rework this PR to simply add an explanatory comment before the `livecheck` block. Of course, the caveat is that there's no guarantee that the first-party pkg file will be available when livecheck surfaces a new version using the GitHub release information.