### PR TITLE
quassel-client: update url, livecheck

### DIFF
--- a/Casks/q/quassel-client.rb
+++ b/Casks/q/quassel-client.rb
@@ -2,15 +2,18 @@ cask "quassel-client" do
   version "0.14.0"
   sha256 "73b1b65f0e75c88d1dd23aa91c1916a6a3c231472a042eca0907689ab0981b60"
 
-  url "https://quassel-irc.org/pub/QuasselClient-macOS-#{version}.dmg"
+  url "https://github.com/quassel/quassel/releases/download/#{version}/QuasselClient-macOS-#{version}.dmg",
+      verified: "github.com/quassel/quassel/"
   name "Quassel IRC"
-  desc "Quassel IRC: Chat comfortably.  Everywhere"
+  desc "Quassel IRC: Chat comfortably. Everywhere"
   homepage "https://quassel-irc.org/"
 
   livecheck do
-    url "https://github.com/quassel/quassel"
+    url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "Quassel Client.app"
 end

--- a/Casks/q/quassel-client.rb
+++ b/Casks/q/quassel-client.rb
@@ -16,4 +16,6 @@ cask "quassel-client" do
   depends_on macos: ">= :high_sierra"
 
   app "Quassel Client.app"
+
+  zap trash: "~/Library/Preferences/org.quassel-irc.client.plist"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates the `quassel-client` cask to use the dmg file from the latest GitHub release instead of quassel-irc.org. The `quassel` cask already does this, so this just brings it in line. This effectively aligns the `livecheck` block with the cask `url` source, as the `livecheck` block was already checking the "latest" GitHub release.

This also adds `depends_on macos: ">= :high_sierra"`, to resolve the related audit.