### PR TITLE
trezor-suite: update url, livecheck

### DIFF
--- a/Casks/t/trezor-suite.rb
+++ b/Casks/t/trezor-suite.rb
@@ -5,17 +5,19 @@ cask "trezor-suite" do
   sha256 arm:   "886e5a47acbe09447bebe8a43628b3b859d55e3c5ee734ed3024eeb877e9ca99",
          intel: "55a16ee64c1f3d111443efc638dffb1788775fe6fd5e1fb9869a301bb860600b"
 
-  url "https://suite.trezor.io/web/static/desktop/Trezor-Suite-#{version}-mac-#{arch}.dmg"
+  url "https://github.com/trezor/trezor-suite/releases/download/v#{version}/Trezor-Suite-#{version}-mac-#{arch}.dmg",
+      verified: "github.com/trezor/trezor-suite/"
   name "TREZOR Suite"
   desc "Companion app for the Trezor hardware wallet"
   homepage "https://suite.trezor.io/"
 
   livecheck do
-    url "https://github.com/trezor/trezor-suite"
+    url :url
     strategy :github_latest
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Trezor Suite.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `trezor-suite` homepage (https://suite.trezor.io/) links to GitHub release assets and the app also uses GitHub releases when updating (this is why the `livecheck` block is using `GithubLatest`). This PR updates the cask to use GitHub release assets instead of files from suite.trezor.io. This effectively aligns the `livecheck` block with the cask `url` source.

This also adds `depends_on macos: ">= :catalina"`, to resolve the related audit error.