### PR TITLE
Remove unsigned apple silicon builds

### DIFF
--- a/Casks/l/lidarr.rb
+++ b/Casks/l/lidarr.rb
@@ -18,4 +18,13 @@ cask "lidarr" do
   app "Lidarr.app"
 
   zap trash: "~/.config/Lidarr/"
+
+  caveats do
+    requires_rosetta
+    <<~EOS
+      The Apple Silicon build for this cask is not functional so the Intel build is
+      required instead.
+        https://github.com/orgs/Homebrew/discussions/3088#discussioncomment-7623916
+    EOS
+  end
 end

--- a/Casks/p/prowlarr.rb
+++ b/Casks/p/prowlarr.rb
@@ -1,11 +1,8 @@
 cask "prowlarr" do
-  arch arm: "arm64", intel: "x64"
-
   version "1.9.4.4039"
-  sha256 arm:   "1824f47e07c0b8f08bedc1592b9fc075b966b14c1f4a6fae85e3c78b9ed4150b",
-         intel: "4ca417871b30c726cd5ad988114f5a6a52c7a5bae4260cce78c5e31f40318837"
+  sha256 "4ca417871b30c726cd5ad988114f5a6a52c7a5bae4260cce78c5e31f40318837"
 
-  url "https://github.com/Prowlarr/Prowlarr/releases/download/v#{version}/Prowlarr.master.#{version}.osx-app-core-#{arch}.zip",
+  url "https://github.com/Prowlarr/Prowlarr/releases/download/v#{version}/Prowlarr.master.#{version}.osx-app-core-x64.zip",
       verified: "github.com/Prowlarr/Prowlarr/"
   name "Prowlarr"
   desc "Indexer manager/proxy for various PVR apps"
@@ -21,4 +18,13 @@ cask "prowlarr" do
   app "Prowlarr.app"
 
   zap trash: "~/.config/Prowlarr"
+
+  caveats do
+    requires_rosetta
+    <<~EOS
+      The Apple Silicon build for this cask is not functional so the Intel build is
+      required instead.
+        https://github.com/orgs/Homebrew/discussions/3088#discussioncomment-7623916
+    EOS
+  end
 end

--- a/Casks/r/radarr.rb
+++ b/Casks/r/radarr.rb
@@ -1,11 +1,8 @@
 cask "radarr" do
-  arch arm: "arm64", intel: "x64"
-
   version "5.1.3.8246"
-  sha256 arm:   "cc6a103f2128f5e588b8f7ef248f8326226a2d6f70deaa5a64b5c1b30c2b28d2",
-         intel: "0ce43a4792c27a4dd76bdf1538100832d6a027b93acd14c08de9827ef879b094"
+  sha256 "0ce43a4792c27a4dd76bdf1538100832d6a027b93acd14c08de9827ef879b094"
 
-  url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.master.#{version}.osx-app-core-#{arch}.zip",
+  url "https://github.com/Radarr/Radarr/releases/download/v#{version}/Radarr.master.#{version}.osx-app-core-x64.zip",
       verified: "github.com/Radarr/Radarr/"
   name "Radarr"
   desc "Fork of Sonarr to work with movies à la Couchpotato"
@@ -22,4 +19,13 @@ cask "radarr" do
   app "Radarr.app"
 
   zap trash: "~/.config/Radarr"
+
+  caveats do
+    requires_rosetta
+    <<~EOS
+      The Apple Silicon build for this cask is not functional so the Intel build is
+      required instead.
+        https://github.com/orgs/Homebrew/discussions/3088#discussioncomment-7623916
+    EOS
+  end
 end

--- a/Casks/s/sonarr.rb
+++ b/Casks/s/sonarr.rb
@@ -17,4 +17,8 @@ cask "sonarr" do
   app "Sonarr.app"
 
   zap trash: "~/.config/Sonarr"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

The Apple Silicon builds for these apps are not functional so only the Intel build should be used.

Context: https://github.com/orgs/Homebrew/discussions/3088#discussioncomment-7623916