### PR TITLE
Update some livecheck blocks to align with cask url source

### DIFF
--- a/Casks/b/bitcoin-core.rb
+++ b/Casks/b/bitcoin-core.rb
@@ -11,8 +11,8 @@ cask "bitcoin-core" do
   homepage "https://bitcoincore.org/"
 
   livecheck do
-    url "https://github.com/bitcoin/bitcoin"
-    strategy :github_latest
+    url "https://bitcoincore.org/en/download/"
+    regex(/href=.*?bitcoin[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}[^"' >]*?\.dmg/i)
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -44,8 +44,8 @@ cask "calibre" do
     sha256 "884061bce0df80085b4a9ce60da1f63530040f615804eb8cf499718a2e314a8e"
 
     livecheck do
-      url "https://github.com/kovidgoyal/calibre"
-      strategy :github_latest
+      url "https://calibre-ebook.com/dist/osx"
+      strategy :header_match
     end
   end
 

--- a/Casks/l/litecoin.rb
+++ b/Casks/l/litecoin.rb
@@ -8,8 +8,8 @@ cask "litecoin" do
   homepage "https://litecoin.org/"
 
   livecheck do
-    url "https://github.com/litecoin-project/litecoin"
-    strategy :github_latest
+    url :homepage
+    regex(/href=.*?litecoin[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg/i)
   end
 
   app "Litecoin-Qt.app"

--- a/Casks/m/mudlet.rb
+++ b/Casks/m/mudlet.rb
@@ -8,7 +8,8 @@ cask "mudlet" do
   homepage "https://www.mudlet.org/"
 
   livecheck do
-    url "https://github.com/Mudlet/Mudlet"
+    url "https://www.mudlet.org/download/"
+    regex(/href=.*?Mudlet[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/n/nwjs.rb
+++ b/Casks/n/nwjs.rb
@@ -10,9 +10,17 @@ cask "nwjs" do
   desc "Call all Node.js modules directly from the DOM and Web Workers"
   homepage "https://nwjs.io/"
 
+  # The upstream download page appends a UNIX epoch timestamp (in milliseconds)
+  # to the JSON URL, so we do the same (in case it affects the returned data).
   livecheck do
-    url "https://github.com/nwjs/nw.js"
-    regex(/^nw[._-]v?(\d+(?:\.\d+)+)$/i)
+    url "https://nwjs.io/versions.json?#{DateTime.now.strftime("%Q")}"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      match = json["stable"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
   end
 
   app "nwjs-sdk-v#{version}-osx-#{arch}/nwjs.app"

--- a/Casks/q/qlc-plus.rb
+++ b/Casks/q/qlc-plus.rb
@@ -8,8 +8,8 @@ cask "qlc-plus" do
   homepage "https://qlcplus.org/"
 
   livecheck do
-    url "https://github.com/mcallegari/qlcplus"
-    regex(/^QLC\+[._-]v?(\d+(?:\.\d+)+)$/i)
+    url "https://qlcplus.org/download"
+    regex(/href=.*?QLC\+[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "QLC+.app"

--- a/Casks/t/tigervnc-viewer.rb
+++ b/Casks/t/tigervnc-viewer.rb
@@ -9,8 +9,8 @@ cask "tigervnc-viewer" do
   homepage "https://tigervnc.org/"
 
   livecheck do
-    url "https://github.com/TigerVNC/tigervnc"
-    strategy :github_latest
+    url "https://sourceforge.net/projects/tigervnc/rss?path=/stable"
+    regex(%r{url=.*?/TigerVNC[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   app "TigerVNC Viewer #{version}.app"

--- a/Casks/t/todour.rb
+++ b/Casks/t/todour.rb
@@ -8,8 +8,8 @@ cask "todour" do
   homepage "https://nerdur.com/todour-pl/"
 
   livecheck do
-    url "https://github.com/SverrirValgeirsson/Todour"
-    strategy :github_latest
+    url :homepage
+    regex(/href=.*?Todour[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "Todour.app"

--- a/Casks/v/vagrant.rb
+++ b/Casks/v/vagrant.rb
@@ -12,8 +12,8 @@ cask "vagrant" do
   homepage "https://www.vagrantup.com/"
 
   livecheck do
-    url "https://github.com/hashicorp/vagrant"
-    strategy :github_latest
+    url "https://developer.hashicorp.com/vagrant/install"
+    regex(/href=[^ >]*?vagrant[._-]v?(\d+(?:\.\d+)+)(?:[._-]darwin)?(?:[._-]#{arch})?\.dmg/i)
   end
 
   pkg "vagrant.pkg"

--- a/Casks/z/zerotier-one.rb
+++ b/Casks/z/zerotier-one.rb
@@ -5,11 +5,11 @@ cask "zerotier-one" do
   url "https://download.zerotier.com/RELEASES/#{version}/dist/ZeroTier%20One.pkg"
   name "ZeroTier One"
   desc "Mesh VPN client"
-  homepage "https://www.zerotier.com/download.shtml"
+  homepage "https://www.zerotier.com/"
 
   livecheck do
-    url "https://github.com/zerotier/ZeroTierOne"
-    strategy :github_latest
+    url "https://www.zerotier.com/download/"
+    regex(/Latest\s+Version[\s:|]+?v?(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR involves casks where the `livecheck` block checks GitHub tags/releases but the cask doesn't use an artifact from GitHub. These are casks where it's possible to obtain version information from the same source as the cask `url`, so these shouldn't be checking GitHub.

[For context, these particular checks were added years ago and there isn't any specific reason why they're checking GitHub instead of the cask `url` source (some of them are a holdover from the previous `appcast` URL in casks). At the time, `livecheck` blocks were being added as quickly as possible without any review (after cask support was added) and a lot of those checks weren't ideal.]

This PR updates these `livecheck` blocks to check a source that aligns with the cask `url`:

* bitcoin-core: Check the first-party download page, which links to the cask `url`.
* calibre: Check the macOS file link from the [download page](https://calibre-ebook.com/download_osx), which redirects to the latest dmg file (i.e., the cask `url`).
* litecoin: Check the homepage, which links to the cask `url`.
* mudlet: Check the first-party download page, which links to [a versioned dmg URL that redirects to] the cask `url`.
* nwjs: Check the `versions.json` file that's used to create the links on the [downloads page](https://nwjs.io/downloads/), one of which is the cask `url`.
* qlc-plus: Check the first-party download page, which links to the cask `url`.
* tigervnc-viewer: Use the `Sourceforge` strategy (checking the `/stable` directory), which aligns with the cask `url` source.
* todour: Check the homepage, which links to the cask `url`.
* vagrant: Check the first-party "Install" page, which links to the cask `url`.
* zerotier-one: Check the first-party download page, which lists the latest version ("Latest Version | 1.12.2") but links to an unversioned dmg file. [The versioned files are found at https://download.zerotier.com/RELEASES/ but a version directory may be created before the release is made public, so it's better to check the download page.]