### PR TITLE
Update some livecheck blocks to check GitHub README file

### DIFF
--- a/Casks/i/itunes-volume-control.rb
+++ b/Casks/i/itunes-volume-control.rb
@@ -1,6 +1,6 @@
 cask "itunes-volume-control" do
   version "1.7.5"
-  sha256 "606b6341d14a0c5833dba70d25e2afe5709e4d860bb4b3c1f23d0fdded1b7ee2"
+  sha256 "0d4d22476e3a1b4891e335d86eb28c46fe663bd6d3226d3a8d0ad5d6a5de76d9"
 
   url "https://raw.githubusercontent.com/alberti42/Volume-Control/main/Releases/VolumeControl-v#{version}.zip",
       verified: "raw.githubusercontent.com/alberti42/Volume-Control/main/Releases/"

--- a/Casks/i/itunes-volume-control.rb
+++ b/Casks/i/itunes-volume-control.rb
@@ -8,10 +8,11 @@ cask "itunes-volume-control" do
   desc "Control the volume of Apple Music and Spotify using keyboard volume keys"
   homepage "https://github.com/alberti42/Volume-Control"
 
+  # Upstream doesn't use GitHub releases or reliably create tags for new
+  # versions. Instead, we match the file links in the README.
   livecheck do
-    url "https://github.com/alberti42/Volume-Control#versions"
-    regex(%r{href=.*?/VolumeControl[._-]v?(\d+(?:\.\d+)+)\.zip}i)
-    strategy :page_match
+    url "https://raw.githubusercontent.com/alberti42/Volume-Control/main/README.md"
+    regex(/VolumeControl[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   auto_updates true

--- a/Casks/m/mtgaprotracker.rb
+++ b/Casks/m/mtgaprotracker.rb
@@ -8,10 +8,12 @@ cask "mtgaprotracker" do
   desc "Advanced Magic: The Gathering Arena tracking tool"
   homepage "https://mtgarena.pro/mtga-pro-tracker/"
 
+  # GitHub releases don't regularly provide a file for macOS. We check the link
+  # to the latest Mac version from the README, as it's unlikely for there to be
+  # a release with a macOS file in the recent releases.
   livecheck do
-    url "https://github.com/Razviar/mtgap/"
-    regex(/Mac\sversion.*?(\d+(?:\.\d+)+)/i)
-    strategy :page_match
+    url "https://raw.githubusercontent.com/Razviar/mtgap/master/README.md"
+    regex(/Mac(?:OS)?\s+version.*?v?(\d+(?:\.\d+)+)/i)
   end
 
   app "mtgaprotracker.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The `livecheck` blocks for `itunes-volume-control` and `mtgaprotracker` check the main page their respective GitHub repositories and match within the `README` content. These pages are ~50 KB each (after compression) but the raw `README.md` files are only 5 KB and 2 KB respectively.

This PR updates the `livecheck` blocks to check the raw `README.md` files, as it achieves the same goal while minimizing data transfer and reducing the content for `PageMatch` to sift through.