### PR TITLE
Add cask `timemachinestatus`

### DIFF
--- a/Casks/t/timemachinestatus.rb
+++ b/Casks/t/timemachinestatus.rb
@@ -1,0 +1,27 @@
+cask "timemachinestatus" do
+  version "0.0.7"
+  sha256 "5d1efca1e780b11eaa9ec02b26b150ef28f6c9d5a82137ceb04a28adb91a134f"
+
+  url "https://github.com/lukepistrol/TimeMachineStatus/releases/download/#{version}/TimeMachineStatus.dmg"
+  name "TimeMachineStatus"
+  desc "Little menu bar app to show more info about Time Machine than the system default"
+  homepage "https://github.com/lukepistrol/TimeMachineStatus"
+
+  livecheck do
+    url "https://github.com/lukepistrol/TimeMachineStatus/releases/latest/download/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "TimeMachineStatus.app"
+
+  uninstall launchctl: "com.lukepistrol.TimeMachineStatusHelper"
+
+  zap trash:  [
+        "~/Library/Application Scripts/com.lukepistrol.TimeMachineStatus*",
+      ],
+      delete: [
+        "~/Library/Preferences/com.lukepistrol.TimeMachineStatus*.plist",
+      ]
+end

--- a/Casks/t/timemachinestatus.rb
+++ b/Casks/t/timemachinestatus.rb
@@ -4,7 +4,7 @@ cask "timemachinestatus" do
 
   url "https://github.com/lukepistrol/TimeMachineStatus/releases/download/#{version}/TimeMachineStatus.dmg"
   name "TimeMachineStatus"
-  desc "Little menu bar app to show more info about Time Machine than the system default"
+  desc "Menu bar app to show Time Machine information"
   homepage "https://github.com/lukepistrol/TimeMachineStatus"
 
   livecheck do
@@ -12,16 +12,15 @@ cask "timemachinestatus" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: ">= :sonoma"
 
   app "TimeMachineStatus.app"
 
   uninstall launchctl: "com.lukepistrol.TimeMachineStatusHelper"
 
-  zap trash:  [
-        "~/Library/Application Scripts/com.lukepistrol.TimeMachineStatus*",
-      ],
-      delete: [
-        "~/Library/Preferences/com.lukepistrol.TimeMachineStatus*.plist",
-      ]
+  zap trash: [
+    "~/Library/Application Scripts/com.lukepistrol.TimeMachineStatus*",
+    "~/Library/Preferences/com.lukepistrol.TimeMachineStatus*.plist",
+  ]
 end


### PR DESCRIPTION
Adds `timemachinestatus` cask for [TimeMachineStatus](https://github.com/lukepistrol/TimeMachineStatus) project.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
