### PR TITLE
abricotine: mark `discontinued`

### DIFF
--- a/Casks/a/abricotine.rb
+++ b/Casks/a/abricotine.rb
@@ -2,11 +2,10 @@ cask "abricotine" do
   version "1.1.4"
   sha256 "3831f239b5e52374addac1740abb3d4e4a47b91771f5bd21a91adf7a103ca9de"
 
-  url "https://github.com/brrd/Abricotine/releases/download/v#{version}/Abricotine-#{version}-mac.zip",
-      verified: "github.com/brrd/Abricotine/"
+  url "https://github.com/brrd/Abricotine/releases/download/v#{version}/Abricotine-#{version}-mac.zip"
   name "abricotine"
   desc "Markdown editor with inline preview"
-  homepage "https://abricotine.brrd.fr/"
+  homepage "https://github.com/brrd/abricotine"
 
   app "Abricotine.app"
 

--- a/Casks/a/abricotine.rb
+++ b/Casks/a/abricotine.rb
@@ -14,4 +14,8 @@ cask "abricotine" do
     "~/Library/Application Support/Abricotine",
     "~/Library/Preferences/com.electron.abricotine.plist",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
Repository is archived as of August 30, 2023, with a note the software is discontinued in the `README.md`

https://github.com/brrd/abricotine/blob/c0afd7a01c2d49582a4fd4a33fd21f7162c4af17/README.md

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
