### PR TITLE
google-chrome: update `depends_on`

### DIFF
--- a/Casks/g/google-chrome.rb
+++ b/Casks/g/google-chrome.rb
@@ -15,7 +15,7 @@ cask "google-chrome" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "Google Chrome.app"
 


### PR DESCRIPTION
```
audit for google-chrome: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined :high_sierra
Error: 1 problem in 1 cask detected.
```