### PR TITLE
mathpix-snipping-tool: update `depends_on`

### DIFF
--- a/Casks/m/mathpix-snipping-tool.rb
+++ b/Casks/m/mathpix-snipping-tool.rb
@@ -15,7 +15,7 @@ cask "mathpix-snipping-tool" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "Mathpix Snipping Tool.app"
 


### PR DESCRIPTION
```
audit for mathpix-snipping-tool: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined :sierra
Error: 1 problem in 1 cask detected.
```