### PR TITLE
mattermost: fix/flip erraneously enabled auto_updates togggle

### DIFF
--- a/Casks/m/mattermost.rb
+++ b/Casks/m/mattermost.rb
@@ -16,7 +16,6 @@ cask "mattermost" do
     strategy :github_latest
   end
 
-  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Mattermost.app"


### PR DESCRIPTION
With #144493 (updated and enabled by #144502) the `auto_updates` toggle was introduced to the Mattermost Cask, however, Mattermost does not offer automatic updates for the desktop application for macOS for the stand-alone app bundle per their official documentation ( https://docs.mattermost.com/collaborate/install-desktop-app.html ).

Because apparently the `auto_updates` setting was introduced during an automated bump I opted to keep but disable it instead of removing it. This way it's hopefully a clearer decision why it may get re-enabled in the future.

Pertinent quote from the Mattermost documentation:

> Download the Desktop App from GitHub
> You can [download the desktop app directly from our GitHub release page](https://github.com/mattermost/desktop/releases). However, when you install the desktop app this way, you can’t manually check for updates, and updates won’t be installed automatically.

Downloading the bundle from the provided release page (as defined in the Cask) is, to the best of my knowledge and local test, functionally equivalent to downloading the GitHub release.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
