### PR TITLE
ibm-cloud-cli: update `pkg` stanza to include `arch`

### DIFF
--- a/Casks/i/ibm-cloud-cli.rb
+++ b/Casks/i/ibm-cloud-cli.rb
@@ -22,7 +22,7 @@ cask "ibm-cloud-cli" do
     end
   end
 
-  pkg "IBM_Cloud_CLI_#{version}.pkg"
+  pkg "IBM_Cloud_CLI_#{version}#{arch}.pkg"
 
   uninstall pkgutil: "com.ibm.cloud.cli",
             delete:  [


### PR DESCRIPTION
Follow on to #160606, as it looks like the `arch` is included in the `pkg` name for install.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
