### PR TITLE
xattred: update `depends_on`

### DIFF
--- a/Casks/x/xattred.rb
+++ b/Casks/x/xattred.rb
@@ -18,7 +18,7 @@ cask "xattred" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "xattred#{version.csv.first.major}#{version.csv.first.minor}/xattred.app"
 


### PR DESCRIPTION
```
audit for xattred: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined :el_capitan
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
