### PR TITLE
x-swiftformat: update `depends_on`

### DIFF
--- a/Casks/x/x-swiftformat.rb
+++ b/Casks/x/x-swiftformat.rb
@@ -7,7 +7,7 @@ cask "x-swiftformat" do
   desc "Xcode extension to format Swift code"
   homepage "https://github.com/ruiaureliano/X-SwiftFormat"
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :ventura"
 
   app "X-SwiftFormat.app"
 


### PR DESCRIPTION
```
audit for x-swiftformat: failed
 - Upstream defined :ventura as the minimum OS version and the cask defined :catalina
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
