### PR TITLE
propresenter: update livecheck, depends_on

### DIFF
--- a/Casks/p/propresenter.rb
+++ b/Casks/p/propresenter.rb
@@ -5,14 +5,16 @@ cask "propresenter" do
 
     livecheck do
       url "https://api.renewedvision.com/v1/pro/upgrade?platform=macos&osVersion=11.0&appVersion=0&buildNumber=0&includeNotes=0"
-      regex(%r{/ProPresenter[._-]v?(\d+(?:\.\d+)+)_(\d+)\.zip}i)
-      strategy :page_match do |page, regex|
-        match = page.match(regex)
-        next if match.blank?
+      strategy :json do |json|
+        json["upgrades"]&.map do |item|
+          next if item["version"].blank? || item["buildNumber"].blank?
 
-        "#{match[1]},#{match[2]}"
+          "#{item["version"]},#{item["buildNumber"]}"
+        end
       end
     end
+
+    depends_on macos: ">= :big_sur"
   end
   on_monterey :or_newer do
     version "7.15,118423570"
@@ -20,24 +22,25 @@ cask "propresenter" do
 
     livecheck do
       url "https://api.renewedvision.com/v1/pro/upgrade?platform=macos&osVersion=#{MacOS.full_version}&appVersion=0&buildNumber=0&includeNotes=0"
-      regex(%r{/ProPresenter[._-]v?(\d+(?:\.\d+)+)_(\d+)\.zip}i)
-      strategy :page_match do |page, regex|
-        match = page.match(regex)
-        next if match.blank?
+      strategy :json do |json|
+        json["upgrades"]&.map do |item|
+          next if item["version"].blank? || item["buildNumber"].blank?
 
-        "#{match[1]},#{match[2]}"
+          "#{item["version"]},#{item["buildNumber"]}"
+        end
       end
     end
+
+    depends_on macos: ">= :monterey"
   end
 
   url "https://renewedvision.com/downloads/propresenter/mac/ProPresenter_#{version.csv.first}_#{version.csv.second}.zip"
   name "ProPresenter"
   desc "Presentation and production application for live events"
-  homepage "https://www.renewedvision.com/propresenter.php"
+  homepage "https://renewedvision.com/propresenter/"
 
   auto_updates true
   conflicts_with cask: "homebrew/cask-versions/propresenter-beta"
-  depends_on macos: ">= :mojave"
 
   app "ProPresenter.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

We're updating the `livecheck` blocks and macOS dependencies for `propresenter-beta` in https://github.com/Homebrew/homebrew-cask-versions/pull/18450, so this PR brings the stable `propresenter` cask in line. Namely, this:

* Brings the macOS dependency up to date and moves it into the respective blocks
* Updates the `livecheck` blocks to use the `Json` strategy, since this is a JSON response and it's pretty straightforward to collect the version information in the cask version format.
* Updates the `homepage`, as the existing URL is redirecting to https://renewedvision.com/propresenter/