### PR TITLE
eclipse-ide: update livecheck

### DIFF
--- a/Casks/e/eclipse-ide.rb
+++ b/Casks/e/eclipse-ide.rb
@@ -12,13 +12,18 @@ cask "eclipse-ide" do
 
   livecheck do
     url "https://www.eclipse.org/downloads/packages/"
-    regex(/Eclipse IDE (\d+-\d+) R Packages/i)
+    regex(/href=.*?eclipse-committers-(\d+-\d+)-R-mac/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map do |release|
-        version_page = Homebrew::Livecheck::Strategy.page_content("https://projects.eclipse.org/releases/#{release[0]}")[:content]
-        version = version_page.scan(%r{href="/projects/technology\.packaging/releases/(\d+(?:\.\d+)*)"}i)
-        "#{version[0][0]},#{release[0]}"
-      end
+      date = page[regex, 1]
+      next if date.blank?
+
+      version_page = Homebrew::Livecheck::Strategy.page_content("https://projects.eclipse.org/releases/#{date}")[:content]
+      next if version_page.blank?
+
+      version = version_page[%r{href=["']?/projects/technology\.packaging/releases/v?(\d+(?:\.\d+)+)/?["']?}i, 1]
+      next if version.blank?
+
+      "#{version},#{date}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `eclipse-ide` contains a `strategy` block that calls `Strategy#page_content` in a loop. This only involves one iteration at the moment but could potentially loop more than once.

This PR reworks the `strategy` block to only call `#page_content` a maximum of one time. `page.scan(regex).map` is generally preferred but the download page only lists one version, so only using the first match here is simpler than collecting all matches and identifying the highest version (like the `bash` formula).