### PR TITLE
beaker-browser: discontinued

### DIFF
--- a/Casks/b/beaker-browser.rb
+++ b/Casks/b/beaker-browser.rb
@@ -21,4 +21,8 @@ cask "beaker-browser" do
     "~/Library/Preferences/com.pfrazee.beaker-browser.plist",
     "~/Library/Saved Application State/com.pfrazee.beaker-browser.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `beaker-browser`](https://github.com/beakerbrowser/beaker) was archived on 2022-12-27. The homepage (beakerbrowser.com) now redirects to [`archive-notice.md` in the GitHub repository](https://github.com/beakerbrowser/beaker/blob/master/archive-notice.md), which explains that development has ended and the project is archived. This PR sets the cask as discontinued.