### PR TITLE
bloomrpc: discontinued

### DIFF
--- a/Casks/b/bloomrpc.rb
+++ b/Casks/b/bloomrpc.rb
@@ -10,4 +10,8 @@ cask "bloomrpc" do
   app "BloomRPC.app"
 
   zap trash: "~/Library/Preferences/io.github.utilitywarehouse.BloomRPC.plist"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `bloomrpc`](https://github.com/bloomrpc/bloomrpc) was archived on 2023-01-04 and the `README` states:

> ## This project was archived in Jan 2023. Its usage is no longer recommended.
>
> ## Why was this project archived?
>
> When BloomRPC was first released in Dec 2018, there were very few GUI gRPC tools available, hence the project tagline: "The missing GUI client for gRPC services". It was a good tool for a few years. Unfortunately, the project stalled in development and issues piled up, leaving users frustrated when things weren't working. We no longer felt that BloomRPC offered a good experience, so we decided to archive it.

This PR sets the cask as discontinued.