### PR TITLE
bootxchanger: discontinued

### DIFF
--- a/Casks/b/bootxchanger.rb
+++ b/Casks/b/bootxchanger.rb
@@ -9,4 +9,8 @@ cask "bootxchanger" do
   homepage "https://namedfork.net/bootxchanger/"
 
   app "BootXChanger.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `bootxchanger`](https://github.com/zydeco/bootxchanger) was archived on 2023-05-15 and the code hasn't been updated since 2010-05-20 (outside of adding a `README` file in 2016). This PR sets the cask as discontinued.

I can't even open the app on my machine (macOS 14, M1 Pro) to create a zap, so that's definitely not a good indicator 😆