### PR TITLE
classroom-assistant: discontinued

### DIFF
--- a/Casks/c/classroom-assistant.rb
+++ b/Casks/c/classroom-assistant.rb
@@ -9,6 +9,17 @@ cask "classroom-assistant" do
 
   app "Classroom Assistant.app"
 
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.classroom-assistant.sfl3",
+    "~/Library/Application Support/Classroom Assistant",
+    "~/Library/Caches/com.electron.classroom-assistant",
+    "~/Library/Caches/com.electron.classroom-assistant.ShipIt",
+    "~/Library/HTTPStorages/com.electron.classroom-assistant",
+    "~/Library/Logs/Classroom Assistant",
+    "~/Library/Preferences/com.electron.classroom-assistant.plist",
+    "~/Library/Saved Application State/com.electron.classroom-assistant.savedState",
+  ]
+
   caveats do
     discontinued
   end

--- a/Casks/c/classroom-assistant.rb
+++ b/Casks/c/classroom-assistant.rb
@@ -7,10 +7,9 @@ cask "classroom-assistant" do
   desc "Tool to clone student repositories in bulk"
   homepage "https://classroom.github.com/assistant"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   app "Classroom Assistant.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `classroom-assistant`](https://github.com/education/classroom-assistant) was archived on 2023-07-14. The `README` states:

> # Deprecated
>
> Classroom Assistant has been deprecated in favor of the `clone student-repos` subcommand of the [GitHub Classroom CLI extension for the GitHub CLI](https://docs.github.com/en/education/manage-coursework-with-github-classroom/teach-with-github-classroom/using-github-classroom-with-github-cli). Classroom Assistant will no longer receive feature or security updates. The backend API's that it rely on may be deactivated in the future. We recommend that you install the GitHub Classroom CLI extension!

This PR sets the cask as discontinued and removes the `livecheck` block, so it will be automatically skipped.