### PR TITLE
code-notes: discontinued

### DIFF
--- a/Casks/c/code-notes.rb
+++ b/Casks/c/code-notes.rb
@@ -5,7 +5,12 @@ cask "code-notes" do
   url "https://github.com/lauthieb/code-notes/releases/download/#{version}/code-notes-#{version}.dmg",
       verified: "github.com/lauthieb/code-notes/"
   name "Code Notes"
+  desc "Code snippet manager"
   homepage "https://lauthieb.github.io/code-notes/"
 
   app "Code Notes.app"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `code-notes`](https://github.com/lauthieb/code-notes) was archived on 2023-09-13. The `README` states:

> [!IMPORTANT]
> I created this project a few years ago when I was still a student. It allowed me to explore exciting technologies like [Electron](https://www.electronjs.org/fr/), [Bulma](https://bulma.io/), and [Vue](https://vuejs.org/).   
> I'm pleased to see that it has gained a substantial user base over time. However, due to my current commitments, I no longer have the time to maintain it. As a result, I am open to the possibility of someone else taking over the project by creating a fork.   
> Please note that this project is no longer maintained by me. Thank you very much for your understanding and for contributing to its growth. ❤️

It may also be worth mentioning that the app isn't signed.

That said, this PR sets the cask as discontinued.