### PR TITLE
Create neardrop.rb

### DIFF
--- a/Casks/n/neardrop.rb
+++ b/Casks/n/neardrop.rb
@@ -1,0 +1,26 @@
+cask "neardrop" do
+  version "2.0.2"
+  sha256 "b270f084d2a25d3c3f7302112739898dbf6e1fd48b4b560d3f80b04c482f95a8"
+
+  url "https://github.com/grishka/NearDrop/releases/download/v2.0.2/NearDrop.app.zip"
+  
+  name "NearDrop"
+  desc "NearDrop is a partial implementation of Google's Nearby Share for macOS"
+  homepage "https://github.com/grishka/NearDrop"
+
+  livecheck do
+    url "https://github.com/grishka/NearDrop/releases/download/v2.0.2/NearDrop.app.zip"
+    strategy :header_match do |headers|
+      headers["location"][%r{/(\d+)/NearDrop.app\.zip}i, 1]
+    end
+  end
+
+  app "NearDrop.app"
+
+  zap trash: [
+        "~/Library/Application Scripts/me.grishka.NearDrop.ShareExtension",
+        "~/Library/Application Scripts/me.grishka.NearDrop",
+        "~/Library/Containers/me.grishka.NearDrop.ShareExtension",
+        "~/Library/Containers/me.grishka.NearDrop",
+      ]
+end


### PR DESCRIPTION
NearDrop allow macOS user to use the NearBy Share protocol to exchange files with Android devices, very much like AirDrop

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [X] `brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
