### PR TITLE
c0re100-qbittorrent: update `depends_on`

### DIFF
--- a/Casks/c/c0re100-qbittorrent.rb
+++ b/Casks/c/c0re100-qbittorrent.rb
@@ -13,7 +13,7 @@ cask "c0re100-qbittorrent" do
   end
 
   conflicts_with cask: "qbittorrent"
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :mojave"
 
   app "qbittorrent.app"
 


### PR DESCRIPTION
```
audit for c0re100-qbittorrent: failed
 - Upstream defined :mojave as the minimum OS version and the cask defined :sierra
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.