### PR TITLE
camo-studio: update `depends_on`

### DIFF
--- a/Casks/c/camo-studio.rb
+++ b/Casks/c/camo-studio.rb
@@ -13,7 +13,7 @@ cask "camo-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "Camo Studio.app"
 


### PR DESCRIPTION
```
audit for camo-studio: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined :high_sierra
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
