### PR TITLE
camtasia: update `depends_on`

### DIFF
--- a/Casks/c/camtasia.rb
+++ b/Casks/c/camtasia.rb
@@ -13,7 +13,7 @@ cask "camtasia" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :big_sur"
 
   app "Camtasia #{version.major}.app"
 


### PR DESCRIPTION
```
audit for camtasia: failed
 - Upstream defined :big_sur as the minimum OS version and the cask defined :mojave
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
