### PR TITLE
cd-to: update `depends_on`

### DIFF
--- a/Casks/c/cd-to.rb
+++ b/Casks/c/cd-to.rb
@@ -6,6 +6,8 @@ cask "cd-to" do
     livecheck do
       skip "Legacy version"
     end
+
+    depends_on macos: ">= :mojave"
   end
   on_monterey :or_newer do
     version "3.1.3"
@@ -15,14 +17,14 @@ cask "cd-to" do
       url :url
       strategy :github_latest
     end
+
+    depends_on macos: ">= :monterey"
   end
 
   url "https://github.com/jbtule/cdto/releases/download/v#{version}/cdto_#{version.dots_to_underscores}.zip"
   name "cd to"
   desc "Finder Toolbar app to open the current directory in the Terminal"
   homepage "https://github.com/jbtule/cdto"
-
-  depends_on macos: ">= :mojave"
 
   app "cd to.app"
 


### PR DESCRIPTION
```
audit for cd-to: failed
 - Upstream defined :monterey as the minimum OS version and the cask defined :mojave
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.