### PR TITLE
camunda-modeler: update `depends_on`

### DIFF
--- a/Casks/c/camunda-modeler.rb
+++ b/Casks/c/camunda-modeler.rb
@@ -12,7 +12,7 @@ cask "camunda-modeler" do
     regex(%r{href=.*?/camunda[._-]?modeler[._-]?v?(\d+(?:\.\d+)+)[._-]?mac\.zip}i)
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "Camunda Modeler.app"
 


### PR DESCRIPTION
```
audit for camunda-modeler: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined :high_sierra
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.