### PR TITLE
dynamic-dark-mode: discontinued

### DIFF
--- a/Casks/d/dynamic-dark-mode.rb
+++ b/Casks/d/dynamic-dark-mode.rb
@@ -13,4 +13,8 @@ cask "dynamic-dark-mode" do
   app "Dynamic Dark Mode.app"
 
   zap trash: "~/Library/Application Scripts/io.github.apollozhu.Dynamic.Launcher"
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `dynamic-dark-mode`](https://github.com/ApolloZhu/Dynamic-Dark-Mode) was archived on 2023-06-26. The most recent release (1.5.2) was on 2019-09-23 and there's been a bit of activity since then (21 commits) but no subsequent release. No explanation was added anywhere that I can see (homepage, `README`, etc.) but archiving the repository presumably means that the project is no longer developed. This PR sets the cask as discontinued.