### PR TITLE
electron-api-demos: discontinued

### DIFF
--- a/Casks/e/electron-api-demos.rb
+++ b/Casks/e/electron-api-demos.rb
@@ -17,4 +17,8 @@ cask "electron-api-demos" do
     "~/Library/Preferences/com.electron.electron-api-demos.plist",
     "~/Library/Saved Application State/com.electron.electron-api-demos.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `electron-api-demos`](https://github.com/electron/electron-api-demos) was archived on 2022-12-05. The most recent release (2.0.2) was on 2019-01-07 and upstream was mostly updating dependencies until 2022-10-17 but there wasn't a subsequent release. No explanation was added to the `README` but archiving the repository presumably means that the Electron folks aren't maintaining these demos anymore. This PR sets the cask as discontinued.