### PR TITLE
black-ink 2.2.8 update sha256

### DIFF
--- a/Casks/b/black-ink.rb
+++ b/Casks/b/black-ink.rb
@@ -1,6 +1,6 @@
 cask "black-ink" do
   version "2.2.8"
-  sha256 "45c971e5675841332b2ce7a01a7b7937dc5a6e8a79ab4cf1dfe27a2124186538"
+  sha256 "bfa2465badbd22bf0f08b87136c992a9259fd2fa05b9482df27674c3ab1df19f"
 
   url "https://redsweater.com/blackink/BlackInk#{version}.zip"
   name "Black Ink"


### PR DESCRIPTION
Version has stayed the same but there is a new sha256 for the download.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
