### PR TITLE
dwarf-fortress: discontinued

### DIFF
--- a/Casks/d/dwarf-fortress.rb
+++ b/Casks/d/dwarf-fortress.rb
@@ -7,16 +7,6 @@ cask "dwarf-fortress" do
   desc "Single-player fantasy game"
   homepage "https://www.bay12games.com/dwarves/"
 
-  livecheck do
-    url "https://www.bay12games.com/dwarves/older_versions.html"
-    strategy :page_match do |page|
-      match = page.match(/href="df[._-]v?(\d+(?:_\d+)+)[._-]osx\.t/i)
-      next if match.blank?
-
-      "0.#{match[1].tr("_", ".")}"
-    end
-  end
-
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/df_osx/df.wrapper.sh"
   binary shimscript, target: "dwarf-fortress"
@@ -35,6 +25,8 @@ cask "dwarf-fortress" do
   end
 
   caveats <<~EOS
+    discontinued
+
     During uninstall, your save data will be copied to /tmp/dwarf-fortress-save
   EOS
 end


### PR DESCRIPTION
no macos releases since 0.47.05 in the past three years, mark the cask discontinued

![image](https://github.com/Homebrew/homebrew-cask/assets/1580956/44e128a0-1e86-4092-92d2-cd848abcebfb)
