### PR TITLE
reaper: update `mojave` build

### DIFF
--- a/Casks/r/reaper.rb
+++ b/Casks/r/reaper.rb
@@ -2,7 +2,7 @@ cask "reaper" do
   version "7.06"
 
   on_mojave :or_older do
-    sha256 "48840f0653df14e606bbec469a84a110a9410c1fda831388523669a7a7b46591"
+    sha256 "ece4276187c5c12b1f7b2e65d7ea164e9be5d02810903ec9adc985935ded86e3"
 
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
   end


### PR DESCRIPTION
Updates the `mojave` build for `7.06`

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.