### PR TITLE
kaleidoscope: update livecheck, conflicts_with

### DIFF
--- a/Casks/k/kaleidoscope.rb
+++ b/Casks/k/kaleidoscope.rb
@@ -10,18 +10,22 @@ cask "kaleidoscope" do
   livecheck do
     url "https://updates.kaleidoscope.app/v#{version.major}/prod/appcast"
     regex(/Kaleidoscope[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.app\.zip/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 
   auto_updates true
   conflicts_with cask: [
     "ksdiff",
+    "homebrew/cask-versions/kaleidoscope3",
     "homebrew/cask-versions/kaleidoscope2",
     "homebrew/cask-versions/ksdiff2",
   ]
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :ventura"
 
   app "Kaleidoscope.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

https://github.com/Homebrew/homebrew-cask-versions/pull/18502 added a `kaleidoscope3` cask, which properly uses a `Sparkle` `livecheck` block to check for new versions instead of using `PageMatch`. This PR brings the `livecheck` block for the main `kaleidoscope` cask in line with the versioned casks (albeit, only working with one `item` and without the logic to filter by major version) and updates the `conflicts_with` arguments to add `kaleidoscope3`.

Past that, this updates `depends_on mac_os:` to `>= :ventura`, to resolve the related audit error.