### PR TITLE
Update `livecheck` blocks to use `Json` strategy

### DIFF
--- a/Casks/b/basecamp.rb
+++ b/Casks/b/basecamp.rb
@@ -13,12 +13,12 @@ cask "basecamp" do
 
   livecheck do
     url "https://bc#{version.major}-desktop.s3.amazonaws.com/mac#{arch}/updates.json"
-    strategy :page_match do |page|
-      minor_version = JSON.parse(page)["version"]
-      major_version = page.match(/basecamp(\d)/i)
-      next if major_version.blank? || minor_version.blank?
+    regex(/basecamp(\d*)[_-]v?(\d+(?:\.\d+)+)/i)
+    strategy :json do |json, regex|
+      match = json["url"]&.match(regex)
+      next if match.blank?
 
-      "#{major_version[1]},#{minor_version}"
+      (match.length > 2) ? "#{match[1]},#{match[2]}" : match[1]
     end
   end
 

--- a/Casks/c/cycling74-max.rb
+++ b/Casks/c/cycling74-max.rb
@@ -6,17 +6,17 @@ cask "cycling74-max" do
   name "Cycling ‘74 Max"
   name "Ableton Max for Live"
   desc "Flexible space to create your own interactive software"
-  homepage "https://cycling74.com/"
+  homepage "https://cycling74.com/products/max"
 
   livecheck do
     url "https://auth.cycling74.com/maxversion"
-    regex(/^\d{2}(\d{2})[._-](\d{2})[._-](\d{2})/i)
-    strategy :page_match do |page, regex|
-      json = JSON.parse(page)
-      match = json["release_date"].match(regex)
-      next if match.blank?
+    regex(/^\d{2}(\d{2})-(\d{2})-(\d{2})/i)
+    strategy :json do |json, regex|
+      id = json["_id"]
+      match = json["release_date"]&.match(regex)
+      next if id.blank? || match.blank?
 
-      "#{json["_id"]}_#{match[1]}#{match[2]}#{match[3]}"
+      "#{id}_#{match[1]}#{match[2]}#{match[3]}"
     end
   end
 

--- a/Casks/f/fleet.rb
+++ b/Casks/f/fleet.rb
@@ -13,10 +13,8 @@ cask "fleet" do
 
   livecheck do
     url "https://data.services.jetbrains.com/products/releases?code=FL&latest=true&type=preview"
-    strategy :page_match do |page|
-      JSON.parse(page)["FL"].map do |release|
-        (release["version"]).to_s
-      end
+    strategy :json do |json|
+      json["FL"]&.map { |release| release["version"] }
     end
   end
 

--- a/Casks/i/insta360-studio.rb
+++ b/Casks/i/insta360-studio.rb
@@ -9,16 +9,24 @@ cask "insta360-studio" do
 
   livecheck do
     url "https://openapi.insta360.com/app/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
-    regex(%r{/([[:xdigit:]]+)/Insta360Studio(\d+)(?:[._-]|%20)(?:\d+(?:\.\d+)+)[._-](\d+(?:[._-]\d+)*)\.pkg}i)
-    strategy :page_match do |page, regex|
-      newest_release = JSON.parse(page)["data"]["apps"]
-                           .find { |app| app["id"] == 38 }["items"]
-                           .select { |item| item["platform"] == "mac" }
-                           .max_by { |item| Version.new(item["version"]) }
+    regex(%r{/(\h+)/Insta360Studio(\d+)(?:[._-]|%20)(?:\d+(?:\.\d+)+)[._-](\d+(?:[._-]\d+)*)\.pkg}i)
+    strategy :json do |json, regex|
+      # Find the Insta360 Studio app
+      app = json.dig("data", "apps")&.find { |item| item["id"] == 38 }
+      next if app.blank?
+
+      # Find the newest macOS version
+      newest_release = app["items"]&.select { |item| item["platform"] == "mac" }
+                                   &.max_by { |item| Version.new(item["version"]) }
       next if newest_release.blank?
 
+      # Find the channel item (there's likely only one object in the array)
+      channel = newest_release["channels"]&.find { |item| item["channel"] == "official" }
+      next if channel.blank?
+
+      # Collect the version parts
       version = newest_release["version"]
-      match = newest_release["channels"][0]["download_url"].match(regex)
+      match = channel["download_url"]&.match(regex)
       next if version.blank? || match.blank?
 
       "#{version},#{match[2]},#{match[1]},#{match[3]}"

--- a/Casks/o/orka3.rb
+++ b/Casks/o/orka3.rb
@@ -13,8 +13,8 @@ cask "orka3" do
 
   livecheck do
     url "https://cli-builds-public.s3.eu-west-1.amazonaws.com/official/latest.json"
-    strategy :page_match do |page|
-      JSON.parse(page)["version"]
+    strategy :json do |json|
+      json["version"]
     end
   end
 

--- a/Casks/r/react-studio.rb
+++ b/Casks/r/react-studio.rb
@@ -10,16 +10,16 @@ cask "react-studio" do
 
   livecheck do
     url "https://c1.neonto.com/studio/verinfo_reactstudio"
-    strategy :page_match do |page|
-      json_data = JSON.parse(page)
-      next if json_data.blank?
-
-      version = json_data["latestVersionDescription"]
-      build = json_data["latestVersion"].to_i
+    strategy :json do |json|
+      version = json["latestVersionDescription"]
+      build = json["latestVersion"]&.to_i
+      next if version.blank? || build.blank?
 
       "#{version},#{build}"
     end
   end
+
+  depends_on macos: ">= :sierra"
 
   app "React Studio.app"
 

--- a/Casks/r/redcine-x-pro.rb
+++ b/Casks/r/redcine-x-pro.rb
@@ -9,10 +9,16 @@ cask "redcine-x-pro" do
 
   livecheck do
     url "https://www.red.com/RedSuiteCentric/SCA-Kilimanjaro/services/Download.Service.ss?downloadIdentifier=redcine-x-pro-mac"
-    strategy :page_match do |page|
-      json = JSON.parse(page)
-      latest = json["data"][0]
-      "#{latest["versionMajor"]}.#{latest["versionMinor"]}.#{latest["versionRevision"]}"
+    regex(/Build[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    strategy :json do |json, regex|
+      json["data"]&.map do |item|
+        next if item["versionIsBeta"] == "T"
+
+        match = item["versionUrl"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
     end
   end
 

--- a/Casks/s/snagit.rb
+++ b/Casks/s/snagit.rb
@@ -9,13 +9,16 @@ cask "snagit" do
 
   livecheck do
     url "https://www.techsmith.com/api/v/1/products/getallversions/100"
-    strategy :page_match do |page|
-      v = JSON.parse(page).first
-      "20#{v["Major"]}.#{v["Minor"]}.#{v["Maintenance"]}"
+    strategy :json do |json|
+      json.map do |item|
+        next if item["Major"].blank? || item["Minor"].blank? || item["Maintenance"].blank?
+
+        "20#{item["Major"]}.#{item["Minor"]}.#{item["Maintenance"]}"
+      end
     end
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Snagit #{version.major}.app"
 

--- a/Casks/v/videofusion.rb
+++ b/Casks/v/videofusion.rb
@@ -11,14 +11,17 @@ cask "videofusion" do
 
   livecheck do
     url "https://lf3-beecdn.bytetos.com/obj/ies-fe-bee/bee_prod/biz_80/bee_prod_80_bee_publish_3563.json"
-    regex(/(\d+(?:_\d+)+).*\.dmg/i)
-    strategy :page_match do |page|
-      JSON.parse(page)["mac_download_pkg"]["channel_default"][/(\d+(?:_\d+)+).*\.dmg/i, 1].tr("_", ".")
+    regex(/Jianying[._-]v?(\d+(?:[._]\d+)+).*\.dmg/i)
+    strategy :json do |json, regex|
+      match = json.dig("mac_download_pkg", "channel_default")&.match(regex)
+      next if match.blank?
+
+      match[1].tr("_", ".")
     end
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :mojave"
 
   app "VideoFusion-macOS.app"
 

--- a/Casks/v/vmware-horizon-client.rb
+++ b/Casks/v/vmware-horizon-client.rb
@@ -10,8 +10,8 @@ cask "vmware-horizon-client" do
   livecheck do
     url "https://customerconnect.vmware.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY"
     regex(%r{/([^/]+)/VMware[._-]Horizon[._-]Client[._-]v?(\d+(?:[.-]\d+)+)\.dmg}i)
-    strategy :page_match do |page|
-      mac_json_info = JSON.parse(page)["dlgEditionsLists"].select { |item| item["name"].match(/mac/i) }&.first
+    strategy :json do |json|
+      mac_json_info = json["dlgEditionsLists"]&.select { |item| item["name"].match(/mac/i) }&.first
       api_item = mac_json_info["dlgList"]&.first
       next if api_item.blank?
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates existing `livecheck` blocks that use `Json#parse` in a `PageMatch` `strategy` block to use the `Json` strategy instead. This approach preceded the `Json` strategy, so I'm bringing these up to date.

This also includes various tweaks to the `livecheck` blocks:

* basecamp: Use a regex to match both major and minor version from the URL (and make the trailing digit after the name (`basecamp3`) optional)
* cycling74-max: Make the date delimiter explicit in the regex and ensure `json["_id"]` exists before returning a version string (i.e., we don't want to return an incomplete version string)
* fleet: `release["version"]` is already a string (e.g., "1.27.192"), so we shouldn't need to call `#to_s` on it
* insta360-studio: Use `\h` instead of `[[:xdigit:]]` in the regex (the latter is portable but more verbose and this is the only instance of it, whereas there are ~45 formulae/casks using `\h`). Rework the `strategy` block to account for potentially-`nil` values and improve clarity.
* react-studio: Account for potentially-`nil` values
* redcine-x-pro: Use a regex to match the version from the filename in the URL, as it may be shorter than the `Major`/`Minor`/`Revision` version (e.g., `55.1` instead of `55.1.52132`). This seems to only be an issue with older versions that use a longer revision (e.g., `55.1.52132` but not `60.0.28` and newer). Modify the `strategy` block to return all the stable versions, instead of assuming that the first version will always be the newest.
* snagit: Account for potentially-`nil` values
* videofusion: Account for potentially-`nil` values
* vmware-horizon-client: Account for potentially-`nil` values

Past that, this adds/updates `depends_on macos:` where needed (`react-studio`, `snagit`, `videofusion`) to resolve related audit errors.

-----

I already have related changes worked out for homebrew/cask-versions and will create a follow-up PR in that repository (https://github.com/Homebrew/homebrew-cask-versions/pull/18527).