### PR TITLE
mylio 24.0.7691

### DIFF
--- a/Casks/m/mylio.rb
+++ b/Casks/m/mylio.rb
@@ -1,9 +1,8 @@
 cask "mylio" do
-  version "22.3.7642"
+  version "24.0.7691"
   sha256 :no_check
 
-  url "https://myliodownloads.s3.amazonaws.com/Mylio.dmg",
-      verified: "myliodownloads.s3.amazonaws.com/"
+  url "https://download.mylio.com/Mylio.dmg"
   name "Mylio"
   desc "Photo organizer"
   homepage "https://mylio.com/"
@@ -12,6 +11,8 @@ cask "mylio" do
     url :url
     strategy :extract_plist
   end
+
+  depends_on macos: ">= :mojave"
 
   app "Mylio.app"
 


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online mylio` is error-free.
- [X] `brew style --fix mylio` reports no offenses.

Other changes:
- Update cask URL
- Add minimum macOS version
