### PR TITLE
`cmd/lib/check` replace `system_command!` with `system_command`

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -29,11 +29,10 @@ module Check
       format_launchjob = lambda { |file|
         name = file.basename(".plist").to_s
 
-        xml, = system_command! "plutil", args:         ["-convert", "xml1", "-o", "-", "--", file],
-                                         print_stderr: false,
-                                         sudo:         true
+        result = system_command "plutil", args: ["-convert", "xml1", "-o", "-", "--", file], sudo: true
+        return name unless result.success?
 
-        label = Plist.parse_xml(xml)["Label"]
+        label = result.plist["Label"]
         (name == label) ? name : "#{name} (#{label})"
       }
 

--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -29,7 +29,9 @@ module Check
       format_launchjob = lambda { |file|
         name = file.basename(".plist").to_s
 
-        xml, = system_command! "plutil", args: ["-convert", "xml1", "-o", "-", "--", file], sudo: true
+        xml, = system_command! "plutil", args:         ["-convert", "xml1", "-o", "-", "--", file],
+                                         print_stderr: false,
+                                         sudo:         true
 
         label = Plist.parse_xml(xml)["Label"]
         (name == label) ? name : "#{name} (#{label})"


### PR DESCRIPTION
Required for #161302 and #161140

A `system_command` error was being passed to `Plist.parse_xml()` causing the workflow to error out.