### PR TITLE
Remove Anki-beta

### DIFF
--- a/Casks/a/anki.rb
+++ b/Casks/a/anki.rb
@@ -26,7 +26,6 @@ cask "anki" do
     strategy :github_latest
   end
 
-  conflicts_with cask: "anki-beta"
   depends_on macos: ">= :high_sierra"
 
   app "Anki.app"


### PR DESCRIPTION
This will update the metadata of Anki to remove "Conflict with: Anki-beta"

https://github.com/Homebrew/homebrew-cask-versions/pull/18513