### PR TITLE
ganache: mark `discontinued`

### DIFF
--- a/Casks/g/ganache.rb
+++ b/Casks/g/ganache.rb
@@ -6,7 +6,7 @@ cask "ganache" do
       verified: "github.com/trufflesuite/ganache-ui/"
   name "Ganache"
   desc "Personal blockchain for Ethereum development"
-  homepage "https://truffleframework.com/ganache/"
+  homepage "https://trufflesuite.com/ganache/"
 
   app "Ganache.app"
 
@@ -16,4 +16,11 @@ cask "ganache" do
     "~/Library/Preferences/org.trufflesuite.ganache.plist",
     "~/Library/Saved Application State/org.trufflesuite.ganache.savedState",
   ]
+
+  caveats do
+    discontinued
+    <<~EOS
+      See https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat for information
+    EOS
+  end
 end


### PR DESCRIPTION
`ganache` is being discontinued upstream, as per this [information](https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat).



- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
