### PR TITLE
llamafin 1.8.2 (new cask)

### DIFF
--- a/Casks/l/llamafin.rb
+++ b/Casks/l/llamafin.rb
@@ -1,0 +1,17 @@
+cask "llamafin" do
+  version "1.8.2"
+  sha256 "edeaf2e457df6f4d92a880ecec2dbb87c84ce3f92ca675c1521491caed204ce5"
+
+  url "https://www.dropbox.com/scl/fi/gs17z7juhx213k1xede2l/llamafin-1.8.2.dmg?rlkey=p3hzaurp9iysjw8opf1nej4sf&dl=1"
+  name "llamafin"
+  desc "Jellyfin Music Player, inspired by Plexamp"
+  homepage "https://www.reddit.com/r/llamafin/"
+
+  app "llamafin.App"
+
+  zap trash: [
+    "~/Library/Application Support/llamafin",
+    "~/Library/Preferences/com.llamafin.app.plist",
+    "~/Library/Saved Application State/com.llamafin.app.savedState",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - The application community lives on Reddit, but the packaged software is hosted on someone's Dropbox. Dropbox URLs are listed in the subreddit's sidebar. The audit fails because `verified` is missing and the URL bases differ. There's nothing in the download URL that indicates a relationship to the subreddit. Any ideas what to do here? 🤔 
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
  - See above comment.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
