### PR TITLE
ci: fix manual auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
       casks:
         description: List of casks to audit (comma-separated)
         required: true
-      skip-install:
+      skip_install:
         description: Skip installation of casks
         required: false
         default: true
         type: boolean
-      new-cask:
+      new_cask:
         description: Apply new cask audit
         required: false
         default: false

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -33,16 +33,13 @@ module Homebrew
     skip_install = args.skip_install?
     new_cask = args.new_cask?
     casks = args.casks if args.casks&.any?
+    pr_url = args.url
 
-    if args.url.present?
-      pr_url = args.url
-
-      labels = if pr_url
-        pr = GitHub::API.open_rest(pr_url)
-        pr.fetch("labels").map { |l| l.fetch("name") }
-      else
-        []
-      end
+    labels = if pr_url
+      pr = GitHub::API.open_rest(pr_url)
+      pr.fetch("labels").map { |l| l.fetch("name") }
+    else
+      []
     end
 
     tap = Tap.fetch(ENV.fetch("GITHUB_REPOSITORY"))


### PR DESCRIPTION
Fixes a couple of issues with manual auditing.

`generate-matrix:` Was not passing through the `labels` parameter because of a bad `if` statement.
`ci:` Lines up the `workflow_dispatch` inputs with the arguments in the `generate_matrix` call.