### PR TITLE
Add `cardo-update`

### DIFF
--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,6 +1,6 @@
 cask 'cardo-update' do
   version :latest
-  sha256 : "261dcca0337d5a97230290267f8285a9a7b02b87f59ab7336c3b1a04fd6f1a1f"
+  sha256 "261dcca0337d5a97230290267f8285a9a7b02b87f59ab7336c3b1a04fd6f1a1f"
 
   url 'https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg'
   name 'Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines'

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,6 +1,6 @@
 cask "cardo-update" do
   version :latest
-  sha256 "261dcca0337d5a97230290267f8285a9a7b02b87f59ab7336c3b1a04fd6f1a1f"
+  sha256 :no_check
 
   url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
   name "Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines"

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,17 +1,17 @@
-cask 'cardo-update' do
+cask "cardo-update" do
   version :latest
   sha256 "261dcca0337d5a97230290267f8285a9a7b02b87f59ab7336c3b1a04fd6f1a1f"
 
-  url 'https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg'
-  name 'Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines'
-  homepage 'https://www.cardosystems.com/download-cardo-updater/'
+  url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
+  name "Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines"
+  homepage "https://www.cardosystems.com/download-cardo-updater/"
 
-  pkg 'cardo_updater_macOS_latest.pkg'
+  pkg "cardo_updater_macOS_latest.pkg"
 
-  uninstall quit:    'com.cardo.fwupdater',
-            pkgutil: 'com.cardo.fwupdater'
+  uninstall quit:    "com.cardo.fwupdater",
+            pkgutil: "com.cardo.fwupdater"
 
   zap rmdir: [
-               '~/Library/Application Support/Cardo Update',
-             ]
+    "~/Library/Application Support/Cardo Update",
+  ]
 end

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -4,6 +4,7 @@ cask "cardo-update" do
 
   url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
   name "Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines"
+  desc "Software to update Packtalk and Freecom motorcycle intercom's"
   homepage "https://www.cardosystems.com/download-cardo-updater/"
 
   pkg "cardo_updater_macOS_latest.pkg"

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,18 +1,27 @@
 cask "cardo-update" do
-  version :latest
+  version "4.2.0.30204"
   sha256 :no_check
 
   url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
-  name "Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines"
-  desc "Software to update Packtalk and Freecom motorcycle intercom's"
+  name "Firmware update tool for PACKTALK and FREECOM unit lines"
+  desc "Update Packtalk and Freecom motorcycle intercoms"
   homepage "https://www.cardosystems.com/download-cardo-updater/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   pkg "cardo_updater_macOS_latest.pkg"
 
   uninstall quit:    "com.cardo.fwupdater",
             pkgutil: "com.cardo.fwupdater"
 
-  zap rmdir: [
+  zap trash: [
     "~/Library/Application Support/Cardo Update",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,5 +1,5 @@
 cask "cardo-update" do
-  version "4.2.0.30204"
+  version "4.2.0"
   sha256 :no_check
 
   url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
@@ -8,8 +8,8 @@ cask "cardo-update" do
   homepage "https://www.cardosystems.com/download-cardo-updater/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://update.cardosystems.com/cardo-app/latest-mac.yml"
+    strategy :electron_builder
   end
 
   pkg "cardo_updater_macOS_latest.pkg"

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,8 +1,8 @@
 cask "cardo-update" do
   version "4.2.0"
-  sha256 :no_check
+  sha256 "4e8698968179412beae7caeb08b5c70190ba912e994d3ce42b5e1c18d67cbca3"
 
-  url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
+  url "https://update.cardosystems.com/cardo-app/Cardo%20Update-#{version}-mac.zip"
   name "Cardo Update"
   desc "Update Packtalk and Freecom motorcycle intercoms"
   homepage "https://www.cardosystems.com/download-cardo-updater/"
@@ -12,13 +12,12 @@ cask "cardo-update" do
     strategy :electron_builder
   end
 
-  pkg "cardo_updater_macOS_latest.pkg"
-
-  uninstall quit:    "com.cardo.fwupdater",
-            pkgutil: "com.cardo.fwupdater"
+  app "Cardo Update.app"
 
   zap trash: [
     "~/Library/Application Support/Cardo Update",
+    "~/Library/Logs/Cardo Update",
+    "~/Library/Preferences/com.cardo.fwupdater.plist",
   ]
 
   caveats do

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -1,0 +1,17 @@
+cask 'cardo-update' do
+  version :latest
+  sha256 : "261dcca0337d5a97230290267f8285a9a7b02b87f59ab7336c3b1a04fd6f1a1f"
+
+  url 'https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg'
+  name 'Cardo Update - firmware update tool for PACKTALK and FREECOM unit lines'
+  homepage 'https://www.cardosystems.com/download-cardo-updater/'
+
+  pkg 'cardo_updater_macOS_latest.pkg'
+
+  uninstall quit:    'com.cardo.fwupdater',
+            pkgutil: 'com.cardo.fwupdater'
+
+  zap rmdir: [
+               '~/Library/Application Support/Cardo Update',
+             ]
+end

--- a/Casks/c/cardo-update.rb
+++ b/Casks/c/cardo-update.rb
@@ -3,7 +3,7 @@ cask "cardo-update" do
   sha256 :no_check
 
   url "https://update.cardosystems.com/cardo-app/cardo_updater_macOS_latest.pkg"
-  name "Firmware update tool for PACKTALK and FREECOM unit lines"
+  name "Cardo Update"
   desc "Update Packtalk and Freecom motorcycle intercoms"
   homepage "https://www.cardosystems.com/download-cardo-updater/"
 


### PR DESCRIPTION
This is a software for updating Cardo Helmet intercom's.

Someone already tried submitting this a long time ago, back when the official website of cardo required to log in to download the software. Now, the problem is solved. 

(credit where credit is due https://github.com/Homebrew/homebrew-cask-drivers/pull/1615 , tks @reznikov )



- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).

- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
