### PR TITLE
Change SHA256 for scilab

### DIFF
--- a/Casks/s/scilab.rb
+++ b/Casks/s/scilab.rb
@@ -3,7 +3,7 @@ cask "scilab" do
 
   on_arm do
     version "2024.0.0"
-    sha256 "4d6128943fa368f0a75e68b687d94e6ec8809e44f816ff0a9270d93bf2eadaf5"
+    sha256 "66c760501aabf592f2cbf03156767c5faa4ab085d2bc391410d8a99c0d67cfa5"
   end
   on_intel do
     version "2024.0.0"


### PR DESCRIPTION
I am getting a SHA256 checksum mismatch error for cask `scilab`. I have tried removing and re-downloading it multiple times and I get the same checksum every time. Using `--force` doesn't help this.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
No, but this PR should fix the issue
```
audit for scilab: failed
 - download not possible: SHA256 mismatch
Expected: 4d6128943fa368f0a75e68b687d94e6ec8809e44f816ff0a9270d93bf2eadaf5
  Actual: 66c760501aabf592f2cbf03156767c5faa4ab085d2bc391410d8a99c0d67cfa5
    File: /Users/nv/Library/Caches/Homebrew/downloads/5651b0267536ef27742c1f0fc7ce8b1e34678bc01369fb130a5dc08da23090af--scilab-2024.0.0-arm64.dmg
To retry an incomplete download, remove the file above.
scilab
  * line 13, col 2: download not possible: SHA256 mismatch
    Expected: 4d6128943fa368f0a75e68b687d94e6ec8809e44f816ff0a9270d93bf2eadaf5
      Actual: 66c760501aabf592f2cbf03156767c5faa4ab085d2bc391410d8a99c0d67cfa5
        File: /Users/nv/Library/Caches/Homebrew/downloads/5651b0267536ef27742c1f0fc7ce8b1e34678bc01369fb130a5dc08da23090af--scilab-2024.0.0-arm64.dmg
    To retry an incomplete download, remove the file above.
Error: 1 problem in 1 cask detected.
```
- [x] `brew style --fix <cask>` reports no offenses.


