### PR TITLE
manual update xtool-creative-space to 1.7.8; url changed

### DIFF
--- a/Casks/x/xtool-creative-space.rb
+++ b/Casks/x/xtool-creative-space.rb
@@ -3,16 +3,15 @@ cask "xtool-creative-space" do
   livecheck_arch = on_arch_conditional arm: "apple", intel: "intel"
 
   on_arm do
-    version "1.6.10,28,64a9a8ed-d7fb-4bf5-806e-7fffac6b5d50,2023-10-08-21-41-33"
-    sha256  "ef36dc68aa7b68fd7d2e2050351261a3264af593688be2d1f18733857c338b84"
+    version "1.7.8,28,bef4f224-d24e-4f63-b111-8670b86dcd49,2023-11-27-17-54-11"
+    sha256  "d98539f34f0b2efe1326065ea61b0c638ba2653a55a194935bdd47a79bae577b"
   end
   on_intel do
-    version "1.6.10,16,796e6d79-1120-4b52-adc2-19b05ceacedf,2023-10-08-21-40-34"
-    sha256 "46f65db2e59f8037709ffaf62a7760ba7109607756ea97c5edfdea62aeafb310"
+    version "1.7.8,16,16d09ac8-b6d6-4335-ae2a-c51788a6acaf,2023-11-27-17-55-01"
+    sha256 "854b9e4c5397a6aa3a958b03dd3bec6c7665393132924fdedc913eefbd85056d"
   end
 
-  url "https://res-us.makeblock.com/efficacy/xcs/production/packages/#{version.csv.second}/#{version.csv.third}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.fourth}-#{arch}.dmg",
-      verified: "res-us.makeblock.com/efficacy/xcs/production/packages/"
+  url "https://storage-us.xtool.com/resource/efficacy/xcs/production/packages/#{version.csv.second}/#{version.csv.third}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.fourth}-#{arch}.dmg"
   name "xTool Creative Space"
   desc "Design and control software for xTool laser machines"
   homepage "https://www.xtool.com/pages/software"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.