### PR TITLE
obs-ndi: add symlinks for plugin files

### DIFF
--- a/Casks/o/obs-ndi.rb
+++ b/Casks/o/obs-ndi.rb
@@ -16,6 +16,26 @@ cask "obs-ndi" do
 
   pkg "obs-ndi-#{version}-macos-universal.pkg"
 
+  # The pkg installs the plugin files to /Library/Application Support/obs-studio/plugins
+  # however OBS Studio expects them to be in ~/Library/Application Support/obs-studio/plugins
+  # so we create symlinks to correctly link the plugin files for OBS Studio.
+  postflight do
+    puts "Creating #{token} symlinks in ~/Library/Application Support/obs-studio/plugins"
+    target = Pathname.new("~/Library/Application Support/obs-studio/plugins").expand_path
+    source = "/Library/Application Support/obs-studio/plugins"
+
+    FileUtils.mkdir_p target
+    File.symlink("#{source}/obs-ndi.plugin", "#{target}/obs-ndi.plugin")
+    File.symlink("#{source}/obs-ndi.plugin.dSYM", "#{target}/obs-ndi.plugin.dSYM")
+  end
+
+  uninstall_preflight do
+    puts "Removing #{token} symlinks from in ~/Library/Application Support/obs-studio/plugins"
+    target = Pathname.new("~/Library/Application Support/obs-studio/plugins").expand_path
+
+    File.unlink("#{target}/obs-ndi.plugin", "#{target}/obs-ndi.plugin.dSYM")
+  end
+
   uninstall pkgutil: [
     "com.newtek.ndi.runtime",
     "fr.palakis.obs-ndi",


### PR DESCRIPTION
This is a potential fix for https://github.com/Homebrew/homebrew-cask/issues/161490 using symlinks.

The issue is that the `pkg` installers create the plugin files in `/Library/Application Support/` because they are run with `-target /`.
OBS Studio expects the files to reside in the user's directory `~/Library/Application Support/` so create symlinks to correctly link them.

This issue seems to affect ALL of the plugins in `homebrew-cask` that are for OBS Studio that use a `pkg` to install.
If this is an acceptable fix, then we should replicate this across the others.

CC: @carlocab - thanks for the suggestion on the issue from February - https://github.com/Homebrew/homebrew-cask/pull/139807#discussion_r1105679828

Closes #161490