### PR TITLE
zulufx 21.0.1,21.30.15

### DIFF
--- a/Casks/z/zulufx.rb
+++ b/Casks/z/zulufx.rb
@@ -1,24 +1,26 @@
 cask "zulufx" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
-  version "20.0.2,20.32.11_1-ca"
-  sha256 arm:   "0b5322a9ff3bbf19d7d6acc204202df5a9594678c746fb859cfae0c5e4eda91e",
-         intel: "d8326f2fe57a95f6eef3488e04f8f6a471f4ef4a3b97675339231fe19f19b328"
+  version "21.0.1,21.30.15"
+  sha256 arm:   "18855c07b2d2c175c8ab6f9d159be58c67cbfb2820f3825e055227c534720120",
+         intel: "827f515e0eff523a8cf18e40723e215524f4041aa621201c40b0e05f552ac8d1"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-fx-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-ca-fx-jdk#{version.csv.first}-macosx_#{arch}.dmg",
       referer: "https://www.azul.com/downloads/"
   name "ZuluFX"
   desc "Azul ZuluFX Java Standard Edition Development Kit"
   homepage "https://www.azul.com/downloads/"
 
   livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=true&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:[._]\d+)*-.*?)-fx-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
+    url "https://api.azul.com/metadata/v1/zulu/packages?os=macos&arch=#{arch}&archive_type=dmg&java_package_type=jdk&javafx_bundled=true&latest=true&release_status=ga&availability_types=ca"
+    regex(/zulu(\d+(?:[._]\d+)*)-ca-fx-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["download_url"]&.match(regex)
+        next if match.blank?
 
-      "#{match[2]},#{match[1]}"
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This PR updates `zulufx` to the latest version, 21.0.1,21.30.15.

The existing `livecheck` block uses a versioned URL, so it only returns versions with the same major as the cask `version`. With this setup, livecheck is unable to surface versions for a higher major, so the cask was only bumped to a new major version if someone noticed the version difference outside of livecheck (like this).

This updates the `livecheck` block to use the newer [Azul Metadata API](https://docs.azul.com/core/install/metadata-api). The query string parameters restrict the results to:

* macOS
* The `arch` [of the execution environment]. Note: `arm`/`x86` return 64- and 32-bit packages, whereas `aarch64` and `x64` (i.e., the `arch` value) restricts the results to 64-bit packages. The `livecheck` block regex specifically matches packages for the `arch`, so we can get rid of `choice` and simply use `arch` instead.
* dmg files
* JDK with JavaFX support
* Only the latest for each major version
* GA release status
* CA availability (i.e., community availability, instead of `sa` (subscriber availability) or `nv` ("non-verified" builds))

The `zulufx` cask has only used CA releases from the start, so this PR also removes the availability suffix (`-ca`) from the `version` (and `livecheck` block regex capture group) in favor of hardcoding it in the `url`.

-----

If/when this PR is merged, I'll bring the `zulu` and versioned `zulu` casks in line with these changes (albeit, the `livecheck` block URL for the versioned casks with also include a `java_version` parameter).