### PR TITLE
zulu: update version format, livecheck

### DIFF
--- a/Casks/z/zulu.rb
+++ b/Casks/z/zulu.rb
@@ -1,24 +1,26 @@
 cask "zulu" do
   arch arm: "aarch64", intel: "x64"
-  choice = on_arch_conditional arm: "arm", intel: "x86"
 
-  version "21.0.1,21.30.15-ca"
+  version "21.0.1,21.30.15"
   sha256 arm:   "92d65ed61bf6c0bea0f9c44a6dd538da8a6c620a78f517c194913d1338fc39e7",
          intel: "f8f46bb00cfb8cecddcf71e10c77a577c9e9843a1e13a35ff05dbeec6f29788f"
 
-  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-jdk#{version.csv.first}-macosx_#{arch}.dmg",
-      referer: "https://www.azul.com/downloads/zulu/zulu-mac/"
+  url "https://cdn.azul.com/zulu/bin/zulu#{version.csv.second}-ca-jdk#{version.csv.first}-macosx_#{arch}.dmg",
+      referer: "https://www.azul.com/downloads/"
   name "Azul Zulu Java Standard Edition Development Kit"
   desc "OpenJDK distribution from Azul"
   homepage "https://www.azul.com/downloads/"
 
   livecheck do
-    url "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?jdk_version=#{version.major}&bundle_type=jdk&javafx=false&ext=dmg&os=macos&arch=#{choice}"
-    strategy :page_match do |page|
-      match = page.match(/zulu(\d+(?:[._]\d+)*-.*?)-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
-      next if match.blank?
+    url "https://api.azul.com/metadata/v1/zulu/packages?os=macos&arch=#{arch}&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&latest=true&release_status=ga&availability_types=ca"
+    regex(/zulu(\d+(?:[._]\d+)*)-ca-jdk(\d+(?:\.\d+)*)-macosx_#{arch}\.dmg/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["download_url"]&.match(regex)
+        next if match.blank?
 
-      "#{match[2]},#{match[1]}"
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --new-cask <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/161748, to bring the main `zulu` cask in line with the recent changes to `zulufx`. Namely this:

* Updates the `version` format to remove the `-ca` suffix, as we're only interested in releases with CA availability anyway. Removing the `-ca` suffix also brings the second part of the version in line with the upstream version format for that part (i.e., the download page uses "Azul Zulu: 21.30.15").
* Updates the `referer` (https://www.azul.com/downloads/zulu/zulu-mac/ redirects to https://www.azul.com/downloads/, so this brings it up to date)
* Updates the `livecheck` block to use the [Azul Metadata API](https://docs.azul.com/core/install/metadata-api), removing the major version restriction in the process (so this will also return new major versions)