### PR TITLE
pollymc: init at 8.0

### DIFF
--- a/Casks/p/pollymc.rb
+++ b/Casks/p/pollymc.rb
@@ -1,0 +1,31 @@
+cask "pollymc" do
+  version "8.0"
+
+  on_mojave :or_older do
+    sha256 "12f692b06a6483cb132b777d552ef4ca746c3268e540117da91d74b1ceb3ea7d"
+
+    url "https://github.com/fn2006/PollyMC/releases/download/#{version}/PollyMC-macOS-Legacy-#{version}.tar.gz"
+  end
+  on_catalina :or_newer do
+    sha256 "675d3fa2a079031f1f3bb890826e7a71b62839150d2cf64b80dea3f29b88b2d3"
+
+    url "https://github.com/fn2006/PollyMC/releases/download/#{version}/PollyMC-macOS-#{version}.tar.gz"
+  end
+
+  name "Prism Launcher"
+  desc "Minecraft launcher"
+  homepage "https://github.com/fn2006/PollyMC"
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "PollyMC.app"
+
+  zap trash: [
+    "~/Library/Application Support/PollyMC/metacache",
+    "~/Library/Application Support/PollyMC/PollyMC-*.log",
+    "~/Library/Application Support/PollyMC/pollymc.cfg",
+    "~/Library/Preferences/org.prismlauncher.PollyMC.plist",
+    "~/Library/Saved Application State/org.prismlauncher.PollyMC.savedState",
+  ]
+end


### PR DESCRIPTION
[PollyMC](https://github.com/fn2006/PollyMC) is a GPLv3-licensed [Minecraft](https://minecraft.net) launcher and a fork of [Prism Launcher](https://github.com/PrismLauncher/PrismLauncher) that:

- Removes the DRM to allow use without a Microsoft account
- Adds support for alternative Minecraft API servers, such as [Ely.by](https://github.com/elyby)
- Adds back the ability to download FTB modpacks from within the launcher
- Adds back support for Mojang accounts (though online-mode servers still won't work with Mojang accounts)

This cask is almost identical to the Prism Launcher cask already in homebrew-cask.

**PollyMC** (two Ls) is NOT AFFILIATED with **PolyMC** (one L). The project originated as a fork of PolyMC, hence the name.

I'll also note that while PollyMC allows users to play Minecraft without verifying that they have a license from Mojang, it is GPLv3 software and does not distribute any of the game's proprietary files. The game itself is downloaded directly from Mojang's servers at runtime, exactly like Prism Launcher. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
