### PR TITLE
add wave v0.5.1 (Wave Terminal)

### DIFF
--- a/Casks/w/wave.rb
+++ b/Casks/w/wave.rb
@@ -1,4 +1,4 @@
-cask "waveterm" do
+cask "wave" do
   version "0.5.1"
   sha256 "fe965fe581a66bbd7c394dbfd7ebb1635cd0bf46329042ef86db123fbd7d5751"
 

--- a/Casks/w/wave.rb
+++ b/Casks/w/wave.rb
@@ -10,14 +10,12 @@ cask "wave" do
 
   livecheck do
     url "https://www.waveterm.dev/download"
-    regex(/href=.*?dl\.waveterm\.dev.+-v(\d+(?:\.\d+)+)\.dmg/i)
+    regex(/href=.*?waveterm.+?[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :catalina"
 
   app "Wave.app"
 
-  zap trash: [
-    "~/.waveterm",
-  ]
+  zap trash: "~/.waveterm"
 end

--- a/Casks/w/waveterm.rb
+++ b/Casks/w/waveterm.rb
@@ -5,17 +5,15 @@ cask "waveterm" do
   url "https://dl.waveterm.dev/builds/waveterm-macos-universal-v#{version}.dmg"
   name "Wave Terminal"
   name "WaveTerm"
-  desc "Modern Terminal for Seamless Workflows"
+  desc "Terminal emulator"
   homepage "https://www.waveterm.dev/"
 
   livecheck do
-    url "https://github.com/wavetermdev/waveterm"
-    strategy :github_releases
+    url "https://www.waveterm.dev/download"
+    regex(/href=.*?dl\.waveterm\.dev.+-v(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  auto_updates false
   depends_on macos: ">= :catalina"
-  depends_on arch: [:intel, :arm64]
 
   app "Wave.app"
 

--- a/Casks/w/waveterm.rb
+++ b/Casks/w/waveterm.rb
@@ -1,0 +1,25 @@
+cask "waveterm" do
+  version "0.5.1"
+  sha256 "fe965fe581a66bbd7c394dbfd7ebb1635cd0bf46329042ef86db123fbd7d5751"
+
+  url "https://dl.waveterm.dev/builds/waveterm-macos-universal-v#{version}.dmg"
+  name "Wave Terminal"
+  name "WaveTerm"
+  desc "Modern Terminal for Seamless Workflows"
+  homepage "https://www.waveterm.dev/"
+
+  livecheck do
+    url "https://github.com/wavetermdev/waveterm"
+    strategy :github_releases
+  end
+
+  auto_updates false
+  depends_on macos: ">= :catalina"
+  depends_on arch: [:intel, :arm64]
+
+  app "Wave.app"
+
+  zap trash: [
+    "~/.waveterm",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for a [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online waveterm` is error-free.
- [x] `brew style --fix waveterm` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Wave Terminal is a new Open Source (Apache 2.0) terminal, available for MacOS and Linux (cask covers only the MacOS build).  We just soft launched the terminal over Thanksgiving and have already had a couple thousand downloads, and over 700 Github Stars.  Wave is maintained by Command Line Inc and as of next week we'll have 5 full-time engineers working on, maintaining, and improving the application.  Our universal build has been signed and notarized.  I'm the founder/creator of Wave Terminal (so I'm authorized to upload/maintain this cask), and am happy to answer any questions or make any changes to the cask that might be required.

Note the application is installed as "Wave.app", but I chose the token "waveterm" to match with our website (https://waveterm.dev), our Github repo (https://github.com/wavetermdev/waveterm), and to clearly show that it is a command line terminal.  We are planning on using the token "waveterm" for other package managers as well (snap, flatpak, aur, etc.).
