### PR TITLE
zecwallet-lite: mark `discontinued`

### DIFF
--- a/Casks/z/zecwallet-lite.rb
+++ b/Casks/z/zecwallet-lite.rb
@@ -8,15 +8,14 @@ cask "zecwallet-lite" do
   desc "Zcash Light Wallet"
   homepage "https://www.zecwallet.co/#download"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   app "Zecwallet Lite.app"
 
   zap trash: [
     "~/Library/Application Support/Zecwallet Lite",
     "~/Library/Application Support/Zcash/zecwallet-light-wallet.debug.log",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
[Repository](https://github.com/adityapk00/zecwallet-lite/) was archived as of 2023-09-26.

This commit marks the application as `discontinued` and removes `livecheck`