### PR TITLE
integrity: add `depends_on`

### DIFF
--- a/Casks/i/integrity.rb
+++ b/Casks/i/integrity.rb
@@ -12,6 +12,8 @@ cask "integrity" do
     regex(/<h3>v?(\d+(?:\.\d+)+)\s(?!.*beta)/i)
   end
 
+  depends_on macos: ">= :mojave"
+
   app "Integrity.app"
 
   zap trash: [


### PR DESCRIPTION
```
audit for integrity: failed
 - Upstream defined :mojave as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
