### PR TITLE
id3-editor: add `depends_on` and `zap`

### DIFF
--- a/Casks/i/id3-editor.rb
+++ b/Casks/i/id3-editor.rb
@@ -12,5 +12,15 @@ cask "id3-editor" do
     regex(/Version\s*v?(\d+(?:\.\d+)+)/i)
   end
 
+  depends_on macos: ">= :big_sur"
+
   app "ID3 Editor.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.pas.id3editor.sfl*",
+    "~/Library/Caches/com.apple.helpd/Generated/ID3 Editor Help*",
+    "~/Library/Logs/id3ed.log",
+    "~/Library/Preferences/com.pas.id3editor.plist",
+    "~/Library/Saved Application State/com.pas.id3editor.savedState",
+  ]
 end


### PR DESCRIPTION
```
audit for id3-editor: failed
 - Upstream defined :big_sur as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.