### PR TITLE
istat-menus: update `depends_on`

### DIFF
--- a/Casks/i/istat-menus.rb
+++ b/Casks/i/istat-menus.rb
@@ -13,7 +13,7 @@ cask "istat-menus" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "iStat Menus.app"
 


### PR DESCRIPTION
```
audit for istat-menus: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined :el_capitan
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.