### PR TITLE
irccloud: mark `discontinued`

### DIFF
--- a/Casks/i/irccloud.rb
+++ b/Casks/i/irccloud.rb
@@ -17,4 +17,8 @@ cask "irccloud" do
     "~/Library/Preferences/com.irccloud.desktop.plist",
     "~/Library/Saved Application State/com.irccloud.desktop.savedState",
   ]
+
+  caveats do
+    discontinued
+  end
 end


### PR DESCRIPTION
[Repository](https://github.com/irccloud/irccloud-desktop) has been archived as of 2023-09-06 and is no longer recommended to be used.