### PR TITLE
ip-in-menu-bar: add `depends_on` and `zap`

### DIFF
--- a/Casks/i/ip-in-menu-bar.rb
+++ b/Casks/i/ip-in-menu-bar.rb
@@ -12,5 +12,13 @@ cask "ip-in-menu-bar" do
     regex(/IP\s+in\s+menubar\s+(\d+(?:\.\d+)+)/i)
   end
 
+  depends_on macos: ">= :mojave"
+
   app "IP in menu bar.app"
+
+  zap trash: [
+    "~/Library/Caches/de.monkeybreadsoftware.freeware.ipinmenubar",
+    "~/Library/HTTPStorages/de.monkeybreadsoftware.freeware.ipinmenubar",
+    "~/Library/Preferences/de.monkeybreadsoftware.freeware.ipinmenubar.plist",
+  ]
 end


### PR DESCRIPTION
```
audit for ip-in-menu-bar: failed
 - Upstream defined :mojave as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.