### PR TITLE
intel-haxm: discontinue

### DIFF
--- a/Casks/i/intel-haxm.rb
+++ b/Casks/i/intel-haxm.rb
@@ -24,6 +24,7 @@ cask "intel-haxm" do
             }
 
   caveats do
+    discontinued
     kext
   end
 end


### PR DESCRIPTION
[Repository](https://github.com/intel/haxm) has been marked archived as of 2023-01-28, with the below comment.


```
This project will no longer be maintained by Intel.

Intel has ceased development and contributions including, but not limited to, maintenance, bug fixes, new releases, or updates, to this project.

Intel no longer accepts patches to this project.

If you have an ongoing need to use this project, are interested in independently developing it, or would like to maintain patches for the open source software community, please create your own fork of this project.

Contact: [webadmin@linux.intel.com](mailto:webadmin@linux.intel.com)
```