### PR TITLE
gitkraken-cli: fix. Don't delete .gitkraken folder

### DIFF
--- a/Casks/g/gitkraken-cli.rb
+++ b/Casks/g/gitkraken-cli.rb
@@ -11,6 +11,4 @@ cask "gitkraken-cli" do
   homepage "https://github.com/gitkraken/gk-cli"
 
   binary "gk"
-
-  zap trash: "~/.gitkraken"
 end


### PR DESCRIPTION
Since the `.gitkraken` folder is shared with the GitKraken Client (Desktop), I'm removing this line so the folder doesn't get deleted after uninstalling `gitkraken-cli` because a user could have both products installed.