### PR TITLE
Update transmission sha256

### DIFF
--- a/Casks/t/transmission.rb
+++ b/Casks/t/transmission.rb
@@ -1,6 +1,6 @@
 cask "transmission" do
   version "4.0.5"
-  sha256 "0edfa1d850f2e0ebd92a6ea739ece1a2d344b786337fe5b2ff97a5099a76c5fa"
+  sha256 "6a0e6838cb247ab1ed1390ef65368b82fc74b4e72cb0e291991f26c221436bc3"
 
   url "https://github.com/transmission/transmission/releases/download/#{version}/Transmission-#{version}.dmg",
       verified: "github.com/transmission/transmission/"


### PR DESCRIPTION
Unfortunately the original transmission 4.0.5 patch was submitted 18 hours ago:

![Screenshot 2023-12-08 at 21 58 26](https://github.com/Homebrew/homebrew-cask/assets/344071/fded064f-84d8-43d5-9426-b3093d55675f)

But it looks like the transmission authors published a new one since then.

![Screenshot 2023-12-08 at 21 58 34](https://github.com/Homebrew/homebrew-cask/assets/344071/36d2c0b5-be8a-4402-b1dd-b9c4f49574fb)

I have updated the sha256 in the cask.

**NOTE**: I have not performed all of the required tasks, I had trouble doing so with the regular homebrew tooling, any guidance appreciated.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Error output:

```
==> Downloading https://github.com/transmission/transmission/releases/download/4.0.5/Transmission-4.0.5.dmg
Already downloaded: /Users/john/Library/Caches/Homebrew/downloads/922a44946d33b5ecfbc87596f4cd51030cdc3bfb64c4ca069c9ee936ad0de2af--Transmission-4.0.5.dmg
audit for transmission: failed
 - download not possible: SHA256 mismatch
Expected: 0edfa1d850f2e0ebd92a6ea739ece1a2d344b786337fe5b2ff97a5099a76c5fa
  Actual: 6a0e6838cb247ab1ed1390ef65368b82fc74b4e72cb0e291991f26c221436bc3
    File: /Users/john/Library/Caches/Homebrew/downloads/922a44946d33b5ecfbc87596f4cd51030cdc3bfb64c4ca069c9ee936ad0de2af--Transmission-4.0.5.dmg
To retry an incomplete download, remove the file above.
transmission
  * line 5, col 2: download not possible: SHA256 mismatch
    Expected: 0edfa1d850f2e0ebd92a6ea739ece1a2d344b786337fe5b2ff97a5099a76c5fa
      Actual: 6a0e6838cb247ab1ed1390ef65368b82fc74b4e72cb0e291991f26c221436bc3
        File: /Users/john/Library/Caches/Homebrew/downloads/922a44946d33b5ecfbc87596f4cd51030cdc3bfb64c4ca069c9ee936ad0de2af--Transmission-4.0.5.dmg
    To retry an incomplete download, remove the file above.
Error: 1 problem in 1 cask detected.
```

I created the PR by hand as none of the existing commands seemed suitable, and this seems causative.