### PR TITLE
surge-xt 1.3.0

### DIFF
--- a/Casks/s/surge-xt.rb
+++ b/Casks/s/surge-xt.rb
@@ -1,6 +1,6 @@
 cask "surge-xt" do
-  version "1.2.3"
-  sha256 "a9531de3113ab2d32cecd3d25d6917d276d1200905f85d56423021dd06c0a5ca"
+  version "1.3.0"
+  sha256 "96b0927dd3c3081fa708a8c07382645c85985ba4c4dba0fbbc2fa1d98f4bb8c6"
 
   url "https://github.com/surge-synthesizer/releases-xt/releases/download/#{version}/surge-xt-macOS-#{version}.dmg",
       verified: "github.com/surge-synthesizer/releases-xt/"


### PR DESCRIPTION
Upgrade surge-xt to 1.3.0 following our Dec 8 release.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
