### PR TITLE
panoply: update sha256 for 5.3.0 release

### DIFF
--- a/Casks/p/panoply.rb
+++ b/Casks/p/panoply.rb
@@ -2,8 +2,8 @@ cask "panoply" do
   arch arm: "arm64-"
 
   version "5.3.0"
-  sha256 arm:   "ae36b9317d7cb62c0b1cd462a06fe0e6e5ab1ffe94a15a88d8a883200d522aab",
-         intel: "dbc48ad94529ec6270203604fcf7289d36ce8a32d467c1778a577d0b2f6fab57"
+  sha256 arm:   "2656f1779cde2f1337b1dd4833d596beca559bdd8e8278a23d9ff3ba4d27c888",
+         intel: "925877f82f579cc344f6ec3db0fad98081cf3425b9459818a8a52b61b764b22a"
 
   url "https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-#{arch}#{version}.dmg"
   name "Panoply netCDF, HDF and GRIB Data Viewer"


### PR DESCRIPTION
I saw that the casks was updated last week, but for some reasons the sha256 (arm and intel) do not match the current value.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.