### PR TITLE
spyder: update sha for 5.5.0 release

### DIFF
--- a/Casks/s/spyder.rb
+++ b/Casks/s/spyder.rb
@@ -1,6 +1,6 @@
 cask "spyder" do
   version "5.5.0"
-  sha256 "522ab177d2803843faeb9c11d59489df23be81c29491a69a5b6db879fa253f8b"
+  sha256 "5a8a17c7eeee4999022ba4f45466349a6232c05c1d4e291acb43fcfc88faef94"
 
   url "https://github.com/spyder-ide/spyder/releases/download/v#{version}/Spyder.dmg",
       verified: "github.com/spyder-ide/spyder/"


### PR DESCRIPTION
Corrected the SHA256 checksum for [Spyder v5.5.0](https://github.com/spyder-ide/spyder/releases/download/v5.5.0/Spyder.dmg).

------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
