### PR TITLE
reactotron 3.1.0

### DIFF
--- a/Casks/r/reactotron.rb
+++ b/Casks/r/reactotron.rb
@@ -1,24 +1,28 @@
 cask "reactotron" do
-  version "2.17.1"
-  sha256 "0b498386dd5feecd8f5137a629cf2f3170c6c92f1d33eb8e40831e4daddfc959"
+  arch arm: "-arm64"
 
-  url "https://github.com/infinitered/reactotron/releases/download/v#{version}/Reactotron-#{version}-mac.zip"
+  version "3.1.0"
+  sha256 arm:   "ff308372dcfb83febde0356319866568dfca1aba08d22b8d8c13cace553c6309",
+         intel: "a7a04aab58f1b6407aa8926d372ce0a842604f69324622e6942f8267fb7061c4"
+
+  url "https://github.com/infinitered/reactotron/releases/download/reactotron-app%40#{version}/Reactotron-#{version}#{arch}-mac.zip"
   name "Reactotron"
   desc "Desktop app for inspecting React JS and React Native projects"
   homepage "https://github.com/infinitered/reactotron"
 
-  # Upstream publishes multiple packages in the same repository, so we can't
-  # rely on the "latest" release being for the application and we can't even
-  # guarantee that the most recent releases will contain a release of the app
-  # (as of writing, the `GithubReleases` strategy doesn't work for this reason).
-  # For the time being, we check the "Quick Installation Guide" file that's
-  # linked in the README.
+  # Upstream publishes multiple packages in the same repository and, due to the
+  # number of packages that are updated around the same time, the most recent
+  # releases may not be for the app. This check searches for `reactotron-app`
+  # releases, as the `GithubReleases` strategy may be unreliable in this
+  # scenario.
   livecheck do
-    url "https://raw.githubusercontent.com/infinitered/reactotron/master/docs/installing.md"
-    regex(%r{releases/tag/v?(\d+(?:\.\d+)+)\)}i)
+    url "https://github.com/infinitered/reactotron/releases?q=reactotron-app+prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tag/reactotron-app(?:%40|@)v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :page_match
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Reactotron.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `reactotron` to the latest version, 3.1.0. Releases now provide an ARM64 zip alongside the usual Intel zip, so this adds ARM64 support in the process.

The existing `livecheck` block is returning an `Unable to get versions` error because the `docs/installing.md` file has been removed from the GitHub repository. Upstream is currently using a `reactotron-app@3.1.0` tag format for the application releases, so I've updated the `livecheck` block to search releases for `reactotron-app` (omitting pre-release releases).

Since upstream creates releases for so many different packages when doing version updates, there's no guarantee that a `reactotron-app` release will be among the most recent releases, so the `GithubReleases` strategy would periodically break if we used it. Searching the releases page isn't as clean but hopefully the chance of it breaking over time is lower.

Past that, this adds `depends_on macos: ">= :catalina"` to resolve the related audit.