### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,6 @@ After making any changes to a cask, existing or new, verify:
 
 - [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
 - [ ] `brew style --fix <cask>` reports no offenses.
-- [ ] `brew install --cask <cask>` worked successfully.
-- [ ] `brew uninstall --cask <cask>` worked successfully.
 
 **If updating an existing cask**:
 
@@ -19,3 +17,5 @@ After making any changes to a cask, existing or new, verify:
 - [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
 - [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
 - [ ] `brew audit --cask --new <cask>` worked successfully.
+- [ ] `brew install --cask <cask>` worked successfully.
+- [ ] `brew uninstall --cask <cask>` worked successfully.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ After making any changes to a cask, existing or new, verify:
 
 **If updating an existing cask**:
 
-- [ ] `brew audit --cask --strict --online <cask>` is error-free.
+- [ ] `brew audit --cask --online <cask>` is error-free.
 
 **If adding a new cask**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,17 @@ _In the following questions `<cask>` is the token of the cask you're submitting.
 After making any changes to a cask, existing or new, verify:
 
 - [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
-- [ ] `brew audit --cask --online <cask>` is error-free.
 - [ ] `brew style --fix <cask>` reports no offenses.
+- [ ] `brew install --cask <cask>` worked successfully.
+- [ ] `brew uninstall --cask <cask>` worked successfully.
 
-Additionally, **if adding a new cask**:
+**If updating an existing cask**:
+
+- [ ] `brew audit --cask --strict --online <cask>` is error-free.
+
+**If adding a new cask**:
 
 - [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
 - [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
 - [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
 - [ ] `brew audit --cask --new <cask>` worked successfully.
-- [ ] `brew install --cask <cask>` worked successfully.
-- [ ] `brew uninstall --cask <cask>` worked successfully.


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Every time I open a new Cask PR, the way I read this template (before the changes in this PR) makes me think I need to run both:

- `brew audit --cask --online <cask>`
- `brew audit --cask --new <cask>`

But `--new` implies both `--strict` and `--online`.

This was my attempt at re-arranging the checklist to be a bit more clear.

I wasn't sure if install/uninstall checks should be included in the 'always' section, or if it's only relevant for new casks. If my assumption was wrong, that can easily be put back.

---

This is part of my attempts to remove ambiguity/make things simpler for new contributors, alongside changes such as the following:

- https://github.com/Homebrew/brew/pull/16327