### PR TITLE
add readwise-reader 0.1.1 (new cask)

### DIFF
--- a/Casks/r/reader.rb
+++ b/Casks/r/reader.rb
@@ -1,4 +1,4 @@
-cask "readwise-reader" do
+cask "reader" do
   version "0.1.1"
   sha256 "f8328a701bdefbd839c484c57827bd05b56be4216722dfe72c4348b823f9048d"
 

--- a/Casks/r/reader.rb
+++ b/Casks/r/reader.rb
@@ -14,6 +14,7 @@ cask "reader" do
     end
   end
 
+  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Reader.app"

--- a/Casks/r/readwise-reader.rb
+++ b/Casks/r/readwise-reader.rb
@@ -9,7 +9,9 @@ cask "readwise-reader" do
 
   livecheck do
     url "https://reader-desktop-releases.readwise.io/update-manifest.json"
-    regex(/"version":\s*"([^"]+)"/i)
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/r/readwise-reader.rb
+++ b/Casks/r/readwise-reader.rb
@@ -1,14 +1,16 @@
 cask "readwise-reader" do
-  version :latest
-  sha256 :no_check
+  version "0.1.1"
+  sha256 "f8328a701bdefbd839c484c57827bd05b56be4216722dfe72c4348b823f9048d"
 
-  # version "0.1.1"
-  # sha256 "a39d51e7b210b2d59fb6a0e1dd689002a9e642e8e9cecba80c9fd5d9fd057f42"
-
-  url "https://reader-desktop-releases.readwise.io/Reader.dmg"
+  url "https://reader-desktop-releases.readwise.io/versions/#{version}/macos/Reader.app.tar.gz"
   name "Readwise Reader"
   desc "Save articles to read, highlight key content, and organize notes for review"
   homepage "https://readwise.io/read/"
+
+  livecheck do
+    url "https://reader-desktop-releases.readwise.io/update-manifest.json"
+    regex(/"version":\s*"([^"]+)"/i)
+  end
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/r/readwise-reader.rb
+++ b/Casks/r/readwise-reader.rb
@@ -1,0 +1,24 @@
+cask "readwise-reader" do
+  version :latest
+  sha256 :no_check
+
+  # version "0.1.1"
+  # sha256 "a39d51e7b210b2d59fb6a0e1dd689002a9e642e8e9cecba80c9fd5d9fd057f42"
+
+  url "https://reader-desktop-releases.readwise.io/Reader.dmg"
+  name "Readwise Reader"
+  desc "Save articles to read, highlight key content, and organize notes for review"
+  homepage "https://readwise.io/read/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Reader.app"
+
+  zap trash: [
+    "~/Library/Application Support/io.readwise.read",
+    "~/Library/Caches/io.readwise.read",
+    "~/Library/HTTPStorages/io.readwise.read.binarycookies",
+    "~/Library/Saved Application State/io.readwise.read.savedState",
+    "~/Library/WebKit/io.readwise.read",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This app is an alpha release because it only launched today, but it will become the canonical stable release 'soon'.

---

This cask is named in line with the brand name used for the equivalent app on iOS:

- https://apps.apple.com/us/app/readwise-reader/id1567599761

And the name they use for the section on the website:

- https://readwise.io/read
  - ![image](https://github.com/Homebrew/homebrew-cask/assets/753891/3759380f-68d1-4591-a75e-81d3503336f0)

'Readwise' is both the name of the company, and of another older product they have.

An existing Readwise app's Cask follows a similar naming pattern here:

- https://github.com/Homebrew/homebrew-cask/blob/master/Casks/r/readwise-ibooks.rb#L5

---

I attempted to figure out how to add livecheck info, but wasn't able to figure it out:

```
⇒ $(brew --repository homebrew/cask)/developer/bin/find-appcast /Applications/Reader.app

Looking for Sparkle appcast… Not found.
Looking for electron-builder appcast… Not found.
```
