### PR TITLE
orion: update sonoma `sha256`

### DIFF
--- a/Casks/o/orion.rb
+++ b/Casks/o/orion.rb
@@ -62,7 +62,7 @@ cask "orion" do
     depends_on macos: :ventura
   end
   on_sonoma :or_newer do
-    sha256 "6eca1ba722ce9cb7362da6e35ca159e50a97607cb4b0bc0b22d2309972475f0f"
+    sha256 "9dbe71da2f6364277ab264aa4819dbd165593ac3b390e6c1e2845a5096aea000"
 
     url "https://browser.kagi.com/updates/14_0/#{version.csv.second}.zip"
 


### PR DESCRIPTION
```  
* exception while auditing orion: SHA256 mismatch
    Expected: 6eca1ba722ce9cb7362da6e35ca159e50a97607cb4b0bc0b22d2309972475f0f
      Actual: 9dbe71da2f6364277ab264aa4819dbd165593ac3b390e6c1e2845a5096aea000
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
