### PR TITLE
omnifocus 4.0.1

### DIFF
--- a/Casks/o/omnifocus.rb
+++ b/Casks/o/omnifocus.rb
@@ -47,6 +47,18 @@ cask "omnifocus" do
 
     uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
   end
+  on_catalina do
+    version "3.15.4"
+    sha256 "1f682c3f0c60bd8bda0cdcc89ae51f6b83e1207a8fd54aff7fb3fcdd738573ef"
+
+    url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
+  end
   on_big_sur do
     version "3.15.4"
     sha256 "1f682c3f0c60bd8bda0cdcc89ae51f6b83e1207a8fd54aff7fb3fcdd738573ef"
@@ -59,9 +71,21 @@ cask "omnifocus" do
 
     uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
   end
+  on_monterey do
+    version "3.15.4"
+    sha256 "1f682c3f0c60bd8bda0cdcc89ae51f6b83e1207a8fd54aff7fb3fcdd738573ef"
+
+    url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
+  end
   on_ventura :or_newer do
-    version "4.0"
-    sha256 "8f39062da389f232161482bc0d71495626ee16f1bf14f3371fe999f3c3f08d69"
+    version "4.0.1"
+    sha256 "d46f007b3baa0924e4a36e100a4e5851667987b9e84668e354c9b45b564a7a6d"
 
     url "https://downloads.omnigroup.com/software/macOS/13/OmniFocus-#{version}.dmg"
 

--- a/Casks/o/omnifocus.rb
+++ b/Casks/o/omnifocus.rb
@@ -47,11 +47,23 @@ cask "omnifocus" do
 
     uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
   end
-  on_catalina :or_newer do
+  on_big_sur do
     version "3.15.4"
     sha256 "1f682c3f0c60bd8bda0cdcc89ae51f6b83e1207a8fd54aff7fb3fcdd738573ef"
 
     url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
+  end
+  on_ventura :or_newer do
+    version "4.0"
+    sha256 "8f39062da389f232161482bc0d71495626ee16f1bf14f3371fe999f3c3f08d69"
+
+    url "https://downloads.omnigroup.com/software/macOS/13/OmniFocus-#{version}.dmg"
 
     livecheck do
       url "https://www.omnigroup.com/download/latest/omnifocus/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.


`brew audit` results are not error-free:
```
% git checkout omnifocus-4
Switched to branch 'omnifocus-4'
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)
% brew audit --strict --online omnifocus
==> Downloading https://downloads.omnigroup.com/software/macOS/13/OmniFocus-4.0.dmg
Already downloaded: /Users/rajiv/Library/Caches/Homebrew/downloads/d45b4996683169fb641392848ce1e3d824a8112a50d2476e15b581ee6b5a291c--OmniFocus-4.0.dmg
==> Downloading and extracting artifacts
==> Downloading https://downloads.omnigroup.com/software/macOS/13/OmniFocus-4.0.dmg
Already downloaded: /Users/rajiv/Library/Caches/Homebrew/downloads/d45b4996683169fb641392848ce1e3d824a8112a50d2476e15b581ee6b5a291c--OmniFocus-4.0.dmg
audit for omnifocus: failed
 - Upstream defined :ventura as the minimum OS version and the cask defined no minimum OS version
omnifocus
  * Upstream defined :ventura as the minimum OS version and the cask defined no minimum OS version
Error: 1 problem in 1 cask detected.
```

This cask has different versions of OmniFocus to support different macOS versions, so the cask does not define a minimum OS version.


This proposed PR is better than running `brew audit` on the current version:
```
% git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
% brew audit --strict --online omnifocus
==> Downloading https://downloads.omnigroup.com/software/macOS/11/OmniFocus-3.15.4.dmg
################################################################################################################################################ 100.0%
==> Downloading and extracting artifacts
==> Downloading https://downloads.omnigroup.com/software/macOS/11/OmniFocus-3.15.4.dmg
Already downloaded: /Users/rajiv/Library/Caches/Homebrew/downloads/9bf3873f220f5c2f7a6063ede282d98a533a40d2088bbfb9b5d0211b10e19223--OmniFocus-3.15.4.dmg
audit for omnifocus: failed
 - Version '3.15.4' differs from '4.0' retrieved by livecheck.
 - Version '3.15.4' differs from '4.0' retrieved by livecheck.
 - Upstream defined :big_sur as the minimum OS version and the cask defined no minimum OS version
omnifocus
  * Version '3.15.4' differs from '4.0' retrieved by livecheck.
  * Upstream defined :big_sur as the minimum OS version and the cask defined no minimum OS version
Error: 2 problems in 1 cask detected.
```
