### PR TITLE
Microsoft Office 16.80.23121017

### DIFF
--- a/Casks/m/microsoft-excel.rb
+++ b/Casks/m/microsoft-excel.rb
@@ -48,8 +48,8 @@ cask "microsoft-excel" do
     end
   end
   on_monterey :or_newer do
-    version "16.79.23111614"
-    sha256 "5ba6095b0ecdcb65512b8e4aacb12acd715040ddd9dd2c9d217f108e323d5d0f"
+    version "16.80.23121017"
+    sha256 "d85909b859be53d2073be944667f6557d65b791e0403cea6d2abc150531dc399"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525135"

--- a/Casks/m/microsoft-office-businesspro.rb
+++ b/Casks/m/microsoft-office-businesspro.rb
@@ -1,6 +1,6 @@
 cask "microsoft-office-businesspro" do
-  version "16.79.23111019"
-  sha256 "162b27686d0e23d68395581aa11ece6f17a0a7889367cfb78d16c38a0cc980ef"
+  version "16.80.23121017"
+  sha256 "06274db9e2556e9e11c595a6c96da63399312363d90135f0da7726adc6091887"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_BusinessPro_Installer.pkg"
   name "Microsoft Office BusinessPro"

--- a/Casks/m/microsoft-office.rb
+++ b/Casks/m/microsoft-office.rb
@@ -1,6 +1,6 @@
 cask "microsoft-office" do
-  version "16.79.23111019"
-  sha256 "be0bbc26b654c93457bc2c359d0738e913bab8d51f2cf97562c41007fceabb99"
+  version "16.80.23121017"
+  sha256 "96fea841201602c82b6ba91ebf841be5c6b58d5a2caf0ff388de354b9d8a2fb1"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_Installer.pkg"
   name "Microsoft Office"

--- a/Casks/m/microsoft-onenote.rb
+++ b/Casks/m/microsoft-onenote.rb
@@ -1,6 +1,6 @@
 cask "microsoft-onenote" do
-  version "16.79.23111019"
-  sha256 "5568a7a9b8656e2e607ebca75cf21885b6037d0c5ed15fcf52c240b6894e7628"
+  version "16.80.23121017"
+  sha256 "22c0da595891ede656b05205e2f42e6f65f938be031839ccdbe48e5ec1795012"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_#{version}_Updater.pkg"
   name "Microsoft OneNote"

--- a/Casks/m/microsoft-outlook.rb
+++ b/Casks/m/microsoft-outlook.rb
@@ -48,8 +48,8 @@ cask "microsoft-outlook" do
     end
   end
   on_monterey :or_newer do
-    version "16.79.23112723"
-    sha256 "45d4a204f79b3dcd0146e232653dae23fd964a44b929ac9af12065a56da7ab02"
+    version "16.80.23121017"
+    sha256 "354090a3705b1e2cc03ae638d4901202c3193b04842080238e2e874648ece17b"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525137"

--- a/Casks/m/microsoft-powerpoint.rb
+++ b/Casks/m/microsoft-powerpoint.rb
@@ -48,8 +48,8 @@ cask "microsoft-powerpoint" do
     end
   end
   on_monterey :or_newer do
-    version "16.79.23111614"
-    sha256 "fc89eeffa3f081253416cdf787cf4dc5ef894afa2c9d241ffcbe5f6a36aef872"
+    version "16.80.23121017"
+    sha256 "f36a0f08cfec8628966f93b3ac23b09bbff4d66d2169fd5919c61e26ce4a7840"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525136"

--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -48,8 +48,8 @@ cask "microsoft-word" do
     end
   end
   on_monterey :or_newer do
-    version "16.79.23111614"
-    sha256 "895e77b5679314bc32fc6e0add7d9caafd425a26e0b278a8ff45ece51cf065e2"
+    version "16.80.23121017"
+    sha256 "fa9d5023b6dadc129b642272a219bb211a5946e8aaebd3b3c0942051bbe5ae02"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525134"

--- a/audit_exceptions/simple_user_agent_for_homepage.json
+++ b/audit_exceptions/simple_user_agent_for_homepage.json
@@ -1,0 +1,9 @@
+[
+  "microsoft-excel",
+  "microsoft-office",
+  "microsoft-office-businesspro",
+  "microsoft-onenote",
+  "microsoft-outlook",
+  "microsoft-powerpoint",
+  "microsoft-word"
+]


### PR DESCRIPTION
Standalone applications installers are updated as well.
Microsoft Auto Updater is already updated.

Passing audit depends on merging a workaround into Homebrew itself
(https://github.com/Homebrew/brew/pull/16349).
The only issue is homepage availability check. Otherwise, the update
just works.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
