### PR TITLE
proxy-audio-device: install audio driver

### DIFF
--- a/Casks/p/proxy-audio-device.rb
+++ b/Casks/p/proxy-audio-device.rb
@@ -8,6 +8,33 @@ cask "proxy-audio-device" do
   homepage "https://github.com/briankendall/proxy-audio-device"
 
   app "Proxy Audio Device Settings.app"
+  artifact "ProxyAudioDevice.driver", target: "/Library/Audio/Plug-Ins/HAL/ProxyAudioDevice.driver"
 
-  # No zap stanza required
+  postflight do
+    set_ownership "/Library/Audio/Plug-Ins/HAL/ProxyAudioDevice.driver",
+                  user:  "root",
+                  group: "wheel"
+
+    system_command "/bin/launchctl",
+                   args:         [
+                     "kickstart",
+                     "-k",
+                     "system/com.apple.audio.coreaudiod",
+                   ],
+                   sudo:         true,
+                   must_succeed: true
+  end
+
+  uninstall_postflight do
+    system_command "/bin/launchctl",
+                   args:         [
+                     "kickstart",
+                     "-k",
+                     "system/com.apple.audio.coreaudiod",
+                   ],
+                   sudo:         true,
+                   must_succeed: true
+  end
+
+  zap trash: "~/Library/Saved Application State/net.briankendall.Proxy-Audio-Device-Settings.savedState"
 end


### PR DESCRIPTION
Fixes https://github.com/briankendall/proxy-audio-device/issues/13

This change does a few things to fix the installation of proxy-audio-device, based on the README for installation:

https://github.com/briankendall/proxy-audio-device#manual-installation

- Install the audio driver to `/Libary/Audio/Plug-Ins/HAL`
- Kickstart `coreaudiod` on install and uninstall for the device to be available
- zap saved application state for the settings app

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
