### PR TITLE
vimr: Update the minimum macOS version to Monterey

### DIFF
--- a/Casks/v/vimr.rb
+++ b/Casks/v/vimr.rb
@@ -20,7 +20,7 @@ cask "vimr" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :monterey"
 
   app "VimR.app"
   binary "#{appdir}/VimR.app/Contents/Resources/vimr"


### PR DESCRIPTION
The minimum required macOS version of VimR changed to Monterey. `brew audit --strict --online vimr` resulted in the following

```
[...]
audit for vimr: failed
- Upstream defined :monterey as the minimum OS version and the cask defined :high_sierra
vimr
* Upstream defined :monterey as the minimum OS version and the cask defined :high_sierra
Error: 1 problem in 1 cask detected.
```

I'm not sure how to pass the audit when changing the minimum macOS version.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
