### PR TITLE
thunderbird: add additional language support

### DIFF
--- a/Casks/t/thunderbird.rb
+++ b/Casks/t/thunderbird.rb
@@ -1,13 +1,49 @@
 cask "thunderbird" do
   version "115.5.2"
 
+  language "af" do
+    sha256 "b738fa535d4836d274a2c69bbe193915bd91a283a18385fffdc0d78e37f41aa8"
+    "af"
+  end
+  language "ar" do
+    sha256 "7e20bbe8bf4f25e1b9263bb58839f9c4347c82e743b4a5f2d83379b5b07a5bd4"
+    "ar"
+  end
+  language "be" do
+    sha256 "fa3efb184e677a511b0203e4157c69d890de7f356b3b260cf9321e28f4e187e6"
+    "be"
+  end
+  language "bg" do
+    sha256 "c3d16e0abdf79bd0781d1fdc930d82efe06e4cfda566638b0cfde9b8a140ce9f"
+    "bg"
+  end
+  language "ca" do
+    sha256 "16133177d89b23a695b2cf170193375f5b3138108edf04b34a94178ceb5ed139"
+    "ca"
+  end
   language "cs" do
     sha256 "d228bf60f0c7e3b6cefbd0ce75bd195b7b905f39831041a79840613f83339f7a"
     "cs"
   end
+  language "cy" do
+    sha256 "917ad8d04b9a78c6f6772481a98a903cd611d3ad66173e96030147bc0b2a2d4b"
+    "cy"
+  end
+  language "da" do
+    sha256 "a5c7d1923881fec4de3bdde1b0c3e7a28a4ef0fcb18b63ea70d8e7e84f97bf79"
+    "da"
+  end
   language "de" do
     sha256 "81beefe08d7b112ad072958f12722980b7afab454ae8ce979954d84a97edca73"
     "de"
+  end
+  language "el" do
+    sha256 "ab23aed85b08d58a0e05ca0d3207f5fdc585df1220505d1650de5a36ba3dc8d9"
+    "el"
+  end
+  language "en-CA" do
+    sha256 "a21bdb1013105b63323772ac2dd426c2332982a401c3ee028e36ae7a454c17be"
+    "en-CA"
   end
   language "en-GB" do
     sha256 "b9fee231bf2aa0c74e6b3a4924cf753b682325c11ab6d9159e978391f509092e"
@@ -17,13 +53,61 @@ cask "thunderbird" do
     sha256 "d859e9b5d81d16737d8f305667c0c9abbd45d4eae4bb637b35b86eb961820f81"
     "en-US"
   end
+  language "es-ES" do
+    sha256 "41a8ad2db200001d368e2d29483abd1e462572d122860dcc95e76e5d3de3c3f9"
+    "es-ES"
+  end
+  language "es-MX" do
+    sha256 "a99e31b93d259ebd4405abfc5b49660cc6af8398b95c6a9ea3d3a68bd8289837"
+    "es-MX"
+  end
+  language "et" do
+    sha256 "25c8bf4672830e49cf181ef487634d3814760e7e5e50f2824ac35712bf545061"
+    "et"
+  end
+  language "fi" do
+    sha256 "3034b10c6c9613b74106658e4100fbe46a63a998dc967f3ebdfab03b27877c5c"
+    "fi"
+  end
   language "fr" do
     sha256 "76430d88efbdb8cbfb918bad20da9444adca406f6e767ed0321245ba50af303a"
     "fr"
   end
+  language "fy" do
+    sha256 "2cb9feeb36422a7f243d07d9782d4b9d42a7a081b7f1a014005c05930897e725"
+    "fy-NL"
+  end
+  language "ga" do
+    sha256 "7a7068df9eaa86921e2cd82a126bc4a80d802ed25fd5a1267b3fd2dddf7f0d9f"
+    "ga-IE"
+  end
+  language "gd" do
+    sha256 "196e098498d04decb5ab4be4b66eb5ca1200c2b74de04d0718a0c39d58c4a75f"
+    "gd"
+  end
   language "gl" do
     sha256 "3d3e2e33835e4455ad773d030c60eeb18745fd94577e86aed200a7e65c182447"
     "gl"
+  end
+  language "he" do
+    sha256 "516df73a769dca18589b261f74071efc63d853fad1f54ba2c20cc230125c6d50"
+    "he"
+  end
+  language "hr" do
+    sha256 "a3783835cfcdda5ad85062e624cdab1bfdb85948ad465abc66432f06cc97f0ef"
+    "hr"
+  end
+  language "hu" do
+    sha256 "0d61989b42d2f0f362e67c426063af7d875b840ecb679cd19e1cf7e45de3bd45"
+    "hu"
+  end
+  language "hy" do
+    sha256 "22e3606275dcbd1bc71483e70342dae7f14550532fef8b5a94187623a153acc0"
+    "hy-AM"
+  end
+  language "is" do
+    sha256 "2f06a732dcab16e8cca5036ed2a46a3d62c4e2a6f31359bad55b34ed306d4a49"
+    "is"
   end
   language "it" do
     sha256 "5d403e822fc1159e5405b32133ec14ea66c9788feb2bf07e9d28dd1f037bbb96"
@@ -33,9 +117,37 @@ cask "thunderbird" do
     sha256 "8ec0154d4a83b0f2561d635c38c9d7034ddafc6b302b91f74884414a239beb6e"
     "ja-JP-mac"
   end
+  language "ka" do
+    sha256 "02d69f14fc3c8a86dac13a374da0ed3c83478221dc9291218f133431f6e44eef"
+    "ka"
+  end
+  language "ko" do
+    sha256 "013be3df747f0ea245c836b11b0f63a0fe8675bafd56d61182aa4cd0e36668fd"
+    "ko"
+  end
+  language "lt" do
+    sha256 "b7f71cf022f3ebb9a0e95f6b5a9b01707627a9075235bebc00b443e6013db314"
+    "lt"
+  end
+  language "lv" do
+    sha256 "3eaf66ce43ac4848dfef8d9bbb01ebe063ac811067d1febc5663a7702f301ac9"
+    "lv"
+  end
+  language "ms" do
+    sha256 "a5849ae02052bede50d87e76496d98ab5429700964a16e9f9ff46cb9d12fd783"
+    "ms"
+  end
+  language "nb" do
+    sha256 "cdf255a447ca41c126ca88df53eac2f5bfa514bde51560852dc9574bc17997b8"
+    "nb-NO"
+  end
   language "nl" do
     sha256 "66bfdc745ece4bb07bf0fe08e02236b633cd6e7ae7ffbef9af7052ff5dc9c6f3"
     "nl"
+  end
+  language "pa-IN" do
+    sha256 "17602f9c02b3c9976f991040df93d48ca388ca6a0da6e54671b3df5971a5f33f"
+    "pa-IN"
   end
   language "pl" do
     sha256 "b007005cd1a7ac3fe4459350ce702de0eacf9dfac71cb23e1fba52a2e50ba399"
@@ -49,13 +161,57 @@ cask "thunderbird" do
     sha256 "c4635cc318efa138533e86b5c62cbfbb1ab14bda986ecb142254960914eb5500"
     "pt-BR"
   end
+  language "rm" do
+    sha256 "5e90915dbfcaf36ff825f30f51ec4989d2e0d08fa7af68784b61d48c00828fad"
+    "rm"
+  end
+  language "ro" do
+    sha256 "1517dfab3d1249ef4429ac7d567d03458936580cd6b387b76ff74306a6a630ee"
+    "ro"
+  end
   language "ru" do
     sha256 "8f34b5c890770b40e7c1000fa9514ebe0ada6231d7377b25c3954ecb5715ee3e"
     "ru"
   end
+  language "sk" do
+    sha256 "fa2354249167734daf1fe0b0d210b038a72504ac3f0a06185aa9379033182343"
+    "sk"
+  end
+  language "sl" do
+    sha256 "198b59213ffb84627a0c6d454d55855d90d99e1fcfca5952e6bbea990c14b199"
+    "sl"
+  end
+  language "sq" do
+    sha256 "e570dd232bb209f40661a0f9d6410d2340b6ca4a021e705945a4b581846903af"
+    "sq"
+  end
+  language "sr" do
+    sha256 "2e7bd3abc06d3871c776b463d150586593228deff2268d2240cf663aa63623ae"
+    "sr"
+  end
+  language "sv" do
+    sha256 "73f95864125f3a72f757a0aba2492800db08722e61d0d195dd1a8a550db8f8a0"
+    "sv-SE"
+  end
+  language "th" do
+    sha256 "fb1905b2f17741ae9fc354a57577a5fc0b966f619427c2d13b19de7fb6393a05"
+    "th"
+  end
+  language "tr" do
+    sha256 "dfab441bc5aa40c07a81b4658887200e051a6b1d41c24ca4559d96f2aa2ceb60"
+    "tr"
+  end
   language "uk" do
     sha256 "53b0d7dedd24a6e2809f2e26da4ce18a7311522378fdda3bee67d5ebf739157f"
     "uk"
+  end
+  language "uz" do
+    sha256 "f67d09eb85f744e30a0ecae4dbe9bdd69348751bdb4352cb2d1e65aa4e90b1e4"
+    "uz"
+  end
+  language "vi" do
+    sha256 "997ccfe83dac6b1ac52a8e77e46d90698fb044097fec1458ddf3eb267e127aa5"
+    "vi"
   end
   language "zh-TW" do
     sha256 "5f00850bb9c6470e264fdc1e804d55db070787c4d85e57164cc2cbe748fa7342"


### PR DESCRIPTION
This PR adds many additional languages that are supported by `thunderbird` but not listed in the languages stanza.  This change brings it more in line with `firefox` for available offerings.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
