### PR TITLE
Use `deprecate!` instead of `discontinued`

### DIFF
--- a/Casks/3/360safe.rb
+++ b/Casks/3/360safe.rb
@@ -7,9 +7,7 @@ cask "360safe" do
   desc "Protection and antivirus security"
   homepage "https://www.360totalsecurity.com/features/360-total-security-mac/"
 
-  app "360Safe.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "360Safe.app"
 end

--- a/Casks/a/a-slower-speed-of-light.rb
+++ b/Casks/a/a-slower-speed-of-light.rb
@@ -7,9 +7,7 @@ cask "a-slower-speed-of-light" do
   desc "First-person game"
   homepage "https://gamelab.mit.edu/games/a-slower-speed-of-light/"
 
-  app "A Slower Speed of Light.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "A Slower Speed of Light.app"
 end

--- a/Casks/a/actual.rb
+++ b/Casks/a/actual.rb
@@ -11,6 +11,8 @@ cask "actual" do
   desc "Privacy-focused app for managing your finances"
   homepage "https://actualbudget.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Actual.app"
 
   zap trash: [
@@ -20,8 +22,4 @@ cask "actual" do
     "~/Library/Preferences/com.shiftreset.actual.plist",
     "~/Library/Saved Application State/com.shiftreset.actual.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/adoptopenjdk.rb
+++ b/Casks/a/adoptopenjdk.rb
@@ -8,6 +8,8 @@ cask "adoptopenjdk" do
   desc "JDK from the Java User Group (JUG)"
   homepage "https://adoptopenjdk.net/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "OpenJDK#{version.major}U-jdk_x64_mac_hotspot_#{version.csv.first}_#{version.csv.second.major}.pkg"
 
   uninstall pkgutil: "net.adoptopenjdk.#{version.major}.jdk"
@@ -19,8 +21,6 @@ cask "adoptopenjdk" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       Temurin is the official successor to this software:
 

--- a/Casks/a/agenda.rb
+++ b/Casks/a/agenda.rb
@@ -7,6 +7,8 @@ cask "agenda" do
   desc "Note taking application focusing on dates"
   homepage "https://agenda.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :mojave"
 
   app "Agenda.app"
@@ -23,7 +25,6 @@ cask "agenda" do
   ]
 
   caveats do
-    discontinued
     <<~EOS
       Newer versions are only available in Mac App Store.
     EOS

--- a/Casks/a/airunlock.rb
+++ b/Casks/a/airunlock.rb
@@ -7,9 +7,7 @@ cask "airunlock" do
   desc "Tool to lock or unlock the macbook using an Android phone via Bluetooth"
   homepage "https://github.com/pinetum/AirUnlock-for-Mac"
 
-  app "AirUnlock.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "AirUnlock.app"
 end

--- a/Casks/a/altdeploy.rb
+++ b/Casks/a/altdeploy.rb
@@ -6,11 +6,9 @@ cask "altdeploy" do
   name "AltDeploy"
   homepage "https://github.com/pixelomer/AltDeploy"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :high_sierra"
 
   app "AltDeploy.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/alva.rb
+++ b/Casks/a/alva.rb
@@ -8,9 +8,7 @@ cask "alva" do
   desc "Create living prototypes with code components"
   homepage "https://meetalva.io/"
 
-  app "Alva.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Alva.app"
 end

--- a/Casks/a/amm.rb
+++ b/Casks/a/amm.rb
@@ -7,9 +7,7 @@ cask "amm" do
   desc "Aria2 Menubar Monitor"
   homepage "https://github.com/15cm/AMM"
 
-  app "AMM.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "AMM.app"
 end

--- a/Casks/a/amorphousdiskmark.rb
+++ b/Casks/a/amorphousdiskmark.rb
@@ -7,6 +7,8 @@ cask "amorphousdiskmark" do
   desc "App to measure storage read/write performance"
   homepage "https://katsurashareware.com/amorphousdiskmark/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "AmorphousDiskMark.app"
 
   zap trash: [
@@ -15,7 +17,6 @@ cask "amorphousdiskmark" do
   ]
 
   caveats do
-    discontinued
     <<~EOS
       Newer versions are only available on the Mac App Store.
     EOS

--- a/Casks/a/android-messages.rb
+++ b/Casks/a/android-messages.rb
@@ -7,13 +7,13 @@ cask "android-messages" do
   desc "Desktop client for Android Messages"
   homepage "https://github.com/chrisknepper/android-messages-desktop"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Android Messages.app"
 
   zap trash: "~/Library/Application Support/Android Messages"
 
   caveats do
-    discontinued
-
     <<~EOS
       #{token} has been deprecated in favor of OrangeDrangon Android Messages.
         brew install --cask orangedrangon-android-messages

--- a/Casks/a/android-sdk.rb
+++ b/Casks/a/android-sdk.rb
@@ -8,6 +8,8 @@ cask "android-sdk" do
   desc "Tools for the Android SDK"
   homepage "https://developer.android.com/studio/releases/sdk-tools"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   binary "#{staged_path}/tools/android"
   binary "#{staged_path}/tools/emulator"
   binary "#{staged_path}/tools/emulator-check"
@@ -35,6 +37,5 @@ cask "android-sdk" do
 
   caveats do
     depends_on_java "8"
-    discontinued
   end
 end

--- a/Casks/a/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/a/anka-build-cloud-controller-and-registry.rb
@@ -16,6 +16,8 @@ cask "anka-build-cloud-controller-and-registry" do
     strategy :header_match
   end
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "AnkaControllerRegistry#{arch}-#{version}.pkg"
 
   uninstall script: {
@@ -28,7 +30,6 @@ cask "anka-build-cloud-controller-and-registry" do
       rmdir: "/Library/Application Support/Veertu/Anka/registry"
 
   caveats do
-    discontinued
     license "https://veertu.com/terms-and-conditions/"
 
     <<~EOS

--- a/Casks/a/ansible-dk.rb
+++ b/Casks/a/ansible-dk.rb
@@ -8,11 +8,9 @@ cask "ansible-dk" do
   desc "Omnibus-based toolkit for working on Ansible-based infrastructure code"
   homepage "https://github.com/omniti-labs/ansible-dk"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "ansible-dk-#{version.major_minor_patch}-1.pkg"
 
   uninstall pkgutil: "com.omniti.labs.ansible-dk"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/appcode.rb
+++ b/Casks/a/appcode.rb
@@ -10,6 +10,8 @@ cask "appcode" do
   desc "IDE for Swift, Objective-C, C, and C++ development"
   homepage "https://www.jetbrains.com/objc/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
@@ -30,8 +32,4 @@ cask "appcode" do
     "~/Library/Logs/AppCode#{version.major_minor}",
     "~/Library/Preferences/AppCode#{version.major_minor}",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/appdelete.rb
+++ b/Casks/a/appdelete.rb
@@ -7,6 +7,8 @@ cask "appdelete" do
   desc "App uninstaller"
   homepage "http://www.reggieashworth.com/appdelete.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "AppDelete.app"
@@ -18,8 +20,4 @@ cask "appdelete" do
     "~/Library/Saved Application State/com.apps4macs.AppDelete.savedState",
     "~/Library/Services/AppDelete.workflow",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/appium.rb
+++ b/Casks/a/appium.rb
@@ -8,6 +8,8 @@ cask "appium" do
   desc "Graphical frontend to Appium automation server"
   homepage "https://appium.io/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Appium Server GUI.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "appium" do
     "~/Library/Preferences/io.appium.desktop.plist",
     "~/Library/Saved Application State/io.appium.desktop.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/apple-events.rb
+++ b/Casks/a/apple-events.rb
@@ -7,6 +7,8 @@ cask "apple-events" do
   desc "Unofficial Apple Events app"
   homepage "https://github.com/insidegui/AppleEvents"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Apple Events.app"
@@ -16,8 +18,4 @@ cask "apple-events" do
     "~/Library/Caches/br.com.guilhermerambo.Apple-Events",
     "~/Library/Preferences/br.com.guilhermerambo.Apple-Events.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/arduino.rb
+++ b/Casks/a/arduino.rb
@@ -7,6 +7,8 @@ cask "arduino" do
   desc "Electronics prototyping platform"
   homepage "https://www.arduino.cc/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "homebrew/cask-versions/arduino-nightly"
 
   app "Arduino.app"
@@ -17,8 +19,4 @@ cask "arduino" do
     "~/Library/Preferences/cc.arduino.Arduino.plist",
     "~/Library/Saved Application State/cc.arduino.Arduino.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/aria2gui.rb
+++ b/Casks/a/aria2gui.rb
@@ -7,6 +7,8 @@ cask "aria2gui" do
   desc "Graphical user interface for Aria2"
   homepage "https://github.com/yangshun1029/aria2gui"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Aria2GUI.app"
 
   zap trash: [
@@ -14,8 +16,4 @@ cask "aria2gui" do
     "~/Library/Preferences/com.Aria2GUI.plist",
     "~/Library/Saved Application State/com.Aria2GUI.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/ark-desktop-wallet.rb
+++ b/Casks/a/ark-desktop-wallet.rb
@@ -8,9 +8,7 @@ cask "ark-desktop-wallet" do
   desc "Multi Platform ARK Desktop Wallet"
   homepage "https://ark.io/"
 
-  app "Ark Desktop Wallet.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Ark Desktop Wallet.app"
 end

--- a/Casks/a/atom.rb
+++ b/Casks/a/atom.rb
@@ -8,6 +8,8 @@ cask "atom" do
   desc "Text editor"
   homepage "https://atom.io/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Atom.app"
@@ -30,8 +32,4 @@ cask "atom" do
     "~/Library/Saved Application State/com.github.atom.savedState",
     "~/Library/WebKit/com.github.atom",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/avocode.rb
+++ b/Casks/a/avocode.rb
@@ -7,6 +7,8 @@ cask "avocode" do
   desc "Collaborate on design files"
   homepage "https://avocode.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
@@ -21,8 +23,4 @@ cask "avocode" do
     "~/Library/Preferences/com.madebysource.avocode.plist",
     "~/Library/Saved Application State/com.madebysource.avocode.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/a/aware.rb
+++ b/Casks/a/aware.rb
@@ -8,9 +8,7 @@ cask "aware" do
   desc "Menubar app to track active computer use"
   homepage "https://awaremac.com/"
 
-  app "Aware.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Aware.app"
 end

--- a/Casks/b/banshee.rb
+++ b/Casks/b/banshee.rb
@@ -8,9 +8,7 @@ cask "banshee" do
   desc "Multimedia management and playback application"
   homepage "https://www.banshee-project.org/"
 
-  app "Banshee.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Banshee.app"
 end

--- a/Casks/b/battery-report.rb
+++ b/Casks/b/battery-report.rb
@@ -7,9 +7,7 @@ cask "battery-report" do
   desc "Creates technical summaries of power supplies"
   homepage "https://www.dssw.co.uk/batteryreport/"
 
-  app "Battery Report.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Battery Report.app"
 end

--- a/Casks/b/beaker-browser.rb
+++ b/Casks/b/beaker-browser.rb
@@ -9,6 +9,8 @@ cask "beaker-browser" do
   desc "Experimental peer-to-peer web browser"
   homepage "https://beakerbrowser.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Beaker Browser.app"
@@ -21,8 +23,4 @@ cask "beaker-browser" do
     "~/Library/Preferences/com.pfrazee.beaker-browser.plist",
     "~/Library/Saved Application State/com.pfrazee.beaker-browser.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/bee.rb
+++ b/Casks/b/bee.rb
@@ -8,6 +8,8 @@ cask "bee" do
   desc "Issue tracker frontend"
   homepage "https://www.neat.io/bee/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Bee.app"
 
   zap trash: [
@@ -19,8 +21,4 @@ cask "bee" do
     "~/Library/Containers/io.neat.Bee-Mutator",
     "~/Library/Containers/io.neat.Bee-Updater",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/bingpaper.rb
+++ b/Casks/b/bingpaper.rb
@@ -7,6 +7,8 @@ cask "bingpaper" do
   desc "Use the Bing daily photo as your wallpaper"
   homepage "https://github.com/pengsrc/BingPaper"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :catalina"
 
   app "BingPaper.app"
@@ -21,8 +23,4 @@ cask "bingpaper" do
         "~/Library/Containers/io.pjw.mac.BingPaper",
         "~/Library/Containers/io.pjw.mac.BingPaperLoginItem",
       ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/blockstack.rb
+++ b/Casks/b/blockstack.rb
@@ -8,11 +8,9 @@ cask "blockstack" do
   desc "Explore the Blockstack internet"
   homepage "https://blockstack.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "Blockstack.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/bloomrpc.rb
+++ b/Casks/b/bloomrpc.rb
@@ -7,11 +7,9 @@ cask "bloomrpc" do
   desc "GUI Client for GRPC Services"
   homepage "https://github.com/uw-labs/bloomrpc"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "BloomRPC.app"
 
   zap trash: "~/Library/Preferences/io.github.utilitywarehouse.BloomRPC.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/bonjour-browser.rb
+++ b/Casks/b/bonjour-browser.rb
@@ -7,11 +7,9 @@ cask "bonjour-browser" do
   desc "Display all the bonjour services on your local network"
   homepage "https://www.tildesoft.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: "<= :mojave"
 
   app "Bonjour Browser.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/bootxchanger.rb
+++ b/Casks/b/bootxchanger.rb
@@ -8,9 +8,7 @@ cask "bootxchanger" do
   desc "Utility to change the boot logo on old Macs"
   homepage "https://namedfork.net/bootxchanger/"
 
-  app "BootXChanger.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "BootXChanger.app"
 end

--- a/Casks/b/bubo.rb
+++ b/Casks/b/bubo.rb
@@ -9,11 +9,9 @@ cask "bubo" do
   desc "Fixes broken bluetooth headset control"
   homepage "https://github.com/jguice/mac-bt-headset-fix"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "bubo.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/b/bunqcommunity-bunq.rb
+++ b/Casks/b/bunqcommunity-bunq.rb
@@ -8,9 +8,7 @@ cask "bunqcommunity-bunq" do
   desc "Unofficial desktop application for the bunq API"
   homepage "https://bunqdesk.top/"
 
-  app "bunqDesktop.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "bunqDesktop.app"
 end

--- a/Casks/c/cakebrew.rb
+++ b/Casks/c/cakebrew.rb
@@ -7,6 +7,8 @@ cask "cakebrew" do
   desc "GUI app for Homebrew"
   homepage "https://github.com/brunophilipe/Cakebrew"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Cakebrew.app"
@@ -16,8 +18,4 @@ cask "cakebrew" do
     "~/Library/Preferences/com.brunophilipe.Cakebrew.plist",
     "~/Library/Saved Application State/com.brunophilipe.Cakebrew.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/candybar.rb
+++ b/Casks/c/candybar.rb
@@ -7,6 +7,8 @@ cask "candybar" do
   desc "Tool to modify file icons"
   homepage "https://panic.com/blog/candybar-mountain-lion-and-beyond/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "CandyBar.app"
 
   zap trash: [
@@ -18,7 +20,6 @@ cask "candybar" do
   ]
 
   caveats do
-    discontinued
     free_license "https://panic.com/bin/setup.php/cb3/PPQA-YAMA-E3KP-VHXG-B6AL-L"
   end
 end

--- a/Casks/c/cantata.rb
+++ b/Casks/c/cantata.rb
@@ -7,11 +7,9 @@ cask "cantata" do
   desc "Qt5 Graphical MPD Client"
   homepage "https://github.com/cdrummond/cantata"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "Cantata.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/caret.rb
+++ b/Casks/c/caret.rb
@@ -7,6 +7,8 @@ cask "caret" do
   name "Caret"
   homepage "https://caret.io/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Caret.app"
 
   zap trash: [
@@ -18,8 +20,4 @@ cask "caret" do
     "~/Library/Preferences/io.caret.plist",
     "~/Library/Saved Application State/io.caret.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/charlessoft-timetracker.rb
+++ b/Casks/c/charlessoft-timetracker.rb
@@ -6,9 +6,7 @@ cask "charlessoft-timetracker" do
   name "TimeTracker"
   homepage "https://charlessoft.com/"
 
-  app "TimeTracker.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "TimeTracker.app"
 end

--- a/Casks/c/chatology.rb
+++ b/Casks/c/chatology.rb
@@ -7,11 +7,9 @@ cask "chatology" do
   desc "Chat manager and message search software"
   homepage "https://flexibits.com/chatology"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :el_capitan"
 
   app "Chatology.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/chrome-devtools.rb
+++ b/Casks/c/chrome-devtools.rb
@@ -7,6 +7,8 @@ cask "chrome-devtools" do
   desc "Standalone Chrome development tools"
   homepage "https://github.com/auchenberg/chrome-devtools-app"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Chrome DevTools App.app"
 
   zap trash: [
@@ -15,8 +17,4 @@ cask "chrome-devtools" do
     "~/Library/Preferences/com.auchenberg.chrome-devtools-app.plist",
     "~/Library/Saved Application State/com.auchenberg.chrome-devtools-app.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/ckb-next.rb
+++ b/Casks/c/ckb-next.rb
@@ -7,6 +7,8 @@ cask "ckb-next" do
   desc "RGB driver"
   homepage "https://github.com/ckb-next/ckb-next"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   pkg "ckb-next.mpkg"
@@ -16,8 +18,4 @@ cask "ckb-next" do
               "org.ckb-next.daemon",
             ],
             launchctl: "org.ckb-next.daemon"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/classroom-assistant.rb
+++ b/Casks/c/classroom-assistant.rb
@@ -7,6 +7,8 @@ cask "classroom-assistant" do
   desc "Tool to clone student repositories in bulk"
   homepage "https://classroom.github.com/assistant"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Classroom Assistant.app"
 
   zap trash: [
@@ -19,8 +21,4 @@ cask "classroom-assistant" do
     "~/Library/Preferences/com.electron.classroom-assistant.plist",
     "~/Library/Saved Application State/com.electron.classroom-assistant.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/clean-me.rb
+++ b/Casks/c/clean-me.rb
@@ -13,13 +13,11 @@ cask "clean-me" do
   desc "System cleaner for logs, caches and more"
   homepage "https://github.com/Kevin-De-Koninck/Clean-Me"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "Clean Me.app"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/cocoapods.rb
+++ b/Casks/c/cocoapods.rb
@@ -8,6 +8,8 @@ cask "cocoapods" do
   desc "Dependency manager for Cocoa projects"
   homepage "https://cocoapods.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with formula: "cocoapods"
 
   app "CocoaPods.app"
@@ -21,8 +23,4 @@ cask "cocoapods" do
   end
 
   zap trash: "~/Library/Preferences/org.cocoapods.CocoaPods.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/coda.rb
+++ b/Casks/c/coda.rb
@@ -7,6 +7,8 @@ cask "coda" do
   desc "Text editor"
   homepage "https://panic.com/coda/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
@@ -20,8 +22,4 @@ cask "coda" do
     "~/Library/Preferences/com.panic.Coda#{version.major}.plist",
     "~/Library/Saved Application State/com.panic.Coda#{version.major}.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/code-notes.rb
+++ b/Casks/c/code-notes.rb
@@ -8,9 +8,7 @@ cask "code-notes" do
   desc "Code snippet manager"
   homepage "https://lauthieb.github.io/code-notes/"
 
-  app "Code Notes.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Code Notes.app"
 end

--- a/Casks/c/code42-crashplan.rb
+++ b/Casks/c/code42-crashplan.rb
@@ -8,6 +8,8 @@ cask "code42-crashplan" do
   desc "Endpoint backup and recovery"
   homepage "https://www.crashplan.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   pkg "Install Code42.pkg"
@@ -18,8 +20,4 @@ cask "code42-crashplan" do
               executable: "Uninstall.app/Contents/Resources/uninstall.sh",
               sudo:       true,
             }
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/colorpicker-developer.rb
+++ b/Casks/c/colorpicker-developer.rb
@@ -6,9 +6,7 @@ cask "colorpicker-developer" do
   name "Developer Color Picker"
   homepage "https://download.panic.com/picker/index.html"
 
-  colorpicker "Developer Color Picker/DeveloperColorPicker.colorPicker"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  colorpicker "Developer Color Picker/DeveloperColorPicker.colorPicker"
 end

--- a/Casks/c/controllermate.rb
+++ b/Casks/c/controllermate.rb
@@ -18,6 +18,8 @@ cask "controllermate" do
   desc "Create virtual mouse, tablet, and joystick devices"
   homepage "https://www.orderedbytes.com/controllermate/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "#temp#/ControllerMate.sparkle_interactive.pkg"
 
   uninstall launchctl: [
@@ -47,7 +49,6 @@ cask "controllermate" do
   ]
 
   caveats do
-    discontinued
     reboot
   end
 end

--- a/Casks/c/couchpotato.rb
+++ b/Casks/c/couchpotato.rb
@@ -8,11 +8,9 @@ cask "couchpotato" do
   desc "Automatic Movie Downloading via NZBs & Torrents"
   homepage "https://couchpota.to/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "CouchPotato.app"
 
   zap trash: "~/Library/Application Support/CouchPotato"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/create-recovery-partition-installer.rb
+++ b/Casks/c/create-recovery-partition-installer.rb
@@ -6,9 +6,7 @@ cask "create-recovery-partition-installer" do
   name "Create Recovery Partition Installer"
   homepage "https://github.com/MagerValp/Create-Recovery-Partition-Installer/"
 
-  app "Create Recovery Partition Installer.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Create Recovery Partition Installer.app"
 end

--- a/Casks/c/createuserpkg.rb
+++ b/Casks/c/createuserpkg.rb
@@ -7,9 +7,7 @@ cask "createuserpkg" do
   desc "Create packages to deploy user accounts"
   homepage "https://magervalp.github.io/CreateUserPkg/"
 
-  app "CreateUserPkg.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "CreateUserPkg.app"
 end

--- a/Casks/c/creepy.rb
+++ b/Casks/c/creepy.rb
@@ -8,11 +8,9 @@ cask "creepy" do
   desc "Geolocation OSINT tool"
   homepage "https://www.geocreepy.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "cree.py.app"
 
   zap trash: "~/.creepy"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/c/cronnix.rb
+++ b/Casks/c/cronnix.rb
@@ -7,9 +7,7 @@ cask "cronnix" do
   name "CronniX"
   homepage "https://code.google.com/archive/p/cronnix/"
 
-  app "CronniX.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "CronniX.app"
 end

--- a/Casks/d/dat.rb
+++ b/Casks/d/dat.rb
@@ -8,6 +8,8 @@ cask "dat" do
   desc "Peer to peer data sharing app built for humans"
   homepage "https://dat-ecosystem.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Dat Desktop.app"
 
   zap trash: [
@@ -20,8 +22,4 @@ cask "dat" do
     "~/.dat",
     "~/.dat-desktop",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/d/dbglass.rb
+++ b/Casks/d/dbglass.rb
@@ -8,9 +8,7 @@ cask "dbglass" do
   desc "PostgreSQL client built with Electron"
   homepage "http://dbglass.web-pal.com/"
 
-  app "DBGlass-darwin-x64/DBGlass.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "DBGlass-darwin-x64/DBGlass.app"
 end

--- a/Casks/d/deathtodsstore.rb
+++ b/Casks/d/deathtodsstore.rb
@@ -6,9 +6,7 @@ cask "deathtodsstore" do
   name "DeathToDSStore"
   homepage "https://www.aorensoftware.com/blog/2011/12/24/death-to-ds_store/"
 
-  app "DeathToDSStore.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "DeathToDSStore.app"
 end

--- a/Casks/d/devdocs.rb
+++ b/Casks/d/devdocs.rb
@@ -7,6 +7,8 @@ cask "devdocs" do
   desc "Full-featured desktop app for DevDocs.io"
   homepage "https://github.com/egoist/devdocs-desktop/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "DevDocs.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "devdocs" do
     "~/Library/Preferences/sh.egoist.devdocs.plist",
     "~/Library/Saved Application State/sh.egoist.devdocs.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/d/dia.rb
+++ b/Casks/d/dia.rb
@@ -8,13 +8,11 @@ cask "dia" do
   desc "Draw structured diagrams"
   homepage "http://dia-installer.de/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on cask: "xquartz"
 
   app "Dia.app"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/d/difffork.rb
+++ b/Casks/d/difffork.rb
@@ -8,9 +8,7 @@ cask "difffork" do
   desc "Compare both folders and files, present the differences in a visual format"
   homepage "https://dotfork.com/"
 
-  app "DiffFork.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "DiffFork.app"
 end

--- a/Casks/d/docker-toolbox.rb
+++ b/Casks/d/docker-toolbox.rb
@@ -7,6 +7,8 @@ cask "docker-toolbox" do
   name "Docker Toolbox"
   homepage "https://www.docker.com/products/docker-toolbox"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on cask: "virtualbox"
 
   pkg "DockerToolbox-#{version}.pkg",
@@ -52,8 +54,4 @@ cask "docker-toolbox" do
   ]
 
   zap trash: "~/.docker"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/d/dozer.rb
+++ b/Casks/d/dozer.rb
@@ -7,6 +7,9 @@ cask "dozer" do
   desc "Tool to hide status bar icons"
   homepage "https://github.com/Mortennn/Dozer"
 
+  # upstream discussion, https://github.com/Mortennn/Dozer/issues/178
+  deprecate! date: "2023-11-26", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
@@ -16,9 +19,4 @@ cask "dozer" do
     "~/Library/Application Support/com.mortennn.Dozer",
     "~/Library/Preferences/com.mortennn.Dozer.plist",
   ]
-
-  # upstream discussion, https://github.com/Mortennn/Dozer/issues/178
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/d/duplicacy.rb
+++ b/Casks/d/duplicacy.rb
@@ -8,12 +8,10 @@ cask "duplicacy" do
   desc "Cloud backup tool"
   homepage "https://duplicacy.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "duplicacy-cli"
 
   app "Duplicacy.app"
   binary "#{appdir}/Duplicacy.app/Contents/Resources/duplicacy_osx_x64_#{version}", target: "duplicacy"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/d/dwarf-fortress.rb
+++ b/Casks/d/dwarf-fortress.rb
@@ -9,6 +9,8 @@ cask "dwarf-fortress" do
 
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/df_osx/df.wrapper.sh"
+  deprecate! date: "2023-12-17", because: :discontinued
+
   binary shimscript, target: "dwarf-fortress"
 
   preflight do
@@ -25,8 +27,6 @@ cask "dwarf-fortress" do
   end
 
   caveats do
-    discontinued
-
     <<~EOS
       During uninstall, your save data will be copied to /tmp/dwarf-fortress-save
     EOS

--- a/Casks/d/dynamic-dark-mode.rb
+++ b/Casks/d/dynamic-dark-mode.rb
@@ -7,14 +7,12 @@ cask "dynamic-dark-mode" do
   desc "Automatic Dark Mode toggle"
   homepage "https://github.com/ApolloZhu/Dynamic-Dark-Mode"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :mojave"
 
   app "Dynamic Dark Mode.app"
 
   zap trash: "~/Library/Application Scripts/io.github.apollozhu.Dynamic.Launcher"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/ebibookreader.rb
+++ b/Casks/e/ebibookreader.rb
@@ -7,11 +7,9 @@ cask "ebibookreader" do
   desc "Ebook reader"
   homepage "https://www.ebookjapan.jp/ebj/reader/mac/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "ebibookreader.pkg"
 
   uninstall pkgutil: "jp.co.ebookjapan.ebibookreader1360.ebiBookReader.pkg"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/eclipse-javascript.rb
+++ b/Casks/e/eclipse-javascript.rb
@@ -7,10 +7,8 @@ cask "eclipse-javascript" do
   desc "Eclipse IDE for JavaScript and web developers"
   homepage "https://eclipse.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse JavaScript.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/eclipse-testing.rb
+++ b/Casks/e/eclipse-testing.rb
@@ -7,10 +7,8 @@ cask "eclipse-testing" do
   desc "Eclipse IDE for testing purposes"
   homepage "https://eclipse.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Testing.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/edex-ui.rb
+++ b/Casks/e/edex-ui.rb
@@ -7,6 +7,8 @@ cask "edex-ui" do
   desc "Sci-fi themed terminal emulator and system monitor"
   homepage "https://github.com/GitSquared/edex-ui"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "eDEX-UI.app"
 
   zap trash: [
@@ -14,8 +16,4 @@ cask "edex-ui" do
     "~/Library/Saved Application State/com.edex.ui.savedState",
     "~/Library/Preferences/com.edex.ui.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/electron-api-demos.rb
+++ b/Casks/e/electron-api-demos.rb
@@ -7,6 +7,8 @@ cask "electron-api-demos" do
   desc "Explore the Electron APIs"
   homepage "https://github.com/electron/electron-api-demos"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Electron API Demos.app"
 
   zap trash: [
@@ -17,8 +19,4 @@ cask "electron-api-demos" do
     "~/Library/Preferences/com.electron.electron-api-demos.plist",
     "~/Library/Saved Application State/com.electron.electron-api-demos.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/electronic-wechat.rb
+++ b/Casks/e/electronic-wechat.rb
@@ -6,6 +6,8 @@ cask "electronic-wechat" do
   name "Electronic WeChat"
   homepage "https://github.com/geeeeeeeeek/electronic-wechat"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Electronic WeChat-darwin-x64/Electronic WeChat.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "electronic-wechat" do
     "~/Library/Preferences/com.electron.electronic-wechat.plist",
     "~/Library/Preferences/com.electron.electronic-wechat.helper.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/encryptr.rb
+++ b/Casks/e/encryptr.rb
@@ -8,14 +8,12 @@ cask "encryptr" do
   desc "Zero-knowledge cloud-based password manager"
   homepage "https://spideroak.support/hc/en-us/categories/115000424503-Encryptr-Password-Manager"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Encryptr.app"
 
   zap trash: [
     "~/Library/Preferences/org.devgeeks.encryptr.plist",
     "~/Library/Saved Application State/org.devgeeks.encryptr.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/energybar.rb
+++ b/Casks/e/energybar.rb
@@ -7,11 +7,9 @@ cask "energybar" do
   desc "Touch Bar widget application"
   homepage "https://github.com/billziss-gh/EnergyBar"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :high_sierra"
 
   app "EnergyBar.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/epichrome.rb
+++ b/Casks/e/epichrome.rb
@@ -7,11 +7,9 @@ cask "epichrome" do
   desc "Tool to create web-based applications that work like standalone apps"
   homepage "https://github.com/dmarmor/epichrome"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "epichrome-#{version}.pkg"
 
   uninstall pkgutil: "org.epichrome.Epichrome"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/epub-to-pdf.rb
+++ b/Casks/e/epub-to-pdf.rb
@@ -7,9 +7,7 @@ cask "epub-to-pdf" do
   name "epub-2-pdf"
   homepage "https://code.google.com/archive/p/epub-2-pdf"
 
-  app "epub-to-pdf.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "epub-to-pdf.app"
 end

--- a/Casks/e/ethereum-wallet.rb
+++ b/Casks/e/ethereum-wallet.rb
@@ -8,6 +8,8 @@ cask "ethereum-wallet" do
   desc "Browser for Ðapps on the Ethereum network"
   homepage "https://github.com/ethereum/mist"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Ethereum Wallet.app"
 
   zap trash: [
@@ -15,8 +17,4 @@ cask "ethereum-wallet" do
     "~/Library/Preferences/com.ethereum.wallet.plist",
     "~/Library/Preferences/com.ethereum.wallet.helper.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/e/expo-xde.rb
+++ b/Casks/e/expo-xde.rb
@@ -7,9 +7,7 @@ cask "expo-xde" do
   name "Expo Development Environment (XDE)"
   homepage "https://expo.io/"
 
-  app "Expo XDE.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Expo XDE.app"
 end

--- a/Casks/f/fastclicker.rb
+++ b/Casks/f/fastclicker.rb
@@ -7,9 +7,7 @@ cask "fastclicker" do
   desc "Auto clicker and mouse automation utility"
   homepage "http://www.advanced-mouse-auto-clicker.com/mac-auto-clicker.html"
 
-  app "FastClicker.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "FastClicker.app"
 end

--- a/Casks/f/flomo.rb
+++ b/Casks/f/flomo.rb
@@ -8,6 +8,8 @@ cask "flomo" do
   desc "Memo note taking and management app"
   homepage "https://flomoapp.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :catalina"
 
   app "flomo.app"
@@ -18,8 +20,6 @@ cask "flomo" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       Flomo versions prior to 2.0 are no longer supported and newer versions
       are hosted on third-party file uploading sites that we can't use in the

--- a/Casks/f/fog.rb
+++ b/Casks/f/fog.rb
@@ -7,6 +7,8 @@ cask "fog" do
   desc "Unofficial overcast.fm podcast app"
   homepage "https://github.com/vitorgalvao/fog"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Fog.app"
 
   uninstall quit: "com.vitorgalvao.fog"
@@ -19,8 +21,4 @@ cask "fog" do
     "~/Library/Preferences/com.vitorgalvao.fog.plist",
     "~/Library/Saved Application State/com.vitorgalvao.fog.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/f/framer-x.rb
+++ b/Casks/f/framer-x.rb
@@ -7,14 +7,14 @@ cask "framer-x" do
   desc "Tool that helps teams design every part of the product experience"
   homepage "https://framer.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Framer X.app"
 
   caveats do
-    discontinued
-
     <<~EOS
       This software has been deprecated in favor of Framer Desktop (framer cask).
       Your Framer X license will be honoured on the new software:

--- a/Casks/f/freesmug-chromium.rb
+++ b/Casks/f/freesmug-chromium.rb
@@ -8,14 +8,12 @@ cask "freesmug-chromium" do
   desc "Google Chromium built to solve Chrome incompatibility issue"
   homepage "http://www.freesmug.org/chromium"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: [
     "chromium",
     "eloston-chromium",
   ]
 
   app "Chromium.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/f/fugu.rb
+++ b/Casks/f/fugu.rb
@@ -7,9 +7,7 @@ cask "fugu" do
   desc "Frontend for OpenSSH's sftp/scp tools"
   homepage "https://sourceforge.net/projects/fugussh/"
 
-  app "Fugu.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Fugu.app"
 end

--- a/Casks/g/ganache.rb
+++ b/Casks/g/ganache.rb
@@ -8,6 +8,8 @@ cask "ganache" do
   desc "Personal blockchain for Ethereum development"
   homepage "https://trufflesuite.com/ganache/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Ganache.app"
 
   zap trash: [
@@ -18,7 +20,6 @@ cask "ganache" do
   ]
 
   caveats do
-    discontinued
     <<~EOS
       See https://consensys.io/blog/consensys-announces-the-sunset-of-truffle-and-ganache-and-new-hardhat for information
     EOS

--- a/Casks/g/glance.rb
+++ b/Casks/g/glance.rb
@@ -7,6 +7,8 @@ cask "glance" do
   desc "Utility to provide quick look previews for files that aren't natively supported"
   homepage "https://github.com/samuelmeuli/glance"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :catalina"
 
   app "Glance.app"
@@ -20,7 +22,6 @@ cask "glance" do
   ]
 
   caveats do
-    discontinued
     <<~EOS
       You must start #{appdir}/Glance.app once manually to setup the QuickLook plugin.
     EOS

--- a/Casks/g/glimmerblocker.rb
+++ b/Casks/g/glimmerblocker.rb
@@ -7,6 +7,8 @@ cask "glimmerblocker" do
   desc "HTTP based ad blocker"
   homepage "https://glimmerblocker.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "GlimmerBlocker.pkg"
 
   uninstall pkgutil:   "org.glimmerblocker.pkg",
@@ -23,8 +25,6 @@ cask "glimmerblocker" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       You must deactivate GlimmerBlocker from the installed preference
       pane before uninstalling. See https://glimmerblocker.org/wiki/Uninstall.

--- a/Casks/g/gmail-notifier.rb
+++ b/Casks/g/gmail-notifier.rb
@@ -7,9 +7,7 @@ cask "gmail-notifier" do
   desc "Minimalist Gmail inbox notifications app"
   homepage "https://github.com/jashephe/Gmail-Notifier"
 
-  app "Gmail Notifier.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Gmail Notifier.app"
 end

--- a/Casks/g/goldendict.rb
+++ b/Casks/g/goldendict.rb
@@ -8,6 +8,8 @@ cask "goldendict" do
   desc "Feature-rich dictionary lookup program"
   homepage "http://goldendict.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "GoldenDict.app"
@@ -18,8 +20,4 @@ cask "goldendict" do
     "~/Library/Saved Application State/org.goldendict.savedState",
     "~/.goldendict",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/goofy.rb
+++ b/Casks/g/goofy.rb
@@ -8,6 +8,8 @@ cask "goofy" do
   desc "Desktop client for Facebook Messenger"
   homepage "https://www.goofyapp.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Goofy.app"
 
   zap trash: [
@@ -18,8 +20,4 @@ cask "goofy" do
     "~/Library/Preferences/cc.buechele.Goofy.plist",
     "~/Library/Saved Application State/cc.buechele.Goofy.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/google-chat-electron.rb
+++ b/Casks/g/google-chat-electron.rb
@@ -10,6 +10,8 @@ cask "google-chat-electron" do
   desc "Standalone app for Google Chat"
   homepage "https://github.com/ankurk91/google-chat-electron"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :catalina"
 
   app "google-chat-electron.app"
@@ -21,8 +23,4 @@ cask "google-chat-electron" do
     "~/Library/Preferences/com.electron.google-chat-electron.plist",
     "~/Library/Saved Application State/com.electron.google-chat-electron.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/googleappengine.rb
+++ b/Casks/g/googleappengine.rb
@@ -8,6 +8,8 @@ cask "googleappengine" do
   desc "Cloud computing platform"
   homepage "https://cloud.google.com/appengine/docs/standard/python/download#appengine_sdk/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "GoogleAppEngineLauncher.app"
 
   zap trash: [
@@ -15,8 +17,4 @@ cask "googleappengine" do
     "~/Library/Preferences/com.google.GoogleAppEngineLauncher.plist",
     "~/Library/Saved Application State/com.google.GoogleAppEngineLauncher.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/gpg-sync.rb
+++ b/Casks/g/gpg-sync.rb
@@ -6,12 +6,10 @@ cask "gpg-sync" do
   name "GPG Sync"
   homepage "https://github.com/firstlookmedia/gpgsync/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "GPGSync-#{version}.pkg"
 
   uninstall pkgutil:   "org.firstlook.gpgsync",
             launchctl: "org.firstlook.gpgsync"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/growlnotify.rb
+++ b/Casks/g/growlnotify.rb
@@ -8,11 +8,9 @@ cask "growlnotify" do
   desc "Notification system"
   homepage "https://growl.github.io/growl/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "GrowlNotify.pkg"
 
   uninstall pkgutil: "info.growl.growlnotify.*pkg"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/gulp.rb
+++ b/Casks/g/gulp.rb
@@ -6,11 +6,9 @@ cask "gulp" do
   name "gulp-app"
   homepage "https://github.com/sindresorhus/gulp-app"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "gulp.app"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/g/guppy.rb
+++ b/Casks/g/guppy.rb
@@ -7,11 +7,9 @@ cask "guppy" do
   desc "Friendly application manager and task runner for React.js"
   homepage "https://github.com/joshwcomeau/guppy"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Guppy.app"
 
   zap trash: "~/Library/Application Support/Guppy"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/h/handbrakebatch.rb
+++ b/Casks/h/handbrakebatch.rb
@@ -6,9 +6,7 @@ cask "handbrakebatch" do
   name "HandBrakeBatch"
   homepage "https://osomac.com/apps/osx/handbrake-batch/"
 
-  app "HandBrakeBatch.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "HandBrakeBatch.app"
 end

--- a/Casks/h/hookshot.rb
+++ b/Casks/h/hookshot.rb
@@ -7,6 +7,8 @@ cask "hookshot" do
   desc "Window snapping tool"
   homepage "https://hookshot.app/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :sierra"
 
@@ -22,8 +24,4 @@ cask "hookshot" do
     "~/Library/HTTPStorages/com.knollsoft.Hookshot.binarycookies",
     "~/Library/Preferences/com.knollsoft.Hookshot.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/h/hotswitch.rb
+++ b/Casks/h/hotswitch.rb
@@ -7,11 +7,9 @@ cask "hotswitch" do
   desc "Fast window switcher using a 2-stroke hotkey"
   homepage "https://oniatsu.github.io/HotSwitch/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "HotSwitch.app"
 
   zap trash: "~/Library/Preferences/com.oniatsu.HotSwitch.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/h/hp-eprint.rb
+++ b/Casks/h/hp-eprint.rb
@@ -7,6 +7,8 @@ cask "hp-eprint" do
   desc "Mobile printing solution"
   homepage "https://h20331.www2.hp.com/hpsub/us/en/eprint/overview.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "HP ePrint Installer.pkg"
 
   uninstall pkgutil: "com.hp.pkg.cloudprint.HP-ePrint-Mobile"
@@ -15,8 +17,4 @@ cask "hp-eprint" do
     "~/Library/Containers/com.hp.cloudprint.HP-ePrint-Mobile",
     "~/Library/PDF Services/HP ePrint",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/h/hue-topia.rb
+++ b/Casks/h/hue-topia.rb
@@ -7,14 +7,12 @@ cask "hue-topia" do
   desc "Manual control over Philips Hue bulbs"
   homepage "https://peacockmedia.software/mac/huetopia/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Hue-topia.app"
 
   zap trash: [
     "~/Library/Application Scripts/com.peacockmedia.Hue-topia",
     "~/Library/Containers/com.peacockmedia.Hue-topia",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/h/hwsensors.rb
+++ b/Casks/h/hwsensors.rb
@@ -7,6 +7,8 @@ cask "hwsensors" do
   desc "Tool to access information from available hardware sensors"
   homepage "https://github.com/kozlekek/HWSensors/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "HWSensors.#{version}.pkg"
 
   uninstall login_item: "HWMonitor",
@@ -17,8 +19,4 @@ cask "hwsensors" do
     "~/Library/Application Support/HWMonitor",
     "~/Library/Preferences/org.hwsensors.HWMonitor.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/i/icons.rb
+++ b/Casks/i/icons.rb
@@ -7,9 +7,7 @@ cask "icons" do
   desc "Tool to generate icons for apps"
   homepage "https://github.com/exherb/icons"
 
-  app "Icons.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Icons.app"
 end

--- a/Casks/i/image-tool.rb
+++ b/Casks/i/image-tool.rb
@@ -7,11 +7,9 @@ cask "image-tool" do
   desc "Scale images and convert image file formats"
   homepage "https://archive.org/details/jimmcgowan-2000s-software"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: "<= :mojave"
 
   app "Image Tool.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/i/imagemin.rb
+++ b/Casks/i/imagemin.rb
@@ -7,11 +7,9 @@ cask "imagemin" do
   desc "Desktop image minifier"
   homepage "https://github.com/imagemin/imagemin-app"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   # Renamed for clarity: app name is inconsistent with its branding.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/4701
   app "imagemin-app-v#{version}-darwin/Atom.app", target: "imagemin.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/i/imo.rb
+++ b/Casks/i/imo.rb
@@ -8,10 +8,11 @@ cask "imo" do
   desc "Video calls and chat"
   homepage "https://imo.im/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Imo.app"
 
   caveats do
-    discontinued
     <<~EOS
       Newer version is only available in Mac App Store.
     EOS

--- a/Casks/i/intel-haxm.rb
+++ b/Casks/i/intel-haxm.rb
@@ -7,6 +7,8 @@ cask "intel-haxm" do
   desc "Hardware-assisted virtualization engine (hypervisor)"
   homepage "https://github.com/intel/haxm"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
   depends_on arch: :x86_64
 
@@ -24,7 +26,6 @@ cask "intel-haxm" do
             }
 
   caveats do
-    discontinued
     kext
   end
 end

--- a/Casks/i/intel-psxe-ce-c-plus-plus.rb
+++ b/Casks/i/intel-psxe-ce-c-plus-plus.rb
@@ -7,6 +7,8 @@ cask "intel-psxe-ce-c-plus-plus" do
   desc "Software development tools"
   homepage "https://software.intel.com/en-us/parallel-studio-xe"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   installer manual: "m_ccompxe_#{version.csv.first}.app"
 
   uninstall script: {
@@ -16,7 +18,6 @@ cask "intel-psxe-ce-c-plus-plus" do
   }
 
   caveats do
-    discontinued
     license "https://software.intel.com/en-us/articles/end-user-license-agreement"
     free_license "https://software.intel.com/en-us/articles/qualify-for-free-software"
   end

--- a/Casks/i/ionic-lab.rb
+++ b/Casks/i/ionic-lab.rb
@@ -7,9 +7,7 @@ cask "ionic-lab" do
   name "IonicLab"
   homepage "https://lab.ionic.io/"
 
-  app "Ionic Lab.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Ionic Lab.app"
 end

--- a/Casks/i/ipartition.rb
+++ b/Casks/i/ipartition.rb
@@ -13,6 +13,8 @@ cask "ipartition" do
   desc "Disk partitioning tool"
   homepage "https://coriolis-systems.com/iPartition/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: "<= :high_sierra"
 
   app "iPartition.app"
@@ -20,7 +22,6 @@ cask "ipartition" do
   zap trash: "~/Library/Preferences/com.coriolis-systems.iPartition.plist"
 
   caveats do
-    discontinued
     free_license "https://coriolis-systems.com/downloads/iPartition.png"
   end
 end

--- a/Casks/i/irccloud.rb
+++ b/Casks/i/irccloud.rb
@@ -7,6 +7,8 @@ cask "irccloud" do
   desc "IRC client"
   homepage "https://github.com/irccloud/irccloud-desktop"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "IRCCloud.app"
 
   zap trash: [
@@ -17,8 +19,4 @@ cask "irccloud" do
     "~/Library/Preferences/com.irccloud.desktop.plist",
     "~/Library/Saved Application State/com.irccloud.desktop.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/i/ishowu.rb
+++ b/Casks/i/ishowu.rb
@@ -7,9 +7,7 @@ cask "ishowu" do
   desc "Screen recorder"
   homepage "https://www.shinywhitebox.com/ishowu"
 
-  app "iShowU.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "iShowU.app"
 end

--- a/Casks/i/iswiff.rb
+++ b/Casks/i/iswiff.rb
@@ -7,11 +7,9 @@ cask "iswiff" do
   desc "Full screen Flash outside the browser"
   homepage "https://echoone.com/iswiff/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: "<= :big_sur"
 
   app "iSwiff.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/j/jad.rb
+++ b/Casks/j/jad.rb
@@ -7,14 +7,14 @@ cask "jad" do
   desc "Java decompiler"
   homepage "https://varaneckas.com/jad/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: "<= :mojave"
 
   binary "jad"
   manpage "jad.1"
 
   caveats do
-    discontinued
-
     <<~EOS
       Instructions on using jad are available in
 

--- a/Casks/j/jenkins-menu.rb
+++ b/Casks/j/jenkins-menu.rb
@@ -7,14 +7,12 @@ cask "jenkins-menu" do
   desc "Menu item which shows the status of a Jenkins CI server"
   homepage "https://github.com/qvacua/jenkins-menu/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Jenkins Menu.app"
 
   zap trash: [
     "~/Library/Caches/com.qvacua.Jenkins-Menu",
     "~/Library/Preferences/com.qvacua.Jenkins-Menu.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/j/joker.rb
+++ b/Casks/j/joker.rb
@@ -6,9 +6,7 @@ cask "joker" do
   name "Joker iOS kernelcache handling utility"
   homepage "http://newosxbook.com/tools/joker.html"
 
-  binary "joker.universal", target: "joker"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  binary "joker.universal", target: "joker"
 end

--- a/Casks/j/jtool.rb
+++ b/Casks/j/jtool.rb
@@ -7,10 +7,8 @@ cask "jtool" do
   desc "Tool to help out reverse engineering, security researchers, and tweak developers"
   homepage "http://newosxbook.com/tools/jtool.html"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   binary "jtool"
   manpage "jtool.1"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/k/kindle.rb
+++ b/Casks/k/kindle.rb
@@ -8,6 +8,8 @@ cask "kindle" do
   desc "Interface for reading and syncing eBooks"
   homepage "https://www.amazon.com/gp/digital/fiona/kcp-landing-page"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :mojave"
 
@@ -25,7 +27,6 @@ cask "kindle" do
   ]
 
   caveats do
-    discontinued
     requires_rosetta
     <<~EOS
       Please see https://www.amazon.com/kindle-dbs/arp/B0C9PRPV28 for information regarding application end of life.

--- a/Casks/k/kitematic.rb
+++ b/Casks/k/kitematic.rb
@@ -8,6 +8,8 @@ cask "kitematic" do
   desc "Visual user interface for Docker Container management"
   homepage "https://kitematic.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Kitematic.app"
 
   zap trash: [
@@ -19,8 +21,4 @@ cask "kitematic" do
     "~/Library/Preferences/com.electron.kitematic.helper.plist",
     "~/Library/Saved Application State/com.electron.kitematic.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/k/kmplayer.rb
+++ b/Casks/k/kmplayer.rb
@@ -7,11 +7,9 @@ cask "kmplayer" do
   desc "Video player"
   homepage "https://www.kmplayer.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "KMPlayer-#{version}.pkg"
 
   uninstall pkgutil: "com.kmplayer.osx"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/k/komodo-edit.rb
+++ b/Casks/k/komodo-edit.rb
@@ -7,9 +7,7 @@ cask "komodo-edit" do
   desc "Text editor"
   homepage "https://www.activestate.com/komodo-edit/"
 
-  app "Komodo Edit #{version.major}.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Komodo Edit #{version.major}.app"
 end

--- a/Casks/k/komodo-ide.rb
+++ b/Casks/k/komodo-ide.rb
@@ -7,9 +7,7 @@ cask "komodo-ide" do
   desc "One IDE for all your languages"
   homepage "https://www.activestate.com/komodo-ide/"
 
-  app "Komodo IDE #{version.major}.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Komodo IDE #{version.major}.app"
 end

--- a/Casks/k/ksdiff.rb
+++ b/Casks/k/ksdiff.rb
@@ -7,6 +7,8 @@ cask "ksdiff" do
   desc "Command-line tool for the App Store version of Kaleidoscope"
   homepage "https://kaleidoscope.app/ksdiff#{version.major}"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: [
     "kaleidoscope",
     "homebrew/cask-versions/kaleidoscope2",
@@ -16,8 +18,4 @@ cask "ksdiff" do
   pkg "ksdiff-#{version.csv.first}/Install ksdiff.pkg"
 
   uninstall pkgutil: "app.kaleidoscope.v#{version.major}.ksdiff.installer.pkg"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/k/kube-cluster.rb
+++ b/Casks/k/kube-cluster.rb
@@ -6,11 +6,9 @@ cask "kube-cluster" do
   name "Kube-Cluster"
   homepage "https://github.com/TheNewNormal/kube-cluster-osx"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Kube-Cluster.app"
 
   zap trash: "~/kube-cluster"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/l/lab.rb
+++ b/Casks/l/lab.rb
@@ -7,9 +7,7 @@ cask "lab" do
   desc "React UI component design tool"
   homepage "https://github.com/c8r/lab/"
 
-  app "Lab.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Lab.app"
 end

--- a/Casks/l/launchrocket.rb
+++ b/Casks/l/launchrocket.rb
@@ -7,11 +7,9 @@ cask "launchrocket" do
   desc "Preference pane to manage Homebrew-installed services"
   homepage "https://github.com/jimbojsb/launchrocket"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   prefpane "LaunchRocket.prefPane"
 
   zap trash: "~/Library/Preferences/com.joshbutts.launchrocket.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/l/lightform.rb
+++ b/Casks/l/lightform.rb
@@ -8,6 +8,8 @@ cask "lightform" do
   desc "AR projection and audio reactivity software for Lightform devices"
   homepage "https://lightform.com/creator"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :mojave"
 
   app "Lightform.app"
@@ -18,8 +20,4 @@ cask "lightform" do
     "~/Library/Preferences/com.lightform.desktop.plist",
     "~/Library/Saved Application State/com.lightform.desktop.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/l/line-bot-designer.rb
+++ b/Casks/l/line-bot-designer.rb
@@ -8,9 +8,7 @@ cask "line-bot-designer" do
   desc "Prototype LINE bots"
   homepage "https://developers.line.biz/en/"
 
-  app "LINE Bot Designer.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "LINE Bot Designer.app"
 end

--- a/Casks/l/linn-konfig.rb
+++ b/Casks/l/linn-konfig.rb
@@ -12,6 +12,8 @@ cask "linn-konfig" do
     strategy :extract_plist
   end
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "konfig_latest_osx.pkg"
 
   uninstall pkgutil: "uk.co.linn.Konfig"
@@ -21,8 +23,4 @@ cask "linn-konfig" do
     "~/Library/Caches/uk.co.linn.Konfig",
     "~/Library/HTTPStorages/uk.co.linn.Konfig",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/l/logdna-agent.rb
+++ b/Casks/l/logdna-agent.rb
@@ -8,14 +8,14 @@ cask "logdna-agent" do
   desc "Agent streams from log files to your LogDNA account"
   homepage "https://logdna.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "logdna-agent-#{version}.pkg"
 
   uninstall pkgutil:   "com.logdna.logdna-agent",
             launchctl: "com.logdna.logdna-agentd"
 
   caveats do
-    discontinued
-
     <<~EOS
       When you first start logdna-agent, you must set your LogDNA Ingestion Key with the command:
         sudo logdna-agent -k <ingestion-key>

--- a/Casks/l/logisim.rb
+++ b/Casks/l/logisim.rb
@@ -8,11 +8,9 @@ cask "logisim" do
   desc "Tool for designing and simulating digital logic circuits"
   homepage "http://www.cburch.com/logisim/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Logisim.app"
 
   zap trash: "~/Library/Preferences/com.cburch.logisim.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/l/luyten.rb
+++ b/Casks/l/luyten.rb
@@ -8,9 +8,7 @@ cask "luyten" do
   desc "Open-source Java decompiler GUI for Procyon"
   homepage "https://deathmarine.github.io/Luyten/"
 
-  app "Luyten.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Luyten.app"
 end

--- a/Casks/m/macdropany.rb
+++ b/Casks/m/macdropany.rb
@@ -7,11 +7,9 @@ cask "macdropany" do
   desc "Syncs any local folder with the cloud"
   homepage "https://github.com/sebthedev/MacDropAny"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "MacDropAny.app"
 
   zap trash: "~/Library/Services/Sync via MacDropAny.workflow"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/machoexplorer.rb
+++ b/Casks/m/machoexplorer.rb
@@ -7,9 +7,7 @@ cask "machoexplorer" do
   desc "Mach-O Executable File Explorer"
   homepage "https://github.com/everettjf/MachOExplorer"
 
-  app "MachOExplorer.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "MachOExplorer.app"
 end

--- a/Casks/m/maria.rb
+++ b/Casks/m/maria.rb
@@ -7,9 +7,7 @@ cask "maria" do
   desc "App/widget for aria2 download tool"
   homepage "https://github.com/shincurry/Maria"
 
-  app "Maria.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Maria.app"
 end

--- a/Casks/m/mattr-slate.rb
+++ b/Casks/m/mattr-slate.rb
@@ -6,6 +6,8 @@ cask "mattr-slate" do
   name "Slate"
   homepage "https://github.com/mattr-/slate"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "slate"
 
@@ -16,8 +18,4 @@ cask "mattr-slate" do
     "~/.slate.js",
     "~/Library/Application Support/com.slate.Slate",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/mauve.rb
+++ b/Casks/m/mauve.rb
@@ -7,9 +7,7 @@ cask "mauve" do
   desc "System for constructing multiple genome alignments"
   homepage "https://darlinglab.org/mauve/mauve.html"
 
-  app "Mauve.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Mauve.app"
 end

--- a/Casks/m/mavensmate.rb
+++ b/Casks/m/mavensmate.rb
@@ -7,9 +7,7 @@ cask "mavensmate" do
   desc "Packaged desktop app for MavensMate server"
   homepage "https://github.com/joeferraro/MavensMate-Desktop"
 
-  app "MavensMate.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "MavensMate.app"
 end

--- a/Casks/m/meld.rb
+++ b/Casks/m/meld.rb
@@ -8,6 +8,8 @@ cask "meld" do
   desc "Visual diff and merge tool"
   homepage "https://yousseb.github.io/meld/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :high_sierra"
 
   app "Meld.app"
@@ -27,8 +29,4 @@ cask "meld" do
     "~/Library/Preferences/org.gnome.meld.plist",
     "~/Library/Saved Application State/org.gnome.meld.savedState/",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/mellowplayer.rb
+++ b/Casks/m/mellowplayer.rb
@@ -8,6 +8,8 @@ cask "mellowplayer" do
   desc "Moved to gitlab"
   homepage "https://colinduquesnoy.github.io/MellowPlayer/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "MellowPlayer.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "mellowplayer" do
     "~/Library/Preferences/com.mellowplayer.3.plist",
     "~/Library/Preferences/com.mellowplayer.mellowplayer.MellowPlayer.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/mob.rb
+++ b/Casks/m/mob.rb
@@ -6,11 +6,9 @@ cask "mob" do
   name "Mob"
   homepage "https://github.com/zenghongtu/Mob"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Mob.app"
 
   zap trash: "~/Library/Application Support/mob"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/mojibar.rb
+++ b/Casks/m/mojibar.rb
@@ -7,9 +7,7 @@ cask "mojibar" do
   desc "Emoji searcher as a menu bar app"
   homepage "https://github.com/muan/mojibar"
 
-  app "Mojibar-darwin-x64/Mojibar.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Mojibar-darwin-x64/Mojibar.app"
 end

--- a/Casks/m/mongodbpreferencepane.rb
+++ b/Casks/m/mongodbpreferencepane.rb
@@ -7,9 +7,7 @@ cask "mongodbpreferencepane" do
   desc "Preference pane to control MongoDB Server"
   homepage "https://github.com/remysaissy/mongodb-macosx-prefspane"
 
-  prefpane "MongoDB.prefPane"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  prefpane "MongoDB.prefPane"
 end

--- a/Casks/m/mplayer-osx-extended.rb
+++ b/Casks/m/mplayer-osx-extended.rb
@@ -8,11 +8,9 @@ cask "mplayer-osx-extended" do
   desc "Video player that uses MPlayer as backend"
   homepage "https://mplayerosx.ch/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "MPlayer OSX Extended.app"
 
   zap trash: "~/.mplayer"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/multibit-hd.rb
+++ b/Casks/m/multibit-hd.rb
@@ -6,11 +6,9 @@ cask "multibit-hd" do
   name "MultiBit HD"
   homepage "https://github.com/Multibit-Legacy/multibit-hd"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "MultiBit HD.app"
 
   uninstall quit: "com.install4j.6925-4794-5772-4956.24"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/mutespotifyads.rb
+++ b/Casks/m/mutespotifyads.rb
@@ -6,13 +6,11 @@ cask "mutespotifyads" do
   name "MuteSpotifyAds"
   homepage "https://github.com/simonmeusel/MuteSpotifyAds"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "MuteSpotifyAds.app"
 
   zap trash: "~/Library/SyncedPreferences/de.simonmeusel.MuteSpotifyAds.plist"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/m/mysql-connector-python.rb
+++ b/Casks/m/mysql-connector-python.rb
@@ -10,6 +10,8 @@ cask "mysql-connector-python" do
   desc "Self-contained Python driver for communicating with MySQL servers"
   homepage "https://dev.mysql.com/downloads/connector/python/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :monterey"
 
   pkg "mysql-connector-python-#{version}-macos13-#{arch}.pkg"
@@ -24,8 +26,4 @@ cask "mysql-connector-python" do
   ]
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/n/namebench.rb
+++ b/Casks/n/namebench.rb
@@ -8,9 +8,7 @@ cask "namebench" do
   desc "DNS server finder"
   homepage "https://code.google.com/archive/p/namebench/"
 
-  app "namebench.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "namebench.app"
 end

--- a/Casks/n/ndm.rb
+++ b/Casks/n/ndm.rb
@@ -8,6 +8,8 @@ cask "ndm" do
   desc "Desktop manager for the Node.js Package Manager (NPM)"
   homepage "https://720kb.github.io/ndm/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "ndm.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "ndm" do
     "~/Library/Preferences/net.720kb.ndm.plist",
     "~/Library/Saved Application State/net.720kb.ndm.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/n/next.rb
+++ b/Casks/n/next.rb
@@ -7,11 +7,9 @@ cask "next" do
   desc "Web browser"
   homepage "https://next.atlas.engineer/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Next.app"
 
   zap trash: "~/Library/Caches/next.browser"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/o/obs-virtualcam.rb
+++ b/Casks/o/obs-virtualcam.rb
@@ -6,13 +6,11 @@ cask "obs-virtualcam" do
   name "OBS Virtual Camera"
   homepage "https://github.com/johnboiles/obs-mac-virtualcam"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :high_sierra"
 
   pkg "obs-mac-virtualcam-#{version.csv.second}-v#{version.csv.first}.pkg"
 
   uninstall pkgutil: "com.johnboiles.obs-mac-virtualcam"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/o/omnidazzle.rb
+++ b/Casks/o/omnidazzle.rb
@@ -7,9 +7,7 @@ cask "omnidazzle" do
   desc "Set of plug-ins to highlight areas of your screen and your mouse pointer"
   homepage "https://support.omnigroup.com/omnidazzle-troubleshooting/"
 
-  app "OmniDazzle.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "OmniDazzle.app"
 end

--- a/Casks/o/openconnect-gui.rb
+++ b/Casks/o/openconnect-gui.rb
@@ -8,14 +8,12 @@ cask "openconnect-gui" do
   desc "GitLab mirror - Graphical OpenConnect client (beta phase)"
   homepage "https://openconnect.github.io/openconnect-gui/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "openconnect-gui/#{version}/OpenConnect-GUI.app"
 
   zap delete: [
     "~/Library/Application Support/OpenConnect-GUI Team",
     "~/Library/Preferences/io.github.openconnect.openconnect-gui.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/o/opera-mobile-emulator.rb
+++ b/Casks/o/opera-mobile-emulator.rb
@@ -7,9 +7,7 @@ cask "opera-mobile-emulator" do
   desc "Browser emulator"
   homepage "https://www.opera.com/developer/mobile-emulator"
 
-  app "Opera Mobile Emulator.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Opera Mobile Emulator.app"
 end

--- a/Casks/p/panic-unison.rb
+++ b/Casks/p/panic-unison.rb
@@ -7,9 +7,7 @@ cask "panic-unison" do
   desc "App to access Usenet Newsgroups"
   homepage "https://panic.com/blog/the-future-of-unison/"
 
-  app "Unison.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Unison.app"
 end

--- a/Casks/p/paragon-vmdk-mounter.rb
+++ b/Casks/p/paragon-vmdk-mounter.rb
@@ -7,13 +7,11 @@ cask "paragon-vmdk-mounter" do
   desc "Mounts a virtual container by double click"
   homepage "https://www.paragon-software.com/home/vd-mounter-mac-free/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "Paragon VMDK Mounter.pkg"
 
   uninstall launchctl: "com.paragon-software.vdmounter",
             kext:      "com.paragon-software.kext.VDMounter",
             pkgutil:   "com.paragon-software.VDMounter.pkg"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/parse.rb
+++ b/Casks/p/parse.rb
@@ -7,11 +7,9 @@ cask "parse" do
   name "Parse"
   homepage "https://parseplatform.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   container type: :naked
 
   binary "parse"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/particle-dev.rb
+++ b/Casks/p/particle-dev.rb
@@ -8,14 +8,12 @@ cask "particle-dev" do
   desc "IDE for programming Particle devices"
   homepage "https://www.particle.io/products/development-tools/particle-desktop-ide"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Particle Dev.app"
 
   zap trash: [
     "~/.particle",
     "~/.particledev",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/patchwork.rb
+++ b/Casks/p/patchwork.rb
@@ -7,9 +7,7 @@ cask "patchwork" do
   desc "Decentralized messaging and sharing app using Secure Scuttlebutt"
   homepage "https://github.com/ssbc/patchwork"
 
-  app "Patchwork.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Patchwork.app"
 end

--- a/Casks/p/pathephone.rb
+++ b/Casks/p/pathephone.rb
@@ -8,6 +8,8 @@ cask "pathephone" do
   desc "Distributed audio player"
   homepage "https://pathephone.github.io/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Pathephone.app"
@@ -19,8 +21,4 @@ cask "pathephone" do
     "~/Library/Preferences/space.metabin.pathephone.plist",
     "~/Library/Saved Application State/space.metabin.pathephone.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/paw.rb
+++ b/Casks/p/paw.rb
@@ -7,6 +7,8 @@ cask "paw" do
   desc "HTTP client that helps testing and describing APIs"
   homepage "https://paw.cloud/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :sierra"
 
@@ -21,8 +23,6 @@ cask "paw" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       #{token} has been renamed 'rapidapi',
       install rapidapi to continue receiving updates;

--- a/Casks/p/pg-commander.rb
+++ b/Casks/p/pg-commander.rb
@@ -8,9 +8,7 @@ cask "pg-commander" do
   desc "PostgreSQL client"
   homepage "https://eggerapps.at/pgcommander/"
 
-  app "PG Commander.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "PG Commander.app"
 end

--- a/Casks/p/phantomjs.rb
+++ b/Casks/p/phantomjs.rb
@@ -8,11 +8,9 @@ cask "phantomjs" do
   desc "Headless web browser"
   homepage "https://phantomjs.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   binary "phantomjs-#{version}-macosx/bin/phantomjs"
 
   zap trash: "~/Library/Application Support/Ofi Labs/PhantomJS/"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/plex-media-player.rb
+++ b/Casks/p/plex-media-player.rb
@@ -7,6 +7,8 @@ cask "plex-media-player" do
   desc "Home media player"
   homepage "https://www.plex.tv/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Plex Media Player.app"
@@ -20,8 +22,6 @@ cask "plex-media-player" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       #{token} has been deprecated in favor of Plex for Desktop and Plex HTPC.
 

--- a/Casks/p/profilecreator.rb
+++ b/Casks/p/profilecreator.rb
@@ -7,6 +7,8 @@ cask "profilecreator" do
   desc "Create standard or customized configuration profiles"
   homepage "https://github.com/erikberglund/ProfileCreator"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "ProfileCreator.app"
@@ -16,8 +18,4 @@ cask "profilecreator" do
     "~/Library/Application Support/ProfilePayloads",
     "~/Library/Preferences/com.github.erikberglund.ProfileCreator.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/projector.rb
+++ b/Casks/p/projector.rb
@@ -12,6 +12,8 @@ cask "projector" do
   desc "Common and client-related code for running Swing applications remotely"
   homepage "https://lp.jetbrains.com/projector/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :high_sierra"
 
   app "projector#{archapp}.app"
@@ -21,8 +23,4 @@ cask "projector" do
     "~/Library/Preferences/com.electron.projector.plist",
     "~/Library/Saved Application State/com.electron.projector.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/protonmail-import-export.rb
+++ b/Casks/p/protonmail-import-export.rb
@@ -7,6 +7,8 @@ cask "protonmail-import-export" do
   desc "Import emails to your secure ProtonMail inbox or make offline backups"
   homepage "https://proton.me/support/export-emails-import-export-app"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "ProtonMail Import-Export app.app"
@@ -19,8 +21,4 @@ cask "protonmail-import-export" do
     "~/Library/Caches/ProtonMail Import-Export app",
     "~/Library/Preferences/com.protonmail.import-export.ProtonMail Import-Export app.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/proximity.rb
+++ b/Casks/p/proximity.rb
@@ -7,12 +7,10 @@ cask "proximity" do
   name "Proximity"
   homepage "https://www.tokyodawn.net/proximity/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   container nested: "macOS/Proximity-VST-AU.dmg"
 
   audio_unit_plugin "Proximity.component"
   vst_plugin "Proximity.vst"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/pulse.rb
+++ b/Casks/p/pulse.rb
@@ -8,14 +8,12 @@ cask "pulse" do
   desc "Logger and network inspector"
   homepage "https://kean.blog/pulse/home"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Pulse.app"
 
   zap trash: [
     "~/Library/Application Scripts/com.github.kean.pulse",
     "~/Library/Containers/com.github.kean.pulse",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/pycharm-ce-with-anaconda-plugin.rb
+++ b/Casks/p/pycharm-ce-with-anaconda-plugin.rb
@@ -8,6 +8,8 @@ cask "pycharm-ce-with-anaconda-plugin" do
   desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "PyCharm CE with Anaconda plugin.app"
@@ -32,8 +34,4 @@ cask "pycharm-ce-with-anaconda-plugin" do
     "~/Library/Preferences/PyCharmCE#{version.major_minor}",
     "~/Library/Saved Application State/com.jetbrains.pycharm.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/p/pycharm-with-anaconda-plugin.rb
+++ b/Casks/p/pycharm-with-anaconda-plugin.rb
@@ -7,6 +7,8 @@ cask "pycharm-with-anaconda-plugin" do
   desc "PyCharm IDE with Anaconda plugin"
   homepage "https://www.jetbrains.com/pycharm/promo/anaconda"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "PyCharm with Anaconda plugin .app"
@@ -24,8 +26,4 @@ cask "pycharm-with-anaconda-plugin" do
     "~/Library/Application Support/JetBrains/PyCharm*",
     "~/Library/Saved Application State/com.jetbrains.pycharm.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/q/qcma.rb
+++ b/Casks/q/qcma.rb
@@ -7,9 +7,7 @@ cask "qcma" do
   name "Qcma"
   homepage "https://codestation.github.io/qcma/"
 
-  app "Qcma.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Qcma.app"
 end

--- a/Casks/q/qdesktop.rb
+++ b/Casks/q/qdesktop.rb
@@ -7,9 +7,7 @@ cask "qdesktop" do
   desc "App to set a website as the desktop background"
   homepage "https://github.com/qvacua/qdesktop"
 
-  app "Qdesktop.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Qdesktop.app"
 end

--- a/Casks/q/quicklookapk.rb
+++ b/Casks/q/quicklookapk.rb
@@ -7,11 +7,9 @@ cask "quicklookapk" do
   desc "Quick Look plugin for Android packages"
   homepage "https://github.com/hezi/QuickLookAPK"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   qlplugin "QuickLookAPK.qlgenerator"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/q/quik.rb
+++ b/Casks/q/quik.rb
@@ -7,11 +7,9 @@ cask "quik" do
   desc "Access and edit GoPro photos and videos"
   homepage "https://community.gopro.com/t5/en/GoPro-Quik-for-desktop/ta-p/394305?profile.language=en"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "GoPro Quik.pkg"
 
   uninstall pkgutil: "com.GoPro.pkg.GoProApp"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/q/qv2ray.rb
+++ b/Casks/q/qv2ray.rb
@@ -8,6 +8,8 @@ cask "qv2ray" do
   desc "V2Ray GUI client with extensive protocol support"
   homepage "https://qv2ray.net/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on formula: "v2ray"
   depends_on macos: ">= :mojave"
 
@@ -18,8 +20,4 @@ cask "qv2ray" do
     "~/Library/Preferences/qv2ray",
     "~/Library/Saved Application State/com.github.qv2ray.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/r/radiant-player.rb
+++ b/Casks/r/radiant-player.rb
@@ -8,6 +8,8 @@ cask "radiant-player" do
   desc "App wrapper for Google Play Music"
   homepage "https://radiant-player.github.io/radiant-player-mac/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Radiant Player.app"
 
   uninstall quit: "com.sajidanwar.Radiant-Player"
@@ -19,8 +21,4 @@ cask "radiant-player" do
     "~/Library/Preferences/com.sajidanwar.Radiant-Player.plist",
     "~/Library/Saved Application State/com.sajidanwar.Radiant-Player.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/r/ramme.rb
+++ b/Casks/r/ramme.rb
@@ -7,9 +7,7 @@ cask "ramme" do
   desc "Unofficial Instagram Desktop App"
   homepage "https://github.com/terkelg/ramme/"
 
-  app "Ramme.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Ramme.app"
 end

--- a/Casks/r/rclone-browser.rb
+++ b/Casks/r/rclone-browser.rb
@@ -7,6 +7,8 @@ cask "rclone-browser" do
   name "Rclone Browser"
   homepage "https://mmozeiko.github.io/RcloneBrowser/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on formula: "rclone"
 
   app "rclone-browser-#{version.csv.first}-#{version.csv.second}-macOS/Rclone Browser.app"
@@ -15,8 +17,4 @@ cask "rclone-browser" do
     "~/Library/Preferences/Rclone Browser.plist",
     "~/Library/Preferences/com.rclone-browser.rclone-browser.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/r/remote-desktop-manager-free.rb
+++ b/Casks/r/remote-desktop-manager-free.rb
@@ -8,6 +8,8 @@ cask "remote-desktop-manager-free" do
   desc "Centralizes all remote connections on a single platform"
   homepage "https://mac.remotedesktopmanager.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "Remote Desktop Manager Free.app"
@@ -18,7 +20,6 @@ cask "remote-desktop-manager-free" do
   ]
 
   caveats do
-    discontinued
     <<~EOS
       TO install the free version run:
 

--- a/Casks/r/robo-3t.rb
+++ b/Casks/r/robo-3t.rb
@@ -8,6 +8,8 @@ cask "robo-3t" do
   desc "MongoDB management tool"
   homepage "https://robomongo.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Robo 3T.app"
 
   uninstall quit: "Robo 3T"
@@ -20,8 +22,4 @@ cask "robo-3t" do
     "~/Library/Saved Application State/com.3tsoftwarelabs.robo3t.savedState",
     "~/Library/Saved Application State/Robo 3T.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/r/rowanj-gitx.rb
+++ b/Casks/r/rowanj-gitx.rb
@@ -8,12 +8,10 @@ cask "rowanj-gitx" do
   desc "Native graphical client for the git version control system"
   homepage "https://rowanj.github.io/gitx/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "gitx"
 
   app "GitX.app"
   binary "#{appdir}/GitX.app/Contents/Resources/gitx"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/samsung-dex.rb
+++ b/Casks/s/samsung-dex.rb
@@ -7,6 +7,8 @@ cask "samsung-dex" do
   desc "Extend some Samsung devices into a desktop-like experience"
   homepage "https://www.samsung.com/us/explore/dex/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "Install Samsung DeX.pkg"
 
   uninstall pkgutil: [
@@ -16,7 +18,6 @@ cask "samsung-dex" do
   ]
 
   caveats do
-    discontinued
     kext
     reboot
   end

--- a/Casks/s/seaglass.rb
+++ b/Casks/s/seaglass.rb
@@ -7,12 +7,10 @@ cask "seaglass" do
   desc "Matrix client"
   homepage "https://github.com/neilalexander/seaglass/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Seaglass.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/security-growler.rb
+++ b/Casks/s/security-growler.rb
@@ -6,9 +6,7 @@ cask "security-growler" do
   name "Security Growler"
   homepage "https://github.com/pirate/security-growler"
 
-  app "Security Growler.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Security Growler.app"
 end

--- a/Casks/s/senuti.rb
+++ b/Casks/s/senuti.rb
@@ -7,9 +7,7 @@ cask "senuti" do
   desc "Transfers songs, playlists, or videos from an iPod to a computer"
   homepage "https://fadingred.com/"
 
-  app "Senuti.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Senuti.app"
 end

--- a/Casks/s/sequel-pro.rb
+++ b/Casks/s/sequel-pro.rb
@@ -8,6 +8,8 @@ cask "sequel-pro" do
   desc "MySQL/MariaDB database management platform"
   homepage "https://www.sequelpro.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Sequel Pro.app"
 
   zap trash: [
@@ -18,8 +20,6 @@ cask "sequel-pro" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       #{token} has been deprecated in favor of Sequel Ace.
         brew install --cask sequel-ace

--- a/Casks/s/sfdx.rb
+++ b/Casks/s/sfdx.rb
@@ -9,6 +9,8 @@ cask "sfdx" do
   desc "SalesForce CLI tools"
   homepage "https://developer.salesforce.com/tools/sfdxcli"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "sfdx-#{arch}.pkg"
 
   uninstall pkgutil: [
@@ -24,8 +26,6 @@ cask "sfdx" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       `sf` is the official successor to this software
 

--- a/Casks/s/shiftit.rb
+++ b/Casks/s/shiftit.rb
@@ -7,6 +7,8 @@ cask "shiftit" do
   desc "Tool to manage the size and position of windows"
   homepage "https://github.com/fikovnik/ShiftIt/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "ShiftIt.app"
@@ -16,8 +18,4 @@ cask "shiftit" do
     "~/Library/Caches/org.shiftitapp.ShiftIt",
     "~/Library/Preferences/org.shiftitapp.ShiftIt.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/sidekick.rb
+++ b/Casks/s/sidekick.rb
@@ -7,11 +7,9 @@ cask "sidekick" do
   desc "Location-based settings manager"
   homepage "http://oomphalot.com/sidekick/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Sidekick.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/sketchbook.rb
+++ b/Casks/s/sketchbook.rb
@@ -8,6 +8,8 @@ cask "sketchbook" do
   desc "Draw, paint, & sketch application"
   homepage "https://www.sketchbook.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "SketchBook_v#{version.csv.first}_mac.pkg"
 
   uninstall quit:    "com.autodesk.SketchBook",
@@ -20,8 +22,6 @@ cask "sketchbook" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       Sketchbook is now handled by Sketchbook, Inc. and Autodesk no longer provides downloads. The app appears to only be available through app stores at this point (see https://www.sketchbook.com/apps).
     EOS

--- a/Casks/s/skiff.rb
+++ b/Casks/s/skiff.rb
@@ -8,6 +8,8 @@ cask "skiff" do
   desc "End-to-end encrypted email, calendar, documents, and files support"
   homepage "https://skiff.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :catalina"
 
@@ -19,7 +21,6 @@ cask "skiff" do
   ]
 
   caveats do
-    discontinued
     <<~EOS
       Newer version is only available in Mac App Store.
     EOS

--- a/Casks/s/smooze.rb
+++ b/Casks/s/smooze.rb
@@ -7,6 +7,8 @@ cask "smooze" do
   desc "Animates scrolling and adds functionality to scroll-wheel mice"
   homepage "https://smooze.co/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :sierra"
 
@@ -23,8 +25,4 @@ cask "smooze" do
     "~/Library/HTTPStorages/co.smooze.macos.binarycookies",
     "~/Library/Preferences/co.smooze.macos.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/snip.rb
+++ b/Casks/s/snip.rb
@@ -7,12 +7,10 @@ cask "snip" do
   desc "Screen capture tool"
   homepage "https://snip.qq.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "Snip_V#{version.sub(/^(\d+\.\d+).*/, '\1')}.pkg"
 
   uninstall quit:    "com.tencent.snip",
             pkgutil: "com.tencent.snip.Snip.pkg"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/socket-io-tester.rb
+++ b/Casks/s/socket-io-tester.rb
@@ -6,9 +6,7 @@ cask "socket-io-tester" do
   name "socket-io-tester.app"
   homepage "https://github.com/AppSaloon/socket.io-tester"
 
-  app "socket-io-tester-darwin-x64/socket-io-tester.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "socket-io-tester-darwin-x64/socket-io-tester.app"
 end

--- a/Casks/s/sonarr-menu.rb
+++ b/Casks/s/sonarr-menu.rb
@@ -7,14 +7,12 @@ cask "sonarr-menu" do
   desc "Utility that adds a menu to the Status Bar for managing Sonarr"
   homepage "https://github.com/jefbarn/Sonarr-Menu/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on cask: "sonarr"
 
   app "Sonarr-Menu.app"
 
   uninstall quit:      "tv.sonarr.Sonarr-Menu",
             launchctl: "tv.sonarr.Sonarr-Menu"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/sourcetrail.rb
+++ b/Casks/s/sourcetrail.rb
@@ -8,14 +8,12 @@ cask "sourcetrail" do
   desc "Code source explorer"
   homepage "https://www.sourcetrail.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Sourcetrail.app"
 
   zap trash: [
     "~/Library/Application Support/Sourcetrail",
     "~/Library/Saved Application State/com.sourcetrail.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/spechtlite.rb
+++ b/Casks/s/spechtlite.rb
@@ -7,9 +7,7 @@ cask "spechtlite" do
   desc "Rule-based proxy"
   homepage "https://github.com/zhuhaow/SpechtLite"
 
-  app "SpechtLite.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "SpechtLite.app"
 end

--- a/Casks/s/spectacle.rb
+++ b/Casks/s/spectacle.rb
@@ -8,6 +8,8 @@ cask "spectacle" do
   desc "Move and resize windows with ease"
   homepage "https://www.spectacleapp.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
 
   app "Spectacle.app"
@@ -21,8 +23,4 @@ cask "spectacle" do
     "~/Library/Cookies/com.divisiblebyzero.Spectacle.binarycookies",
     "~/Library/Preferences/com.divisiblebyzero.Spectacle.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/spotifree.rb
+++ b/Casks/s/spotifree.rb
@@ -7,9 +7,7 @@ cask "spotifree" do
   desc "Automatically mutes ads on Spotify (not supported)"
   homepage "https://github.com/ArtemGordinsky/Spotifree/"
 
-  app "Spotifree.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Spotifree.app"
 end

--- a/Casks/s/spotspot.rb
+++ b/Casks/s/spotspot.rb
@@ -8,9 +8,7 @@ cask "spotspot" do
   desc "Spotify mini-player"
   homepage "https://will-stone.github.io/SpotSpot/"
 
-  app "SpotSpot.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "SpotSpot.app"
 end

--- a/Casks/s/steelseries-engine.rb
+++ b/Casks/s/steelseries-engine.rb
@@ -8,6 +8,8 @@ cask "steelseries-engine" do
   desc "Settings for SteelSeries peripherals and accessories"
   homepage "https://steelseries.com/engine"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   auto_updates true
   conflicts_with cask: "steelseries-gg"
   depends_on macos: ">= :sierra"
@@ -37,8 +39,4 @@ cask "steelseries-engine" do
     "~/Library/Preferences/com.steelseries.ssenext.client.plist",
     "~/Library/Saved Application State/com.steelseries.ssenext.client.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/s/svgcleaner.rb
+++ b/Casks/s/svgcleaner.rb
@@ -7,6 +7,8 @@ cask "svgcleaner" do
   desc "Tool to clean up SVG files by removing unnecessary data"
   homepage "https://github.com/RazrFalcon/svgcleaner-gui/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with formula: "svgcleaner"
 
   app "SVGCleaner.app"
@@ -16,8 +18,4 @@ cask "svgcleaner" do
     "~/Library/Preferences/com.svgcleaner.svgcleaner.plist",
     "~/Library/Saved Application State/com.yourcompany.SVGCleaner.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/t/tagger.rb
+++ b/Casks/t/tagger.rb
@@ -8,9 +8,7 @@ cask "tagger" do
   desc "Music metadata editor supporting batch edits and importing VGMdb data"
   homepage "https://bilalh.github.io/projects/tagger/"
 
-  app "Tagger.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Tagger.app"
 end

--- a/Casks/t/termhere.rb
+++ b/Casks/t/termhere.rb
@@ -8,6 +8,8 @@ cask "termhere" do
   desc "Finder extension for opening a terminal from the current directory"
   homepage "https://hbang.ws/apps/termhere/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "TermHere.app"
 
   zap trash: [
@@ -20,8 +22,4 @@ cask "termhere" do
     "~/Library/Logs/DiagnosticReports/TermHere Finder Extension*",
     "~/Library/Preferences/ws.hbang.TermHere.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/t/timings.rb
+++ b/Casks/t/timings.rb
@@ -7,6 +7,8 @@ cask "timings" do
   desc "Time tracking"
   homepage "https://www.mediaatelier.com/Timings3/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Timings.app"
 
   zap trash: [
@@ -14,8 +16,4 @@ cask "timings" do
     "~/Library/Caches/com.mediaatelier.Timings",
     "~/Library/Preferences/com.mediaatelier.Timings.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/t/toland-qlmarkdown.rb
+++ b/Casks/t/toland-qlmarkdown.rb
@@ -7,11 +7,9 @@ cask "toland-qlmarkdown" do
   desc "QuickLook generator for Markdown files"
   homepage "https://github.com/toland/qlmarkdown"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   qlplugin "QLMarkdown.qlgenerator"
 
   # No zap stanza required
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/t/trinity.rb
+++ b/Casks/t/trinity.rb
@@ -8,6 +8,8 @@ cask "trinity" do
   desc "Cryptocurrency wallet"
   homepage "https://trinity.iota.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Trinity.app"
 
   uninstall quit: "org.iota.trinity"
@@ -19,8 +21,4 @@ cask "trinity" do
     "~/Library/Preferences/org.iota.trinity.plist",
     "~/Library/Saved Application State/org.iota.trinity.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/t/twilioquest.rb
+++ b/Casks/t/twilioquest.rb
@@ -8,6 +8,8 @@ cask "twilioquest" do
   desc "Learn to code and lead your crew on a mission to save The Cloud in a 16bit game"
   homepage "https://www.twilio.com/quest"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "TwilioQuest.app"
 
   uninstall pkgutil: [
@@ -20,8 +22,4 @@ cask "twilioquest" do
     "~/Library/Preferences/com.electron.twilioquest.plist",
     "~/Library/Saved Application State/com.electron.twilioquest.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/u/ui-browser.rb
+++ b/Casks/u/ui-browser.rb
@@ -8,6 +8,8 @@ cask "ui-browser" do
   desc "Assistant for Apple's Accessibility and AppleScript GUI scripting"
   homepage "https://latenightsw.com/freeware/ui-browser/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :sierra"
 
   app "UI Browser.app"
@@ -16,8 +18,4 @@ cask "ui-browser" do
     "~/Library/Caches/com.apple.helpd/Generated/com.pfiddlesoft.uibrowser.help*",
     "~/Library/Preferences/com.pfiddlesoft.uibrowser.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/u/upterm.rb
+++ b/Casks/u/upterm.rb
@@ -7,6 +7,8 @@ cask "upterm" do
   desc "Terminal emulator for the 21st century"
   homepage "https://github.com/railsware/upterm"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Upterm.app"
 
   zap trash: [
@@ -17,8 +19,4 @@ cask "upterm" do
     "~/Library/Saved Application State/com.github.railsware.upterm.savedState",
     "~/.upterm",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/v/videostream.rb
+++ b/Casks/v/videostream.rb
@@ -7,6 +7,8 @@ cask "videostream" do
   desc "Stream media from your computer to Chromecast"
   homepage "https://getvideostream.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "Videostream.pkg"
 
   uninstall launchctl: [
@@ -15,8 +17,4 @@ cask "videostream" do
             ],
             pkgutil:   "com.videostream",
             signal:    ["TERM", "com.videostream"]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/v/vlc-webplugin.rb
+++ b/Casks/v/vlc-webplugin.rb
@@ -7,9 +7,7 @@ cask "vlc-webplugin" do
   desc "Web browser plugin"
   homepage "https://www.videolan.org/vlc/download-macosx.html"
 
-  internet_plugin "VLC Plugin.plugin"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  internet_plugin "VLC Plugin.plugin"
 end

--- a/Casks/v/vpn-enabler.rb
+++ b/Casks/v/vpn-enabler.rb
@@ -22,12 +22,13 @@ cask "vpn-enabler" do
   desc "VPN settings utility"
   homepage "https://cutedgesystems.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :el_capitan"
 
   app "VPN Enabler.app"
 
   caveats do
-    discontinued
     <<~EOS
       Download for newer version is walled.
     EOS

--- a/Casks/w/webcamoid.rb
+++ b/Casks/w/webcamoid.rb
@@ -8,6 +8,8 @@ cask "webcamoid" do
   desc "Webcam suite"
   homepage "https://webcamoid.github.io/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Webcamoid.app"
 
   uninstall quit:      "com.webcamoidprj.webcamoid",
@@ -25,8 +27,4 @@ cask "webcamoid" do
     "~/Library/Preferences/org.webcamoid.cmio.AkVCam.Assistant.plist",
     "~/Library/Saved Application State/com.webcamoidprj.webcamoid.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/w/webpack-dashboard.rb
+++ b/Casks/w/webpack-dashboard.rb
@@ -7,6 +7,8 @@ cask "webpack-dashboard" do
   desc "Electron Desktop GUI for Webpack Dashboard"
   homepage "https://github.com/FormidableLabs/electron-webpack-dashboard"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Webpack Dashboard.app"
 
   zap trash: [
@@ -15,8 +17,4 @@ cask "webpack-dashboard" do
     "~/Library/Preferences/org.formidable.WebpackDashboard.plist",
     "~/Library/Saved Application State/org.formidable.WebpackDashboard.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/w/webrecorder-player.rb
+++ b/Casks/w/webrecorder-player.rb
@@ -6,6 +6,8 @@ cask "webrecorder-player" do
   name "Webrecorder Player"
   homepage "https://github.com/webrecorder/webrecorder-player/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Webrecorder Player.app"
 
   zap trash: [
@@ -14,8 +16,4 @@ cask "webrecorder-player" do
     "~/Library/Preferences/org.webrecorder.webrecorderplayer.plist",
     "~/Library/Saved Application State/org.webrecorder.webrecorderplayer.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/w/wey.rb
+++ b/Casks/w/wey.rb
@@ -7,6 +7,8 @@ cask "wey" do
   desc "Open-source Slack desktop app"
   homepage "https://github.com/yue/wey"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Wey.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "wey" do
     "~/Library/Saved Application State/org.yue.wey.savedState",
     "~/Library/WebKit/org.yue.wey",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/w/wjoy.rb
+++ b/Casks/w/wjoy.rb
@@ -7,9 +7,7 @@ cask "wjoy" do
   desc "Nintendo wiimote driver"
   homepage "https://github.com/alxn1/wjoy"
 
-  app "Wjoy.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Wjoy.app"
 end

--- a/Casks/w/wkhtmltopdf.rb
+++ b/Casks/w/wkhtmltopdf.rb
@@ -8,6 +8,8 @@ cask "wkhtmltopdf" do
   desc "HTML to PDF renderer"
   homepage "https://wkhtmltopdf.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "wkhtmltox-#{version}.macos-cocoa.pkg"
 
   uninstall pkgutil: "org.wkhtmltopdf.wkhtmltox",
@@ -28,7 +30,6 @@ cask "wkhtmltopdf" do
   # No zap stanza required
 
   caveats do
-    discontinued
     files_in_usr_local
   end
 end

--- a/Casks/w/wonderfultools-screensaver.rb
+++ b/Casks/w/wonderfultools-screensaver.rb
@@ -7,11 +7,9 @@ cask "wonderfultools-screensaver" do
   desc "Screensaver based on opening video from Apple's September 2019 event"
   homepage "https://github.com/aidev1065/Wonderful-Tools-Screensaver/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   screen_saver "WonderfulTools.saver"
 
   zap trash: "~/Library/Caches/WonderfulTools"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/w/writefull.rb
+++ b/Casks/w/writefull.rb
@@ -8,6 +8,8 @@ cask "writefull" do
   desc "Provides feedback on your writing"
   homepage "https://writefullapp.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Writefull.app"
 
   zap trash: [
@@ -18,8 +20,4 @@ cask "writefull" do
     "~/Library/Preferences/com.paraphrase.Writefull.plist",
     "~/Library/Saved Application State/com.paraphrase.Writefull.savedState",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/x/x-mirage.rb
+++ b/Casks/x/x-mirage.rb
@@ -7,9 +7,7 @@ cask "x-mirage" do
   desc "AirPlay and Google Cast receiver"
   homepage "https://www.x-mirage.com/x-mirage/"
 
-  app "X-Mirage.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "X-Mirage.app"
 end

--- a/Casks/x/xamarin-studio.rb
+++ b/Casks/x/xamarin-studio.rb
@@ -8,11 +8,9 @@ cask "xamarin-studio" do
   desc "IDE for mobile app development"
   homepage "https://www.visualstudio.com/vs/visual-studio-mac/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   conflicts_with cask: "xamarin"
 
   app "Xamarin Studio.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/x/xamarin-workbooks.rb
+++ b/Casks/x/xamarin-workbooks.rb
@@ -8,13 +8,11 @@ cask "xamarin-workbooks" do
   desc "C# documentation and coding materials"
   homepage "https://docs.microsoft.com/en-us/xamarin/tools/workbooks/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: ">= :el_capitan"
 
   pkg "XamarinInteractive-#{version}.pkg"
 
   uninstall pkgutil: "com.xamarin.Inspector"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/x/xampp-vm.rb
+++ b/Casks/x/xampp-vm.rb
@@ -8,9 +8,7 @@ cask "xampp-vm" do
   desc "Virtual machine with apache distribution containing MySQL, PHP, and Perl"
   homepage "https://www.apachefriends.org/index.html"
 
-  app "xampp-osx-#{version}-vm.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "xampp-osx-#{version}-vm.app"
 end

--- a/Casks/x/xtorrent.rb
+++ b/Casks/x/xtorrent.rb
@@ -7,11 +7,9 @@ cask "xtorrent" do
   desc "Torrent client"
   homepage "http://www.xtorrent.com/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   depends_on macos: "<= :catalina"
 
   app "Xtorrent.app"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/y/yo.rb
+++ b/Casks/y/yo.rb
@@ -7,6 +7,8 @@ cask "yo" do
   desc "Utility to emit Notification Center messages from the command-line"
   homepage "https://github.com/sheagcraig/yo"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   pkg "yo-#{version}.pkg"
 
   uninstall delete:    "/usr/local/bin/yo_scheduler",
@@ -15,8 +17,4 @@ cask "yo" do
               "com.sheagcraig.yo.on_demand",
             ],
             pkgutil:   "com.sheagcraig.yo"
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/y/youtrack-workflow.rb
+++ b/Casks/y/youtrack-workflow.rb
@@ -7,10 +7,11 @@ cask "youtrack-workflow" do
   desc "Create and edit workflows for YouTrack"
   homepage "https://www.jetbrains.com/youtrack/download/get_youtrack.html#materials=workflow-editor"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "youtrack-workflow.app"
 
   caveats do
-    discontinued
     depends_on_java
   end
 end

--- a/Casks/y/yu-writer.rb
+++ b/Casks/y/yu-writer.rb
@@ -8,6 +8,8 @@ cask "yu-writer" do
   desc "Markdown editor"
   homepage "https://ivarptr.github.io/yu-writer.site/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Yu Writer.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "yu-writer" do
     "~/Library/Preferences/com.github.yu-writer.helper.plist",
     "~/Library/Preferences/com.github.yu-writer.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/z/zazu.rb
+++ b/Casks/z/zazu.rb
@@ -8,6 +8,8 @@ cask "zazu" do
   desc "Extensible and open-source launcher for hackers, creators and dabblers"
   homepage "https://zazuapp.org/"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Zazu.app"
 
   zap trash: [
@@ -16,8 +18,4 @@ cask "zazu" do
     "~/Library/Preferences/com.tinytacoteam.zazu.helper.plist",
     "~/Library/Preferences/com.tinytacoteam.zazu.plist",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/z/zdoom.rb
+++ b/Casks/z/zdoom.rb
@@ -7,9 +7,7 @@ cask "zdoom" do
   desc "Source port of Doom"
   homepage "https://zdoom.org/index"
 
-  app "ZDoom.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "ZDoom.app"
 end

--- a/Casks/z/zecwallet-lite.rb
+++ b/Casks/z/zecwallet-lite.rb
@@ -8,14 +8,12 @@ cask "zecwallet-lite" do
   desc "Zcash Light Wallet"
   homepage "https://www.zecwallet.co/#download"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Zecwallet Lite.app"
 
   zap trash: [
     "~/Library/Application Support/Zecwallet Lite",
     "~/Library/Application Support/Zcash/zecwallet-light-wallet.debug.log",
   ]
-
-  caveats do
-    discontinued
-  end
 end

--- a/Casks/z/zeebe-modeler.rb
+++ b/Casks/z/zeebe-modeler.rb
@@ -8,9 +8,7 @@ cask "zeebe-modeler" do
   desc "Desktop Application for modeling Zeebe Workflows with BPMN"
   homepage "https://zeebe.io/"
 
-  app "Zeebe Modeler.app"
+  deprecate! date: "2023-12-17", because: :discontinued
 
-  caveats do
-    discontinued
-  end
+  app "Zeebe Modeler.app"
 end

--- a/Casks/z/zsa-wally.rb
+++ b/Casks/z/zsa-wally.rb
@@ -8,6 +8,8 @@ cask "zsa-wally" do
   desc "Flash tool for ZSA keyboards"
   homepage "https://ergodox-ez.com/pages/wally"
 
+  deprecate! date: "2023-12-17", because: :discontinued
+
   app "Wally.app"
 
   zap trash: [
@@ -16,8 +18,6 @@ cask "zsa-wally" do
   ]
 
   caveats do
-    discontinued
-
     <<~EOS
       Keymapp is the official successor to this software:
 


### PR DESCRIPTION
See https://github.com/Homebrew/brew/pull/16292

Move all instances of `discontinued` in the `caveats` stanza to a `deprecate!` call.

For now, I've left the date for all of these as today[^1] (`2023-12-17`) because it doesn't seem to me like it will be a good use of my time to go through each and figure out an appropriate date. If that isn't the best solution, though, I'm happy to hear about alternatives.

This PR was made using `brew style --fix` with https://github.com/Homebrew/brew/pull/16351 checked out, and then the non-autocorrectable (when the `caveats` stanza includes more than just `discontinued`) offenses were handled manually.

Note: this PR cannot be merged until a new Homebrew/brew tag (4.2.0) is made.

[^1]: Except for [`dozer`](https://github.com/Homebrew/homebrew-cask/pull/162720/files#diff-9b1d480e6a661641513c177189843d9c87a595e3da674c09cd3e9b624b5f63fc) which I set to `2023-11-26` because there was a comment