### PR TITLE
ci/manual_audit: ensure casks are loaded from the tap

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -125,7 +125,7 @@ module CiMatrix
 
     cask_files_to_check = if cask_names.any?
       cask_names.map do |cask_name|
-        Cask::CaskLoader.load(cask_name).sourcefile_path
+        Cask::CaskLoader.load(cask_name).sourcefile_path.relative_path_from(tap.path)
       end
     else
       changed_files[:modified_cask_files]


### PR DESCRIPTION
When manual auditing, load casks from the tap, not the API
