### PR TITLE
cljstyle: use `github_latest` livecheck strategy

### DIFF
--- a/Casks/c/cljstyle.rb
+++ b/Casks/c/cljstyle.rb
@@ -13,4 +13,6 @@ cask "cljstyle" do
   end
 
   binary "cljstyle"
+
+  # No zap stanza required
 end

--- a/Casks/c/cljstyle.rb
+++ b/Casks/c/cljstyle.rb
@@ -7,5 +7,10 @@ cask "cljstyle" do
   desc "Tool for formatting Clojure code"
   homepage "https://github.com/greglook/cljstyle"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   binary "cljstyle"
 end


### PR DESCRIPTION
Upstream are using tags that have no corresponding release/binary.