### PR TITLE
duckduckgo 1.68.0

### DIFF
--- a/Casks/d/duckduckgo.rb
+++ b/Casks/d/duckduckgo.rb
@@ -1,8 +1,8 @@
 cask "duckduckgo" do
-  version "1.67.1"
-  sha256 "5fdd991bbff147b9bf8056d4a1e7e5bf1dc400bd664be8b4973f1dbb55fd19fc"
+  version "1.68.0,93"
+  sha256 "d4c7202e43d2fe29381af4ed2a87ba83f7a837713180e9c0c02833e91238e149"
 
-  url "https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-#{version}.dmg"
+  url "https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-#{version.csv.first}.#{version.csv.second}.dmg"
   name "DuckDuckGo"
   desc "Web browser focusing on privacy"
   homepage "https://duckduckgo.com/"
@@ -10,7 +10,7 @@ cask "duckduckgo" do
   livecheck do
     url "https://staticcdn.duckduckgo.com/macos-desktop-browser/appcast2.xml"
     strategy :sparkle do |items|
-      items.find { |item| item.channel.nil? }&.short_version
+      items.find { |item| item.channel.nil? }&.nice_version
     end
   end
 


### PR DESCRIPTION
The `url` now includes the two parts of the version from the appcast.