### PR TITLE
openscad: openscad as binary

### DIFF
--- a/Casks/o/openscad.rb
+++ b/Casks/o/openscad.rb
@@ -15,6 +15,7 @@ cask "openscad" do
   conflicts_with cask: "homebrew/cask-versions/openscad-snapshot"
 
   app "OpenSCAD.app"
+  binary "#{appdir}/OpenSCAD.app/Contents/MacOS/OpenSCAD", target: "openscad"
 
   zap trash: [
     "~/Library/Caches/org.openscad.OpenSCAD",


### PR DESCRIPTION
## Description

One advantage of openscad over other 3D CAD software is that it can be run through CLI. This way, it can quickly generate STL files without opening its GUI.

On Linux distributions, this can be done by calling `openscad`, which calls the OpenSCAD executable. This PR makes this behavior possible without providing the full path of the binary when using CLI on Mac.

## Verification

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
