### PR TITLE
wordpresscom: fix livecheck and add arm64

### DIFF
--- a/Casks/w/wordpresscom.rb
+++ b/Casks/w/wordpresscom.rb
@@ -1,6 +1,5 @@
 cask "wordpresscom" do
-  arch arm:   "arm64",
-       intel: "x64"
+  arch arm: "arm64", intel: "x64"
 
   version "8.0.3"
   sha256 arm:   "fa918e3df870deafe299b11a16b3753f6fb8a1af36b0c616620c1c1b98e20ec8",

--- a/Casks/w/wordpresscom.rb
+++ b/Casks/w/wordpresscom.rb
@@ -1,23 +1,35 @@
 cask "wordpresscom" do
-  version "8.0.3"
-  sha256 "cc5f9daccc774eb9a3fbd3533e26357ff3dd226aa95355028fdfb1d745b6619e"
+  arch arm:   "arm64",
+       intel: "x64"
 
-  url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=app&ref=update&version=#{version}"
+  version "8.0.3"
+  sha256 arm:   "fa918e3df870deafe299b11a16b3753f6fb8a1af36b0c616620c1c1b98e20ec8",
+         intel: "98f54a7559b57146dc3689c83609d82f0c57fa0f2576d5a84b38b18ea1e2bec7"
+
+  url "https://github.com/Automattic/wp-desktop/releases/download/v#{version}/wordpress.com-macOS-dmg-#{version}-#{arch}.dmg",
+      verified: "github.com/Automattic/wp-desktop/"
   name "WordPress.com"
   desc "WordPress client"
   homepage "https://apps.wordpress.com/desktop/"
 
   livecheck do
-    url "https://public-api.wordpress.com/rest/v1.1/desktop/osx/download?type=dmg"
-    strategy :header_match
+    url :url
+    strategy :github_latest
   end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "WordPress.com.app"
 
   zap trash: [
     "~/Library/Application Support/Wordpress.com",
-    "~/Library/Preferences/com.automattic.wordpress.helper.plist",
-    "~/Library/Preferences/com.automattic.wordpress.plist",
+    "~/Library/Application Support/Caches/wordpressdesktop-updater",
+    "~/Library/Caches/com.automattic.wordpress",
+    "~/Library/Caches/com.automattic.wordpress.ShipIt",
+    "~/Library/Preferences/ByHost/com.automattic.wordpress.ShipIt.*.plist",
+    "~/Library/Preferences/com.automattic.wordpress*.plist",
+    "~/Library/HTTPStorages/com.automattic.wordpress",
     "~/Library/Saved Application State/com.automattic.wordpress.savedState",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Cask wordpresscom has the following out-of-date:

- The livecheck seems to not work correctly.
- It lacks support for Apple Silicon, although there is a download for it from [wordpress.com](https://apps.wordpress.com/d/osx-silicon/).
- Upstream defined :high_sierra as the minimum OS version and the cask defined no minimum OS version.
- It is missing `auto_updates true`.
- A `find` revealed additional lines to add to the zap stanza, as well as one path which was no longer present. That path (`~/Library/Preferences/com.automattic.wordpress.helper.plist`) was incorporated into a similar path (`~/Library/Preferences/com.automattic.wordpress.plist`) with a wildcard * in this commit, so it is not lost for those who do have it from an older version.

See https://github.com/orgs/Homebrew/discussions/4988#discussioncomment-7879360 for more detail about some of the decisions made, regarding changing the livecheck url and strategy and the download url and type (dmg instead of zip).

Thank you for maintaining this great project. Regards.
