### PR TITLE
orbstack: Use official update feed URL

### DIFF
--- a/Casks/o/orbstack.rb
+++ b/Casks/o/orbstack.rb
@@ -11,7 +11,7 @@ cask "orbstack" do
   homepage "https://orbstack.dev/"
 
   livecheck do
-    url "https://cdn-updates.orbstack.dev/#{arch}/appcast.new.xml"
+    url "https://api-updates.orbstack.dev/#{arch}/appcast.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
OrbStack does staged update rollouts. Please use this instead of the direct CDN URL so that Homebrew stays in sync with the expected stable version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
