### PR TITLE
brave-browser 1.61.109.0 (zero-day patch)

### DIFF
--- a/Casks/b/brave-browser.rb
+++ b/Casks/b/brave-browser.rb
@@ -2,9 +2,9 @@ cask "brave-browser" do
   arch arm: "arm64", intel: "x64"
   folder = on_arch_conditional arm: "stable-arm64", intel: "stable"
 
-  version "1.61.104.0"
-  sha256 arm:   "844664fc50ed6a0d8c5e9fd16cc6d4aa7f78d12d55192af1b24ca0cbcb587175",
-         intel: "68325a2a1ed5e33c67404aa17a119ec1e562af5761bfeadd853bec86aa2cadbf"
+  version "1.61.109.0"
+  sha256 arm:   "efce433c3cf22b545a264a76d3ebc8f5e209953c2a4655e8bb034fc88a928860",
+         intel: "cbb9bfa453e0da538e1d2687b64f4dcca59d15ae21ed2271a4278585221e862c"
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Browser-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"


### PR DESCRIPTION
This fixes a zero-day in Chrome/Brave, Brave just published this 4 hours ago.

> High CVE-2023-7024: Heap buffer overflow in WebRTC. Reported by Clément Lecigne and Vlad Stolyarov of Google's Threat Analysis Group on 2023-12-19

* https://github.com/brave/brave-browser/releases/tag/v1.61.109
* https://chromereleases.googleblog.com/2023/12/stable-channel-update-for-desktop_20.html

The SHAs in this PR came from:
* https://github.com/brave/brave-browser/releases/download/v1.61.109/Brave-Browser-arm64.dmg.sha256 (arm)
* https://github.com/brave/brave-browser/releases/download/v1.61.109/Brave-Browser-x64.dmg.sha256 (intel)


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
