### PR TITLE
roam 88.0.0-beta001 (new cask)

### DIFF
--- a/Casks/r/roam.rb
+++ b/Casks/r/roam.rb
@@ -27,4 +27,4 @@ cask "roam" do
       "~/Library/Preferences/inc.wonder.roam.plist",
       "~/Library/Saved Application State/inc.wonder.roam.savedState",
     ]
-  end
+end

--- a/Casks/r/roam.rb
+++ b/Casks/r/roam.rb
@@ -1,0 +1,30 @@
+cask "roam" do
+    arch arm: "arm64", intel: "x64"
+
+    version "88.0.0-beta001"
+    sha256 arm:   "81807014148697a43b1c395673c8de426689b14028d609ebbaad93e625ff6791",
+           intel: "4fd069f400d8c369753ef6a160eaedb12a3252b8eb415755770f9a5f6055fb92"
+
+    url "https://download.ro.am/Roam/8a86d88cfc9da3551063102e9a4e2a83/latest/darwin/#{arch}/Roam.dmg"
+    name "roam"
+    desc "Is your whole company in one HQ"
+    homepage "https://ro.am/"
+
+    livecheck do
+      skip "No livecheck to perform"
+    end
+
+    auto_updates true
+    depends_on macos: ">= :catalina"
+
+    app "Roam.app"
+
+    uninstall quit: "inc.wonder.roam"
+
+    zap trash: [
+      "~/Library/Caches/inc.wonder.roam",
+      "~/Library/Caches/inc.wonder.roam.ShipIt",
+      "~/Library/Preferences/inc.wonder.roam.plist",
+      "~/Library/Saved Application State/inc.wonder.roam.savedState",
+    ]
+  end

--- a/Casks/r/roam.rb
+++ b/Casks/r/roam.rb
@@ -1,30 +1,31 @@
 cask "roam" do
-    arch arm: "arm64", intel: "x64"
+  arch arm: "arm64", intel: "x64"
 
-    version "88.0.0-beta001"
-    sha256 arm:   "81807014148697a43b1c395673c8de426689b14028d609ebbaad93e625ff6791",
-           intel: "4fd069f400d8c369753ef6a160eaedb12a3252b8eb415755770f9a5f6055fb92"
+  version "88.0.0-beta001"
+  sha256 arm:   "81807014148697a43b1c395673c8de426689b14028d609ebbaad93e625ff6791",
+         intel: "4fd069f400d8c369753ef6a160eaedb12a3252b8eb415755770f9a5f6055fb92"
 
-    url "https://download.ro.am/Roam/8a86d88cfc9da3551063102e9a4e2a83/latest/darwin/#{arch}/Roam.dmg"
-    name "roam"
-    desc "Is your whole company in one HQ"
-    homepage "https://ro.am/"
+  url "https://download.ro.am/Roam/8a86d88cfc9da3551063102e9a4e2a83/latest/darwin/#{arch}/Roam.dmg"
+  name "Roam"
+  desc "Virtual office"
+  homepage "https://ro.am/"
 
-    livecheck do
-      skip "No livecheck to perform"
-    end
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
-    auto_updates true
-    depends_on macos: ">= :catalina"
+  auto_updates true
+  depends_on macos: ">= :catalina"
 
-    app "Roam.app"
+  app "Roam.app"
 
-    uninstall quit: "inc.wonder.roam"
+  uninstall quit: "inc.wonder.roam"
 
-    zap trash: [
-      "~/Library/Caches/inc.wonder.roam",
-      "~/Library/Caches/inc.wonder.roam.ShipIt",
-      "~/Library/Preferences/inc.wonder.roam.plist",
-      "~/Library/Saved Application State/inc.wonder.roam.savedState",
-    ]
+  zap trash: [
+    "~/Library/Caches/inc.wonder.roam",
+    "~/Library/Caches/inc.wonder.roam.ShipIt",
+    "~/Library/Preferences/inc.wonder.roam.plist",
+    "~/Library/Saved Application State/inc.wonder.roam.savedState",
+  ]
 end


### PR DESCRIPTION
This adds Roam to brew!

Roam is a communications software that includes chat and video calling.

Roam is currently releasing "betas" every week; however, these are the stable releases by the developer.

Test Plan: manual

```
brew install --cask roam
brew uninstall roam
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
