### PR TITLE
orka: update livecheck

### DIFF
--- a/Casks/o/orka.rb
+++ b/Casks/o/orka.rb
@@ -10,7 +10,14 @@ cask "orka" do
 
   livecheck do
     url "https://orkadocs.macstadium.com/docs/downloads"
-    regex(%r{href=.*?/official/(\d+(?:\.\d+)+)/macos/orka\.pkg}i)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        next unless match[0].start_with?("#{version.major}.")
+
+        match[0]
+      end
+    end
   end
 
   pkg "orka.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Now that Orka 3 is released, the download page used in the `orka` `livecheck` block returns an `Unable to get versions` error, since the page no longer links to a v2 pkg file. This updates the `livecheck` block to check versioned URLs on the page, which includes the latest 2.x version information. This may need to be updated again in the future if upstream removes the 2.x links but this works for now.