### PR TITLE
mcgimp: disable

### DIFF
--- a/Casks/m/mcgimp.rb
+++ b/Casks/m/mcgimp.rb
@@ -7,10 +7,7 @@ cask "mcgimp" do
   desc "Recompiled GIMP installation"
   homepage "https://www.partha.com/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/McGimp-(\d+(?:\.\d+)*)\.app\.zip}i)
-  end
+  disable! date: "2023-12-24", because: :discontinued
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The cask zip file for `mcgimp` no longer exists and the homepage no longer links to an `mcgimp` file (or any other for that matter). This deprecates the cask, as this software doesn't seem to exist upstream anymore.