### PR TITLE
igv: update livecheck

### DIFF
--- a/Casks/i/igv.rb
+++ b/Casks/i/igv.rb
@@ -8,19 +8,8 @@ cask "igv" do
   homepage "https://software.broadinstitute.org/software/igv/"
 
   livecheck do
-    url "https://data.broadinstitute.org/igv/projects/downloads/"
+    url "https://igv.org/doc/desktop/DownloadPage/"
     regex(/href=.*?IGV[._-]MacApp[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-    strategy :page_match do |page, regex|
-      major_minor = page.scan(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i).max_by do |match|
-        Version.new(match.first)
-      end.first
-      next if major_minor.blank?
-
-      version_page = Homebrew::Livecheck::Strategy.page_content(url.sub(%r{/$}, "") + "/#{major_minor}/")
-      next if version_page[:content].blank?
-
-      version_page[:content].scan(regex).map(&:first)
-    end
   end
 
   app "IGV_#{version}.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `igv` now returns an `Unable to get versions` error. The `strategy` block only checks the version directory for the highest version but the [3.0 directory](https://data.broadinstitute.org/igv/projects/downloads/3.0/) only contains preview versions (and only for Linux and Windows).

To fix this, we could modify the `strategy` block to check additional version directory pages if the first one doesn't return a result. However, this isn't ideal, so I've opted to return this to checking the download page from the website, as it simply links to the 2.16.2 file used in the cask (i.e., we only make one request instead of 2+).

If there's a specific reason why we need to check the directory listing pages that I'm forgetting/overlooking (there's no explanation in https://github.com/Homebrew/homebrew-cask/pull/157140), do let me know and I can rework the `strategy` block instead.