### PR TITLE
ilya-birman-typography-layout 3.9

### DIFF
--- a/Casks/i/ilya-birman-typography-layout.rb
+++ b/Casks/i/ilya-birman-typography-layout.rb
@@ -1,19 +1,18 @@
 cask "ilya-birman-typography-layout" do
-  version "3.8"
-  sha256 "9c6fd58ef2f527a400e850358c38f4c36a5f264e66d03a464f1d70102c5ce9df"
+  version "3.9"
+  sha256 "64b4f7b1421cc4275864c25941646ddf2d3075212a77e9ba1c2d27b726afe123"
 
-  url "https://ilyabirman.ru/typography-layout/download/ilya-birman-typolayout-#{version}-mac.dmg"
+  url "https://ilyabirman.ru/typography-layout/download/ilya-birman-typolayout-#{version}-mac.zip"
   name "Ilya Birman Typography Layout"
   desc "Typography keyboard layout"
   homepage "https://ilyabirman.ru/typography-layout/"
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/ilya[._-]birman[._-]typolayout[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg}i)
+    regex(/href=.*?ilya[._-]birman[._-]typolayout[._-]v?(\d+(?:\.\d+)+)[._-]mac\.(?:dmg|zip)/i)
   end
 
-  keyboard_layout \
-    "Install Ilya Birman Typography Layout.app/Contents/Resources/Layout/Ilya Birman Typography Layout.bundle"
+  keyboard_layout "Ilya Birman Typography Layout.bundle"
 
   # No zap stanza required
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `ilya-birman-typography-layout` to version 3.9. The archive for 3.9 simply contains the `Ilya Birman Typography Layout.bundle` file.

The existing `livecheck` block was giving an `Unable to get versions` error because the file is now a zip instead of a dmg, so the regex wasn't matching the new file. This updates the `livecheck` block to match both dmg and zip files.