### PR TITLE
ebmac: update urls

### DIFF
--- a/Casks/e/ebmac.rb
+++ b/Casks/e/ebmac.rb
@@ -13,4 +13,10 @@ cask "ebmac" do
   end
 
   app "EBMac.app"
+
+  zap trash: [
+    "~/Library/Application Support/EBMac",
+    "~/Library/Preferences/info.ebstudio.EBMac.plist",
+    "~/Library/Saved Application State/info.ebstudio.EBMac.savedState",
+  ]
 end

--- a/Casks/e/ebmac.rb
+++ b/Casks/e/ebmac.rb
@@ -2,10 +2,10 @@ cask "ebmac" do
   version "1.46.1"
   sha256 "dc537911d917a694360bc739f9a188d5610a1ecc4b935beb3f89dad55a54ee4d"
 
-  url "http://ebstudio.info/download/ebpocket/EBMac#{version}.dmg"
+  url "https://ebstudio.info/download/ebpocket/EBMac#{version}.dmg"
   name "EBMac"
   desc "Electronic dictionary viewer"
-  homepage "http://ebstudio.info/manual/EBMac/"
+  homepage "https://ebstudio.info/manual/EBMac/"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The ebstudio.info URLs in the `ebmac` cask mistakenly redirect from http://ebstudio.info/ to https://ebstudio.info/ebstudio.info/, though they should simply redirect to https://ebstudio.info/. As a result, the cask URL returns a 404 and the `livecheck` block returns an `Unable to get versions` error because the redirected URLs don't exist.

This resolves the issue by updating the `homepage` and `url` to use HTTPS, to avoid the broken redirection.