### PR TITLE
mounty 2.4

### DIFF
--- a/Casks/m/mounty.rb
+++ b/Casks/m/mounty.rb
@@ -11,13 +11,12 @@ cask "mounty" do
     version "2.4"
     sha256 "b5f0867af3ee034c61582bc40e6ebeae549cb4570381ba82d012aca8d5c72888"
 
-    depends_on cask: "macfuse"
-    depends_on formula: "gromgit/fuse/ntfs-3g-mac"
-
     livecheck do
       url :homepage
       regex(/Latest\s+version:\s*(\d+(?:\.\d+)+)/i)
     end
+    depends_on cask: "macfuse"
+    depends_on formula: "gromgit/fuse/ntfs-3g-mac"
   end
 
   url "https://mounty.app/releases/Mounty-#{version}.dmg"

--- a/Casks/m/mounty.rb
+++ b/Casks/m/mounty.rb
@@ -8,8 +8,11 @@ cask "mounty" do
     end
   end
   on_big_sur :or_newer do
-    version "2.3"
-    sha256 "452326c4b96b231f62e3840e71f9b2bca0f0f2af4f7f4ddeaef54af5459b43e2"
+    version "2.4"
+    sha256 "b5f0867af3ee034c61582bc40e6ebeae549cb4570381ba82d012aca8d5c72888"
+
+    depends_on cask: "macfuse"
+    depends_on formula: "gromgit/fuse/ntfs-3g-mac"
 
     livecheck do
       url :homepage


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

I have added two dependencies (macFUSE and gromgit/fuse/ntfs-3g-mac) to Cask file, there were missing.