### PR TITLE
phd2 2.6.13

### DIFF
--- a/Casks/p/phd2.rb
+++ b/Casks/p/phd2.rb
@@ -1,16 +1,30 @@
 cask "phd2" do
-  version "2.6.12"
-  sha256 "3f30394349b963b3bc7164a7341743667c5d9a5c9e1da2d2b18ac25506a7c508"
+  version "2.6.13"
 
-  url "https://openphdguiding.org/PHD2-#{version}-OSX-64.zip"
+  on_ventura :or_older do
+    sha256 "3d098cc6ccaa7ddf5040e51ca9f423647fe167948d7d92bece456fa207491b7f"
+
+    url "https://openphdguiding.org/PHD2-#{version}-OSX-64.zip"
+
+    livecheck do
+      url "https://openphdguiding.org/downloads/"
+      regex(/href=.*?PHD2[._-]v?(\d+(?:\.\d+)+)-OSX-64\.zip/i)
+    end
+  end
+  on_sonoma :or_newer do
+    sha256 "c8ea80bfaa57d7092e7b8ce67f6b905a768bf0b9e810f3c1faa065072feace2d"
+
+    url "https://openphdguiding.org/PHD2-#{version}-OSX-64-sonoma+.zip"
+
+    livecheck do
+      url "https://openphdguiding.org/downloads/"
+      regex(/href=.*?PHD2[._-]v?(\d+(?:\.\d+)+)-OSX-64-sonoma\+\.zip/i)
+    end
+  end
+
   name "PHD2"
   desc "Telescope guiding software"
   homepage "https://openphdguiding.org/"
-
-  livecheck do
-    url "https://openphdguiding.org/changelog/"
-    regex(%r{href=.*?/PHD2-(\d+(?:\.\d+)*)-OSX-64\.zip}i)
-  end
 
   app "PHD2.app"
 end

--- a/Casks/p/phd2.rb
+++ b/Casks/p/phd2.rb
@@ -27,4 +27,10 @@ cask "phd2" do
   homepage "https://openphdguiding.org/"
 
   app "PHD2.app"
+
+  zap trash: [
+    "~/Documents/PHD2",
+    "~/Library/Preferences/org.openphdguiding.phd2.plist",
+    "~/Library/Saved Application State/org.openphdguiding.phd2.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `phd2` to the latest version, 2.6.13. I'm not sure if this is a new thing but [upstream provides separate files](https://openphdguiding.org/downloads/) for macOS Sonoma (and above) and Ventura (and below), so I've modified the cask to use the appropriate file for each.

The existing `livecheck` block returns an `Unable to get versions` error, so this updates it to check the download page (which contains the file links). The file name differs for the different macOS versions, so each of the `on_` blocks has a separate `livecheck` block.

If there's a better way to handle this situation, do let me know (my cask knowledge is always lacking).