### PR TITLE
fliqlo: fix cask for macOS Ventura and older

### DIFF
--- a/Casks/f/fliqlo.rb
+++ b/Casks/f/fliqlo.rb
@@ -1,17 +1,31 @@
 cask "fliqlo" do
-  version "1.9.1"
-  sha256 "99785b30f28e4b252950758d944d4f2e822daf597de5f2612ab778321cb4a677"
+  on_ventura :or_older do
+    version "1.8.6"
+    sha256 "a0d0fac34347cba027e067ad46b04efcff2220f7d5e712de4dcaaf9844c31c1a"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: "<= :ventura"
+  end
+  on_sonoma :or_newer do
+    version "1.9.1"
+    sha256 "99785b30f28e4b252950758d944d4f2e822daf597de5f2612ab778321cb4a677"
+
+    livecheck do
+      url :homepage
+      regex(%r{href=.*?/Fliqlo%20v?(\d+(?:\.\d+)+)\.dmg}i)
+    end
+
+    depends_on macos: ">= :sonoma"
+  end
 
   url "https://fliqlo.com/download/Fliqlo%20#{version}.dmg",
       referer: "https://fliqlo.com/#about"
   name "Fliqlo"
   desc "Flip clock screensaver"
   homepage "https://fliqlo.com/"
-
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/Fliqlo%20v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
 
   screen_saver "Fliqlo.saver"
 

--- a/Casks/f/fliqlo.rb
+++ b/Casks/f/fliqlo.rb
@@ -6,8 +6,6 @@ cask "fliqlo" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: "<= :ventura"
   end
   on_sonoma :or_newer do
     version "1.9.1"
@@ -15,10 +13,8 @@ cask "fliqlo" do
 
     livecheck do
       url :homepage
-      regex(%r{href=.*?/Fliqlo%20v?(\d+(?:\.\d+)+)\.dmg}i)
+      regex(/href=.*?Fliqlo%20v?(\d+(?:\.\d+)+)\.dmg/i)
     end
-
-    depends_on macos: ">= :sonoma"
   end
 
   url "https://fliqlo.com/download/Fliqlo%20#{version}.dmg",


### PR DESCRIPTION
This PR fixes the Fliqlo cask to restore compatibility with macOS Ventura or earlier broken as of https://github.com/Homebrew/homebrew-cask/commit/ebb11158a124138f1ab4332f3b4321cbb3592241.

As per "Notes on Fliqlo for Mac" at https://fliqlo.com/screensaver/:

> The latest Fliqlo version 1.9.x requires macOS 14 Sonoma. If you're using macOS 13 Ventura or earlier, use Fliqlo 1.8.6.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online fliqlo` is error-free.
- [x] `brew style --fix fliqlo` reports no offenses.