### PR TITLE
mplab-xc8, mplab-xc32: update livecheck

### DIFF
--- a/Casks/m/mplab-xc32.rb
+++ b/Casks/m/mplab-xc32.rb
@@ -8,7 +8,7 @@ cask "mplab-xc32" do
   homepage "https://www.microchip.com/mplab/compilers"
 
   livecheck do
-    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/downloads-documentation"
+    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc32"
     regex(%r{href=.*?ProductDocuments/SoftwareTools/xc32[._-]v?(\d+(?:\.\d+)+)-full-install-osx-installer\.dmg}i)
   end
 

--- a/Casks/m/mplab-xc8.rb
+++ b/Casks/m/mplab-xc8.rb
@@ -8,7 +8,7 @@ cask "mplab-xc8" do
   homepage "https://www.microchip.com/mplab/compilers"
 
   livecheck do
-    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/downloads-documentation"
+    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc8"
     regex(%r{href=.*?ProductDocuments/SoftwareTools/xc8[._-]v?(\d+(?:\.\d+)+)-full-install-macos-x64-installer\.dmg}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `mplab-xc8` redirects to https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers but returns an `Unable to get versions` error, since the page doesn't contain a link to the installer file. This PR resolves the issue by updating the `livecheck` block to check the "MPLAB XC8 Compiler" page (linked from the existing page as "View XC8 Compiler Downloads"), which links to the cask file.

Edit: To be expected, the checks for `mplab-xc16` and `mplab-xc32` are broken in the same way. I've added a commit to take care of `mplab-xc32` but I'll create a separate PR for `mplab-xc16`, as a new version is available.