### PR TITLE
sonic3air: add `depends_on`

### DIFF
--- a/Casks/s/sonic3air.rb
+++ b/Casks/s/sonic3air.rb
@@ -13,6 +13,8 @@ cask "sonic3air" do
     regex(/v(\d+(?:\.\d+)*)/i)
   end
 
+  depends_on macos: ">= :high_sierra"
+
   app "Sonic 3 AIR.app"
   artifact "Manual.pdf", target: "~/Library/Application Support/sonic3air/Manual.pdf"
   artifact "doc", target: "~/Library/Application Support/sonic3air/doc"


### PR DESCRIPTION
```
audit for sonic3air: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.