### PR TITLE
sdm: add `depends_on`

### DIFF
--- a/Casks/s/sdm.rb
+++ b/Casks/s/sdm.rb
@@ -15,6 +15,8 @@ cask "sdm" do
     end
   end
 
+  depends_on macos: ">= :high_sierra"
+
   app "SDM.app"
 
   uninstall delete: "#{appdir}/SDM.app/Contents/Resources/sdm-socket"


### PR DESCRIPTION
```
audit for sdm: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
