### PR TITLE
trailer: add `depends_on`

### DIFF
--- a/Casks/t/trailer.rb
+++ b/Casks/t/trailer.rb
@@ -8,6 +8,8 @@ cask "trailer" do
   desc "Managing Pull Requests and Issues For GitHub & GitHub Enterprise"
   homepage "https://ptsochantaris.github.io/trailer/"
 
+  depends_on macos: ">= :big_sur"
+
   app "Trailer.app"
 
   uninstall quit: "com.housetrip.Trailer"


### PR DESCRIPTION
```
audit for trailer: failed
 - Upstream defined :big_sur as the minimum OS version and the cask defined no minimum OS version
 ```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.