### PR TITLE
obsbot-webcam: update `depends_on`

### DIFF
--- a/Casks/o/obsbot-webcam.rb
+++ b/Casks/o/obsbot-webcam.rb
@@ -13,7 +13,7 @@ cask "obsbot-webcam" do
     regex(/Obsbot[._-]WebCam[._-]OA[._-]E[._-]MacOS[._-](\d+(?:\.\d+)+)[._-]release\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :big_sur"
 
   app "OBSBOT_WebCam.app"
 


### PR DESCRIPTION
```
audit for obsbot-webcam: failed
 - Upstream defined :big_sur as the minimum OS version and the cask defined :high_sierra
 ```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
