### PR TITLE
franz: add `depends_on`

### DIFF
--- a/Casks/f/franz.rb
+++ b/Casks/f/franz.rb
@@ -12,6 +12,7 @@ cask "franz" do
   homepage "https://meetfranz.com/"
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Franz.app"
 


### PR DESCRIPTION
```
audit for franz: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined no minimum OS version
 ```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x]  `brew style --fix <cask>` reports no offenses.
