### PR TITLE
minitube: update `depends_on`

### DIFF
--- a/Casks/m/minitube.rb
+++ b/Casks/m/minitube.rb
@@ -12,7 +12,7 @@ cask "minitube" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "Minitube.app"
 


### PR DESCRIPTION
```
audit for minitube: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined :sierra
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.