### PR TITLE
gaphor: update `depends_on`

### DIFF
--- a/Casks/g/gaphor.rb
+++ b/Casks/g/gaphor.rb
@@ -8,6 +8,8 @@ cask "gaphor" do
   desc "UML/SysML modeling tool"
   homepage "https://gaphor.org/"
 
+  depends_on macos: ">= :high_sierra"
+
   app "Gaphor.app"
 
   uninstall quit: "Gaphor-#{version}"


### PR DESCRIPTION
```
audit for gaphor: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.