### PR TITLE
mplab-xc16: update livecheck

### DIFF
--- a/Casks/m/mplab-xc16.rb
+++ b/Casks/m/mplab-xc16.rb
@@ -8,7 +8,7 @@ cask "mplab-xc16" do
   homepage "https://www.microchip.com/mplab/compilers"
 
   livecheck do
-    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/downloads-documentation"
+    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc16"
     regex(%r{href=.*?ProductDocuments/SoftwareTools/xc16[._-]v?(\d+(?:\.\d+)+)-full-install-osx64-installer\.dmg}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

As described in https://github.com/Homebrew/homebrew-cask/pull/163501, the existing livecheck block redirects to https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers but returns an `Unable to get versions` error, since the page doesn't contain a link to the installer file. This resolves the issue by updating the `livecheck` block to check the "MPLAB XC16 Compiler" page (linked from the existing page as "View XC16 Compiler Downloads"), which links to the cask file.

A 2.10 version is available but my local machine isn't supported (macOS Sonoma, ARM64), so I can't debug the install to sort it out. There are a couple previous PRs that attempted to update this to 2.10 (#145808, #154311), so it seems like there are some issues that need to be worked out. I've pared this PR down to just the `livecheck` block change, to allow it to move forward.