### PR TITLE
new: (predator-screensaver) Add cask for `1.0.6`

### DIFF
--- a/Casks/p/predator-screensaver.rb
+++ b/Casks/p/predator-screensaver.rb
@@ -4,7 +4,7 @@ cask "predator-screensaver" do
 
   url "https://github.com/vpeschenkov/Predator/releases/download/#{version}/Predator.saver.zip"
   name "predator-screensaver"
-  desc "A predator-inspired clock screensaver."
+  desc "Predator-inspired clock screensaver"
   homepage "https://github.com/vpeschenkov/Predator"
 
   livecheck do

--- a/Casks/p/predator-screensaver.rb
+++ b/Casks/p/predator-screensaver.rb
@@ -1,0 +1,23 @@
+cask "predator-screensaver" do
+  version "1.0.6"
+  sha256 "6b0b132188a5ee1c1e54a633d280eb842edf183e42b55fae5ca043c38b87164b"
+
+  url "https://github.com/vpeschenkov/Predator/releases/download/#{version}/Predator.saver.zip"
+  name "predator-screensaver"
+  desc "A predator-inspired clock screensaver."
+  homepage "https://github.com/vpeschenkov/Predator"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  screen_saver "Predator.saver"
+
+  zap trash: [
+    "~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/" \
+    "ByHost/Predator.*",
+    "~/Library/Preferences/ByHost/Predator.*",
+    "~/Library/Screen Savers/Predator.saver",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

I'd like to note that this cask was already refused in #63415, on the basis that it was not notable enough.

I would like to attempt another submission, as the original one was by the screensaver's own author, in May of 2019, when the cask had [_only ~20 stars_ on github](https://star-history.com/#vpeschenkov/Predator&Date).

Currently, this screensaver has **~150 stars** on github, a bit _more_ than the [Wonderful Tools Screensaver](https://github.com/heysaik/Wonderful-Tools-Screensaver) (one of the 4 screensaver casks in the stable homebrew tap), which is _based off of an official Apple Event_ from the same year, and evidently the repo traffic indicates users find it more notable than a screensaver inspired by an official Apple Event.

This screensaver is _also_ featured as **one of the 15** clock screensavers in [awesome-macos-screensavers](https://github.com/agarrharr/awesome-macos-screensavers), a repo which has **~3.6k stars**, and it evidently is notable enough to make such an affluent list of clock screensavers.

In addition, my cask has added proper livecheck and zap trash configurations, which the original author lacked in their submission.

I'd appreciate if you would reconsider this cask for submission now that it has garnered significantly more popularity than when it was first submitted, and I'd like to thank you for your time reviewing this submission.

~froggie