### PR TITLE
qqmacmgr: disable in favor of `tencent-lemon`

### DIFF
--- a/Casks/q/qqmacmgr.rb
+++ b/Casks/q/qqmacmgr.rb
@@ -7,10 +7,8 @@ cask "qqmacmgr" do
   name "腾讯电脑管家"
   homepage "https://lemon.qq.com/index_o.html"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/QQMacMgr_(\d+(?:\.\d+)*)\.dmg}i)
-  end
+  # `tencent-lemon` is the maintained cask
+  deprecate! date: "2024-01-01", because: "Use tencent-lemon cask instead"
 
   app "QQMacMgr.app"
 end

--- a/Casks/q/qqmacmgr.rb
+++ b/Casks/q/qqmacmgr.rb
@@ -8,7 +8,15 @@ cask "qqmacmgr" do
   homepage "https://lemon.qq.com/index_o.html"
 
   # `tencent-lemon` is the maintained cask
-  deprecate! date: "2024-01-01", because: "Use tencent-lemon cask instead"
+  disable! date: "2024-01-01", because: :discontinued
 
   app "QQMacMgr.app"
+
+  caveats do
+    <<~EOS
+      tencent-lemon is the successor to this software:
+
+        brew install --cask tencent-lemon
+    EOS
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

both `qqmacmgr` and `tencent-lemon` are the same sw, while `tencent-lemon` is maintained copy while `qqmacmgr` was lastly updated four years ago.