### PR TITLE
flomo: disable

### DIFF
--- a/Casks/f/flomo.rb
+++ b/Casks/f/flomo.rb
@@ -8,7 +8,7 @@ cask "flomo" do
   desc "Memo note taking and management app"
   homepage "https://flomoapp.com/"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-01-01", because: "download artifact not available"
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
```
==> Downloading https://flomo-resource.oss-cn-shanghai.aliyuncs.com/flomo_mac_v0.1.5.zip
curl: (28) Failed to connect to flomo-resource.oss-cn-shanghai.aliyuncs.com port 443 after 75005 ms: Couldn't connect to server
curl: (28) Failed to connect to flomo-resource.oss-cn-shanghai.aliyuncs.com port 443 after 75001 ms: Couldn't connect to server
curl: (28) Failed to connect to flomo-resource.oss-cn-shanghai.aliyuncs.com port 443 after 75000 ms: Couldn't connect to server
curl: (28) Failed to connect to flomo-resource.oss-cn-shanghai.aliyuncs.com port 443 after 75227 ms: Couldn't connect to server
Error: Download failed on Cask 'flomo' with message: Download failed: https://flomo-resource.oss-cn-shanghai.aliyuncs.com/flomo_mac_v0.1.5.zip
```