### PR TITLE
music-remote: update url

### DIFF
--- a/Casks/m/music-remote.rb
+++ b/Casks/m/music-remote.rb
@@ -2,7 +2,7 @@ cask "music-remote" do
   version "1.2"
   sha256 :no_check
 
-  url "https://marioaguzman.github.io/musicremote/updater/Music%20Remote.zip"
+  url "https://marioaguzman.github.io/musicremote/updater/Music%20Remote.dmg"
   name "Music Remote"
   desc "Remote application for Music.app"
   homepage "https://marioaguzman.github.io/musicremote/"


### PR DESCRIPTION
```
==> Downloading https://marioaguzman.github.io/musicremote/updater/Music%20Remote.zip
curl: (22) The requested URL returned error: 404
Error: Download failed on Cask 'music-remote' with message: Download failed: https://marioaguzman.github.io/musicremote/updater/Music%20Remote.zip
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
