### PR TITLE
Added post-flight script to link installed directory to current version.

### DIFF
--- a/Casks/f/flutter.rb
+++ b/Casks/f/flutter.rb
@@ -22,10 +22,11 @@ cask "flutter" do
   binary "flutter/bin/flutter"
 
   postflight do
-    # Allow existing shell profiles to work by linking the current version to the `latest` directory.
-    unless (latest_path = staged_path.dirname/"current").directory?
-      FileUtils.ln_s staged_path, latest_path, force: true
-    end
+    FileUtils.ln_sf("#{staged_path.to_s}/flutter", "#{HOMEBREW_PREFIX}/share/flutter")
+  end
+
+  uninstall_postflight do
+    FileUtils.rm_f("#{HOMEBREW_PREFIX}/share/flutter")
   end
 
   zap trash: "~/.flutter"

--- a/Casks/f/flutter.rb
+++ b/Casks/f/flutter.rb
@@ -21,5 +21,13 @@ cask "flutter" do
   binary "flutter/bin/dart"
   binary "flutter/bin/flutter"
 
+  postflight do
+    # Allow existing shell profiles to work by linking the current version to the `latest` directory.
+    unless (latest_path = staged_path.dirname/"current").directory?
+      FileUtils.ln_s staged_path, latest_path, force: true
+    end
+  end
+
   zap trash: "~/.flutter"
+
 end

--- a/Casks/f/flutter.rb
+++ b/Casks/f/flutter.rb
@@ -30,5 +30,4 @@ cask "flutter" do
   end
 
   zap trash: "~/.flutter"
-
 end

--- a/Casks/f/flutter.rb
+++ b/Casks/f/flutter.rb
@@ -22,7 +22,7 @@ cask "flutter" do
   binary "flutter/bin/flutter"
 
   postflight do
-    FileUtils.ln_sf("#{staged_path.to_s}/flutter", "#{HOMEBREW_PREFIX}/share/flutter")
+    FileUtils.ln_sf("#{staged_path}/flutter", "#{HOMEBREW_PREFIX}/share/flutter")
   end
 
   uninstall_postflight do


### PR DESCRIPTION
### **Description & explanation:**
This is to create a symlink of the installed version to folder `current`. For examples, linking
`/opt/homebrew/Caskroom/flutter/3.16.5` to `/opt/homebrew/Caskroom/flutter/current`. 

This will allow existing shell profiles to work by linking the current version to the `current` directory.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

~~Additionally, **if adding a new cask**:~~

- [ ] ~~Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).~~
- [ ] ~~Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).~~
- [ ] ~~Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).~~
- [ ] ~~`brew audit --cask --new <cask>` worked successfully.~~
- [ ] ~~`brew install --cask <cask>` worked successfully.~~
- [ ] ~~`brew uninstall --cask <cask>` worked successfully.~~
