### PR TITLE
pacifist: add `depends_on`

### DIFF
--- a/Casks/p/pacifist.rb
+++ b/Casks/p/pacifist.rb
@@ -18,7 +18,7 @@ cask "pacifist" do
   app "Pacifist.app"
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.charlessoft.pacifist.sfl2",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.charlessoft.pacifist.sfl*",
     "~/Library/Preferences/com.charlessoft.pacifist.plist",
     "~/Library/Saved Application State/com.charlessoft.pacifist.savedState",
   ]

--- a/Casks/p/pacifist.rb
+++ b/Casks/p/pacifist.rb
@@ -13,6 +13,7 @@ cask "pacifist" do
   end
 
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   app "Pacifist.app"
 


### PR DESCRIPTION
```
audit for pacifist: failed
 - Upstream defined :mojave as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
