### PR TITLE
threema-work: update `depends_on`

### DIFF
--- a/Casks/t/threema-work.rb
+++ b/Casks/t/threema-work.rb
@@ -12,7 +12,7 @@ cask "threema-work" do
     regex(/Threema\s*Work\s*(\d+(?:\.\d+)+)\s*for\s*Desktop/i)
   end
 
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :catalina"
 
   app "Threema Work.app"
 


### PR DESCRIPTION
```
audit for threema-work: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined :el_capitan
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.