### PR TITLE
mp3tag: add `depends_on`

### DIFF
--- a/Casks/m/mp3tag.rb
+++ b/Casks/m/mp3tag.rb
@@ -12,6 +12,8 @@ cask "mp3tag" do
     regex(/href=.*?Mp3tag[._-]?(\d+(?:\.\d+)+)\.zip/i)
   end
 
+  depends_on macos: ">= :mojave"
+
   app "Mp3tag.app"
 
   zap trash: [


### PR DESCRIPTION
```
audit for mp3tag: failed
 - Upstream defined :mojave as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.