### PR TITLE
tmpdisk: add `depends_on`

### DIFF
--- a/Casks/t/tmpdisk.rb
+++ b/Casks/t/tmpdisk.rb
@@ -7,6 +7,8 @@ cask "tmpdisk" do
   desc "Ram disk management"
   homepage "https://github.com/imothee/tmpdisk"
 
+  depends_on macos: ">= :mojave"
+
   app "TmpDisk.app"
 
   zap trash: "~/Library/Preferences/com.imothee.TmpDisk.plist"


### PR DESCRIPTION
```
audit for tmpdisk: failed
 - Upstream defined :mojave as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.