### PR TITLE
mendeley-reference-manager: add `depends_on` and `requires_rosetta`

### DIFF
--- a/Casks/m/mendeley-reference-manager.rb
+++ b/Casks/m/mendeley-reference-manager.rb
@@ -12,6 +12,8 @@ cask "mendeley-reference-manager" do
     strategy :electron_builder
   end
 
+  depends_on macos: ">= :high_sierra"
+
   app "Mendeley Reference Manager.app"
 
   zap trash: [
@@ -20,4 +22,8 @@ cask "mendeley-reference-manager" do
     "~/Library/Preferences/com.elsevier.mendeley.plist",
     "~/Library/Saved Application State/com.elsevier.mendeley.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
```
audit for mendeley-reference-manager: failed
 - Upstream defined :high_sierra as the minimum OS version and the cask defined no minimum OS version
```

Application downloads an `x64` dmg file.  Added `requires_rosetta` as a `caveat`

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.