### PR TITLE
foxglove-studio: add `depends_on`

### DIFF
--- a/Casks/f/foxglove-studio.rb
+++ b/Casks/f/foxglove-studio.rb
@@ -13,6 +13,8 @@ cask "foxglove-studio" do
     strategy :github_latest
   end
 
+  depends_on macos: ">= :catalina"
+
   app "Foxglove Studio.app"
 
   zap trash: [


### PR DESCRIPTION
```
audit for foxglove-studio: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.