### PR TITLE
logseq: add `depends_on`

### DIFF
--- a/Casks/l/logseq.rb
+++ b/Casks/l/logseq.rb
@@ -16,6 +16,7 @@ cask "logseq" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Logseq.app"
 


### PR DESCRIPTION
```
audit for logseq: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.