### PR TITLE
stringz: add `depends_on`

### DIFF
--- a/Casks/s/stringz.rb
+++ b/Casks/s/stringz.rb
@@ -7,6 +7,8 @@ cask "stringz" do
   desc "Editor for localizable files"
   homepage "https://github.com/mohakapt/Stringz"
 
+  depends_on macos: ">= :catalina"
+
   app "Stringz.app"
 
   zap trash: [


### PR DESCRIPTION
```
audit for stringz: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined no minimum OS version
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.