### PR TITLE
Split textsniper into textsniper-paddle and textsniper-gumroad

### DIFF
--- a/Casks/t/textsniper-gumroad.rb
+++ b/Casks/t/textsniper-gumroad.rb
@@ -14,6 +14,7 @@ cask "textsniper-gumroad" do
   end
 
   auto_updates true
+  conflicts_with cask: "textsniper-paddle"
   depends_on macos: ">= :catalina"
 
   app "TextSniper.app"

--- a/Casks/t/textsniper-gumroad.rb
+++ b/Casks/t/textsniper-gumroad.rb
@@ -25,6 +25,7 @@ cask "textsniper-gumroad" do
   zap trash: [
     "~/Library/Application Scripts/com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
     "~/Library/Application Support/com.valerijs.boguckis.gumroad.TextSniper",
+    "~/Library/Application Support/TextSniper",
     "~/Library/Caches/com.valerijs.boguckis.gumroad.TextSniper",
     "~/Library/Containers/com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
     "~/Library/Preferences/com.valerijs.boguckis.gumroad.TextSniper.plist",

--- a/Casks/t/textsniper-gumroad.rb
+++ b/Casks/t/textsniper-gumroad.rb
@@ -1,0 +1,32 @@
+cask "textsniper-gumroad" do
+  version "1.10.1"
+  sha256 "3542eedfa1a1d15b8d5351d7fee0ae28451d0b3d01d474995f214bf675eb76d2"
+
+  url "https://s3.amazonaws.com/textsniper.app/Gumroad/TextSniper#{version}.dmg",
+      verified: "s3.amazonaws.com/textsniper.app/"
+  name "TextSniper"
+  desc "Extract text from images and other digital documents in seconds"
+  homepage "https://textsniper.app/"
+
+  livecheck do
+    url "https://textsniper.app/api/downloads/mac-latest"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "TextSniper.app"
+
+  uninstall  launchctl: "com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
+             quit:      "com.valerijs.boguckis.gumroad.TextSniper",
+             delete:    "/Applications/TextSniper.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
+    "~/Library/Application Support/com.valerijs.boguckis.gumroad.TextSniper",
+    "~/Library/Caches/com.valerijs.boguckis.gumroad.TextSniper",
+    "~/Library/Containers/com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
+    "~/Library/Preferences/com.valerijs.boguckis.gumroad.TextSniper.plist",
+  ]
+end

--- a/Casks/t/textsniper-paddle.rb
+++ b/Casks/t/textsniper-paddle.rb
@@ -1,4 +1,4 @@
-cask "textsniper" do
+cask "textsniper-paddle" do
   version "1.10.1"
   sha256 "a553dd9fdf54b8a12950db71519cf3aee6aa7b18d590d32813b71c2e1bc6a010"
 

--- a/Casks/t/textsniper-paddle.rb
+++ b/Casks/t/textsniper-paddle.rb
@@ -14,6 +14,7 @@ cask "textsniper-paddle" do
   end
 
   auto_updates true
+  conflicts_with cask: "textsniper-gumroad"
   depends_on macos: ">= :catalina"
 
   app "TextSniper.app"

--- a/Casks/t/textsniper-paddle.rb
+++ b/Casks/t/textsniper-paddle.rb
@@ -25,6 +25,7 @@ cask "textsniper-paddle" do
   zap trash: [
     "~/Library/Application Scripts/com.valerijs.boguckis.TextSniper-LaunchAtLoginHelper",
     "~/Library/Application Support/com.valerijs.boguckis.TextSniper",
+    "~/Library/Application Support/TextSniper",
     "~/Library/Caches/com.valerijs.boguckis.TextSniper",
     "~/Library/Containers/com.valerijs.boguckis.TextSniper-LaunchAtLoginHelper",
     "~/Library/Preferences/com.valerijs.boguckis.TextSniper.plist",

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -15,5 +15,6 @@
   "remotion": "multiapp",
   "streamlabs-obs": "streamlabs",
   "tea": "ossapp",
+  "textsniper": "textsniper-paddle",
   "tibco-jaspersoft-studio": "jaspersoft-studio"
 }


### PR DESCRIPTION
TextSniper looks to have at some point moved from using Paddle to Gumroad to sell licenses. They've dealt with this by having two versions of the app, one for licenses from Paddle, and one for licenses from Gumroad. The existing `textsniper` cask was the Paddle version. This PR splits the cask into two, one for each version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
