### PR TITLE
harmony: deprecate

### DIFF
--- a/Casks/h/harmony.rb
+++ b/Casks/h/harmony.rb
@@ -8,6 +8,8 @@ cask "harmony" do
   desc "Music player"
   homepage "https://getharmony.xyz/"
 
+  deprecate! date: "2024-01-03", because: :discontinued
+
   app "Harmony.app"
 
   uninstall signal: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `harmony`](https://github.com/vincelwt/harmony) was archived on 2022-09-12. The most recent commit was on 2017-12-02 and the most recent release was on 2018-03-10 (not sure why the 0.9.x versions were released months after the most recent commit). The `README` wasn't updated to explain the project status before the repository was archived but this seems to suggest that it isn't being developed anymore, so this PR deprecates the cask accordingly.