### PR TITLE
aquaterm: deprecate

### DIFF
--- a/Casks/a/aquaterm.rb
+++ b/Casks/a/aquaterm.rb
@@ -7,6 +7,9 @@ cask "aquaterm" do
   desc "Graphics renderer"
   homepage "https://sourceforge.net/projects/aquaterm/"
 
+  # No releases since 2013
+  deprecate! date: "2024-01-04", because: :unmaintained
+
   depends_on macos: ">= :high_sierra"
 
   pkg "AquaTermInstaller.pkg"


### PR DESCRIPTION
`aquaterm` last release was in 2013, and as such should be considered unmaintained.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.