### PR TITLE
textsniper: change to Gumroad version

### DIFF
--- a/Casks/t/textsniper.rb
+++ b/Casks/t/textsniper.rb
@@ -3,9 +3,9 @@ cask "textsniper" do
   sha256 "3542eedfa1a1d15b8d5351d7fee0ae28451d0b3d01d474995f214bf675eb76d2"
 
   url "https://s3.amazonaws.com/textsniper.app/Gumroad/TextSniper#{version}.dmg",
-      verified: "s3.amazonaws.com/textsniper.app/"
+      verified: "s3.amazonaws.com/textsniper.app/Gumroad/"
   name "TextSniper"
-  desc "Extract text from images and other digital documents in seconds"
+  desc "Extract text from images and other digital documents"
   homepage "https://textsniper.app/"
 
   livecheck do
@@ -31,5 +31,10 @@ cask "textsniper" do
     "~/Library/Preferences/com.valerijs.boguckis.gumroad.TextSniper.plist",
   ]
 
-  caveats "Older licence keys (those issued through Paddle) won't work with this version of #{token}. Download #{token} from #{homepage}/download instead."
+  caveats do
+    <<~EOS
+      Older licence keys (those issued through Paddle) won't work with this version
+      of #{token}. Download #{token} from #{homepage}/download instead.
+    EOS
+  end
 end

--- a/Casks/t/textsniper.rb
+++ b/Casks/t/textsniper.rb
@@ -1,8 +1,8 @@
 cask "textsniper" do
   version "1.10.1"
-  sha256 "a553dd9fdf54b8a12950db71519cf3aee6aa7b18d590d32813b71c2e1bc6a010"
+  sha256 "3542eedfa1a1d15b8d5351d7fee0ae28451d0b3d01d474995f214bf675eb76d2"
 
-  url "https://s3.amazonaws.com/textsniper.app/TextSniper#{version}.dmg",
+  url "https://s3.amazonaws.com/textsniper.app/Gumroad/TextSniper#{version}.dmg",
       verified: "s3.amazonaws.com/textsniper.app/"
   name "TextSniper"
   desc "Extract text from images and other digital documents in seconds"
@@ -18,15 +18,18 @@ cask "textsniper" do
 
   app "TextSniper.app"
 
-  uninstall  launchctl: "com.valerijs.boguckis.TextSniper-LaunchAtLoginHelper",
-             quit:      "com.valerijs.boguckis.TextSniper",
+  uninstall  launchctl: "com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
+             quit:      "com.valerijs.boguckis.gumroad.TextSniper",
              delete:    "/Applications/TextSniper.app"
 
   zap trash: [
-    "~/Library/Application Scripts/com.valerijs.boguckis.TextSniper-LaunchAtLoginHelper",
-    "~/Library/Application Support/com.valerijs.boguckis.TextSniper",
-    "~/Library/Caches/com.valerijs.boguckis.TextSniper",
-    "~/Library/Containers/com.valerijs.boguckis.TextSniper-LaunchAtLoginHelper",
-    "~/Library/Preferences/com.valerijs.boguckis.TextSniper.plist",
+    "~/Library/Application Scripts/com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
+    "~/Library/Application Support/com.valerijs.boguckis.gumroad.TextSniper",
+    "~/Library/Application Support/TextSniper",
+    "~/Library/Caches/com.valerijs.boguckis.gumroad.TextSniper",
+    "~/Library/Containers/com.valerijs.boguckis.gumroad.TextSniper-LaunchAtLoginHelper",
+    "~/Library/Preferences/com.valerijs.boguckis.gumroad.TextSniper.plist",
   ]
+
+  caveats "Older licence keys (those issued through Paddle) won't work with this version of #{token}. Download #{token} from #{homepage}/download instead."
 end

--- a/Casks/t/textsniper.rb
+++ b/Casks/t/textsniper.rb
@@ -31,10 +31,8 @@ cask "textsniper" do
     "~/Library/Preferences/com.valerijs.boguckis.gumroad.TextSniper.plist",
   ]
 
-  caveats do
-    <<~EOS
-      Older licence keys (those issued through Paddle) won't work with this version
-      of #{token}. Download #{token} from #{homepage}/download instead.
-    EOS
-  end
+  caveats <<~EOS
+    Older licence keys (those issued through Paddle) won't work with this version
+    of #{token}. Download #{token} from #{homepage}/download instead.
+  EOS
 end


### PR DESCRIPTION
As per #163705, change the `textsniper` cask to use the Gumroad version instead of the Paddle version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
