### PR TITLE
Add WakaTime.app 5.0.0

### DIFF
--- a/Casks/w/wakatime.rb
+++ b/Casks/w/wakatime.rb
@@ -8,11 +8,6 @@ cask "wakatime" do
   desc "System tray app for automatic time tracking"
   homepage "https://wakatime.com/mac"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   depends_on macos: ">= :catalina"
 
   app "WakaTime.app"

--- a/Casks/w/wakatime.rb
+++ b/Casks/w/wakatime.rb
@@ -1,0 +1,26 @@
+cask "wakatime" do
+  version "5.0.0"
+  sha256 "8c59f4c9d5f7c4ca1797b3e4fabc4c03c78e8c7283603de80cfd3941cdd12a37"
+
+  url "https://github.com/wakatime/macos-wakatime/releases/download/v#{version}/macos-wakatime.zip",
+      verified: "github.com/wakatime/macos-wakatime/"
+  name "Wakatime"
+  desc "System tray app for automatic time tracking"
+  homepage "https://wakatime.com/mac"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "WakaTime.app"
+
+  zap trash: [
+    "~/Library/Application Support/macos-wakatime.WakaTime",
+    "~/Library/Caches/macos-wakatime.WakaTime",
+    "~/Library/HTTPStorages/macos-wakatime.WakaTime",
+    "~/Library/Preferences/macos-wakatime.WakaTime.plist",
+  ]
+end


### PR DESCRIPTION
Adding [Wakatime desktop app](https://github.com/wakatime/macos-wakatime), version 5.0.0

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix wakatime` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new wakatime` worked successfully.
- [x] `brew install --cask wakatime` worked successfully.
- [x] `brew uninstall --cask wakatime` worked successfully.
