### PR TITLE
keycast: deprecate

### DIFF
--- a/Casks/k/keycast.rb
+++ b/Casks/k/keycast.rb
@@ -7,5 +7,7 @@ cask "keycast" do
   desc "Record keystroke for screencast"
   homepage "https://github.com/cho45/KeyCast"
 
+  deprecate! date: "2024-01-05", because: :discontinued
+
   app "KeyCast.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `keycast`](https://github.com/cho45/KeyCast) was archived on 2023-02-03. The most recent release is 1.1, from 2015-02-20. The most recent commit on the `master` branch was on 2015-05-02. [There are branches from 2017 and 2019 where the author attempted to update the project to Swift 3 and 5 respectively but the commits suggest that the result wasn't functional.]

The `README` wasn't updated to explain the project status before archiving but it seems to be discontinued at this point, so this PR deprecates the cask.