### PR TITLE
p4 and perforce: add ARM support

### DIFF
--- a/Casks/p/p4.rb
+++ b/Casks/p/p4.rb
@@ -1,8 +1,23 @@
 cask "p4" do
-  version "2023.2,2535420"
-  sha256 "8a24804e48247104a1e59e99620e57bbe456018fef84b2dff911175908057017"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/p4"
+  version "2023.2,2535420"
+
+  on_arm do
+    sha256 "00264b87bf4ebb26286bc089fc0686d913d921b9b39bc67bf436af3702ac18b1"
+
+    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx12#{arch}/p4"
+
+    binary "bin.macosx12#{arch}", target: "p4"
+  end
+  on_intel do
+    sha256 "8a24804e48247104a1e59e99620e57bbe456018fef84b2dff911175908057017"
+
+    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015#{arch}/p4"
+
+    binary "bin.macosx1015#{arch}", target: "p4"
+  end
+
   name "Perforce Helix Command-Line Client (P4)"
   desc "Use it to gain instant access to operations and complete control over the system"
   homepage "https://www.perforce.com/products/helix-core-apps/command-line-client"
@@ -16,10 +31,8 @@ cask "p4" do
   end
 
   conflicts_with cask: "perforce"
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :sierra"
   container type: :naked
-
-  binary "bin.macosx1015x86_64", target: "p4"
 
   # No zap stanza required
 end

--- a/Casks/p/p4.rb
+++ b/Casks/p/p4.rb
@@ -1,23 +1,11 @@
 cask "p4" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "12arm64", intel: "1015x86_64"
 
   version "2023.2,2535420"
+  sha256 arm:   "00264b87bf4ebb26286bc089fc0686d913d921b9b39bc67bf436af3702ac18b1",
+         intel: "8a24804e48247104a1e59e99620e57bbe456018fef84b2dff911175908057017"
 
-  on_arm do
-    sha256 "00264b87bf4ebb26286bc089fc0686d913d921b9b39bc67bf436af3702ac18b1"
-
-    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx12#{arch}/p4"
-
-    binary "bin.macosx12#{arch}", target: "p4"
-  end
-  on_intel do
-    sha256 "8a24804e48247104a1e59e99620e57bbe456018fef84b2dff911175908057017"
-
-    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015#{arch}/p4"
-
-    binary "bin.macosx1015#{arch}", target: "p4"
-  end
-
+  url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx#{arch}/p4"
   name "Perforce Helix Command-Line Client (P4)"
   desc "Use it to gain instant access to operations and complete control over the system"
   homepage "https://www.perforce.com/products/helix-core-apps/command-line-client"
@@ -33,6 +21,8 @@ cask "p4" do
   conflicts_with cask: "perforce"
   depends_on macos: ">= :sierra"
   container type: :naked
+
+  binary "bin.macosx#{arch}", target: "p4"
 
   # No zap stanza required
 end

--- a/Casks/p/perforce.rb
+++ b/Casks/p/perforce.rb
@@ -1,8 +1,19 @@
 cask "perforce" do
-  version "2023.2,2535420"
-  sha256 "dbccb96d5a954a038ae6f3f49bf7ec9cd43b7094bec56f04ecb2c8ea41a93a8e"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015x86_64/helix-core-server.tgz"
+  version "2023.2,2535420"
+
+  on_arm do
+    sha256 "51d6052f9809013aaadab66d2568e827b41b21927894d2794ececad51c25c5b5"
+
+    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx12#{arch}/helix-core-server.tgz"
+  end
+  on_intel do
+    sha256 "dbccb96d5a954a038ae6f3f49bf7ec9cd43b7094bec56f04ecb2c8ea41a93a8e"
+
+    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015#{arch}/helix-core-server.tgz"
+  end
+
   name "Perforce Helix Core Server"
   name "Perforce Helix Command-Line Client (P4)"
   name "Perforce Helix Broker (P4Broker)"

--- a/Casks/p/perforce.rb
+++ b/Casks/p/perforce.rb
@@ -1,19 +1,11 @@
 cask "perforce" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "12arm64", intel: "1015x86_64"
 
   version "2023.2,2535420"
+  sha256 arm:   "51d6052f9809013aaadab66d2568e827b41b21927894d2794ececad51c25c5b5",
+         intel: "dbccb96d5a954a038ae6f3f49bf7ec9cd43b7094bec56f04ecb2c8ea41a93a8e"
 
-  on_arm do
-    sha256 "51d6052f9809013aaadab66d2568e827b41b21927894d2794ececad51c25c5b5"
-
-    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx12#{arch}/helix-core-server.tgz"
-  end
-  on_intel do
-    sha256 "dbccb96d5a954a038ae6f3f49bf7ec9cd43b7094bec56f04ecb2c8ea41a93a8e"
-
-    url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx1015#{arch}/helix-core-server.tgz"
-  end
-
+  url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx#{arch}/helix-core-server.tgz"
   name "Perforce Helix Core Server"
   name "Perforce Helix Command-Line Client (P4)"
   name "Perforce Helix Broker (P4Broker)"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

As discussed in https://github.com/Homebrew/homebrew-cask/pull/163776#issuecomment-1878109538 prefers ARM variants for perforce and p4 (CLI only) casks.

Notes
- Have tried to follow canonical approaches for doing this using the `on_` stanzas but willing to take feedback. I believe the livecheck should work and help update sha256sums for both archs still?
- Not sure if the `arch` stanza is really needed here, but seems easiest to do this similarly to other Casks.
- x86_64 and ARM versions seem always released/patched at the same time that I have observed thus far, so should be no need to have separate version numbers for each.
- Corrects minimum MacOS for both casks to match (Sierra). Technically Perforce say "10.12+" (Sierra), even though their binary folders imply 10.15+.
- Allows ARM installs for any MacOS version. Technically they [only support MacOS 12+](https://www.perforce.com/perforce/doc.current/user/relnotes.txt) (Monterey), but not aware of issues installing on Big Sur, so seems simpler to allow rather than cutting off.

cc @krehel 