### PR TITLE
Add `ci-skip-homepage` label.

### DIFF
--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -26,6 +26,7 @@ jobs:
         github.event.label.name == 'ci-retry' ||
         github.event.label.name == 'ci-skip-appcast' ||
         github.event.label.name == 'ci-skip-install' ||
+        github.event.label.name == 'ci-skip-homepage' ||
         github.event.label.name == 'ci-skip-livecheck' ||
         github.event.label.name == 'ci-skip-livecheck-min-os' ||
         github.event.label.name == 'ci-skip-repository' ||
@@ -40,5 +41,5 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           once-label: ci-requeue
           continuous-label: ci-retry
-          trigger-labels: ci-skip-appcast,ci-skip-install,ci-skip-livecheck,ci-syntax-only,ci-skip-repository,ci-skip-livecheck-min-os
+          trigger-labels: ci-skip-appcast,ci-skip-install,ci-skip-homepage,ci-skip-livecheck,ci-syntax-only,ci-skip-repository,ci-skip-livecheck-min-os
           workflow: ci.yml

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -144,8 +144,12 @@ module CiMatrix
 
       audit_exceptions = []
 
+      if labels.include?("ci-skip-homepage")
+        audit_exceptions << %w[homepage_https_availability]
+      end
+
       if labels.include?("ci-skip-livecheck")
-        audit_exceptions << %w[hosting_with_livecheck https_availability
+        audit_exceptions << %w[hosting_with_livecheck livecheck_https_availability
                                livecheck_min_os livecheck_version]
       end
 

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -144,9 +144,7 @@ module CiMatrix
 
       audit_exceptions = []
 
-      if labels.include?("ci-skip-homepage")
-        audit_exceptions << %w[homepage_https_availability]
-      end
+      audit_exceptions << %w[homepage_https_availability] if labels.include?("ci-skip-homepage")
 
       if labels.include?("ci-skip-livecheck")
         audit_exceptions << %w[hosting_with_livecheck livecheck_https_availability


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/brew/pull/16438.

Alternatively, we could add a `ci-skip-https` label instead.
