### PR TITLE
orangedrangon-android-messages: add `livecheck`

### DIFF
--- a/Casks/o/orangedrangon-android-messages.rb
+++ b/Casks/o/orangedrangon-android-messages.rb
@@ -7,6 +7,11 @@ cask "orangedrangon-android-messages" do
   desc "Desktop client for Android Messages"
   homepage "https://github.com/OrangeDrangon/android-messages-desktop"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   conflicts_with cask: "android-messages"
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
This adds a `livecheck` stanza to check `:github_latest` to avoid pre-releases and tags not marked with actual releases.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.