### PR TITLE
Update OpenOffice desc

### DIFF
--- a/Casks/o/openoffice.rb
+++ b/Casks/o/openoffice.rb
@@ -37,7 +37,7 @@ cask "openoffice" do
   url "https://downloads.sourceforge.net/openofficeorg.mirror/Apache_OpenOffice_#{version}_MacOS_x86-64_install_#{language}.dmg",
       verified: "sourceforge.net/openofficeorg.mirror/"
   name "Apache OpenOffice"
-  desc "Free and open-source productivity suite"
+  desc "Legacy open-source office suite, see LibreOffice for active development"
   homepage "https://www.openoffice.org/"
 
   app "OpenOffice.app"


### PR DESCRIPTION
> The project has continued to release minor updates that fix bugs, update dictionaries and sometimes include feature enhancements. The most recent maintenance release was 4.1.14 on February, 27 2023.

> Difficulties maintaining a sufficient number of contributors to keep the project viable have persisted for several years. In January 2015 the project reported a lack of active developers and code contributions

> In September 2016, OpenOffice's project management committee chair Dennis Hamilton began a discussion of possibly discontinuing the project, after the Apache board had put them on monthly reporting due to the project's ongoing problems handling security issues

Source: https://www.wikiwand.com/en/Apache_OpenOffice

Hence, the reasoning in using Legacy in desc

As for Redirecting users to LibreOffice
> LibreOffice is the successor to OpenOffice.org, commonly known as OpenOffice, which had its last major update in 2014. LibreOffice adds many extra features and improved Microsoft Office compatibility, and has regular releases with security updates. [Learn more about the history of OpenOffice and LibreOffice here](https://en.wikipedia.org/wiki/LibreOffice#History), and check out this comparison:
![image](https://github.com/Homebrew/homebrew-cask/assets/66227691/8c1dd557-226a-4f68-a94d-2b0a1814d865)
 https://blog.documentfoundation.org/blog/2020/10/12/open-letter-to-apache-openoffice/