### PR TITLE
lighttable: deprecate

### DIFF
--- a/Casks/l/lighttable.rb
+++ b/Casks/l/lighttable.rb
@@ -8,6 +8,8 @@ cask "lighttable" do
   desc "IDE"
   homepage "http://lighttable.com/"
 
+  deprecate! date: "2024-01-06", because: :discontinued
+
   app "lighttable-#{version}-mac/LightTable.app"
   binary "lighttable-#{version}-mac/light"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `lighttable`](https://github.com/LightTable/LightTable) was archived on 2022-10-21, along with all the other repositories in the LightTable organization. The most recent release was 0.8.1 on 2016-01-21 and the most recent commit on the `develop` branch is from 2021-06-25. The most recent status updates about the project are from [2019-03-31](http://lighttable.com/2019/03/31/New-year-old-plans/) (on lightable.com) and [2020-12-09](https://github.com/LightTable/LightTable/discussions/2506) (a GitHub discussion).

The `README` wasn't updated before the repository was archived but this seems to suggest that `lighttable` isn't going to be developed further, so this PR deprecates the cask.