### PR TITLE
emby-server ==> embyserver rename

### DIFF
--- a/Casks/e/embyserver.rb
+++ b/Casks/e/embyserver.rb
@@ -1,4 +1,4 @@
-cask "emby-server" do
+cask "embyserver" do
   version "4.7.14.0"
   sha256 "1331ba4a00c8d3fa261463629d0460b127ac12360f0d08f3a6e67a43408220e2"
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -2,6 +2,7 @@
   "ankerslicer": "ankermake",
   "betterdummy": "betterdisplay",
   "cloudapp": "zight",
+  "emby-server": "embyserver",
   "epilogue-operator": "epilogue-playback",
   "figmadaemon": "figma-agent",
   "fly-key": "flykey",


### PR DESCRIPTION
Rename `emby-server` to `embyserver` to conform to token standards.