### PR TITLE
manymc: deprecate

### DIFF
--- a/Casks/m/manymc.rb
+++ b/Casks/m/manymc.rb
@@ -7,6 +7,8 @@ cask "manymc" do
   desc "Minecraft launcher with native arm64 support"
   homepage "https://github.com/MinecraftMachina/ManyMC"
 
+  deprecate! date: "2024-01-07", because: :discontinued
+
   depends_on arch: :arm64
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `manymc`](https://github.com/MinecraftMachina/ManyMC) was archived on 2022-10-20. Before archiving, the `README` was updated to say that ManyMC was no longer being updated and to recommend Prism Launcher instead:

> > ### ⚠️ The ManyMC launcher is no longer being updated.
>
> Prism Launcher is the official continuation of ManyMC. It is actively developed by numerous maintainers, and directly inherits all of ManyMC's ARM patches. Migrating is super easy:
>
> 1. Close all launchers
> 2. Run the following commands from a Terminal:
> 
>    ```bash
>    cd ~/Library/Application\ Support
>    mv ManyMC PrismLauncher
>    cd PrismLauncher
>    mv manymc.cfg prismlauncher.cfg
>    rm -r meta metacache cache libraries
>    ```
>
> Find Prism here:
> https://github.com/PrismLauncher/PrismLauncher
> https://discord.gg/prismlauncher

This PR deprecates the `manymc` cask accordingly. We already have a `prismlauncher` cask and users can follow the [migration instructions from the ManyMC `README`](https://github.com/MinecraftMachina/ManyMC#%EF%B8%8F-the-manymc-launcher-is-no-longer-being-updated).