### PR TITLE
prism: update livecheck and zap

### DIFF
--- a/Casks/p/prism.rb
+++ b/Casks/p/prism.rb
@@ -7,6 +7,9 @@ cask "prism" do
   desc "Statistical analysis and graphing software"
   homepage "https://graphpad.com/"
 
+  # The `osVersion` parameter is required but doesn't seem to have an effect on
+  # the version in the appcast. However, we may want to monitor this over time
+  # (e.g. when the newest macOS release is higher than the hardcoded version).
   livecheck do
     url "https://licenses.graphpad.com/updates?version=#{version}&configuration=full&platform=Mac&osVersion=14"
     strategy :sparkle, &:short_version

--- a/Casks/p/prism.rb
+++ b/Casks/p/prism.rb
@@ -8,8 +8,8 @@ cask "prism" do
   homepage "https://graphpad.com/"
 
   livecheck do
-    url "https://www.graphpad.com/updates"
-    regex(/"version":"(\d+(?:\.\d+)+)/i)
+    url "https://licenses.graphpad.com/updates?version=#{version}&configuration=full&platform=Mac&osVersion=14"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true
@@ -17,14 +17,19 @@ cask "prism" do
 
   app "Prism #{version.major}.app"
 
-  zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.graphpad.prism.sfl*",
-    "~/Library/Application Support/GraphPad",
-    "~/Library/Caches/com.GraphPad.Prism",
-    "~/Library/HTTPStorages/com.GraphPad.Prism",
-    "~/Library/Preferences/com.GraphPad.Prism.autocomplete.plist",
-    "~/Library/Preferences/com.GraphPad.Prism.plist",
-    "~/Library/Saved Application State/com.GraphPad.Prism.savedState",
-    "~/Library/WebKit/com.GraphPad.Prism",
-  ]
+  zap delete: [
+        "/Library/Application Support/GraphPad",
+        "/Library/GraphPad",
+      ],
+      trash:  [
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.graphpad.prism.sfl*",
+        "~/Library/Application Support/GraphPad",
+        "~/Library/Caches/com.GraphPad.Prism",
+        "~/Library/HTTPStorages/com.GraphPad.Prism",
+        "~/Library/Logs/GraphPad",
+        "~/Library/Preferences/com.GraphPad.Prism.autocomplete.plist",
+        "~/Library/Preferences/com.GraphPad.Prism.plist",
+        "~/Library/Saved Application State/com.GraphPad.Prism.savedState",
+        "~/Library/WebKit/com.GraphPad.Prism",
+      ]
 end


### PR DESCRIPTION
The PR changes the livecheck strategy to sparkle. The current strategy picks up Windows-only [versions](https://www.graphpad.com/updates/prism-10-1-2-release-notes).

Additionally, I am adding a few more items to the zap.
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
