### PR TITLE
freecad 0.21.2

### DIFF
--- a/Casks/f/freecad.rb
+++ b/Casks/f/freecad.rb
@@ -11,9 +11,12 @@ cask "freecad" do
   desc "3D parametric modeler"
   homepage "https://www.freecad.org/"
 
+  # Upstream uses GitHub releases to indicate that a version is released
+  # (there's also sometimes a notable gap between the release being created
+  # and the homepage being updated), so the `GithubLatest` strategy is necessary.
   livecheck do
-    url "https://www.freecad.org/downloads.php"
-    regex(/FreeCAD[._-]v?(\d+(?:\.\d+)+)[._-]mac[._-]#{arch}\.dmg/i)
+    url :stable
+    strategy :github_latest
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/f/freecad.rb
+++ b/Casks/f/freecad.rb
@@ -1,11 +1,11 @@
 cask "freecad" do
-  arch arm: "arm64", intel: "intel_x86"
+  arch arm: "arm64", intel: "intel-x86_64"
 
-  version "0.21.1"
-  sha256 arm:   "b6959ca9e0e2f7cddda2cf1e97a26f3e2e65205f2e8e53b3c5dccd062f0be14f",
-         intel: "633dd754e7732c531a019fe74068e43883f8f329c25fe85bfcc91fa26186451f"
+  version "0.21.2"
+  sha256 arm:   "88f51e816075c586bcde89eab0b5edc4a260294eefc11bf5a917d7818330ad50",
+         intel: "e22dfd804c2b09aa559cd3ec2de6e1d7321022c04a354857fc9936b7b6d2e5bb"
 
-  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version}/FreeCAD-#{version}-mac-#{arch}.dmg",
+  url "https://github.com/FreeCAD/FreeCAD/releases/download/#{version}/FreeCAD-#{version}-macOS-#{arch}.dmg",
       verified: "github.com/FreeCAD/FreeCAD/"
   name "FreeCAD"
   desc "3D parametric modeler"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.