### PR TITLE
moderndeck: deprecate

### DIFF
--- a/Casks/m/moderndeck.rb
+++ b/Casks/m/moderndeck.rb
@@ -8,10 +8,7 @@ cask "moderndeck" do
   desc "Modified version of TweetDeck with a material inspired theme"
   homepage "https://moderndeck.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-01-09", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `moderndeck`](https://github.com/dangeredwolf/ModernDeck) was archived on 2023-07-04. The [homepage](https://moderndeck.app/) redirects to an [issue](https://github.com/dangeredwolf/ModernDeck/issues/357) explaining that Twitter API changes made ModernDeck unusable and that development on the project was halted. The `README` was updated to the link to the same issue before the repository was archived, making it clear that this isn't being developed anymore.

This PR deprecates the `moderndeck` cask accordingly and removes the `livecheck` block (so it will be automatically skipped as deprecated).