### PR TITLE
reaper 7.08: Fix universal checksum

### DIFF
--- a/Casks/r/reaper.rb
+++ b/Casks/r/reaper.rb
@@ -7,7 +7,7 @@ cask "reaper" do
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
   end
   on_catalina :or_newer do
-    sha256 "223b605a15e960b689ed8094d9ffe5c39ba4b636c193bb6fa9dd8e1a509a33ee"
+    sha256 "3e0600c12491c1ec3e40bc7afc6b3e275bf7899e14db66e7e95f1759993c3f3d"
 
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_universal.dmg"
   end


### PR DESCRIPTION
Checksum was wrong, causing:

```text
==> Upgrading 1 outdated package:
reaper 7.07 -> 7.08
==> Upgrading reaper
==> Downloading https://dlcf.reaper.fm/7.x/reaper708_universal.dmg
Already downloaded: /Users/dronenb/Library/Caches/Homebrew/downloads/19b1f49ec3d1f539093486fd8780a7e3c77768c42d0979194990574ed77ff1c8--reaper708_universal.dmg
==> Purging files for version 7.08 of Cask reaper
Error: reaper: SHA256 mismatch
Expected: 223b605a15e960b689ed8094d9ffe5c39ba4b636c193bb6fa9dd8e1a509a33ee
  Actual: 3e0600c12491c1ec3e40bc7afc6b3e275bf7899e14db66e7e95f1759993c3f3d
    File: /Users/dronenb/Library/Caches/Homebrew/downloads/19b1f49ec3d1f539093486fd8780a7e3c77768c42d0979194990574ed77ff1c8--reaper708_universal.dmg
To retry an incomplete download, remove the file above
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
