### PR TITLE
Set auto_updates in Naver Whale

### DIFF
--- a/Casks/n/naver-whale.rb
+++ b/Casks/n/naver-whale.rb
@@ -17,6 +17,8 @@ cask "naver-whale" do
     end
   end
 
+  auto_updates true
+
   app "Whale.app"
 
   zap trash: [


### PR DESCRIPTION
Naver Whale includes an auto-updater, similar to other Chromium browsers.

<img width="1200" alt="스크린샷 2024-01-10 오후 12 29 47" src="https://github.com/Homebrew/homebrew-cask/assets/47051820/299f57ca-c167-4f2c-b748-ccbca41a132b">

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.