### PR TITLE
markedit 1.15.0 (new cask)

### DIFF
--- a/Casks/m/markedit.rb
+++ b/Casks/m/markedit.rb
@@ -1,0 +1,27 @@
+cask "markedit" do
+  version "1.15.0"
+  sha256 "4f01ef61e4eb5daf994d051a28d0790846780ce6cf8b436966452325e32861fa"
+
+  url "https://github.com/MarkEdit-app/MarkEdit/releases/download/v#{version}/MarkEdit-#{version}.dmg"
+  name "markedit"
+  desc "TextEdit, but dedicated to Markdown"
+  homepage "https://github.com/MarkEdit-app/MarkEdit"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "MarkEdit.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/app.cyan.markedit",
+    "~/Library/Application Scripts/app.cyan.markedit.preview-extension",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/app.cyan.markedit.sfl3",
+    "~/Library/Containers/app.cyan.markedit",
+    "~/Library/Containers/app.cyan.markedit.preview-extension",
+    "~/Library/Saved Application State/app.cyan.markedit.savedState",
+  ]
+end

--- a/Casks/m/markedit.rb
+++ b/Casks/m/markedit.rb
@@ -3,7 +3,7 @@ cask "markedit" do
   sha256 "4f01ef61e4eb5daf994d051a28d0790846780ce6cf8b436966452325e32861fa"
 
   url "https://github.com/MarkEdit-app/MarkEdit/releases/download/v#{version}/MarkEdit-#{version}.dmg"
-  name "markedit"
+  name "MarkEdit"
   desc "TextEdit, but dedicated to Markdown"
   homepage "https://github.com/MarkEdit-app/MarkEdit"
 

--- a/Casks/m/markedit.rb
+++ b/Casks/m/markedit.rb
@@ -4,7 +4,7 @@ cask "markedit" do
 
   url "https://github.com/MarkEdit-app/MarkEdit/releases/download/v#{version}/MarkEdit-#{version}.dmg"
   name "MarkEdit"
-  desc "TextEdit, but dedicated to Markdown"
+  desc "Markdown editor"
   homepage "https://github.com/MarkEdit-app/MarkEdit"
 
   livecheck do


### PR DESCRIPTION
Adding MarkEdit version 1.15.0

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online markedit` is error-free.
- [x] `brew style --fix markedit` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
