### PR TITLE
microsoft-teams 23320.3110.2622.1325

### DIFF
--- a/Casks/m/microsoft-teams.rb
+++ b/Casks/m/microsoft-teams.rb
@@ -1,6 +1,6 @@
 cask "microsoft-teams" do
-  version "23320.3107.2575.3762"
-  sha256 "52a566b01f2f35ba97ef22b9cf7fe1110926abe00507715820937789b7490389"
+  version "23320.3110.2622.1325"
+  sha256 "040134e7b49f89f5133a93e0587fa0c1b8fc0658d7dcaf526b207481c1a5578b"
 
   url "https://statics.teams.cdn.office.net/production-osx/#{version}/MicrosoftTeams.pkg",
       verified: "statics.teams.cdn.office.net/production-osx/"

--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -1,4 +1,3 @@
 {
-    "microsoft-teams": "https://www.microsoft.com/en/microsoft-teams/group-chat-software/",
     "onedrive": "https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage"
 }


### PR DESCRIPTION
Fixes the following `audit` error:
```
audit for microsoft-teams: failed
 - https://www.microsoft.com/en/microsoft-teams/group-chat-software/ is in the secure connection audit skiplist but does not need to be skipped
microsoft-teams
  * https://www.microsoft.com/en/microsoft-teams/group-chat-software/ is in the secure connection audit skiplist but does not need to be skipped
Error: 1 problem in 1 cask detected.
Error: `brew audit` failed!
```