### PR TITLE
nocturn: deprecate

### DIFF
--- a/Casks/n/nocturn.rb
+++ b/Casks/n/nocturn.rb
@@ -7,5 +7,7 @@ cask "nocturn" do
   desc "Multi-platform Twitter client"
   homepage "https://github.com/k0kubun/Nocturn"
 
+  deprecate! date: "2024-01-11", because: :discontinued
+
   app "Nocturn-darwin-x64/Nocturn.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `nocturn`](https://github.com/k0kubun/Nocturn) was archived on 2023-04-07. Before the repository was archived, the `README` was updated to include a ["Status" section](https://github.com/k0kubun/Nocturn#status) section that says:

> Twitter suspended Nocturn on Apr 5th, 2023.

The commit message is "No longer maintained since it's suspended". This makes it clear that the project isn't being developed further, so this PR deprecates `nocturn` accordingly.