### PR TITLE
notch-simulator: deprecate

### DIFF
--- a/Casks/n/notch-simulator.rb
+++ b/Casks/n/notch-simulator.rb
@@ -7,6 +7,8 @@ cask "notch-simulator" do
   desc "Simulate the notch on the MacBook Pro"
   homepage "https://github.com/megabitsenmzq/Notch-Simulator"
 
+  deprecate! date: "2024-01-12", because: :discontinued
+
   app "Notch Simulator.app"
 
   zap trash: "~/Library/Containers/com.JinyuMeng.Notch-Simulator"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `notch-simulator`](https://github.com/megabitsenmzq/Notch-Simulator) was archived on 2023-10-22. The most recent release was on 2021-10-28 and the most recent commit was on 2021-11-02.

The `README` wasn't updated (to explain the project status) before the repository was archived, so I can only assume that the lack of a recent commit/release and archiving the repository are signals that the project isn't being developed anymore. With that in mind, this PR deprecates the cask.