### PR TITLE
noti: deprecate

### DIFF
--- a/Casks/n/noti.rb
+++ b/Casks/n/noti.rb
@@ -8,6 +8,8 @@ cask "noti" do
   desc "Utility to show notifications from an Android device"
   homepage "https://noti.center/"
 
+  deprecate! date: "2024-01-13", because: :discontinued
+
   auto_updates true
 
   app "Noti.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `noti`](https://github.com/jariz/Noti) was archived on 2022-07-06. Before it was archived, the `README` was updated to include:

> **UNMAINTAINED**: Noti is now unmaintained. If you wish to take over maintainership, please reach out to me on [twitter](https://twitter.com/jari_io).
> **PLEASE NOTE**: the noti.center domain has been hijacked and filled with spam and shouldn't be considered legitimate anymore. This repo is the only official place to get noti on the web.

This makes it clear that the project is no longer maintained, so this PR deprecates the cask accordingly