### PR TITLE
adobe-acrobat-reader: update livecheck

### DIFF
--- a/Casks/a/adobe-acrobat-reader.rb
+++ b/Casks/a/adobe-acrobat-reader.rb
@@ -8,8 +8,10 @@ cask "adobe-acrobat-reader" do
   homepage "https://acrobat.adobe.com/us/en/acrobat/pdf-reader.html"
 
   livecheck do
-    url "https://armmf.adobe.com/arm-manifests/mac/AcrobatDC/reader/current_version.txt"
-    regex(/(\d+(?:\.\d+)+)/i)
+    url "https://rdc.adobe.io/reader/products?lang=en&site=landing&os=Mac%20OS%2010.15&api_key=dc-get-adobereader-cdn"
+    strategy :json do |json|
+      json.dig("products", "reader").map { |product| product["version"] }
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
This updates the `livecheck` for `adobe-acrobat-reader` to utilise a source that will only return versions relevant for MacOS.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
