### PR TITLE
openbazaar: deprecate

### DIFF
--- a/Casks/o/openbazaar.rb
+++ b/Casks/o/openbazaar.rb
@@ -7,6 +7,8 @@ cask "openbazaar" do
   name "OpenBazaar#{version.major}"
   homepage "https://www.openbazaar.org/"
 
+  deprecate! date: "2024-01-14", because: :discontinued
+
   app "OpenBazaar#{version.major}.app"
 
   zap trash: [

--- a/Casks/o/openbazaar.rb
+++ b/Casks/o/openbazaar.rb
@@ -2,10 +2,9 @@ cask "openbazaar" do
   version "2.4.10"
   sha256 "ba5632071b75ce80c7b1151d0a2e6775d3576e67ea77e36455895e56dc805cad"
 
-  url "https://github.com/OpenBazaar/openbazaar-desktop/releases/download/v#{version}/OpenBazaar#{version.major}-#{version}.dmg",
-      verified: "github.com/OpenBazaar/openbazaar-desktop/"
-  name "OpenBazaar#{version.major}"
-  homepage "https://www.openbazaar.org/"
+  url "https://github.com/OpenBazaar/openbazaar-desktop/releases/download/v#{version}/OpenBazaar#{version.major}-#{version}.dmg"
+  name "OpenBazaar"
+  homepage "https://github.com/OpenBazaar/openbazaar-desktop/"
 
   deprecate! date: "2024-01-14", because: :discontinued
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `openbazaar`](https://github.com/OpenBazaar/openbazaar-desktop) was archived on 2023-03-28. The most recent release and commit were from 2020-12-29. The `README` wasn't updated to explain the situation before the project was archived.

openbazaar.org simply contains a message saying "openbazaar 3.0 - coming soon". There is an openbazaar3-rust repository (last updated 2023-04-20) but archiving `openbazaar-desktop` seems to make it clear that the desktop app isn't being supported anymore. This PR deprecates the cask accordingly.