### PR TITLE
oso-cloud: update homepage

### DIFF
--- a/Casks/o/oso-cloud.rb
+++ b/Casks/o/oso-cloud.rb
@@ -8,7 +8,7 @@ cask "oso-cloud" do
       verified: "d3i4cc4dqewpo9.cloudfront.net/"
   name "OSO Cloud CLI"
   desc "Tool for interacting with OSO Cloud"
-  homepage "https://cloud-docs.osohq.com/get-started/quickstart"
+  homepage "https://www.osohq.com/docs/reference/client-apis/cli"
 
   binary "oso_cli_mac_osx_#{arch}", target: "oso-cloud"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

```
$ curl -I https://cloud-docs.osohq.com/get-started/quickstart
HTTP/2 404
cache-control: public, max-age=0, must-revalidate
content-type: text/plain; charset=utf-8
date: Mon, 15 Jan 2024 22:34:51 GMT
server: Vercel
strict-transport-security: max-age=63072000
x-vercel-error: NOT_FOUND
x-vercel-id: iad1::8w22f-1705358091372-1af047ac50d7
content-length: 39

$ curl -I https://www.osohq.com/docs/reference/client-apis/cli
HTTP/2 200
accept-ranges: bytes
access-control-allow-origin: *
age: 11789
cache-control: public, max-age=0, must-revalidate
content-disposition: inline; filename="cli"
content-type: text/html; charset=utf-8
date: Mon, 15 Jan 2024 22:35:14 GMT
etag: "93152790c7854a516cc4088ed5902c9c"
server: Vercel
strict-transport-security: max-age=63072000; includeSubDomains; preload
x-matched-path: /reference/client-apis/cli
x-vercel-cache: HIT
x-vercel-id: iad1:iad1:iad1::48889-1705358114277-3e2495350e2a
content-length: 250568
```