### PR TITLE
nextcloud: various updates

### DIFF
--- a/Casks/n/nextcloud.rb
+++ b/Casks/n/nextcloud.rb
@@ -1,35 +1,37 @@
 cask "nextcloud" do
-  on_el_capitan :or_older do
-    version "2.6.5.20200710-legacy"
-    sha256 "4c67e50361dd5596fb884002d1ed907fe109d607fba2cabe07e505addd164519"
+  on_big_sur :or_older do
+    version "3.8.1"
+    sha256 "448647db0068ff9a2b669ff2f9d715a36b4e5e1af82e9849e57d9f7078d1bd2e"
 
-    url "https://github.com/nextcloud/desktop/releases/download/v#{version.major_minor_patch}/Nextcloud-#{version}.pkg",
-        verified: "github.com/nextcloud/desktop/"
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :mojave"
   end
-  on_sierra :or_newer do
+  on_monterey :or_newer do
     version "3.11.0"
     sha256 "e2e42c4d255546e32d11e3c2c20d8e805aa08425d6f7994f0a1fa3c3438047b3"
 
-    url "https://github.com/nextcloud-releases/desktop/releases/download/v#{version}/Nextcloud-#{version}.pkg",
-        verified: "github.com/nextcloud-releases/desktop/"
-  end
+    livecheck do
+      url :url
+      regex(/^Nextcloud[._-]v?(\d+(?:\.\d+)+)\.pkg$/i)
+      strategy :github_latest do |json, regex|
+        json["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
 
-  name "Nextcloud"
-  desc "Desktop sync client for Nextcloud software products"
-  homepage "https://nextcloud.com/"
-
-  livecheck do
-    url :url
-    regex(/^Nextcloud[._-]v?(\d+(?:\.\d+)+)\.pkg$/i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
-
-        match[1]
+          match[1]
+        end
       end
     end
   end
+
+  url "https://github.com/nextcloud-releases/desktop/releases/download/v#{version}/Nextcloud-#{version}.pkg",
+      verified: "github.com/nextcloud-releases/desktop/"
+  name "Nextcloud"
+  desc "Desktop sync client for Nextcloud software products"
+  homepage "https://nextcloud.com/"
 
   auto_updates true
 


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-cask/issues/164715

Note that this also drops support for anything older than `mojave (10.14)` to not have to repeat the `on_{os}` block a whole handful of times.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.