### PR TITLE
Microsoft Office 16.81.24011420

### DIFF
--- a/Casks/m/microsoft-auto-update.rb
+++ b/Casks/m/microsoft-auto-update.rb
@@ -3,9 +3,17 @@ cask "microsoft-auto-update" do
     version "4.40.21101001"
     sha256 "f638f7e0da9ee659c323f2ede0f176804bfe9a615a8f8b6320bd2e69d91ef2b2"
   end
-  on_sierra :or_newer do
-    version "4.66.23121017"
-    sha256 "e1d0fb04740282af67235329cd3d51229168bdde69d57b38ecfeaf66969170fd"
+  on_sierra do
+    version "4.51.22091101"
+    sha256 "ea9e59eb60604ad9785cb0c81bd490de5c7d32527f1da7064d4f77226e2dc907"
+  end
+  on_high_sierra do
+    version "4.63.23091003"
+    sha256 "abde56323f4753a90a99ca26a3c62060a498328bd90e0421395ec14a47d49101"
+  end
+  on_mojave :or_newer do
+    version "4.67.24011420"
+    sha256 "eeb36b75aca79ad829c4ea181db537a66cfa1f757617d2c6ff88508d45d2c1c3"
   end
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_AutoUpdate_#{version}_Updater.pkg"

--- a/Casks/m/microsoft-excel.rb
+++ b/Casks/m/microsoft-excel.rb
@@ -48,8 +48,8 @@ cask "microsoft-excel" do
     end
   end
   on_monterey :or_newer do
-    version "16.80.23121017"
-    sha256 "d85909b859be53d2073be944667f6557d65b791e0403cea6d2abc150531dc399"
+    version "16.81.24011420"
+    sha256 "d252df9f51fdefb76bcf0747719e2943712f82ac6e977ff682af8237d47ae4dd"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525135"

--- a/Casks/m/microsoft-office-businesspro.rb
+++ b/Casks/m/microsoft-office-businesspro.rb
@@ -1,6 +1,6 @@
 cask "microsoft-office-businesspro" do
-  version "16.80.23121017"
-  sha256 "06274db9e2556e9e11c595a6c96da63399312363d90135f0da7726adc6091887"
+  version "16.81.24011420"
+  sha256 "a9be856fd6d75b5dd58a56c6b9cd2abd70a6b902318989f47d53397c1e13403b"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_BusinessPro_Installer.pkg"
   name "Microsoft Office BusinessPro"

--- a/Casks/m/microsoft-office.rb
+++ b/Casks/m/microsoft-office.rb
@@ -1,6 +1,6 @@
 cask "microsoft-office" do
-  version "16.80.23121017"
-  sha256 "96fea841201602c82b6ba91ebf841be5c6b58d5a2caf0ff388de354b9d8a2fb1"
+  version "16.81.24011420"
+  sha256 "b7f7453191df5429e08e7577866b10f5e4fc641f98dc894fb344eb68e53b203e"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_365_and_Office_#{version}_Installer.pkg"
   name "Microsoft Office"

--- a/Casks/m/microsoft-onenote.rb
+++ b/Casks/m/microsoft-onenote.rb
@@ -1,6 +1,6 @@
 cask "microsoft-onenote" do
-  version "16.80.23121017"
-  sha256 "22c0da595891ede656b05205e2f42e6f65f938be031839ccdbe48e5ec1795012"
+  version "16.81.24011420"
+  sha256 "194fa90eb4cec54d09395aaf9ab8275629eb2c6260d76ead345a26ee8c6901ee"
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_#{version}_Updater.pkg"
   name "Microsoft OneNote"

--- a/Casks/m/microsoft-outlook.rb
+++ b/Casks/m/microsoft-outlook.rb
@@ -48,8 +48,8 @@ cask "microsoft-outlook" do
     end
   end
   on_monterey :or_newer do
-    version "16.80.23121017"
-    sha256 "354090a3705b1e2cc03ae638d4901202c3193b04842080238e2e874648ece17b"
+    version "16.81.24011420"
+    sha256 "a26ce8970cdffc987f5387f55a2c9ef33a69f7165a4a5f803b71a2fb89462bda"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525137"

--- a/Casks/m/microsoft-powerpoint.rb
+++ b/Casks/m/microsoft-powerpoint.rb
@@ -48,8 +48,8 @@ cask "microsoft-powerpoint" do
     end
   end
   on_monterey :or_newer do
-    version "16.80.23121017"
-    sha256 "f36a0f08cfec8628966f93b3ac23b09bbff4d66d2169fd5919c61e26ce4a7840"
+    version "16.81.24011420"
+    sha256 "86b27182adb03745a7d538fec48b0b6a82e8a6198ca531b8d11df0a882c44484"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525136"

--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -48,8 +48,8 @@ cask "microsoft-word" do
     end
   end
   on_monterey :or_newer do
-    version "16.80.23121017"
-    sha256 "fa9d5023b6dadc129b642272a219bb211a5946e8aaebd3b3c0942051bbe5ae02"
+    version "16.81.24011420"
+    sha256 "af0920fed5d4c9a873b079f3d9e0dd9549b2e132f4cfd2142df31d46da008d3b"
 
     livecheck do
       url "https://go.microsoft.com/fwlink/p/?linkid=525134"


### PR DESCRIPTION
Standalone applications and Microsoft AutoUpdate are updated as well.

Based on release notes (https://learn.microsoft.com/en-us/officeupdates/release-history-microsoft-autoupdate), the current Microsoft AutoUpdate version must depend on macOS Mojave.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
