### PR TITLE
vscodium: remove `uninstall`

### DIFF
--- a/Casks/v/vscodium.rb
+++ b/Casks/v/vscodium.rb
@@ -16,8 +16,6 @@ cask "vscodium" do
   app "VSCodium.app"
   binary "#{appdir}/VSCodium.app/Contents/Resources/app/bin/codium"
 
-  uninstall quit: "com.vscodium"
-
   zap trash: [
     "~/.vscode-oss",
     "~/Library/Application Support/VSCodium",


### PR DESCRIPTION
Partial revert of #164815 after discussions this change will hard quit the application on upgrade and that behavior is not desired.