### PR TITLE
visual-studio-code: remove `uninstall`

### DIFF
--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -22,8 +22,6 @@ cask "visual-studio-code" do
   app "Visual Studio Code.app"
   binary "#{appdir}/Visual Studio Code.app/Contents/Resources/app/bin/code"
 
-  uninstall quit: "com.microsoft.VSCode"
-
   zap trash: [
     "~/.vscode",
     "~/Library/Application Support/Code",


### PR DESCRIPTION
Partial revert of #164808 after discussions this change will hard quit the application on upgrade and that behavior is not desired.