### PR TITLE
zed: remove `uninstall`

### DIFF
--- a/Casks/z/zed.rb
+++ b/Casks/z/zed.rb
@@ -18,8 +18,6 @@ cask "zed" do
   app "Zed.app"
   binary "#{appdir}/Zed.app/Contents/MacOS/cli", target: "zed"
 
-  uninstall quit: "dev.zed.Zed"
-
   zap trash: [
     "~/.config/Zed",
     "~/Library/Application Support/Zed",


### PR DESCRIPTION
Partial revert of #164784 after discussions this change will hard quit the application on upgrade and that behavior is not desired.