### PR TITLE
playdate-simulator: update `uninstall_preflight`

### DIFF
--- a/Casks/p/playdate-simulator.rb
+++ b/Casks/p/playdate-simulator.rb
@@ -19,7 +19,7 @@ cask "playdate-simulator" do
 
   uninstall_preflight do
     Pathname("/usr/local/bin").glob("arm-*").each do |exec|
-      exec.unlink if exec.exist? && exec.readlink.to_s.include?("playdate")
+      Utils.gain_permissions_remove(exec) if exec.exist? && exec.readlink.to_s.include?("playdate")
     end
   end
 


### PR DESCRIPTION
This should close #164483.

Playdate Simulator writes files into `/usr/local/bin` which is permissioned 755 and owned by `root:wheel`.  This prevents the uninstall of files as part of the `uninstall_preflight` directive unless sudo is used to execute the unlink command.

This PR replaces the unlink with the `Utils.gain_permissions_remove` call which should prompt the user for sudo credentials and allow the removal of files.