### PR TITLE
tastytrade 2.8.0

### DIFF
--- a/Casks/t/tastytrade.rb
+++ b/Casks/t/tastytrade.rb
@@ -1,14 +1,11 @@
 cask "tastytrade" do
-  version "2.8.0"
-  
-  if Hardware::CPU.intel?
-    sha256 "98ace9292f65022780328fb3a61c98c6542e62046390770d16b8942a9b9e6be8"
-    url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}.dmg"
-  else
-    sha256 "62532bc7b23a439e501c0eff1c3bab216adcbc5c64c05539d06fcdf5d1705088"
-    url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}-aarch64.dmg"
-  end
+  arch arm: "-aarch64"
 
+  version "2.8.0"
+  sha256 arm:   "62532bc7b23a439e501c0eff1c3bab216adcbc5c64c05539d06fcdf5d1705088",
+         intel: "98ace9292f65022780328fb3a61c98c6542e62046390770d16b8942a9b9e6be8"
+  
+  url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}#{arch}.dmg"
   name "tastytrade"
   desc "Desktop trading platform"
   homepage "https://tastytrade.com/technology/"

--- a/Casks/t/tastytrade.rb
+++ b/Casks/t/tastytrade.rb
@@ -1,11 +1,14 @@
 cask "tastytrade" do
-  arch arm: "-aarch64"
+  version "2.8.0"
+  
+  if Hardware::CPU.intel?
+    sha256 "98ace9292f65022780328fb3a61c98c6542e62046390770d16b8942a9b9e6be8"
+    url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}.dmg"
+  else
+    sha256 "62532bc7b23a439e501c0eff1c3bab216adcbc5c64c05539d06fcdf5d1705088"
+    url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}-aarch64.dmg"
+  end
 
-  version "2.5.4"
-  sha256 arm:   "51f21ecd02cd7b0acf13d80f712e87a2a163d79a8b1721cebc78559deb1615fe",
-         intel: "da585b646afba35104957cbfb433c4b27cc9f1ee6fd69f3a045397c3a27d5c7f"
-
-  url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}#{arch}.dmg"
   name "tastytrade"
   desc "Desktop trading platform"
   homepage "https://tastytrade.com/technology/"

--- a/Casks/t/tastytrade.rb
+++ b/Casks/t/tastytrade.rb
@@ -11,7 +11,19 @@ cask "tastytrade" do
   homepage "https://tastytrade.com/technology/"
 
   livecheck do
-    skip "No version information available"
+    url "https://tastytrade.com/page-data/technology/page-data.json"
+    strategy :json do |json|
+      static_hashes = json["staticQueryHashes"]
+
+      version = static_hashes.map do |static_hash|
+        content = Homebrew::Livecheck::Strategy.page_content("https://tastytrade.com/page-data/sq/d/#{static_hash}.json")
+        next if content.blank? || content[:content].blank?
+
+        hash_json = JSON.parse(content[:content])
+        version = hash_json.dig("data", "contentstackGlobalSettings", "tastyworksSoftware", "desktopVersion")
+        break version if version.present?
+      end
+    end
   end
 
   auto_updates true

--- a/Casks/t/tastytrade.rb
+++ b/Casks/t/tastytrade.rb
@@ -4,7 +4,7 @@ cask "tastytrade" do
   version "2.8.0"
   sha256 arm:   "62532bc7b23a439e501c0eff1c3bab216adcbc5c64c05539d06fcdf5d1705088",
          intel: "98ace9292f65022780328fb3a61c98c6542e62046390770d16b8942a9b9e6be8"
-  
+
   url "https://download.tastytrade.com/desktop-#{version.major}.x.x/#{version}/tastytrade-#{version}#{arch}.dmg"
   name "tastytrade"
   desc "Desktop trading platform"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [*] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [*] `brew style --fix <cask>` reports no offenses.

brew audit --cask --online <cask> failed with the error mentioned in [https://github.com/Homebrew/homebrew-cask/pull/164225](issue 164225), but I was able to install with `brew install --cask ./tastytrade.rb` and I believe it is working fine.

This happened in Homebrew 4.2.4-69-g36024e2
