### PR TITLE
marathon-infinity: Update version, app name, depends_on

### DIFF
--- a/Casks/m/marathon-infinity.rb
+++ b/Casks/m/marathon-infinity.rb
@@ -1,6 +1,6 @@
 cask "marathon-infinity" do
-  version "20231125"
-  sha256 "19efb62b3759b6f572ad83b1d041e6044dfbdbdfd25a2e5dcc6e2cdc48e35038"
+  version "20240119"
+  sha256 "3bc394e1ef12c0d53038caa37d88ed3d20d9878f53811bcb90028eaf9f914790"
 
   url "https://github.com/Aleph-One-Marathon/alephone/releases/download/release-#{version}/MarathonInfinity-#{version}-Mac.dmg",
       verified: "github.com/Aleph-One-Marathon/alephone/"
@@ -13,7 +13,9 @@ cask "marathon-infinity" do
     regex(%r{href=.*?/MarathonInfinity[._-]v?(\d+(?:\.\d+)*)[._-]Mac\.dmg}i)
   end
 
-  app "Marathon Infinity.app"
+  depends_on macos: ">= :high_sierra"
+
+  app "Classic Marathon Infinity.app"
 
   zap trash: [
     "~/Library/Application Support/Marathon Infinity",


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

----

Updated version of #164898 

closes #164898