### PR TITLE
marathon2: Update version, app name, depends_on

### DIFF
--- a/Casks/m/marathon2.rb
+++ b/Casks/m/marathon2.rb
@@ -1,7 +1,7 @@
 cask "marathon2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  version "20231125"
-  sha256 "709ab94e35a8cf83167afe6fcf14a862db945a9193deeae2ec98826f1812da52"
+  version "20240119"
+  sha256 "0b9e1bce0b857e42ca54ac161fa1fb7b0f533a1c00e13d48785489970d9d9fd7"
 
   url "https://github.com/Aleph-One-Marathon/alephone/releases/download/release-#{version}/Marathon2-#{version}-Mac.dmg",
       verified: "github.com/Aleph-One-Marathon/alephone/"
@@ -14,7 +14,9 @@ cask "marathon2" do
     regex(%r{href=.*?/Marathon2[._-]v?(\d+(?:\.\d+)*)[._-]Mac\.dmg}i)
   end
 
-  app "Marathon 2.app"
+  depends_on macos: ">= :high_sierra"
+
+  app "Classic Marathon 2.app"
 
   zap trash: [
     "~/Library/Application Support/Marathon 2",


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

----

Updated version of #164896 

closes #164896