### PR TITLE
Revert "eudic 4.6.0"

### DIFF
--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -1,6 +1,6 @@
 cask "eudic" do
-  version "4.6.0,1144"
-  sha256 "b46f41ddf1a9ff18fc296c56ef7e9c949e5537e0603a2eed5b878c388ac232f2"
+  version "4.5.9,1141"
+  sha256 "b152c1d9998094bafcc3ec4cd042f2d0402dffe1d16ccfa529b2972a41131311"
 
   url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.csv.second}",
       verified:   "static.frdic.com/",


### PR DESCRIPTION
The eudic 4.6.0 has been officially withdrawn, and the latest version available for download is 4.5.9.


This reverts commit efbcef69b18dca32632eb25da50f1fba2eca896f.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) 
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
