### PR TITLE
Fix new RuboCop `Cask/ArrayAlphabetization` offenses

### DIFF
--- a/Casks/f/firefox.rb
+++ b/Casks/f/firefox.rb
@@ -255,8 +255,8 @@ cask "firefox" do
       ],
       rmdir: [
         "~/Library/Application Support/Mozilla", #  May also contain non-Firefox data
-        "~/Library/Caches/Mozilla/updates/Applications",
-        "~/Library/Caches/Mozilla/updates",
         "~/Library/Caches/Mozilla",
+        "~/Library/Caches/Mozilla/updates",
+        "~/Library/Caches/Mozilla/updates/Applications",
       ]
 end

--- a/Casks/f/flycast.rb
+++ b/Casks/f/flycast.rb
@@ -15,8 +15,8 @@ cask "flycast" do
   app "Flycast.app"
 
   zap rmdir: [
-    "~/.reicast",
-    "~/.flycast",
     "/Library/Application Support/Flycast/",
+    "~/.flycast",
+    "~/.reicast",
   ]
 end

--- a/Casks/g/google-earth-pro.rb
+++ b/Casks/g/google-earth-pro.rb
@@ -22,10 +22,10 @@ cask "google-earth-pro" do
 
   zap launchctl: [
         "com.google.keystone.agent",
-        "com.google.keystone.system.agent",
         "com.google.keystone.daemon",
-        "com.google.keystone.xpcservice",
+        "com.google.keystone.system.agent",
         "com.google.keystone.system.xpcservice",
+        "com.google.keystone.xpcservice",
       ],
       pkgutil:   "com.google.pkg.Keystone",
       trash:     [

--- a/Casks/l/league-of-legends.rb
+++ b/Casks/l/league-of-legends.rb
@@ -30,8 +30,8 @@ cask "league-of-legends" do
         "~/Library/Saved Application State/com.riotgames.LeagueofLegends.LeagueClientUx.savedState",
       ],
       rmdir: [
+        "/Users/Shared/Riot Games",
         "~/Documents/League of Legends",
         "~/Library/Application Support/Riot Games",
-        "/Users/Shared/Riot Games",
       ]
 end

--- a/Casks/l/lego-mindstorms-ev3.rb
+++ b/Casks/l/lego-mindstorms-ev3.rb
@@ -29,8 +29,8 @@ cask "lego-mindstorms-ev3" do
   ]
 
   zap pkgutil: [
-    "com.ni.pkg.legodriver",
     "com.microsoft.silverlight.plugin",
+    "com.ni.pkg.legodriver",
     "com.ximian.mono-*",
   ]
 end

--- a/Casks/m/mamp.rb
+++ b/Casks/m/mamp.rb
@@ -28,9 +28,9 @@ cask "mamp" do
             delete:  "/Applications/MAMP"
 
   zap delete: [
+        "/Library/Application Support/appsolute",
         "/Library/LaunchDaemons/de.appsolute.mampprohelper.plist",
         "/Library/PrivilegedHelperTools/de.appsolute.mampprohelper",
-        "/Library/Application Support/appsolute",
       ],
       trash:  [
         "~/Library/Application Support/appsolute",

--- a/Casks/m/microsoft-auto-update.rb
+++ b/Casks/m/microsoft-auto-update.rb
@@ -69,7 +69,7 @@ cask "microsoft-auto-update" do
         "~/Library/Saved Application State/com.microsoft.autoupdate2.savedState",
       ],
       rmdir: [
-        "~/Library/Caches/Microsoft/uls",
         "~/Library/Caches/Microsoft",
+        "~/Library/Caches/Microsoft/uls",
       ]
 end

--- a/Casks/o/outset.rb
+++ b/Casks/o/outset.rb
@@ -26,8 +26,8 @@ cask "outset" do
             delete:    "/usr/local/outset"
 
   zap trash: [
-    "/Library/LaunchAgents/io.macadmins.outset.login.plist",
     "/Library/LaunchAgents/io.macadmins.outset.login-window.plist",
+    "/Library/LaunchAgents/io.macadmins.outset.login.plist",
     "/Library/LaunchAgents/io.macadmins.outset.on-demand.plist",
     "/Library/LaunchDaemons/io.macadmins.outset.boot.plist",
     "/Library/LaunchDaemons/io.macadmins.outset.cleanup.plist",

--- a/Casks/q/quiterss.rb
+++ b/Casks/q/quiterss.rb
@@ -16,8 +16,8 @@ cask "quiterss" do
 
   zap delete: [
     "~/.config/QuiteRss",
-    "~/Library/Caches/QuiteRss",
     "~/Library/Application Support/QuiteRss",
+    "~/Library/Caches/QuiteRss",
     "~/Library/Preferences/org.quiterss.QuiteRSS.plist",
   ]
 end

--- a/Casks/s/steamcmd.rb
+++ b/Casks/s/steamcmd.rb
@@ -37,7 +37,7 @@ cask "steamcmd" do
 
   zap trash: "~/Library/Application Support/Steam/logs/stderr.txt",
       rmdir: [
-        "~/Library/Application Support/Steam/logs",
         "~/Library/Application Support/Steam",
+        "~/Library/Application Support/Steam/logs",
       ]
 end

--- a/Casks/s/surge.rb
+++ b/Casks/s/surge.rb
@@ -27,8 +27,8 @@ cask "surge" do
             delete:    "/Library/PrivilegedHelperTools/com.nssurge.surge-mac.helper"
 
   zap delete: [
-    "~/Library/Application Support/Surge",
     "~/Library/Application Support/com.nssurge.surge-mac",
+    "~/Library/Application Support/Surge",
     "~/Library/Caches/com.nssurge.surge-mac",
     "~/Library/Caches/com.nssurge.surge-mac.plist",
     "~/Library/HTTPStorages/com.nssurge.surge-mac",


### PR DESCRIPTION
- More fixes for https://github.com/Homebrew/brew/pull/16365 now we've made the decision to treat `zap` and `uninstall` the same, and hence we now scan all `zap` stanzas not just trash.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
