### PR TITLE
cernbox: add `zap` and `requires_rosetta`

### DIFF
--- a/Casks/c/cernbox.rb
+++ b/Casks/c/cernbox.rb
@@ -17,4 +17,20 @@ cask "cernbox" do
   uninstall signal:     ["TERM", "ch.cern.cernbox"],
             login_item: "cernbox",
             pkgutil:    "ch.cern.cernbox"
+
+  zap trash: [
+    "~/Library/Application Scripts/ch.cern.cernbox",
+    "~/Library/Application Scripts/ch.cern.cernbox.FinderSyncExt",
+    "~/Library/Containers/ch.cern.cernbox.FinderSyncExt",
+    "~/Library/Group Containers/ch.cern.cernbox",
+    "~/Library/HTTPStorages/ch.cern.cernbox",
+    "~/Library/LaunchAgents/ch.cern.cernbox.plist",
+    "~/Library/Preferences/cernbox",
+    "~/Library/Preferences/ch.cern.cernbox.plist",
+    "~/Library/Saved Application State/ch.cern.cernbox.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Cask requires Rosetta as it is an `x86_64` package. Added a zap as it was missing.

------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.