### PR TITLE
wave 0.6.0 (updated sha256 sum)

### DIFF
--- a/Casks/w/wave.rb
+++ b/Casks/w/wave.rb
@@ -1,6 +1,6 @@
 cask "wave" do
   version "0.6.0"
-  sha256 "7adaeb4aa3ce072c812950db0656018969f609f842105f1a2cbdb486101e2180"
+  sha256 "d976574ec528feef63ae17819dca02ccaa2c3064e89efa593a5e52a37ba8a54c"
 
   url "https://dl.waveterm.dev/builds/waveterm-macos-universal-v#{version}.dmg"
   name "Wave Terminal"


### PR DESCRIPTION
A release candidate build's SHA256 hash got uploaded to the cask file.  This new hash is the correct hash for the final build (just published the final v0.6.0 release on github a couple minutes ago).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
