### PR TITLE
various: use `url :url` instead of `url :stable` for `livecheck`

### DIFF
--- a/Casks/d/deviceinfo.rb
+++ b/Casks/d/deviceinfo.rb
@@ -8,7 +8,7 @@ cask "deviceinfo" do
   homepage "https://github.com/CoreNion/DeviceInfo/"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/f/freecad.rb
+++ b/Casks/f/freecad.rb
@@ -15,7 +15,7 @@ cask "freecad" do
   # (there's also sometimes a notable gap between the release being created
   # and the homepage being updated), so the `GithubLatest` strategy is necessary.
   livecheck do
-    url :stable
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/m/masscode.rb
+++ b/Casks/m/masscode.rb
@@ -12,7 +12,7 @@ cask "masscode" do
   homepage "https://masscode.io/"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Casks/o/outline-manager.rb
+++ b/Casks/o/outline-manager.rb
@@ -9,7 +9,7 @@ cask "outline-manager" do
   homepage "https://www.getoutline.org/"
 
   livecheck do
-    url :stable
+    url :url
     regex(/(?:manager[._-])?v?(\d+(?:\.\d+)+)/i)
     strategy :github_latest
   end

--- a/Casks/r/reader.rb
+++ b/Casks/r/reader.rb
@@ -9,7 +9,7 @@ cask "reader" do
   homepage "https://readwise.io/read/"
 
   livecheck do
-    url :stable
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/s/semeru-jdk-open.rb
+++ b/Casks/s/semeru-jdk-open.rb
@@ -12,7 +12,7 @@ cask "semeru-jdk-open" do
   homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^jdk[._-](\d+(?:[.+]\d+)*)[._-](.+?)$/i)
     strategy :github_latest do |json, regex|
       json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }

--- a/Casks/s/syncplay.rb
+++ b/Casks/s/syncplay.rb
@@ -9,7 +9,7 @@ cask "syncplay" do
   homepage "https://syncplay.pl/"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

For `homebrew-cask` we use the default `url` of `:url` for `livecheck` instead of `:stable`.