### PR TITLE
qfinder-pro: revert to 7.10.0.1204

### DIFF
--- a/Casks/q/qfinder-pro.rb
+++ b/Casks/q/qfinder-pro.rb
@@ -1,6 +1,6 @@
 cask "qfinder-pro" do
-  version "7.10.1.1222"
-  sha256 "76c46e5318cd659769e24302d8ada43e6f8e48376476e7f44149da7719900edd"
+  version "7.10.0.1204"
+  sha256 "d5da4e9118262419ae6d8f48ce3affa03037abebc0d3bdf1df471ca6b465d5d1"
 
   url "https://download.qnap.com/Storage/Utility/QNAPQfinderProMac-#{version}.dmg"
   name "Qnap Qfinder Pro"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


----

![image](https://github.com/Homebrew/homebrew-cask/assets/1580956/ccb08e68-7ecd-44fa-ba90-6301d83f6a3c)


same thing in https://update.qnap.com/SoftwareRelease.xml

```
$ brew livecheck qfinder-pro
qfinder-pro: 7.10.0.1204 ==> 7.10.0.1204
```