### PR TITLE
sound-control 3.1.5

### DIFF
--- a/Casks/s/sound-control.rb
+++ b/Casks/s/sound-control.rb
@@ -1,6 +1,6 @@
 cask "sound-control" do
-  version "3.1.1"
-  sha256 "fe96c2450d78fd6c759f986c40b791d6e09849085773ff17d12f3dd2833a0c6e"
+  version "3.1.5"
+  sha256 "74fa2956341453a5c41f0ab0b1abcf6dc52283072846b55d648c9859ba082c50"
 
   url "https://s3.amazonaws.com/staticz.net/downloads/soundcontrol/SoundControl_#{version}.dmg",
       verified: "s3.amazonaws.com/staticz.net/downloads/soundcontrol/"
@@ -9,12 +9,18 @@ cask "sound-control" do
   homepage "https://staticz.com/soundcontrol/"
 
   livecheck do
-    url "http://staticz.net/updates/soundcontrol.rss"
-    strategy :sparkle
+    url :homepage
+    regex(%r{/download/(\d+)}i)
+    strategy :page_match do |page, _regex|
+      version = page[/Sound Control v?(\d+(?:\.\d+)+) Release Notes/i, 1]
+      next if version.blank?
+
+      version.to_s
+    end
   end
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :big_sur"
 
   app "Sound Control.app"
 


### PR DESCRIPTION
While looking to update `sound-control` to `3.1.5`, I updated several things:

- Updated version to the latest `3.1.5` and sha256 hash accordingly.
- Removed Sparke Livecheck that had been added with the most recent sound-control update (`3.1.1`)
  - The Sparkle [Appcast Feed](http://staticz.net/updates/soundcontrol.rss) does not seem to be currently supported by StaticZ, the maker of SoundControl as it has not been updated since v3.1.1.  As of 2024-01-24 it should include v3.1.5 released 2024-01-22.
  - The Sparkle Appcast Feed seems malformed (note link with 'beta' in path and minimum version of 12, not 11.4 per release notes)
  -  I have created a support ticket with StaticZ (the creator of Sound Control) on 2024-01-24 to ask if their intent is to support Sparkle going forward.  Based on previous unanswered tickets, I do not expect a response, but will update the PR here if I hear anything.
- Reverted to the last livecheck from 2023-10-08 commit, but removed  the build detection
  -  The build was being pulled from the download trial URL of the product page, but this value appears to be a product ID of sorts, not a build number (note values in the path of trial downloads for other StaticZ products).
- Reverted the `depends_on` to `big_sur` to reflect what is in the [releases notes for v3.1.5](https://staticz.com/sound_control_3_1_5_release_notes/).



- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

