### PR TITLE
jazz2-resurrection: Update 2.5.0 file hash

### DIFF
--- a/Casks/j/jazz2-resurrection.rb
+++ b/Casks/j/jazz2-resurrection.rb
@@ -3,7 +3,7 @@ cask "jazz2-resurrection" do
   arch arm: "ARM64", intel: "x64"
 
   version "2.5.0"
-  sha256 "748027e79902082d1cd6c969f25f69099d6004666e021d86edbfeb1af40d853d"
+  sha256 "e724d0650032f9272bfc25c512b342fd2c0ed728a3230e0b5bc59f4e6b9bd6f7"
 
   url "https://github.com/deathkiller/jazz2/releases/download/#{version}/Jazz2_#{version}_MacOS.zip",
       verified: "github.com/deathkiller/jazz2/"


### PR DESCRIPTION
This only updates the file hash.  The application author did something unusual and re-released this version with a couple of hotfixes, but didn't change the version number.  Hence, the hash changed.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
