### PR TITLE
mumu-player 1.2.142 (new cask)

### DIFF
--- a/Casks/m/mumuplayer.rb
+++ b/Casks/m/mumuplayer.rb
@@ -1,0 +1,52 @@
+cask "mumuplayer" do
+  version "1.2.145"
+  sha256 "fe5e5285d077522b5c4ecc3b1804928f10c13ac031baa29cf32f3a45dabfdb5f"
+
+  url "https://a11.gdl.netease.com/MuMuPlayerPro-v#{version}.dmg",
+      verified: "a11.gdl.netease.com/"
+  name "Mumu Player Pro"
+  name "MuMu模拟器Pro"
+  desc "Android emulator"
+  homepage "https://mumu.163.com/mac/"
+
+  livecheck do
+    url "https://mumu.nie.netease.com/api/mac/pro/appcast/alter?architecture=arm64&version=#{version}"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json["items"]&.map do |item|
+        match = item["version"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+  depends_on arch: :arm64
+
+  app "MuMuPlayer.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/9699UND7H5.group.com.netease.mumu.nemux",
+    "~/Library/Application Support/com.netease.mumu.nemux",
+    "~/Library/Caches/com.netease.mumu.nemux",
+    "~/Library/Caches/com.netease.mumu.nemux.emulator",
+    "~/Library/Caches/com.netease.mumu.nemux.installer",
+    "~/Library/Group Containers/9699UND7H5.group.com.netease.mumu.nemux",
+    "~/Library/HTTPStorages/com.netease.mumu.nemux",
+    "~/Library/HTTPStorages/com.netease.mumu.nemux.binarycookies",
+    "~/Library/HTTPStorages/com.netease.mumu.nemux.emulator",
+    "~/Library/HTTPStorages/com.netease.mumu.nemux.installer",
+    "~/Library/Preferences/com.netease.mumu.nemux.emulator.plist",
+    "~/Library/Preferences/com.netease.mumu.nemux.installer.plist",
+    "~/Library/Preferences/com.netease.mumu.nemux.plist",
+    "~/Library/Preferences/group.com.netease.mumu.plist",
+    "~/Library/Saved Application State/com.netease.mumu.nemux.emulator.savedState",
+    "~/Library/Saved Application State/com.netease.mumu.nemux.installer.savedState",
+    "~/Library/Saved Application State/com.netease.mumu.nemux.savedState",
+    "~/Library/WebKit/com.netease.mumu.nemux",
+    "~/Library/WebKit/com.netease.mumu.nemux.emulator",
+  ]
+end

--- a/Casks/m/mumuplayer.rb
+++ b/Casks/m/mumuplayer.rb
@@ -29,24 +29,13 @@ cask "mumuplayer" do
   app "MuMuPlayer.app"
 
   zap trash: [
-    "~/Library/Application Scripts/9699UND7H5.group.com.netease.mumu.nemux",
+    "~/Library/Application Scripts/*.group.com.netease.mumu.nemux",
     "~/Library/Application Support/com.netease.mumu.nemux",
-    "~/Library/Caches/com.netease.mumu.nemux",
-    "~/Library/Caches/com.netease.mumu.nemux.emulator",
-    "~/Library/Caches/com.netease.mumu.nemux.installer",
-    "~/Library/Group Containers/9699UND7H5.group.com.netease.mumu.nemux",
-    "~/Library/HTTPStorages/com.netease.mumu.nemux",
-    "~/Library/HTTPStorages/com.netease.mumu.nemux.binarycookies",
-    "~/Library/HTTPStorages/com.netease.mumu.nemux.emulator",
-    "~/Library/HTTPStorages/com.netease.mumu.nemux.installer",
-    "~/Library/Preferences/com.netease.mumu.nemux.emulator.plist",
-    "~/Library/Preferences/com.netease.mumu.nemux.installer.plist",
-    "~/Library/Preferences/com.netease.mumu.nemux.plist",
-    "~/Library/Preferences/group.com.netease.mumu.plist",
-    "~/Library/Saved Application State/com.netease.mumu.nemux.emulator.savedState",
-    "~/Library/Saved Application State/com.netease.mumu.nemux.installer.savedState",
-    "~/Library/Saved Application State/com.netease.mumu.nemux.savedState",
-    "~/Library/WebKit/com.netease.mumu.nemux",
-    "~/Library/WebKit/com.netease.mumu.nemux.emulator",
+    "~/Library/Caches/com.netease.mumu.nemux*",
+    "~/Library/Group Containers/*.group.com.netease.mumu.nemux",
+    "~/Library/HTTPStorages/com.netease.mumu.nemux*",
+    "~/Library/Preferences/*.netease.mumu*.plist",
+    "~/Library/Saved Application State/com.netease.mumu.nemux*.savedState",
+    "~/Library/WebKit/com.netease.mumu.nemux*",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


Hi there, 

I am having trouble installing `<cask>` using the command `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>`. The error message I receive is "It seems the App source '/opt/homebrew/Caskroom/mumu-player-pro/1.2.142/MuMu模拟器Pro.app' is not there." I'm unsure why this is happening and would appreciate your assistance in resolving this issue.