### PR TITLE
eudic 4.6.0

### DIFF
--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -12,7 +12,16 @@ cask "eudic" do
 
   livecheck do
     url "https://www.eudic.net/update/eudic_mac.xml"
-    strategy :sparkle
+    regex(/href=.*?eudicmac\.dmg\?v=(\d+(?:-\d+)+)/i)
+    strategy :sparkle do |item, regex|
+      download_page = Homebrew::Livecheck::Strategy.page_content("https://www.eudic.net/v4/en/app/download")
+      next if download_page[:content].blank?
+
+      match = download_page[:content].match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[1]}"
+    end
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -1,5 +1,5 @@
 cask "eudic" do
-  version "4.6.0,1144"
+  version "4.6.0,2023-12-29"
   sha256 "b46f41ddf1a9ff18fc296c56ef7e9c949e5537e0603a2eed5b878c388ac232f2"
 
   url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.csv.second}",

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -1,5 +1,5 @@
 cask "eudic" do
-  version "4.6.0,2023-12-29"
+  version "4.6.0,2023-12-30"
   sha256 "b46f41ddf1a9ff18fc296c56ef7e9c949e5537e0603a2eed5b878c388ac232f2"
 
   url "https://static.frdic.com/pkg/eudicmac.dmg?v=#{version.csv.second}",


### PR DESCRIPTION
Correct the version value used in URL string interpolation to download v4.6.0. Previously, URL with v=1144 will download v4.5.9 and cause sha256 mismatch (b152c1d9998094bafcc3ec4cd042f2d0402dffe1d16ccfa529b2972a41131311 instead of b46f41ddf1a9ff18fc296c56ef7e9c949e5537e0603a2eed5b878c388ac232f2).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
