### PR TITLE
eloston-chromium 121.0.6167.85-1.1,1706477461

### DIFF
--- a/Casks/e/eloston-chromium.rb
+++ b/Casks/e/eloston-chromium.rb
@@ -2,12 +2,12 @@ cask "eloston-chromium" do
   arch arm: "arm64", intel: "x86-64"
 
   on_arm do
-    version "120.0.6099.129-1.1,1704473311"
-    sha256 "4b0e003e08dabadc498d8cf07f7cfbaea282ae3eeb30773080ce503c206b2ec1"
+    version "121.0.6167.85-1.1,1706477461"
+    sha256 "15a3ca0adf87c74343322a6f8220f16282b0df80358c42ec7f0e982e1344759a"
   end
   on_intel do
-    version "120.0.6099.129-1.1,1704447342"
-    sha256 "895fc268038dec015f19fc78e496577ffa2cd81de56324ca21de134e88f1cd01"
+    version "121.0.6167.85-1.1,1706477461"
+    sha256 "8504fd995782b36e0f915982ca1e372e4cd7c9707ba915093b3ff4687c395abd"
   end
 
   url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/download/#{version.csv.first}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",

--- a/Casks/e/eloston-chromium.rb
+++ b/Casks/e/eloston-chromium.rb
@@ -10,26 +10,20 @@ cask "eloston-chromium" do
     sha256 "895fc268038dec015f19fc78e496577ffa2cd81de56324ca21de134e88f1cd01"
   end
 
-  url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/download/#{version.csv.first}_#{arch}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",
+  url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/download/#{version.csv.first}__#{version.csv.second}/ungoogled-chromium_#{version.csv.first}_#{arch}-macos.dmg",
       verified: "github.com/ungoogled-software/ungoogled-chromium-macos/"
   name "Ungoogled Chromium"
   desc "Google Chromium, sans integration with Google"
   homepage "https://ungoogled-software.github.io/ungoogled-chromium-binaries/"
 
-  # Releases are separated by architecture, so we have to check multiple recent
-  # releases instead of only the "latest" release.
   livecheck do
     url :url
     regex(/^v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?$/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
 
-        match = release["tag_name"]&.match(regex)
-        next if match.blank?
-
-        (match.length >= 2) ? "#{match[1]},#{match[2]}" : match[1]
-      end
+      (match.length >= 2) ? "#{match[1]},#{match[2]}" : match[1]
     end
   end
 


### PR DESCRIPTION
This PR updates cask `eloston-chromium` to version `121.0.6167.85-1.1,1706477461` and update the livecheck to use the same GitHub release for both arm and intel (since [this release](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/121.0.6167.85-1.1__1706477461)).

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
