### PR TITLE
developer/bin: disable `Style/TopLevelMethodDefinition` rubocop

### DIFF
--- a/developer/bin/casks-without-zap
+++ b/developer/bin/casks-without-zap
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Style/TopLevelMethodDefinition
+
 require "find"
 require "json"
 require "open-uri"
@@ -114,3 +116,5 @@ end.freeze
 Open3.capture2("/usr/bin/pbcopy", stdin_data: "#{CASK_LISTS.join("\n")}\n")
 puts("Copied lists to clipboard. Replace the information in the issue.")
 system("open", ONLINE_ISSUE)
+
+# rubocop:enable Style/TopLevelMethodDefinition

--- a/developer/bin/find-appcast
+++ b/developer/bin/find-appcast
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Style/TopLevelMethodDefinition
+
 require "open3"
 require "pathname"
 require "yaml"
@@ -89,3 +91,5 @@ App = Pathname(ARGV[0]).freeze
 
 find_sparkle(App)
 find_electron_builder(App)
+
+# rubocop:enable Style/TopLevelMethodDefinition

--- a/developer/bin/generate_cask_token
+++ b/developer/bin/generate_cask_token
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Style/TopLevelMethodDefinition
+
 #
 # generate_cask_token
 #
@@ -433,3 +435,5 @@ if ARGV.length != 1
 end
 
 report
+
+# rubocop:enable Style/TopLevelMethodDefinition

--- a/developer/bin/list_login_items_for_app
+++ b/developer/bin/list_login_items_for_app
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Style/TopLevelMethodDefinition
+
 #
 # list_login_items_for_app
 #
@@ -64,3 +66,4 @@ end
 
 process_args
 list_login_items_for_app $app_path # rubocop:disable Style/GlobalVars
+# rubocop:enable Style/TopLevelMethodDefinition

--- a/developer/bin/list_running_app_ids
+++ b/developer/bin/list_running_app_ids
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# rubocop:disable Style/TopLevelMethodDefinition
+# rubocop:disable Style/GlobalVars, Style/TopLevelMethodDefinition
 
 #
 # list_running_app_ids
@@ -19,7 +19,6 @@ require "io/console"
 ### globals
 ###
 
-# rubocop:disable Style/GlobalVars
 $opt_test = nil
 $COLUMNS = IO.console.winsize.last
 
@@ -123,5 +122,4 @@ if $opt_test
 else
   report_apps
 end
-# rubocop:enable Style/GlobalVars
-# rubocop:enable Style/TopLevelMethodDefinition
+# rubocop:enable Style/GlobalVars, Style/TopLevelMethodDefinition

--- a/developer/bin/list_running_app_ids
+++ b/developer/bin/list_running_app_ids
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# rubocop:disable Style/TopLevelMethodDefinition
+
 #
 # list_running_app_ids
 #
@@ -122,3 +124,4 @@ else
   report_apps
 end
 # rubocop:enable Style/GlobalVars
+# rubocop:enable Style/TopLevelMethodDefinition


### PR DESCRIPTION
A new Rubocop was enabled in this PR, https://github.com/Homebrew/brew/pull/16538
Which is causing some errors in internal scripts, disabling the rubocop on the individual files to unblock CI.