### PR TITLE
nrfutil 1.0.0-60fe18a (new cask)

### DIFF
--- a/Casks/n/nrfutil.rb
+++ b/Casks/n/nrfutil.rb
@@ -1,0 +1,17 @@
+cask "nrfutil" do
+  version "1.0.0-60fe18a"
+  sha256 "229af1183c16cef8e18554ef3a922cb56f16eb7ee8dce76d16a0ace94e7fc6d1"
+
+  url "https://developer.nordicsemi.com/.pc-tools/nrfutil/universal-osx/nrfutil-launcher-universal-apple-darwin-#{version}"
+  name "nrfutil"
+  desc "Unified CLI utility for Nordic Semiconductor products"
+  homepage "https://www.nordicsemi.com/Products/Development-tools/nrf-util"
+
+  livecheck do
+    url "https://developer.nordicsemi.com/.pc-tools/nrfutil/universal-osx/"
+    regex(/nrfutil-launcher-universal-apple-darwin[._-]v?(\d+(?:\.\d+)+(?:[._-]\h+)?)/i)
+  end
+
+  binary "nrfutil-launcher-universal-apple-darwin-#{version}", target: "nrfutil"
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Apologies, as this is my first submission to homebrew-casks, so a bit new to this - however, this was an itch, so I thought I'd give it a shot in case it helped others. (And yes, https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools/download, for which there is already a cask, is different to nrfutil - I know, it's super confusing, how Nordic names these things...).

For `brew audit`, I seemed to have some issues around the URL being "unversioned" (at least from the perspective of the automated tests):

```
victorhooi@Victors-MBP homebrew-cask % brew audit --new --cask nrfutil
==> Downloading and extracting artifacts
==> Downloading https://developer.nordicsemi.com/.pc-tools/nrfutil/universal-osx/nrfutil-launcher-universal-apple-darwin-1.
#################################################################################################################### 100.0%
==> Downloading https://developer.nordicsemi.com/.pc-tools/nrfutil/universal-osx/nrfutil-launcher-universal-apple-darwin-1.
Already downloaded: /Users/victorhooi/Library/Caches/Homebrew/downloads/a1c3d337fe8b24e70e0f2aa2325114af8a58a5a13ce4dfdf8b72712f57c4a56c--nrfutil-launcher-universal-apple-darwin-1.0.0-60fe18a
audit for nrfutil: failed
 - Use `sha256 :no_check` when URL is unversioned.
nrfutil
  * Use `sha256 :no_check` when URL is unversioned.
Error: 1 problem in 1 cask detected.
```

I've included a SHA256 sum in the cask, as that's safer - however, Nordic are a bit funny in terms of listing versions. I'm not sure of the best way to satisfy the above audit rule?

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
