### PR TITLE
Explicitly require system_command in cmds

### DIFF
--- a/cmd/lib/changed_files.rb
+++ b/cmd/lib/changed_files.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
+require "system_command"
+
 module ChangedFiles
+  # TODO: replace with public API like Utils.safe_popen_read that's less likely to be volatile to changes
+  # see https://github.com/Homebrew/brew/pull/16540#issuecomment-1913737000
+  include SystemCommand::Mixin
+
   def changed_files
     commit_range_start = system_command!("git", args: ["rev-parse", "origin"], chdir: path).stdout.chomp
     commit_range_end = system_command!("git", args: ["rev-parse", "HEAD"], chdir: path).stdout.chomp

--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -1,12 +1,16 @@
-# typed: false
 # frozen_string_literal: true
 
 require "forwardable"
+require "system_command"
 
 APPLE_LAUNCHJOBS_REGEX =
   /\A(?:application\.)?com\.apple\.(installer|Preview|Safari|systemevents|systempreferences|Terminal)(?:\.|$)/
 
 module Check
+  # TODO: replace with public API like Utils.safe_popen_read that's less likely to be volatile to changes
+  # see https://github.com/Homebrew/brew/pull/16540#issuecomment-1913737000
+  extend SystemCommand::Mixin
+
   CHECKS = {
     installed_apps:       lambda {
       ["/Applications", File.expand_path("~/Applications")]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.


This explicitly requires and mixes in SystemCommand, as discussed in https://github.com/Homebrew/brew/pull/16540