### PR TITLE
Add conflicts_with to zed

### DIFF
--- a/Casks/z/zed.rb
+++ b/Casks/z/zed.rb
@@ -13,6 +13,7 @@ cask "zed" do
   end
 
   auto_updates true
+  conflicts_with cask: "zed-preview"
   depends_on macos: ">= :catalina"
 
   app "Zed.app"


### PR DESCRIPTION
Adds `conflicts_with` to the `zed` cask as the preview cask PR has been approved and is about to be merged - https://github.com/Homebrew/homebrew-cask-versions/pull/19124

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
