### PR TITLE
sideserver 1.0.6 (new cask)

### DIFF
--- a/Casks/s/sideserver.rb
+++ b/Casks/s/sideserver.rb
@@ -1,0 +1,30 @@
+cask "sideserver" do
+  version "1.0.6"
+  sha256 :no_check
+
+  url "https://github.com/SideStore/SideServer-macOS/releases/download/v1.0.6/SideServer.dmg",
+      verified: "github.com/SideStore/SideServer-macOS/"
+  name "SideServer"
+  desc "Alternative iOS app store for seamless sideloading"
+  homepage "https://sidestore.io/"
+
+  livecheck do
+    url :stable
+    strategy :git
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "SideServer.app"
+
+  uninstall launchctl: "io.SideStore.SideServer-LaunchAtLoginHelper",
+            quit:      "io.SideStore.SideServer",
+            delete:    "/Applications/SideServer.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/io.SideStore.SideServer-LaunchAtLoginHelper",
+    "~/Library/HTTPStorages/io.SideStore.SideServer",
+    "~/Library/Preferences/io.SideStore.SideServer.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
  - With the exception of the following, with reasoning below:
    - Upstream defined :mojave as the minimum OS version and the cask defined :catalina
      - The [SideStore website](https://sidestore.io/) states MacOS 10.15 (Catalina) as the minimum version
    - GitHub fork (not canonical repository)
      - SideStore is a fork of AltStore (there is already a cask for it called altserver), however with significant improvements. Therefore it is valuable to have a separate cask for it.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
  - Exceptions listed above.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
