### PR TITLE
onedrive 24.010.0114.0003

### DIFF
--- a/Casks/o/onedrive.rb
+++ b/Casks/o/onedrive.rb
@@ -1,6 +1,6 @@
 cask "onedrive" do
-  version "23.246.1127.0002"
-  sha256 "965e16125bfd72f5be68a4d1d67a1aa4777695510c7564a1881d7c09b99946ae"
+  version "24.010.0114.0003"
+  sha256 "0668f4b4223620537c2187f3763743d259a94af2b0b14f3ac4545dceeb9df1d1"
 
   url "https://oneclient.sfx.ms/Mac/Installers/#{version}/universal/OneDrive.pkg",
       verified: "oneclient.sfx.ms/Mac/Installers/"

--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -1,3 +1,2 @@
 {
-    "onedrive": "https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage"
 }


### PR DESCRIPTION
Fixes the following:
```
|-> brew bump --open-pr homebrew/cask/onedrive
==> onedrive
Current cask version:     23.246.1127.0002
Latest livecheck version: 24.010.0114.0003
Latest Repology version:  2.4.25
Open pull requests:       none
Closed pull requests:     none
==> Downloading https://oneclient.sfx.ms/Mac/Installers/24.010.0114.0003/universal/OneDrive.pkg
################################################################################################################ 100.0%
==> replace /version\s+["']23\.246\.1127\.0002["']/m with "version \"24.010.0114.0003\""
==> replace "965e16125bfd72f5be68a4d1d67a1aa4777695510c7564a1881d7c09b99946ae" with "0668f4b4223620537c2187f3763743d259
==> Downloading https://oneclient.sfx.ms/Mac/Installers/24.010.0114.0003/universal/OneDrive.pkg
Already downloaded: /Users/miccal/Library/Caches/Homebrew/downloads/ed3f0aee354fc91289de6bad49b698bb478cce32098bcd2cd4e58bf687768264--OneDrive.pkg
audit for onedrive: failed
 - https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage is in the secure connection audit skiplist but does not need to be skipped
onedrive
  * https://www.microsoft.com/en-us/microsoft-365/onedrive/online-cloud-storage is in the secure connection audit skiplist but does not need to be skipped
Error: 1 problem in 1 cask detected.
Error: `brew audit` failed!
```