### PR TITLE
dehelper: update livecheck

### DIFF
--- a/Casks/d/dehelper.rb
+++ b/Casks/d/dehelper.rb
@@ -8,7 +8,7 @@ cask "dehelper" do
   name "Dehelper"
   name "德语助手"
   desc "Chinese-German dictionary"
-  homepage "https://www.eudic.net/v4/de/app/download"
+  homepage "https://www.eudic.net/v#{version.major}/de/app/dehelper"
 
   livecheck do
     url "https://www.eudic.net/update/dehelper_mac.xml"

--- a/Casks/d/dehelper.rb
+++ b/Casks/d/dehelper.rb
@@ -1,18 +1,27 @@
 cask "dehelper" do
-  version "4.6.1"
-  sha256 :no_check
+  version "4.6.1,2024-01-06"
+  sha256 "e20a93c9f00fae04038a9efe157563e084ccbcfa69b97265c8cbfdf241c612d7"
 
-  url "https://static.frdic.com/pkg/dhmac.dmg",
+  url "https://static.frdic.com/pkg/dhmac.dmg?v=#{version.csv.second}",
       verified:   "static.frdic.com/",
       user_agent: :fake
   name "Dehelper"
   name "德语助手"
   desc "Chinese-German dictionary"
-  homepage "https://www.eudic.net/v#{version.major}/de/app/dehelper"
+  homepage "https://www.eudic.net/v4/de/app/download"
 
   livecheck do
     url "https://www.eudic.net/update/dehelper_mac.xml"
-    strategy :sparkle, &:short_version
+    regex(/href=.*?dhmac\.dmg\?v=(\d+(?:-\d+)+)/i)
+    strategy :sparkle do |item, regex|
+      download_page = Homebrew::Livecheck::Strategy.page_content("https://www.eudic.net/v4/de/app/download")
+      next if download_page[:content].blank?
+
+      match = download_page[:content].match(regex)
+      next if match.blank?
+
+      "#{item.short_version},#{match[1]}"
+    end
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


The download link for this App has problems from time to time, although new versions are officially released, they often seem to forget to update the software behind the download link, resulting in the download still being the old version.

This problem also occurred a few days ago with `Eudic`, which is a sibling of `Dehelper` and is run by the same company. `Eudic` cask handled the download link in a different way, and tested it very well, so this modification is basically a copy-paste of `Eudic`'s changes, with the appropriate link replaced with `Dehelper`'s.
