### PR TITLE
acronis-true-image: deprecate

### DIFF
--- a/Casks/a/acronis-true-image.rb
+++ b/Casks/a/acronis-true-image.rb
@@ -7,10 +7,7 @@ cask "acronis-true-image" do
   desc "Full image backup and cloning software"
   homepage "https://www.acronis.com/personal/computer-backup/"
 
-  livecheck do
-    url "https://www.acronis.com/en-us/support/updates/index.html"
-    regex(/Acronis\s*True\s*Image\s*(\d+(?:\.\d+)*)/i)
-  end
+  deprecate! date: "2024-02-07", because: :discontinued
 
   pkg "Install Acronis True Image.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

----

The application has been deprecated upstream in favour of a new software "Acronis Cyber Protect Home Office" which can be added separately if desired.
https://www.acronis.com/en-us/homecomputing/thanks/home-office/