### PR TITLE
Add ELECOM Mouse Assistant v5.2.13.000

### DIFF
--- a/Casks/e/elecom-mouse-assistant.rb
+++ b/Casks/e/elecom-mouse-assistant.rb
@@ -1,0 +1,29 @@
+cask "elecom-mouse-assistant" do
+  version "5.2.13.000"
+  sha256 "9896a8efa0cb6de3f8e0ecf1d39f21e14f9c2f7a0798dbf36649bcd9d4944e2e"
+
+  url "https://dl.elecom.co.jp/support/download/peripheral/mouse/assistant/mac/ELECOM_Mouse_Installer_#{version}.zip"
+  name "ELECOM Mouse Assistant"
+  desc "Software to more effectively use an ELECOM mouse"
+  homepage "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
+
+  livecheck do
+    url "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
+    regex(/ELECOM_Mouse_Installer_(\d+(?:\.\d+)+)\.zip/i)
+  end
+
+  depends_on macos: ">= :el_capitan"
+
+  pkg "ELECOM_Mouse_Installer_#{version}.pkg"
+
+  uninstall launchctl: "jp.com.ELECOM.autorun",
+            pkgutil:   [
+              "jp.co.elecom.ELECOM-Mouse-Util",
+              "jp.co.elecom.mouse.ELECOM-Uninstall",
+              "jp.co.elecom.mousePane",
+            ]
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/e/elecom-mouse-assistant.rb
+++ b/Casks/e/elecom-mouse-assistant.rb
@@ -23,6 +23,8 @@ cask "elecom-mouse-assistant" do
               "jp.co.elecom.mousePane",
             ]
 
+  # No zap stanza required
+
   caveats do
     reboot
   end

--- a/Casks/e/elecom-mouse-util.rb
+++ b/Casks/e/elecom-mouse-util.rb
@@ -1,4 +1,4 @@
-cask "elecom-mouse-assistant" do
+cask "elecom-mouse-util" do
   version "5.2.13.000"
   sha256 "9896a8efa0cb6de3f8e0ecf1d39f21e14f9c2f7a0798dbf36649bcd9d4944e2e"
 
@@ -9,7 +9,7 @@ cask "elecom-mouse-assistant" do
 
   livecheck do
     url "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
-    regex(/ELECOM_Mouse_Installer_(\d+(?:\.\d+)+)\.zip/i)
+    regex(/ELECOM[._-]Mouse[._-]Installer[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
Add new cask ELECOM Mouse Assistant @ v.5.2.13.000. It configures mouse options for ELECOM mice. It was previously part of homebrew-cask-drivers, but that project is deprecated and this cask was never migrated. The reason for not migrating seemed to be it was missing a `zap` stanza, which is unecessary if there's an uninstall stanza. I recreated this cask formula following the cookbook. I also confirmed the uninstall stanza is configured correctly for this latest version of the package, which happens to be the same as before.

The cask formula from homebrew-cask-drivers which was referenced in part can be viewed here: https://github.com/Homebrew/homebrew-cask-drivers/blob/c6ba38948541587b2b3634fd0acb1c9bd6257e1a/Casks/elecom-mouse-assistant.rb

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
