### PR TITLE
itk-snap: update version format, livecheck

### DIFF
--- a/Casks/i/itk-snap.rb
+++ b/Casks/i/itk-snap.rb
@@ -1,15 +1,9 @@
 cask "itk-snap" do
   arch arm: "arm64", intel: "x86_64"
-  livecheck_arch = on_arch_conditional arm: "M1", intel: "Intel"
 
-  on_arm do
-    version "4.0.2,13696"
-    sha256 "aba01235a44b9080fae2c5cf0b35485f96b335f1a50442ee4fb941d4c4846501"
-  end
-  on_intel do
-    version "4.0.2,13697"
-    sha256 "333071f6703e6d3a8554fcc33f2a632cf3106a0bdc230893807a4c288e9e13da"
-  end
+  version "4.0.2"
+  sha256 arm:   "aba01235a44b9080fae2c5cf0b35485f96b335f1a50442ee4fb941d4c4846501",
+         intel: "333071f6703e6d3a8554fcc33f2a632cf3106a0bdc230893807a4c288e9e13da"
 
   url "https://downloads.sourceforge.net/itk-snap/itksnap-#{version.csv.first}-Darwin-#{arch}.dmg",
       verified: "downloads.sourceforge.net/itk-snap/"
@@ -18,14 +12,12 @@ cask "itk-snap" do
   homepage "http://www.itksnap.org/pmwiki/pmwiki.php"
 
   livecheck do
-    url "http://www.itksnap.org/pmwiki/pmwiki.php?n=Main.Downloads"
-    regex(%r{
-      >\s*ITK-SNAP\s+v?(\d+(?:\.\d+)+)\s*<.*?
-      /download/snap/register\.php\?[^"' >]*?link=(\d+)[^>]*?>
-      \s*MacOS\s+Binary\s+\(#{livecheck_arch}\s+processor
-    }imx)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    url "https://sourceforge.net/projects/itk-snap/rss?path=/itk-snap"
+    regex(%r{url=.*?/itksnap[._-]v?(\d+(?:\.\d+)+)(?:-(\d+(?:\.\d+)*))?[._-]Darwin[._-]#{arch}\.dmg}i)
+    strategy :sourceforge do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

Per the discussion in https://github.com/Homebrew/homebrew-cask/pull/166301, the second part of the `itk-snap` `version` (the `link` number on the first-party download page) can increase even when the version hasn't changed. This can lead to unnecessary version bump PRs like the previously-linked one.

The cask uses a file from SourceForge and the first-party download pages contain a message that states, "If the link above does not work, you can find all ITK-SNAP binary downloads in the [SourceForge files area](https://sourceforge.net/projects/itk-snap/files/itk-snap/)". This suggests that checking the SourceForge project for new versions is fine and there may not be any benefit to checking the first-party download page.

We would normally check SourceForge for new versions in this scenario anyway, so this PR updates the `version` format (to remove the unused second part) and `livecheck` block accordingly.

Closes #166301.