### PR TITLE
Remove auto_updates for apparency

### DIFF
--- a/Casks/a/apparency.rb
+++ b/Casks/a/apparency.rb
@@ -48,7 +48,6 @@ cask "apparency" do
   desc "Inspect application bundles"
   homepage "https://www.mothersruin.com/software/Apparency/"
 
-  auto_updates true
   depends_on macos: ">= :mojave"
 
   app "Apparency.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

`brew audit --strict --online apparency` does throw an error.

> Upstream defined :monterey as the minimum OS version and the cask defined :mojave

It is caused by the app's current version only supporting Monterey but the Homebrew cask supporting older OSs by downloading older versions of the app. So in my opinion the cask works correctly and it is just a limitation of `brew audit`.