### PR TITLE
Update amazon-workspaces.rb with caveats that it requires Rosetta

### DIFF
--- a/Casks/a/amazon-workspaces.rb
+++ b/Casks/a/amazon-workspaces.rb
@@ -25,4 +25,8 @@ cask "amazon-workspaces" do
     "~/Library/Preferences/com.amazon.workspaces.plist",
     "~/Library/Saved Application State/com.amazon.workspaces.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
It does requires Rosetta on an Apple Silicon machine to run.

![CleanShot 2024-02-13 at 13 57 48](https://github.com/Homebrew/homebrew-cask/assets/395123/0f88e740-ea0d-4e77-93ac-b6fcb097c17e)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
