### PR TITLE
qtox: deprecate

### DIFF
--- a/Casks/q/qtox.rb
+++ b/Casks/q/qtox.rb
@@ -8,6 +8,8 @@ cask "qtox" do
   desc "Instant messaging and video conferencing app"
   homepage "https://qtox.github.io/"
 
+  deprecate! date: "2024-02-13", because: :discontinued
+
   app "qTox.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The GitHub repository for `qtox` was archived on 2023-02-12. Before the repository was archived, the `README` was updated to explain that the project is unmaintained:

> # This repository and qTox are unmaintained!
>
> Due to a lack of resources, qTox is no longer maintained.
>
> If someone with provable C++ experience and sufficient resources to maintain qTox wants to take over I'm happy to discuss that. Meanwhile **be careful about "official forks" of qTox** unless you read it here, they are probably not official.

This PR deprecates the cask accordingly.