### PR TITLE
navicat-premium: fix download url

### DIFF
--- a/Casks/n/navicat-premium.rb
+++ b/Casks/n/navicat-premium.rb
@@ -2,7 +2,7 @@ cask "navicat-premium" do
   version "16.3.4"
   sha256 :no_check
 
-  url "https://download.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
+  url "https://dn.navicat.com/download/navicat#{version.major_minor.no_dots}_premium_en.dmg"
   name "Navicat Premium"
   desc "Database administration and development tool"
   homepage "https://www.navicat.com/products/navicat-premium"


### PR DESCRIPTION
Fixes outdated download URL for Navicat Premium macOS, which gave a certificate error, updated URL now is https://dn.navicat.com/download/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
