### PR TITLE
timestamp: deprecate

### DIFF
--- a/Casks/t/timestamp.rb
+++ b/Casks/t/timestamp.rb
@@ -8,5 +8,7 @@ cask "timestamp" do
   desc "Improved clock for the menu bar"
   homepage "https://mzdr.github.io/timestamp/"
 
+  deprecate! date: "2024-02-14", because: :discontinued
+
   app "Timestamp.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The GitHub repository for `timestamp` was archived on 2023-07-24. The most recent commit was on 2022-01-02 and the most recent release (1.0.1) is from 2016-09-08. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project is no longer being developed. This PR deprecates the cask accordingly.