### PR TITLE
outline-manager: update livecheck

### DIFF
--- a/Casks/o/outline-manager.rb
+++ b/Casks/o/outline-manager.rb
@@ -8,10 +8,13 @@ cask "outline-manager" do
   desc "Tool to create and manage Outline servers, powered by Shadowsocks"
   homepage "https://www.getoutline.org/"
 
+  # The GitHub repository contains tag/releases for other software and the
+  # "latest" release may not be for Outline Manager, so we have to check
+  # multiple releases to identify the latest version.
   livecheck do
     url :url
-    regex(/(?:manager[._-])?v?(\d+(?:\.\d+)+)/i)
-    strategy :github_latest
+    regex(%r{^(?:manager(?:[._-]macos)?[/._-])?v?(\d+(?:\.\d+)+)$}i)
+    strategy :github_releases
   end
 
   app "Outline Manager.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing `livecheck` block for `outline-manager` uses the `GithubLatest` strategy but this is erroneously returning 1.8.1 (instead of 1.14.0) because the "latest" release is for Outline Server instead of Outline Manager.

This PR updates the `livecheck` block to use the `GithubReleases` strategy, as it's currently necessary to check multiple releases to identify the newest Outline Manager version. I've also tweaked the regex to match tags like `manager_macos/v1.15.1` (in addition to `manager-v1.14.0` or `v1.9.0`), as there are some tags with that format and we want to match those if upstream starts creating releases with that tag format.