### PR TITLE
linear-linear 1.22.3,2402136lleoz6iq

### DIFF
--- a/Casks/l/linear-linear.rb
+++ b/Casks/l/linear-linear.rb
@@ -1,11 +1,11 @@
 cask "linear-linear" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.22.1"
-  sha256 arm:   "41529ad0de3400f5606880a5054d530077e43c4c930795d64eae7a3e6d6fa694",
-         intel: "4f12aa0bd8477b356c6717a5ced28be309a76fd8dae1c06967c27799a2f7a597"
+  version "1.22.3,2402136lleoz6iq"
+  sha256 arm:   "be22bd2e346bbe00b6e1335dba5b71283005da5b0889dba0aecdd4c1f7e31bff",
+         intel: "9074b6ccdf2c7cd29723240ea32db8f95ebab56c1dcd304443ebd0a872abf5fb"
 
-  url "https://download.todesktop.com/200315glz2793v6/Linear%20#{version}-#{arch}-mac.zip",
+  url "https://download.todesktop.com/200315glz2793v6/Linear%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}-mac.zip",
       verified: "download.todesktop.com/200315glz2793v6/"
   name "Linear"
   desc "App to manage software development and track bugs"
@@ -13,10 +13,19 @@ cask "linear-linear" do
 
   livecheck do
     url "https://download.todesktop.com/200315glz2793v6/latest-mac.yml"
-    strategy :electron_builder
+    regex(/Linear\sv?(\d+(?:\.\d+)+)(?:\s-\sBuild\s([a-z\d]+?))?-#{arch}-mac\.zip/)
+    strategy :electron_builder do |yaml, regex|
+      yaml["files"]&.map do |item|
+        match = item["url"]&.match(regex)
+        next if match.blank?
+
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
+    end
   end
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Linear.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `linear-linear` to the latest version 1.22.3 (build 2402136lleoz6iq).

The file name format changed in this release to also include a build identifier, so this updates the `livecheck` block to handle this new format.

[Credit to @p-linnane for bringing this to my attention.]