### PR TITLE
sysdig-inspect: add `livecheck`

### DIFF
--- a/Casks/s/sysdig-inspect.rb
+++ b/Casks/s/sysdig-inspect.rb
@@ -7,6 +7,11 @@ cask "sysdig-inspect" do
   desc "Interface for container troubleshooting and security investigation"
   homepage "https://github.com/draios/sysdig-inspect"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Sysdig Inspect-darwin-x64/Sysdig Inspect.app"
 
   zap trash: [


### PR DESCRIPTION
This adds an explicit `livecheck` to `sysdig-inspect` for checking latest releases.  Recently this application has a tag that is being pulled as the latest version but does not have any releases nor is it marked as latest.

------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.