### PR TITLE
batteryboi: update livecheck

### DIFF
--- a/Casks/b/batteryboi.rb
+++ b/Casks/b/batteryboi.rb
@@ -9,8 +9,14 @@ cask "batteryboi" do
   homepage "https://batteryboi.ovatar.io/"
 
   livecheck do
-    url "https://api.ovatar.io/version?id=com.ovatar.batteryapp"
-    strategy :sparkle
+    url :url
+    regex(/^(?:Version[._-]?)?v?(\d+(?:\.\d+)+)(?:#(\d+))?$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+    end
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The existing check for `batteryboi` is returning a `302 HOST ERROR` response with the following body: `{"message":"database not connected host not connected","error_code":302,"status":"DATABSE_ERROR"}`. The cask uses a GitHub release asset, so this PR updates the `livecheck` block to use the `GithubLatest` strategy instead.

If it ends up being preferable to check the existing URL, we can always revert this if/when the upstream server works again but this will fix the check in the interim time.