### PR TITLE
canva: fix typo calling out upstream typo

### DIFF
--- a/Casks/c/canva.rb
+++ b/Casks/c/canva.rb
@@ -22,7 +22,7 @@ cask "canva" do
     "~/Library/Application Support/Canva",
     "~/Library/Caches/com.canva.CanvaDesktop",
     "~/Library/Caches/com.canva.CanvaDesktop.ShipIt",
-    # `availablility` is mispelled upstream
+    # `availablility` is misspelled upstream
     "~/Library/LaunchAgents/com.canva.availablility-check-agent.plist",
     "~/Library/Logs/Canva",
     "~/Library/Preferences/com.canva.CanvaDesktop.plist",


### PR DESCRIPTION
![xzibit-yo-dawg-3308x2200-v0-3k5va7yeocla1](https://github.com/Homebrew/homebrew-cask/assets/105994585/19f26086-cc0e-41d2-abc8-f73d30f584bd)
