### PR TITLE
insta360-studio 4.9.2

### DIFF
--- a/Casks/i/insta360-studio.rb
+++ b/Casks/i/insta360-studio.rb
@@ -1,15 +1,22 @@
 cask "insta360-studio" do
-  version "4.9.1,2023,068d309c5f7268f99dce70a523b264cb,20231123_173818_1700732479763"
-  sha256 "e24350316374ee69e3ba7572d3c41e0cb0adde6001ce603810bab4e139c0f40b"
+  version "4.9.2,2024,bc4b56f9064b80abb16e09ca203cad94,RC_build38,20240201_132647_signed_1706765253956"
+  sha256 "3c1cc46980be7e7f220a599357337115d20f8e9aff7ad5a370cd0889a4ea9509"
 
-  url "https://file.insta360.com/static/#{version.csv.third}/Insta360Studio#{version.csv.second}_#{version.csv.first}_#{version.csv.fourth}.pkg"
+  url "https://file.insta360.com/static/#{version.csv.third}/Insta360Studio#{version.csv.second}_#{version.csv.first}(#{version.csv.fourth})_#{version.csv.fifth}.pkg"
   name "Insta360 Studio"
   desc "Video and photo editor"
   homepage "https://www.insta360.com/"
 
   livecheck do
     url "https://openapi.insta360.com/app/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
-    regex(%r{/(\h+)/Insta360Studio(\d+)(?:[._-]|%20)(?:\d+(?:\.\d+)+)[._-](\d+(?:[._-]\d+)*)\.pkg}i)
+    regex(%r{
+      /(\h+)/
+      Insta360Studio(\d+)
+      (?:[._-]|%20)(?:\d+(?:\.\d+)+)
+      (?:[._-]?\(([^)]+?)\))?
+      [._-](\d+(?:[._-](?:\d+|signed))*)
+      \.pkg
+    }ix)
     strategy :json do |json, regex|
       # Find the Insta360 Studio app
       app = json.dig("data", "apps")&.find { |item| item["id"] == 38 }
@@ -29,11 +36,11 @@ cask "insta360-studio" do
       match = channel["download_url"]&.match(regex)
       next if version.blank? || match.blank?
 
-      "#{version},#{match[2]},#{match[1]},#{match[3]}"
+      "#{version},#{match[2]},#{match[1]},#{match[3]}#{",#{match[4]}" if match[4].present?}"
     end
   end
 
-  pkg "Insta360Studio#{version.csv.second}_#{version.csv.first}_#{version.csv.fourth}.pkg"
+  pkg "Insta360Studio#{version.csv.second}_#{version.csv.first}(#{version.csv.fourth})_#{version.csv.fifth}.pkg"
 
   uninstall quit:    "com.insta360.studio",
             pkgutil: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

This updates `insta360-studio` to the latest version linked from the [download page](https://www.insta360.com/download/hot-download), 4.9.2.

The existing `livecheck` block returns an `Unable to get versions` error because the file format has changed to include `(RC_build38)` text after the version and `_signed` text in the trailing text (i.e., https://file.insta360.com/static/bc4b56f9064b80abb16e09ca203cad94/Insta360Studio2024_4.9.2(RC_build38)_20240201_132647_signed_1706765253956.pkg for 4.9.2, https://file.insta360.com/static/068d309c5f7268f99dce70a523b264cb/Insta360Studio2023_4.9.1_20231123_173818_1700732479763.pkg for 4.9.1). This PR also updates the `livecheck` block to match both the old and new formats.