### PR TITLE
Revert version of Warp to the correct stable version

### DIFF
--- a/Casks/w/warp.rb
+++ b/Casks/w/warp.rb
@@ -10,7 +10,7 @@ cask "warp" do
   livecheck do
     url "https://releases.warp.dev/channel_versions.json"
     strategy :json do |json|
-      json["stable"]["version"][1..-1]
+      json["stable"]["version"][1..]
     end
   end
 

--- a/Casks/w/warp.rb
+++ b/Casks/w/warp.rb
@@ -7,6 +7,13 @@ cask "warp" do
   desc "Rust-based terminal"
   homepage "https://www.warp.dev/"
 
+  livecheck do
+    url "https://releases.warp.dev/channel_versions.json"
+    strategy :json do |json|
+      json["stable"]["version"][1..-1]
+    end
+  end
+
   auto_updates true
 
   app "Warp.app"

--- a/Casks/w/warp.rb
+++ b/Casks/w/warp.rb
@@ -1,16 +1,11 @@
 cask "warp" do
-  version "0.2024.02.16.17.24.stable_00"
-  sha256 "403bc06f399f5e735d58f2050ea023c4ccc7564207b7bac17eac9450f8c32272"
+  version "0.2024.02.13.08.02.stable_00"
+  sha256 "1c4d6bc23d1956fae36512c364839706d0ae467d30a96f251efec7e55c283073"
 
   url "https://app.warp.dev/download/brew?version=v#{version}"
   name "Warp"
   desc "Rust-based terminal"
   homepage "https://www.warp.dev/"
-
-  livecheck do
-    url "https://storage.googleapis.com/warp-releases/channel_versions.json"
-    regex(/v(\d+(?:\.\d+)+\.stable_\d+)/i)
-  end
 
   auto_updates true
 


### PR DESCRIPTION
This PR reverts the version of Warp in homebrew to the correct version that is meant to be rolled out to Mac users. The version `0.2024.02.16.17.24.stable_00` was meant to only be released to Linux users. 

This inconsistency is breaking some Warp users. I'll spare you the details, but **users who download Warp via homebrew have to log in every time they use Warp because of version inconsistency issues**.

As part of this change, I also removed the livecheck within this file since it is not fully correct and can lead to bumping to the wrong version. I (as a Warp engineer) will own a robust fix in a followup.

The version previously listed in this PR,
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
