### PR TITLE
opencomic 1.1.0 (new cask)

### DIFF
--- a/Casks/o/opencomic.rb
+++ b/Casks/o/opencomic.rb
@@ -1,0 +1,20 @@
+cask "opencomic" do
+  version "1.1.0"
+  sha256 "98d0b314162c398f6f99dd2e0c6cdeb01e6940db830d7ea610a998818ecc2bd4"
+
+  url "https://github.com/ollm/OpenComic/releases/download/v#{version}/OpenComic-#{version}.dmg"
+  name "OpenComic"
+  desc "Comic and Manga reader"
+  homepage "https://github.com/ollm/OpenComic"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "opencomic.app"
+
+  zap trash: "~/Library/Application Support/OpenComic"
+end


### PR DESCRIPTION
This adds https://github.com/ollm/OpenComic, which is a offline comic and manga reader.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
