### PR TITLE
camtasia 2023.3.7

### DIFF
--- a/Casks/c/camtasia.rb
+++ b/Casks/c/camtasia.rb
@@ -1,6 +1,6 @@
 cask "camtasia" do
-  version "2023.2.1"
-  sha256 "06a2bd26632a1c20fb0b29274cef3a23b28bd0d42cfd70968a2ad51baf727306"
+  version "2023.3.7"
+  sha256 "5d4aecc8d0bcaebce8f3f00ed700a1818becebc48292cce1b7dafddd7bfff3db"
 
   url "https://download.techsmith.com/camtasiamac/releases/#{version.major[-2..]}#{version.minor_patch.no_dots}/Camtasia.dmg"
   name "Camtasia"
@@ -9,7 +9,7 @@ cask "camtasia" do
 
   livecheck do
     url "https://support.techsmith.com/api/v2/help_center/en-us/articles/115006624748"
-    regex(/Camtasia\s*\(Mac\)\s*(\d+(?:\.\d+)+)/i)
+    regex(/Camtasia\s*(\d+(?:\.\d+)+)/i)
   end
 
   auto_updates true
@@ -19,7 +19,14 @@ cask "camtasia" do
 
   zap trash: [
     "/Users/Shared/TechSmith/Camtasia",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.techsmith.camtasia#{version.major}.sfl*",
     "~/Library/Application Support/TechSmith/Camtasia*",
+    "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.techsmith.camtasia*",
+    "~/Library/Caches/com.techsmith.camtasia*",
+    "~/Library/HTTPStorages/com.techsmith.camtasia*",
+    "~/Library/HTTPStorages/com.techsmith.camtasia*.binarycookies",
     "~/Library/Preferences/com.techsmith.camtasia*.plist",
+    "~/Library/Saved Application State/com.techsmith.camtasia*.savedState",
+    "~/Library/WebKit/com.techsmith.camtasia*",
   ]
 end


### PR DESCRIPTION
Updates to latest version 2023.3.7

Cask no longer includes the word "Mac" in the article used for `livecheck`, and this is now several versions behind current.  This updates the livecheck accordingly to match the current format.

Updated the `zap` to include additional items.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.