### PR TITLE
authy: deprecate

### DIFF
--- a/Casks/a/authy.rb
+++ b/Casks/a/authy.rb
@@ -12,6 +12,8 @@ cask "authy" do
     strategy :header_match
   end
 
+  deprecate! date: "2024-03-19", because: :discontinued
+
   auto_updates true
 
   app "Authy Desktop.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The Authy Desktop app will [reach end of life (EOL) on 2024-03-19](https://help.twilio.com/articles/19753631228315). This PR adds a future deprecation but leaves the `livecheck` block intact until then. I will create a PR on/after 2024-03-19 to remove the `livecheck` block once the deprecation takes effect.