### PR TITLE
subsurface: update `sha256`

### DIFF
--- a/Casks/s/subsurface.rb
+++ b/Casks/s/subsurface.rb
@@ -2,7 +2,8 @@ cask "subsurface" do
   version "6.0.5094"
   sha256 "4b7f26abeb05c3b538c307fa6dec6724f691b9f1565d09dc38700045adb5c55c"
 
-  url "https://subsurface-divelog.org/downloads/Subsurface-#{version}-CICD-release.dmg"
+  url "https://subsurface-divelog.org/downloads/Subsurface-#{version}-CICD-release.dmg",
+      user_agent: :fake
   name "Subsurface"
   desc "Open source divelog program"
   homepage "https://subsurface-divelog.org/"

--- a/Casks/s/subsurface.rb
+++ b/Casks/s/subsurface.rb
@@ -1,6 +1,6 @@
 cask "subsurface" do
   version "6.0.5094"
-  sha256 "03d39ac7c77aaa5e8bbaf6aeb1b201c78873f463f0bb732b6287fb587c3a5417"
+  sha256 "4b7f26abeb05c3b538c307fa6dec6724f691b9f1565d09dc38700045adb5c55c"
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}-CICD-release.dmg"
   name "Subsurface"


### PR DESCRIPTION
Hash was not updated with last version bump. 

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

No, I get a 'cask unavailable', when I try to tap homebrew/cask I end up going in a circle.

- [ ] `brew style --fix <cask>` reports no offenses.

My own unfamiliarity means this didn't work either. 

Additionally, **if adding a new cask**: 
Not adding new cask.
