### PR TITLE
nzbget: deprecate

### DIFF
--- a/Casks/n/nzbget.rb
+++ b/Casks/n/nzbget.rb
@@ -8,10 +8,7 @@ cask "nzbget" do
   desc "Usenet downloader focusing on efficiency"
   homepage "https://nzbget.net/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-02-19", because: :discontinued
 
   app "NZBGet.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

The [GitHub repository for `nzbget`](https://github.com/nzbget/nzbget/) was archived on 2022-11-18. The most recent release (21.1) was on 2021-06-03 and the most recent commit commit was on 2021-09-30. The `README` wasn't updated to explain the project status before the repository was archived but all of the repositories in the [nzbget organization](https://github.com/nzbget) are now archived and this seems to suggest that `nzbget` isn't being developed/maintained further. This PR deprecates the cask accordingly and removes the `livecheck` block so it will be automatically skipped.