### PR TITLE
polkadot-js: add `livecheck`

### DIFF
--- a/Casks/p/polkadot-js.rb
+++ b/Casks/p/polkadot-js.rb
@@ -8,6 +8,25 @@ cask "polkadot-js" do
   desc "Portal into the Polkadot and Substrate networks"
   homepage "https://polkadot.js.org/"
 
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
+  livecheck do
+    url :url
+    regex(/^Polkadot[._-]JS[._-]Apps[._-]mac[._-](\d+(?:\.\d+)*)\.(?:dmg|pkg|zip)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
   app "Polkadot-JS Apps.app"
 
   zap trash: [


### PR DESCRIPTION
`polkadot-js` has not provided a macOS version in their latest release, and for some time this has been showing up as a false positive for a version update.

This adds a `livecheck` strategy to check the latest releases for a macOS specific file rather than relying solely on the implicit `git` livecheck.

It follows a pattern that is already present in other Casks such as [Electron Fiddle](https://github.com/Homebrew/homebrew-cask/blob/c53ce12b6338c606151efe96feb560215279ec60/Casks/e/electron-fiddle.rb) for obtaining this information

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.