### PR TITLE
endless-sky-high-dpi 0.10.6 (new cask)

### DIFF
--- a/Casks/e/endless-sky-high-dpi.rb
+++ b/Casks/e/endless-sky-high-dpi.rb
@@ -1,0 +1,17 @@
+cask "endless-sky-high-dpi" do
+  version "0.10.6"
+  sha256 "c297e6278697ab62714d67e05b2acfb5283bc5fcab86d45bd606bb02d90c9a75"
+
+  url "https://github.com/endless-sky/endless-sky-high-dpi/archive/refs/tags/v#{version}.tar.gz",
+      verified: "github.com/endless-sky/endless-sky-high-dpi/"
+  name "Endless Sky High-DPI"
+  desc "High-DPI plugin for Endless Sky"
+  homepage "https://endless-sky.github.io/"
+
+  depends_on cask: "endless-sky"
+
+  highdpi_dir = "endless-sky-high-dpi-#{version}"
+  artifact highdpi_dir, target: "~/Library/Application Support/endless-sky/plugins/#{highdpi_dir}"
+
+  zap trash: "~/Library/Application Support/endless-sky/plugins/#{highdpi_dir}"
+end


### PR DESCRIPTION
Adds the High-DPI plugin for Endless Sky, which I assume most users will want. Depends on the `endless-sky` cask rather than being a separate install, and is automatically discovered & enabled for existing installations.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
