### PR TITLE
paletro 1.10.0

### DIFF
--- a/Casks/p/paletro.rb
+++ b/Casks/p/paletro.rb
@@ -1,6 +1,6 @@
 cask "paletro" do
-  version "1.9.0"
-  sha256 "1c103e2d77d39d1ea7304879f9464a143baa42021fcd30da6637abad75ef7cf5"
+  version "1.10.0"
+  sha256 "df1ec9aac253766ce1a59aab5e0a439e4d0cec2e50cd8ddb0f7c32f748c08ffd"
 
   url "https://appmakes.io/paletro/download/Paletro-#{version}.dmg"
   name "Paletro"


### PR DESCRIPTION
The appcast hasn't been updated but the version is available and listed in the [changelog](https://appmakes.io/paletro/changelog). I checked and it doesn't seem like the appcast URL has changed. This is also the version from the unversioned URL (https://appmakes.io/paletro/download/Paletro.dmg) listed on the website.