### PR TITLE
yojimbo: update hash and add zap stanza

### DIFF
--- a/Casks/y/yojimbo.rb
+++ b/Casks/y/yojimbo.rb
@@ -14,4 +14,14 @@ cask "yojimbo" do
   end
 
   app "Yojimbo.app"
+
+  zap trash: [
+    "~/Library/Caches/com.apple.helpd/Generated/Yojimbo Help*#{version}",
+    "~/Library/Caches/com.barebones.yojimbo4",
+    "~/Library/HTTPStorages/com.barebones.yojimbo4",
+    "~/Library/Logs/Yojimbo",
+    "~/Library/Preferences/com.barebones.yojimbo4.plist",
+    "~/Library/Saved Application State/com.barebones.yojimbo4.savedState",
+    "~/Yojimbo",
+  ]
 end

--- a/Casks/y/yojimbo.rb
+++ b/Casks/y/yojimbo.rb
@@ -1,6 +1,6 @@
 cask "yojimbo" do
   version "4.6.3"
-  sha256 "fc9e1ef31ca48aced4d17c433ad24da1bc94be61a2b40e8a8b7e04f92ae9d023"
+  sha256 "1496c28e14c86ef501d9e66caf1620abd2f80acb15ca78eb42a9cc03f1aba50f"
 
   url "https://s3.amazonaws.com/BBSW-download/Yojimbo_#{version}.dmg",
       verified: "s3.amazonaws.com/BBSW-download/"


### PR DESCRIPTION
The binary for Yojimbo appears to have been updated without a version bump.

Also adds a zap stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
