### PR TITLE
cmd/lib/ci_matrix: add `ci-skip-token` label

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -159,6 +159,8 @@ module CiMatrix
                                bitbucket_repository]
       end
 
+      audit_exceptions << %w[token_conflicts token_valid token_bad_words] if labels.include?("ci-skip-token")
+
       audit_args << "--except" << audit_exceptions.join(",") if audit_exceptions.any?
 
       cask_content = path.read


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Needed for https://github.com/Homebrew/homebrew-cask/pull/166807
Would be used for cases where the token fails the audit when a new cask is added, however an exception is being made.

Would have also been useful here - https://github.com/Homebrew/homebrew-cask/pull/166353
