### PR TITLE
dnsmonitor 1.0.1 (new cask)

### DIFF
--- a/Casks/d/dnsmonitor.rb
+++ b/Casks/d/dnsmonitor.rb
@@ -2,11 +2,10 @@ cask "dnsmonitor" do
   version "1.0.1"
   sha256 "ba0a54877cea0e3731271621ee09f4a6877548b5bdcbf785ba38862600bbabaf"
 
-  url "https://github.com/objective-see/DNSMonitor/releases/download/v#{version}/DNSMonitor_#{version}.zip",
-      verified: "github.com/objective-see/DNSMonitor/"
+  url "https://github.com/objective-see/DNSMonitor/releases/download/v#{version}/DNSMonitor_#{version}.zip"
   name "dnsmonitor"
   desc "Monitor DNS activity"
-  homepage ""
+  homepage "https://github.com/objective-see/DNSMonitor/"
 
   livecheck do
     url :url
@@ -16,5 +15,6 @@ cask "dnsmonitor" do
   depends_on macos: ">= :catalina"
 
   app "DNSMonitor.app"
-  binary "#{appdir}/DNSMonitor.app/Contents/MacOS/DNSMonitor", target: "dnsmonitor"
+
+  # No zap stanza required
 end

--- a/Casks/d/dnsmonitor.rb
+++ b/Casks/d/dnsmonitor.rb
@@ -1,0 +1,20 @@
+cask "dnsmonitor" do
+  version "1.0.1"
+  sha256 "ba0a54877cea0e3731271621ee09f4a6877548b5bdcbf785ba38862600bbabaf"
+
+  url "https://github.com/objective-see/DNSMonitor/releases/download/v#{version}/DNSMonitor_#{version}.zip",
+      verified: "github.com/objective-see/DNSMonitor/"
+  name "dnsmonitor"
+  desc "Monitor DNS activity"
+  homepage ""
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "DNSMonitor.app"
+  binary "#{appdir}/DNSMonitor.app/Contents/MacOS/DNSMonitor", target: "dnsmonitor"
+end


### PR DESCRIPTION
A utility for monitoring DNS requests and responses on macOS

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
