### PR TITLE
steam: remove Steam.AppBundle during uninstall

### DIFF
--- a/Casks/s/steam.rb
+++ b/Casks/s/steam.rb
@@ -25,7 +25,8 @@ cask "steam" do
               "com.valvesoftware.steam",
               "com.valvesoftware.steam.helper",
               "com.valvesoftware.steam.helper.EH",
-            ]
+            ],
+            delete:    "~/Library/Application Support/Steam/Steam.AppBundle"
 
   zap trash: [
     "~/Library/Application Support/Steam/",


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

Steam.app (7MB) that is installed by this cask from artifcat is just a wrapper launcher that is responsible for making sure `Steam.AppBundle` (800MB) is always up to date. So let's also remove this actual app during uninstall.
