### PR TITLE
ytmdesktop-youtube-music 2.0.1

### DIFF
--- a/Casks/y/ytmdesktop-youtube-music.rb
+++ b/Casks/y/ytmdesktop-youtube-music.rb
@@ -1,15 +1,39 @@
 cask "ytmdesktop-youtube-music" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.0.0"
-  sha256 arm:   "c7a7734d295eaa3a8a7d42db2c2013618fd3fc06e9600d1c1485e1eec153b0cd",
-         intel: "8be61191307a1609adfac81fec6d440f17a0f81f1b94b618ef37332262a8d8c8"
+  on_arm do
+    version "2.0.0"
+    sha256 "c7a7734d295eaa3a8a7d42db2c2013618fd3fc06e9600d1c1485e1eec153b0cd"
+  end
+  on_intel do
+    version "2.0.1"
+    sha256 "ed17891bd7182b8b1ae3a0adc5239eac8c3fbf5ec207512d0928e234433030b2"
+  end
 
   url "https://github.com/ytmdesktop/ytmdesktop/releases/download/v#{version}/YouTube-Music-Desktop-App-darwin-#{arch}-#{version}.zip",
       verified: "github.com/ytmdesktop/"
   name "YouTube Music Desktop App"
   desc "YouTube music client"
   homepage "https://ytmdesktop.app/"
+
+  # Not every GitHub release provides a file for both architectures, so we check
+  # multiple recent releases instead of only the "latest" release.
+  livecheck do
+    url :url
+    regex(/Desktop[._-]App[._-]darwin[._-](?:#{arch})[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg|zip)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
ARM builds are not being published until some issues are resolved, so it makes sense to separate the versions for ARM and Intel till they start publishing the ARM builds again.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.