### PR TITLE
macupdate: disable

### DIFF
--- a/Casks/m/macupdate.rb
+++ b/Casks/m/macupdate.rb
@@ -7,10 +7,7 @@ cask "macupdate" do
   desc "Software updater"
   homepage "https://www.macupdate.com/desktop"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-02-22", because: :discontinued
 
   app "MacUpdate Desktop.app"
 


### PR DESCRIPTION
The website states that the app is no longer supported by it's developer and the download link is no longer working.

----
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
