### PR TITLE
logi-options-plus: remove uninstall script

### DIFF
--- a/Casks/l/logi-options-plus.rb
+++ b/Casks/l/logi-options-plus.rb
@@ -23,37 +23,34 @@ cask "logi-options-plus" do
     sudo:       true,
   }
 
-  uninstall script: [
-    executable: "logioptionsplus_installer.app/Contents/MacOS/logioptionsplus_installer",
-    args:       ["--quiet", "--uninstall"],
-    sudo:       true,
-  ]
+  uninstall launchctl: [
+              "com.logi.cp-dev-mgr",
+              "com.logi.optionsplus",
+              "com.logi.optionsplus.updater",
+            ],
+            quit:      [
+              "com.logi.cp-dev-mgr",
+              "com.logi.optionsplus",
+              "com.logi.optionsplus.driverhost",
+              "com.logi.optionsplus.updater",
+              "com.logitech.FirmwareUpdateTool",
+            ],
+            delete:    [
+              "/Applications/logioptionsplus.app",
+              "/Applications/Utilities/Logi Options+ Driver Installer.bundle",
+              "/Library/Application Support/Logitech.localized/LogiOptionsPlus",
+            ],
+            rmdir:     "/Library/Application Support/Logitech.localized"
 
-  zap launchctl: [
-        "com.logi.cp-dev-mgr",
-        "com.logi.optionsplus",
-        "com.logi.optionsplus.agent",
-        "com.logi.optionsplus.updater",
-      ],
-      quit:      [
-        "com.logi.cp-dev-mgr",
-        "com.logi.optionsplus",
-        "com.logi.optionsplus.agent",
-        "com.logi.optionsplus.updater",
-      ],
-      delete:    [
-        "/Applications/logioptionsplus.app",
-        "/Library/LaunchAgents/com.logi.optionsplus.plist",
-        "/Library/LaunchDaemons/com.logi.optionsplus.updater.plist",
-      ],
-      trash:     [
-        "/Users/Shared/LogiOptionsPlus",
-        "~/Library/Application Support/LogiOptionsPlus",
-        "~/Library/Application Support/logioptionsplus",
-        "~/Library/Preferences/com.logi.cp-dev-mgr.plist",
-        "~/Library/Preferences/com.logi.optionsplus.plist",
-        "~/Library/Saved Application State/com.logi.optionsplus.savedState",
-      ]
+  zap trash: [
+    "/Users/Shared/logi",
+    "/Users/Shared/LogiOptionsPlus",
+    "~/Library/Application Support/LogiOptionsPlus",
+    "~/Library/Preferences/com.logi.cp-dev-mgr.plist",
+    "~/Library/Preferences/com.logi.optionsplus.driverhost.plist",
+    "~/Library/Preferences/com.logi.optionsplus.plist",
+    "~/Library/Saved Application State/com.logi.optionsplus.savedState",
+  ]
 
   caveats do
     reboot


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The built-in uninstall script removes all user-specific files which forces the user to re-setup the application after running brew upgrade.

Fixes: #167495