### PR TITLE
vitalsource-bookshelf: Add livecheck

### DIFF
--- a/Casks/v/vitalsource-bookshelf.rb
+++ b/Casks/v/vitalsource-bookshelf.rb
@@ -10,7 +10,7 @@ cask "vitalsource-bookshelf" do
 
   livecheck do
     url "https://support.vitalsource.com/hc/en-gb/p/download"
-    regex(/href=["']?[^'" >]*VitalSource[-_.]Bookshelf[-_.](\d+(?:\.\d+)+)\.dmg/i)
+    regex(/href=.*?VitalSource[-_.]Bookshelf[-_.]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :mojave"

--- a/Casks/v/vitalsource-bookshelf.rb
+++ b/Casks/v/vitalsource-bookshelf.rb
@@ -9,7 +9,8 @@ cask "vitalsource-bookshelf" do
   homepage "https://www.vitalsource.com/bookshelf-features"
 
   livecheck do
-    skip "No version information available"
+    url "https://support.vitalsource.com/hc/en-gb/p/download"
+    regex(/href=["']?[^'" >]*VitalSource[-_.]Bookshelf[-_.](\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
The livecheck URL is Cloudflare-protected, and needs `:user_agent => :browser`.
**This mustn’t be merged before Homebrew/brew#16741 is resolved**

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free. **ONLY** if the Cloudflare-protected livecheck URLs problem is fixed, i.e., Homebrew/brew#16741 is resolved.
- [x] `brew style --fix <cask>` reports no offenses.

~Additionally, **if adding a new cask**:~
