### PR TITLE
chirp: update `sha256`

### DIFF
--- a/Casks/c/chirp.rb
+++ b/Casks/c/chirp.rb
@@ -1,6 +1,6 @@
 cask "chirp" do
   version "20240224"
-  sha256 "4abe3a22e901a8c429e662bc8045d6d199ac6591dcd714b7572fa2937fa71ade"
+  sha256 "b82e6d3ff3942799fe196a5331f3283fcdec1bceefa2a8e6262d96a83c35e2f0"
 
   url "https://trac.chirp.danplanet.com/chirp_next/next-#{version}/chirp-next-#{version}.app.zip"
   name "CHIRP"


### PR DESCRIPTION
Possibly a bad update.  BrewTestBot opened a PR for this version in #167523 before the time it shows release on upstream.

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.