### PR TITLE
Remove auto_updates for Suspicious Package

### DIFF
--- a/Casks/s/suspicious-package.rb
+++ b/Casks/s/suspicious-package.rb
@@ -68,8 +68,6 @@ cask "suspicious-package" do
   desc "Application for inspecting installer packages"
   homepage "https://www.mothersruin.com/software/SuspiciousPackage/"
 
-  auto_updates true
-
   app "Suspicious Package.app"
   binary "#{appdir}/Suspicious Package.app/Contents/SharedSupport/spkg"
 


### PR DESCRIPTION
While Suspicious Package has an in-app mechanism to detect if it is out of date, it only sends the user to a download page (compared to a real self-update). So updating via Homebrew would be much easier.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

`brew audit --strict --online suspicious-package` does throw an error.

> Upstream defined :monterey as the minimum OS version and the cask defined no minimum OS version

The error was also thrown before my change. It is caused by the app's current version only supporting Monterey but the Homebrew cask supporting older OSs by downloading older versions of the app. So in my opinion the cask works correctly and it is just a limitation of brew audit.