### PR TITLE
figtree: add livecheck

### DIFF
--- a/Casks/f/figtree.rb
+++ b/Casks/f/figtree.rb
@@ -4,7 +4,13 @@ cask "figtree" do
 
   url "https://github.com/rambaut/figtree/releases/download/v#{version}/FigTree.v#{version}.dmg"
   name "FigTree"
+  desc "Phylogenetic tree viewer"
   homepage "https://github.com/rambaut/figtree/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "FigTree v#{version}.app"
   qlplugin "QuickLook Plugin/FigTreeQuickLookPlugin.qlgenerator"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `figtree` but this is currently returning an unstable version as newest (1.4.5pre). The [related release](https://github.com/rambaut/figtree/releases/tag/v1.4.5pre) is marked as pre-release on GitHub.

This PR addresses the issue by adding a `livecheck` block that uses the `GithubLatest` strategy, which correctly returns 1.4.4 as the newest version. The cask uses a GitHub release asset, so checking releases (instead of Git tags) is the correct approach anyway.

Besides that, this adds a `desc` to resolve the related audit. As usual, feel free to update it with a better description.