### PR TITLE
docker: link docker-compose completions

### DIFF
--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -81,6 +81,15 @@ cask "docker" do
   binary "Docker.app/Contents/Resources/etc/docker.fish-completion",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker.fish"
 
+  on_monterey :or_newer do
+    binary "Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
+           target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
+    binary "Docker.app/Contents/Resources/etc/docker-compose.zsh-completion",
+           target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker-compose"
+    binary "Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
+           target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
+  end
+
   postflight do
     kubectl_target = Pathname("/usr/local/bin/kubectl")
 

--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -38,6 +38,13 @@ cask "docker" do
     end
 
     depends_on macos: ">= :monterey"
+
+    binary "Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
+           target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
+    binary "Docker.app/Contents/Resources/etc/docker-compose.zsh-completion",
+           target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker-compose"
+    binary "Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
+           target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
   end
 
   url "https://desktop.docker.com/mac/main/#{arch}/#{version.csv.second}/Docker.dmg"
@@ -80,15 +87,6 @@ cask "docker" do
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker"
   binary "Docker.app/Contents/Resources/etc/docker.fish-completion",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker.fish"
-
-  on_monterey :or_newer do
-    binary "Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
-           target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
-    binary "Docker.app/Contents/Resources/etc/docker-compose.zsh-completion",
-           target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker-compose"
-    binary "Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
-           target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
-  end
 
   postflight do
     kubectl_target = Pathname("/usr/local/bin/kubectl")


### PR DESCRIPTION
The Docker cask provides docker-compose completion scripts. Link them to their appropriate locations to get shell completions.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
