### PR TITLE
stashpad 1.2.28 (new cask)

### DIFF
--- a/Casks/s/stashpad.rb
+++ b/Casks/s/stashpad.rb
@@ -1,0 +1,26 @@
+cask "stashpad" do
+  arch arm: "-arm64"
+
+  version "1.2.28"
+  sha256 arm:   "38631d69db2316ca513a4f7331fa3e15248720ea252e596a81e91842791ddd8b",
+         intel: "2139046350c14907030700c548b2e6899553baba20fa4cb8c995c717eeb6c068"
+
+  url "https://github.com/stashpad/sp-desktop-release/releases/download/v#{version}/Stashpad-#{version}#{arch}.dmg",
+      verified: "github.com/stashpad/sp-desktop-release/"
+  name "Stashpad"
+  desc "Notes app for collaborative work"
+  homepage "https://www.stashpad.com/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Stashpad.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.stashpad.app.sfl*",
+    "~/Library/Application Support/Stashpad",
+    "~/Library/Caches/Stashpad",
+    "~/Library/Logs/Stashpad",
+    "~/Library/Preferences/com.stashpad.app.plist",
+    "~/Library/Saved Application State/com.stashpad.app.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Adds Stashpad, a collaborative keyboard-driven note-taking application geared towards technical teams.

Note the repository for the application is a release-only repository, so minimum notability has not been reached.