### PR TITLE
beyond-compare: Fix paths

### DIFF
--- a/Casks/b/beyond-compare.rb
+++ b/Casks/b/beyond-compare.rb
@@ -2,13 +2,13 @@ cask "beyond-compare" do
   version "4.4.7.28397"
   sha256 "a9ba4cea125bbfe00fa3e79de39937197ae5d479d94710f5b93da5bda377a0ce"
 
-  url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
+  url "https://www.scootersoftware.com/files/BCompareOSX-#{version}.zip"
   name "Beyond Compare"
   desc "Compare files and folders"
   homepage "https://www.scootersoftware.com/"
 
   livecheck do
-    url "https://www.scootersoftware.com/download.php?zz=v4changelog"
+    url "https://www.scootersoftware.com/download"
     regex(/BCompareOSX[_.-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 


### PR DESCRIPTION
A couple of paths changed, so I've updated the formula to match where the current download is, and where the current download page is for the livecheck to use.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
