### PR TITLE
clibor: update livecheck

### DIFF
--- a/Casks/c/clibor.rb
+++ b/Casks/c/clibor.rb
@@ -15,7 +15,7 @@ cask "clibor" do
 
   livecheck do
     url "https://chigusa-web.com/clibor-for-mac-en/download/"
-    regex(/Clibor\.dmg\s–\sv?(\d+(?:\.\d+)+)/i)
+    regex(/Clibor\.dmg\s*(?:[–—-]|&[a-z]+;)?\s*v?(\d+(?:\.\d+)+)/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `clibor` currently returns an `Unable to get versions` error. The regex aims to match text like "Clibor.dmg - v1.3" but the dash has been replaced by an `&ndash;` HTML entity. This addresses the issue by updating the regex to match either a literal dash (en, em, or hyphen) or an HTML entity.