### PR TITLE
triage: limit open pull requests created by a user

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,6 +10,24 @@ permissions:
   contents: read
 
 jobs:
+  limit-pull-requests:
+    if: >
+      always() && github.repository_owner == 'Homebrew' &&
+      (github.event_name == 'pull_request_target' &&
+       github.event.action == 'opened')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Homebrew/actions/limit-pull-requests@master
+        with:
+          except-users: |
+            BrewTestBot
+          comment-limit: 15
+          comment: |
+            Hi, thanks for your contribution to Homebrew! You already have >=15 open pull requests, so please get them ready to be merged or close them before you open more. If CI fails on any of them, please fix it or ask for help doing so.
+            If you are performing simple version bumps, @BrewTestBot automatically bumps [a list of formulae](https://github.com/${{ github.repository }}/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at issues and pull requests labelled https://github.com/${{ github.repository }}/labels/help%20wanted and see if you can help to fix any of them. Thanks!
+          close-limit: 30
+          close: true
+
   triage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
See also: Homebrew/homebrew-core#164475.

This is directly copied from `Homebrew/homebrew-core`'s [`triage.yml`](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/triage.yml), but I'm not sure if the limits should be the same as in core, so please advise.
