### PR TITLE
playdate-simulator & playdate-mirror: update `url`

### DIFF
--- a/Casks/p/playdate-mirror.rb
+++ b/Casks/p/playdate-mirror.rb
@@ -2,8 +2,8 @@ cask "playdate-mirror" do
   version "1.1.0"
   sha256 "0536af36fa47727f8b7c08062c0ade8ff1c4fd84111577aedd4448a6dbf52b05"
 
-  url "https://download-keycdn.panic.com/mirror/Mirror-#{version}.zip",
-      verified: "download-keycdn.panic.com/mirror/"
+  url "https://download-cdn.panic.com/mirror/Mirror-#{version}.zip",
+      verified: "download-cdn.panic.com/mirror/"
   name "Playdate Mirror"
   desc "Application that streams gameplay audio and video from your Playdate"
   homepage "https://play.date/mirror"

--- a/Casks/p/playdate-simulator.rb
+++ b/Casks/p/playdate-simulator.rb
@@ -2,8 +2,8 @@ cask "playdate-simulator" do
   version "2.3.1"
   sha256 "c621d78c93de17d743239b0864670ce5d58623a616839079a1e33623e780bdc6"
 
-  url "https://download-keycdn.panic.com/playdate_sdk/PlaydateSDK-#{version}.zip",
-      verified: "download-keycdn.panic.com/playdate_sdk/"
+  url "https://download-cdn.panic.com/playdate_sdk/PlaydateSDK-#{version}.zip",
+      verified: "download-cdn.panic.com/playdate_sdk/"
   name "Playdate SDK"
   desc "Playdate Lua and C APIs, docs and Simulator for local development"
   homepage "https://play.date/dev/"


### PR DESCRIPTION
Old URL gives expired certificate, hence prevent update I received new URL from Panic support

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I have no clue, plz test for Yourself. I believe simple correction of URL shouldn't break stuff, but i am homebrew newbie, so feel free to reject and do it properly :)

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
