### PR TITLE
ci: remove julia cleanup step on macos-13+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Clean up CI machine
         run: |
-          if ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
+          if [ "${{ matrix.runner }}" == 'macos-12' ] && ! brew uninstall --cask julia && ! rm -r /Applications/Julia-*.app; then
             echo '::warning::Removing Julia is no longer necessary.'
           fi
 


### PR DESCRIPTION
We are getting the following error now:
```
Error: Cask 'julia' is not installed.
rm: /Applications/Julia-*.app: No such file or directory
Warning: Removing Julia is no longer necessary.
```