### PR TITLE
netbeans: update livecheck

### DIFF
--- a/Casks/n/netbeans.rb
+++ b/Casks/n/netbeans.rb
@@ -10,7 +10,7 @@ cask "netbeans" do
   # Major releases sometimes only use the major version (13) instead of
   # major/minor (13.0).
   livecheck do
-    url "https://netbeans.apache.org/download/index.html"
+    url "https://netbeans.apache.org/front/main/download/"
     regex(/>\s*Apache\s*NetBeans\s*v?(\d+(?:\.\d+)*)\s*</im)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block URL for `netbeans` redirects from https://netbeans.apache.org/download/index.html to https://netbeans.apache.org/front/main/download/index.html. This updates the URL to avoid the redirection and omit the trailing `index.html` (as the page loads fine without it).