### PR TITLE
prismlauncher 8.2

### DIFF
--- a/Casks/p/prismlauncher.rb
+++ b/Casks/p/prismlauncher.rb
@@ -1,16 +1,16 @@
 cask "prismlauncher" do
-  version "8.0"
+  version "8.2"
 
   on_mojave :or_older do
-    sha256 "0a300849f35b8d409f405975eb09bfc566f4715414b8afefdfdb069158436c13"
+    sha256 "5f5d539b7204e3dab4a89beaf3bb659e669941cd033a70ec5f9f4108b7a38824"
 
-    url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-Legacy-#{version}.tar.gz",
+    url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-Legacy-#{version}.zip",
         verified: "github.com/PrismLauncher/PrismLauncher/"
   end
   on_catalina :or_newer do
-    sha256 "3828eb687ea2b9443b2ab1fef3134e67fe614d702d4fa8ce44dca7cf6b1c8b31"
+    sha256 "12813f8c34e55440edd6d690d174fdf7aa64826e8169c429bc8eb889bb510b42"
 
-    url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-#{version}.tar.gz",
+    url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-#{version}.zip",
         verified: "github.com/PrismLauncher/PrismLauncher/"
   end
 


### PR DESCRIPTION
The macOS artifacts have changed from [`.tar.gz`](https://github.com/PrismLauncher/PrismLauncher/releases/tag/8.0) to [`.zip`](https://github.com/PrismLauncher/PrismLauncher/releases/tag/8.2), so I have updated the URLs accordingly. In addition, the hash for the legacy macOS artifact was calculated manually as `brew bump-cask-pr` does not calculate it (is there something I'm missing there?).

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.