### PR TITLE
workflows/triage: add token to `limit-pull-requests`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -8,6 +8,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   limit-pull-requests:


### PR DESCRIPTION
The workflow does not currently have the permissions to add a comment.
This PR adds the same token used to add comments in the `/rebase` action.

Seen in: https://github.com/Homebrew/homebrew-cask/actions/runs/8164050831/job/22318535289?pr=168322#step:2:61