### PR TITLE
criptext: switch to use http due to cert issue

### DIFF
--- a/Casks/c/criptext.rb
+++ b/Casks/c/criptext.rb
@@ -2,10 +2,10 @@ cask "criptext" do
   version "0.31.0,2.0.82"
   sha256 :no_check
 
-  url "https://cdn.criptext.com/Criptext-Email-Desktop/mac/Criptext-latest.dmg"
+  url "http://cdn.criptext.com/Criptext-Email-Desktop/mac/Criptext-latest.dmg"
   name "Criptext"
   desc "Email service that's built around privacy"
-  homepage "https://criptext.com/"
+  homepage "http://criptext.com/"
 
   livecheck do
     url :url


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

notified upstream about their site cert issue

![image](https://github.com/Homebrew/homebrew-cask/assets/1580956/50331cd2-8a65-4684-9815-7da99bda147b)
