### PR TITLE
samsung-magician 8.0.0.900 (new cask)

### DIFF
--- a/Casks/s/samsung-magician.rb
+++ b/Casks/s/samsung-magician.rb
@@ -1,0 +1,40 @@
+cask "samsung-magician" do
+  version "8.0.0.900"
+  sha256 "674c48a9b9bd6a3ca8deaf0dd2dc757701b16b40229b1f1fe275ec9cc67c3590"
+
+  url "https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_installer_Official_#{version}.pkg"
+  name "Samsung Magician"
+  desc "Samsung consumer memory products software utility"
+  homepage "https://semiconductor.samsung.com/consumer-storage/support/tools/"
+
+  livecheck do
+    url :homepage
+    regex(/Samsung[._-]Magician[._-]installer[._-]Official[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| (match[0]).to_s }
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "samsung-portable-ssd-t7"
+  depends_on macos: ">= :high_sierra"
+
+  pkg "Samsung_Magician_installer_Official_#{version}.pkg"
+
+  uninstall launchctl: ["com.samsung.magicianapp", "com.samsung.magiciansvc"],
+            quit:      ["/Applications/SamsungMagician.app", "com.samsung.magician.*", "com.samsung.magiciansvc"],
+            kext:      ["com.samsung.magicianpssd.driver", "com.samsung.magicianpssd.driverX"],
+            pkgutil:   ["com.samsung.magician.*", "com.samsung.magicianpssduniversal.*"],
+            delete:    ["/Applications/SamsungMagician.app", "/Library/Extensions/SamsungMagicianPSSDDriver.kext",
+                        "/Library/Extensions/SamsungMagicianPSSDDriverX.kext"]
+
+  zap trash: [
+    "~/Library/LaunchAgents/com.samsung.magicianapp.plist",
+    "~/Library/LaunchAgents/com.samsung.magiciansvc.plist",
+  ]
+
+  caveats do
+    reboot
+    kext
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Used samsung-portable-ssd-t7 Cask as model because of similarities. 