### PR TITLE
mitmproxy 10.2.3

### DIFF
--- a/Casks/m/mitmproxy.rb
+++ b/Casks/m/mitmproxy.rb
@@ -1,6 +1,6 @@
 cask "mitmproxy" do
   arch arm: "arm64", intel: "x86_64"
-  
+
   version "10.2.3"
   sha256 arm:   "546d0ea87fe4076a54b8769568bf42716063cad20722a1f8fa7f5ce31f31789b",
          intel: "3ab8fbbb8d1e3fe25d33e994edb7e589fd58b34821f3a5a09d4cf7f40b82405f"

--- a/Casks/m/mitmproxy.rb
+++ b/Casks/m/mitmproxy.rb
@@ -1,8 +1,11 @@
 cask "mitmproxy" do
-  version "10.2.2"
-  sha256 "4b1b7447de18d3a2b52b3123917b8df749371a2030b779d368462b58b20777d1"
+  arch arm: "arm64", intel: "x86_64"
+  
+  version "10.2.3"
+  sha256 arm:   "546d0ea87fe4076a54b8769568bf42716063cad20722a1f8fa7f5ce31f31789b",
+         intel: "3ab8fbbb8d1e3fe25d33e994edb7e589fd58b34821f3a5a09d4cf7f40b82405f"
 
-  url "https://downloads.mitmproxy.org/#{version}/mitmproxy-#{version}-macos-x86_64.tar.gz"
+  url "https://downloads.mitmproxy.org/#{version}/mitmproxy-#{version}-macos-#{arch}.tar.gz"
   name "mitmproxy"
   desc "Intercept, modify, replay, save HTTP/S traffic"
   homepage "https://mitmproxy.org/"
@@ -23,8 +26,4 @@ cask "mitmproxy" do
   binary "mitmproxy.app/Contents/MacOS/mitmweb"
 
   zap trash: "~/.mitmproxy"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Starting with mitmproxy 10.2.3 we're now shipping arm64 binaries, so the Cask gets some updates! 😃 

-------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
