### PR TITLE
Fix GHDL 4.1.0 Install

### DIFF
--- a/Casks/g/ghdl.rb
+++ b/Casks/g/ghdl.rb
@@ -1,9 +1,9 @@
 cask "ghdl" do
   arch arm: "llvm", intel: "mcode"
 
-  version "4.0.0"
-  sha256 arm:   "55140a3fd5762f051d751db1aeb8f42d53100beb8ac6468e4b1b517b7c50ab02",
-         intel: "d35d2e9bba77759721268ef032642ac9120d223e05675a3005bc933495089f21"
+  version "4.1.0"
+  sha256 arm:   "f46cfeee85c4d76720f5c0d6ad283754bc1dae57ce9f1a3942086bc270094ddc",
+         intel: "8521aafad389eb769de25db13ecaaaade8444431447eb5e801dc2fcf981cdeed"
 
   url "https://github.com/ghdl/ghdl/releases/download/v#{version}/ghdl-macos-11-#{arch}.tgz"
   name "ghdl"
@@ -16,6 +16,18 @@ cask "ghdl" do
   end
 
   binary "bin/ghdl"
+  binary "bin/ghwdump"
+
+  postflight do
+    puts "Creating library symlinks in #{HOMEBREW_PREFIX}/include and #{HOMEBREW_PREFIX}/lib"
+    File.symlink("#{staged_path}/include/ghdl", "#{HOMEBREW_PREFIX}/include/ghdl")
+    File.symlink("#{staged_path}/lib/ghdl", "#{HOMEBREW_PREFIX}/lib/ghdl")
+  end
+
+  uninstall_postflight do
+    puts "Removing library symlinks in #{HOMEBREW_PREFIX}/include and #{HOMEBREW_PREFIX}/lib"
+    File.unlink("#{HOMEBREW_PREFIX}/include/ghdl", "#{HOMEBREW_PREFIX}/lib/ghdl")
+  end
 
   # No zap stanza required
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ghdl` is error-free.
- [x] `brew style --fix ghdl` reports no offenses.

---

Hi, After #168502 was merged trying to use GHDL results in the following error:

```
ghdl:warning: ieee library directory '/usr/local/lib/ghdl/ieee/v08/' not found
ghdl:error: cannot find "std" library
```

The new version expects the following binary and directories to be linked, whereas the previous version does not. Reverting to 79b16a28985e0c66ac3b22ba9e3192aae5412e51 confirms that GHDL 3.0.0 works fine without the binary and directories being linked.

```
/usr/local/Caskroom/ghdl/4.0.0/bin/ghwdump
/usr/local/Caskroom/ghdl/4.0.0/include/ghdl
/usr/local/Caskroom/ghdl/4.0.0/lib/ghdl
```

I added a link and unlink step in the postflight, which seems to have resolved the issue.

I am not entirely sure why ghdl is a cask, as it seems it could easily be a formula, If that is the preferred fix, I can create a formula as well. 