### PR TITLE
sonarr: update version, url and livecheck

### DIFF
--- a/Casks/s/sonarr.rb
+++ b/Casks/s/sonarr.rb
@@ -1,18 +1,19 @@
 cask "sonarr" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.0.0.748"
-  sha256 arm:   "4f6cfa4a0451079df914d20ed695fbf7f5ba2a5014788f8833ee16ce57d1b54a",
-         intel: "c5e1c185edcd0bd3cc410ceb390c6f3ea68601124f2cdc45b2fc6b3e1f0b266f"
+  version "4.0.2.1183"
+  sha256 arm:   "9808f3fac1c15739161d755d7cc5c4bc9a41f2cd6d47519db30aa5a9f3100d82",
+         intel: "0e83249a17616f809fd651a1f1ae1106a568625a4cc52f3bf82f82ef13d0553a"
 
-  url "https://download.sonarr.tv/v#{version.major}/main/#{version}/Sonarr.main.#{version}.osx-#{arch}-app.zip"
+  url "https://github.com/Sonarr/Sonarr/releases/download/v#{version}/Sonarr.main.#{version}.osx-#{arch}-app.zip",
+      verified: "github.com/Sonarr/Sonarr/"
   name "Sonarr"
   desc "PVR for Usenet and BitTorrent users"
   homepage "https://sonarr.tv/"
 
   livecheck do
-    url "https://download.sonarr.tv/v4/main/"
-    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
Sonarr download url format changed with latest update and so this should bring it up to date, updating livecheck accordingly. Also adds postflight for the manual signing steps required to run sonarr after installation.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
