### PR TITLE
mqttfx 5.7.0

### DIFF
--- a/Casks/m/mqttfx.rb
+++ b/Casks/m/mqttfx.rb
@@ -1,14 +1,15 @@
 cask "mqttfx" do
-  arch arm: "aarch64", intel: "amd64"
+  arch arm: "applesilicon", intel: "intel"
 
-  version "5.6.0"
-  sha256 arm:   "295bf52305a6ddd36b569e746dd8df5a43db27d819d13c4f5f05c8cf1aa49eea",
-         intel: "5740a166b77116f6f7a929f33eea8e111b44c93d6dc343884d87ea100a46ba26"
+  version "5.7.0"
+  sha256 arm:   "7c2e1bdca94fe3f94611c24d6378ac9d258030f15426c05047dcf33a9b711de3",
+         intel: "c992a54d7d873c055566651df07d9cb89bdcc347fa2db5ee1ed98bdd4abb9157"
 
-  url "https://download.softblade.de/mqttfx-#{version}-macos-#{arch}.dmg"
+  url "https://download.softblade.net/mqttfx-#{version}-macos-#{arch}.dmg",
+      verified: "download.softblade.net/"
   name "MQTT.fx"
   desc "IoT route testing tool"
-  homepage "https://softblade.de/en/welcome/"
+  homepage "https://softblade.de/"
 
   livecheck do
     url "https://softblade.de/download/"


### PR DESCRIPTION
Updated the arch tags and URLs

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.