### PR TITLE
Update depth-fetch=0 setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Check out Pull Request
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Generate CI matrix
@@ -87,7 +87,7 @@ jobs:
       - name: Check out Pull Request
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Clean up CI machine


### PR DESCRIPTION
Update depth-fetch=0 setting. The default option is 1, which gives an optimized build for performance. Depth 0 means pulling everything, which the code doesn't need to. I updated it to 2; it seems CI needs at least the last 2 commits to work. It doesn't change anything functionally, but I believe it's important to minimize network traffic, considering the intense number of test runs in this repo.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.