### PR TITLE
love2d: checksum mismatch

### DIFF
--- a/Casks/l/love.rb
+++ b/Casks/l/love.rb
@@ -1,6 +1,6 @@
 cask "love" do
   version "11.5"
-  sha256 "c8ff4b57274b87772a91af4efa532721848b935eef1e0b72ac0464fb177631a5"
+  sha256 "6795bb3a1656af6a2fdfe741e150787b481886d3a280327a261a3fdded586913"
 
   url "https://github.com/love2d/love/releases/download/#{version}/love-#{version}-macos.zip",
       verified: "github.com/love2d/love/"


### PR DESCRIPTION
Updating the SHA256 signature for the cask `love` because `brew install --cask love` is failing due to the mismatching signature:
```
❯ brew install --cask love
==> Downloading https://github.com/love2d/love/releases/download/11.5/love-11.5-macos.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/188601229/d28d074e-6ee3-4c4f-8b63-6d3b86d7d80d?
########################################################################################################################################## 100.0%
Error: SHA256 mismatch
Expected: c8ff4b57274b87772a91af4efa532721848b935eef1e0b72ac0464fb177631a5
  Actual: 6795bb3a1656af6a2fdfe741e150787b481886d3a280327a261a3fdded586913
    File: /Users/***/Library/Caches/Homebrew/downloads/e440f1c51f25d22aece3e2b045902586d2cd91a6afb9f9651a94df26a9045ef7--love-11.5-macos.zip
To retry an incomplete download, remove the file above.
```

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

### Verification Output

```
❯ brew audit --cask --online love
==> Downloading https://github.com/love2d/love/releases/download/11.5/love-11.5-macos.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/188601229/d28d074e-6ee3-4c4f-8b63-6d3b86d7d80d?
########################################################################################################################################## 100.0%
```

```
❯ brew style --fix love

1 file inspected, no offenses detected
```

```
❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source love
==> Downloading https://github.com/love2d/love/releases/download/11.5/love-11.5-macos.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/188601229/d28d074e-6ee3-4c4f-8b63-6d3b86d7d80d?
########################################################################################################################################## 100.0%
==> Installing Cask love
==> Moving App 'love.app' to '/Applications/love.app'
==> Linking Binary 'love' to '/opt/homebrew/bin/love'
🍺  love was successfully installed!
```

```
❯ love --version
LOVE 11.5 (Mysterious Mysteries)
```
