### PR TITLE
lantern: update zap

### DIFF
--- a/Casks/l/lantern.rb
+++ b/Casks/l/lantern.rb
@@ -24,6 +24,8 @@ cask "lantern" do
             quit:      "com.getlantern.lantern"
 
   zap trash: [
+    "~/Library/Application Support/byteexec/lantern",
+    "~/Library/Application Support/byteexec/sysproxy-cmd",
     "~/Library/Application Support/Lantern",
     "~/Library/Logs/Lantern",
   ]


### PR DESCRIPTION
Cleanup files `lantern` and `sysproxy-cmd`, which Lantern creates in the directory `~/Library/Application Support/byteexec/` to "take control of the system proxy" upon receiving administrator approval & password on first run. These are _possibly_ the only files Lantern creates within an unexpected directory, but that is unverified.

These files are both binary-encoded plists, and I couldn't ascertain their general purpose. Both make reference to Lantern, and should be removed during its zap.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
