### PR TITLE
mendeley: deprecate

### DIFF
--- a/Casks/m/mendeley.rb
+++ b/Casks/m/mendeley.rb
@@ -7,10 +7,7 @@ cask "mendeley" do
   desc "Research management tool"
   homepage "https://www.mendeley.com/reference-management/mendeley-desktop"
 
-  livecheck do
-    url "https://www.mendeley.com/autoupdates/installer/Mac-x64/stable-incoming"
-    strategy :header_match
-  end
+  deprecate! date: "2024-03-12", because: :discontinued
 
   app "Mendeley Desktop.app"
 
@@ -21,4 +18,12 @@ cask "mendeley" do
     "~/Library/Preferences/com.mendeley.Mendeley Desktop.plist",
     "~/Library/Saved Application State/com.mendeley.desktop.savedState",
   ]
+
+  caveats do
+    <<~EOS
+      mendeley-reference-manager is the successor to this software:
+
+        brew install --cask mendeley-reference-manager
+    EOS
+  end
 end


### PR DESCRIPTION
Software has been deprecated upstream as of 2022-09-01.  The successor is `mendeley-reference-manager` which has been in the Cask repo for some time.  The software is still downloadable, so marking only as `deprecate` instead of `disable`

Announcement [here](https://blog.mendeley.com/2022/02/22/introducing-mendeley-reference-manager-designed-for-todays-researcher-workflow/)

> As part of the continued evolution of Mendeley, from 1 September 2022, users will no longer be able to download and install Mendeley Desktop software. Existing users of Mendeley Desktop will continue to be able to sign into, use and sync their Mendeley Desktop.
Longer-term, once we are confident that the new Mendeley Reference Manager sufficiently meets your reference management needs, we will begin the process of stopping all sign-ins to Mendeley Desktop. We will be sure to give you plenty of notice before this happens.