### PR TITLE
bettermouse: checksum mismatch 

### DIFF
--- a/Casks/b/bettermouse.rb
+++ b/Casks/b/bettermouse.rb
@@ -1,6 +1,6 @@
 cask "bettermouse" do
   version "1.5.4620"
-  sha256 "b7a6a8fa03adf4fb291b056636dfd2d93ba956576ff85948ceda4fe6bda5a9be"
+  sha256 "518945748a569711c37664df584b4234abc686e8d12ab9196a585402b5410d36"
 
   url "https://better-mouse.com/wp-content/uploads/BetterMouse.#{version}.zip"
   name "BetterMouse"


### PR DESCRIPTION
This updates the checksum for `bettermouse`:

```
==> Downloading https://better-mouse.com/wp-content/uploads/BetterMouse.1.5.4620.zip
Already downloaded: /Users/<username>/Library/Caches/Homebrew/downloads/b742c86c1c63ea2fa113c9a26df8b7f0875020140e472d3195f8e0af543bb03c--BetterMouse.1.5.4620.zip
Error: SHA256 mismatch
Expected: b7a6a8fa03adf4fb291b056636dfd2d93ba956576ff85948ceda4fe6bda5a9be
  Actual: 518945748a569711c37664df584b4234abc686e8d12ab9196a585402b5410d36
    File: /Users/<username>/Library/Caches/Homebrew/downloads/b742c86c1c63ea2fa113c9a26df8b7f0875020140e472d3195f8e0af543bb03c--BetterMouse.1.5.4620.zip
To retry an incomplete download, remove the file above.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online bettermouse` is error-free.
  - Had to run `brew audit --cask bettermouse` because my changes are not in the main repo yet
- [x] `brew style --fix bettermouse` reports no offenses.

Additionally, **if adding a new cask**:

Not adding a new cask

---
