### PR TITLE
calibre 7.7.0

### DIFF
--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -40,8 +40,8 @@ cask "calibre" do
     end
   end
   on_ventura :or_newer do
-    version "7.6.0"
-    sha256 "a7d6eaca6e3b8ff62b355da1cc897762d52ac148a1e1ce36a6eeb59006b240cb"
+    version "7.7.0"
+    sha256 "daa3d316e0e72e6dfb9a898d4a8f03f5d5c7c3eede1d5d37519668ce145809bf"
 
     livecheck do
       url "https://calibre-ebook.com/dist/osx"


### PR DESCRIPTION
calibre is on the autobump list, but the [last run](https://github.com/Homebrew/homebrew-cask/actions/runs/8283340102/job/22666271405#step:5:345) failed to bump.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
