### PR TITLE
tuxguitar 1.6.1

### DIFF
--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -1,6 +1,6 @@
 cask "tuxguitar" do
   version "1.6.1"
-  sha256 "d83fa6298f3c32bbe52636402f71ddc73a6d7d7ef809459d278529c0177de6a6"
+  sha256 "44380e39dbbc711aec2e5d5b0b9ba0e128024980919e27f0d934a29e26ea3b8c"
 
   url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz",
       verified: "github.com/helge17/tuxguitar/"

--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -5,7 +5,7 @@ cask "tuxguitar" do
   url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz"
   name "TuxGuitar"
   desc "Multitrack guitar tablature editor and player"
-  homepage "https://www.tuxguitar.app"
+  homepage "https://www.tuxguitar.app/"
 
   app "tuxguitar-#{version}-macosx-cocoa-64.app"
 end

--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -1,11 +1,11 @@
 cask "tuxguitar" do
-  version "1.5.6"
-  sha256 "fa53ebd78fa507bbb2a654e17efb6913957cf5eb8cceeb6da3423c82ff6e18ff"
+  version "1.6.1"
+  sha256 "d83fa6298f3c32bbe52636402f71ddc73a6d7d7ef809459d278529c0177de6a6"
 
-  url "https://downloads.sourceforge.net/tuxguitar/tuxguitar-#{version}-macosx-cocoa-64.app.tar.gz"
+  url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz"
   name "TuxGuitar"
   desc "Multitrack guitar tablature editor and player"
-  homepage "https://sourceforge.net/projects/tuxguitar/"
+  homepage "https://www.tuxguitar.app"
 
   app "tuxguitar-#{version}-macosx-cocoa-64.app"
 end

--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -2,10 +2,13 @@ cask "tuxguitar" do
   version "1.6.1"
   sha256 "d83fa6298f3c32bbe52636402f71ddc73a6d7d7ef809459d278529c0177de6a6"
 
-  url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz"
+  url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz",
+      verified: "github.com/helge17/tuxguitar/"
   name "TuxGuitar"
   desc "Multitrack guitar tablature editor and player"
   homepage "https://www.tuxguitar.app/"
 
   app "tuxguitar-#{version}-macosx-cocoa-64.app"
+
+  zap trash: "~/Library/Application Support/tuxguitar"
 end


### PR DESCRIPTION
A new team take the lead to maintain tuxguitar which was orphan since a long time.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

Sorry I was unable to do it with brew command. I edit the file by hand in GitHub web interface ... :-( and submit a patched version. sha256 has been computed using shasum -a 256 ...
If you can share a pointer to perform the test I would love.
I try  brew bump-cask-pr  which fails with Error: This cask's tap is not a Git repository!

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
