### PR TITLE
syncthing: update livecheck to GithubLatest

### DIFF
--- a/Casks/s/syncthing.rb
+++ b/Casks/s/syncthing.rb
@@ -8,6 +8,12 @@ cask "syncthing" do
   desc "Real time file synchronisation software"
   homepage "https://syncthing.net/"
 
+  livecheck do
+    url :url
+    regex(/v?(\d+(?:[\.\-]\d+)+)/i)
+    strategy :github_latest
+  end
+
   auto_updates true
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

Our current livecheck strategy picks up pre-releases.

```
==> syncthing
Current cask version:     1.27.4-1
Latest livecheck version: 1.27.4-2
Latest Repology version:  1.27.4
Open pull requests:       none
Closed pull requests:     none
==> Downloading https://github.com/syncthing/syncthing-macos/releases/download/v1.27.4-2/Syncthing-1.27.4-2.dmg
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/60985120/56fb99a6-4fdd-4a54-9e66-005530ac4b12?X-Amz-
############################################################################################################################################### 100.0%
==> replace /version\s+["']1\.27\.4\-1["']/m with "version \"1.27.4-2\""
==> replace "c510b42a7ce3d979ce9e985c59f572ea1396485f8cb142796a8991942f66f57a" with "c722c52dfae2911127a05f0fe2c42b51a51c403d7a35d0d82b26c11ab621d1c5"
==> Downloading https://github.com/syncthing/syncthing-macos/releases/download/v1.27.4-2/Syncthing-1.27.4-2.dmg
Already downloaded: /Users/razvanazamfirei/Library/Caches/Homebrew/downloads/0df432ea8df141742fb540fa048d84ee4155a08c846092f3deeb6f781ff611ac--Syncthing-1.27.4-2.dmg
audit for syncthing: failed
 - v1.27.4-2 is a GitHub pre-release.
syncthing
  * line 5, col 2: v1.27.4-2 is a GitHub pre-release.
Error: 1 problem in 1 cask detected.
Error: `brew audit` failed!
```