### PR TITLE
katalon-studio: update livecheck

### DIFF
--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -9,7 +9,7 @@ cask "katalon-studio" do
 
   livecheck do
     url :homepage
-    regex(/href=.*(\d+(?:\.\d+)+)/i)
+    regex(/href=.*(\d+(?:\.\d+)+)\/Katalon/i)
   end
 
   app "Katalon Studio.app"

--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask "katalon-studio" do
   arch arm: "%20Arm64"
-  app_suffix = on_arch_conditional arm: "Arm64"
+  app_suffix = on_arch_conditional arm: " Arm64"
 
   version "9.3.2"
   sha256 arm:   "f80d385a4ba8b77d0fcadee4576b651766849e70d54cbd11ad30ad222be17e78",

--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -1,6 +1,6 @@
 cask "katalon-studio" do
-  version "8.6.9"
-  sha256 "e6e485784e02158acfffe9793c28b539785ef11f281cc40ca568626b2572a459"
+  version "9.3.2"
+  sha256 "e0f6e76dc483ac08cece373af0e0716e6a0467dade31e8711051ce8ceb24590f"
 
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   name "Katalon Studio"

--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -9,7 +9,7 @@ cask "katalon-studio" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*\/(\d+(?:\.\d+)+)\/Katalon}i)
+    regex(%r{href=.*/(\d+(?:\.\d+)+)/Katalon}i)
   end
 
   app "Katalon Studio.app"

--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -9,7 +9,7 @@ cask "katalon-studio" do
 
   livecheck do
     url :homepage
-    regex(/href=.*(\d+(?:\.\d+)+)\/Katalon/i)
+    regex(%r{href=.*\/(\d+(?:\.\d+)+)\/Katalon}i)
   end
 
   app "Katalon Studio.app"

--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -1,8 +1,12 @@
 cask "katalon-studio" do
-  version "9.3.2"
-  sha256 "e0f6e76dc483ac08cece373af0e0716e6a0467dade31e8711051ce8ceb24590f"
+  arch arm: "%20Arm64"
+  app_suffix = on_arch_conditional arm: "Arm64"
 
-  url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
+  version "9.3.2"
+  sha256 arm:   "f80d385a4ba8b77d0fcadee4576b651766849e70d54cbd11ad30ad222be17e78",
+         intel: "e0f6e76dc483ac08cece373af0e0716e6a0467dade31e8711051ce8ceb24590f"
+
+  url "https://download.katalon.com/#{version}/Katalon%20Studio#{arch}.dmg"
   name "Katalon Studio"
   desc "Test automation solution"
   homepage "https://katalon.com/download"
@@ -12,7 +16,7 @@ cask "katalon-studio" do
     regex(%r{href=.*/(\d+(?:\.\d+)+)/Katalon}i)
   end
 
-  app "Katalon Studio.app"
+  app "Katalon Studio#{app_suffix}.app"
 
   zap trash: [
     "~/.katalon",

--- a/Casks/k/katalon-studio.rb
+++ b/Casks/k/katalon-studio.rb
@@ -5,11 +5,11 @@ cask "katalon-studio" do
   url "https://download.katalon.com/#{version}/Katalon%20Studio.dmg"
   name "Katalon Studio"
   desc "Test automation solution"
-  homepage "https://www.katalon.com/download/"
+  homepage "https://katalon.com/download"
 
   livecheck do
-    url "https://github.com/katalon-studio/katalon-studio"
-    strategy :github_latest
+    url :homepage
+    regex(/href=.*(\d+(?:\.\d+)+)/i)
   end
 
   app "Katalon Studio.app"


### PR DESCRIPTION
The GitHub [latest releases](https://github.com/katalon-studio/katalon-studio/releases) are incorrectly set as `v8` while it’s already `v9` on their [website](https://katalon.com/download).

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
