### PR TITLE
Update kitty.rb add kitten binary

### DIFF
--- a/Casks/k/kitty.rb
+++ b/Casks/k/kitty.rb
@@ -11,13 +11,20 @@ cask "kitty" do
 
   app "kitty.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/kitty.wrapper.sh"
-  binary shimscript, target: "kitty"
+  kitty_shimscript = "#{staged_path}/kitty.wrapper.sh"
+  binary kitty_shimscript, target: "kitty"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  kitten_shimscript = "#{staged_path}/kitten.wrapper.sh"
+  binary kitten_shimscript, target: "kitten"
 
   preflight do
-    File.write shimscript, <<~EOS
+    File.write kitty_shimscript, <<~EOS
       #!/bin/sh
       exec '#{appdir}/kitty.app/Contents/MacOS/kitty' "$@"
+    EOS
+    File.write kitten_shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/kitty.app/Contents/MacOS/kitten' "$@"
     EOS
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Kitty is packaged with the `kitten` executable. This PR adds `kitten` as a binary so that is it added to the homebrew bin directory.

This is necessary for running the kitten command, as well as, bash autocompletion for the kitty command. If kitten is not on the path, autocompletion will have errors. 

cc @kovidgoyal

