### PR TITLE
fixed SHA256 sum mismatch

### DIFF
--- a/Casks/r/rawtherapee.rb
+++ b/Casks/r/rawtherapee.rb
@@ -1,6 +1,6 @@
 cask "rawtherapee" do
   version "5.10"
-  sha256 "36f061dc293f8141d20910dde62c976fa57c3dd3f8708a628b3aece9c9ca14cf"
+  sha256 "013cd1e98d06023c85c304ce3e99c3ffc14430fb7a366b516697e654c0508c79"
 
   url "https://www.rawtherapee.com/shared/builds/mac/RawTherapee_macOS_13.3_Universal_#{version}.zip"
   name "RawTherapee"


### PR DESCRIPTION
Fixes this error:
```
Error: rawtherapee: SHA256 mismatch
Expected: 36f061dc293f8141d20910dde62c976fa57c3dd3f8708a628b3aece9c9ca14cf
  Actual: 013cd1e98d06023c85c304ce3e99c3ffc14430fb7a366b516697e654c0508c79
    File: /Users/admin/Library/Caches/Homebrew/downloads/cb5896b4dc730ca4734983a90cdb8f62f8b8c2c8cd3bc490c3abe0c8058019df--RawTherapee_macOS_13.3_Universal_5.10.zip
To retry an incomplete download, remove the file above.
```
