### PR TITLE
Update kstars SHA265

### DIFF
--- a/Casks/k/kstars.rb
+++ b/Casks/k/kstars.rb
@@ -1,6 +1,6 @@
 cask "kstars" do
   version "3.6.9"
-  sha256 "afb69e848195e12d437057596ccaf9bd46175427ade7ae7d98ca00c61a4a5655"
+  sha256 "0c7bbb1020ea416b78db92e5532003c340d4bd9368e9549e84bc3f23c328531b"
 
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg",
       verified: "indilib.org/jdownloads/kstars/"


### PR DESCRIPTION
Set value to match contents of [https://www.indilib.org/jdownloads/kstars/kstars-3.6.9.dmg.sha256
](https://www.indilib.org/jdownloads/kstars/kstars-3.6.9.dmg.sha256)

This also matches the error current install displays:

```
Expected: afb69e848195e12d437057596ccaf9bd46175427ade7ae7d98ca00c61a4a5655
  Actual: 0c7bbb1020ea416b78db92e5532003c340d4bd9368e9549e84bc3f23c328531b
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

- [ ] `brew audit --cask --online <cask>` is error-free.
No - shows it as unavailable - but install can see it.

- [ ] `brew style --fix <cask>` reports no offenses.
No - this looks in /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/kstars.rb - on my m1 mac - there is no homebrew-cask directory there:

```
ls /opt/homebrew/Library/Taps/homebrew/
homebrew-bundle/
```

---

Hope this can go ahead despite the audit and style issue - it's just the SHA that needs updating - code style etc are the same as they were.