### PR TITLE
wire: update livecheck

### DIFF
--- a/Casks/w/wire.rb
+++ b/Casks/w/wire.rb
@@ -8,9 +8,21 @@ cask "wire" do
   desc "Collaboration platform focusing on security"
   homepage "https://wire.com/"
 
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
     url :url
     regex(%r{^macos[/._-]v?(\d+(?:\.\d+)+)$}i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end.flatten
+    end
   end
 
   pkg "Wire.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Adds an explicit livecheck for GitHub Releases.  The current check is picking up pre-releases, and because not every release contains a file for macOS, we have to iterate through the releases to find a match.