### PR TITLE
Fix background-music uninstall on macOS 14.4

### DIFF
--- a/Casks/b/background-music.rb
+++ b/Casks/b/background-music.rb
@@ -16,9 +16,7 @@ cask "background-music" do
 
   uninstall_postflight do
     system_command "/usr/bin/killall",
-                   args:         [
-                     "coreaudiod",
-                   ],
+                   args:         ["coreaudiod"],
                    sudo:         true,
                    must_succeed: true
   end

--- a/Casks/b/background-music.rb
+++ b/Casks/b/background-music.rb
@@ -15,11 +15,9 @@ cask "background-music" do
   pkg "BackgroundMusic-#{version}.pkg"
 
   uninstall_postflight do
-    system_command "/bin/launchctl",
+    system_command "/usr/bin/killall",
                    args:         [
-                     "kickstart",
-                     "-kp",
-                     "system/com.apple.audio.coreaudiod",
+                     "coreaudiod",
                    ],
                    sudo:         true,
                    must_succeed: true


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Fix https://github.com/kyleneideck/BackgroundMusic/issues/727

Steps to reproduce: install background-music on macOS 14.4 and try to uninstall it. You will get the error mentioned on the issue above.

See: https://forums.developer.apple.com/forums/thread/748228
