### PR TITLE
vivid: update `sha256`, add `depends_on`

### DIFF
--- a/Casks/v/vivid.rb
+++ b/Casks/v/vivid.rb
@@ -1,6 +1,6 @@
 cask "vivid" do
   version "2.9"
-  sha256 "f864d540f8ec2add56590956bf33b9979302dec0314c69451274e0921172d291"
+  sha256 "45f180d875f38882eac81293fc524458ed6f1dcffac4927cf28cfbb8c617dcb4"
 
   url "https://lumen-digital.com/apps/vivid/releases/Vivid#{version}.zip",
       verified: "lumen-digital.com/apps/vivid/releases/"
@@ -12,6 +12,8 @@ cask "vivid" do
     url "https://lumen-digital.com/apps/vivid/appcast.xml"
     strategy :sparkle, &:short_version
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Vivid.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Follow on from conversation at https://github.com/Homebrew/homebrew-cask/pull/168836#issuecomment-2002007331 where upstream has changed `sha256` without version update.  This PR gets the Cask into a working state as we work to understand future expectations from upstream