### PR TITLE
various: update `coreaudiod` stop command

### DIFF
--- a/Casks/b/blackhole-16ch.rb
+++ b/Casks/b/blackhole-16ch.rb
@@ -17,12 +17,8 @@ cask "blackhole-16ch" do
   pkg "BlackHole16ch.v#{version}.pkg"
 
   uninstall_postflight do
-    system_command "/bin/launchctl",
-                   args:         [
-                     "kickstart",
-                     "-kp",
-                     "system/com.apple.audio.coreaudiod",
-                   ],
+    system_command "/usr/bin/killall",
+                   args:         ["coreaudiod"],
                    sudo:         true,
                    must_succeed: true
   end

--- a/Casks/b/blackhole-2ch.rb
+++ b/Casks/b/blackhole-2ch.rb
@@ -17,12 +17,8 @@ cask "blackhole-2ch" do
   pkg "BlackHole2ch.v#{version}.pkg"
 
   uninstall_postflight do
-    system_command "/bin/launchctl",
-                   args:         [
-                     "kickstart",
-                     "-kp",
-                     "system/com.apple.audio.coreaudiod",
-                   ],
+    system_command "/usr/bin/killall",
+                   args:         ["coreaudiod"],
                    sudo:         true,
                    must_succeed: true
   end

--- a/Casks/b/blackhole-64ch.rb
+++ b/Casks/b/blackhole-64ch.rb
@@ -17,12 +17,8 @@ cask "blackhole-64ch" do
   pkg "BlackHole64ch.v#{version}.pkg"
 
   uninstall_postflight do
-    system_command "/bin/launchctl",
-                   args:         [
-                     "kickstart",
-                     "-kp",
-                     "system/com.apple.audio.coreaudiod",
-                   ],
+    system_command "/usr/bin/killall",
+                   args:         ["coreaudiod"],
                    sudo:         true,
                    must_succeed: true
   end

--- a/Casks/p/proxy-audio-device.rb
+++ b/Casks/p/proxy-audio-device.rb
@@ -15,23 +15,15 @@ cask "proxy-audio-device" do
                   user:  "root",
                   group: "wheel"
 
-    system_command "/bin/launchctl",
-                   args:         [
-                     "kickstart",
-                     "-k",
-                     "system/com.apple.audio.coreaudiod",
-                   ],
+    system_command "/usr/bin/killall",
+                   args:         ["coreaudiod"],
                    sudo:         true,
                    must_succeed: true
   end
 
   uninstall_postflight do
-    system_command "/bin/launchctl",
-                   args:         [
-                     "kickstart",
-                     "-k",
-                     "system/com.apple.audio.coreaudiod",
-                   ],
+    system_command "/usr/bin/killall",
+                   args:         ["coreaudiod"],
                    sudo:         true,
                    must_succeed: true
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Follow-on to #169322, where it was raised that `launchctl` can no longer be used to stop `coreaudiod` as per [Apple docs](https://developer.apple.com/documentation/macos-release-notes/macos-14_4-release-notes#Core-Audio)

```
To improve security and stability, using launchctl kickstart -k is no longer permitted for critical system processes. If a process must be forcefully terminated, it is recommended to use kill instead. (123028502)
```

This PR accordingly updates Casks where `launchctl kickstart -k` was being used for this purpose, and replaces with the recommended kill command.