### PR TITLE
figma: revert #169346

### DIFF
--- a/Casks/f/figma.rb
+++ b/Casks/f/figma.rb
@@ -1,9 +1,9 @@
 cask "figma" do
   arch arm: "mac-arm", intel: "mac"
 
-  version "116.16.13"
-  sha256 arm:   "e1fceb438e70a027592822a25017ec634aead601f56433cc6d837d364761afbd",
-         intel: "1c7701a09cb5fbc41e292fd97ef918e8634a8904184549bb536b6ad3be9b1df8"
+  version "116.16.14"
+  sha256 arm:   "f6c37bbb3782641d519d3859dcc18b2ec66b02192bb18df091f235431003295f",
+         intel: "8b14523d9b7740aedd16d35b315f094829b75c34324f7c45094003369649e07e"
 
   url "https://desktop.figma.com/#{arch}/Figma-#{version}.zip"
   name "Figma"

--- a/Casks/f/figma.rb
+++ b/Casks/f/figma.rb
@@ -1,9 +1,9 @@
 cask "figma" do
   arch arm: "mac-arm", intel: "mac"
 
-  version "116.17.11"
-  sha256 arm:   "26026d512bb0a29674f62d1525e6cae1123fc6c3744a013ddd8108d0ab8b8365",
-         intel: "b6f3d82bbdb00beee3ccc564cb2ba288eed030c5ad62fdc9e3f28d2236a19bd8"
+  version "116.16.13"
+  sha256 arm:   "e1fceb438e70a027592822a25017ec634aead601f56433cc6d837d364761afbd",
+         intel: "1c7701a09cb5fbc41e292fd97ef918e8634a8904184549bb536b6ad3be9b1df8"
 
   url "https://desktop.figma.com/#{arch}/Figma-#{version}.zip"
   name "Figma"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Reverts #169346, which the version bump appears to have been pulled.

Checking the upstream releases file shows -

```
{
"version": "116.16.14",
"rollback": true,
"url": "https://desktop.figma.com/mac/Figma-116.16.14.zip"
}
```

So this PR is 2 parts -

- Revert to the previous version `116.16.13`, before the above PR.
- Bump `116.16.13` to the latest version `116.16.14`
