### PR TITLE
Improve Ghidra formula

### DIFF
--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -44,6 +44,5 @@ cask "ghidra" do
 
   caveats do
     depends_on_java "17+"
-    requires_rosetta
   end
 end

--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -30,7 +30,10 @@ cask "ghidra" do
 
   postflight do
     #The decompile and sleigh binaries need to have the quarantine flag taken off (equivalent of right clicking and clicking open from Finder before Ghidra can use them)
-    xattr -d com.apple.quarantine "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_{arm,x86}_64/{decompile,sleigh}"
+    system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/decompile'")
+    system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/sleigh'")
+    system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_x86_64/decompile'")
+    system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_x86_64/sleigh'")
   end
 
   uninstall_preflight do

--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -28,6 +28,11 @@ cask "ghidra" do
     FileUtils.mv(staged_path, "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}")
   end
 
+  postflight do
+    #The decompile and sleigh binaries need to have the quarantine flag taken off (equivalent of right clicking and clicking open from Finder before Ghidra can use them)
+    xattr -d com.apple.quarantine "#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_{arm,x86}_64/{decompile,sleigh}"
+  end
+
   uninstall_preflight do
     FileUtils.mv("#{caskroom_path}/#{version.csv.first}-#{version.csv.second}", staged_path)
   end

--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -29,7 +29,7 @@ cask "ghidra" do
   end
 
   postflight do
-    #The decompile and sleigh binaries need to have the quarantine flag taken off (equivalent of right clicking and clicking open from Finder before Ghidra can use them)
+    # The decompiler binaries need the quarantine flag taken off before Ghidra can use them
     system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/decompile'")
     system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/sleigh'")
     system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_x86_64/decompile'")

--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -30,6 +30,7 @@ cask "ghidra" do
 
   postflight do
     # The decompiler binaries need the quarantine flag taken off before Ghidra can use them
+    # Its the same thing as right clicking in Finder and clicking Open, and confirming on the dialog
     system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/decompile'")
     system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_arm_64/sleigh'")
     system("xattr -d com.apple.quarantine '#{caskroom_path}/#{version.csv.first}-#{version.csv.second}/ghidra_#{version.csv.first}_PUBLIC/Ghidra/Features/Decompiler/os/mac_x86_64/decompile'")


### PR DESCRIPTION
Two improvements:
* automatically de-quarantine the decompiler binaries
* remove the outdated rosetta warning

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

