### PR TITLE
maestral 1.9.1

### DIFF
--- a/Casks/m/maestral.rb
+++ b/Casks/m/maestral.rb
@@ -1,6 +1,6 @@
 cask "maestral" do
-  version "1.8.0"
-  sha256 "19e8a8c2985599dbfdf0eff2c1fa0cde2caf012ee5242a3bb3e8686b6d1873b6"
+  version "1.9.1"
+  sha256 "a4fb3e6e81ea59781aaf6d8192557314847ddbcc8793dda392f07ecae961e078"
 
   url "https://github.com/SamSchott/maestral/releases/download/v#{version}/Maestral-#{version}.dmg",
       verified: "github.com/SamSchott/maestral/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Bump maestral to 1.9.1 https://github.com/samschott/maestral/releases/tag/v1.9.1