### PR TITLE
eclipse-java: make Contents/Eclipse read-only to install plugins in user folder and preserve code signing

### DIFF
--- a/Casks/e/eclipse-java.rb
+++ b/Casks/e/eclipse-java.rb
@@ -17,6 +17,15 @@ cask "eclipse-java" do
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Java.app"
 
+  # https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.isv/reference/misc/multi_user_installs.html
+  postflight do
+    set_permissions "/Applications/Eclipse Java.app/Contents/Eclipse", "0555"
+  end
+
+  uninstall_preflight do
+    set_permissions "/Applications/Eclipse Java.app/Contents/Eclipse", "0755"
+  end
+
   zap trash: [
     "~/.eclipse",
     "~/eclipse-workspace",


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Eclipse installs plugins and updates inside the Eclipse.app by default, invalidating the code signature.
To have Eclipse install plugins and updates in the user folder instead, the Eclipse.app/Contents/Eclipse folder is made read-only (0555) at install time, and reset to (0755) before uninstall.
See https://help.eclipse.org/latest/topic/org.eclipse.platform.doc.isv/reference/misc/multi_user_installs.html
 