### PR TITLE
New Ghidra version: 11.0.2

### DIFF
--- a/Casks/g/ghidra.rb
+++ b/Casks/g/ghidra.rb
@@ -1,6 +1,6 @@
 cask "ghidra" do
-  version "11.0.1,20240130"
-  sha256 "a0bc9450aa3a231096b13a823c66311b9f84cb9cec4624393221cfed40ef6924"
+  version "11.0.2,20240326"
+  sha256 "4f16ae3f288f8c01fd1872e8e55b25c79744e7b1e8a9383c5e576668ca7d1906"
 
   url "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_#{version.csv.first}_build/ghidra_#{version.csv.first}_PUBLIC_#{version.csv.second}.zip",
       verified: "github.com/NationalSecurityAgency/ghidra/"


### PR DESCRIPTION
Source: https://github.com/NationalSecurityAgency/ghidra/releases/