### PR TITLE
Clean up #tr usage in livecheck blocks

### DIFF
--- a/Casks/g/godspeed.rb
+++ b/Casks/g/godspeed.rb
@@ -11,10 +11,7 @@ cask "godspeed" do
   livecheck do
     url "https://api.godspeedapp.com/update-check/latest"
     strategy :json do |json|
-      name = json["name"]
-      next if name.blank?
-
-      name.tr("v", "")
+      json["name"]&.tr("v", "")
     end
   end
 

--- a/Casks/g/guilded.rb
+++ b/Casks/g/guilded.rb
@@ -9,8 +9,8 @@ cask "guilded" do
 
   livecheck do
     url "https://www.guilded.gg/AppBuilds/mac/release-mac.yml"
-    strategy :electron_builder do |data|
-      data["version"].tr("-release", "")
+    strategy :electron_builder do |yaml|
+      yaml["version"]&.sub(/[._-]release.*$/i, "")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `#tr` call in the `livecheck` block for `guilded` appears to be intended to remove the `-release` suffix from the `version` value but `#tr` isn't the best method for this. While it technically works, `#tr` removes any instance of those characters from the entire string and this can lead to unexpected behavior.

This replaces the `#tr` call with `#sub`, using a regex to anchor the replacement to the end of the string. We could use `#delete_suffix` if the suffix will never change but some of the files use a `-release-mac` suffix, so that may not be guaranteed.

Besides that, this simplifies the `livecheck` block for `godspeed`.