### PR TITLE
Ente: Update description and indicate support for auto_updates 

### DIFF
--- a/Casks/e/ente.rb
+++ b/Casks/e/ente.rb
@@ -7,12 +7,13 @@ cask "ente" do
   name "Ente"
   desc "Desktop client for Ente Photos"
   homepage "https://ente.io/"
-  auto_updates true
 
   livecheck do
     url :url
     strategy :github_latest
   end
+
+  auto_updates true
 
   app "ente.app"
 

--- a/Casks/e/ente.rb
+++ b/Casks/e/ente.rb
@@ -5,8 +5,9 @@ cask "ente" do
   url "https://github.com/ente-io/photos-desktop/releases/download/v#{version}/ente-#{version}-universal.dmg",
       verified: "github.com/ente-io/photos-desktop/"
   name "Ente"
-  desc "Desktop client for Ente"
+  desc "Desktop client for Ente Photos"
   homepage "https://ente.io/"
+  auto_updates true
 
   livecheck do
     url :url


### PR DESCRIPTION
Hi, I'm one of the maintainers of Ente (you can see me in the [source repository](https://github.com/ente-io/ente))

This PR has two changes:

* Clarify in the description of this cask that this is for "Ente Photos".

* This was an existing oversight, but the app already uses its own auto update functionality (based on Electron's auto updater). So add the `auto_updates true` flag as recommended by the [Homebrew Cask FAQ](https://docs.brew.sh/FAQ#why-arent-some-apps-included-during-brew-upgrade)

Thank you!

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
