### PR TITLE
tuta-mail: use github versioned url for `sha256`

### DIFF
--- a/Casks/t/tuta-mail.rb
+++ b/Casks/t/tuta-mail.rb
@@ -1,8 +1,9 @@
 cask "tuta-mail" do
   version "220.240321.0"
-  sha256 :no_check
+  sha256 "b38264909750aed31ba6ff81b98ad741d176bb99f8d7906dd9ffa098aa43fba3"
 
-  url "https://app.tuta.com/desktop/tutanota-desktop-mac.dmg"
+  url "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-#{version}/tutanota-desktop-mac.dmg",
+      verified: "github.com/tutao/tutanota/"
   name "Tuta Mail"
   desc "Email client"
   homepage "https://tuta.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

GitHub repo shown on homepage https://tuta.com/

Release `sha256` matches what is currently available on homepage:
```
❯ curl -sL "https://app.tuta.com/desktop/tutanota-desktop-mac.dmg" | sha256sum
b38264909750aed31ba6ff81b98ad741d176bb99f8d7906dd9ffa098aa43fba3  -
```

Previous releases are available:
* #169435 - https://github.com/tutao/tutanota/releases/tag/tutanota-desktop-release-220.240319.1
* #169407 - https://github.com/tutao/tutanota/releases/tag/tutanota-desktop-release-220.240318.1