### PR TITLE
protonmail-bridge: use github versioned url for `sha256`

### DIFF
--- a/Casks/p/protonmail-bridge.rb
+++ b/Casks/p/protonmail-bridge.rb
@@ -1,15 +1,16 @@
 cask "protonmail-bridge" do
   version "3.10.0"
-  sha256 :no_check
+  sha256 "6677757d5438b8aa2af9e2467044a265f51e08704f1960727f672ca9aa6f01b7"
 
-  url "https://proton.me/download/bridge/Bridge-Installer.dmg"
+  url "https://github.com/ProtonMail/proton-bridge/releases/download/v#{version}/Bridge-Installer.dmg",
+      verified: "github.com/ProtonMail/proton-bridge/"
   name "Proton Mail Bridge"
   desc "Bridges Proton Mail to email clients supporting IMAP and SMTP protocols"
   homepage "https://proton.me/mail/bridge"
 
   livecheck do
     url :url
-    strategy :extract_plist
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Switch to GitHub similar to `proton-mail` Cask.

Matching `sha256`:
```
❯ curl -sL "https://proton.me/download/bridge/Bridge-Installer.dmg" | sha256sum
6677757d5438b8aa2af9e2467044a265f51e08704f1960727f672ca9aa6f01b7  -
```