### PR TITLE
Ente: Remove livecheck override

### DIFF
--- a/Casks/e/ente.rb
+++ b/Casks/e/ente.rb
@@ -8,11 +8,6 @@ cask "ente" do
   desc "Desktop client for Ente Photos"
   homepage "https://ente.io/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
 
   app "ente.app"


### PR DESCRIPTION
As recommended in https://github.com/Homebrew/homebrew-cask/pull/170056#discussion_r1541507565, since we don't use pre-releases, drop the livecheck block.

---

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
