### PR TITLE
treesheets 8473991279, with source switched to GitHub Releases

### DIFF
--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -10,6 +10,7 @@ cask "treesheets" do
 
   livecheck do
     url :url
+    regex(/^(\d+)$/)
     strategy :github_latest
   end
 

--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -1,16 +1,25 @@
 cask "treesheets" do
-  version "2022.08.02,20220802020630"
-  sha256 :no_check
+  version "8473991279"
+  sha256 "34c56edb4d2eff97662fa3f4bb097f9e740e0360cacf15269cfd14726893f18f"
 
-  url "https://strlen.com/treesheets/treesheets_osx.zip"
+  url "https://github.com/aardappel/treesheets/releases/download/#{version}/mac_treesheets.zip",
+      verified: "github.com/aardappel/treesheets/"
   name "TreeSheets"
   desc "Hierarchical spreadsheet and outline application"
   homepage "https://strlen.com/treesheets/"
 
   livecheck do
     url :url
-    strategy :extract_plist
+    strategy :github_latest
   end
 
-  app "TreeSheets.app"
+  app "build/Build/Products/Release/TreeSheets.app"
+
+  uninstall quit: "dot3labs.TreeSheets"
+
+  zap trash: [
+    "~/Library/Preferences/dot3labs.TreeSheets.plist",
+    "~/Library/Preferences/TreeSheets Preferences",
+    "~/Library/Saved Application State/dot3labs.TreeSheets.savedState",
+  ]
 end

--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -1,6 +1,6 @@
 cask "treesheets" do
-  version "8473991279"
-  sha256 "34c56edb4d2eff97662fa3f4bb097f9e740e0360cacf15269cfd14726893f18f"
+  version "8504377142"
+  sha256 "163fa4b9e36605b838b7b611062433b7ed6f16ae609e258e2ca94244b62606cb"
 
   url "https://github.com/aardappel/treesheets/releases/download/#{version}/mac_treesheets.zip",
       verified: "github.com/aardappel/treesheets/"


### PR DESCRIPTION
### Changes

- update `treesheets` to version `8473991279`
- fetch from GitHub Releases, which is now the source used by the download link on [the TreeSheets website](https://strlen.com/treesheets/) and in its [GitHub readme](https://github.com/aardappel/treesheets?tab=readme-ov-file#windowsubuntu-ltsmacos-users)
- add `zap trash` harvested from AppCleaner anecdote
- add `uninstall quit` id

### Checks

#### Checks for 'edit cask'

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

#### Relevant checks from 'new cask' section

- [x] `brew uninstall --cask <cask>` worked successfully.
