### PR TITLE
deprecate: auryo.rb

### DIFF
--- a/Casks/a/auryo.rb
+++ b/Casks/a/auryo.rb
@@ -8,5 +8,7 @@ cask "auryo" do
   desc "Unofficial desktop app for Soundcloud"
   homepage "https://auryo.com/"
 
+  deprecate! date: "2021-02-10", because: :discontinued
+
   app "Auryo.app"
 end


### PR DESCRIPTION
Via project page: https://github.com/sneljo1/auryo

> [Discontinued] Auryo - Unofficial Soundcloud Desktop App

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
