### PR TITLE
avast-secure-browser: arch and livecheck updates

### DIFF
--- a/Casks/a/avast-secure-browser.rb
+++ b/Casks/a/avast-secure-browser.rb
@@ -1,24 +1,30 @@
 cask "avast-secure-browser" do
-  version "122.0.5288.130"
-  sha256 :no_check
+  arch arm: "arm", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "-arm"
 
-  url "https://cdn-download.avastbrowser.com/AvastSecureBrowserSetup.pkg",
-      verified: "cdn-download.avastbrowser.com/"
+  on_arm do
+    version "122.0.5287.130"
+    sha256 "acf1380a8e1438f5bc6b5827102f3805e2460c7f7d6ff4ad698a64db3f6dd996"
+  end
+  on_intel do
+    version "122.0.5288.130"
+    sha256 "8dcd39f00da935c77ffa90d14ab093ee3398927bc0f270190c0ec012ee5554a8"
+  end
+
+  url "https://cdn-update.avast.securebrowser.com/browser/mac/#{arch}/#{version}/AvastSecureBrowser.dmg",
+      verified: "cdn-update.avast.securebrowser.com/"
   name "Avast Secure Browser"
   desc "Web browser focusing on privacy"
   homepage "https://www.avast.com/secure-browser#mac"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://update.avastbrowser.com/sparkle/browser#{livecheck_arch}/appcast.xml"
+    strategy :sparkle
   end
 
-  depends_on arch: :x86_64
+  auto_updates true
 
-  pkg "AvastSecureBrowserSetup.pkg"
-
-  uninstall quit:    "com.avast.browser",
-            pkgutil: "com.avast.browser"
+  app "Avast Secure Browser.app"
 
   zap trash: [
         "~/Library/Application Support/AVAST Software/Browser",


### PR DESCRIPTION
- Rework to support ARM and Intel native packages

- Switch from `:extract_plist` strategy to `:sparkle`

- Add `auto_updates true`

-----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
