### PR TITLE
twitch-studio: deprecate

### DIFF
--- a/Casks/t/twitch-studio.rb
+++ b/Casks/t/twitch-studio.rb
@@ -8,12 +8,7 @@ cask "twitch-studio" do
   desc "Free streaming software designed for new streamers"
   homepage "https://www.twitch.tv/broadcast/studio/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist do |versions|
-      versions.values.filter_map(&:short_version).first
-    end
-  end
+  deprecate! date: "2024-03-31", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
Application has been discontinued formally from upstream on 2023-09-19, as per [this source](https://help.twitch.tv/s/article/twitch-studio-mac-faq?language=en_US)

<img width="839" alt="twitch-studio" src="https://github.com/Homebrew/homebrew-cask/assets/39449589/c0b2d1ae-ed91-423c-a0cf-095a4becdcdb">
