### PR TITLE
mutedeck: fix installer command

### DIFF
--- a/Casks/m/mutedeck.rb
+++ b/Casks/m/mutedeck.rb
@@ -16,7 +16,7 @@ cask "mutedeck" do
 
   depends_on macos: ">= :big_sur"
 
-  installer manual: "MuteDeck-#{version}-Installer"
+  installer manual: "MuteDeck-#{version}-Installer.app"
 
   uninstall launchctl: "application.com.mutedeck.mac",
             quit:      "com.mutedeck.mac",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Fixing incorrect filename for installer command after installing the cask