### PR TITLE
paragon-extfs: Conflicts with new paragon-extfs11 in cask-versions

### DIFF
--- a/Casks/p/paragon-extfs.rb
+++ b/Casks/p/paragon-extfs.rb
@@ -14,6 +14,7 @@ cask "paragon-extfs" do
     end
   end
 
+  conflicts_with cask: "paragon-extfs11"
   depends_on macos: ">= :sierra"
 
   installer manual: "FSInstaller.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

`paragon-extfs11` was added in https://github.com/Homebrew/homebrew-cask-versions/pull/19848.

The only difference between versions 11 and 12 is the migration to the new licensing system. If you have a license in the old system, you must use version 11.

Per Paragon support:

> Using new Licensing Center is currently the only difference between
> these versions. [...] Download the compatible installer for this license
> using "Download" button, and remove current version.