### PR TITLE
chore: podman-desktop add auto-updates true

### DIFF
--- a/Casks/p/podman-desktop.rb
+++ b/Casks/p/podman-desktop.rb
@@ -16,6 +16,7 @@ cask "podman-desktop" do
     strategy :github_latest
   end
 
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Podman Desktop.app"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

The `podman-desktop` app is capable of auto-updating itself, and should be marked as such.