### PR TITLE
p4 update checksum - disable sha256

### DIFF
--- a/Casks/p/p4.rb
+++ b/Casks/p/p4.rb
@@ -2,9 +2,11 @@ cask "p4" do
   # NOTE: "4" is not a version number, but an intrinsic part of the product name
   arch arm: "12arm64", intel: "1015x86_64"
 
-  version "2023.2,2563409"
-  sha256 arm:   "c825bb42d24312184b7a5f937d78e9b549392b10ecf0248375a2bc7aa5486e3b",
-         intel: "818d345df408b6a01693c0a501d80cba4473d90719e6910ccaa08380b6c13dd6"
+  version "2023.2,2578891"
+  # arm:   https://filehost.perforce.com/perforce/r23.2/bin.macosx12arm64/SHA256SUMS
+  # intel: https://filehost.perforce.com/perforce/r23.2/bin.macosx1015x86_64/SHA256SUMS
+  sha256 arm:   "120fcd7e2756a5ef31e3ae0eb69f88ac5e451f73e36429376466cf3e86d1b33c",
+         intel: "3d994f626cef4a599e98da4383f37b06d205d5420b90188a307fe0de189b0ae8"
 
   url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx#{arch}/p4"
   name "Perforce Helix Command-Line Client (P4)"

--- a/Casks/p/p4.rb
+++ b/Casks/p/p4.rb
@@ -3,10 +3,7 @@ cask "p4" do
   arch arm: "12arm64", intel: "1015x86_64"
 
   version "2023.2,2578891"
-  # arm:   https://filehost.perforce.com/perforce/r23.2/bin.macosx12arm64/SHA256SUMS
-  # intel: https://filehost.perforce.com/perforce/r23.2/bin.macosx1015x86_64/SHA256SUMS
-  sha256 arm:   "120fcd7e2756a5ef31e3ae0eb69f88ac5e451f73e36429376466cf3e86d1b33c",
-         intel: "3d994f626cef4a599e98da4383f37b06d205d5420b90188a307fe0de189b0ae8"
+  sha256 :no_check
 
   url "https://filehost.perforce.com/perforce/r#{version.major[-2..]}.#{version.minor}/bin.macosx#{arch}/p4"
   name "Perforce Helix Command-Line Client (P4)"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Perforce has a tendency to update minor versions in place, with the patch version only discoverable by running the binary and/or checking the documented SHA256SUM URL for changes/mod dates.

In #168330 referencing #163174 , it was mentioned removing the checksum. Does that mean just changing to:
```
sha256 :no_check
```
If we don't want to remove sha256 sums in the meantime, this change'll suffice. But it will break again when they update.