### PR TITLE
obsidian: update `depends_on`

### DIFF
--- a/Casks/o/obsidian.rb
+++ b/Casks/o/obsidian.rb
@@ -14,7 +14,7 @@ cask "obsidian" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "Obsidian.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
```
audit for obsidian: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined :high_sierra
```