### PR TITLE
spotify: update `depends_on`

### DIFF
--- a/Casks/s/spotify.rb
+++ b/Casks/s/spotify.rb
@@ -27,7 +27,7 @@ cask "spotify" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :catalina"
 
   app "Spotify.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
```
audit for spotify: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined :el_capitan
 ```