### PR TITLE
insomnia: add `depends_on`

### DIFF
--- a/Casks/i/insomnia.rb
+++ b/Casks/i/insomnia.rb
@@ -17,6 +17,7 @@ cask "insomnia" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Insomnia.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

```
audit for insomnia: failed
 - Upstream defined :catalina as the minimum OS version and the cask defined no minimum OS version
 ```