### PR TITLE
fujifilm-x-raw-studio 1.22.0 (new cask)

### DIFF
--- a/Casks/f/fujifilm-x-raw-studio.rb
+++ b/Casks/f/fujifilm-x-raw-studio.rb
@@ -1,0 +1,23 @@
+cask "fujifilm-x-raw-studio" do
+  version "1.22.0"
+  sha256 "a6f72c8ca5bbe83c5a6d2bab0c64c611112c195e617518c075b2530ac065a638"
+
+  url "https://dl.fujifilm-x.com/support/software/x-raw-studio-mac#{version.no_dots}-p2ep21rl/XRawStudio#{version.no_dots}.dmg"
+  name "fujifilm-x-raw-studio"
+  desc "Convert RAW images captured with Fujifilm cameras"
+  homepage "https://fujifilm-x.com/global/products/software/x-raw-studio/"
+
+  livecheck do
+    url "https://fujifilm-x.com/en-us/support/download/software/x-raw-studio/"
+    regex(/Mac\s*Version\s*:\s*v?(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: ">= :sierra"
+
+  app "FUJIFILM X RAW STUDIO.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.fujifilm.denji",
+    "~/Library/Preferences/com.fujifilm.denji.X-RAW-STUDIO.plist",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This cask is for the [Fujifilm X RAW Studio](https://fujifilm-x.com/global/products/software/x-raw-studio/) program.

I included "Fujifilm" in the description not as a redundant inclusion of the app vendor name, but to clarify that it only converts Fujifilm RAW (.RAF) files, and not RAW files captured with other cameras.