### PR TITLE
zoho-workdrive-truesync 3.7.56 (new cask)

### DIFF
--- a/Casks/z/zoho-workdrive-truesync.rb
+++ b/Casks/z/zoho-workdrive-truesync.rb
@@ -1,0 +1,33 @@
+cask "zoho-workdrive-truesync" do
+  version "3.7.56"
+  sha256 :no_check
+
+  url "https://files-accl.zohopublic.com/public/tsbin/download/c488f53fb0fe339a8a3868a16d56ede6"
+  name "Zoho WorkDrive TrueSync"
+  desc "Sync files to/from Zoho WorkDrive"
+  homepage "https://www.zoho.com/workdrive/truesync.html?src=zdocs"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "ZohoWorkDriveTS.pkg"
+
+  uninstall launchctl: [
+              "com.zoho.truesync.upgrader",
+              "com.zoho.workdrivefs.Mounter.Helper",
+            ],
+            pkgutil:   "org.zoho.ZohoWorkDrive"
+
+  zap trash: [
+    "/Library/Application Support/zohotruesync",
+    "/Library/PrivilegedHelperTools/com.zoho.workdrivefs.Mounter.Helper",
+    "~/.zohoworkdrivets",
+    "~/Library/Application Scripts/com.zohosync.truesync",
+    "~/Library/Containers/com.zohosync.truesync",
+    "~/Library/Preferences/org.zoho.ZohoWorkDriveTrueSync.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
