### PR TITLE
zoho-docs: disable

### DIFF
--- a/Casks/z/zoho-docs.rb
+++ b/Casks/z/zoho-docs.rb
@@ -8,10 +8,7 @@ cask "zoho-docs" do
   desc "Sync files to/from Zoho Docs"
   homepage "https://www.zoho.com/docs/desktop-sync.html"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-04-03", because: :no_longer_available
 
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Is no longer available upstream. Seems to have been indirectly replaced with "Zoho WorkDrive TrueSync".
PR to add the new cask here - https://github.com/Homebrew/homebrew-cask/pull/170514
But it isn't a direct replacement, so not going with a rename at this stage.