### PR TITLE
arctic 24.1.1 (new cask), deprecate final-cut-library-manager

### DIFF
--- a/Casks/a/arctic.rb
+++ b/Casks/a/arctic.rb
@@ -1,0 +1,31 @@
+cask "arctic" do
+  version "24.1.1,19,20240403132247"
+  sha256 "066769d586e60d50360075fddc58b1a69201d721d5bbcb45dadccd0ca46fd35b"
+
+  url "https://updates.hedge.video/arctic/macos/updates/production/Arctic_20240403132247_v#{version.csv.first}b#{version.csv.second}/Arctic-#{version.csv.second}.zip"
+  name "Arctic"
+  desc "Display and manage Final Cut Pro X libraries"
+  homepage "https://hedge.video/arctic"
+
+  livecheck do
+    url "https://updates.hedge.video/arctic/macos/appcast/arctic-prod.xml"
+    strategy :sparkle do |item|
+      date = item.url[/Arctic[._-](\d+)[._-]/, 1]
+      "#{item.short_version},#{item.version},#{date}"
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Arctic.app"
+
+  zap trash: [
+    "~/Library/Application Support/Arctic",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/video.hedge.arctic.mac.sfl*",
+    "~/Library/HTTPStorages/video.hedge.Arctic.Mac",
+    "~/Library/HTTPStorages/video.hedge.Arctic.Mac.binarycookies",
+    "~/Library/Logs/Arctic",
+    "~/Library/Preferences/video.hedge.Arctic.Mac.plist",
+    "~/Library/Saved Application State/video.hedge.Arctic.Mac.savedState",
+  ]
+end

--- a/Casks/f/final-cut-library-manager.rb
+++ b/Casks/f/final-cut-library-manager.rb
@@ -8,10 +8,7 @@ cask "final-cut-library-manager" do
   desc "Displays Final Cut Pro X libraries"
   homepage "https://www.arcticwhiteness.com/finalcutlibrarymanager/"
 
-  livecheck do
-    url "https://www.arcticwhiteness.com/finalcutlibrarymanager/download/"
-    regex(/href=.*?FinalCutLibraryManager[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
-  end
+  deprecate! date: "2024-04-03", because: :discontinued
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
See: https://blog.hedge.video/a-new-home-for-final-cut-library-manager/

The previous download is still available for now, so renaming may not be the best option.
We could deprecate the old instead.