### PR TITLE
schildichat: change livecheck strategy

### DIFF
--- a/Casks/s/schildichat.rb
+++ b/Casks/s/schildichat.rb
@@ -8,11 +8,7 @@ cask "schildichat" do
   desc "Matrix client based on Element with a more traditional IM experience"
   homepage "https://schildi.chat/desktop/"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+(?:-sc\.?\d+)?)$/i)
-    strategy :github_latest
-  end
+  deprecate! date: "2024-04-06", because: :discontinued
 
   app "SchildiChat.app"
 


### PR DESCRIPTION
Latest version doesn't have the macOS .dmg file and so changed the livecheck strategy to the github releases with asset checking.

(comment moved from bottom to top)

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
