### PR TITLE
samsung-magician 8.1.0.800

### DIFF
--- a/Casks/s/samsung-magician.rb
+++ b/Casks/s/samsung-magician.rb
@@ -1,0 +1,49 @@
+cask "samsung-magician" do
+  version "8.1.0.800"
+  sha256 "29a24c1d78096a682b9a541622a188cc9f84af0ed220198f13a2278bba5ff568"
+
+  url "https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_Installer_Official_#{version}.pkg"
+  name "Samsung Magician"
+  desc "Manages Samsung memory products (portable SSDs, memory cards, USB flash drives)"
+  homepage "https://semiconductor.samsung.com/consumer-storage/support/tools/"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?Samsung[._-]Magician[._-]Installer[._-]Official[._-](\d+(?:\.\d+)+)\.pkg/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  pkg "Samsung_Magician_Installer_Official_#{version}.pkg"
+
+  uninstall launchctl: [
+              "com.samsung.magicianapp",
+              "com.samsung.magiciansvc",
+            ],
+            signal:    [
+              ["QUIT", "com.samsung.magician.8.0"],
+              ["TERM", "com.samsung.magiciansvc"],
+            ],
+            kext:      [
+              "com.samsung.magicianpssd.driver",
+              "com.samsung.magicianpssd.driverx",
+            ],
+            pkgutil:   [
+              "com.samsung.magician.svc",
+              "com.samsung.magicianpssduniversal.driverpkg",
+              "com.samsung.magicianpssduniversal.driverXpkg",
+            ],
+            delete:    [
+              "/Applications/SamsungMagician.app",
+              "~/Desktop/SamsungMagician.app",
+              "~/Library/Application Support/Samsung/Samsung Magician",
+            ]
+
+  zap trash: "~/Library/Application Support/Samsung Magician"
+
+  caveats do
+    reboot
+    kext
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Hello,

As this is my first contribution, there probably are improvements I need to make, don't hesitate to tell me!

I tried to follow the https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request guide as best I could, but the `brew test <CHANGED_FORMULA|CHANGED_CASK>` command on step 5 returned an `Error: No available formula with the name "samsung-magician"`, and I could not find a modifier for casks. I guess it's only used for formulae.

Important notice : the pkg install process spawns 3 popups, I don't know if I should automate the responses, especially the first one given the question (relative to the user location). And I don't know if the `pkg choices` stanza would work, given that I did not find the related strings with the `installer -showChoicesXML` command.

For the cask :
- I don't know if the description is short enough, I considered removing the part between ()
- For `auto_updates`, the software does provide an `Updates` menu, but I don't know yet if it updates itself or if it opens a web page, I'll check when they release a new version and correct if needed.
- I tried the `quit` way before `signal`, with no success, and I tried `TERM` before `QUIT` for `com.samsung.magician.8.0`.
- I voluntarily excluded a package (`com.samsung.magician.softwarepkg`) from `pkgutil` as it generated errors during uninstall.

Thanks!