### PR TITLE
aladin 12.060 fixed

### DIFF
--- a/Casks/a/aladin.rb
+++ b/Casks/a/aladin.rb
@@ -1,8 +1,10 @@
 cask "aladin" do
+  arch arm: "arm", intel: "amd"
+
   version "12.060"
   sha256 :no_check
 
-  url "https://aladin.cds.unistra.fr/java/download/Aladin.dmg"
+  url "https://aladin.cds.unistra.fr/java/Aladin.#{arch}.dmg"
   name "Aladin Desktop"
   desc "Interactive sky atlas"
   homepage "https://aladin.cds.unistra.fr/AladinDesktop/"
@@ -12,11 +14,15 @@ cask "aladin" do
     regex(%r{<h1>\s*Official\s+version\s*(?:<[^/>]*>\s*)?v?(\d+(?:\.\d+)+)}i)
   end
 
-  app "Aladin.app"
+  installer script: {
+    executable: "Aladin Sky Atlas Installer.app/Contents/MacOS/JavaApplicationStub",
+    args:       ["-q"],
+  }
+
+  uninstall script: {
+    executable: "/Applications/Aladin Sky Atlas/Aladin Sky Atlas Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+    args:       ["-q"],
+  }
 
   zap trash: "~/.aladin"
-
-  caveats do
-    depends_on_java
-  end
 end

--- a/Casks/a/aladin.rb
+++ b/Casks/a/aladin.rb
@@ -1,8 +1,10 @@
 cask "aladin" do
+  arch arm: "arm", intel: "amd"
   version "12.060"
-  sha256 :no_check
+  sha256 arm: "d196277ef3c2964d49c34f0ca4b393711470d71f67a253d7eb82674b2ca2c9c4",
+    intel: "4c03dfaebde6585b7c58cea8a442219bd387a9075ad7560028875cf0cf26b616"
 
-  url "https://aladin.cds.unistra.fr/java/download/Aladin.dmg"
+  url "https://aladin.cds.unistra.fr/java/Aladin.#{arch}.dmg"
   name "Aladin Desktop"
   desc "Interactive sky atlas"
   homepage "https://aladin.cds.unistra.fr/AladinDesktop/"
@@ -12,11 +14,18 @@ cask "aladin" do
     regex(%r{<h1>\s*Official\s+version\s*(?:<[^/>]*>\s*)?v?(\d+(?:\.\d+)+)}i)
   end
 
-  app "Aladin.app"
-
+  installer script: {
+    executable: "Aladin Sky Atlas Installer.app/Contents/MacOS/JavaApplicationStub",
+    args: ["-q"], # install4j, Unattended mode
+    }
+  uninstall script: {
+    executable: "/Applications/Aladin Sky Atlas/Aladin Sky Atlas Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+    args: ["-q"],
+    }
   zap trash: "~/.aladin"
 
-  caveats do
-    depends_on_java
-  end
+  # Aladin 12 has a built-in jre
+  # caveats do
+    # depends_on_java
+  # end
 end

--- a/Casks/a/aladin.rb
+++ b/Casks/a/aladin.rb
@@ -1,10 +1,8 @@
 cask "aladin" do
-  arch arm: "arm", intel: "amd"
-
   version "12.060"
   sha256 :no_check
 
-  url "https://aladin.cds.unistra.fr/java/Aladin.#{arch}.dmg"
+  url "https://aladin.cds.unistra.fr/java/download/Aladin.dmg"
   name "Aladin Desktop"
   desc "Interactive sky atlas"
   homepage "https://aladin.cds.unistra.fr/AladinDesktop/"
@@ -14,20 +12,11 @@ cask "aladin" do
     regex(%r{<h1>\s*Official\s+version\s*(?:<[^/>]*>\s*)?v?(\d+(?:\.\d+)+)}i)
   end
 
-  installer script: {
-    executable: "Aladin Sky Atlas Installer.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"], # install4j, Unattended mode
-  }
-
-  uninstall script: {
-    executable: "/Applications/Aladin Sky Atlas/Aladin Sky Atlas Uninstaller.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"],
-  }
+  app "Aladin.app"
 
   zap trash: "~/.aladin"
 
-  # Aladin 12 has a built-in jre
-  # caveats do
-  # depends_on_java
-  # end
+  caveats do
+    depends_on_java
+  end
 end

--- a/Casks/a/aladin.rb
+++ b/Casks/a/aladin.rb
@@ -2,8 +2,7 @@ cask "aladin" do
   arch arm: "arm", intel: "amd"
 
   version "12.060"
-  sha256 arm:   "d196277ef3c2964d49c34f0ca4b393711470d71f67a253d7eb82674b2ca2c9c4",
-         intel: "4c03dfaebde6585b7c58cea8a442219bd387a9075ad7560028875cf0cf26b616"
+  sha256 :no_check
 
   url "https://aladin.cds.unistra.fr/java/Aladin.#{arch}.dmg"
   name "Aladin Desktop"

--- a/Casks/a/aladin.rb
+++ b/Casks/a/aladin.rb
@@ -1,8 +1,9 @@
 cask "aladin" do
   arch arm: "arm", intel: "amd"
+
   version "12.060"
-  sha256 arm: "d196277ef3c2964d49c34f0ca4b393711470d71f67a253d7eb82674b2ca2c9c4",
-    intel: "4c03dfaebde6585b7c58cea8a442219bd387a9075ad7560028875cf0cf26b616"
+  sha256 arm:   "d196277ef3c2964d49c34f0ca4b393711470d71f67a253d7eb82674b2ca2c9c4",
+         intel: "4c03dfaebde6585b7c58cea8a442219bd387a9075ad7560028875cf0cf26b616"
 
   url "https://aladin.cds.unistra.fr/java/Aladin.#{arch}.dmg"
   name "Aladin Desktop"
@@ -16,16 +17,18 @@ cask "aladin" do
 
   installer script: {
     executable: "Aladin Sky Atlas Installer.app/Contents/MacOS/JavaApplicationStub",
-    args: ["-q"], # install4j, Unattended mode
-    }
+    args:       ["-q"], # install4j, Unattended mode
+  }
+
   uninstall script: {
     executable: "/Applications/Aladin Sky Atlas/Aladin Sky Atlas Uninstaller.app/Contents/MacOS/JavaApplicationStub",
-    args: ["-q"],
-    }
+    args:       ["-q"],
+  }
+
   zap trash: "~/.aladin"
 
   # Aladin 12 has a built-in jre
   # caveats do
-    # depends_on_java
+  # depends_on_java
   # end
 end


### PR DESCRIPTION
The URL in the previous cask is actually an outdated version which is ~11.0.
The latest version 12 is provided by specific amd64 and arm architecture.
Furthermore, the dmg packages are distributed with Java runtime in it.
It also contains an installer in the dmg tarball.


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
