### PR TITLE
stellarium: update minimum system requirements

### DIFF
--- a/Casks/s/stellarium.rb
+++ b/Casks/s/stellarium.rb
@@ -1,21 +1,62 @@
 cask "stellarium" do
-  version "24.1"
-  sha256 "ca0fa67fb193d4c7aa5bd1f51840a4d40b3637c009ad228d9108664aa36a7776"
+  on_high_sierra :or_older do
+    version "0.22.2"
+    sha256 "5e8c2ee315f8c00a393e7bd22461f9b48355538cec39e1bb771e92a5795bcfb4"
 
-  url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt6-macOS.zip",
-      verified: "github.com/Stellarium/stellarium/"
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version}/Stellarium-#{version}-x86_64.zip",
+        verified: "github.com/Stellarium/stellarium/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_mojave do
+    version "24.1"
+    sha256 "64174eac7608146397ba1d3bbafbcc005e3d8f863590db87c4cdd31abdd7cd01"
+
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
+        verified: "github.com/Stellarium/stellarium/"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
+  on_catalina do
+    version "24.1"
+    sha256 "64174eac7608146397ba1d3bbafbcc005e3d8f863590db87c4cdd31abdd7cd01"
+
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
+        verified: "github.com/Stellarium/stellarium/"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
+  on_big_sur :or_newer do
+    version "24.1"
+    sha256 "ca0fa67fb193d4c7aa5bd1f51840a4d40b3637c009ad228d9108664aa36a7776"
+
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt6-macOS.zip",
+        verified: "github.com/Stellarium/stellarium/"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
+
   name "Stellarium"
   desc "Tool to render realistic skies in real time on the screen"
   homepage "https://stellarium.org/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sierra"
 
   app "Stellarium.app"
 
-  zap trash: "~/Library/Preferences/Stellarium"
+  zap trash: [
+    "~/Library/Application Support/Stellarium",
+    "~/Library/Preferences/Stellarium",
+  ]
 end


### PR DESCRIPTION
The minimum system requirement of the latest version is not Big sur, but Mojave.
Reference [release note](https://github.com/Stellarium/stellarium/releases/latest).
There are two built packages, the one with qt6 is at least Big sur, and the qt5 one supports more old macOS.
And add a legacy version to support down to Sierra.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
