### PR TITLE
Update btp.rb to new EULA version cookie

### DIFF
--- a/Casks/b/btp.rb
+++ b/Casks/b/btp.rb
@@ -7,7 +7,7 @@ cask "btp" do
 
   url "https://tools.hana.ondemand.com/additional/btp-cli-darwin-#{arch}-#{version}.tar.gz",
       cookies: {
-        "eula_3_1_agreed" => "tools.hana.ondemand.com/developer-license-3_1.txt",
+        "eula_3_2_agreed" => "tools.hana.ondemand.com/developer-license-3_2.txt",
       }
   name "SAP Business Technology Platform Command Line Interface"
   desc "CLI for the SAP Business Technology Platform"
@@ -23,6 +23,6 @@ cask "btp" do
   # No zap stanza required
 
   caveats do
-    license "https://tools.hana.ondemand.com/developer-license-3_1.txt"
+    license "https://tools.hana.ondemand.com/developer-license-3_2.txt"
   end
 end


### PR DESCRIPTION
https://tools.hana.ondemand.com/#cloud-btpcli has updated the license version for all downloads from 3.1 (https://tools.hana.ondemand.com/developer-license-3_1.txt) to 3.2 (https://tools.hana.ondemand.com/developer-license-3_2.txt). The new cookie name and value is required to restore updates

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
