### PR TITLE
spotify: update uninstall

### DIFF
--- a/Casks/s/spotify.rb
+++ b/Casks/s/spotify.rb
@@ -31,7 +31,10 @@ cask "spotify" do
 
   app "Spotify.app"
 
-  uninstall launchctl: "com.spotify.webhelper",
+  uninstall launchctl: [
+              "com.spotify.client.startuphelper",
+              "com.spotify.webhelper",
+            ],
             quit:      "com.spotify.client"
 
   zap trash: [


### PR DESCRIPTION
The PR updates the uninstall stanza for Spotify, and (hopefully) fixes #161665. 

After doing more digging, it seems like the Gatekeeper issue stems from the Startup Helper used by Spotify. Coincidentally, uninstalling Spotify leaves `com.spotify.client.startuphelper` stranded. I assume that gets initialized only after the application launches, which is why we're not catching it in CI. 

Since the codesigning issue can be a bit challenging to replicate, I am unable to verify that this is a definitive fix. However, this should help narrow down the possibilities.

```log
AUTHREQ_ATTRIBUTION: msgID=499.80, attribution={accessing={TCCDProcess: identifier=com.spotify.client.startuphelper, pid=3517, auid=501, euid=501, binary_path=/Applications/Spotify.app/Contents/Library/LoginItems/StartUpHelper.app/Contents/MacOS/StartUpHelper}, requesting={TCCDProcess: identifier=com.apple.syspolicyd, pid=499, auid=0, euid=0, binary_path=/usr/libexec/syspolicyd}, },
default	11:18:51.637489-0400	
kernel	ASP: Security policy would not allow process: 3517, /Applications/Spotify.app/Contents/Library/LoginItems/StartUpHelper.app/Contents/MacOS/StartUpHelper
```