### PR TITLE
videofusion 5.7.0, update livecheck source

### DIFF
--- a/Casks/v/videofusion.rb
+++ b/Casks/v/videofusion.rb
@@ -1,19 +1,23 @@
 cask "videofusion" do
-  version "5.5.0.9965"
-  sha256 "c6574eff0ded13b9498ea682c86967a3c28ee9f3525c68cb38a1c0a46cc3cacf"
+  version "5.7.0.10096"
+  sha256 "ac29972426f7fd078786015e671e583b3c651012e0451bf806a946a6e6e288a7"
 
   url "https://lf3-package.vlabstatic.com/obj/faceu-packages/Jianying_#{version.dots_to_underscores}_jianyingpro_0_creatortool.dmg",
       verified: "lf3-package.vlabstatic.com/obj/faceu-packages/"
   name "VideoFusion"
   name "剪映专业版"
-  desc "Video editor"
-  homepage "https://lv.ulikecam.com/"
+  name "Jianying Pro"
+  desc "Free all-in-one video editor"
+  homepage "https://www.capcut.cn/"
 
   livecheck do
-    url "https://lf3-beecdn.bytetos.com/obj/ies-fe-bee/bee_prod/biz_80/bee_prod_80_bee_publish_3563.json"
-    regex(/Jianying[._-]v?(\d+(?:[._]\d+)+).*\.dmg/i)
+    url "https://lv-api-hl.ulikecam.com/service/settings/v3/?&aid=3704&rom_version=9965&version_code=328960&channel=jianyingpro_0&device_platform=mac"
+    regex(/Jianying[._-]v?(\d+(?:[._]\d+)+).+?\.dmg/i)
     strategy :json do |json, regex|
-      match = json.dig("mac_download_pkg", "channel_default")&.match(regex)
+      url = json.dig("data", "settings", "update_reminder", "lastest_stable_url")
+      next if url.blank?
+
+      match = url.match(regex)
       next if match.blank?
 
       match[1].tr("_", ".")


### PR DESCRIPTION
The livecheck source is updated, and the syntax is referenced from Cask [Capcut](Casks/c/capcut.rb).
The old checklive URL seems not keep updating.
The homepage URL is deprecated, it will redirect to the one in PR.

***BTW***: I recommend changing this cask from 'videofusion' to 'jianying' in future,  because this software is concentrated in the Chinese market (Capcut is the international version). The users are almost in Chinese cultural sphere. The initial name 'videofusion' is only used in the package name now, 'JianYing (剪映)' is the official name. Majority of jianying's users don't know videofusion is equal to jianying.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
