### PR TITLE
deepl: downgrade to 24.1.1725245

### DIFF
--- a/Casks/d/deepl.rb
+++ b/Casks/d/deepl.rb
@@ -13,8 +13,8 @@ cask "deepl" do
     end
   end
   on_big_sur :or_newer do
-    version "24.1.2756848"
-    sha256 "ca6dc9700e4134925c0e3d74cddbc1b63e80b2e4edb3be5273fca1059236d8ad"
+    version "24.1.1725245"
+    sha256 "ca6f32ffb0ed78d806aa5c89fcb737c97115349ff9595796f09d29d4cefa4405"
 
     url "https://www.deepl.com/macos/download/#{version.major_minor}/#{version.patch}/DeepL_#{version}.tar.gz"
 


### PR DESCRIPTION
Checked the livecheck url and noticed that the version is retracted but don't know why.

----

Reverts Homebrew/homebrew-cask#166774