### PR TITLE
securid: disabled by login requirements

### DIFF
--- a/Casks/s/securid.rb
+++ b/Casks/s/securid.rb
@@ -7,10 +7,7 @@ cask "securid" do
   desc "Authentication software"
   homepage "https://community.rsa.com/t5/securid-software-token-for-macos/tkb-p/securid-software-token-macos"
 
-  livecheck do
-    url :homepage
-    regex(/SecurID\s*Software\s*Token\s*(\d+(?:\.\d+)*)\s*for\s*macOS/i)
-  end
+  disable! date: "2024-04-09", because: :no_longer_meets_criteria
 
   container nested: "RSASecurIDMac#{version.no_dots}.dmg"
 


### PR DESCRIPTION
Both download and livecheck url are not accessible by login process.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
