### PR TITLE
samsung-portable-ssd-t7: livecheck regex update

### DIFF
--- a/Casks/s/samsung-portable-ssd-t7.rb
+++ b/Casks/s/samsung-portable-ssd-t7.rb
@@ -9,7 +9,7 @@ cask "samsung-portable-ssd-t7" do
 
   livecheck do
     url :homepage
-    regex(/SamsungPortableSSD[._-]Setup[._-]Mac[._-]v?(\d+(?:\.\d+)+)\.zip.*\n*\s*.*Version\sv?(\d+(?:\.\d+)+)/i)
+    regex(/SamsungPortableSSD[._-]Setup[._-]Mac[._-]v?(\d+(?:\.\d+)+)[._-]v?(\d+(?:\.\d+)+)/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end


### PR DESCRIPTION
Livecheck regex changed.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
