### PR TITLE
brightintosh: deprecate

### DIFF
--- a/Casks/b/brightintosh.rb
+++ b/Casks/b/brightintosh.rb
@@ -7,10 +7,7 @@ cask "brightintosh" do
   desc "Utility that allows increased screen brightness"
   homepage "https://www.brightintosh.de/"
 
-  livecheck do
-    url "https://c.brightintosh.de/updates/appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2024-04-11", because: :moved_to_mas
 
   depends_on macos: ">= :monterey"
   depends_on arch: :arm64


### PR DESCRIPTION
Removes the `brightintosh` cask because I can no longer provide the prebuilt application at this time.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
