### PR TITLE
mutedeck: set auto_updates to true

### DIFF
--- a/Casks/m/mutedeck.rb
+++ b/Casks/m/mutedeck.rb
@@ -14,6 +14,7 @@ cask "mutedeck" do
     regex(/<title>\s*v?(\d+(?:\.\d+)+)[ <"]/i)
   end
 
+  auto_updates true
   depends_on macos: ">= :big_sur"
 
   installer manual: "MuteDeck-#{version}-Installer.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

As this cask auto updates, setting the `auto_updates` flag to true to avoid errors when the cask version bumps
