### PR TITLE
sc-menu 1.3 (new cask)

### DIFF
--- a/Casks/s/sc-menu.rb
+++ b/Casks/s/sc-menu.rb
@@ -1,0 +1,23 @@
+cask "sc-menu" do
+  version "1.3"
+  sha256 "7d79f053558113cf67cebfde36e5888c048751beb871619daa3450ebb8087265"
+
+  url "https://github.com/boberito/sc_menu/releases/download/#{version}/SC_Menu.dmg"
+  name "SC Menu"
+  desc "Simple smartcard menu item"
+  homepage "https://github.com/boberito/sc_menu"
+
+  livecheck do
+    url :url
+    strategy :github_releases
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "SC Menu.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.ttinc.sc-menu",
+    "~/Library/Containers/com.ttinc.sc-menu",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [-] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Note: This is a new application (released last month) and so doesn't yet meet the "notability" threshold as identified in the `brew audit --cask --new` check, but I think that with the aid of being available in Homebrew, it will grow in prominence fairly quickly. The tool is incredibly helpful for users of Smartcards (also known as PIV or CAC cards). It's already gotten some traction in the Mac Admins Slack workspace's #smartcards channel, as well as among colleagues in my organization that I've shared it with. I think this will enjoy popularity from users in government and industries that use smartcards. 

Would there be a way to consider it?