### PR TITLE
dexed: add livecheck to avoid pre-release

### DIFF
--- a/Casks/d/dexed.rb
+++ b/Casks/d/dexed.rb
@@ -8,6 +8,11 @@ cask "dexed" do
   desc "DX7 FM synthesiser"
   homepage "https://asb2m10.github.io/dexed/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   pkg "dexed-#{version}.mpkg"
 
   uninstall pkgutil: [


### PR DESCRIPTION
There is nightly release and so add the livecheck to avoid that.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
