### PR TITLE
topaz-video-ai: fix `livecheck`, bump version

### DIFF
--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -7,7 +7,8 @@ cask "topaz-video-ai" do
   desc "Video upscaler and quality enhancer"
   homepage "https://www.topazlabs.com/topaz-video-ai"
 
-  # The version for some releases is missing the last digit, so we add ".0" to the end in these cases
+  # The version for some releases is missing the last digit, so we add ".0"
+  # to the end in these cases
   livecheck do
     url "https://community.topazlabs.com/c/video-ai/video-ai-releases/69"
     regex(/>Topaz\sVideo\sAI\sv?(\d+(?:\.\d+)+)\s*</i)

--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -13,7 +13,7 @@ cask "topaz-video-ai" do
     regex(/>Topaz\sVideo\sAI\sv?(\d+(?:\.\d+)+)\s*</i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
-        version = match.first
+        version = match[0]
         next version if version.split(".").length >= 3
 
         "#{version}.0"

--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -1,15 +1,24 @@
 cask "topaz-video-ai" do
-  version "4.2.2"
-  sha256 "7acfe62de9d8a467833de68ef2f8c5f27973d4311ff1b447175e33adccfeb6b1"
+  version "5.0.0"
+  sha256 "a3f44986efad9cdef0d96fd202331b3c20b8e144f37b32ac78a0a3a9471e7871"
 
   url "https://downloads.topazlabs.com/deploy/TopazVideoAI/#{version}/TopazVideoAI-#{version}.dmg"
   name "Topaz Video AI"
   desc "Video upscaler and quality enhancer"
   homepage "https://www.topazlabs.com/topaz-video-ai"
 
+  # The version for some releases is missing the last digit, so we add ".0" to the end in these cases
   livecheck do
     url "https://community.topazlabs.com/c/video-ai/video-ai-releases/69"
     regex(/>Topaz\sVideo\sAI\sv?(\d+(?:\.\d+)+)\s*</i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        version = match.first
+        next version if version.split(".").length >= 3
+
+        "#{version}.0"
+      end
+    end
   end
 
   app "Topaz Video AI.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The version as listed in the releases page was missing a `.0`, so add it when there is only a major minor version provided.
The alternative would be to follow the link to the "post", and then collect the version from the binary.