### PR TITLE
elk: deprecate because of inactive maintenance

### DIFF
--- a/Casks/e/elk.rb
+++ b/Casks/e/elk.rb
@@ -10,13 +10,7 @@ cask "elk" do
   desc "Mastodon web client"
   homepage "https://github.com/elk-zone/elk-native"
 
-  livecheck do
-    url :url
-    regex(/elk[._-]native[._-]v?(\d+(?:\.\d+)+)/i)
-    strategy :github_latest
-  end
-
-  deprecate! date: "2024-04-11", because: "is no longer maintained. It's recommended to use Elk as a PWA instead"
+  deprecate! date: "2024-04-11", because: :unmaintained
 
   app "Elk.app"
 

--- a/Casks/e/elk.rb
+++ b/Casks/e/elk.rb
@@ -10,6 +10,8 @@ cask "elk" do
   desc "Mastodon web client"
   homepage "https://github.com/elk-zone/elk-native"
 
+  deprecate! date: "2024-04-11", because: "is no longer maintained. It's recommended to use Elk as a PWA instead"
+
   livecheck do
     url :url
     regex(/elk[._-]native[._-]v?(\d+(?:\.\d+)+)/i)

--- a/Casks/e/elk.rb
+++ b/Casks/e/elk.rb
@@ -10,13 +10,13 @@ cask "elk" do
   desc "Mastodon web client"
   homepage "https://github.com/elk-zone/elk-native"
 
-  deprecate! date: "2024-04-11", because: "is no longer maintained. It's recommended to use Elk as a PWA instead"
-
   livecheck do
     url :url
     regex(/elk[._-]native[._-]v?(\d+(?:\.\d+)+)/i)
     strategy :github_latest
   end
+
+  deprecate! date: "2024-04-11", because: "is no longer maintained. It's recommended to use Elk as a PWA instead"
 
   app "Elk.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Elk (native version) is no longer actively developed and the team is now recommended to use Elk (PWA version is still actively developed and maintained). See https://github.com/Homebrew/homebrew-cask/pull/171057 for reference.