### PR TITLE
josm: Use Java 21 package

### DIFF
--- a/Casks/j/josm.rb
+++ b/Casks/j/josm.rb
@@ -1,8 +1,8 @@
 cask "josm" do
   version "19039"
-  sha256 "57cf9452ee257f713e0d1e47e911e6e877b4306f4232f9ee629fa6794dfe014a"
+  sha256 "c80f907fbe8c6e8ba22dd1fda35462f29b5b1bbd18668235de9040f4a8bad7fd"
 
-  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java17-#{version}.zip",
+  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java21-#{version}.zip",
       verified: "github.com/JOSM/josm/"
   name "JOSM"
   desc "Extensible editor for OpenStreetMap"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

As a stupid question, would it be possible to use downloads from the JOSM website so I don't have to remember to update the Java version here next time we bump the version in the installers we distribute on our main page?

The download on our main site for macOS is https://josm.openstreetmap.de/download/macosx/josm-macosx.zip, FTR.