### PR TITLE
astropad: deprecate

### DIFF
--- a/Casks/a/astropad.rb
+++ b/Casks/a/astropad.rb
@@ -7,10 +7,7 @@ cask "astropad" do
   desc "Utility to turn an iPad into a drawing tablet"
   homepage "https://astropad.com/"
 
-  livecheck do
-    url "https://s3.amazonaws.com/astropad.com/downloads/sparkle.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2024-04-11", because: :discontinued
 
   app "Astropad.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
<img width="1424" alt="astropad-discontinued" src="https://github.com/Homebrew/homebrew-cask/assets/39449589/97ae585c-6c93-4e11-990e-c5111b135204">

