### PR TITLE
airfoil 5.12.1

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -1,5 +1,5 @@
 cask "airfoil" do
-  version "5.11.8"
+  version "5.12.1"
   sha256 :no_check
 
   url "https://rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
@@ -8,12 +8,12 @@ cask "airfoil" do
   homepage "https://rogueamoeba.com/airfoil/mac/"
 
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.airfoil&platform=osx"
     strategy :sparkle
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sonoma"
 
   app "Airfoil/Airfoil Satellite.app"
   app "Airfoil/Airfoil.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `airfoil` to the latest stable version, 5.12.1.

This also modifies the `livecheck` block URL, as the existing approach was causing the latest version to be omitted from the appcast. The `system` and `version` values restrict what versions appear in the appcast and the current combination makes the appcast return 5.11.8 as the latest version. [For what it's worth, the `system` value is `1441` and the `version` value is `5C0800` on macOS 14.4.1 running Airfoil 5.11.8.] The appcast includes 5.12.1 if the `system` and `version` values are omitted but I'm not sure whether this is an appropriate approach in the long run.

It's also worth mentioning that [Airfoil 15.12.0+ requires macOS 14.4 or higher](https://rogueamoeba.com/support/knowledgebase/releasenotes/?product=Airfoil+for+Mac) but I don't think we have a way of handling that beyond a Sonoma requirement. macOS 11 to 14.3.1 uses 5.11.8 and I'm not sure whether there will be further updates there. The situation is the same for Audio Hijack 4.4.0 (vs. 4.3.3) and Piezo 1.9.1 (vs. 1.8.2), so I'll create follow-up PRs for those as well.