### PR TITLE
audio-hijack 4.4.0

### DIFF
--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -1,5 +1,5 @@
 cask "audio-hijack" do
-  version "4.3.3"
+  version "4.4.0"
   sha256 :no_check
 
   url "https://rogueamoeba.com/audiohijack/download/AudioHijack.zip"
@@ -7,9 +7,15 @@ cask "audio-hijack" do
   desc "Records audio from any application"
   homepage "https://rogueamoeba.com/audiohijack/"
 
+  # The Sparkle feed contents varies based on the provided [macOS] `system`
+  # value (e.g., 1441 for 14.4.1) and we only receive an older version if we
+  # omit it. If we use a hardcoded `system` value, eventually the `livecheck`
+  # block can get stuck on an older version until the `system` value is updated
+  # to a newer macOS version. To avoid this, we simply check the versions listed
+  # on the related Support Center page.
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
+    url "https://rogueamoeba.com/support/knowledgebase/?showCategory=Audio+Hijack"
+    regex(/Audio\s+Hijack\s+v?(\d+(?:\.\d+)+)/im)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `audio-hijack` to the latest version, 4.4.0.

This also updates the `livecheck` block to check the Support Page instead of the Sparkle feed. The Sparkle feed only returns the latest version when an appropriate `system` value is provided but we're using an old version that 4.4.0 doesn't support. Omitting the `system` value returns 4.0.4 instead of 4.4.0, so we can't do that. If we use a hardcoded `1441` value (for macOS 14.4.1), we will eventually end up in a situation again where livecheck will always return an older version until we update the `system` value, so that isn't a sustainable approach.

Our options seem to be to check either the Support Center (https://rogueamoeba.com/support/knowledgebase/?showCategory=Audio+Hijack) or the Release Notes
(https://rogueamoeba.com/support/knowledgebase/releasenotes/?product=Audio+Hijack) page. The Release Notes are more complete but the download size will grow with each new release, so I've opted for the Support Center page. This isn't ideal but it works and isn't tied to a specific macOS version. If we go with this approach, I'll create a follow-up PR to bring the other Rogue Amoeba checks in line.

Past that, 4.4.0 requires macOS 14.4 or higher but they haven't updated the application to require Sonoma, so we can't update this to `depends_on macos: ">= :sonoma"`.