### PR TITLE
piezo 1.9.1

### DIFF
--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -1,5 +1,5 @@
 cask "piezo" do
-  version "1.8.2"
+  version "1.9.1"
   sha256 :no_check
 
   url "https://rogueamoeba.com/piezo/download/Piezo.zip"
@@ -7,9 +7,15 @@ cask "piezo" do
   desc "Audio recording application"
   homepage "https://rogueamoeba.com/piezo/"
 
+  # The Sparkle feed contents varies based on the provided [macOS] `system`
+  # value (e.g., 1441 for 14.4.1) and we only receive an older version if we
+  # omit it. If we use a hardcoded `system` value, eventually the `livecheck`
+  # block can get stuck on an older version until the `system` value is updated
+  # to a newer macOS version. To avoid this, we simply check the versions listed
+  # on the related Support Center page.
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
+    url "https://rogueamoeba.com/support/knowledgebase/?showCategory=Piezo"
+    regex(/Piezo\s+v?(\d+(?:\.\d+)+)/im)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `piezo` to the latest version, 1.9.1.

This also updates the `livecheck` block to check the Support Page instead of the Sparkle feed. The Sparkle feed only returns the latest version when an appropriate `system` value is provided but we're using an old version that 1.9.1 doesn't support. Omitting the `system` value returns 1.2.2 instead of 1.9.1, so we can't do that. If we use a hardcoded `1441` value (for macOS 14.4.1), we will eventually end up in a situation again where livecheck will always return an older version until we update the `system` value, so that isn't a sustainable approach.

Our options seem to be to check either the Support Center (https://rogueamoeba.com/support/knowledgebase/?showCategory=Piezo) or the Release Notes
(https://rogueamoeba.com/support/knowledgebase/releasenotes/?product=Piezo) page. The Release Notes are more complete but the download size will grow with each new release, so I've opted for the Support Center page. As with `audio-hijack`, this isn't ideal but it works and isn't tied to a specific macOS version.

Past that, 1.9.1 requires macOS 14.4 or higher but they haven't updated the application to require Sonoma, so we can't update this to depends_on macos: ">= :sonoma".