### PR TITLE
airfoil 5.12.1, audio-hijack 4.4.0

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -1,19 +1,40 @@
 cask "airfoil" do
-  version "5.12.1"
   sha256 :no_check
 
-  url "https://rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
+  on_ventura :or_older do
+    version "5.11.8"
+
+    url "https://rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
+
+    # NOTE: The `system` value will need to be kept up to date with the latest
+    # macOS Ventura version (e.g. 1366 for 13.6.6).
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1366&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :big_sur"
+  end
+  on_sonoma :or_newer do
+    version "5.12.1"
+
+    url "https://rogueamoeba.com/airfoil/mac/download/Airfoil-ARK.zip"
+
+    # NOTE: The `system` value will need to be kept up to date with the latest
+    # macOS version (e.g. 1441 for 14.4.1).
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :sonoma"
+  end
+
   name "Airfoil"
   desc "Sends audio from computer to outputs"
   homepage "https://rogueamoeba.com/airfoil/mac/"
 
-  livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&bundleid=com.rogueamoeba.airfoil&platform=osx"
-    strategy :sparkle
-  end
-
   auto_updates true
-  depends_on macos: ">= :sonoma"
 
   app "Airfoil/Airfoil Satellite.app"
   app "Airfoil/Airfoil.app"

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -1,25 +1,40 @@
 cask "audio-hijack" do
-  version "4.4.0"
   sha256 :no_check
 
-  url "https://rogueamoeba.com/audiohijack/download/AudioHijack.zip"
+  on_ventura :or_older do
+    version "4.3.3"
+
+    url "https://rogueamoeba.com/audiohijack/download/AudioHijack.zip"
+
+    # NOTE: The `system` value will need to be kept up to date with the latest
+    # macOS Ventura version (e.g. 1366 for 13.6.6).
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1366&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :big_sur"
+  end
+  on_sonoma :or_newer do
+    version "4.4.0"
+
+    url "https://rogueamoeba.com/audiohijack/download/AudioHijack-ARK.zip"
+
+    # NOTE: The `system` value will need to be kept up to date with the latest
+    # macOS version (e.g. 1441 for 14.4.1).
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
+    depends_on macos: ">= :sonoma"
+  end
+
   name "Audio Hijack"
   desc "Records audio from any application"
   homepage "https://rogueamoeba.com/audiohijack/"
 
-  # The Sparkle feed contents varies based on the provided [macOS] `system`
-  # value (e.g., 1441 for 14.4.1) and we only receive an older version if we
-  # omit it. If we use a hardcoded `system` value, eventually the `livecheck`
-  # block can get stuck on an older version until the `system` value is updated
-  # to a newer macOS version. To avoid this, we simply check the versions listed
-  # on the related Support Center page.
-  livecheck do
-    url "https://rogueamoeba.com/support/knowledgebase/?showCategory=Audio+Hijack"
-    regex(/Audio\s+Hijack\s+v?(\d+(?:\.\d+)+)/im)
-  end
-
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "Audio Hijack.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This reworks the recent `airfoil` 5.12.1 and `audio-hijack` 4.4.0 updates to use the new `-ARK.zip` files. For example, `Airfoil.zip` is for the older 5.11.8 version whereas 5.12.1 is `Airfoil-ARK.zip` (I overlooked this before). This is why the `audio-hijack` 4.4.0 update didn't properly report the required macOS version (i.e., it was still the 4.3.3 app, which only requires Big Sur).

This also reverts the `livecheck` blocks to the `Sparkle` approach, since we need to gate the check to specific macOS versions and trying to accomplish that by parsing the Support Center page may be too challenging/unreliable. The `system` value in the `Sparkle` feed URLs will need to be updated periodically, of course. We could try using `MacOS.full_version.to_s.tr(".", "")` instead but I'm not sure if there would be any issues with this multiple-version setup.

If this seems reasonable, I'll update the open `piezo` PR to use a similar approach.