### PR TITLE
Update Rogue Amoeba livecheck blocks

### DIFF
--- a/Casks/f/farrago.rb
+++ b/Casks/f/farrago.rb
@@ -7,8 +7,10 @@ cask "farrago" do
   desc "Audio playback"
   homepage "https://rogueamoeba.com/farrago/"
 
+  # NOTE: The `system` value will need to be kept up to date with the latest
+  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.farrago&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.farrago&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 

--- a/Casks/f/fission.rb
+++ b/Casks/f/fission.rb
@@ -7,8 +7,10 @@ cask "fission" do
   desc "Audio editor"
   homepage "https://rogueamoeba.com/fission/"
 
+  # NOTE: The `system` value will need to be kept up to date with the latest
+  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.fission&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.fission&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -7,8 +7,10 @@ cask "loopback" do
   desc "Cable-free audio router"
   homepage "https://rogueamoeba.com/loopback/"
 
+  # NOTE: The `system` value will need to be kept up to date with the latest
+  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -7,8 +7,10 @@ cask "soundsource" do
   desc "Sound and audio controller"
   homepage "https://rogueamoeba.com/soundsource/"
 
+  # NOTE: The `system` value will need to be kept up to date with the latest
+  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1231&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` blocks for some Rogue Amoeba casks (`farrago`, `fission`, `loopback`, `soundsource`) use an older [macOS] `system` value and this may eventually cause the check to quietly stop returning the latest version. This recently happened with `airfoil`, `audio-hijack`, and `piezo`. This happened because there are now two versions of each: a newer version that requires macOS 14.4+ and an older version that supports older macOS versions.

This PR updates the `system` value in the aforementioned casks to use `1441` (for macOS 14.4.1), which is the latest macOS version at the moment. This will help to ensure that we continue to surface the latest version even if these applications get the same treatment as the others (i.e., a newer 14.4+ variant alongside an older version).