### PR TITLE
eudic: switch to `version :latest`

### DIFF
--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -1,5 +1,5 @@
 cask "eudic" do
-  version "4.6.0"
+  version :latest
   sha256 :no_check
 
   url "https://static.eudic.net/pkg/eudicmac.dmg",
@@ -8,11 +8,6 @@ cask "eudic" do
   name "欧路词典"
   desc "European dictionary"
   homepage "https://www.eudic.net/v4/en/app/eudic"
-
-  livecheck do
-    url "https://static.eudic.net/pkg/eudic_mac.xml"
-    strategy :sparkle, &:short_version
-  end
 
   auto_updates true
   depends_on macos: ">= :high_sierra"

--- a/Casks/e/eudic.rb
+++ b/Casks/e/eudic.rb
@@ -9,7 +9,6 @@ cask "eudic" do
   desc "European dictionary"
   homepage "https://www.eudic.net/v4/en/app/eudic"
 
-  auto_updates true
   depends_on macos: ">= :high_sierra"
 
   app "Eudic.app"


### PR DESCRIPTION
The `eudic` cask is seldom in sync between the appcast and the actual version being downloaded, and seems to differ depending on the downloading location (possible CDN issues).
As this has gone on for some time, switch to use `version :latest`, as in-app updates are available here, and the binaries are unversioned anyway.