### PR TITLE
openttd: update minimum macOS version

### DIFF
--- a/Casks/o/openttd.rb
+++ b/Casks/o/openttd.rb
@@ -7,7 +7,15 @@ cask "openttd" do
       skip "Legacy version"
     end
   end
-  on_mojave :or_newer do
+  on_mojave do
+    version "13.4"
+    sha256 "085cdb35867dca1dcfb8a1748417e7ba6431551ebc33df290a4e48b244d8d376"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_catalina :or_newer do
     version "14.0"
     sha256 "1a8cc5a92a69d559c85af3bf6e31583ef7acbce2d2664b0401947024c3fd458b"
 


### PR DESCRIPTION
Minimum macOS has been [bumped to 10.15](https://github.com/OpenTTD/OpenTTD/pull/10745) due to need for C++17's `std::filesystem` support.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
