### PR TITLE
morpheus: deprecate

### DIFF
--- a/Casks/m/morpheus.rb
+++ b/Casks/m/morpheus.rb
@@ -8,7 +8,7 @@ cask "morpheus" do
   desc "Modelling environment for multi-cellular systems biology"
   homepage "https://morpheus.gitlab.io/"
 
-  deprecate! date: "2024-04-15", because: :no_longer_available
+  deprecate! date: "2024-04-15", because: :discontinued
 
   conflicts_with cask: "homebrew/cask-versions/morpheus-beta"
 

--- a/Casks/m/morpheus.rb
+++ b/Casks/m/morpheus.rb
@@ -8,10 +8,7 @@ cask "morpheus" do
   desc "Modelling environment for multi-cellular systems biology"
   homepage "https://morpheus.gitlab.io/"
 
-  livecheck do
-    url "https://imc.zih.tu-dresden.de/morpheus/packages/mac/"
-    regex(/href=.*?Morpheus[._-](\d+(?:\.\d+)*)\.dmg/i)
-  end
+  deprecate! date: "2024-04-15", because: :no_longer_available
 
   conflicts_with cask: "homebrew/cask-versions/morpheus-beta"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

`morpheus` (as of v2.3.7) has recently moved to [homebrew/core](https://github.com/Homebrew/homebrew-core/pull/162155), while `morpheus` releases are [no longer available as Cask upstream](https://morpheus.gitlab.io/faq/installation/macos/#install-homebrew) since v2.2.6 in 2021 (see [2.2.5](https://morpheus.gitlab.io/download/2.2.5/#downloads) vs. [2.2.6](https://morpheus.gitlab.io/download/2.2.6/#downloads) release info and list of [available packages](https://imc.zih.tu-dresden.de/morpheus/packages/mac/)) and should therefore be deprecated, also [in the spirit of deduplication](https://github.com/Homebrew/homebrew-cask/issues/15603).