### PR TITLE
fix: Add must_succeed: false to flox cask

### DIFF
--- a/Casks/f/flox.rb
+++ b/Casks/f/flox.rb
@@ -21,9 +21,10 @@ cask "flox" do
   pkg "flox-#{version}.#{arch}-darwin.pkg"
 
   uninstall early_script: {
-              executable: "/usr/bin/killall",
-              args:       ["-9", "pkgdb"],
-              sudo:       true,
+              executable:   "/usr/bin/killall",
+              args:         ["-9", "pkgdb"],
+              sudo:         true,
+              must_succeed: false,
             },
             launchctl:    [
               "org.nixos.darwin-store",


### PR DESCRIPTION
`brew uninstall --cask flox` fails if not done immediately following an installation. During review of
https://github.com/Homebrew/homebrew-cask/pull/170971 we saw a failure on uninstall if it happened _right_ after installation since the installation kicks off an indexing job via a process named `pkgdb`.  That is killed via `early_script` in the cask. (We tried `quit` and `signal` but neither worked). However, if you want to perform an uninstallation after the index job has completed, there is no `pkgdb` process running. This change adds `must_succeed: false` to the `early_quit` stanza, so in the event the kill doesn't match any process, the uninstallation will continue normally.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
