### PR TITLE
akiflow 2.41.107

### DIFF
--- a/Casks/a/akiflow.rb
+++ b/Casks/a/akiflow.rb
@@ -1,6 +1,6 @@
 cask "akiflow" do
-  version "2.38.9"
-  sha256 "45adb1d9cc84a778705fe5116e6f4d08772c2c42380622246c25c3eb5a5c3947"
+  version "2.41.107-9bd4a3ff"
+  sha256 "f41815589336cb8ae97d25c27962df011c1c431817651beec459bc92cb4b3be2"
 
   url "https://download.akiflow.com/builds/Akiflow-#{version}-universal.dmg"
   name "Akiflow"

--- a/Casks/a/akiflow.rb
+++ b/Casks/a/akiflow.rb
@@ -8,7 +8,8 @@ cask "akiflow" do
   homepage "https://akiflow.com/"
 
   livecheck do
-    skip "Constantly changes between download page and direct download"
+    url "https://download.akiflow.com/builds/download"
+    strategy :header_match 
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/a/akiflow.rb
+++ b/Casks/a/akiflow.rb
@@ -1,18 +1,24 @@
 cask "akiflow" do
-  version "2.41.107-9bd4a3ff"
+  version "2.41.107,9bd4a3ff"
   sha256 "f41815589336cb8ae97d25c27962df011c1c431817651beec459bc92cb4b3be2"
 
-  url "https://download.akiflow.com/builds/Akiflow-#{version}-universal.dmg"
+  url "https://download.akiflow.com/builds/Akiflow-#{version.csv.first}-#{version.csv.second}-universal.dmg"
   name "Akiflow"
-  desc "Time blocking platform to save 2 hours every day"
+  desc "Time blocking and productivity platform"
   homepage "https://akiflow.com/"
 
   livecheck do
-    url "https://download.akiflow.com/builds/download"
-    strategy :header_match 
+    url "https://akiflow.com/download/latest"
+    regex(/Akiflow[._-](\d+(?:\.\d+)+)[._-](\h+)[._-]universal\.dmg/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "Akiflow.app"
 


### PR DESCRIPTION
Bump to `2.41.107-9bd4a3ff`

The previous version was failing with 

```
audit for akiflow: failed
 - The binary URL https://download.akiflow.com/builds/Akiflow-2.38.9-universal.dmg is not reachable (HTTP status code 404)
 - download not possible: Download failed on Cask 'akiflow' with message: Download failed: https://download.akiflow.com/builds/Akiflow-2.38.9-universal.dmg
```
---
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.