### PR TITLE
Akiflow livecheck

### DIFF
--- a/Casks/a/akiflow.rb
+++ b/Casks/a/akiflow.rb
@@ -1,6 +1,6 @@
 cask "akiflow" do
-  version "2.38.9"
-  sha256 "45adb1d9cc84a778705fe5116e6f4d08772c2c42380622246c25c3eb5a5c3947"
+  version "2.41.107-9bd4a3ff"
+  sha256 "f41815589336cb8ae97d25c27962df011c1c431817651beec459bc92cb4b3be2"
 
   url "https://download.akiflow.com/builds/Akiflow-#{version}-universal.dmg"
   name "Akiflow"

--- a/Casks/a/akiflow.rb
+++ b/Casks/a/akiflow.rb
@@ -8,7 +8,8 @@ cask "akiflow" do
   homepage "https://akiflow.com/"
 
   livecheck do
-    skip "Constantly changes between download page and direct download"
+    url "https://download.akiflow.com/builds/download"
+    strategy :header_match 
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
Depends on https://github.com/Homebrew/homebrew-cask/pull/171484

This works fine except for the new hash info in the URL. I'll update this PR depending on the result of the discussion from https://github.com/Homebrew/homebrew-cask/pull/171484

```
  * Version '2.41.107-9bd4a3ff' differs from '2.41.107' retrieved by livecheck.
```

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
