### PR TITLE
redisinsight 2.48

### DIFF
--- a/Casks/r/redisinsight.rb
+++ b/Casks/r/redisinsight.rb
@@ -14,7 +14,7 @@ cask "redisinsight" do
   # GitHub releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/RedisInsight/RedisInsight"
-    strategy :github_latest
+    strategy :git
   end
 
   auto_updates true

--- a/Casks/r/redisinsight.rb
+++ b/Casks/r/redisinsight.rb
@@ -1,7 +1,7 @@
 cask "redisinsight" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.46.0"
+  version "2.48.0"
   sha256 :no_check
 
   url "https://download.redisinsight.redis.com/latest/RedisInsight-mac-#{arch}.dmg"
@@ -19,7 +19,7 @@ cask "redisinsight" do
 
   auto_updates true
 
-  app "RedisInsight.app"
+  app "Redis Insight.app"
 
   zap trash: [
     "~/Library/Preferences/org.RedisLabs.RedisInsight-V#{version.major}.plist",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Right now installation fails:

```sh
❯ brew install --cask redisinsight
==> Downloading https://download.redisinsight.redis.com/latest/RedisInsight-mac-arm64.dmg
Already downloaded: /Users/v7rulnik/Library/Caches/Homebrew/downloads/ea999d2d5931d7024288aa13e24bfcc62f238c0470d5d89406b766525a6703f8--RedisInsight-mac-arm64.dmg
Warning: No checksum defined for cask 'redisinsight', skipping verification.
==> Installing Cask redisinsight
==> Purging files for version 2.46.0 of Cask redisinsight
Error: It seems the App source '/opt/homebrew/Caskroom/redisinsight/2.46.0/RedisInsight.app' is not there.
```

Looks like redis changed the app name recently:
![image](https://github.com/Homebrew/homebrew-cask/assets/5969049/edfd01f3-a2dd-4379-9bcf-7d102282f513)

Audit fails because for some reasons latest release stands for 2.46, but in reality latest is 2.48 https://github.com/RedisInsight/RedisInsight/releases 