### PR TITLE
grammarly: deprecate/disable

### DIFF
--- a/Casks/g/grammarly.rb
+++ b/Casks/g/grammarly.rb
@@ -7,10 +7,7 @@ cask "grammarly" do
   desc "Utility to fix grammar errors and style issues in text"
   homepage "https://www.grammarly.com/"
 
-  livecheck do
-    url "https://update.grammarly.com/desktop-editor/osx"
-    regex(/GrammarlyEditor[._-]?v?(\d+(?:\.\d+)+)[._-]osx\.zip/i)
-  end
+  disable! date: "2024-04-24", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The Grammarly Editor app is being sunset in favour of the web app - https://app.grammarly.com/
It will no longer be functional after the 24th of April.
