### PR TITLE
default-folder-x: update sha256

### DIFF
--- a/Casks/d/default-folder-x.rb
+++ b/Casks/d/default-folder-x.rb
@@ -1,6 +1,6 @@
 cask "default-folder-x" do
   version "6.0.5"
-  sha256 "b929486a0e5a9370a2271b6516727f4798b5341db5e4453acfea66677d4dcc50"
+  sha256 "24e73aa2f5301ed57c5ce8e4ca1ef656db6a74b8bc261d5122fc282c627fd115"
 
   url "https://www.stclairsoft.com/download/DefaultFolderX-#{version}.dmg"
   name "Default Folder X"


### PR DESCRIPTION
It seems that the upstream update package without versioning.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
