### PR TITLE
calibre 7.9.0

### DIFF
--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -40,8 +40,8 @@ cask "calibre" do
     end
   end
   on_ventura :or_newer do
-    version "7.8.0"
-    sha256 "ba003e7a40b1fdfc8879bd750d30ee982e22444921833d9672cd783fe4cc49ee"
+    version "7.9.0"
+    sha256 "d60753b0075850a06096d95aadb959ffa7cfc1ef8218655e153d1bf4b39ab70d"
 
     livecheck do
       url "https://calibre-ebook.com/dist/osx"


### PR DESCRIPTION
Same situation as #170750, maybe calibre should leaved out from autobump or autobump workflow should be updated to macos-14?

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
