### PR TITLE
autobump: remove calibre

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -54,7 +54,6 @@ busycal
 buttercup
 c0re100-qbittorrent
 cahier
-calibre
 camtasia
 canva
 capacities


### PR DESCRIPTION
See #171800. Autobump is unreliable.