### PR TITLE
unity: update livecheck

### DIFF
--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -1,9 +1,9 @@
 cask "unity" do
   arch arm: "Arm64"
 
-  version "2023.2.18f1,1cb755715f58"
-  sha256 arm:   "bf0ef992547263bcd2ca521e11214ff65fa9acdb2f1a41ca460341e450f737e0",
-         intel: "770ae7cdb0e3859a08a7b6be168fa8c66cd118595e405c021cdb74715eb837cd"
+  version "6000.0.0b15,8008bc0c1b74"
+  sha256 arm:   "234333ac0be1ab1c6d46ffebb4bed8fdfbd76f61ef075cf3b06951b58722139a",
+         intel: "c867687c3aa2695ac2ddaaba4cf89a0161c48a26a626fd2edaba0d63fd18ed87"
 
   url "https://download.unity3d.com/download_unity/#{version.csv.second}/MacEditorInstaller#{arch}/Unity-#{version.csv.first}.pkg",
       verified: "download.unity3d.com/download_unity/"
@@ -13,7 +13,7 @@ cask "unity" do
 
   livecheck do
     url "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
-    regex(%r{/download_unity/(\h+)/MacEditorInstaller/Unity-(\d+(?:\.\d+)+[a-z]*\d*)\.pkg}i)
+    regex(%r{/download(?:_unity)?/([a-f0-9]+)/MacEditorInstaller/Unity-(\d+.\d+.\d+[a-z]*\d*).pkg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end

--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -1,9 +1,9 @@
 cask "unity" do
   arch arm: "Arm64"
 
-  version "6000.0.0b15,8008bc0c1b74"
-  sha256 arm:   "234333ac0be1ab1c6d46ffebb4bed8fdfbd76f61ef075cf3b06951b58722139a",
-         intel: "c867687c3aa2695ac2ddaaba4cf89a0161c48a26a626fd2edaba0d63fd18ed87"
+  version "2023.2.18f1,1cb755715f58"
+  sha256 arm:   "bf0ef992547263bcd2ca521e11214ff65fa9acdb2f1a41ca460341e450f737e0",
+         intel: "770ae7cdb0e3859a08a7b6be168fa8c66cd118595e405c021cdb74715eb837cd"
 
   url "https://download.unity3d.com/download_unity/#{version.csv.second}/MacEditorInstaller#{arch}/Unity-#{version.csv.first}.pkg",
       verified: "download.unity3d.com/download_unity/"
@@ -13,9 +13,14 @@ cask "unity" do
 
   livecheck do
     url "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
-    regex(%r{/download(?:_unity)?/([a-f0-9]+)/MacEditorInstaller/Unity-(\d+.\d+.\d+[a-z]*\d*).pkg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    regex(%r{/(\h+)/MacEditorInstaller/Unity[._-]v?(\d+(?:\.\d+)+[a-z]*\d*)\.pkg}i)
+    strategy :json do |json, regex|
+      json["official"]&.map do |release|
+        match = release["downloadUrl"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
# Purpose of the change
Unity udpated their donwload url, so the regex was not working anymore. I have made the `_unity` option in the url. After my changes, `livecheck` is picking up all the available versions.

Before my changes: 
```sh
brew livecheck --debug --cask unity --verbose
Cask:             unity
Livecheckable?:   Yes

URL:              https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json
Strategies:       PageMatch
Strategy:         PageMatch
Regex:            /\/download_unity\/(\h+)\/MacEditorInstaller\/Unity-(\d+(?:\.\d+)+[a-z]*\d*)\.pkg/i

Matched Versions:
2019.4.40f1,ffc62b691db5 => #<Version:0x0000000105a4dcf0 @version="2019.4.40f1,ffc62b691db5", @detected_from_url=false>
2020.3.48f1,b805b124c6b7 => #<Version:0x0000000105a4db60 @version="2020.3.48f1,b805b124c6b7", @detected_from_url=false>
2021.3.37f1,3b6005ad5ad6 => #<Version:0x0000000105a4da20 @version="2021.3.37f1,3b6005ad5ad6", @detected_from_url=false>
2022.1.23f1,9636b062134a => #<Version:0x0000000105a4d890 @version="2022.1.23f1,9636b062134a", @detected_from_url=false>
2023.1.13f1,ffeab063bb93 => #<Version:0x0000000105a4d750 @version="2023.1.13f1,ffeab063bb93", @detected_from_url=false>
2022.3.24f1,334eb2a0b267 => #<Version:0x0000000105a4d5c0 @version="2022.3.24f1,334eb2a0b267", @detected_from_url=false>
2023.2.18f1,1cb755715f58 => #<Version:0x0000000105a4d480 @version="2023.2.18f1,1cb755715f58", @detected_from_url=false>
```

After my changes: 
```sh
brew livecheck --debug --cask unity --verbose
Cask:             unity
Livecheckable?:   Yes

URL:              https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json
Strategies:       PageMatch
Strategy:         PageMatch
Regex:            /\/([a-f0-9]+)\/MacEditorInstaller\/Unity-(\d+\.\d+\.\d+[a-z]*\d*)\.pkg/i

Matched Versions:
2019.4.40f1,ffc62b691db5 => #<Version:0x0000000107946af8 @version="2019.4.40f1,ffc62b691db5", @detected_from_url=false>
2020.3.48f1,b805b124c6b7 => #<Version:0x0000000107946940 @version="2020.3.48f1,b805b124c6b7", @detected_from_url=false>
2021.3.37f1,3b6005ad5ad6 => #<Version:0x00000001079466e8 @version="2021.3.37f1,3b6005ad5ad6", @detected_from_url=false>
2022.1.23f1,9636b062134a => #<Version:0x00000001079464e0 @version="2022.1.23f1,9636b062134a", @detected_from_url=false>
2023.1.13f1,ffeab063bb93 => #<Version:0x00000001079462d8 @version="2023.1.13f1,ffeab063bb93", @detected_from_url=false>
2022.3.24f1,334eb2a0b267 => #<Version:0x00000001079460d0 @version="2022.3.24f1,334eb2a0b267", @detected_from_url=false>
2023.2.18f1,1cb755715f58 => #<Version:0x0000000107945ec8 @version="2023.2.18f1,1cb755715f58", @detected_from_url=false>
2022.2.0b16,3c3b3e6cd1d7 => #<Version:0x0000000107945d60 @version="2022.2.0b16,3c3b3e6cd1d7", @detected_from_url=false>
2023.3.0b10,52ddac442a2c => #<Version:0x0000000107945b58 @version="2023.3.0b10,52ddac442a2c", @detected_from_url=false>
6000.0.0b15,8008bc0c1b74 => #<Version:0x00000001079458d8 @version="6000.0.0b15,8008bc0c1b74", @detected_from_url=false>
```