### PR TITLE
yes24-ebook 1.0.1.12001

### DIFF
--- a/Casks/y/yes24-ebook.rb
+++ b/Casks/y/yes24-ebook.rb
@@ -1,22 +1,21 @@
 cask "yes24-ebook" do
-  version "1.0.1.11001"
-  sha256 "1b4edec91b05b1151eee8ff06115136baf4962952d588278912305598c6a66e0"
+  version "1.0.1.12001"
+  sha256 "b2be9ddf88af78e0c9ca6e91fa97ccedc87b55b66e561fb767db46aaf4afda36"
 
-  url "http://cdn.k-epub.com/UPGRADE/PC_CREMA/mac/#{version}/Yes24eBook.dmg",
-      verified: "cdn.k-epub.com/UPGRADE/"
-  name "yes24-ebook"
+  url "https://ebookcdn.yes24.com/UPGRADE/PC_CREMA/mac/#{version}/YES24eBook.dmg"
+  name "YES24eBook"
   desc "Crema Ebook reader for Yes24"
   homepage "https://www.yes24.com/Main/default.aspx"
 
   livecheck do
     url "https://cremaupdate.k-epub.com/sv_update.aspx?usrid=&old=0"
-    regex(%r{/([^/]+)/Yes24eBook\.dmg}i)
+    regex(%r{/v?(\d+(?:\.\d+)+)/YES24eBook\.dmg}i)
   end
 
   auto_updates true
   depends_on macos: ">= :big_sur"
 
-  app "YES24_eBook.app"
+  app "YES24eBook.app"
 
   zap trash: [
     "~/Library/Application Scripts/com.yes24.macEBook",


### PR DESCRIPTION
This may need to be re-named to just `yes24ebook` given that the `.app` name has changed, but I would suggest we hold off until we see what happens in the next release.