### PR TITLE
deepl 24.4.2912025

### DIFF
--- a/Casks/d/deepl.rb
+++ b/Casks/d/deepl.rb
@@ -3,27 +3,55 @@ cask "deepl" do
     version "3.7.292629"
     sha256 "efcac4988a606d9793a3bdb8e7e73dce8e3d06ed2249a4434eb54c1624b40b87"
 
-    url "https://www.deepl.com/macos/download/#{version}/DeepL_#{version}.zip"
+    url "https://www.deepl.com/macos/download/old/#{version.major_minor}/#{version.patch}/DeepL.zip"
 
     livecheck do
-      url "https://appdownload.deepl.com/macos/update.json"
-      strategy :json do |json|
-        json["currentRelease"]
+      url "https://appdownload.deepl.com/macos/"
+      regex(%r{^old/v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.(?:zip|tar\.gz)$}i)
+      strategy :xml do |xml|
+        xml.get_elements("//ListBucketResult//Contents//Key").map do |item|
+          match = item.text.match(regex)
+          next if match.blank?
+
+          "#{match[1]}.#{match[2]}"
+        end
       end
     end
+
+    depends_on macos: ">= :catalina"
   end
-  on_big_sur :or_newer do
-    version "24.1.2756848"
-    sha256 "ca6dc9700e4134925c0e3d74cddbc1b63e80b2e4edb3be5273fca1059236d8ad"
+  on_big_sur do
+    version "24.2.1798840"
+    sha256 "dacbf3dbd42eab3b1d3c4b48e0f0672146d07d94627b7ad073985fe41e9e9217"
 
-    url "https://www.deepl.com/macos/download/#{version.major_minor}/#{version.patch}/DeepL_#{version}.tar.gz"
+    url "https://www.deepl.com/macos/download/#{version.major_minor}/#{version.patch}/DeepL.tar.gz"
 
     livecheck do
-      url "https://appdownload.deepl.com/macos/bigsur/update.json"
-      strategy :json do |json|
-        json["currentRelease"]
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :big_sur"
+  end
+  on_monterey :or_newer do
+    version "24.4.2912025"
+    sha256 "29283358a53110abe658dea93db7e4f2845439dca0f1e9a12aa37a65ac5315dc"
+
+    url "https://www.deepl.com/macos/download/#{version.major_minor}/#{version.patch}/DeepL.tar.gz"
+
+    livecheck do
+      url "https://appdownload.deepl.com/macos/"
+      regex(%r{^v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.tar\.gz$}i)
+      strategy :xml do |xml|
+        xml.get_elements("//ListBucketResult//Contents//Key").map do |item|
+          match = item.text.match(regex)
+          next if match.blank?
+
+          "#{match[1]}.#{match[2]}"
+        end
       end
     end
+
+    depends_on macos: ">= :monterey"
   end
 
   name "DeepL"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

It was brought to my attention in https://github.com/Homebrew/homebrew-cask/pull/170781#issuecomment-2076326154 that the existing `livecheck` block for `deepl` isn't returning the latest version. This PR updates the `livecheck` blocks to check https://appdownload.deepl.com/macos/ (an XML response) and uses a regex with the `Xml` strategy to match versions from relevant tar.gz/zip file paths.

This updates the cask to the latest advertised version, 24.4.2912025, and bumps the macOS requirement to Monterey (surfaced by the related audit).

The existing `url` for the older version doesn't work anymore, so I updated it to the current URL found in the aforementioned XML data and also updated the `livecheck` block accordingly.

Closes #170781.