### PR TITLE
Update eclecticlight casks livecheck and zap

### DIFF
--- a/Casks/c/cirrus.rb
+++ b/Casks/c/cirrus.rb
@@ -9,12 +9,17 @@ cask "cirrus" do
   homepage "https://eclecticlight.co/cirrus-bailiff/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/cirrus(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Cirrus']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/c/cirrus.rb
+++ b/Casks/c/cirrus.rb
@@ -9,22 +9,23 @@ cask "cirrus" do
   homepage "https://eclecticlight.co/cirrus-bailiff/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/cirrus(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/cirrus(\d+)\.zip}i)
     strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"
+      page.scan(regex).map do |match|
+        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
+      end
     end
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "cirrus#{version.csv.first.major}#{version.csv.first.minor}/Cirrus.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.cirrusmac.sfl*",
     "~/Library/Caches/co.eclecticlight.CirrusMac",
+    "~/Library/HTTPStorages/co.eclecticlight.CirrusMac",
     "~/Library/Preferences/co.eclecticlight.CirrusMac.plist",
     "~/Library/Saved Application State/co.eclecticlight.CirrusMac.savedState",
   ]

--- a/Casks/d/dintch.rb
+++ b/Casks/d/dintch.rb
@@ -9,12 +9,12 @@ cask "dintch" do
   homepage "https://eclecticlight.co/dintch"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    strategy :page_match do |page|
-      match = page.match(%r{(\d+)/(\d+)/dintch(\d+)\.zip}i)
-      next if match.blank?
-
-      "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/dintch(\d+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
+      end
     end
   end
 
@@ -23,6 +23,7 @@ cask "dintch" do
   app "dintch#{version.csv.first.no_dots}/Dintch.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.dintch.sfl*",
     "~/Library/Caches/co.eclecticlight.Dintch",
     "~/Library/HTTPStorages/co.eclecticlight.Dintch",
     "~/Library/Preferences/co.eclecticlight.Dintch.plist",

--- a/Casks/d/dintch.rb
+++ b/Casks/d/dintch.rb
@@ -9,12 +9,17 @@ cask "dintch" do
   homepage "https://eclecticlight.co/dintch"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/dintch(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Dintch']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/l/lockrattler.rb
+++ b/Casks/l/lockrattler.rb
@@ -9,12 +9,17 @@ cask "lockrattler" do
   homepage "https://eclecticlight.co/lockrattler-systhist/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/lockrattler(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='LockRattler']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/l/lockrattler.rb
+++ b/Casks/l/lockrattler.rb
@@ -6,11 +6,11 @@ cask "lockrattler" do
       verified: "eclecticlightdotcom.files.wordpress.com/"
   name "Lock Rattler"
   desc "Checks security systems and reports issues"
-  homepage "https://eclecticlight.co/"
+  homepage "https://eclecticlight.co/lockrattler-systhist/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/lockrattler(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/lockrattler(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -18,12 +18,13 @@ cask "lockrattler" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :high_sierra"
 
   app "lockrattler#{version.csv.first.major}#{version.csv.first.minor}/LockRattler.app"
 
   zap trash: [
     "~/Library/Caches/co.eclecticlight.LockRattler",
+    "~/Library/HTTPStorages/co.eclecticlight.LockRattler",
     "~/Library/Preferences/co.eclecticlight.LockRattler.plist",
     "~/Library/Saved Application State/co.eclecticlight.LockRattler.savedState",
   ]

--- a/Casks/m/metamer.rb
+++ b/Casks/m/metamer.rb
@@ -9,16 +9,21 @@ cask "metamer" do
   homepage "https://eclecticlight.co/xattred-sandstrip-xattr-tools/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/metamer(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Metamer']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :mojave"
 
   app "metamer#{version.csv.first.no_dots}/Metamer.app"
 

--- a/Casks/m/metamer.rb
+++ b/Casks/m/metamer.rb
@@ -9,23 +9,24 @@ cask "metamer" do
   homepage "https://eclecticlight.co/xattred-sandstrip-xattr-tools/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    strategy :page_match do |page|
-      match = page.match(%r{(\d+)/(\d+)/metamer(\d+)\.zip}i)
-      next if match.blank?
-
-      "#{match[3].split("", 2).join(".")},#{match[1]}.#{match[2]}"
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/metamer(\d+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
+      end
     end
   end
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :high_sierra"
 
   app "metamer#{version.csv.first.no_dots}/Metamer.app"
 
   zap trash: [
-    "~/Library/Caches/co.eclecticlight.Metamer/",
-    "~/Library/HTTPStorages/co.eclecticlight.Metamer/",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.metamer.sfl*",
+    "~/Library/Caches/co.eclecticlight.Metamer",
+    "~/Library/HTTPStorages/co.eclecticlight.Metamer",
     "~/Library/Preferences/co.eclecticlight.Metamer.plist",
-    "~/Library/Saved Application State/co.eclecticlight.Metamer.savedState/",
+    "~/Library/Saved Application State/co.eclecticlight.Metamer.savedState",
   ]
 end

--- a/Casks/m/mints.rb
+++ b/Casks/m/mints.rb
@@ -9,12 +9,17 @@ cask "mints" do
   homepage "https://eclecticlight.co/mints-a-multifunction-utility/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/mints(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Mints']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/m/mints.rb
+++ b/Casks/m/mints.rb
@@ -9,8 +9,8 @@ cask "mints" do
   homepage "https://eclecticlight.co/mints-a-multifunction-utility/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/mints(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/mints(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -18,11 +18,12 @@ cask "mints" do
     end
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "mints#{version.csv.first.no_dots}/Mints.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.mints.sfl*",
     "~/Library/Caches/co.eclecticlight.Mints",
     "~/Library/HTTPStorages/co.eclecticlight.Mints",
     "~/Library/Preferences/co.eclecticlight.Mints.plist",

--- a/Casks/s/signet.rb
+++ b/Casks/s/signet.rb
@@ -9,12 +9,17 @@ cask "signet" do
   homepage "https://eclecticlight.co/taccy-signet-precize-alifix-utiutility-alisma/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/signet(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Signet']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/s/signet.rb
+++ b/Casks/s/signet.rb
@@ -9,8 +9,8 @@ cask "signet" do
   homepage "https://eclecticlight.co/taccy-signet-precize-alifix-utiutility-alisma/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/signet(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/signet(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -18,10 +18,13 @@ cask "signet" do
     end
   end
 
+  depends_on macos: ">= :high_sierra"
+
   app "#{token}#{version.csv.first.no_dots}/Signet.app"
 
   zap trash: [
     "~/Library/Caches/co.eclecticlight.Signet",
+    "~/Library/HTTPStorages/co.eclecticlight.Signet",
     "~/Library/Preferences/co.eclecticlight.Signet.plist",
     "~/Library/Saved Application State/co.eclecticlight.Signet.savedState",
   ]

--- a/Casks/s/silentknight.rb
+++ b/Casks/s/silentknight.rb
@@ -1,24 +1,44 @@
 cask "silentknight" do
-  version "2.07,2023.11"
-  sha256 "90bc1b10f02f09c2a684a0f04242f2e93b1aadd912e5341bc5a7415cfe8f0c62"
+  on_mojave :or_older do
+    version "1.21,2022.06"
+    sha256 "c1cbb734f620e073f1c08c473edaa036c2b5ccdca02baa99ca117f86c10ad505"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :el_capitan"
+  end
+  on_catalina :or_newer do
+    version "2.07,2023.11"
+    sha256 "90bc1b10f02f09c2a684a0f04242f2e93b1aadd912e5341bc5a7415cfe8f0c62"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+      regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+      strategy :xml do |xml, regex|
+        item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='SilentKnight#{version.major}']]"]
+        next unless item
+
+        version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+        match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+        next if version.blank? || match.blank?
+
+        # Temporarily override the version to account for a one-off mismatch
+        version = "2.07" if version == "2.7"
+
+        "#{version},#{match[1]}.#{match[2]}"
+      end
+    end
+
+    depends_on macos: ">= :catalina"
+  end
 
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.csv.second.major}/#{version.csv.second.minor}/silentknight#{version.csv.first.no_dots}.zip",
       verified: "eclecticlightdotcom.files.wordpress.com/"
   name "SilentKnight"
   desc "Automatically checks computer's security"
   homepage "https://eclecticlight.co/lockrattler-systhist/"
-
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/silentknight([^1]\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
-    end
-  end
-
-  depends_on macos: ">= :catalina"
 
   app "silentknight#{version.csv.first.no_dots}/SilentKnight.app"
 

--- a/Casks/s/silentknight.rb
+++ b/Casks/s/silentknight.rb
@@ -1,26 +1,6 @@
 cask "silentknight" do
-  on_mojave :or_older do
-    version "1.21,2022.06"
-    sha256 "c1cbb734f620e073f1c08c473edaa036c2b5ccdca02baa99ca117f86c10ad505"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "2.07,2023.11"
-    sha256 "90bc1b10f02f09c2a684a0f04242f2e93b1aadd912e5341bc5a7415cfe8f0c62"
-
-    livecheck do
-      url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-      regex(%r{(\d+)/(\d+)/silentknight([^1]\d+)\.zip}i)
-      strategy :page_match do |page, regex|
-        page.scan(regex).map do |match|
-          "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-        end
-      end
-    end
-  end
+  version "2.07,2023.11"
+  sha256 "90bc1b10f02f09c2a684a0f04242f2e93b1aadd912e5341bc5a7415cfe8f0c62"
 
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.csv.second.major}/#{version.csv.second.minor}/silentknight#{version.csv.first.no_dots}.zip",
       verified: "eclecticlightdotcom.files.wordpress.com/"
@@ -28,12 +8,24 @@ cask "silentknight" do
   desc "Automatically checks computer's security"
   homepage "https://eclecticlight.co/lockrattler-systhist/"
 
-  depends_on macos: ">= :el_capitan"
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/silentknight([^1]\d+)\.zip}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
+      end
+    end
+  end
+
+  depends_on macos: ">= :catalina"
 
   app "silentknight#{version.csv.first.no_dots}/SilentKnight.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.silentknight.sfl*",
     "~/Library/Caches/co.eclecticlight.SilentKnight",
+    "~/Library/HTTPStorages/co.eclecticlight.SilentKnight",
     "~/Library/Preferences/co.eclecticlight.SilentKnight.plist",
     "~/Library/Saved Application State/co.eclecticlight.SilentKnight.savedState",
   ]

--- a/Casks/s/silnite.rb
+++ b/Casks/s/silnite.rb
@@ -18,7 +18,7 @@ cask "silnite" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
+  depends_on macos: ">= :big_sur"
 
   pkg "silnite#{version.csv.first}/silniteInstaller.pkg"
 

--- a/Casks/s/silnite.rb
+++ b/Casks/s/silnite.rb
@@ -9,12 +9,10 @@ cask "silnite" do
   homepage "https://eclecticlight.co/lockrattler-systhist/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/silnite[._-]?v?(\d+(?:\.\d+)*\w?)\.zip}i)
+    url "https://eclecticlight.co/downloads/"
+    regex(%r{href=.*?/(\d+)/(\d+)/silnite[^"' >]*?\.zip[^>]*?>\s*silnite\s+v?(\d+(?:\.\d+)*)[^a-z)]}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2]},#{match[0]}.#{match[1]}"
-      end
+      page.scan(regex).map { |match| "#{match[2]},#{match[0]}.#{match[1]}" }
     end
   end
 

--- a/Casks/s/spundle.rb
+++ b/Casks/s/spundle.rb
@@ -9,8 +9,8 @@ cask "spundle" do
   homepage "https://eclecticlight.co/dintch/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{(\d+)/(\d+)/Spundle(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/Spundle(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -23,7 +23,9 @@ cask "spundle" do
   app "spundle#{version.csv.first.no_dots}/Spundle.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.spundle.sfl*",
     "~/Library/Caches/co.eclecticlight.Spundle",
+    "~/Library/HTTPStorages/co.eclecticlight.Spundle",
     "~/Library/Preferences/co.eclecticlight.Spundle.plist",
     "~/Library/Saved Application State/co.eclecticlight.Spundle.savedState",
   ]

--- a/Casks/s/spundle.rb
+++ b/Casks/s/spundle.rb
@@ -9,12 +9,17 @@ cask "spundle" do
   homepage "https://eclecticlight.co/dintch/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/Spundle(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Spundle']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/t/taccy.rb
+++ b/Casks/t/taccy.rb
@@ -9,8 +9,8 @@ cask "taccy" do
   homepage "https://eclecticlight.co/taccy-signet-precize-alifix-utiutility-alisma/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/taccy(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/taccy(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"

--- a/Casks/t/taccy.rb
+++ b/Casks/t/taccy.rb
@@ -9,12 +9,17 @@ cask "taccy" do
   homepage "https://eclecticlight.co/taccy-signet-precize-alifix-utiutility-alisma/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/taccy(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Taccy']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/t/thetimemachinemechanic.rb
+++ b/Casks/t/thetimemachinemechanic.rb
@@ -5,16 +5,22 @@ cask "thetimemachinemechanic" do
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.csv.second.major}/#{version.csv.second.minor}/t2m2#{version.csv.first.no_dots}.zip",
       verified: "eclecticlightdotcom.files.wordpress.com/"
   name "The Time Machine Mechanic"
+  name "T2M2"
   desc "Time Machine log viewer & status inspector"
   homepage "https://eclecticlight.co/consolation-t2m2-and-log-utilities/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/t2m2(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='T2M22']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/t/thetimemachinemechanic.rb
+++ b/Casks/t/thetimemachinemechanic.rb
@@ -5,13 +5,12 @@ cask "thetimemachinemechanic" do
   url "https://eclecticlightdotcom.files.wordpress.com/#{version.csv.second.major}/#{version.csv.second.minor}/t2m2#{version.csv.first.no_dots}.zip",
       verified: "eclecticlightdotcom.files.wordpress.com/"
   name "The Time Machine Mechanic"
-  name "T2M2"
   desc "Time Machine log viewer & status inspector"
   homepage "https://eclecticlight.co/consolation-t2m2-and-log-utilities/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/t2m2(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/t2m2(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -19,13 +18,14 @@ cask "thetimemachinemechanic" do
     end
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :big_sur"
 
   app "t2m2#{version.csv.first.major}#{version.csv.first.minor}/TheTimeMachineMechanic.app"
 
   zap trash: [
-    "~/Library/Caches/co.eclecticlight.TheTimeMachineMechanic",
-    "~/Library/Preferences/co.eclecticlight.TheTimeMachineMechanic.plist",
-    "~/Library/Saved Application State/co.eclecticlight.TheTimeMachineMechanic.savedState",
+    "~/Library/Caches/co.eclecticlight.TheTimeMachineMechanic2",
+    "~/Library/HTTPStorages/co.eclecticlight.TheTimeMachineMechanic2",
+    "~/Library/Preferences/co.eclecticlight.TheTimeMachineMechanic2.plist",
+    "~/Library/Saved Application State/co.eclecticlight.TheTimeMachineMechanic2.savedState",
   ]
 end

--- a/Casks/u/ulbow.rb
+++ b/Casks/u/ulbow.rb
@@ -9,12 +9,17 @@ cask "ulbow" do
   homepage "https://eclecticlight.co/consolation-t2m2-and-log-utilities/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/ulbow(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Ulbow']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/u/ulbow.rb
+++ b/Casks/u/ulbow.rb
@@ -9,8 +9,8 @@ cask "ulbow" do
   homepage "https://eclecticlight.co/consolation-t2m2-and-log-utilities/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/ulbow(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/ulbow(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -18,11 +18,12 @@ cask "ulbow" do
     end
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "ulbow#{version.csv.first.no_dots}/Ulbow.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.ulbow.sfl*",
     "~/Library/Caches/co.eclecticlight.Ulbow",
     "~/Library/HTTPStorages/co.eclecticlight.Ulbow",
     "~/Library/Preferences/co.eclecticlight.Ulbow.plist",

--- a/Casks/x/xattred.rb
+++ b/Casks/x/xattred.rb
@@ -9,8 +9,8 @@ cask "xattred" do
   homepage "https://eclecticlight.co/xattred-sandstrip-xattr-tools/"
 
   livecheck do
-    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-    regex(%r{/(\d+)/(\d+)/xattred(\d+)\.zip}i)
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/xattred(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -23,7 +23,9 @@ cask "xattred" do
   app "xattred#{version.csv.first.major}#{version.csv.first.minor}/xattred.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.xattred.sfl*",
     "~/Library/Caches/co.eclecticlight.xattred",
+    "~/Library/HTTPStorages/co.eclecticlight.xattred",
     "~/Library/Preferences/co.eclecticlight.xattred.plist",
     "~/Library/Saved Application State/co.eclecticlight.xattred.savedState",
   ]

--- a/Casks/x/xattred.rb
+++ b/Casks/x/xattred.rb
@@ -9,12 +9,17 @@ cask "xattred" do
   homepage "https://eclecticlight.co/xattred-sandstrip-xattr-tools/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/xattred(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='xattred']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/x/xprocheck.rb
+++ b/Casks/x/xprocheck.rb
@@ -10,7 +10,7 @@ cask "xprocheck" do
 
   livecheck do
     url :homepage
-    regex(%r{/(\d+)/(\d+)/xprocheck(\d+)\.zip}i)
+    regex(%r{href=.*?/(\d+)/(\d+)/xprocheck(\d+)\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
@@ -22,5 +22,10 @@ cask "xprocheck" do
 
   app "xprocheck#{version.csv.first.no_dots}/XProCheck.app"
 
-  zap trash: "~/Library/Saved Application State/co.eclecticlight.XProCheck.savedState"
+  zap trash: [
+    "~/Library/Caches/co.eclecticlight.XProCheck",
+    "~/Library/HTTPStorages/co.eclecticlight.XProCheck",
+    "~/Library/Preferences/co.eclecticlight.XProCheck.plist",
+    "~/Library/Saved Application State/co.eclecticlight.XProCheck.savedState",
+  ]
 end

--- a/Casks/x/xprocheck.rb
+++ b/Casks/x/xprocheck.rb
@@ -9,12 +9,17 @@ cask "xprocheck" do
   homepage "https://eclecticlight.co/consolation-t2m2-and-log-utilities/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/xprocheck(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2].split("", 2).join(".")},#{match[0]}.#{match[1]}"
-      end
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='XProCheck']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
+      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      next if version.blank? || match.blank?
+
+      "#{version},#{match[1]}.#{match[2]}"
     end
   end
 


### PR DESCRIPTION
I was going through the process of adding a new cask for an app by eclectic light and noticed several were pulling updates from a 3rd party gist, needed zaps, wrong depends_on version, etc.