### PR TITLE
1password: migrate casks (1)

### DIFF
--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -16,8 +16,6 @@ cask "1password-cli" do
     regex(%r{href=.*?/op_apple_universal[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
   end
 
-  conflicts_with cask: "1password-cli1"
-
   binary "op"
 
   zap trash: "~/.op"

--- a/Casks/1/1password-cli@1.rb
+++ b/Casks/1/1password-cli@1.rb
@@ -1,0 +1,21 @@
+cask "1password-cli@1" do
+  version "1.12.9"
+  sha256 "ff9af6a6aef58111f2279b30cebf158a2e14651176b40a649b30a12b772724a3"
+
+  url "https://cache.agilebits.com/dist/1P/op/pkg/v#{version}/op_apple_universal_v#{version}.pkg",
+      verified: "cache.agilebits.com/dist/1P/op/pkg/"
+  name "1Password CLI"
+  desc "Command-line helper for the 1Password password manager"
+  homepage "https://developer.1password.com/docs/cli/v1/usage/"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/product_history/CLI"
+    regex(%r{href=.*?/op_apple_universal[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+  end
+
+  pkg "op_apple_universal_v#{version}.pkg"
+
+  uninstall pkgutil: "com.1password.op"
+
+  zap trash: "~/.op"
+end

--- a/Casks/1/1password-cli@beta.rb
+++ b/Casks/1/1password-cli@beta.rb
@@ -1,0 +1,21 @@
+cask "1password-cli@beta" do
+  version "2.23.0-beta.01"
+  sha256 "79f6b4fb2b58733c6b69a1ac9ccfb4f7255eec20a089ed29322ca93c76710856"
+
+  url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_apple_universal_v#{version}.pkg",
+      verified: "cache.agilebits.com/dist/1P/op2/pkg/"
+  name "1Password CLI"
+  desc "Command-line helper for the 1Password password manager"
+  homepage "https://developer.1password.com/docs/cli"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/product_history/CLI2"
+    regex(%r{href=.*?/op_apple_universal[._-]v?(\d+(?:\.\d+)+-beta\.\d+)\.pkg}i)
+  end
+
+  pkg "op_apple_universal_v#{version}.pkg"
+
+  uninstall pkgutil: "com.1password.op"
+
+  zap trash: "~/.config/op"
+end

--- a/Casks/1/1password.rb
+++ b/Casks/1/1password.rb
@@ -16,10 +16,6 @@ cask "1password" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "homebrew/cask-versions/1password-beta",
-    "homebrew/cask-versions/1password-nightly",
-  ]
   depends_on macos: ">= :catalina"
 
   app "1Password.app"

--- a/Casks/1/1password@7.rb
+++ b/Casks/1/1password@7.rb
@@ -1,0 +1,27 @@
+cask "1password@7" do
+  version "7.9.11"
+  sha256 "11b14910a2cf0e544e317e49f4a62491e5190545ed684236a295f51d722f30db"
+
+  url "https://c.1password.com/dist/1P/mac#{version.major}/1Password-#{version}.zip"
+  name "1Password"
+  desc "Password manager that keeps all passwords secure behind one password"
+  homepage "https://1password.com/"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/product_history/OPM#{version.major}"
+    regex(%r{href=.*?/1Password-(\d+(?:\.\d+)+)\.pkg}i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "1Password #{version.major}.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/*.agilebits.onepassword*",
+    "~/Library/Containers/*.agilebits.onepassword*",
+    "~/Library/Group Containers/2BUA8C4S2C.com.agilebits",
+    "~/Library/Logs/1Password",
+    "~/Library/Preferences/com.agilebits.onepassword*",
+  ]
+end

--- a/Casks/1/1password@beta.rb
+++ b/Casks/1/1password@beta.rb
@@ -1,0 +1,52 @@
+cask "1password@beta" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "8.10.32-11.BETA"
+  sha256 arm:   "2ab0d81dfa5529886baabc5f3acb9faf94b39d30411ffba880d338ae46c797e7",
+         intel: "69f2831633f793819d43a0aa37032fb3e61c06748d95a20140f048298feb7b5f"
+
+  url "https://downloads.1password.com/mac/1Password-#{version}-#{arch}.zip"
+  name "1Password"
+  desc "Password manager"
+  homepage "https://1password.com/"
+
+  livecheck do
+    url "https://app-updates.agilebits.com/product_history/OPM#{version.major}"
+    regex(%r{href=.*?/1Password[._-]?v?(\d+(?:.\d+)*(?:[._-]BETA))[._-]?\$ARCH\.zip}i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "1Password.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/2BUA8C4S2C.com.1password*",
+    "~/Library/Application Scripts/2BUA8C4S2C.com.agilebits",
+    "~/Library/Application Scripts/com.1password.1password-launcher",
+    "~/Library/Application Scripts/com.1password.browser-support",
+    "~/Library/Application Support/1Password",
+    "~/Library/Application Support/Arc/User Data/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.1password.1password.sfl*",
+    "~/Library/Application Support/CrashReporter/1Password*",
+    "~/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Google/Chrome Dev/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge Beta/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge Canary/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge Dev/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Microsoft Edge/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Mozilla/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Application Support/Vivaldi/NativeMessagingHosts/com.1password.1password.json",
+    "~/Library/Containers/2BUA8C4S2C.com.1password.browser-helper",
+    "~/Library/Containers/com.1password.1password*",
+    "~/Library/Containers/com.1password.browser-support",
+    "~/Library/Group Containers/2BUA8C4S2C.com.1password",
+    "~/Library/Group Containers/2BUA8C4S2C.com.agilebits",
+    "~/Library/Logs/1Password",
+    "~/Library/Preferences/com.1password.1password.plist",
+    "~/Library/Preferences/group.com.1password.plist",
+    "~/Library/Saved Application State/com.1password.1password.savedState",
+  ]
+end

--- a/Casks/1/1password@nightly.rb
+++ b/Casks/1/1password@nightly.rb
@@ -1,0 +1,32 @@
+cask "1password@nightly" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version :latest
+  sha256 :no_check
+
+  url "https://c.1password.com/dist/1P/mac8/1Password-latest.NIGHTLY-#{arch}.zip"
+  name "1Password Nightly"
+  desc "Password manager"
+  homepage "https://1password.com/"
+
+  depends_on macos: ">= :catalina"
+
+  app "1Password.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/2BUA8C4S2C.com.1password",
+    "~/Library/Application Scripts/2BUA8C4S2C.com.1password.browser-helper",
+    "~/Library/Application Scripts/com.1password.1password-launcher",
+    "~/Library/Application Scripts/com.1password.browser-support",
+    "~/Library/Application Support/1Password",
+    "~/Library/Application Support/CrashReporter/1Password*.plist",
+    "~/Library/Containers/2BUA8C4S2C.com.1password.browser-helper",
+    "~/Library/Containers/com.1password.1password-launcher",
+    "~/Library/Containers/com.1password.browser-support",
+    "~/Library/Group Containers/*.com.1password",
+    "~/Library/Group Containers/*.com.agilebits",
+    "~/Library/Logs/DiagnosticReports/1Password*",
+    "~/Library/Preferences/*1password.plist",
+    "~/Library/Saved Application State/com.1password.1password.savedState",
+  ]
+end


### PR DESCRIPTION
Removing `conflicts_with cask` from this migration, will add back in a separate PR. 

The merge order is: 
1) #172357
2) https://github.com/Homebrew/homebrew-cask-versions/pull/20188
3) #172356 (rebase and merge)