### PR TITLE
Create kitsas.rb

### DIFF
--- a/Casks/k/kitsas.rb
+++ b/Casks/k/kitsas.rb
@@ -1,0 +1,20 @@
+cask "kitsas" do
+  version "5.5"
+  sha256 "5e98b1bb0df610ea755b186ebd48f0f04047507301474104b72b68ef3fdf6d97"
+
+  url "https://github.com/petriaarnio/kitupiikki/releases/download/mac-v#{version}/Kitsas-#{version}.dmg"
+  name "Kitsas"
+  desc "Finnish bookkeeping software for small organisations"
+  homepage "https://github.com/artoh/kitupiikki"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Kitsas.app"
+
+  uninstall quit: "fi.atfos.kitsas"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Audit issues
I receive 2 errors from the audit command but I don't think they are actual issues. I included my output here and the explanations later on:
```
$ brew audit --cask --new kitsas
==> Downloading https://github.com/petriaarnio/kitupiikki/releases/download/mac-v5.5/Kitsas-5.5.dmg
Already downloaded: /Users/onnimonni/Library/Caches/Homebrew/downloads/8ca4a688a853bc746d0767098fe33ce8cf17b8481f4232220080cc815ebe4f46--Kitsas-5.5.dmg
==> Downloading and extracting artifacts
==> Downloading https://github.com/petriaarnio/kitupiikki/releases/download/mac-v5.5/Kitsas-5.5.dmg
Already downloaded: /Users/onnimonni/Library/Caches/Homebrew/downloads/8ca4a688a853bc746d0767098fe33ce8cf17b8481f4232220080cc815ebe4f46--Kitsas-5.5.dmg
audit for kitsas: failed
 - GitHub fork (not canonical repository)
 - Signature verification failed:
/private/tmp/cask-audit20240428-24178-9s5m84/Kitsas.app: rejected

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
kitsas
  * line 5, col 2: GitHub fork (not canonical repository)
  * line 5, col 2: Signature verification failed:
    /private/tmp/cask-audit20240428-24178-9s5m84/Kitsas.app: rejected

    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 2 problems in 1 cask detected.
```

### GitHub fork (not canonical repository)
**GitHub fork (not canonical repository)** issue should not be an issue. This is not a fork but I think this is caused because the GitHub repository url is `kitupiikki` which doesn't match to `kitsas`.

The software was originally called `kitupiikki` it's not a fork but the maintainer didn't want to rename the repository too.

###  Signature verification failed
**- Signature verification failed:** issue should also not be an issue.

I can open the application just fine. Also if I check the signature with codesign it seems to be signed properly. Maybe this is caused by the sha256 being wrong?
```
$ codesign -dv --verbose=4 /Applications/Kitsas.app
Executable=/Applications/Kitsas.app/Contents/MacOS/Kitsas
Identifier=fi.atfos.kitsas
Format=app bundle with Mach-O universal (x86_64 arm64)
CodeDirectory v=20400 size=84243 flags=0x0(none) hashes=2622+7 location=embedded
VersionPlatform=1
VersionMin=720896
VersionSDK=918528
Hash type=sha256 size=32
CandidateCDHash sha256=14a46d1f43a69cba07a5100cb38cdb6d5bd4d336
CandidateCDHashFull sha256=14a46d1f43a69cba07a5100cb38cdb6d5bd4d336810207cf67c405f103c8a648
Hash choices=sha256
CMSDigest=14a46d1f43a69cba07a5100cb38cdb6d5bd4d336810207cf67c405f103c8a648
CMSDigestType=2
Executable Segment base=0
Executable Segment limit=10108928
Executable Segment flags=0x1
Page size=4096
CDHash=14a46d1f43a69cba07a5100cb38cdb6d5bd4d336
Signature size=8965
Authority=Developer ID Application: Atfos Oy (FJ2CG9GU7J)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=14. Apr 2024 at 08:49:22
Info.plist entries=23
TeamIdentifier=FJ2CG9GU7J
Sealed Resources version=2 rules=13 files=48
Internal requirements count=1 size=208
```


