### PR TITLE
android-platform-tools: update homepage, livecheck

### DIFF
--- a/Casks/a/android-platform-tools.rb
+++ b/Casks/a/android-platform-tools.rb
@@ -6,11 +6,11 @@ cask "android-platform-tools" do
       verified: "google.com/android/repository/"
   name "Android SDK Platform-Tools"
   desc "Android SDK component"
-  homepage "https://developer.android.com/studio/releases/platform-tools"
+  homepage "https://developer.android.com/tools/releases/platform-tools"
 
   livecheck do
     url :homepage
-    regex(/data-text=.*?v?(\d+(?:\.\d+)+)["'> (]/i)
+    regex(/data-text=["']?[^"' >]*?v?(\d+(?:\.\d+)+)["'> (]/i)
   end
 
   binary "#{staged_path}/platform-tools/adb"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `homepage` redirects to the same URL but with `tools` in the path instead of `studio`. This updates the URL to avoid the redirection.

This also updates the `livecheck` block to better match within the `data-text` attribute value (as that appears to be the intention).