### PR TITLE
ableton-live: migrate casks

### DIFF
--- a/Casks/a/ableton-live-intro@11.rb
+++ b/Casks/a/ableton-live-intro@11.rb
@@ -1,0 +1,30 @@
+cask "ableton-live-intro@11" do
+  version "11.3.22"
+  sha256 "544bb47609c5e34bbbe834a049c2dfeb0f7bb72d3334db8e15812460d19765f0"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_intro_#{version}_universal.dmg"
+  name "Ableton Live Intro"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  livecheck do
+    cask "ableton-live-suite@11"
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Intro.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/a/ableton-live-lite@11.rb
+++ b/Casks/a/ableton-live-lite@11.rb
@@ -1,0 +1,30 @@
+cask "ableton-live-lite@11" do
+  version "11.3.22"
+  sha256 "3b7dab85e3e479c67387528231da324bfc613c7324b205a4981e68d6918e735b"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_lite_#{version}_universal.dmg"
+  name "Ableton Live Lite"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/products/live-lite/"
+
+  livecheck do
+    cask "ableton-live-suite@11"
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Lite.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/a/ableton-live-standard@11.rb
+++ b/Casks/a/ableton-live-standard@11.rb
@@ -1,0 +1,30 @@
+cask "ableton-live-standard@11" do
+  version "11.3.22"
+  sha256 "0085a9d703709c71a6bbb4364860a02229c83714d3024c5bf7d4151f5f5f8010"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_standard_#{version}_universal.dmg"
+  name "Ableton Live Standard"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  livecheck do
+    cask "ableton-live-suite@11"
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Standard.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Music/Ableton",
+  ]
+end

--- a/Casks/a/ableton-live-suite@11.rb
+++ b/Casks/a/ableton-live-suite@11.rb
@@ -1,0 +1,37 @@
+cask "ableton-live-suite@11" do
+  version "11.3.22"
+  sha256 "fde19cc28ecf98e16151bf6b9e42147d25492d6d62e9573a311bca3d3776bf55"
+
+  url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
+  name "Ableton Live Suite"
+  desc "Sound and music editor"
+  homepage "https://www.ableton.com/en/live/"
+
+  livecheck do
+    url "https://www.ableton.com/en/release-notes/live-#{version.major}/"
+    regex(/(\d+(?:\.\d+)+)\s*Release\s*Notes/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Ableton Live #{version.major} Suite.app"
+
+  uninstall quit: "com.ableton.live"
+
+  zap trash: [
+    "/Library/Logs/DiagnosticReports/Max_*.*_resource.diag",
+    "~/Library/Application Support/Ableton",
+    "~/Library/Application Support/CrashReporter/Ableton *_*.plist",
+    "~/Library/Application Support/CrashReporter/Live_*.plist",
+    "~/Library/Application Support/CrashReporter/Max_*.plist",
+    "~/Library/Application Support/Cycling '74",
+    "~/Library/Caches/Ableton",
+    "~/Library/Preferences/Ableton",
+    "~/Library/Preferences/com.ableton.live.plist*",
+    "~/Library/Preferences/com.cycling74.Max*.plist*",
+    "~/Music/Ableton",
+    "~/Documents/Max [0-9]",
+    "/Users/Shared/Max [0-9]",
+  ]
+end


### PR DESCRIPTION
Migrate with https://github.com/Homebrew/homebrew-cask-versions/pull/20194