### PR TITLE
various casks (signing issues): migrate

### DIFF
--- a/Casks/c/chromedriver@beta.rb
+++ b/Casks/c/chromedriver@beta.rb
@@ -1,0 +1,29 @@
+cask "chromedriver@beta" do
+  arch arm: "arm64", intel: "x64"
+
+  version "125.0.6422.14"
+  sha256 arm:   "3fe6d38083e6f26e0b0f2d6c34111812512f2b8d1a87f8c023155ea99a423261",
+         intel: "2dcc0f090681addfa8562476b7781e445da67b157382409a24f127396cdb8fd3"
+
+  url "https://storage.googleapis.com/chrome-for-testing-public/#{version}/mac-#{arch}/chromedriver-mac-#{arch}.zip",
+      verified: "storage.googleapis.com/chrome-for-testing-public/"
+  name "ChromeDriver"
+  desc "Automated testing of webapps for Google Chrome"
+  homepage "https://chromedriver.chromium.org/"
+
+  livecheck do
+    url "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+    regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :json do |json, regex|
+      json["channels"]["Beta"]["version"]&.scan(regex) { |match| match[0] }
+    end
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "chromedriver"
+
+  binary "chromedriver-mac-#{arch}/chromedriver"
+
+  # No zap stanza required
+end

--- a/Casks/d/deadbeef@nightly.rb
+++ b/Casks/d/deadbeef@nightly.rb
@@ -1,0 +1,22 @@
+cask "deadbeef@nightly" do
+  version :latest
+  sha256 :no_check
+
+  url "https://downloads.sourceforge.net/deadbeef/travis/macOS/master/deadbeef-devel-macos-universal.zip",
+      verified: "downloads.sourceforge.net/deadbeef/"
+  name "DeaDBeeF"
+  desc "Modular audio player"
+  homepage "https://deadbeef.sourceforge.io/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  depends_on macos: ">= :high_sierra"
+
+  app "DeaDBeeF.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.deadbeef.deadbeef.plist",
+    "~/Library/Preferences/deadbeef",
+    "~/Library/Saved Application State/com.deadbeef.deadbeef.savedState",
+  ]
+end

--- a/Casks/g/geogebra@5.rb
+++ b/Casks/g/geogebra@5.rb
@@ -1,0 +1,29 @@
+cask "geogebra@5" do
+  version "5.2.840.0"
+  sha256 "08881a2fd55ecb38f8cbe353dc9b2448a7bd39f840c9f1b0f6eb87a19bfd083e"
+
+  url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-MacOS-Installer-withJava-#{version.dots_to_hyphens}.zip"
+  name "GeoGebra"
+  desc "Solve, save and share math problems, graph functions, etc"
+  homepage "https://www.geogebra.org/"
+
+  livecheck do
+    url "https://download.geogebra.org/package/mac"
+    regex(%r{/GeoGebra[._-]MacOS[._-]Installer[._-]withJava[._-]v?(\d+(?:-\d+)+)\.zip}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"][regex, 1]
+      next if match.blank?
+
+      match.tr("-", ".")
+    end
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  app "Geogebra.app"
+
+  uninstall quit:       "org.geogebra#{version.major}.mac",
+            login_item: "Geogebra"
+
+  zap trash: "~/Library/Saved Application State/org.geogebra5.mac.savedState"
+end

--- a/Casks/k/keepassxc@snapshot.rb
+++ b/Casks/k/keepassxc@snapshot.rb
@@ -1,0 +1,19 @@
+cask "keepassxc@snapshot" do
+  version :latest
+  sha256 :no_check
+
+  url "https://snapshot.keepassxc.org/latest/" do |page|
+    file_path = page[/href="([^"]+-snapshot\.dmg)"/, 1]
+    URI.join(page.url, file_path)
+  end
+  name "KeePassXC"
+  desc "Password manager app"
+  homepage "https://keepassxc.org/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  app "KeePassXC.app"
+  binary "#{appdir}/KeePassXC.app/Contents/MacOS/keepassxc-cli"
+
+  zap trash: "~/.keepassxc"
+end

--- a/Casks/m/mumble@snapshot.rb
+++ b/Casks/m/mumble@snapshot.rb
@@ -1,0 +1,32 @@
+cask "mumble@snapshot" do
+  version "1.5.629"
+  sha256 "d5e0f164e8f63ce79b0c2bc9d1e059213d80c3c5cd9e28c065657bc0594495ea"
+
+  url "https://dl.mumble.info/snapshot/mumble_client-#{version}.x64.dmg"
+  name "Mumble Snapshot"
+  desc "Open-source, low-latency, high quality voice chat software for gaming"
+  homepage "https://mumble.info/"
+
+  livecheck do
+    url "https://dl.mumble.info/latest/snapshot/client-macos-x64"
+    regex(/mumble[._-]client[._-](.+?)(?:\.x64|~snapshot)?\.dmg/i)
+    strategy :header_match do |headers, regex|
+      headers["content-disposition"][regex, 1].tr("~", "_")
+    end
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "mumble"
+  depends_on macos: ">= :high_sierra"
+
+  app "Mumble.app"
+
+  zap trash: [
+    "/Library/ScriptingAdditions/MumbleOverlay.osax",
+    "~/Library/Application Support/Mumble",
+    "~/Library/Logs/Mumble.log",
+    "~/Library/Preferences/net.sourceforge.mumble.Mumble.plist",
+    "~/Library/Saved Application State/net.sourceforge.mumble.Mumble.savedState",
+  ]
+end

--- a/Casks/o/openemu@experimental.rb
+++ b/Casks/o/openemu@experimental.rb
@@ -1,0 +1,40 @@
+cask "openemu@experimental" do
+  on_high_sierra :or_older do
+    version "2.0.9.1"
+    sha256 "62c44e823fef65c583cbf5e6f84faa03618d713f45610f73bc23fb34cbf64762"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_mojave :or_newer do
+    version "2.4.1"
+    sha256 "57b6f2b6005119efecb566e8cf611e12f1d0171dcd1f96797a0e9b4c33d3cdb4"
+  end
+
+  url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}-experimental.zip",
+      verified: "github.com/OpenEmu/OpenEmu/"
+  name "OpenEmu"
+  desc "Retro video game emulation"
+  homepage "https://openemu.org/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  auto_updates true
+  conflicts_with cask: "openemu"
+  depends_on macos: ">= :mojave"
+
+  app "OpenEmu.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.openemu.openemu.sfl*",
+    "~/Library/Application Support/OpenEmu",
+    "~/Library/Application Support/org.openemu.OEXPCCAgent.Agents",
+    "~/Library/Caches/OpenEmu",
+    "~/Library/Caches/org.openemu.OpenEmu",
+    "~/Library/Cookies/org.openemu.OpenEmu.binarycookies",
+    "~/Library/HTTPStorages/org.openemu.OpenEmu.binarycookies",
+    "~/Library/Preferences/org.openemu.*.plist",
+    "~/Library/Saved Application State/org.openemu.OpenEmu.savedState",
+  ]
+end

--- a/Casks/o/openscad@snapshot.rb
+++ b/Casks/o/openscad@snapshot.rb
@@ -1,0 +1,27 @@
+cask "openscad@snapshot" do
+  version "2024.04.29"
+  sha256 "e33a68f9ecf0fd5416b7c663dbdb02dcaeb4fa6b83cffa3992fab8e3c83f733a"
+
+  url "https://files.openscad.org/snapshots/OpenSCAD-#{version}.dmg"
+  name "OpenSCAD"
+  desc "Programmable solid 3D CAD modeller"
+  homepage "https://www.openscad.org/downloads.html#snapshots"
+
+  livecheck do
+    url "https://files.openscad.org/snapshots/.snapshot_macos.js"
+    regex(/OpenSCAD[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "openscad"
+
+  app "OpenSCAD.app"
+  binary "#{appdir}/OpenSCAD.app/Contents/MacOS/OpenSCAD", target: "openscad"
+
+  zap trash: [
+    "~/Library/Caches/org.openscad.OpenSCAD",
+    "~/Library/Preferences/org.openscad.OpenSCAD.plist",
+    "~/Library/Saved Application State/org.openscad.OpenSCAD.savedState",
+  ]
+end

--- a/Casks/p/pgadmin3.rb
+++ b/Casks/p/pgadmin3.rb
@@ -1,0 +1,25 @@
+cask "pgadmin3" do
+  # NOTE: "3" is not a version number, but indicates a different vendor
+  version "1.22.2"
+  sha256 "35a140e5a15d2acbdd981819c6f891ad197af520914a26964920424621fe5c31"
+
+  url "https://ftp.postgresql.org/pub/pgadmin/pgadmin3/v#{version}/osx/pgadmin3-#{version}.dmg",
+      verified: "ftp.postgresql.org/pub/pgadmin/pgadmin3/"
+  name "pgAdmin"
+  desc "Administration and development platform for PostgreSQL"
+  homepage "https://www.pgadmin.org/"
+
+  livecheck do
+    url "https://pgadmin-archive.postgresql.org/pgadmin3/index.html"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)(?:/index.html)/?["' >]}i)
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  app "pgAdmin3.app"
+
+  zap trash: [
+    "~/Library/Preferences/pgadmin3 Preferences",
+    "~/Library/Saved Application State/org.postgresql.pgadmin.savedState",
+  ]
+end

--- a/Casks/p/playcover-community@beta.rb
+++ b/Casks/p/playcover-community@beta.rb
@@ -1,0 +1,32 @@
+cask "playcover-community@beta" do
+  version "3.0.0-beta.2"
+  sha256 "d20d5d50085f248143e9eaaab2c65156aae461e90bdb32e50a751b58e15b4555"
+
+  url "https://github.com/PlayCover/PlayCover/releases/download/#{version}/PlayCover_#{version}.dmg"
+  name "PlayCover"
+  desc "Sideload iOS apps and games"
+  homepage "https://github.com/PlayCover/PlayCover"
+
+  livecheck do
+    url :url
+    regex(/(\d+(?:\.\d+)+[._-]beta(\.\d+)?)/i)
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  auto_updates true
+  conflicts_with cask: "playcover-community"
+  depends_on arch: :arm64
+  depends_on macos: ">= :monterey"
+
+  app "PlayCover.app"
+
+  zap trash: [
+    "~/Library/Application Support/io.playcover.PlayCover",
+    "~/Library/Caches/io.playcover.PlayCover",
+    "~/Library/Containers/io.playcover.PlayCover",
+    "~/Library/Frameworks/PlayTools.framework",
+    "~/Library/Preferences/io.playcover.PlayCover.plist",
+    "~/Library/Saved Application State/io.playcover.PlayCover.savedState",
+  ]
+end

--- a/Casks/q/qbittorrent@lt20.rb
+++ b/Casks/q/qbittorrent@lt20.rb
@@ -1,0 +1,33 @@
+cask "qbittorrent@lt20" do
+  version "4.6.4"
+  sha256 "be24d257b8c5b6d1f7aa77bbf96df64edbbf5991cfed0c81b38663a213f60694"
+
+  url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}_lt20.dmg",
+      verified: "downloads.sourceforge.net/qbittorrent/qbittorrent-mac/"
+  name "qBittorrent"
+  desc "Edition of qBitorrent based on libtorrent-rasterbar 2.0.x"
+  homepage "https://www.qbittorrent.org/"
+
+  livecheck do
+    url "https://sourceforge.net/projects/qbittorrent/rss?path=/qbittorrent-mac"
+    regex(/qbittorrent[._-]v?(\d+(?:\.\d+)+)[._-]lt20\.dmg/i)
+    strategy :page_match
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "qbittorrent"
+  depends_on macos: ">= :mojave"
+
+  # Renamed for consistency: app name is different in the Finder and in a shell.
+  app "qbittorrent.app", target: "qBittorrent.app"
+
+  zap trash: [
+    "~/.config/qBittorrent",
+    "~/Library/Application Support/qBittorrent",
+    "~/Library/Caches/qBittorrent",
+    "~/Library/Preferences/org.qbittorrent.qBittorrent.plist",
+    "~/Library/Preferences/qBittorrent",
+    "~/Library/Saved Application State/org.qbittorrent.qBittorrent.savedState",
+  ]
+end

--- a/Casks/q/qgis@ltr.rb
+++ b/Casks/q/qgis@ltr.rb
@@ -1,0 +1,29 @@
+cask "qgis@ltr" do
+  version "3.34.6,20240419_184338"
+  sha256 "a694b3999d88638484463ff33f3f33f7c53ce3b587c80383bed4a8bb17556a63"
+
+  url "https://qgis.org/downloads/macos/ltr/qgis_ltr_final-#{version.csv.first.dots_to_underscores}_#{version.csv.second}.dmg"
+  name "QGIS LTR"
+  desc "Geographic Information System"
+  homepage "https://www.qgis.org/"
+
+  livecheck do
+    url "https://qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
+    regex(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0].tr("_", ".")},#{match[1]}" }
+    end
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  depends_on macos: ">= :high_sierra"
+
+  app "QGIS-LTR.app"
+
+  zap trash: [
+    "~/Library/Application Support/QGIS",
+    "~/Library/Caches/QGIS",
+    "~/Library/Saved Application State/org.qgis.qgis*.savedState",
+  ]
+end

--- a/Casks/r/reflector@2.rb
+++ b/Casks/r/reflector@2.rb
@@ -1,0 +1,24 @@
+cask "reflector@2" do
+  version "2.7.3"
+  sha256 "fd9e4c1ee48d113c09c5e2736001a20e3eff6fdf655ec974b814a190c1c8b76e"
+
+  url "https://download.airsquirrels.com/Reflector#{version.major}/Mac/Reflector-#{version}.dmg"
+  name "Reflector"
+  desc "Wireless screen-mirroring application"
+  homepage "https://www.airsquirrels.com/reflector/"
+
+  livecheck do
+    url "https://updates.airsquirrels.com/Reflector#{version.major}/Mac/Reflector#{version.major}.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  app "Reflector #{version.major}.app"
+
+  zap trash: [
+    "~/Library/Application Support/Logs/Reflector.log",
+    "~/Library/Caches/com.squirrels.Reflector-#{version.major}",
+    "~/Library/Preferences/com.squirrels.Reflector-#{version.major}.plist",
+  ]
+end

--- a/Casks/s/slicer@preview.rb
+++ b/Casks/s/slicer@preview.rb
@@ -1,0 +1,27 @@
+cask "slicer@preview" do
+  version :latest
+  sha256 :no_check
+
+  url "https://download.slicer.org/find?os=macosx&stability=nightly" do |page|
+    require "json"
+    file_path = JSON.parse(page)["download_url"]
+    URI.join(page.url, file_path)
+  end
+  name "3D Slicer"
+  desc "Medical image processing and visualization system"
+  homepage "https://www.slicer.org/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "slicer"
+
+  app "Slicer.app"
+
+  zap trash: [
+    "~/.config/www.na-mic.org",
+    "~/Library/Application Support/NA-MIC",
+    "~/Library/Preferences/org.slicer.slicer.plist",
+    "~/Library/Preferences/Slicer.plist",
+    "~/Library/Saved Application State/org.slicer.slicer.savedState",
+  ]
+end

--- a/Casks/s/smcfancontrol@beta.rb
+++ b/Casks/s/smcfancontrol@beta.rb
@@ -1,0 +1,26 @@
+cask "smcfancontrol@beta" do
+  version "2.6.1"
+  sha256 "d9dcd2c01e2583b74e14a6303ffd75d659dea7f99e1e42de4d8fcb0115cbcec3"
+
+  url "https://github.com/hholtmann/smcFanControl/releases/download/#{version}%C3%9F1/smcFanControl_#{version.dots_to_underscores}.zip"
+  name "smcFanControl"
+  desc "Sets a minimum speed for built-in fans"
+  homepage "https://github.com/hholtmann/smcFanControl"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)[^ß]?/i)
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "smcfancontrol"
+
+  app "smcFanControl.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.eidac.smcfancontrol#{version.major}.sfl*",
+    "~/Library/Application Support/smcFanControl",
+    "~/Library/Caches/com.eidac.smcFanControl#{version.major}",
+  ]
+end

--- a/Casks/s/sonarr@beta.rb
+++ b/Casks/s/sonarr@beta.rb
@@ -1,0 +1,26 @@
+cask "sonarr@beta" do
+  version "3.0.9.1555"
+  sha256 "50ede276cd42c41b9a3f66ca2495b16b0f99b4b773615ab602f069acf10c5a04"
+
+  url "https://download.sonarr.tv/v#{version.major}/develop/#{version}/Sonarr.develop.#{version}.macos.zip"
+  name "Sonarr Beta"
+  desc "PVR for Usenet and BitTorrent users"
+  homepage "https://sonarr.tv/"
+
+  livecheck do
+    url "https://download.sonarr.tv/v3/develop/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "sonarr"
+  depends_on cask: "mono-mdk"
+
+  app "Sonarr.app"
+
+  zap trash: [
+    "~/.config/Sonarr",
+    "~/Library/Saved Application State/com.osx.sonarr.tv.savedState",
+  ]
+end

--- a/Casks/t/transmission@nightly.rb
+++ b/Casks/t/transmission@nightly.rb
@@ -1,0 +1,31 @@
+cask "transmission@nightly" do
+  version :latest
+  sha256 :no_check
+
+  url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/" do |page|
+    file_path = page[/href="([^"]+.dmg)"/, 1]
+    URI.join(page.url, file_path)
+  end
+  name "Transmission"
+  desc "Open-source BitTorrent client"
+  homepage "https://transmissionbt.com/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "transmission"
+  depends_on macos: ">= :mojave"
+
+  app "Transmission.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.m0k.transmission.sfl*",
+    "~/Library/Application Support/Transmission",
+    "~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/org.m0k.transmission.help",
+    "~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/Transmission Help*",
+    "~/Library/Caches/org.m0k.transmission",
+    "~/Library/Cookies/org.m0k.transmission.binarycookies",
+    "~/Library/Preferences/org.m0k.transmission.LSSharedFileList.plist",
+    "~/Library/Preferences/org.m0k.transmission.plist",
+    "~/Library/Saved Application State/org.m0k.transmission.savedState",
+  ]
+end

--- a/Casks/v/vlc@nightly.rb
+++ b/Casks/v/vlc@nightly.rb
@@ -1,0 +1,43 @@
+cask "vlc@nightly" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version :latest
+  sha256 :no_check
+
+  url "https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/" do |page|
+    folder_path = page[%r{\d+-\d+/}]
+    url URI.join(page.url, folder_path) do |version_page|
+      file_path = version_page[/href="([^"]+.dmg)"/, 1]
+      URI.join(version_page.url, file_path)
+    end
+  end
+  name "VLC media player"
+  desc "Open-source cross-platform multimedia player"
+  homepage "https://www.videolan.org/vlc/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "vlc"
+
+  app "VLC.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/vlc.wrapper.sh"
+  binary shimscript, target: "vlc"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
+    EOS
+  end
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*",
+    "~/Library/Application Support/org.videolan.vlc",
+    "~/Library/Application Support/VLC",
+    "~/Library/Caches/org.videolan.vlc",
+    "~/Library/Preferences/org.videolan.vlc",
+    "~/Library/Preferences/org.videolan.vlc.plist",
+    "~/Library/Saved Application State/org.videolan.vlc.savedState",
+  ]
+end

--- a/Casks/v/vscodium@insiders.rb
+++ b/Casks/v/vscodium@insiders.rb
@@ -1,0 +1,33 @@
+cask "vscodium@insiders" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.88.0.24095-insider"
+  sha256 arm:   "fddfedb021922d3639eab004ef6d4097feecc02046ca3d3c6cdc4329c70bd860",
+         intel: "40c43c1c403bc29627f252bf5a7143192644a374d3d4fd09e2621a005b343fc0"
+
+  url "https://github.com/VSCodium/vscodium-insiders/releases/download/#{version}/VSCodium.#{arch}.#{version}.dmg",
+      verified: "github.com/VSCodium/vscodium-insiders/"
+  name "VSCodium"
+  name "VSCodium Insiders"
+  desc "Code editor"
+  homepage "https://vscodium.com/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  depends_on macos: ">= :catalina"
+
+  app "VSCodium - Insiders.app"
+  binary "#{appdir}/VSCodium - Insiders.app/Contents/Resources/app/bin/codium-insiders", target: "codium-insiders"
+
+  zap trash: [
+    "~/.vscodium-insiders",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.vscodium.vscodiuminsiders.sfl*",
+    "~/Library/Application Support/VSCodium - Insiders",
+    "~/Library/Caches/com.vscodium.VSCodiumInsiders",
+    "~/Library/Caches/com.vscodium.VSCodiumInsiders.ShipIt",
+    "~/Library/Caches/VSCodium - Insiders",
+    "~/Library/HTTPStorages/com.vscodium.VSCodiumInsiders",
+    "~/Library/Preferences/com.vscodium.VSCodiumInsiders*.plist",
+    "~/Library/Saved Application State/com.vscodium.VSCodiumInsiders.savedState",
+  ]
+end

--- a/Casks/w/whoozle-android-file-transfer@nightly.rb
+++ b/Casks/w/whoozle-android-file-transfer@nightly.rb
@@ -1,0 +1,21 @@
+cask "whoozle-android-file-transfer@nightly" do
+  version :latest
+  sha256 :no_check
+
+  url "https://github.com/whoozle/android-file-transfer-linux/releases/download/continuous/AndroidFileTransferForLinux.dmg",
+      verified: "github.com/whoozle/android-file-transfer-linux/"
+  name "Android File Transfer"
+  desc "Android File Transfer for Linux"
+  homepage "https://whoozle.github.io/android-file-transfer-linux/"
+
+  deprecate! date: "2025-05-01", because: :unsigned
+
+  conflicts_with cask: "whoozle-android-file-transfer"
+  depends_on macos: ">= :sierra"
+
+  app "Android File Transfer for Linux.app"
+  binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"
+  binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-mount"
+
+  # No zap stanza required
+end

--- a/Casks/w/wine@devel.rb
+++ b/Casks/w/wine@devel.rb
@@ -1,0 +1,75 @@
+cask "wine@devel" do
+  version "9.7"
+  sha256 "f4c7fbc424fec28a6ec8791e392c2ae918c15d3e0b11034d65edc438e8014f6c"
+
+  # Current winehq packages are deprecated and these are packages from
+  # the new maintainers that will eventually be pushed to Winehq.
+  # See https://www.winehq.org/pipermail/wine-devel/2021-July/191504.html
+  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version}/wine-devel-#{version}-osx64.tar.xz",
+      verified: "github.com/Gcenx/macOS_Wine_builds/"
+  name "WineHQ-devel"
+  desc "Compatibility layer to run Windows applications"
+  homepage "https://wiki.winehq.org/MacOS"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/^v?((?:\d+(?:\.\d+)+)(?:-RC\d)?)$/i)
+  end
+
+  conflicts_with cask: [
+    "wine-stable",
+    "wine-staging",
+  ]
+  depends_on cask: "gstreamer-runtime"
+  depends_on macos: ">= :catalina"
+
+  app "Wine Devel.app"
+  dir_path = "#{appdir}/Wine Devel.app/Contents/Resources"
+  binary "#{dir_path}/start/bin/appdb"
+  binary "#{dir_path}/start/bin/winehelp"
+  binary "#{dir_path}/wine/bin/msidb"
+  binary "#{dir_path}/wine/bin/msiexec"
+  binary "#{dir_path}/wine/bin/notepad"
+  binary "#{dir_path}/wine/bin/regedit"
+  binary "#{dir_path}/wine/bin/regsvr32"
+  binary "#{dir_path}/wine/bin/wine"
+  binary "#{dir_path}/wine/bin/wine-preloader"
+  binary "#{dir_path}/wine/bin/wine64"
+  binary "#{dir_path}/wine/bin/wine64-preloader"
+  binary "#{dir_path}/wine/bin/wineboot"
+  binary "#{dir_path}/wine/bin/winecfg"
+  binary "#{dir_path}/wine/bin/wineconsole"
+  binary "#{dir_path}/wine/bin/winedbg"
+  binary "#{dir_path}/wine/bin/winefile"
+  binary "#{dir_path}/wine/bin/winemine"
+  binary "#{dir_path}/wine/bin/winepath"
+  binary "#{dir_path}/wine/bin/wineserver"
+
+  zap trash: [
+        "~/.local/share/applications/wine*",
+        "~/.local/share/icons/hicolor/**/application-x-wine*",
+        "~/.local/share/mime/application/x-wine*",
+        "~/.local/share/mime/packages/x-wine*",
+        "~/.wine",
+        "~/.wine32",
+        "~/Library/Saved Application State/org.winehq.wine-devel.wine.savedState",
+      ],
+      rmdir: [
+        "~/.local/share/applications",
+        "~/.local/share/icons",
+        "~/.local/share/mime",
+      ]
+
+  caveats <<~EOS
+    #{token} supports both 32-bit and 64-bit. It is compatible with an existing
+    32-bit wine prefix, but it will now default to 64-bit when you create a new
+    wine prefix. The architecture can be selected using the WINEARCH environment
+    variable which can be set to either win32 or win64.
+
+    To create a new pure 32-bit prefix, you can run:
+      $ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+
+    See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
+  EOS
+end

--- a/Casks/w/wine@staging.rb
+++ b/Casks/w/wine@staging.rb
@@ -1,0 +1,75 @@
+cask "wine@staging" do
+  version "9.7"
+  sha256 "8d5231668c862f7cffa8b5ff2d19d30b550859c13967bee4e62ffc7d309ca699"
+
+  # Current winehq packages are deprecated and these are packages from
+  # the new maintainers that will eventually be pushed to Winehq.
+  # See https://www.winehq.org/pipermail/wine-devel/2021-July/191504.html
+  url "https://github.com/Gcenx/macOS_Wine_builds/releases/download/#{version.major_minor}/wine-staging-#{version}-osx64.tar.xz",
+      verified: "github.com/Gcenx/macOS_Wine_builds/"
+  name "WineHQ-staging"
+  desc "Compatibility layer to run Windows applications"
+  homepage "https://wiki.winehq.org/MacOS"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(/^v?((?:\d+(?:\.\d+)+)(?:-RC\d)?)$/i)
+  end
+
+  conflicts_with cask: [
+    "wine-stable",
+    "wine-devel",
+  ]
+  depends_on cask: "gstreamer-runtime"
+  depends_on macos: ">= :catalina"
+
+  app "Wine Staging.app"
+  dir_path = "#{appdir}/Wine Staging.app/Contents/Resources"
+  binary "#{dir_path}/start/bin/appdb"
+  binary "#{dir_path}/start/bin/winehelp"
+  binary "#{dir_path}/wine/bin/msidb"
+  binary "#{dir_path}/wine/bin/msiexec"
+  binary "#{dir_path}/wine/bin/notepad"
+  binary "#{dir_path}/wine/bin/regedit"
+  binary "#{dir_path}/wine/bin/regsvr32"
+  binary "#{dir_path}/wine/bin/wine"
+  binary "#{dir_path}/wine/bin/wine-preloader"
+  binary "#{dir_path}/wine/bin/wine64"
+  binary "#{dir_path}/wine/bin/wine64-preloader"
+  binary "#{dir_path}/wine/bin/wineboot"
+  binary "#{dir_path}/wine/bin/winecfg"
+  binary "#{dir_path}/wine/bin/wineconsole"
+  binary "#{dir_path}/wine/bin/winedbg"
+  binary "#{dir_path}/wine/bin/winefile"
+  binary "#{dir_path}/wine/bin/winemine"
+  binary "#{dir_path}/wine/bin/winepath"
+  binary "#{dir_path}/wine/bin/wineserver"
+
+  zap trash: [
+        "~/.local/share/applications/wine*",
+        "~/.local/share/icons/hicolor/**/application-x-wine*",
+        "~/.local/share/mime/application/x-wine*",
+        "~/.local/share/mime/packages/x-wine*",
+        "~/.wine",
+        "~/.wine32",
+        "~/Library/Saved Application State/org.winehq.wine-staging.wine.savedState",
+      ],
+      rmdir: [
+        "~/.local/share/applications",
+        "~/.local/share/icons",
+        "~/.local/share/mime",
+      ]
+
+  caveats <<~EOS
+    #{token} supports both 32-bit and 64-bit. It is compatible with an existing
+    32-bit wine prefix, but it will now default to 64-bit when you create a new
+    wine prefix. The architecture can be selected using the WINEARCH environment
+    variable which can be set to either win32 or win64.
+
+    To create a new pure 32-bit prefix, you can run:
+      $ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
+
+    See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
+  EOS
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -37,6 +37,7 @@
   "seaglass": "all",
   "servpane": "all",
   "shadowsocksx-ng-r": "all",
+  "smcfancontrol@beta": "all",
   "splitshow": "all",
   "steveschow-gfxcardstatus": "all",
   "strawberry-wallpaper": "all",


### PR DESCRIPTION
Migrated casks from homebrew/cask-versions with signing issues will be added here for tracking
Merge with https://github.com/Homebrew/homebrew-cask-versions/pull/20212
Note: All unsigned casks with the exception of `wine@devel` and `wine@staging` have been deprecated with an effective date of 2025/05/01.