### PR TITLE
1password7 remove conflicts

### DIFF
--- a/Casks/1/1password.rb
+++ b/Casks/1/1password.rb
@@ -17,7 +17,6 @@ cask "1password" do
 
   auto_updates true
   conflicts_with cask: [
-    "1password@7",
     "1password@beta",
     "1password@nightly",
   ]

--- a/Casks/1/1password@7.rb
+++ b/Casks/1/1password@7.rb
@@ -13,11 +13,6 @@ cask "1password@7" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "1password",
-    "1password@beta",
-    "1password@nightly",
-  ]
   depends_on macos: ">= :high_sierra"
 
   app "1Password #{version.major}.app"

--- a/Casks/1/1password@beta.rb
+++ b/Casks/1/1password@beta.rb
@@ -18,7 +18,6 @@ cask "1password@beta" do
   auto_updates true
   conflicts_with cask: [
     "1password",
-    "1password@7",
     "1password@nightly",
   ]
   depends_on macos: ">= :catalina"

--- a/Casks/1/1password@nightly.rb
+++ b/Casks/1/1password@nightly.rb
@@ -11,7 +11,6 @@ cask "1password@nightly" do
 
   conflicts_with cask: [
     "1password",
-    "1password@7",
     "1password@beta",
   ]
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes conflicts that were recently added in #172356. 1Password7 doesn't conflict with the current version of 1Password (version 8) - I have been running both side-by-side with no issues for some time. Additionally, there is a good use case for installing both, as 1Password7 is the last version of 1Password that supports local vaults, and was useful in migration. I'd appreciate it if this PR can be accepted to allow installing both versions.