### PR TITLE
canva: fixed plist typo as this is resolved in 1.86.0

### DIFF
--- a/Casks/c/canva.rb
+++ b/Casks/c/canva.rb
@@ -22,8 +22,7 @@ cask "canva" do
     "~/Library/Application Support/Canva",
     "~/Library/Caches/com.canva.CanvaDesktop",
     "~/Library/Caches/com.canva.CanvaDesktop.ShipIt",
-    # `availablility` is misspelled upstream
-    "~/Library/LaunchAgents/com.canva.availablility-check-agent.plist",
+    "~/Library/LaunchAgents/com.canva.availability-check-agent.plist",
     "~/Library/Logs/Canva",
     "~/Library/Preferences/com.canva.CanvaDesktop.plist",
     "~/Library/Saved Application State/com.canva.CanvaDesktop.savedState",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The latest release (`1.86.0`) addresses the typo in the plist, so this now correctly references `~/Library/LaunchAgents/com.canva.availability-check-agent.plist`.  
The updated release also cleans up the previously misspelled plist. 
