### PR TITLE
zotero@beta 7.0.0-beta.77

### DIFF
--- a/Casks/z/zotero@beta.rb
+++ b/Casks/z/zotero@beta.rb
@@ -1,6 +1,6 @@
 cask "zotero@beta" do
-  version "7.0.0-beta.76,91054acfe"
-  sha256 "95da6459a205c840b8ce852d9bc8eb8627c93302b8a476ea72ccc3f3e216f2df"
+  version "7.0.0-beta.77,adaa61f2c"
+  sha256 "17cec0ba33d48cfde381e0fed0d2ac1fd49e39f1c2a80e83e0931b1c1f58b2ef"
 
   url "https://download.zotero.org/client/beta/#{version.csv.first}%2B#{version.csv.second}/Zotero-#{version.csv.first}%2B#{version.csv.second}.dmg"
   name "Zotero Beta"
@@ -11,7 +11,7 @@ cask "zotero@beta" do
     url "https://www.zotero.org/download/client/update/0/0/Darwin/en-US/beta/Darwin%25/update.xml"
     strategy :xml do |xml|
       xml.get_elements("//update[@type='major']").map do |element|
-        element.attributes["displayVersion"].split("+").join(",")
+        element.attributes["displayVersion"]&.tr("+", ",")
       end
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `zotero@beta` to the latest version, 7.0.0-beta.77.

This also replaces the `.split("+").join(",")` code in the `strategy` block with `&.tr("+", ",")`. This accomplishes the same thing with less overhead and uses the safe navigation operator to account for the potential absence of the `displayVersion` attribute.