### PR TITLE
tad: add arm64 arch

### DIFF
--- a/Casks/t/tad.rb
+++ b/Casks/t/tad.rb
@@ -1,8 +1,12 @@
 cask "tad" do
-  version "0.13.0"
-  sha256 "4c71f6f6a0fadf65891663d1a0462dd8d3576a4c62bdd8721012cbdd61ee1fee"
+  arch arm: "aarch64", intel: "x86-64"
+  suffix = on_arch_conditional arm: "-arm64", intel: ""
 
-  url "https://github.com/antonycourtney/tad/releases/download/v#{version}/Tad-#{version}.dmg",
+  version "0.13.0"
+  sha256  intel: "4c71f6f6a0fadf65891663d1a0462dd8d3576a4c62bdd8721012cbdd61ee1fee",
+          arm:   "9c129a65fdf94b4b32b6e26d8836a56d4284bff9a6e1df657cc23d19e5c802b1"
+
+  url "https://github.com/antonycourtney/tad/releases/download/v#{version}/Tad-#{version}#{suffix}.dmg",
       verified: "github.com/antonycourtney/tad/"
   name "Tad"
   desc "Desktop application for viewing and analyzing tabular data"
@@ -12,6 +16,8 @@ cask "tad" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :catalina"
 
   app "Tad.app"
   binary "#{appdir}/Tad.app/Contents/Resources/tad.sh", target: "tad"

--- a/Casks/t/tad.rb
+++ b/Casks/t/tad.rb
@@ -1,12 +1,11 @@
 cask "tad" do
-  arch arm: "aarch64", intel: "x86-64"
-  suffix = on_arch_conditional arm: "-arm64", intel: ""
+  arch arm: "-arm64"
 
   version "0.13.0"
-  sha256  intel: "4c71f6f6a0fadf65891663d1a0462dd8d3576a4c62bdd8721012cbdd61ee1fee",
-          arm:   "9c129a65fdf94b4b32b6e26d8836a56d4284bff9a6e1df657cc23d19e5c802b1"
+  sha256  arm:   "9c129a65fdf94b4b32b6e26d8836a56d4284bff9a6e1df657cc23d19e5c802b1",
+          intel: "4c71f6f6a0fadf65891663d1a0462dd8d3576a4c62bdd8721012cbdd61ee1fee"
 
-  url "https://github.com/antonycourtney/tad/releases/download/v#{version}/Tad-#{version}#{suffix}.dmg",
+  url "https://github.com/antonycourtney/tad/releases/download/v#{version}/Tad-#{version}#{arch}.dmg",
       verified: "github.com/antonycourtney/tad/"
   name "Tad"
   desc "Desktop application for viewing and analyzing tabular data"


### PR DESCRIPTION
[Tad](https://www.tadviewer.com/) releases contain arm64 disk images : take them in account in the existing brew formula.

Also, `brew audit --cask --strict --online tad` suggested to set a minimum OS version.

Thanks!

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
