### PR TITLE
unity: update livecheck

### DIFF
--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -16,9 +16,11 @@ cask "unity" do
     regex(%r{/(\h+)/MacEditorInstaller/Unity[._-]v?(\d+(?:\.\d+)+[a-z]*\d*)\.pkg}i)
     strategy :json do |json, regex|
       json["official"]&.map do |release|
+        # Keep only 202X.X.XfX versions
+        next unless release["version"].start_with?("202")
+
         match = release["downloadUrl"]&.match(regex)
         next if match.blank?
-        next if match[2].start_with?("6000") # Skip Unity 6 Preview release
 
         "#{match[2]},#{match[1]}"
       end

--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -18,6 +18,7 @@ cask "unity" do
       json["official"]&.map do |release|
         match = release["downloadUrl"]&.match(regex)
         next if match.blank?
+        next if match[2].start_with?("6000") # Skip Unity 6 Preview release
 
         "#{match[2]},#{match[1]}"
       end

--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -13,10 +13,10 @@ cask "unity" do
 
   livecheck do
     url "https://public-cdn.cloud.unity3d.com/hub/prod/releases-darwin.json"
-    regex(%r{/(\h+)/MacEditorInstaller/Unity[._-]v?(\d+(?:\.\d+)+[a-z]*\d*)\.pkg}i)
+    regex(%r{/(\h+)/MacEditorInstaller/Unity[._-]v?(\d+(?:\.\d+)+(?:f\d+)?)\.pkg}i)
     strategy :json do |json, regex|
       json["official"]&.map do |release|
-        # Keep only 202X.X.XfX versions
+        # Only use 202X.X.XfX versions until Unity 6 (6000) is a full release
         next unless release["version"].start_with?("202")
 
         match = release["downloadUrl"]&.match(regex)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This updates the livecheck for `unity` to temporarily skip over the Unity 6 Preview release until it is formal later this year.  This change will need to be removed once Unity 6 is out of preview.  

Due to an updated numbering scheme, the preview version is showing as latest.  Previous number scheme used years (2023), while this preview version of Unity 6 is using (6000).  More details can be found [here](https://forum.unity.com/threads/unity-6-new-naming-convention.1558592/)

The json file used for livecheck also has this marked as an official release, which also causes this to be picked up and mixed with other non-preview releases.  