### PR TITLE
rstudio@daily: migrate

### DIFF
--- a/Casks/r/rstudio@daily.rb
+++ b/Casks/r/rstudio@daily.rb
@@ -1,0 +1,35 @@
+cask "rstudio@daily" do
+  version "2024.07.0-daily-89"
+  sha256 "ed5f5767789aeca16c42b76d87dea0b88b679a96aacdef32a7d8d90acb24bf86"
+
+  url "https://s3.amazonaws.com/rstudio-ide-build/electron/macos/RStudio-#{version}.dmg",
+      verified: "s3.amazonaws.com/rstudio-ide-build/electron/macos/"
+  name "RStudio Daily"
+  desc "Data science software focusing on R and Python"
+  homepage "https://dailies.rstudio.com/"
+
+  livecheck do
+    url "https://dailies.rstudio.com/rstudio/latest/index.json"
+    strategy :json do |json|
+      json["products"]["electron"]["platforms"]["macos"]["version"]
+        &.tr("+", "-")
+    end
+  end
+
+  conflicts_with cask: "rstudio"
+  depends_on macos: ">= :catalina"
+
+  app "RStudio.app"
+
+  zap trash: "~/.rstudio-desktop"
+
+  caveats <<~EOS
+    #{token} depends on R. The R Project provides official binaries:
+
+      brew install --cask r
+
+    Alternatively, the Homebrew-compiled version of R omits the GUI app:
+
+      brew install r
+  EOS
+end


### PR DESCRIPTION
Migrate with https://github.com/Homebrew/homebrew-cask-versions/pull/20216

This cask had to be reworked. 