### PR TITLE
mucommander 1.4.0-1

### DIFF
--- a/Casks/m/mucommander.rb
+++ b/Casks/m/mucommander.rb
@@ -1,8 +1,11 @@
 cask "mucommander" do
-  version "1.3.0-1"
-  sha256 "55c8fbc57ab646d6a6683a6f42a79513e9251189e385097496b1cce9445482d0"
+  arch arm: "aarch64", intel: "x86_64"
 
-  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-#{version}.dmg",
+  version "1.4.0-1"
+  sha256 arm:   "4f42c228b3d7e81857a2ad401474370bef3e0dd8d2dba88df21bd681457988f4",
+         intel: "ef56bf88e0aef6743c3d145750a2d808ebbe4fb818242c4e2f57783f9414b36e"
+
+  url "https://github.com/mucommander/mucommander/releases/download/#{version}/muCommander-#{version}-#{arch}.dmg",
       verified: "github.com/mucommander/mucommander/"
   name "muCommander"
   desc "File manager with a dual-pane interface"


### PR DESCRIPTION
Update mucommander from 1.3.0-1 to 1.4.0-1

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
