### PR TITLE
Battery: Update description and add caveats to reduce installation confusion

### DIFF
--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -4,7 +4,7 @@ cask "battery" do
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-mac-arm64.dmg"
   name "Battery"
-  desc "App for managing battery charging on Apple Silicon computers. (Also installs a CLI on first use.)"
+  desc "App for managing battery charging. (Also installs a CLI on first use.)"
   homepage "https://github.com/actuallymentor/battery/"
 
   auto_updates true

--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -13,7 +13,7 @@ cask "battery" do
 
   app "battery.app"
 
-  caveat "The macOS app (battery) must be run at least once to complete installation of the CLI."
+  caveats "The macOS app (battery) must be run at least once to complete installation of the CLI."
 
   uninstall delete: "/usr/local/bin/smc"
 

--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -4,7 +4,7 @@ cask "battery" do
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-mac-arm64.dmg"
   name "Battery"
-  desc "App and CLI for managing the battery charging status"
+  desc "App for managing battery charging on Apple Silicon computers. (Also installs a CLI on first use.)"
   homepage "https://github.com/actuallymentor/battery/"
 
   auto_updates true
@@ -23,6 +23,4 @@ cask "battery" do
     "~/Library/Preferences/org.mentor.Battery.plist",
     "~/Library/Saved Application State/co.palokaj.battery.savedState",
   ]
-
-  caveats "The macOS app (battery) must be run at least once to complete installation of the CLI."
 end

--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -4,7 +4,7 @@ cask "battery" do
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-mac-arm64.dmg"
   name "Battery"
-  desc "macOS app and CLI for managing the battery charging status"
+  desc "App and CLI for managing the battery charging status"
   homepage "https://github.com/actuallymentor/battery/"
 
   auto_updates true
@@ -12,8 +12,6 @@ cask "battery" do
   depends_on arch: :arm64
 
   app "battery.app"
-
-  caveats "The macOS app (battery) must be run at least once to complete installation of the CLI."
 
   uninstall delete: "/usr/local/bin/smc"
 
@@ -25,4 +23,6 @@ cask "battery" do
     "~/Library/Preferences/org.mentor.Battery.plist",
     "~/Library/Saved Application State/co.palokaj.battery.savedState",
   ]
+
+  caveats "The macOS app (battery) must be run at least once to complete installation of the CLI."
 end

--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -4,7 +4,7 @@ cask "battery" do
 
   url "https://github.com/actuallymentor/battery/releases/download/v#{version}/battery-#{version}-mac-arm64.dmg"
   name "Battery"
-  desc "CLI for managing the battery charging status"
+  desc "macOS app and CLI for managing the battery charging status"
   homepage "https://github.com/actuallymentor/battery/"
 
   auto_updates true
@@ -12,6 +12,8 @@ cask "battery" do
   depends_on arch: :arm64
 
   app "battery.app"
+
+  caveat "The macOS app (battery) must be run at least once to complete installation of the CLI."
 
   uninstall delete: "/usr/local/bin/smc"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ X ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ X ] `brew audit --cask --online <cask>` is error-free.
- [ X ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This cask appeared to install the battery CLI, but the CLI doesn't work or isn't present unless the macOS app is run at least once. This change both:
   - Makes it more obvious that there is an app
   - Makes it clear that the CLI will not work unless the app is run once
