### PR TITLE
USAGE: remove Homebrew/cask-versions references

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -120,19 +120,18 @@ Since the Homebrew Cask repository is a Homebrew tap, you’ll pull down the lat
 
 Homebrew [automatically taps and keeps Homebrew Cask updated](https://github.com/Homebrew/homebrew-cask/pull/15381). `brew update` is all that is required.
 
-## Additional Taps (optional)
+## Additional Tap (optional)
 
-The primary Homebrew Cask tap includes most of the casks that a typical user will be interested in. There are a few additional taps where we store different kinds of casks.
+The primary Homebrew Cask tap includes most of the casks that a typical user will be interested in. There is an additional tap where we store different fonts as casks.
 
 | tap name | description |
 | -------- | ----------- |
-| [homebrew/cask-versions](https://github.com/Homebrew/homebrew-cask-versions) | contains alternate versions of casks (_e.g._ betas, nightly releases, old versions)
 | [homebrew/cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts)       | contains casks that install fonts
 
-You can tap any of the above with the `brew tap` command:
+You can tap the above with the `brew tap` command:
 
 ```bash
-brew tap <tap_name>
+brew tap homebrew/cask-fonts
 ```
 
 after which casks from the new tap will be available to `search` or `install` just like casks from the main tap. `brew update` will automatically keep your new tap up to date.


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
