### PR TITLE
streamlink-twitch-gui 2.5.0

### DIFF
--- a/Casks/s/streamlink-twitch-gui.rb
+++ b/Casks/s/streamlink-twitch-gui.rb
@@ -1,6 +1,6 @@
 cask "streamlink-twitch-gui" do
-  version "2.4.1"
-  sha256 "6cea7d3faa97f72962fae7049ba84f2fe5dc1110b3e70660c77dde890df3180a"
+  version "2.5.0"
+  sha256 "cfbca3d748de0c640566a07255c663f1934a32e3776254426fa02e6fe3516a77"
 
   url "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v#{version}/streamlink-twitch-gui-v#{version}-macOS.tar.gz"
   name "Streamlink Twitch GUI"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.