### PR TITLE
various casks: remove deprecated casks

### DIFF
--- a/Casks/a/arduino.rb
+++ b/Casks/a/arduino.rb
@@ -9,8 +9,6 @@ cask "arduino" do
 
   deprecate! date: "2023-12-17", because: :discontinued
 
-  conflicts_with cask: "arduino-nightly"
-
   app "Arduino.app"
   binary "#{appdir}/Arduino.app/Contents/Java/arduino-builder"
 

--- a/Casks/b/bbedit.rb
+++ b/Casks/b/bbedit.rb
@@ -14,6 +14,7 @@ cask "bbedit" do
   end
 
   auto_updates true
+  conflicts_with cask: "bbedit@14"
   depends_on macos: ">= :catalina"
 
   app "BBEdit.app"

--- a/Casks/f/fertigt-slate.rb
+++ b/Casks/f/fertigt-slate.rb
@@ -7,8 +7,6 @@ cask "fertigt-slate" do
   desc "Window management application"
   homepage "https://github.com/fertigt/slate_arm64"
 
-  conflicts_with cask: "slate"
-
   app "Slate.app"
 
   zap trash: [

--- a/Casks/f/forklift.rb
+++ b/Casks/f/forklift.rb
@@ -13,7 +13,6 @@ cask "forklift" do
   end
 
   auto_updates true
-  conflicts_with cask: "forklift3"
   depends_on macos: ">= :monterey"
 
   app "ForkLift.app"

--- a/Casks/i/intellij-idea-ce.rb
+++ b/Casks/i/intellij-idea-ce.rb
@@ -21,7 +21,6 @@ cask "intellij-idea-ce" do
   end
 
   auto_updates true
-  conflicts_with cask: "intellij-idea-ce19"
   depends_on macos: ">= :high_sierra"
 
   app "IntelliJ IDEA CE.app"

--- a/Casks/i/iterm2.rb
+++ b/Casks/i/iterm2.rb
@@ -37,7 +37,6 @@ cask "iterm2" do
 
   auto_updates true
   conflicts_with cask: [
-    "iterm2-legacy",
     "iterm2@beta",
     "iterm2@nightly",
   ]

--- a/Casks/i/iterm2@beta.rb
+++ b/Casks/i/iterm2@beta.rb
@@ -16,7 +16,6 @@ cask "iterm2@beta" do
   auto_updates true
   conflicts_with cask: [
     "iterm2",
-    "iterm2-legacy",
     "iterm2@nightly",
   ]
   depends_on macos: ">= :catalina"

--- a/Casks/i/iterm2@nightly.rb
+++ b/Casks/i/iterm2@nightly.rb
@@ -15,7 +15,6 @@ cask "iterm2@nightly" do
 
   conflicts_with cask: [
     "iterm2",
-    "iterm2-legacy",
     "iterm2@beta",
   ]
   depends_on macos: ">= :catalina"

--- a/Casks/k/kaleidoscope.rb
+++ b/Casks/k/kaleidoscope.rb
@@ -23,7 +23,6 @@ cask "kaleidoscope" do
     kaleidoscope@2
     kaleidoscope@3
     ksdiff
-    ksdiff2
   ]
   depends_on macos: ">= :ventura"
 

--- a/Casks/k/kaleidoscope@2.rb
+++ b/Casks/k/kaleidoscope@2.rb
@@ -29,7 +29,6 @@ cask "kaleidoscope@2" do
     kaleidoscope
     kaleidoscope@3
     ksdiff
-    ksdiff2
   ]
   depends_on macos: ">= :sierra"
 

--- a/Casks/k/kaleidoscope@3.rb
+++ b/Casks/k/kaleidoscope@3.rb
@@ -29,7 +29,6 @@ cask "kaleidoscope@3" do
     kaleidoscope
     kaleidoscope@2
     ksdiff
-    ksdiff2
   ]
   depends_on macos: ">= :big_sur"
 

--- a/Casks/k/ksdiff.rb
+++ b/Casks/k/ksdiff.rb
@@ -12,7 +12,7 @@ cask "ksdiff" do
   conflicts_with cask: [
     "kaleidoscope",
     "kaleidoscope@2",
-    "ksdiff2",
+    "kaleidoscope@3",
   ]
 
   pkg "ksdiff-#{version.csv.first}/Install ksdiff.pkg"

--- a/Casks/m/morpheus.rb
+++ b/Casks/m/morpheus.rb
@@ -10,8 +10,6 @@ cask "morpheus" do
 
   deprecate! date: "2024-04-15", because: :discontinued
 
-  conflicts_with cask: "morpheus-beta"
-
   app "Morpheus.app"
 
   zap trash: [

--- a/Casks/o/omniplan.rb
+++ b/Casks/o/omniplan.rb
@@ -76,7 +76,6 @@ cask "omniplan" do
   homepage "https://www.omnigroup.com/omniplan/"
 
   auto_updates true
-  conflicts_with cask: "omniplan3"
 
   app "OmniPlan.app"
 

--- a/Casks/p/paragon-extfs.rb
+++ b/Casks/p/paragon-extfs.rb
@@ -14,7 +14,7 @@ cask "paragon-extfs" do
     end
   end
 
-  conflicts_with cask: "paragon-extfs11"
+  conflicts_with cask: "paragon-extfs@11"
   depends_on macos: ">= :sierra"
 
   installer manual: "FSInstaller.app"

--- a/Casks/p/processing.rb
+++ b/Casks/p/processing.rb
@@ -19,10 +19,7 @@ cask "processing" do
     end
   end
 
-  conflicts_with cask: [
-    "processing2",
-    "processing@3",
-  ]
+  conflicts_with cask: "processing@3"
   depends_on macos: ">= :catalina"
 
   app "Processing.app"

--- a/Casks/p/processing@3.rb
+++ b/Casks/p/processing@3.rb
@@ -16,10 +16,7 @@ cask "processing@3" do
     end
   end
 
-  conflicts_with cask: [
-    "processing",
-    "processing2",
-  ]
+  conflicts_with cask: "processing"
 
   app "Processing.app"
 

--- a/Casks/r/rambox.rb
+++ b/Casks/r/rambox.rb
@@ -9,7 +9,6 @@ cask "rambox" do
   homepage "https://rambox.app/"
 
   auto_updates true
-  conflicts_with cask: "rambox-ce"
 
   app "Rambox.app"
 

--- a/Casks/s/sublime-text.rb
+++ b/Casks/s/sublime-text.rb
@@ -14,10 +14,7 @@ cask "sublime-text" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "sublime-text3",
-    "sublime-text@dev",
-  ]
+  conflicts_with cask: "sublime-text@dev"
 
   app "Sublime Text.app"
   binary "#{appdir}/Sublime Text.app/Contents/SharedSupport/bin/subl"

--- a/Casks/s/sublime-text@dev.rb
+++ b/Casks/s/sublime-text@dev.rb
@@ -14,10 +14,7 @@ cask "sublime-text@dev" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "sublime-text",
-    "sublime-text3",
-  ]
+  conflicts_with cask: "sublime-text"
 
   app "Sublime Text.app"
   binary "#{appdir}/Sublime Text.app/Contents/SharedSupport/bin/subl"

--- a/Casks/t/tsh.rb
+++ b/Casks/t/tsh.rb
@@ -13,7 +13,7 @@ cask "tsh" do
     regex(/tsh[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
-  conflicts_with cask:    "tsh13",
+  conflicts_with cask:    "tsh@13",
                  formula: "teleport"
 
   pkg "tsh-#{version}.pkg"

--- a/Casks/v/vmware-fusion-tech@preview.rb
+++ b/Casks/v/vmware-fusion-tech@preview.rb
@@ -26,14 +26,7 @@ cask "vmware-fusion-tech@preview" do
   end
 
   auto_updates true
-  conflicts_with cask: %w[
-    vmware-fusion
-    vmware-fusion7
-    vmware-fusion8
-    vmware-fusion10
-    vmware-fusion11
-    vmware-fusion12
-  ]
+  conflicts_with cask: "vmware-fusion"
   depends_on macos: ">= :big_sur"
 
   app "VMware Fusion Tech Preview.app"

--- a/Casks/v/vmware-fusion.rb
+++ b/Casks/v/vmware-fusion.rb
@@ -16,14 +16,7 @@ cask "vmware-fusion" do
   end
 
   auto_updates true
-  conflicts_with cask: [
-    "vmware-fusion-tech@preview",
-    "vmware-fusion10",
-    "vmware-fusion11",
-    "vmware-fusion12",
-    "vmware-fusion7",
-    "vmware-fusion8",
-  ]
+  conflicts_with cask: "vmware-fusion-tech@preview"
   depends_on macos: ">= :monterey"
 
   app "VMware Fusion.app"

--- a/Casks/x/xmind.rb
+++ b/Casks/x/xmind.rb
@@ -13,7 +13,7 @@ cask "xmind" do
     strategy :header_match
   end
 
-  conflicts_with cask: "xmind8"
+  conflicts_with cask: "xmind@beta"
 
   app "Xmind.app"
 

--- a/Casks/x/xmind@beta.rb
+++ b/Casks/x/xmind@beta.rb
@@ -15,10 +15,7 @@ cask "xmind@beta" do
     end
   end
 
-  conflicts_with cask: [
-    "xmind",
-    "xmind8",
-  ]
+  conflicts_with cask: "xmind"
 
   app "Xmind.app"
 


### PR DESCRIPTION
This removes casks that were formerly included in `homebrew/cask-versions` and not migrated over.