### PR TITLE
todesk: update livecheck

### DIFF
--- a/Casks/t/todesk.rb
+++ b/Casks/t/todesk.rb
@@ -1,6 +1,6 @@
 cask "todesk" do
   version "4.7.2.1"
-  sha256 :no_check # required as upstream package is updated in-place
+  sha256 "cba50ad3b10523f71175953d4606d3daf122d344dd1e5f130fd190a93ba509e8"
 
   url "https://dl.todesk.com/macos/ToDesk_#{version}.pkg"
   name "ToDesk"

--- a/Casks/t/todesk.rb
+++ b/Casks/t/todesk.rb
@@ -1,6 +1,6 @@
 cask "todesk" do
   version "4.7.2.1"
-  sha256 "dbc167b9f720430990fcc0e3d035f99a0f649017b0a81f21ca8be61ed5d3266e"
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://dl.todesk.com/macos/ToDesk_#{version}.pkg"
   name "ToDesk"

--- a/Casks/t/todesk.rb
+++ b/Casks/t/todesk.rb
@@ -1,6 +1,6 @@
 cask "todesk" do
   version "4.7.2.1"
-  sha256 "cba50ad3b10523f71175953d4606d3daf122d344dd1e5f130fd190a93ba509e8"
+  sha256 "dbc167b9f720430990fcc0e3d035f99a0f649017b0a81f21ca8be61ed5d3266e"
 
   url "https://dl.todesk.com/macos/ToDesk_#{version}.pkg"
   name "ToDesk"

--- a/Casks/t/todesk.rb
+++ b/Casks/t/todesk.rb
@@ -8,8 +8,8 @@ cask "todesk" do
   homepage "https://www.todesk.com/"
 
   livecheck do
-    url "https://dl.todesk.com/macos/uplog.html"
-    regex(%r{<div\sclass="text">(\d+(?:\.\d+)+)</div>}i)
+    url "https://www.todesk.com/download.html"
+    regex(/ToDesk[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
   auto_updates true

--- a/Casks/t/todesk.rb
+++ b/Casks/t/todesk.rb
@@ -2,7 +2,9 @@ cask "todesk" do
   version "4.7.2.1"
   sha256 "cba50ad3b10523f71175953d4606d3daf122d344dd1e5f130fd190a93ba509e8"
 
-  url "https://dl.todesk.com/macos/ToDesk_#{version}.pkg"
+  url "https://dl.todesk.com/macos/ToDesk_#{version}.pkg",
+      user_agent: :fake,
+      referer:    "https://www.todesk.com/"
   name "ToDesk"
   desc "Remote control software"
   homepage "https://www.todesk.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `todesk` checks an upstream release notes page but the response body only contains a `<script>` element when checked with curl, so it gives an `Unable to get versions` error. This seems to be true regardless of headers (e.g., user agent, etc.).

This updates the `livecheck` block to check the download page and match the version from the pkg URL (found in some JavaScript code).