### PR TITLE
clickup 3.3.79

### DIFF
--- a/Casks/c/clickup.rb
+++ b/Casks/c/clickup.rb
@@ -1,22 +1,32 @@
 cask "clickup" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.3.57"
-  sha256 arm:   "b24b87c66d0e2bd60412c9cf4728ab7daf68c5b058576600cecdadf774d25935",
-         intel: "3dcbea893e1fb51b624c012a67271444a58d28822c136c6377feae0a66e16033"
+  version "3.3.79,240105hz1mbg8s0"
+  sha256 arm:   "fd0a88bc4396f35e10409a07f4e5576acbc3fd787ed5639e076c6517ff263e34",
+         intel: "3fad667921e5abf3e40ac70419a7e4565bd452b50c359c39817f970b37095ce7"
 
-  url "https://download.todesktop.com/210531zdwwjv8ke/ClickUp%20#{version}-#{arch}.dmg",
-      verified: "download.todesktop.com/210531zdwwjv8ke/"
+  url "https://download.todesktop.com/221003ra4tebclw/ClickUp%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}.dmg",
+      verified: "download.todesktop.com/221003ra4tebclw/"
   name "ClickUp"
   desc "Productivity platform for tasks, docs, goals, and chat"
   homepage "https://clickup.com/"
 
+  # NOTE: The magic string in the URL (e.g. `221003ra4tebclw`) may need to be
+  # updated over time, as the existing URL may only return an old version.
   livecheck do
-    url "https://download.todesktop.com/210531zdwwjv8ke/latest-mac.yml"
-    strategy :electron_builder
+    url "https://download.todesktop.com/221003ra4tebclw/latest-mac.yml"
+    regex(/ClickUp\s*v?(\d+(?:\.\d+)+).*?Build\s*([a-z0-9]+)[._-]#{arch}\.dmg/i)
+    strategy :electron_builder do |yaml|
+      yaml["files"]&.map do |item|
+        match = item["url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "ClickUp.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `clickup` to the latest version, 3.3.79.

The magic string (ID) in the URLs (e.g. `221003ra4tebclw`) seems to change over time and the `livecheck` block will consistently return an old version until the URL is updated. Hopefully this doesn't happen very often but it has made us miss updates for seven months at this point.

For what it's worth, the magic string can be found in the `Install Clickup.app/Contents/Info.plist` `dict`:

```
...
	<key>ToDesktop ID</key>
	<string>221003ra4tebclw</string>
...
```

If you run `strings` on `Install Clickup.app/Contents/MacOS/ToDesktop Installer`, you can see that the ToDesktop ID is interpolated into the URL: `https://download.todesktop.com/%@/td-latest-mac.json`.