### PR TITLE
sync 2.2.36

### DIFF
--- a/Casks/s/sync.rb
+++ b/Casks/s/sync.rb
@@ -1,15 +1,15 @@
 cask "sync" do
-  version "2.2.35"
-  sha256 :no_check
+  version "2.2.36"
+  sha256 "394642c32c9788967da57eab64bcdd1ff66c699bc64d5b0e08e19c951fc33cf7"
 
-  url "https://www.sync.com/download/apple/Sync.dmg"
+  url "https://www.sync.com/download/apple/Sync-#{version}.dmg"
   name "Sync"
   desc "Store, share and access files from anywhere"
   homepage "https://www.sync.com/"
 
   livecheck do
     url "https://www.sync.com/install/"
-    regex(/(\d+(?:\.\d+)+)\n.*release\s*notes/i)
+    regex(/href=.*?Sync[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "Sync.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `sync` to the latest version, 2.2.36.

The upstream install page (https://www.sync.com/install/) now links to a versioned dmg file. The `livecheck` block was returning an `Unable to get versions` error but I've updated the regex to match the version from the dmg URL.