### PR TITLE
vyprvpn: update livecheck

### DIFF
--- a/Casks/v/vyprvpn.rb
+++ b/Casks/v/vyprvpn.rb
@@ -9,8 +9,8 @@ cask "vyprvpn" do
   homepage "https://www.vyprvpn.com/"
 
   livecheck do
-    url "https://www.goldenfrog.com/downloads/vyprvpn/desktop/mac-feed.xml"
-    strategy :sparkle, &:short_version
+    url "https://www.vyprvpn.com/vpn-apps/vpn-for-mac"
+    regex(/href=.*?VyprVPN[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `vyprvpn`  checks a Sparkle feed but this only contains an entry for 5.0.1, while the cask uses version 5.1.0.10003. This updates the `livecheck` block to check the download page for the Mac app, which contains a link to the 5.1.0.10003 dmg.