### PR TITLE
jaspersoft-studio: remove livecheck

### DIFF
--- a/Casks/j/jaspersoft-studio.rb
+++ b/Casks/j/jaspersoft-studio.rb
@@ -8,11 +8,6 @@ cask "jaspersoft-studio" do
   desc "Eclipse-based report development tool for JasperReports"
   homepage "https://community.jaspersoft.com/downloads/community-edition/"
 
-  livecheck do
-    url "https://sourceforge.net/projects/jasperstudio/files/"
-    regex(%r{url=.*?/jasperstudio/files/JasperSoftStudio[._-]v?(\d+(?:\.\d+)+)}i)
-  end
-
   # https://community.jaspersoft.com/knowledgebase/faq/faqs-on-community-edition-changes-effective-january-25-2024-r4629/
   deprecate! date: "2024-02-11", because: :repo_removed
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`jaspersoft-studio` was deprecated in #166482, as the SourceForge project has been removed. This removes the `livecheck` block, so it will be automatically skipped as deprecated.

Jaspersoft Studio community edition is available for download at https://community.jaspersoft.com/download-jaspersoft/community-edition/jaspersoft-studio_mac but you have to create an account to download it.