### PR TITLE
zettelkasten: downgrade to 3.2022.8

### DIFF
--- a/Casks/z/zettelkasten.rb
+++ b/Casks/z/zettelkasten.rb
@@ -15,6 +15,11 @@ cask "zettelkasten" do
 
   app "Zettelkasten.app"
 
+  zap trash: [
+    "~/.Zettelkasten",
+    "~/Library/Saved Application State/de.danielluedecke.zettelkasten.ZettelkastenApp.savedState",
+  ]
+
   caveats do
     depends_on_java "8"
   end

--- a/Casks/z/zettelkasten.rb
+++ b/Casks/z/zettelkasten.rb
@@ -1,6 +1,6 @@
 cask "zettelkasten" do
-  version "3.2023.10"
-  sha256 "3c9bf950bc6eda0e335b463be6625e3ca668c8339dde0f600707afdb87e3c924"
+  version "3.2022.8"
+  sha256 "62917c18dfd2dd2d8acd7d2ce4db6a4b036fc92a03877da108e85f8c5efcaeea"
 
   url "https://github.com/Zettelkasten-Team/Zettelkasten/releases/download/v#{version}/Package.dmg.zip",
       verified: "github.com/Zettelkasten-Team/Zettelkasten/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`zettelkasten` was upgraded to 3.2023.10 in #158445 but the related release has since been removed from the GitHub project, so the cask `url` gives a 404 (Not Found) response. The repository contains tags for v3.2023.10 (2023-10-24) and v3.2023.12 (2023-12-30) but the latest release (with the `Package.dmg.zip` file we use) is 3.2022.8.

This downgrades the cask to the latest available release, 3.2022.8.