### PR TITLE
focus-booster: remove livecheck

### DIFF
--- a/Casks/f/focus-booster.rb
+++ b/Casks/f/focus-booster.rb
@@ -8,11 +8,6 @@ cask "focus-booster" do
   desc "Time tracker"
   homepage "https://www.focusboosterapp.com/"
 
-  livecheck do
-    url "https://www.focusboosterapp.com/download"
-    regex(%r{href=.*?/focusboosterv?(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   disable! date: "2024-04-28", because: :no_longer_available
 
   app "focus booster.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`focus-booster` was disabled in #172410, as the application has been officially discontinued. This removes the `livecheck` block, so it will be automatically skipped as disabled.