### PR TITLE
glaze 2.0

### DIFF
--- a/Casks/g/glaze.rb
+++ b/Casks/g/glaze.rb
@@ -1,11 +1,14 @@
 cask "glaze" do
-  arch arm: "m1", intel: "Intel"
+  arch arm: "arm64", intel: "Intel"
 
-  version "1.1.1"
-  sha256 arm:   "8b6a86a10bdf24754b946fab6fd750787db0272efad0312b4e6c354e06f1a74f",
-         intel: "a33c52f059a5364d68c036da80fe4afeabc5d1a4355f51fa0b29cf6333785669"
-
+  on_arm do
+    version "2.0"
+    sha256 "16bb21a2872c30b97ac78b0496dd4b3acefe8481fea571064ec66bc68005212c"
+  end
   on_intel do
+    version "1.1.1"
+    sha256 "1d5d4503b47cfadcbf79062ddd5d5691b8ab03f4e0939835855c66f9c3a3267f"
+
     depends_on macos: ">= :ventura"
   end
 
@@ -16,7 +19,7 @@ cask "glaze" do
 
   livecheck do
     url "https://glaze.cs.uchicago.edu/downloads.html"
-    regex(/Glaze[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
+    regex(/href=.*?Glaze[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
   app "Glaze.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `glaze` to the newest version, 2.0. This version is only available for ARM64 and the newest Intel version is still 1.1.1.

The existing `livecheck` block for `glaze` is incorrectly returning 0.0.3 as the newest version, as the architecture suffix for 2.0 is `-arm64` instead of the previous `-m1`. This updates the related `arch` value for `arm`, so the check will correctly match the newest version.