### PR TITLE
anka-build-cloud-controller-and-registry: remove livecheck

### DIFF
--- a/Casks/a/anka-build-cloud-controller-and-registry.rb
+++ b/Casks/a/anka-build-cloud-controller-and-registry.rb
@@ -10,12 +10,6 @@ cask "anka-build-cloud-controller-and-registry" do
   desc "Virtual machine management GUI/API and registry"
   homepage "https://veertu.com/"
 
-  livecheck do
-    url "https://veertu.com/downloads/anka-build-cloud-controller-registry-darwin-#{arch.downcase}-latest"
-    regex(/AnkaControllerRegistry#{arch}[._-]?v?(\d+(?:\.\d+)*[._-]\h+)\.pkg/i)
-    strategy :header_match
-  end
-
   deprecate! date: "2023-12-17", because: :discontinued
 
   pkg "AnkaControllerRegistry#{arch}-#{version}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`anka-build-cloud-controller-and-registry` was deprecated in #161924, when the cask was separated into `anka-build-cloud-controller` and `anka-build-cloud-registry`. This removes the `livecheck` block, so it will be automatically skipped as deprecated.