### PR TITLE
diskmaker-x: remove livecheck

### DIFF
--- a/Casks/d/diskmaker-x.rb
+++ b/Casks/d/diskmaker-x.rb
@@ -3,20 +3,11 @@ cask "diskmaker-x" do
     version "8.0.3"
     sha256 "79b490dc829775450aafadeddd0afc58bdcef9c60fc82d9db1427c51b57e88a7"
 
-    livecheck do
-      skip "Legacy version"
-    end
-
     app "DiskMaker X #{version.major} for macOS Mojave.app"
   end
   on_catalina :or_newer do
     version "9.0"
     sha256 "96845cd375543401b822fb4e17d2ecc300fcb621f56afcdad613ae11c9afddce"
-
-    livecheck do
-      url :homepage
-      regex(/DiskMaker\s*X\s*(\d+(?:\.\d+)+)/i)
-    end
 
     app "DiskMaker X #{version.major} for macOS Catalina.app"
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`diskmaker-x` was disabled in #171361, as the website wasn't available. diskmakerx.com loads at the moment but the app isn't developed anymore, so keeping the cask disabled still makes sense.

This removes the `livecheck` blocks, so it will be automatically skipped as disabled.