### PR TITLE
wow: remove livecheck

### DIFF
--- a/Casks/w/wow.rb
+++ b/Casks/w/wow.rb
@@ -8,13 +8,6 @@ cask "wow" do
   desc "Stream Wow TV content (formerly Sky Ticket)"
   homepage "https://wowtv.de/"
 
-  livecheck do
-    url "https://web.static.nowtv.com/watch/player/wowtv/de/latest/update.json"
-    strategy :json do |json|
-      json["platforms"]["darwin"]["version"]
-    end
-  end
-
   disable! date: "2024-02-27", because: :unmaintained
 
   app "WOW.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wow` was disabled in #167607, as the app is discontinued. This removes the `livecheck` block, so it will be automatically skipped as disabled.