### PR TITLE
kicad 8.0.2-1

### DIFF
--- a/Casks/k/kicad.rb
+++ b/Casks/k/kicad.rb
@@ -1,8 +1,8 @@
 cask "kicad" do
   version "8.0.2"
-  sha256 "f12fb0e642d3adcb8903df6be32b6a5273d56c53b3eec0ef65972875cf7b2b82"
+  sha256 "cfce083d69205d5f53cbde7fdfebd63d3b0d2006ea8336ab0da83f6308f3daf2"
 
-  url "https://github.com/KiCad/kicad-source-mirror/releases/download/#{version}/kicad-unified-universal-#{version}.dmg",
+  url "https://github.com/KiCad/kicad-source-mirror/releases/download/#{version}/kicad-unified-universal-#{version}-1.dmg",
       verified: "github.com/KiCad/kicad-source-mirror/"
   name "KiCad"
   desc "Electronics design automation suite"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

File ` kicad-unified-universal-8.0.2.dmg` no longer exist: https://github.com/KiCad/kicad-source-mirror/releases/tag/8.0.2
Has been changed to 8.0.2-1 recently. I'm not macos user (using this cask on CI) so I don't really verify if it works - just updated filename and updated sha