### PR TITLE
threema-work: adjust version to 1.2.41

### DIFF
--- a/Casks/t/threema-work.rb
+++ b/Casks/t/threema-work.rb
@@ -1,5 +1,5 @@
 cask "threema-work" do
-  version "2.0"
+  version "1.2.41"
   sha256 :no_check
 
   url "https://releases.threema.ch/web-electron/v1/release/Threema-Work-Latest.dmg"
@@ -8,8 +8,8 @@ cask "threema-work" do
   homepage "https://work.threema.ch/"
 
   livecheck do
-    url "https://work.threema.ch/en/changelog#chl=1"
-    regex(/Threema\s*Work\s*(\d+(?:\.\d+)+)\s*for\s*Desktop/i)
+    url "https://threema.ch/en/work/changelog"
+    regex(/>\s*Threema\s+Work\s+v?(\d+(?:\.\d+)+)\s+for\s+Desktop\s*</i)
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `Threema Work.app` in the `Threema-Work-Latest.dmg` file is version 1.2.41 and the 2.0 versions on the Changelog page (https://threema.ch/en/work/changelog) are all beta versions at the moment. This aligns the cask `version` with the actual app version.

This also updates the `livecheck` block to resolve the URL redirection and adjusts the regex to make sure it only matches stable versions.