### PR TITLE
Update squirrel.rb: fix download url and checksum

### DIFF
--- a/Casks/s/squirrel.rb
+++ b/Casks/s/squirrel.rb
@@ -1,8 +1,8 @@
 cask "squirrel" do
   version "0.18"
-  sha256 "db8522e83b725e5253da04d41a76ed58eeb39f0aaf1c6e73ac4dba567dcf2286"
+  sha256 "467e23babbd1b0c74887a45b299e750aa4398f069f77345b00f436b68c310a3a"
 
-  url "https://github.com/rime/squirrel/releases/download/#{version}/Squirrel-#{version}.pkg",
+  url "https://github.com/rime/squirrel/releases/download/#{version}/Squirrel-#{version}.zip",
       verified: "github.com/rime/squirrel/"
   name "Squirrel"
   desc "Rime input method engine"


### PR DESCRIPTION
Follow up https://github.com/rime/squirrel/releases/tag/0.18

Fixes https://github.com/rime/squirrel/issues/873

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
