### PR TITLE
fix(gitify): add preflight steps to reduce errors during `brew upgrade`

### DIFF
--- a/Casks/g/gitify.rb
+++ b/Casks/g/gitify.rb
@@ -24,17 +24,6 @@ cask "gitify" do
     opoo "Unable to forcibly close Gitify.app"
   end
 
-  postflight do
-    retries ||= 3
-    ohai "Attempting to relaunch Gitify.app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "open", args: ["-a", "/Applications/Gitify.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to automatically relaunch Gitify.app. Please open manually"
-    system_command "open", args: ["-a", "Gitify"]
-  end
-
   uninstall quit: [
     "com.electron.gitify",
     "com.electron.gitify.helper",

--- a/Casks/g/gitify.rb
+++ b/Casks/g/gitify.rb
@@ -18,6 +18,10 @@ cask "gitify" do
     system_command "/usr/bin/pkill", args: ["-f", "Gitify.app"]
   end
 
+  postflight do
+    system_command "open", args: ["-a", "Gitify.app"]
+  end
+
   uninstall quit: [
     "com.electron.gitify",
     "com.electron.gitify.helper",

--- a/Casks/g/gitify.rb
+++ b/Casks/g/gitify.rb
@@ -14,6 +14,10 @@ cask "gitify" do
 
   app "Gitify.app"
 
+  preflight do
+    system_command "/usr/bin/pkill", args: ["-f", "Gitify.app"]
+  end
+
   uninstall quit: [
     "com.electron.gitify",
     "com.electron.gitify.helper",

--- a/Casks/g/gitify.rb
+++ b/Casks/g/gitify.rb
@@ -25,6 +25,13 @@ cask "gitify" do
   end
 
   postflight do
+    retries ||= 3
+    ohai "Attempting to relaunch Gitify.app to avoid unwanted user intervention" if retries >= 3
+    return unless system_command "open", args: ["-a", "/Applications/Gitify.app"]
+  rescue RuntimeError
+    sleep 1
+    retry unless (retries -= 1).zero?
+    opoo "Unable to automatically relaunch Gitify.app. Please open manually"
     system_command "open", args: ["-a", "Gitify"]
   end
 

--- a/Casks/g/gitify.rb
+++ b/Casks/g/gitify.rb
@@ -15,7 +15,13 @@ cask "gitify" do
   app "Gitify.app"
 
   preflight do
-    system_command "/usr/bin/killall", args: ["-q", "Gitify"]
+    retries ||= 3
+    ohai "Attempting to close Gitify.app to avoid unwanted user intervention" if retries >= 3
+    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/Gitify.app"]
+  rescue RuntimeError
+    sleep 1
+    retry unless (retries -= 1).zero?
+    opoo "Unable to forcibly close Gitify.app"
   end
 
   postflight do

--- a/Casks/g/gitify.rb
+++ b/Casks/g/gitify.rb
@@ -15,11 +15,11 @@ cask "gitify" do
   app "Gitify.app"
 
   preflight do
-    system_command "/usr/bin/pkill", args: ["-f", "Gitify.app"]
+    system_command "/usr/bin/killall", args: ["-q", "Gitify"]
   end
 
   postflight do
-    system_command "open", args: ["-a", "Gitify.app"]
+    system_command "open", args: ["-a", "Gitify"]
   end
 
   uninstall quit: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Appreciate any wisdom from the maintainers.  🙏 

We've been seeing the error documented at https://github.com/gitify-app/gitify/issues/918 when performing a `brew upgrade` for Gitify.

My most recent theory is it's due to the previous `Gitify.app` is left running which causes the resource not found issue. 