### PR TITLE
quiet 2.1.2 (new cask)

### DIFF
--- a/Casks/q/quiet.rb
+++ b/Casks/q/quiet.rb
@@ -1,0 +1,21 @@
+cask "quiet" do
+  version "2.1.2"
+  sha256 "f3fbe187e6710bdda02172777173d0340dc5a97a502d07c3c817b2f7a2897555"
+
+  url "https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%40#{version}/Quiet-#{version}.dmg",
+      verified: "github.com/TryQuiet/quiet/"
+  name "Quiet"
+  desc "Desktop app for Quiet"
+  homepage "https://tryquiet.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Quiet.app"
+
+  zap trash: "~/Library/Application Support/Quiet2"
+end

--- a/Casks/q/quiet.rb
+++ b/Casks/q/quiet.rb
@@ -5,12 +5,25 @@ cask "quiet" do
   url "https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%40#{version}/Quiet-#{version}.dmg",
       verified: "github.com/TryQuiet/quiet/"
   name "Quiet"
-  desc "Desktop app for Quiet"
+  desc "A private, p2p alternative to Slack and Discord built on Tor & IPFS"
   homepage "https://tryquiet.org/"
 
+  # Upstream creates GitHub releases for both stable and alpha versions for
+  # both desktop and mobile versions, so it is necessary to check recent
+  # releases to match the latest stable desktop version.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^@quiet\/desktop@\d+(?:.\d+)+$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/q/quiet.rb
+++ b/Casks/q/quiet.rb
@@ -2,7 +2,7 @@ cask "quiet" do
   version "2.1.2"
   sha256 "f3fbe187e6710bdda02172777173d0340dc5a97a502d07c3c817b2f7a2897555"
 
-  url "https://github.com/TryQuiet/quiet/releases/download/%40quiet%2Fdesktop%40#{version}/Quiet-#{version}.dmg",
+  url "https://github.com/TryQuiet/quiet/releases/download/@quiet/desktop@#{version}/Quiet-#{version}.dmg",
       verified: "github.com/TryQuiet/quiet/"
   name "Quiet"
   desc "A private, p2p alternative to Slack and Discord built on Tor & IPFS"
@@ -13,7 +13,7 @@ cask "quiet" do
   # releases to match the latest stable desktop version.
   livecheck do
     url :url
-    regex(/^@quiet\/desktop@\d+(?:.\d+)+$/i)
+    regex(/^@quiet\/desktop@(\d+(?:\.\d+)+)$/i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next if release["draft"] || release["prerelease"]

--- a/Casks/q/quiet.rb
+++ b/Casks/q/quiet.rb
@@ -5,7 +5,7 @@ cask "quiet" do
   url "https://github.com/TryQuiet/quiet/releases/download/@quiet/desktop@#{version}/Quiet-#{version}.dmg",
       verified: "github.com/TryQuiet/quiet/"
   name "Quiet"
-  desc "A private, p2p alternative to Slack and Discord built on Tor & IPFS"
+  desc "Private, p2p alternative to Slack and Discord built on Tor & IPFS"
   homepage "https://tryquiet.org/"
 
   # Upstream creates GitHub releases for both stable and alpha versions for
@@ -13,7 +13,7 @@ cask "quiet" do
   # releases to match the latest stable desktop version.
   livecheck do
     url :url
-    regex(/^@quiet\/desktop@(\d+(?:\.\d+)+)$/i)
+    regex(%r{^@quiet/desktop@(\d+(?:\.\d+)+)$}i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next if release["draft"] || release["prerelease"]


### PR DESCRIPTION
This commit adds a new cask formula for the Quiet desktop app for Mac

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
