### PR TITLE
synology-photo-station-uploader: disable

### DIFF
--- a/Casks/s/synology-photo-station-uploader.rb
+++ b/Casks/s/synology-photo-station-uploader.rb
@@ -7,36 +7,5 @@ cask "synology-photo-station-uploader" do
   desc "Bulk upload photos and videos to Synology Photo Station"
   homepage "https://www.synology.com/"
 
-  livecheck do
-    url "https://www.synology.com/en-us/releaseNote/PhotoStationUploader"
-    strategy :patch_match do |page|
-      match = page.match(/<h3>Version:\s(\d+(?:\.\d+)+)-(\d+)/i)
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
-
-  pkg "SynologyPhotoStationUploader-#{version.after_comma}-Mac-Installer.pkg"
-
-  uninstall launchctl: [
-              "com.synology.PhotoUploaderFinderSync",
-              "com.synology.PhotoUploaderShellApp",
-              "com.synology.PhotoUploaderUninstaller",
-              "com.synology.SynoSIMBL_RefreshFinder",
-            ],
-            quit:      "com.synology.PhotoStationUploader",
-            pkgutil:   [
-              "com.synology.photostationuploader.installer",
-              "inc.synology.photostationuploader",
-            ]
-
-  zap trash: [
-        "~/Library/Application Scripts/com.synology.PhotoUploaderShellApp.PhotoUploaderFinderSync",
-        "~/Library/Application Scripts/group.com.synology.PhotoUploader",
-        "~/Library/Application Support/Synology/Photo Station Uploader",
-        "~/Library/Containers/com.synology.PhotoUploaderShellApp.PhotoUploaderFinderSync",
-        "~/Library/Group Containers/group.com.synology.PhotoUploader",
-        "~/Library/Saved Application State/com.synology.PhotoStationUploader.savedState",
-      ],
-      rmdir: "~/Library/Application Support/Synology"
+  disable! date: "2024-05-07", because: :no_longer_available
 end


### PR DESCRIPTION
Disabled synology-photo-station-uploader because the download is no longer aviable on the website.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
