### PR TITLE
Update livecheck/homepage to avoid redirections

### DIFF
--- a/Casks/c/clip-studio-paint.rb
+++ b/Casks/c/clip-studio-paint.rb
@@ -8,7 +8,7 @@ cask "clip-studio-paint" do
   homepage "https://www.clipstudio.net/en"
 
   livecheck do
-    url "https://www.clipstudio.net/en/dl/release_note/v2"
+    url "https://www.clipstudio.net/en/dl/release_note/v2/"
     regex(/Clip\s+Studio\s+Paint\s+(?:v|Ver\.?|Version)?\s*(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/d/dropbox@beta.rb
+++ b/Casks/d/dropbox@beta.rb
@@ -9,7 +9,7 @@ cask "dropbox@beta" do
       verified: "dropbox.com/"
   name "Dropbox"
   desc "Client for the Dropbox cloud storage service"
-  homepage "https://www.dropboxforum.com/t5/Desktop-client-builds/bd-p/101003016"
+  homepage "https://www.dropboxforum.com/t5/Dropbox-desktop-client-builds/bd-p/101003016"
 
   livecheck do
     url :homepage

--- a/Casks/g/genymotion.rb
+++ b/Casks/g/genymotion.rb
@@ -12,7 +12,7 @@ cask "genymotion" do
     sha256 "beb88db7cfed503ed95ff68377fac0848256c300caf78b4be7b8b8c62ade80eb"
 
     livecheck do
-      url "https://www.genymotion.com/download/"
+      url "https://www.genymotion.com/product-desktop/download/"
       regex(/href=.*?Genymotion[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg)/i)
     end
   end

--- a/Casks/m/monotype.rb
+++ b/Casks/m/monotype.rb
@@ -8,7 +8,7 @@ cask "monotype" do
   homepage "https://support.monotype.com/en/articles/7860542-monotype-desktop-app"
 
   livecheck do
-    url "https://support.monotype.com/en/articles/7859464-release-notes"
+    url "https://support.monotype.com/en/articles/8617063-latest-release-notes"
     regex(/<p>Version\s*v?(\d+(?:\.\d+)+)[ "<]/i)
   end
 

--- a/Casks/n/notesnook.rb
+++ b/Casks/n/notesnook.rb
@@ -12,7 +12,7 @@ cask "notesnook" do
   homepage "https://notesnook.com/"
 
   livecheck do
-    url "https://notesnook.com/releases/darwin/latest-mac.yml"
+    url "https://notesnook.com/api/v1/releases/darwin/latest/latest-mac.yml"
     strategy :electron_builder
   end
 

--- a/Casks/q/qgis@ltr.rb
+++ b/Casks/q/qgis@ltr.rb
@@ -8,7 +8,7 @@ cask "qgis@ltr" do
   homepage "https://www.qgis.org/"
 
   livecheck do
-    url "https://qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
+    url "https://download.qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
     regex(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0].tr("_", ".")},#{match[1]}" }

--- a/Casks/s/salt.rb
+++ b/Casks/s/salt.rb
@@ -11,7 +11,7 @@ cask "salt" do
   homepage "https://saltproject.io/"
 
   livecheck do
-    url "https://repo.saltproject.io/salt/py3/macos/latest"
+    url "https://repo.saltproject.io/salt/py3/macos/latest/"
     regex(/salt[._-]v?(\d+(?:\.\d+)+)-py3-#{arch}\.pkg/)
   end
 

--- a/Casks/s/shearwater-cloud.rb
+++ b/Casks/s/shearwater-cloud.rb
@@ -5,10 +5,10 @@ cask "shearwater-cloud" do
   url "https://downloads.shearwater.com/livedownloads/ShearwaterCloudInstaller_#{version}.dmg"
   name "Shearwater Cloud"
   desc "Review, edit and share dive log data"
-  homepage "https://www.shearwater.com/"
+  homepage "https://shearwater.com/"
 
   livecheck do
-    url "https://www.shearwater.com/cloud/"
+    url "https://shearwater.com/pages/shearwater-cloud"
     regex(/href=.*?ShearwaterCloudInstaller[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/s/shift.rb
+++ b/Casks/s/shift.rb
@@ -5,13 +5,14 @@ cask "shift" do
   sha256 arm:   "ed9648e7b1c62d54a20b43ec1a4dfc19a7f5a5af8ef2b91e271d9aafaa555a63",
          intel: "b2ad6011b0981c7d840495687bf73e683570781c7f9c36f7ae09d76d703255e8"
 
-  url "https://updates.tryshift.com/v#{version.major_minor_patch}/stable/shift-v#{version}-stable-#{arch}.dmg"
+  url "https://updates.tryshift.com/v#{version.major_minor_patch}/stable/shift-v#{version}-stable-#{arch}.dmg",
+      verified: "updates.tryshift.com/"
   name "Shift"
   desc "Workstation to streamline your accounts, apps, and workflows"
-  homepage "https://tryshift.com/"
+  homepage "https://shift.com/"
 
   livecheck do
-    url "https://tryshift.com/download/?platform=mac"
+    url "https://shift.com/download/?platform=mac"
     regex(/href=.*?(\d+(?:[._-]\d+)+)[._-]stable.*?\.dmg/i)
   end
 

--- a/Casks/t/thingsmacsandboxhelper.rb
+++ b/Casks/t/thingsmacsandboxhelper.rb
@@ -5,7 +5,7 @@ cask "thingsmacsandboxhelper" do
   url "https://static.culturedcode.com/things/thingssandboxhelper/#{version}/ThingsHelper.zip"
   name "Things Helper"
   desc "Helper application for Things"
-  homepage "https://culturedcode.com/things/mac/help/things-sandboxing-helper-things#{version.major}/"
+  homepage "https://culturedcode.com/things/help/things-sandboxing-helper-things#{version.major}/"
 
   livecheck do
     url :homepage

--- a/Casks/y/youlean-loudness-meter.rb
+++ b/Casks/y/youlean-loudness-meter.rb
@@ -8,7 +8,7 @@ cask "youlean-loudness-meter" do
   homepage "https://youlean.co/youlean-loudness-meter/"
 
   livecheck do
-    url "https://youlean.co/download/"
+    url "https://youlean.co/download-youlean-loudness-meter/"
     regex(%r{href=.*?/(\w+)/(\w+)/youlean[._-]loudness[._-]meter[._-]\d+[._-]v?(\d+(?:\.\d+)+)[._-]macOS\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the `livecheck` block `url` and/or `homepage` for various casks to resolve unnecessary redirections. This doesn't include URLs that redirect from an upstream URL to a third-party host (e.g., AWS, etc.), as those sorts of redirections can be useful.