### PR TITLE
topaz-sharpen-ai: deprecate

### DIFF
--- a/Casks/t/topaz-sharpen-ai.rb
+++ b/Casks/t/topaz-sharpen-ai.rb
@@ -18,6 +18,7 @@ cask "topaz-sharpen-ai" do
       match.tr("-", ".")
     end
   end
+  deprecate! date: "2024-05-07", because: :discontinued
 
   app "Topaz Sharpen AI.app"
 

--- a/Casks/t/topaz-sharpen-ai.rb
+++ b/Casks/t/topaz-sharpen-ai.rb
@@ -7,17 +7,6 @@ cask "topaz-sharpen-ai" do
   desc "AI-powered image sharpener that produces natural results"
   homepage "https://www.topazlabs.com/sharpen-ai"
 
-  livecheck do
-    url "https://community.topazlabs.com/c/releases/sharpen-ai"
-    strategy :page_match do |page|
-      match = page[%r{href=.*?/sharpen[._-]ai[._-]v?(\d+(?:-\d+)+)}i, 1]
-      next if match.blank?
-
-      match += ".0"
-
-      match.tr("-", ".")
-    end
-  end
   deprecate! date: "2024-05-07", because: :discontinued
 
   app "Topaz Sharpen AI.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Is listed as discontinued upstream - https://docs.topazlabs.com/other-apps/legacy
Like topaz-denoise-ai.