### PR TITLE
steelseries-exactmouse-tool 1.0 (new cask)

### DIFF
--- a/Casks/s/steelseries-exactmouse-tool.rb
+++ b/Casks/s/steelseries-exactmouse-tool.rb
@@ -1,0 +1,24 @@
+cask "steelseries-exactmouse-tool" do
+  version "1.0"
+  sha256 :no_check
+
+  url "https://downloads.steelseriescdn.com/drivers/tools/steelseries-exactmouse-tool.dmg",
+      verified: "steelseriescdn.com/"
+  name "SteelSeries ExactMouse Tool"
+  desc "Keyboard and mouse configuration tool"
+  homepage "https://steelseries.com/downloads"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  app "SteelSeries ExactMouse Tool.app"
+
+  uninstall quit: "com.SteelSeries.SteelSeries-ExactMouse-Tool"
+
+  zap trash: [
+    "~/Library/Caches/com.apple.helpd/Generated/com.SteelSeries.SteelSeries-ExactMouse-Tool.help",
+    "~/Library/Preferences/com.SteelSeries.SteelSeries-ExactMouse-Tool.plist",
+  ]
+end


### PR DESCRIPTION
This was dropped when the "drivers" tab was migrated back into casks. Re-adding it because I need it.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Submitting this to see what the CI says, as discussed in #173168 