### PR TITLE
carbon-copy-cloner@6 6.1.11.7667 (new cask)

### DIFF
--- a/Casks/c/carbon-copy-cloner@6.rb
+++ b/Casks/c/carbon-copy-cloner@6.rb
@@ -1,0 +1,39 @@
+cask "carbon-copy-cloner@6" do
+  version "6.1.11.7667"
+  sha256 "97553ede1d2c778d4d5767c3597855c2be084ebe5045010979d08180e46dddef"
+
+  url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip",
+      verified: "bombich.scdn1.secure.raxcdn.com/software/files/"
+  name "Carbon Copy Cloner 6"
+  desc "Hard disk backup and cloning utility"
+  homepage "https://bombich.com/"
+
+  livecheck do
+    url "https://api.bombich.com/download/ccc?v=ccc6&l=alternate"
+    strategy :header_match
+  end
+
+  auto_updates true
+  conflicts_with cask: [
+    "carbon-copy-cloner",
+    "carbon-copy-cloner@5",
+  ]
+  depends_on macos: ">= :catalina"
+
+  app "Carbon Copy Cloner.app"
+
+  uninstall quit:       [
+              "com.bombich.ccc",
+              "com.bombich.cccuseragent",
+            ],
+            login_item: "CCC User Agent"
+
+  zap trash: [
+    "/Library/LaunchDaemons/com.bombich.ccchelper.plist",
+    "~/Library/Application Support/com.bombich.ccc",
+    "~/Library/Caches/com.bombich.ccc",
+    "~/Library/Preferences/com.bombich.ccc.plist",
+    "~/Library/Preferences/com.bombich.cccuseragent.plist",
+    "~/Library/Saved Application State/com.bombich.ccc.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Adds a version of `carbon-copy-cloner`, pinned to version 6, as major versions require new licenses.