### PR TITLE
Change SHA256 for scilab one more time

### DIFF
--- a/Casks/s/scilab.rb
+++ b/Casks/s/scilab.rb
@@ -3,7 +3,7 @@ cask "scilab" do
 
   on_arm do
     version "2024.0.0"
-    sha256 "66c760501aabf592f2cbf03156767c5faa4ab085d2bc391410d8a99c0d67cfa5"
+    sha256 "7d635ad455815378c8df8d177004c6067cf8402f8e5fbae2c53cb41c9c8bb0a4"
   end
   on_intel do
     version "2024.0.0"


### PR DESCRIPTION
I am hitting similar issue as #161519. Here is the console output:
```
➜  ~ brew install --cask scilab
==> Caveats
scilab requires Java 8. You can install it with:
  brew install --cask temurin@8

==> Downloading https://www.utc.fr/~mottelet/scilab/download/2024.0.0/scilab-2024.0.0-arm64.dmg
Already downloaded: /Users/ych/Library/Caches/Homebrew/downloads/5651b0267536ef27742c1f0fc7ce8b1e34678bc01369fb130a5dc08da23090af--scilab-2024.0.0-arm64.dmg
Error: SHA256 mismatch
Expected: 66c760501aabf592f2cbf03156767c5faa4ab085d2bc391410d8a99c0d67cfa5
  Actual: 7d635ad455815378c8df8d177004c6067cf8402f8e5fbae2c53cb41c9c8bb0a4
    File: /Users/ych/Library/Caches/Homebrew/downloads/5651b0267536ef27742c1f0fc7ce8b1e34678bc01369fb130a5dc08da23090af--scilab-2024.0.0-arm64.dmg
To retry an incomplete download, remove the file above.
```

For some reason [scilab-2024.0.0-arm64.dmg](https://www.utc.fr/~mottelet/scilab/download/2024.0.0/scilab-2024.0.0-arm64.dmg) was updated without changing its version 🤷‍♂️.
![image](https://github.com/Homebrew/homebrew-cask/assets/552025/cff3e617-9a83-4cd3-86ca-ff52a1ecb8fa)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
