### PR TITLE
tinymediamanager 5.0.5

### DIFF
--- a/Casks/t/tinymediamanager.rb
+++ b/Casks/t/tinymediamanager.rb
@@ -5,14 +5,14 @@ cask "tinymediamanager" do
   sha256 arm:   "8ed75f5381bf1978c28730ee8db9f6c504401f57a84c7c972eb58af45b3beeb4",
          intel: "fc690cb7e2ba33b6b93de18691330ca36f6fac4e1bae60bcbfff59e28fe9024f"
 
-  url "https://release.tinymediamanager.org/v#{version.major}/dist/tinyMediaManager_#{version}_macos-x86_64.dmg"
+  url "https://release.tinymediamanager.org/v#{version.major}/dist/tinyMediaManager-#{version}-macos-#{arch}.dmg"
   name "tinyMediaManager"
   desc "Media management tool"
   homepage "https://www.tinymediamanager.org/"
 
   livecheck do
     url "https://release.tinymediamanager.org/"
-    regex(%r{href=.*?/tinyMediaManager[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg}i)
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg}i)
   end
 
   auto_updates true

--- a/Casks/t/tinymediamanager.rb
+++ b/Casks/t/tinymediamanager.rb
@@ -12,12 +12,15 @@ cask "tinymediamanager" do
 
   livecheck do
     url "https://release.tinymediamanager.org/"
-    regex(/href=.*?v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg/i)
+    regex(/href=.*?v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 
   auto_updates true
 
   app "tinyMediaManager.app"
 
-  # No zap stanza required
+  zap trash: [
+    "~/Library/Application Support/tinyMediaManager",
+    "~/Library/Saved Application State/org.tinyMediaManager.tinymediamanager.savedState",
+  ]
 end

--- a/Casks/t/tinymediamanager.rb
+++ b/Casks/t/tinymediamanager.rb
@@ -5,14 +5,14 @@ cask "tinymediamanager" do
   sha256 arm:   "8ed75f5381bf1978c28730ee8db9f6c504401f57a84c7c972eb58af45b3beeb4",
          intel: "fc690cb7e2ba33b6b93de18691330ca36f6fac4e1bae60bcbfff59e28fe9024f"
 
-  url "https://release.tinymediamanager.org/v#{version.major}/dist/tinyMediaManager_#{version}_macos-x86_64.zip"
+  url "https://release.tinymediamanager.org/v#{version.major}/dist/tinyMediaManager_#{version}_macos-x86_64.dmg"
   name "tinyMediaManager"
   desc "Media management tool"
   homepage "https://www.tinymediamanager.org/"
 
   livecheck do
     url "https://release.tinymediamanager.org/"
-    regex(%r{href=.*?/tinyMediaManager[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.zip}i)
+    regex(%r{href=.*?/tinyMediaManager[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg}i)
   end
 
   auto_updates true

--- a/Casks/t/tinymediamanager.rb
+++ b/Casks/t/tinymediamanager.rb
@@ -1,15 +1,18 @@
 cask "tinymediamanager" do
-  version "4.3.16"
-  sha256 "6e3213d50ed50ac2a9973607af41d357acd3dc4003d7a4228814c480922ca385"
+  arch arm: "aarch64", intel: "x86_64"
 
-  url "https://release.tinymediamanager.org/v#{version.major}/dist/tmm_#{version}_macos-x86_64.zip"
+  version "5.0.5"
+  sha256 arm:   "8ed75f5381bf1978c28730ee8db9f6c504401f57a84c7c972eb58af45b3beeb4",
+         intel: "fc690cb7e2ba33b6b93de18691330ca36f6fac4e1bae60bcbfff59e28fe9024f"
+
+  url "https://release.tinymediamanager.org/v#{version.major}/dist/tinyMediaManager_#{version}_macos-x86_64.zip"
   name "tinyMediaManager"
   desc "Media management tool"
   homepage "https://www.tinymediamanager.org/"
 
   livecheck do
     url "https://release.tinymediamanager.org/"
-    regex(%r{href=.*?/tmm[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.zip}i)
+    regex(%r{href=.*?/tinyMediaManager[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.zip}i)
   end
 
   auto_updates true

--- a/Casks/t/tinymediamanager.rb
+++ b/Casks/t/tinymediamanager.rb
@@ -12,7 +12,7 @@ cask "tinymediamanager" do
 
   livecheck do
     url "https://release.tinymediamanager.org/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg}i)
+    regex(/href=.*?v?(\d+(?:\.\d+)+)[._-]macos[._-]x86[._-]64\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
- Add support for aarch64 images
- Upgrade to version 5
- Fix the download and livecheck URL

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
