### PR TITLE
active-trader-pro 1.0.55 (unversioned pkg)

### DIFF
--- a/Casks/a/active-trader-pro.rb
+++ b/Casks/a/active-trader-pro.rb
@@ -1,8 +1,8 @@
 cask "active-trader-pro" do
   version "1.0.55"
-  sha256 "394689bce9630cd949a40ae9914533acaf028f8d08019833dbb7a49f3416866e"
+  sha256 :no_check
 
-  url "https://www.fidelity.com/webcontent/Codeweaver/activetrader-#{version}.zip"
+  url "https://www.fidelity.com/webcontent/CodeweaverInstaller/ActiveTraderPro.pkg"
   name "Active Trader Pro"
   desc "Trading platform"
   homepage "https://www.fidelity.com/trading/advanced-trading-tools/active-trader-pro/overview"
@@ -14,7 +14,7 @@ cask "active-trader-pro" do
 
   depends_on macos: ">= :sierra"
 
-  app "Active Trader Pro.app"
+  pkg "ActiveTraderPro.pkg"
 
   uninstall quit: "com.fmr.activetrader"
 


### PR DESCRIPTION
Fidelity has changed the URL for Active Trader Pro to be an unversioned link, and at the same time has switched from using a zip archive to using a pkg installer.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
