### PR TITLE
Use `Xml` strategy for plist `livecheck` blocks

### DIFF
--- a/Casks/a/apparency.rb
+++ b/Casks/a/apparency.rb
@@ -37,9 +37,12 @@ cask "apparency" do
 
     livecheck do
       url "https://www.mothersruin.com/software/Apparency/data/ApparencyVersionInfo.plist"
-      regex(/CFBundleShortVersionString.*?\n.*?(\d+(?:\.\d+)+).*?\n.*?CFBundleVersion.*?\n.*?(\d+(?:\.\d+)*)/i)
-      strategy :page_match do |page, regex|
-        page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      strategy :xml do |xml|
+        short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
+        version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+        next if short_version.blank? || version.blank?
+
+        "#{short_version},#{version}"
       end
     end
   end

--- a/Casks/a/archaeology.rb
+++ b/Casks/a/archaeology.rb
@@ -9,9 +9,12 @@ cask "archaeology" do
 
   livecheck do
     url "https://www.mothersruin.com/software/Archaeology/data/ArchaeologyVersionInfo.plist"
-    regex(/CFBundleShortVersionString.*?\n.*?(\d+(?:\.\d+)*).*?\n.*?CFBundleVersion.*?\n.*?(\d+(?:\.\d+)*)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    strategy :xml do |xml|
+      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      next if short_version.blank? || version.blank?
+
+      "#{short_version},#{version}"
     end
   end
 

--- a/Casks/h/hapigo.rb
+++ b/Casks/h/hapigo.rb
@@ -9,7 +9,9 @@ cask "hapigo" do
 
   livecheck do
     url "https://hapigo.com/update/cast.plist"
-    regex(%r{<key>version</key>\s*\n\s*<string>(\d+(?:\.\d+)+)</string>}i)
+    strategy :xml do |xml|
+      xml.get_elements("//key[text()='version']").map { |item| item.next_element&.text&.strip }
+    end
   end
 
   auto_updates true

--- a/Casks/l/lingon-x.rb
+++ b/Casks/l/lingon-x.rb
@@ -27,7 +27,9 @@ cask "lingon-x" do
 
   livecheck do
     url "https://www.peterborgapps.com/updates/lingonx#{version.major}.plist"
-    regex(%r{<key>version</key>\s*\n\s*<string>(\d+(?:\.\d+)+)</string>}i)
+    strategy :xml do |xml|
+      xml.get_elements("//key[text()='version']").map { |item| item.next_element&.text&.strip }
+    end
   end
 
   auto_updates true

--- a/Casks/m/macfuse.rb
+++ b/Casks/m/macfuse.rb
@@ -10,7 +10,9 @@ cask "macfuse" do
 
   livecheck do
     url "https://osxfuse.github.io/releases/CurrentRelease.plist"
-    regex(/macfuse[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :xml do |xml|
+      xml.get_elements("//key[text()='Version']").map { |item| item.next_element&.text&.strip }
+    end
   end
 
   auto_updates true

--- a/Casks/m/macfuse@dev.rb
+++ b/Casks/m/macfuse@dev.rb
@@ -10,7 +10,9 @@ cask "macfuse@dev" do
 
   livecheck do
     url "https://osxfuse.github.io/releases/DeveloperRelease.plist"
-    regex(/macfuse[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :xml do |xml|
+      xml.get_elements("//key[text()='Version']").map { |item| item.next_element&.text&.strip }
+    end
   end
 
   auto_updates true

--- a/Casks/o/openvanilla.rb
+++ b/Casks/o/openvanilla.rb
@@ -10,12 +10,12 @@ cask "openvanilla" do
 
   livecheck do
     url "https://raw.githubusercontent.com/openvanilla/openvanilla/master/Source/Mac/OpenVanilla-Info.plist"
-    strategy :page_match do |page|
-      shortversion = page.match(/CFBundleShortVersionString.*?\n.*?(\d+(?:\.\d+)+)/i)
-      version = page.match(/CFBundleVersion.*?\n.*?(\d+(?:\.\d+)*)/i)
-      next if shortversion.blank? || version.blank?
+    strategy :xml do |xml|
+      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      next if short_version.blank? || version.blank?
 
-      "#{shortversion[1]},#{version[1]}"
+      "#{short_version},#{version}"
     end
   end
 

--- a/Casks/p/pastebot.rb
+++ b/Casks/p/pastebot.rb
@@ -10,7 +10,9 @@ cask "pastebot" do
 
   livecheck do
     url "https://tapbots.net/pastebot#{version.major}/update.plist"
-    regex(%r{<key>shortVersion</key>.*\n.*<string>(\d+(?:\.\d+)+)</string>}i)
+    strategy :xml do |xml|
+      xml.get_elements("//key[text()='shortVersion']").map { |item| item.next_element&.text&.strip }
+    end
   end
 
   depends_on macos: ">= :mojave"

--- a/Casks/s/suspicious-package.rb
+++ b/Casks/s/suspicious-package.rb
@@ -57,9 +57,12 @@ cask "suspicious-package" do
 
     livecheck do
       url "https://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist"
-      regex(/CFBundleShortVersionString.*?\n.*?(\d+(?:\.\d+)*).*?\n.*?CFBundleVersion.*?\n.*?(\d+(?:\.\d+)*)/i)
-      strategy :page_match do |page, regex|
-        page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      strategy :xml do |xml|
+        short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
+        version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+        next if short_version.blank? || version.blank?
+
+        "#{short_version},#{version}"
       end
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `livecheck` blocks that check a plist file using the `PageMatch` strategy to use the `Xml` strategy instead.