### PR TITLE
little-snitch: update livecheck

### DIFF
--- a/Casks/l/little-snitch.rb
+++ b/Casks/l/little-snitch.rb
@@ -9,8 +9,14 @@ cask "little-snitch" do
 
   livecheck do
     url "https://sw-update.obdev.at/update-feeds/littlesnitch#{version.major}.plist"
-    strategy :xml do |xml|
-      xml.get_elements("//key[text()='BundleShortVersionString']").map { |item| item.next_element&.text&.strip }
+    regex(/LittleSnitch[._-]v?(\d+(?:\.\d+)+)\.dmg/)
+    strategy :xml do |xml, regex|
+      xml.get_elements("//key[text()='DownloadURL']").map do |item|
+        match = item.next_element&.text&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
     end
   end
 

--- a/Casks/l/little-snitch.rb
+++ b/Casks/l/little-snitch.rb
@@ -8,8 +8,10 @@ cask "little-snitch" do
   homepage "https://www.obdev.at/products/littlesnitch/index.html"
 
   livecheck do
-    url "https://www.obdev.at/products/littlesnitch/download.html"
-    regex(%r{href=.*?/LittleSnitch[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    url "https://sw-update.obdev.at/update-feeds/littlesnitch#{version.major}.plist"
+    strategy :xml do |xml|
+      xml.get_elements("//key[text()='BundleShortVersionString']").map { |item| item.next_element&.text&.strip }
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
Switched the `livecheck` `url` to use the same site as the in-app updater.

There are also `nightly` releases, and I am not sure how best to ensure that these are not picked up.