### PR TITLE
navicat-premium-essentials: deprecate

### DIFF
--- a/Casks/n/navicat-premium-essentials.rb
+++ b/Casks/n/navicat-premium-essentials.rb
@@ -5,11 +5,9 @@ cask "navicat-premium-essentials" do
   url "https://dn.navicat.com/download/navicatess#{version.major_minor.no_dots}_premium_en.dmg"
   name "Navicat Premium Essentials"
   desc "Database administration and development tool"
-  homepage "https://navicat.com/products/navicat-essentials"
+  homepage "https://www.navicat.com/products/navicat-premium"
 
-  livecheck do
-    cask "navicat-premium"
-  end
+  deprecate! date: "2024-05-14", because: :discontinued
 
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Updated the homepage to match https://github.com/Homebrew/homebrew-cask/blob/a48d877966546820c1c14688c4ee8c04f4d3c4e8/Casks/n/navicat-premium.rb as the homepage specific to `navicat-premium-essentials` no longer exists.

The current version is still downloadable, however it does not appear to have been updated to the latest version (17, currently) with the rest of the `navicat` product suite.

Can be undeprecated in the future if the above state changes.