### PR TITLE
touch-bar-simulator: deprecate

### DIFF
--- a/Casks/t/touch-bar-simulator.rb
+++ b/Casks/t/touch-bar-simulator.rb
@@ -4,20 +4,12 @@ cask "touch-bar-simulator" do
     sha256 "4abe55de716ae56a41031cdb1d3b27bf6b1efae18b33b80bb0419669a9a76aa1"
 
     url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch-Bar-Simulator-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
   end
   on_mojave do
     version "3.2.0"
     sha256 "bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6"
 
     url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
   end
   on_catalina :or_newer do
     version "4.2.0"
@@ -29,6 +21,8 @@ cask "touch-bar-simulator" do
   name "Touch Bar Simulator"
   desc "Touch Bar as a standalone app"
   homepage "https://github.com/sindresorhus/touch-bar-simulator"
+
+  deprecate! date: "2024-05-14", because: :discontinued
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
[Repository](https://github.com/sindresorhus/touch-bar-simulator) is archived and app is discontinued.
