### PR TITLE
.github/workflows/ci.yml: remove `brew uninstall` dependencies steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,12 +228,6 @@ jobs:
         if: always() && steps.install.outcome == 'success' && !fromJSON(steps.info.outputs.manual_installer)
         timeout-minutes: 30
 
-      - name: Uninstall formula dependencies
-        run: |
-          brew uninstall --formula ${{ join(fromJSON(steps.info.outputs.formula_dependencies), ' ') }}
-        if: always() && steps.install.outcome == 'success' && join(fromJSON(steps.info.outputs.formula_dependencies)) != ''
-        timeout-minutes: 30
-
       - name: Uninstall cask dependencies
         run: |
           brew uninstall --cask ${{ join(fromJSON(steps.info.outputs.cask_dependencies), ' ') }}


### PR DESCRIPTION
`brew autoremove` is now run by default after https://github.com/Homebrew/brew/pull/17261 - so the dependencies will be automatically removed in the main `brew uninstall <token>` step.

CI failure seen in: https://github.com/Homebrew/homebrew-cask/pull/173807