### PR TITLE
import_google_fonts: create directory if missing

### DIFF
--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -182,6 +182,10 @@ def write_cask(cask):
         if f.read() == content:
           return False
 
+    directory = os.path.dirname(path)
+    if not os.path.exists(directory):
+      os.makedirs(directory)
+
     with open(path, "w") as f:
         f.write(content)
 


### PR DESCRIPTION
This change is really only needed right now because the directories don't exist yet. But it confirms that the script is working as intended after migration to this repo.

https://github.com/Homebrew/homebrew-cask/pull/173832

It is probably worth merging this in case there are new Google Fonts that start with a number, where there isn't an existing directory.