### PR TITLE
jellyfin-media-player 1.10.0

### DIFF
--- a/Casks/j/jellyfin-media-player.rb
+++ b/Casks/j/jellyfin-media-player.rb
@@ -1,9 +1,13 @@
 cask "jellyfin-media-player" do
-  version "1.9.1"
-  sha256 "6ed5f5c1489c177de45f46fdbeefee8cc9eee7faff75d03e3840f522849674d2"
+  version "1.10.0"
+  arch arm: "AppleSilicon", intel: "Intel"
 
-  url "https://github.com/jellyfin/jellyfin-media-player/releases/download/v#{version}/JellyfinMediaPlayer-#{version}-macos-notarized.dmg",
+  sha256 arm:   "1fd584132af2107d7aaeb46c66a5b05ba78a2f56150b6f54482abe6bb705acd0",
+         intel: "dda9b26971a8c25eea9e759ab89aa8bf5abd4e4b805dc37827d13bddc6da1ab5"
+  
+  url "https://github.com/jellyfin/jellyfin-media-player/releases/download/v#{version}/JellyfinMediaPlayer-#{arch}.dmg",
       verified: "github.com/jellyfin/jellyfin-media-player/"
+
   name "Jellyfin Media Player"
   desc "Jellyfin desktop client"
   homepage "https://jellyfin.org/"

--- a/Casks/j/jellyfin-media-player.rb
+++ b/Casks/j/jellyfin-media-player.rb
@@ -1,13 +1,12 @@
 cask "jellyfin-media-player" do
-  version "1.10.0"
   arch arm: "AppleSilicon", intel: "Intel"
 
+  version "1.10.0"
   sha256 arm:   "1fd584132af2107d7aaeb46c66a5b05ba78a2f56150b6f54482abe6bb705acd0",
          intel: "dda9b26971a8c25eea9e759ab89aa8bf5abd4e4b805dc37827d13bddc6da1ab5"
-  
+
   url "https://github.com/jellyfin/jellyfin-media-player/releases/download/v#{version}/JellyfinMediaPlayer-#{arch}.dmg",
       verified: "github.com/jellyfin/jellyfin-media-player/"
-
   name "Jellyfin Media Player"
   desc "Jellyfin desktop client"
   homepage "https://jellyfin.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `jellyfin-media-player` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

NOTE: I was only able to test AppleSilicon, so if someone could confirm this for Intel that'd be great, so the pull request can be merged :)
