### PR TITLE
wd-security 2.1.2.144 (new cask)

### DIFF
--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -22,12 +22,13 @@ cask "wd-security" do
     sudo:       true,
   }
 
-  uninstall script: {
-    # replicating #{staged_path}/installer.sh
-    executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
-    args:       ["-uninstall", "-silent"],
-    sudo:       true,
-  }
+  uninstall launchctl: "com.wdc.WDPrivilegedHelper",
+            script:    {
+              # replicating #{staged_path}/installer.sh
+              executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
+              args:       ["-uninstall", "-silent"],
+              sudo:       true,
+            }
 
   zap trash: [
     "/Library/LaunchDaemons/com.wdc.WDPrivilegedHelper.plist",

--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -1,0 +1,34 @@
+cask "wd-security" do
+  version "2.1.2.144"
+  sha256 :no_check
+
+  url "https://downloads.wdc.com/wdapp/WD_Security_MACOS.zip",
+      verified: "downloads.wdc.com/wdapp/"
+  name "WD Security"
+  desc "Lock and unlock Western Digital external drives with hardware encryption"
+  homepage "https://support-en.wd.com/app/answers/detailweb/a_id/50696"
+
+  livecheck do
+    url "https://support-en.wd.com/app/answers/detailweb/a_id/29490"
+    regex(/Version:?\s*(\d+(?:\.\d+)+)/i)
+  end
+
+  container nested: "WD Security Installer.dmg"
+
+  installer script: {
+    # replicating #{staged_path}/installer.sh
+    executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
+    args:       ["-install", "-silent"],
+  }
+
+  uninstall script: {
+    # replicating #{staged_path}/installer.sh
+    executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
+    args:       ["-uninstall", "-silent"],
+  }
+
+  zap trash: [
+    "/Library/LaunchDaemons/com.wdc.WDPrivilegedHelper.plist",
+    "~/Library/Preferences/com.wdc.branded.security.plist",
+  ]
+end

--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -26,6 +26,7 @@ cask "wd-security" do
     # replicating #{staged_path}/installer.sh
     executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
     args:       ["-uninstall", "-silent"],
+    sudo:       true,
   }
 
   zap trash: [

--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -22,7 +22,8 @@ cask "wd-security" do
     sudo:       true,
   }
 
-  uninstall launchctl: "com.wdc.WDPrivilegedHelper",
+  uninstall quit: ["com.wdc.WDPrivilegedHelper", "com.wdc.branded.security"],
+            launchctl: "com.wdc.WDPrivilegedHelper",
             script:    {
               # replicating #{staged_path}/installer.sh
               executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",

--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -22,7 +22,12 @@ cask "wd-security" do
     sudo:       true,
   }
 
-  uninstall quit: ["com.wdc.WDPrivilegedHelper", "com.wdc.branded.security"],
+  uninstall early_script: {
+              executable:   "/usr/bin/killall",
+              args:         ["-9", "com.wdc.WDPrivilegedHelper"],
+              sudo:         true,
+              must_succeed: false,
+            },
             launchctl: "com.wdc.WDPrivilegedHelper",
             script:    {
               # replicating #{staged_path}/installer.sh

--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -19,6 +19,7 @@ cask "wd-security" do
     # replicating #{staged_path}/installer.sh
     executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
     args:       ["-install", "-silent"],
+    sudo:       true,
   }
 
   uninstall script: {


### PR DESCRIPTION
Obscure and kinda dusty app, but used by the very popular Backblaze software for their [mailed restore drives](https://www.backblaze.com/computer-backup/docs/use-a-usb-restore-drive)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
