### PR TITLE
openbb-terminal: deprecate

### DIFF
--- a/Casks/o/openbb-terminal.rb
+++ b/Casks/o/openbb-terminal.rb
@@ -1,5 +1,4 @@
 cask "openbb-terminal" do
-  # raised an issue about the x86.64 typo, https://github.com/OpenBB-finance/OpenBBTerminal/issues/5405
   arch arm: "ARM64", intel: "x86.64"
 
   version "3.2.5"
@@ -12,10 +11,7 @@ cask "openbb-terminal" do
   desc "Open-source investment research terminal"
   homepage "https://openbb.co/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-05-16", because: :discontinued
 
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
Application has been discontinued upstream.

<img width="1411" alt="Screenshot 2024-05-16 at 7 31 54 AM" src="https://github.com/Homebrew/homebrew-cask/assets/39449589/66ee4aee-030b-4150-9205-8786986cfb10">

<img width="1382" alt="Screenshot 2024-05-16 at 7 32 55 AM" src="https://github.com/Homebrew/homebrew-cask/assets/39449589/43c23872-c2ad-4ff1-9e29-fb33cee7db8b">
