### PR TITLE
Fix yandex-cloud-cli.rb

### DIFF
--- a/Casks/y/yandex-cloud-cli.rb
+++ b/Casks/y/yandex-cloud-cli.rb
@@ -1,5 +1,5 @@
 cask "yandex-cloud-cli" do
-  version "0.123.0"
+  version "0.124.0"
   sha256 :no_check
 
   url "https://storage.yandexcloud.net/yandexcloud-yc/install.sh",
@@ -17,7 +17,7 @@ cask "yandex-cloud-cli" do
 
   installer script: {
     executable: "install.sh",
-    args:       ["-i", "#{staged_path}/#{token}", "-n"],
+    args:       ["-i", "#{staged_path}/#{token}", "-r", "/dev/null"],
   }
   installer script: {
     executable: "yandex-cloud-cli/bin/yc",


### PR DESCRIPTION
Fixes Homebrew/homebrew-cask#173982
Plus bump to 0.124.0 version
Couldn't run brew audit (disabled for local files)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
