### PR TITLE
developer/bin/list_running_app_ids: fix redundant `require` statement

### DIFF
--- a/developer/bin/list_running_app_ids
+++ b/developer/bin/list_running_app_ids
@@ -12,7 +12,6 @@
 ###
 
 require "open3"
-require "set"
 require "io/console"
 
 ###


### PR DESCRIPTION
I think this was caused by the rubocop bump
https://github.com/Homebrew/brew/pull/17323