### PR TITLE
Add `calibrite-profiler`

### DIFF
--- a/Casks/c/calibrite-profiler.rb
+++ b/Casks/c/calibrite-profiler.rb
@@ -1,0 +1,26 @@
+cask "calibrite-profiler" do
+  version "1.3.1"
+  sha256 "8adce527e8aeb9d271405a4c9fc865e24498494eae282f32268ed3a495982691"
+
+  url "https://github.com/LUMESCA/calibrite-profiler-releases/releases/download/v#{version}/calibrite-PROFILER-#{version}.dmg",
+      verified: "github.com/LUMESCA/calibrite-profiler-releases/"
+  name "calibrite PROFILER"
+  desc "Display calibration software for Calibrite, ColorChecker and X-Rite devices"
+  homepage "https://calibrite.com/calibrite-profiler/"
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "calibrite PROFILER.app"
+
+  zap trash: [
+    "~/Library/Application Support/calibrite PROFILER",
+    "~/Library/Application Support/calibrite-profiler",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.calibrite.profiler.sfl*",
+    "~/Library/Caches/calibrite PROFILER",
+    "~/Library/Logs/calibrite PROFILER",
+    "~/Library/Logs/calibrite-profiler",
+    "~/Library/Preferences/com.calibrite.profiler.plist",
+    "~/Library/Saved Application State/com.calibrite.profiler.savedState",
+  ]
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -2,6 +2,7 @@
   "aerial@beta": "all",
   "altdeploy": "all",
   "bitbar": "all",
+  "calibrite-profiler": "all",
   "cleartext": "all",
   "comma-chameleon": "all",
   "crypter": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully. ***See below***
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This app isn't open source - it just uses GitHub releases for asset hosting. The latest stable release as per the download page and release notes is the current "pre-release" as marked on GitHub. Add to `github_prerelease_allowlist` to ignore the lint.

The `brew audit --cask --new` check fails with two issues:

```lang=plain
 - Upstream defined :high_sierra as the minimum OS version and the cask defined :catalina
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

The first is a conflict between `Info.plist` (which says High Sierra 10.13) and [the vendor website](https://calibrite.com/software-downloads/) (which says Catalina 10.15). The second is the same GitHub issue as the pre-release above, but with no obvious equivalent allowlist to exempt it.

This cask previously existed in `cask-drivers` as `calibrite-ccprofiler` - it was renamed at some point and never updated, then removed completely during the migration back to `cask` due to lack of use.
