### PR TITLE
vscodium: add livecheck

### DIFF
--- a/Casks/v/vscodium.rb
+++ b/Casks/v/vscodium.rb
@@ -10,6 +10,27 @@ cask "vscodium" do
   desc "Binary releases of VS Code without MS branding/telemetry/licensing"
   homepage "https://github.com/VSCodium/vscodium"
 
+  # Not every GitHub release provides a file for macOS, so we check multiple
+  # recent releases instead of only the "latest" release. NOTE: We should be
+  # able to use `strategy :github_latest` when subsequent releases provide
+  # files for macOS again.
+  livecheck do
+    url :url
+    regex(/^VScodium[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `vscodium` and it correctly returns 1.89.1.24130 as the latest version but the releases after 1.88.1.24104 haven't provided assets for macOS because of a temporary technical issue (see https://github.com/VSCodium/vscodium/issues/1868).

This adds a `GithubReleases` `livecheck` block to restrict matching to releases with dmg files. We should be able to switch to `strategy :github_latest` once upstream provides dmg files in subsequent releases but this addresses the issue for the moment.