### PR TITLE
affinity-*: use versioned url, update livecheck

### DIFF
--- a/Casks/a/affinity-designer.rb
+++ b/Casks/a/affinity-designer.rb
@@ -1,28 +1,31 @@
 cask "affinity-designer" do
-  version "2.4.2"
-  sha256 :no_check
+  version "2.4.2,2371"
+  sha256 "94f19ba7c058978b8f9498b0cd5ba77926e3ed9fc25b22f155de24d43c2c2958"
 
-  url "https://store.serif.com/download/60f51f/"
-  name "Affinity Designer #{version.major}"
+  url "https://s3-eu-west-1.amazonaws.com/affinity-update/mac2/retail/Affinity%20Designer%20#{version.csv.first.major}%20Affinity%20Store%20#{version.csv.second}.zip",
+      verified: "s3-eu-west-1.amazonaws.com/"
+  name "Affinity Designer #{version.csv.first.major}"
   desc "Professional graphic design software"
   homepage "https://affinity.serif.com/en-us/designer/"
 
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://go.seriflabs.com/affinity-update-mac-retail-designer#{version.csv.first.major}"
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version}"
+    end
   end
 
   auto_updates true
   depends_on macos: ">= :catalina"
 
-  app "Affinity Designer #{version.major}.app"
+  app "Affinity Designer #{version.csv.first.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/Affinity Designer 2",
-    "~/Library/Caches/com.seriflabs.affinitydesigner2",
-    "~/Library/HTTPStorages/com.seriflabs.affinitydesigner2",
-    "~/Library/Preferences/com.seriflabs.affinitydesigner2.plist",
-    "~/Library/Saved Application State/com.seriflabs.affinitydesigner2.savedState",
-    "~/Library/WebKit/com.seriflabs.affinitydesigner2",
+    "~/Library/Application Support/Affinity Designer #{version.csv.first.major}",
+    "~/Library/Caches/com.seriflabs.affinitydesigner#{version.csv.first.major}",
+    "~/Library/HTTPStorages/com.seriflabs.affinitydesigner#{version.csv.first.major}",
+    "~/Library/Preferences/com.seriflabs.affinitydesigner#{version.csv.first.major}.plist",
+    "~/Library/Saved Application State/com.seriflabs.affinitydesigner#{version.csv.first.major}.savedState",
+    "~/Library/WebKit/com.seriflabs.affinitydesigner#{version.csv.first.major}",
   ]
 end

--- a/Casks/a/affinity-designer@1.rb
+++ b/Casks/a/affinity-designer@1.rb
@@ -1,15 +1,16 @@
 cask "affinity-designer@1" do
   version "1.10.8"
-  sha256 :no_check
+  sha256 "7c3d9ce7e42dd8f3b3cf7f37aaffde3a59f33087007b9a2c81d86baceaa39ef6"
 
-  url "https://store.serif.com/download/aa4dee/"
+  url "https://s3-eu-west-1.amazonaws.com/affinity-update/mac/retail/Affinity%20Designer-#{version}.app.zip",
+      verified: "s3-eu-west-1.amazonaws.com/"
   name "Affinity Designer"
   desc "Professional graphic design software"
   homepage "https://affinity.serif.com/en-us/designer/"
 
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://go.seriflabs.com/affinity-update-mac-retail-designer"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/a/affinity-photo.rb
+++ b/Casks/a/affinity-photo.rb
@@ -1,28 +1,31 @@
 cask "affinity-photo" do
-  version "2.4.2"
-  sha256 :no_check
+  version "2.4.2,2371"
+  sha256 "84b18af04a7272bcfd4c9009e34de5e8d297e892ae168b1fe64322f148506299"
 
-  url "https://store.serif.com/download/89007d/"
-  name "Affinity Photo #{version.major}"
+  url "https://s3-eu-west-1.amazonaws.com/affinity-update/mac2/retail/Affinity%20Photo%20#{version.csv.first.major}%20Affinity%20Store%20#{version.csv.second}.zip",
+      verified: "s3-eu-west-1.amazonaws.com/"
+  name "Affinity Photo #{version.csv.first.major}"
   desc "Professional image editing software"
   homepage "https://affinity.serif.com/en-us/photo/"
 
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://go.seriflabs.com/affinity-update-mac-retail-photo#{version.csv.first.major}"
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version}"
+    end
   end
 
   auto_updates true
   depends_on macos: ">= :catalina"
 
-  app "Affinity Photo #{version.major}.app"
+  app "Affinity Photo #{version.csv.first.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/Affinity Photo 2",
-    "~/Library/Caches/com.seriflabs.affinityphoto2",
-    "~/Library/HTTPStorages/com.seriflabs.affinityphoto2",
-    "~/Library/Preferences/com.seriflabs.affinityphoto2.plist",
-    "~/Library/Saved Application State/com.seriflabs.affinityphoto2.savedState",
-    "~/Library/WebKit/com.seriflabs.affinityphoto2",
+    "~/Library/Application Support/Affinity Photo #{version.csv.first.major}",
+    "~/Library/Caches/com.seriflabs.affinityphoto#{version.csv.first.major}",
+    "~/Library/HTTPStorages/com.seriflabs.affinityphoto#{version.csv.first.major}",
+    "~/Library/Preferences/com.seriflabs.affinityphoto#{version.csv.first.major}.plist",
+    "~/Library/Saved Application State/com.seriflabs.affinityphoto#{version.csv.first.major}.savedState",
+    "~/Library/WebKit/com.seriflabs.affinityphoto#{version.csv.first.major}",
   ]
 end

--- a/Casks/a/affinity-photo@1.rb
+++ b/Casks/a/affinity-photo@1.rb
@@ -1,15 +1,16 @@
 cask "affinity-photo@1" do
   version "1.10.8"
-  sha256 :no_check
+  sha256 "02b1f30f890ae58cab9fa8bf9a509f4a9d8ad8c09de79baf499cd6f6fdd5bfb1"
 
-  url "https://store.serif.com/download/075b51/"
+  url "https://s3-eu-west-1.amazonaws.com/affinity-update/mac/retail/Affinity%20Photo-#{version}.app.zip",
+      verified: "s3-eu-west-1.amazonaws.com/"
   name "Affinity Photo"
   desc "Professional image editing software"
   homepage "https://affinity.serif.com/en-us/photo/"
 
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://go.seriflabs.com/affinity-update-mac-retail-photo"
+    strategy :sparkle, &:version
   end
 
   auto_updates true

--- a/Casks/a/affinity-publisher.rb
+++ b/Casks/a/affinity-publisher.rb
@@ -1,28 +1,31 @@
 cask "affinity-publisher" do
-  version "2.4.2"
-  sha256 :no_check
+  version "2.4.2,2371"
+  sha256 "06b2f36dc4bfa772c06c8cfbd7e02bf739822e9303521a40e70ec1998f897bf9"
 
-  url "https://store.serif.com/download/668dfb/"
-  name "Affinity Publisher #{version.major}"
+  url "https://s3-eu-west-1.amazonaws.com/affinity-update/mac2/retail/Affinity%20Publisher%20#{version.csv.first.major}%20Affinity%20Store%20#{version.csv.second}.zip",
+      verified: "s3-eu-west-1.amazonaws.com/"
+  name "Affinity Publisher #{version.csv.first.major}"
   desc "Professional desktop publishing software"
   homepage "https://affinity.serif.com/en-us/publisher/"
 
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://go.seriflabs.com/affinity-update-mac-retail-publisher#{version.csv.first.major}"
+    strategy :sparkle do |item|
+      "#{item.short_version},#{item.version}"
+    end
   end
 
   auto_updates true
   depends_on macos: ">= :catalina"
 
-  app "Affinity Publisher #{version.major}.app"
+  app "Affinity Publisher #{version.csv.first.major}.app"
 
   zap trash: [
-    "~/Library/Application Support/Affinity Publisher #{version.major}",
-    "~/Library/Caches/com.seriflabs.affinitypublisher#{version.major}",
-    "~/Library/HTTPStorages/com.seriflabs.affinitypublisher#{version.major}",
-    "~/Library/Preferences/com.seriflabs.affinitypublisher#{version.major}.plist",
-    "~/Library/Saved Application State/com.seriflabs.affinitypublisher#{version.major}.savedState",
-    "~/Library/WebKit/com.seriflabs.affinitypublisher#{version.major}",
+    "~/Library/Application Support/Affinity Publisher #{version.csv.first.major}",
+    "~/Library/Caches/com.seriflabs.affinitypublisher#{version.csv.first.major}",
+    "~/Library/HTTPStorages/com.seriflabs.affinitypublisher#{version.csv.first.major}",
+    "~/Library/Preferences/com.seriflabs.affinitypublisher#{version.csv.first.major}.plist",
+    "~/Library/Saved Application State/com.seriflabs.affinitypublisher#{version.csv.first.major}.savedState",
+    "~/Library/WebKit/com.seriflabs.affinitypublisher#{version.csv.first.major}",
   ]
 end

--- a/Casks/a/affinity-publisher@1.rb
+++ b/Casks/a/affinity-publisher@1.rb
@@ -1,15 +1,16 @@
 cask "affinity-publisher@1" do
   version "1.10.8"
-  sha256 :no_check
+  sha256 "6d5675970b745775bd5c35d28d20e1c68fe0771cdc2c17161f6762c2730a1278"
 
-  url "https://store.serif.com/download/7ef252/"
+  url "https://s3-eu-west-1.amazonaws.com/affinity-update/mac/retail/Affinity%20Publisher-#{version}.app.zip",
+      verified: "s3-eu-west-1.amazonaws.com/"
   name "Affinity Publisher"
   desc "Professional desktop publishing software"
   homepage "https://affinity.serif.com/en-us/publisher/"
 
   livecheck do
-    url :url
-    strategy :header_match
+    url "https://go.seriflabs.com/affinity-update-mac-retail-publisher"
+    strategy :sparkle, &:version
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The Affinity casks contain `livecheck` blocks using the `HeaderMatch` strategy but the URLs don't seem to redirect outside of a browser, even with a different user agent (i.e., it simply returns a 200 response instead of a 301/302). This updates these `livecheck` blocks to check the Sparkle feeds that the apps use to check for updates.