### PR TITLE
streamlink-twitch-gui 2.5.2

### DIFF
--- a/Casks/s/streamlink-twitch-gui.rb
+++ b/Casks/s/streamlink-twitch-gui.rb
@@ -1,6 +1,6 @@
 cask "streamlink-twitch-gui" do
-  version "2.5.1"
-  sha256 "6d56969a4ff50f6f69de44542dc2e4b37c6adcc9078ec5fa2c566847f6d14ee2"
+  version "2.5.2"
+  sha256 "bb653d1d358e462fb80f238fe031fa7842fd064d829a67a1fc8f184bb6933a1a"
 
   url "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v#{version}/streamlink-twitch-gui-v#{version}-macOS.tar.gz"
   name "Streamlink Twitch GUI"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
