### PR TITLE
ScreenMemory 1.20.3 (new cask)

### DIFF
--- a/Casks/s/screenmemory.rb
+++ b/Casks/s/screenmemory.rb
@@ -1,0 +1,24 @@
+cask "screenmemory" do
+  version "1.20.3"
+  sha256 "f0c2566ae23a849e2eef12ca9bdf195de26d933a800930596c6cdaa47a1c9e21"
+
+  url "https://f005.backblazeb2.com/file/screenmemory/ScreenMemory.#{version}.dmg",
+      verified: "f005.backblazeb2.com/file/screenmemory/"
+  name "ScreenMemory"
+  desc "Record your screen and go back in time to see what you worked on"
+  homepage "https://screenmemory.app/"
+
+  livecheck do
+    url "https://f005.backblazeb2.com/file/screenmemory/appcast.xml"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "ScreenMemory.app"
+
+  zap trash: [
+    "~/Library/HTTPStorages/com.jontelang.screenmemory",
+    "~/Library/Preferences/com.jontelang.screenmemory.plist",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online screenmemory` is error-free.
- [X] `brew style --fix screenmemory` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [X] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [X] `brew audit --cask --new screenmemory` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask screenmemory` worked successfully.
- [X] `brew uninstall --cask screenmemory` worked successfully.

---
