### PR TITLE
chatwork: update depends_on, livecheck

### DIFF
--- a/Casks/c/chatwork.rb
+++ b/Casks/c/chatwork.rb
@@ -12,7 +12,7 @@ cask "chatwork" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "ChatWork.app"
 

--- a/Casks/c/chatwork.rb
+++ b/Casks/c/chatwork.rb
@@ -1,5 +1,7 @@
 cask "chatwork" do
-  version "2.8.3.7370"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
+
+  version "2.8.3"
   sha256 :no_check
 
   url "https://desktop-app.chatwork.com/installer/ChatWork.dmg"
@@ -8,10 +10,13 @@ cask "chatwork" do
   homepage "https://www.chatwork.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://desktop-release.chatwork.com/darwin/#{livecheck_arch}/latest?version=0.0.0"
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "ChatWork.app"

--- a/Casks/c/chatwork.rb
+++ b/Casks/c/chatwork.rb
@@ -1,5 +1,5 @@
 cask "chatwork" do
-  version "2.8.2.7340"
+  version "2.8.3.7370"
   sha256 :no_check
 
   url "https://desktop-app.chatwork.com/installer/ChatWork.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Support for macOS 10.14 and below has ended (see [support article](https://support-en.chatwork.com/hc/en-us/articles/26721434190361-01-30-2024-App-desktop-version-to-end-support-for-macOS-10-14-and-below)).
