### PR TITLE
Add Cask FreeFileSync 13.6

### DIFF
--- a/Casks/f/freefilesync.rb
+++ b/Casks/f/freefilesync.rb
@@ -1,0 +1,41 @@
+cask "freefilesync" do
+  version "13.6"
+  sha256 :no_check
+
+  url "https://freefilesync.org/download/FreeFileSync_#{version}_macOS.zip"
+  name "freefilesync"
+  desc "Synchronize Files and Folders"
+  homepage "https://freefilesync.org/"
+
+  livecheck do
+    url "https://freefilesync.org/download.php"
+    regex(/href=.*?FreeFileSync[._-](\d+(?:\.\d+)+)[._-]macOS\.zip/i)
+  end
+
+  auto_updates false
+
+  pkg "FreeFileSync_#{version}.pkg",
+      choices: [
+        {
+          "choiceIdentifier" => "installer_choice_1",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 1,
+        },
+        {
+          "choiceIdentifier" => "installer_choice_2",
+          "choiceAttribute"  => "selected",
+          "attributeSetting" => 1,
+        },
+      ]
+
+  uninstall pkgutil: [
+    "org.freefilesync.pkg.FreeFileSync",
+    "org.freefilesync.pkg.RealTimeSync",
+  ]
+
+  zap trash: [
+    "~/Library/Application Support/FreeFileSync",
+    "~/Library/Preferences/org.freefilesync.FreeFileSync.plist",
+    "~/Library/Preferences/org.freefilesync.RealTimeSync.plist",
+  ]
+end


### PR DESCRIPTION


After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online freefilesync` is error-free.
- [x] `brew style --fix freefilesync` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new freefilesync` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask freefilesync` worked successfully.
- [x] `brew uninstall --cask freefilesync` worked successfully.

---
I again propose adding freefilesync via cask because with sha256 no_check it seems to work well