### PR TITLE
loungy: update livecheck

### DIFF
--- a/Casks/l/loungy.rb
+++ b/Casks/l/loungy.rb
@@ -7,6 +7,11 @@ cask "loungy" do
   desc "Application launcher"
   homepage "https://github.com/MatthiasGrandl/Loungy"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Loungy.app"
 
   zap trash: [


### PR DESCRIPTION
Tags don't line up with releases. Latest tags do not have binaries.