### PR TITLE
vmware-horizon-client: update `livecheck`, downgrade to same as upstream

### DIFF
--- a/Casks/v/vmware-horizon-client.rb
+++ b/Casks/v/vmware-horizon-client.rb
@@ -1,6 +1,6 @@
 cask "vmware-horizon-client" do
-  version "2312.2-8.12.2-23764102,CART25FQ1_MAC_2312.2"
-  sha256 "a1370fbda317f98c147b3a63bcaade2120ae40d20f220b419b76949b279bba65"
+  version "2312.1-8.12.1-23531248,CART25FQ1_MAC_2312.1"
+  sha256 "007dbce07b319d7eb633d937135b0f39c72b0d4bbc38ae1939b05fc676bd4f2e"
 
   url "https://download3.omnissa.com/software/#{version.csv.second}/VMware-Horizon-Client-#{version.csv.first}.dmg",
       verified: "download3.omnissa.com/software/"
@@ -8,13 +8,27 @@ cask "vmware-horizon-client" do
   desc "Virtual machine client"
   homepage "https://www.vmware.com/"
 
-  # TODO: Once upstream completes migration to the "Broadcom Support Portal"
-  # workout an updated livecheck strategy
   livecheck do
-    url "https://maintenance.vmware.com/horizon-client-download.html"
+    url "https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY"
     regex(%r{/([^/]+)/VMware[._-]Horizon[._-]Client[._-]v?(\d+(?:[.-]\d+)+)\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    strategy :json do |json|
+      mac_json_info = json["dlgEditionsLists"]&.select { |item| item["name"].match(/mac/i) }&.first
+      api_item = mac_json_info["dlgList"]&.first
+      next if api_item.blank?
+
+      download_group = api_item["code"]
+      product_id = api_item["productId"]
+      pid = api_item["releasePackageId"]
+      next if download_group.blank? || product_id.blank? || pid.blank?
+
+      url = "https://customerconnect.omnissa.com/channel/public/api/v1.0/dlg/details?locale=en_US&downloadGroup=#{download_group}&productId=#{product_id}&rPId=#{pid}"
+      download_item = Homebrew::Livecheck::Strategy.page_content(url)
+      next if download_item[:content].blank?
+
+      match = download_item[:content].match(regex)
+      next if match.blank?
+
+      "#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream's website has been migrated and is functional again. The version is also downgraded in this PR to match what is being distributed upstream.