### PR TITLE
wd-security 2.1.2.144 (new cask)

### DIFF
--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -1,0 +1,38 @@
+cask "wd-security" do
+  version "2.1.2.144"
+  sha256 :no_check
+
+  url "https://downloads.wdc.com/wdapp/WD_Security_MACOS.zip",
+      verified: "downloads.wdc.com/wdapp/"
+  name "WD Security"
+  desc "Lock and unlock Western Digital external drives with hardware encryption"
+  homepage "https://support-en.wd.com/app/answers/detailweb/a_id/50696"
+
+  livecheck do
+    url "https://support-en.wd.com/app/answers/detailweb/a_id/29490"
+    regex(/Version:?\s*(\d+(?:\.\d+)+)/i)
+  end
+
+  container nested: "WD Security Installer.dmg"
+
+  installer script: {
+    # replicating #{staged_path}/installer.sh
+    executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
+    args:       ["-install", "-silent"],
+    sudo:       true,
+  }
+
+  uninstall launchctl: "com.wdc.WDPrivilegedHelper",
+            script:    {
+              # replicating #{staged_path}/installer.sh
+              executable: "#{staged_path}/exec/WD Security Installer.app/Contents/MacOS/WD Security Installer",
+              args:       ["-uninstall", "-silent"],
+              sudo:       true,
+            },
+            delete:    [
+              "/Library/LaunchDaemons/com.wdc.WDPrivilegedHelper.plist",
+              "/Library/PrivilegedHelperTools/com.wdc.WDPrivilegedHelper",
+            ]
+
+  zap trash: "~/Library/Preferences/com.wdc.branded.security.plist"
+end

--- a/Casks/w/wd-security.rb
+++ b/Casks/w/wd-security.rb
@@ -35,4 +35,8 @@ cask "wd-security" do
             ]
 
   zap trash: "~/Library/Preferences/com.wdc.branded.security.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Reattempt of https://github.com/Homebrew/homebrew-cask/pull/173945: may have found a fix for the failing workflow, borrowed from `anydesk.rb`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
