### PR TITLE
paraview 5.12.0

### DIFF
--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -14,7 +14,7 @@ cask "paraview" do
 
   livecheck do
     url "https://www.paraview.org/files/listing.txt"
-    regex(%r{/v?(\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:\.\d+)+).*?[._-]#{arch}\.dmg}i)
+    regex(%r{/v?(?:\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:\.\d+)+).*?[._-]#{arch}\.dmg}i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -14,7 +14,8 @@ cask "paraview" do
 
   livecheck do
     url "https://www.paraview.org/files/listing.txt"
-    regex(/ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX#{min_macos_version}[._-]Python3\.10[._-]#{arch}\.dmg/i)
+    regex(%r{(?<!nightly/)ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX#{min_macos_version}[._-]Python3\.10[._-]#{arch}
+          \.dmg}ix)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -14,8 +14,7 @@ cask "paraview" do
 
   livecheck do
     url "https://www.paraview.org/files/listing.txt"
-    regex(%r{(?<!nightly/)ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX#{min_macos_version}[._-]Python3\.10[._-]#{arch}
-          \.dmg}ix)
+    regex(%r{/v?(\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:\.\d+)+).*?[._-]#{arch}\.dmg}i)
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -1,12 +1,16 @@
 cask "paraview" do
   arch arm: "arm64", intel: "x86_64"
-  min_macos_version = on_arch_conditional arm: "11.0", intel: "10.15"
 
-  version "5.12.0"
-  sha256 arm:   "6b50e2d90fd2d2caf1792a66358a854f59aa9c4825b3a8ec997339c893c94bb6",
-         intel: "1b9aca43835a58fb490137031434e4fcbdd4a07247038e3931624a0139917f4b"
+  on_arm do
+    version "5.12.0,MPI-OSX11.0-Python3.10"
+    sha256 "6b50e2d90fd2d2caf1792a66358a854f59aa9c4825b3a8ec997339c893c94bb6"
+  end
+  on_intel do
+    version "5.12.0,MPI-OSX10.15-Python3.10"
+    sha256 "1b9aca43835a58fb490137031434e4fcbdd4a07247038e3931624a0139917f4b"
+  end
 
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX#{min_macos_version}-Python3.10-#{arch}.dmg",
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.csv.first.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
       user_agent: :fake
   name "ParaView"
   desc "Data analysis and visualization application"
@@ -14,13 +18,18 @@ cask "paraview" do
 
   livecheck do
     url "https://www.paraview.org/files/listing.txt"
-    regex(%r{/v?(?:\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:\.\d+)+).*?[._-]#{arch}\.dmg}i)
+    regex(%r{/v?(?:\d+(?:\.\d+)+)/ParaView[._-]v?(\d+(?:[.-]\d+)+)(?:[._-](.*?))?[._-](?:#{arch}|universal)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match[1] ? "#{match[0]},#{match[1]}" : match[0]
+      end
+    end
   end
 
   depends_on macos: ">= :sierra"
 
-  app "ParaView-#{version}.app"
-  binary "#{appdir}/ParaView-#{version}.app/Contents/MacOS/paraview"
+  app "ParaView-#{version.csv.first}.app"
+  binary "#{appdir}/ParaView-#{version.csv.first}.app/Contents/MacOS/paraview"
 
   zap trash: [
     "~/.config/ParaView",

--- a/Casks/p/paraview.rb
+++ b/Casks/p/paraview.rb
@@ -1,12 +1,12 @@
 cask "paraview" do
   arch arm: "arm64", intel: "x86_64"
-  min_macos_version = on_arch_conditional arm: "11.0", intel: "10.13"
+  min_macos_version = on_arch_conditional arm: "11.0", intel: "10.15"
 
-  version "5.11.2"
-  sha256 arm:   "0fc82a819996b80014df24e96095b87f9ceae0f65a0c2bf8157aa2ddda4baa0b",
-         intel: "f225784e0b4fa7677b7fc2a4bf7860e9842a032792fe696479f84e4783783220"
+  version "5.12.0"
+  sha256 arm:   "6b50e2d90fd2d2caf1792a66358a854f59aa9c4825b3a8ec997339c893c94bb6",
+         intel: "1b9aca43835a58fb490137031434e4fcbdd4a07247038e3931624a0139917f4b"
 
-  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX#{min_macos_version}-Python3.9-#{arch}.dmg",
+  url "https://www.paraview.org/paraview-downloads/download.php?submit=Download&version=v#{version.major_minor}&type=binary&os=macOS&downloadFile=ParaView-#{version}-MPI-OSX#{min_macos_version}-Python3.10-#{arch}.dmg",
       user_agent: :fake
   name "ParaView"
   desc "Data analysis and visualization application"
@@ -14,7 +14,7 @@ cask "paraview" do
 
   livecheck do
     url "https://www.paraview.org/files/listing.txt"
-    regex(/ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX#{min_macos_version}[._-]Python3\.9[._-]#{arch}\.dmg/i)
+    regex(/ParaView[._-](\d+(?:\.\d+)+)[._-]MPI[._-]OSX#{min_macos_version}[._-]Python3\.10[._-]#{arch}\.dmg/i)
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
Bump paraview to 5.12.
Bump Paraview bundled python version to 3.10 (in URLs). Update sha256 hashes.
Bump required MacOS version to 10.15 (indicated by URL).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
