### PR TITLE
philips-hue-sync: use versioned url, update livecheck

### DIFF
--- a/Casks/p/philips-hue-sync.rb
+++ b/Casks/p/philips-hue-sync.rb
@@ -1,24 +1,25 @@
 cask "philips-hue-sync" do
-  version "1.12.0.64"
-  sha256 :no_check
+  version "1.12.0.64,8b10db6f-3066-451c-b08a-d1b860935be1,64"
+  sha256 "1b18327ca982c48660ec267be7aff437f0d8bc299eba1c2791d56a787a4b4b1e"
 
-  url "https://firmware.meethue.com/v1/download?deviceTypeId=HueSyncMac",
-      verified: "firmware.meethue.com/v1/"
+  url "https://firmware.meethue.com/storage/huesyncmac/#{version.csv.third}/#{version.csv.second}/HueSyncInstaller_#{version.csv.first}.pkg",
+      verified: "firmware.meethue.com/storage/huesyncmac/"
   name "Philips Hue Sync"
   desc "Control your smart light system"
   homepage "https://www.philips-hue.com/en-us/explore-hue/propositions/entertainment/sync-with-pc"
 
   livecheck do
-    url :url
-    regex(/HueSyncInstaller[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
-    strategy :header_match
+    url "https://firmware.meethue.com/v1/download?deviceTypeId=HueSyncMac"
+    regex(%r{/([^/]+)/([^/]+)/HueSyncInstaller[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[3]},#{match[2]},#{match[1]}"
+    end
   end
 
-  pkg "HueSyncInstaller.pkg"
-
-  preflight do
-    staged_path.glob("HueSyncInstaller_*.pkg").first.rename(staged_path/"HueSyncInstaller.pkg")
-  end
+  pkg "HueSyncInstaller_#{version.csv.first}.pkg"
 
   uninstall quit:    [
               "com.lighting.huesync",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Use a versioned `url`, enabling the checksum, and related updates.
Should fix https://github.com/Homebrew/homebrew-cask/issues/174385