### PR TITLE
joplin: revert #174434

### DIFF
--- a/Casks/j/joplin.rb
+++ b/Casks/j/joplin.rb
@@ -1,9 +1,9 @@
 cask "joplin" do
   arch arm: "-arm64"
 
-  version "2.14.21"
-  sha256 arm:   "789ea54c98e40d0fecb9ce7950cd967f768ceec4f3d2d2aad6de514b54a4e3df",
-         intel: "b4d08c913c940be658c6a5c4c4233abd486d2bdc8e9037339ce34613e45fafa9"
+  version "2.14.20"
+  sha256 arm:   "961df5860434fd6c1cad7dadfe86d2cd749f9fbc2f2d8d9798af1462c82b3e75",
+         intel: "5f8c25126dcfea074e758fbb1650a7d46ce605c05a4f9522a15f5096cdfeb649"
 
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}#{arch}.DMG",
       verified: "github.com/laurent22/joplin/"


### PR DESCRIPTION
This reverts #174434 which has a bug and has been pulled from releases.
