### PR TITLE
texshop: various updates

### DIFF
--- a/Casks/t/texshop.rb
+++ b/Casks/t/texshop.rb
@@ -1,10 +1,10 @@
 cask "texshop" do
   version "5.35"
-  sha256 "4ef9286e0d4c03f609690c39e2f219e31ee538abe454c125760fc68ba5d7a17f"
+  sha256 "d6da42bc81f19f69de3e31f6a5b05e8937856ccdb07360a80873f898fe33c9a4"
 
   url "https://pages.uoregon.edu/koch/texshop/texshop-64/texshop#{version.no_dots}.zip"
   name "TeXShop"
-  desc "TeX previewer"
+  desc "LaTeX and TeX editor and previewer"
   homepage "https://pages.uoregon.edu/koch/texshop/"
 
   livecheck do
@@ -20,9 +20,12 @@ cask "texshop" do
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/texshop.sfl*",
     "~/Library/Application Support/TeXShop",
+    "~/Library/Caches/com.apple.helpd/Generated/TeXShop Help*",
     "~/Library/Caches/com.apple.helpd/SDMHelpData/Other/English/HelpSDMIndexFile/TeXShop Help*",
     "~/Library/Caches/TeXShop",
+    "~/Library/HTTPStorages/TeXShop",
     "~/Library/Preferences/TeXShop.plist",
     "~/Library/TeXShop",
+    "~/Library/WebKit/TeXShop",
   ]
 end


### PR DESCRIPTION
Note from the `livecheck` `url` the new and relatively recent `<pubDate>`:
```
|-> curl https://pages.uoregon.edu/koch/texshop/texshop-64/texshopappcast.xml
<?xml version="1.0" standalone="yes"?>
<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
    <channel>
        <title>TeXShop</title>
        <item>
            <title>5.35</title>
            <pubDate>Sat, 18 May 2024 08:50:17 -0700</pubDate>
            <sparkle:minimumSystemVersion>10.13.0</sparkle:minimumSystemVersion>
            <sparkle:releaseNotesLink>https://pages.uoregon.edu/koch/texshop/texshop-64/texshop535.html</sparkle:releaseNotesLink>
            <enclosure url="https://pages.uoregon.edu/koch/texshop/texshop-64/texshop535.zip" sparkle:version="5.35" sparkle:shortVersionString="5.35" length="69616806" type="application/octet-stream" sparkle:edSignature="souP56c5L+2kSV6XD/SoWTHOqrDcEmWQnblVgY4ZCaP+/Pjrsp3rDila45PW5AEh7DYzV22Kl3LQz8QnLsOcDw==" sparkle:dsaSignature="MCwCFGW5LfrkFToQHKmZPWn3Fwa9Rvj4AhRWCUcGly6TyuUSSDtejx8jdGmrzA=="/>
        </item>
    </channel>
</rss>
```