### PR TITLE
blitz-gg 2.1.165 (new cask)

### DIFF
--- a/Casks/b/blitz-gg.rb
+++ b/Casks/b/blitz-gg.rb
@@ -1,0 +1,35 @@
+cask "blitz-gg" do
+  version "2.1.165"
+  sha256 "27200493c22532a90d60a4059d486fb8295b7eafe36221f5d9c69dcd82fb0b75"
+
+  url "https://blitz-main.blitz.gg/Blitz-x64-#{version}.dmg"
+  name "Blitz"
+  desc "Performance analysis software"
+  homepage "https://blitz.gg/"
+
+  livecheck do
+    url "https://blitz.gg/download/mac"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Blitz.app"
+
+  uninstall quit: "com.blitz.app"
+
+  zap trash: [
+    "~/Library/Application Support/Blitz",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.blitz.app.sfl*",
+    "~/Library/Caches/com.blitz.app.ShipIt",
+    "~/Library/Cookies/com.blitz.app.binarycookies",
+    "~/Library/Logs/Blitz",
+    "~/Library/Preferences/com.blitz.app.plist",
+    "~/Library/Saved Application State/com.blitz.app.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

It seems that the cask existed but at some point they changed a bunch of the subdomain names, and was removed in #138248.