### PR TITLE
rustrover 2024.1,241.15989.199

### DIFF
--- a/Casks/r/rustrover.rb
+++ b/Casks/r/rustrover.rb
@@ -1,17 +1,16 @@
 cask "rustrover" do
   arch arm: "-aarch64"
 
-  version "2024.1,241.15989.180"
-  sha256 arm:   "05196688c43f9727acd5ffe735e431aa339dbe7e96e705470e50e40c877ebc9d",
-         intel: "86b832fd27e27262aeba5233cdf33178fda39b4968195c868c3d2096907bb1ba"
+  version "2024.1,241.15989.199"
+  sha256 :no_check
 
-  url "https://download.jetbrains.com/rustrover/RustRover-#{version.csv.second}#{arch}.dmg"
+  url "https://download.jetbrains.com/rustrover/RustRover-#{version.csv.first}#{arch}.dmg"
   name "RustRover"
   desc "Rust IDE"
   homepage "https://www.jetbrains.com/rust/"
 
   livecheck do
-    url "https://data.services.jetbrains.com/products/releases?code=RR&latest=true&type=eap"
+    url "https://data.services.jetbrains.com/products/releases?code=RR&latest=true&type=release"
     strategy :json do |json|
       json["RR"].map do |release|
         "#{release["version"]},#{release["build"]}"
@@ -20,16 +19,16 @@ cask "rustrover" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :high_sierra"
 
-  app "RustRover #{version.before_comma} EAP.app", target: "RustRover.app"
+  app "RustRover.app"
   binary "#{appdir}/RustRover.app/Contents/MacOS/rustrover"
 
   zap trash: [
     "~/Library/Application Support/JetBrains/RustRover#{version.major_minor}",
     "~/Library/Caches/JetBrains/RustRover#{version.major_minor}",
     "~/Library/Logs/JetBrains/RustRover#{version.major_minor}",
-    "~/Library/Preferences/com.jetbrains.rustrover-EAP.plist",
-    "~/Library/Saved Application State/com.jetbrains.rustrover-EAP.SavedState",
+    "~/Library/Preferences/com.jetbrains.rustrover.plist",
+    "~/Library/Saved Application State/com.jetbrains.rustrover.savedState",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

RustRover is now released but the existing `livecheck` block restricts the check to EAP (unstable) versions and incorrectly returns 2024.1,241.15989.180 (the newest EAP release) as the latest version. This updates the `livecheck` block to only check stable (`release`) versions going forward and updates the cask to 2024.1,241.15989.199.

The stable dmg files use the version (`2024.1`) instead of the build (`241.15989.199`), so we unfortunately have to use `sha256 :no_check` now, as the dmg can be updated to a new build without any change to the file name.