### PR TITLE
dmg-canvas: use versioned url

### DIFF
--- a/Casks/d/dmg-canvas.rb
+++ b/Casks/d/dmg-canvas.rb
@@ -1,17 +1,19 @@
 cask "dmg-canvas" do
-  version "4.0.8,400032"
-  sha256 :no_check
+  version "4.0.8"
+  sha256 "8cd7204af752fd04364da5d5c7e2a383b83f50fac5e04a26b23e64e1e5d92321"
 
-  url "https://arweb-assets.s3.amazonaws.com/downloads/dmgcanvas/DMGCanvas.dmg",
+  url "https://arweb-assets.s3.amazonaws.com/downloads/dmgcanvas/versions/DMGCanvas#{version}.zip",
       verified: "arweb-assets.s3.amazonaws.com/downloads/dmgcanvas/"
   name "DMG Canvas"
   desc "Stylised disk images made easy"
   homepage "https://www.araelium.com/dmgcanvas"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://www.araelium.com/support/dmgcanvas/download-previous-versions"
+    regex(/href=.*?DMGCanvas[._-]?v?(\d+(?:\.\d+)+)\.(?:dmg|pkg|zip)/i)
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "DMG Canvas.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

In reviewing `dmg-canvas` recently, I noticed that versions can be found on an [upstream page listing previous versions](https://www.araelium.com/support/dmgcanvas/download-previous-versions), which includes the current one. Assuming this is updated in a timely fashion (i.e., when a new release is made), we can use the versioned zip files and check the aforementioned page for version information instead of having to use `ExtractPlist`.

Related to #171006.