### PR TITLE
snipy: disable

### DIFF
--- a/Casks/s/snipy.rb
+++ b/Casks/s/snipy.rb
@@ -7,10 +7,7 @@ cask "snipy" do
   desc "Snippet manager with sharing support"
   homepage "https://snipy.io/"
 
-  livecheck do
-    url "https://ta-production-snipy-releases.s3.amazonaws.com/latest-mac.yml"
-    strategy :electron_builder
-  end
+  disable! date: "2024-05-23", because: :no_longer_available
 
   auto_updates true
 


### PR DESCRIPTION
The snipy is disabled because it is no longer available.
https://x.com/snipyio/status/1520757106483380224

> We’ve decided to make Snipy a web app so it’s platform independent and accessible by far more users. 


