### PR TITLE
subsurface 6.0.5144 fix sha256

### DIFF
--- a/Casks/s/subsurface.rb
+++ b/Casks/s/subsurface.rb
@@ -1,6 +1,6 @@
 cask "subsurface" do
   version "6.0.5144"
-  sha256 "c8944ada9b85dfa49f755a83c0b7aa8c6a877876eb8cdd160ac554887014e751"
+  sha256 "77d3e9fdd2722b618056ae5a743f98d691ce468239c402248d38b26b21730c8a"
 
   url "https://subsurface-divelog.org/downloads/Subsurface-#{version}-CICD-release.dmg",
       user_agent: :fake


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I noticed that subsurface was not updateable. I tried removing it but then ended up in a situation where I couldn't install it anymore. I have verified the sha256 many times, over multiple internet connections.