### PR TITLE
Hopper Disassembler 5.15.6  (new cask)

### DIFF
--- a/Casks/h/hopper-disassembler.rb
+++ b/Casks/h/hopper-disassembler.rb
@@ -1,0 +1,26 @@
+cask "hopper-disassembler" do
+  version "5.15.6"
+  sha256 "9c85aded5ff3ca500868927c4462775ab9f1d25bb66a90ff0b6cfdd50d375691"
+
+  url "https://www.hopperapp.com/downloader/hopperv4/Hopper-#{version}-demo.dmg",
+      user_agent: :fake
+  name "Hopper Disassembler"
+  desc "Reverse engineering tool that lets you disassemble, decompile and debug your app"
+  homepage "https://www.hopperapp.com/"
+
+  livecheck do
+    skip "Cannot get version info unless livecheck can specify user_agent"
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Hopper Disassembler v4.app"
+
+  zap trash: [
+    "~/Library/Application Support/Hopper Disassembler v4",
+    "~/Library/Application Support/Hopper",
+    "~/Library/Caches/com.cryptic-apps.hopper-web-4",
+    "~/Library/Preferences/com.cryptic-apps.hopper-web-4.plist",
+    "~/Library/Saved Application State/com.cryptic-apps.hopper-web-4.savedState",
+  ]
+end


### PR DESCRIPTION
Hopper Disassembler was [previously removed](https://github.com/Homebrew/homebrew-cask/pull/49245) because [only the demo version is installed](https://github.com/Homebrew/homebrew-cask/pull/49053#issuecomment-401103111). However, this is [not true in the current Hopper Disassembler](https://github.com/orgs/Homebrew/discussions/5080), i.e., the demo version can be updated to the full version if the license file is specified. So, I add the Hopper Disassembler again in this pull request.

Please note that I was not able to implement the `livecheck` because [`livecheck` curl request cannot specify `useragent`](https://github.com/Homebrew/brew/issues/15350). If this is changed, I will implement the `livecheck`.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
