### PR TITLE
carbon-copy-cloner 7.0.1.8016

### DIFF
--- a/Casks/c/carbon-copy-cloner.rb
+++ b/Casks/c/carbon-copy-cloner.rb
@@ -1,16 +1,30 @@
 cask "carbon-copy-cloner" do
-  version "7.0.8010"
-  sha256 "82065f77eecac9f7e33eaa98fe2c62aececdae7d205c69e9079e36efd64aa08b"
+  version "7.0.1,8016"
+  sha256 "93a289d8ca2766587acdae35b3015fc90fab73ebf4f6a5ae1035b95f04044307"
 
-  url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version}.zip",
+  url "https://bombich.scdn1.secure.raxcdn.com/software/files/ccc-#{version.csv.first}.#{version.csv.second}.zip",
       verified: "bombich.scdn1.secure.raxcdn.com/software/files/"
   name "Carbon Copy Cloner"
   desc "Hard disk backup and cloning utility"
   homepage "https://bombich.com/"
 
+  # The filename uses a format like 1.2.3456 for 1.2 (3456) or 1.2.3.4567 for
+  # 1.2.3 (4567). Since there are a variable number of parts in the version and
+  # the secondary number is appended after the version, this can cause
+  # livecheck to incorrectly treat the cask version as newer than the upstream
+  # version (e.g., 1.2.3456 is seen as newer than 1.2.3.4567 because 3456 is
+  # greater than 3). As a result, we have to artificially split the secondary
+  # number and use a two part version format like 1.2,3456 for version
+  # comparison to work properly.
   livecheck do
     url "https://bombich.com/software/download_ccc.php?v=latest"
-    strategy :header_match
+    regex(/ccc[._-]v?(\d+(?:\.\d+)+)(?:\.(\d{3,}))/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      match[2] ? "#{match[1]},#{match[2]}" : match[1]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `carbon-copy-cloner` to 7.0.1.8016. This cask is in `autobump.txt` but it won't be updated to this version because `7.0.8010` is seen as newer than `7.0.1.8016` from the standpoint of `Version` comparison (i.e., 8010 > 1). This will continue to be an issue whenever updating from a version with fewer version parts to a version with more version parts (e.g., 3 to 4, as here).

To address this, I've updated the `version` and `livecheck` block to artificially split the secondary number and use a two part version format like 1.2,3456. This will ensure that the version and the secondary number are compared separately.