### PR TITLE
Fixed scilab recipe to use the official MacOS download site.

### DIFF
--- a/Casks/s/scilab.rb
+++ b/Casks/s/scilab.rb
@@ -10,14 +10,13 @@ cask "scilab" do
     sha256 "382c38c43510ef12a9375c4c9ec777863ab9c241cffbac4e753596f35378e69c"
   end
 
-  url "https://www.scilab.org/download/#{version}/scilab-#{version}-#{arch}.dmg",
-      verified: "scilab.org/download/"
+  url "https://www.scilab.org/download/#{version}/scilab-#{version}-#{arch}.dmg"
   name "Scilab"
   desc "Software for numerical computation"
   homepage "https://www.scilab.org/"
 
   livecheck do
-    url "https://www.scilab.org/download/"
+    url "https://www.scilab.org/download/latest/"
     regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 

--- a/Casks/s/scilab.rb
+++ b/Casks/s/scilab.rb
@@ -10,14 +10,14 @@ cask "scilab" do
     sha256 "382c38c43510ef12a9375c4c9ec777863ab9c241cffbac4e753596f35378e69c"
   end
 
-  url "https://www.utc.fr/~mottelet/scilab/download/#{version}/scilab-#{version}-#{arch}.dmg",
-      verified: "utc.fr/~mottelet/scilab/"
+  url "https://www.scilab.org/download/#{version}/scilab-#{version}-#{arch}.dmg",
+      verified: "scilab.org/download/"
   name "Scilab"
   desc "Software for numerical computation"
   homepage "https://www.scilab.org/"
 
   livecheck do
-    url "https://www.utc.fr/~mottelet/scilab_for_macOS.html"
+    url "https://www.scilab.org/download/"
     regex(/href=.*?scilab[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 


### PR DESCRIPTION
This should avoid using the slow and unreliable outdated MacOS specific site.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
