### PR TITLE
qgroundcontrol: use versioned GitHub URL

### DIFF
--- a/Casks/q/qgroundcontrol.rb
+++ b/Casks/q/qgroundcontrol.rb
@@ -1,15 +1,15 @@
 cask "qgroundcontrol" do
   version "4.3.0"
-  sha256 :no_check
+  sha256 "32ff5f37fdb877905859cd933f58d449033095000a415943527e21c5707971f2"
 
-  url "https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg",
-      verified: "d176tv9ibo4jno.cloudfront.net/latest/"
+  url "https://github.com/mavlink/qgroundcontrol/releases/download/v#{version}/QGroundControl.dmg",
+      verified: "github.com/mavlink/qgroundcontrol/"
   name "QGroundControl"
   desc "Ground control station for drones"
   homepage "http://qgroundcontrol.com/"
 
   livecheck do
-    url "https://github.com/mavlink/qgroundcontrol/releases/"
+    url :url
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `qgroundcontrol` checks the latest GitHub release, as the first-party website only links to an unversioned dmg file on Cloudfront (which the cask uses). This updates the cask to use the dmg file from the latest GitHub release, aligning the source of the cask `url` and `livecheck` block. Besides that, the GitHub release asset URL is versioned, so we can specify a `sha256` instead of using `:no_check`.