### PR TITLE
.workflows/triage: skip `missing description` label for fonts

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -67,6 +67,7 @@ jobs:
             - label: missing description
               path: Casks/.+
               missing_content: \n  desc .+\n
+              missing_content: cask "font-
 
             - label: extract_plist livecheck
               path: Casks/.+


### PR DESCRIPTION
We don't require a `desc` stanza for fonts, so don't add the `missing-description` label.