### PR TITLE
tresorit: update url

### DIFF
--- a/Casks/t/tresorit.rb
+++ b/Casks/t/tresorit.rb
@@ -2,8 +2,7 @@ cask "tresorit" do
   version "3.5.3013.4230"
   sha256 :no_check
 
-  url "https://installerstorage.blob.core.windows.net/public/install/Tresorit.dmg",
-      verified: "installerstorage.blob.core.windows.net/"
+  url "https://installer.tresorit.com/Tresorit.dmg"
   name "Tresorit"
   desc "Client for the Tresorit cloud storage service"
   homepage "https://tresorit.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `tresorit` checks the cask dmg URL but the server no longer returns an `x-ms-meta-version` header in the response. The [first-party download page](https://tresorit.com/download) links to a dmg file from installer.tresorit.com instead and that URL returns a response with the expected `x-ms-meta-version` header.

This updates the cask to use the current URL from the download page, fixing the `livecheck` block in the process.