### PR TITLE
workflows/triage: quote string ending in hyphen

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -67,7 +67,6 @@ jobs:
             - label: missing description
               path: Casks/.+
               missing_content: \n  desc .+\n
-              missing_content: cask "font-[^"]+"
 
             - label: extract_plist livecheck
               path: Casks/.+

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -67,7 +67,7 @@ jobs:
             - label: missing description
               path: Casks/.+
               missing_content: \n  desc .+\n
-              missing_content: cask "font-
+              missing_content: cask "font-[^"]+"
 
             - label: extract_plist livecheck
               path: Casks/.+


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The triage CI workflow is currently failing with "SyntaxError: No number after minus sign in JSON at position 1" (related to #174976).