### PR TITLE
PULL_REQUEST_TEMPLATE: better previously refused casks search query

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ After making any changes to a cask, existing or new, verify:
 Additionally, **if adding a new cask**:
 
 - [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
-- [ ] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=pullrequests).
+- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
 - [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
 - [ ] `brew audit --cask --new <cask>` worked successfully.
 - [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.


### PR DESCRIPTION
GitHub has also changed repo search URL

**Does not affect casks**

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] ~The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).~
- [ ] ~`brew audit --cask --online <cask>` is error-free.~
- [ ] ~`brew style --fix <cask>` reports no offenses.~