### PR TITLE
rerun-workflow.yml: add support for rerunning failed jobs only

### DIFF
--- a/.github/workflows/rerun-workflow.yml
+++ b/.github/workflows/rerun-workflow.yml
@@ -23,7 +23,9 @@ jobs:
       startsWith(github.repository, 'Homebrew/') &&
       (
         github.event.label.name == 'ci-requeue' ||
+        github.event.label.name == 'ci-requeue-failed-jobs' ||
         github.event.label.name == 'ci-retry' ||
+        github.event.label.name == 'ci-retry-failed-jobs' ||
         github.event.label.name == 'ci-skip-appcast' ||
         github.event.label.name == 'ci-skip-install' ||
         github.event.label.name == 'ci-skip-homepage' ||
@@ -43,3 +45,11 @@ jobs:
           continuous-label: ci-retry
           trigger-labels: ci-skip-appcast,ci-skip-install,ci-skip-homepage,ci-skip-livecheck,ci-syntax-only,ci-skip-repository,ci-skip-livecheck-min-os
           workflow: ci.yml
+      - name: Re-run CI failed jobs
+        uses: reitermarkus/rerun-workflow@440187d88f68a23cfb30caab5f33ac1bcce31b6a
+        with:
+              token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+              once-label: ci-requeue-failed-jobs
+              continuous-label: ci-retry-failed-jobs
+              workflow: ci.yml
+              failed-jobs-only: true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This adds the ability for `ci-requeue-failed-jobs` and `ci-retry-failed-jobs` labels to be used, that re-run only the failed jobs instead of the whole test suite. It is useful for re-running failed jobs using the label, or in the few cases where we have flaky upstream servers, it can be difficult to get all the jobs to complete with `ci-retry`, this enables us to only retry the jobs that failed on a schedule.

Labels have not yet been added.