### PR TITLE
Update sha256 sum for therm

### DIFF
--- a/Casks/t/therm.rb
+++ b/Casks/t/therm.rb
@@ -1,6 +1,6 @@
 cask "therm" do
   version "0.6.4"
-  sha256 "96ea558143ae60de68eecbfcd9e70aaeab2901d852189ef364ed2e6fc269d055"
+  sha256 "30b1c67a1d297f5e05de47faa66d6cf118c5a450aac2f222098e4fb1cf80d650"
 
   url "https://github.com/trufae/Therm/releases/download/#{version}/Therm-#{version}.zip"
   name "Therm"


### PR DESCRIPTION
Since 6ae35e9 there has been a new version with the same version number resulting in a checksum mismatch.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The old checksum from commit 6ae35e932f7eb23e81f0a228ddc97105705aa30f is for what's now called [Therm-0.6.4.zip_broken.zip](https://github.com/trufae/Therm/releases/tag/0.6.4) in the upstream repo.
This new checksum is for the new release zip that the url evaluates to, i.e. https://github.com/trufae/Therm/releases/download/0.6.4/Therm-0.6.4.zip