### PR TITLE
quiterss: disable

### DIFF
--- a/Casks/q/quiterss.rb
+++ b/Casks/q/quiterss.rb
@@ -7,10 +7,7 @@ cask "quiterss" do
   desc "Free news feeds reader"
   homepage "https://quiterss.org/"
 
-  livecheck do
-    url "https://quiterss.org/en/download"
-    regex(/href=.*?QuiteRSS[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
-  end
+  disable! date: "2024-05-28", because: :no_longer_available
 
   app "quiterss.app"
 


### PR DESCRIPTION
Upstream site and binaries seem to no longer exist, and Linux distributions have [dropped](https://github.com/QuiteRSS/quiterss/issues/1470) the package years ago due to a dependency on a deprecated QT component.
