### PR TITLE
Add `flox` cask to autobump.txt

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -205,6 +205,7 @@ fleet
 flipper
 flirc
 floorp
+flox
 flutter
 fmail2
 focusrite-control


### PR DESCRIPTION
Hi,

We (flox team) added `flox` cask a little over a month ago and I'm looking how we can be a good citizen in homebrew ecosystem and keeping `flox` cask up-to-date.

Every ~2weeks we usually do a release of `flox` and my first though was to automatically create a pull request with a version bump. Just like we were [already doing so far]( https://github.com/Homebrew/homebrew-cask/pulls?q=is%3Apr+flox+is%3Aclosed).

As I was looking deeper I've seen that there is an `.github/autobump.txt` list of casks and and autobump.yml github workflow. I couldn't find any information what is the criteria to add a cask to the list other that it needs livecheck defined in the cask definition.

So I'm opening this PR and adding `flox` to the autobump list if I understood the process correctly. I hope that adding flox to the list can make less burden to the homebrew maintainers.

And if this is not the process I should do, please feel free to close this PR.

Thank you.