### PR TITLE
kubenav: deprecate

### DIFF
--- a/Casks/k/kubenav.rb
+++ b/Casks/k/kubenav.rb
@@ -8,6 +8,10 @@ cask "kubenav" do
   desc "Navigator for your Kubernetes clusters right in your pocket"
   homepage "https://kubenav.io/"
 
+  deprecate! date: "2024-05-31", because: :discontinued
+
+  depends_on macos: ">= :monterey"
+
   app "kubenav.app"
   binary "#{appdir}/kubenav.app/Contents/MacOS/kubenav"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Upstream is no longer providing builds for macOS per https://github.com/kubenav/kubenav/pull/585