### PR TITLE
Fix OSDN urls

### DIFF
--- a/Casks/font/font-g/font-genjyuugothic-l.rb
+++ b/Casks/font/font-g/font-genjyuugothic-l.rb
@@ -9,7 +9,8 @@ cask "font-genjyuugothic-l" do
   homepage "http://jikasei.me/font/genjyuu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    regex(/href=.*genjyuugothic-l[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
   end
 
   font "GenJyuuGothicL-Bold.ttf"

--- a/Casks/font/font-g/font-genjyuugothic-l.rb
+++ b/Casks/font/font-g/font-genjyuugothic-l.rb
@@ -1,12 +1,16 @@
 cask "font-genjyuugothic-l" do
-  version "20150607,8.643"
+  version "20150607"
   sha256 "d2fccec290232df110d1116fef4411416875acf7647084c9ab7d7eb5e8a80c50"
 
-  url "https://osdn.dl.osdn.jp/users/#{version.csv.second.major}/#{version.csv.second.no_dots}/genjyuugothic-l-#{version.csv.first}.zip",
-      verified: "osdn.jp/"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/users/8/8643/genjyuugothic-l-#{version}.zip",
+      verified: "ftp.iij.ad.jp/pub/osdn.jp/users/"
   name "Gen Jyuu GothicL"
   desc "Weak-Rounded version of Gen Shin Gothic"
   homepage "http://jikasei.me/font/genjyuu/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   font "GenJyuuGothicL-Bold.ttf"
   font "GenJyuuGothicL-ExtraLight.ttf"

--- a/Casks/font/font-g/font-genjyuugothic-x.rb
+++ b/Casks/font/font-g/font-genjyuugothic-x.rb
@@ -8,7 +8,8 @@ cask "font-genjyuugothic-x" do
   homepage "http://jikasei.me/font/genjyuu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    regex(/href=.*genjyuugothic-x[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
   end
 
   font "GenJyuuGothicX-Bold.ttf"

--- a/Casks/font/font-g/font-genjyuugothic-x.rb
+++ b/Casks/font/font-g/font-genjyuugothic-x.rb
@@ -1,11 +1,15 @@
 cask "font-genjyuugothic-x" do
-  version "20150607,8.644"
+  version "20150607"
   sha256 "e4a0ea11b8155056ad2b678c8501b2e76dd99b8c8eb5363d396fe7c3079201b3"
 
-  url "https://osdn.dl.osdn.jp/users/#{version.csv.second.major}/#{version.csv.second.no_dots}/genjyuugothic-x-#{version.csv.first}.zip",
-      verified: "osdn.jp/"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/users/8/8644/genjyuugothic-x-#{version}.zip",
+      verified: "ftp.iij.ad.jp/pub/osdn.jp/users/"
   name "Gen Jyuu GothicX"
   homepage "http://jikasei.me/font/genjyuu/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   font "GenJyuuGothicX-Bold.ttf"
   font "GenJyuuGothicX-ExtraLight.ttf"

--- a/Casks/font/font-g/font-genjyuugothic.rb
+++ b/Casks/font/font-g/font-genjyuugothic.rb
@@ -8,7 +8,8 @@ cask "font-genjyuugothic" do
   homepage "http://jikasei.me/font/genjyuu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    regex(/href=.*genjyuugothic[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
   end
 
   font "GenJyuuGothic-Bold.ttf"

--- a/Casks/font/font-g/font-genjyuugothic.rb
+++ b/Casks/font/font-g/font-genjyuugothic.rb
@@ -1,11 +1,15 @@
 cask "font-genjyuugothic" do
-  version "20150607,8.642"
+  version "20150607"
   sha256 "916bbc234b110835b9a66ea47fd62e553fd9a524226b1b1fdac6668f0fc95809"
 
-  url "https://osdn.dl.osdn.jp/users/#{version.csv.second.major}/#{version.csv.second.no_dots}/genjyuugothic-#{version.csv.first}.zip",
-      verified: "osdn.jp/"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/users/8/8642/genjyuugothic-#{version}.zip",
+      verified: "ftp.iij.ad.jp/pub/osdn.jp/users/"
   name "Gen Jyuu Gothic"
   homepage "http://jikasei.me/font/genjyuu/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   font "GenJyuuGothic-Bold.ttf"
   font "GenJyuuGothic-ExtraLight.ttf"

--- a/Casks/font/font-g/font-genshingothic.rb
+++ b/Casks/font/font-g/font-genshingothic.rb
@@ -8,7 +8,8 @@ cask "font-genshingothic" do
   homepage "http://jikasei.me/font/genshin/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    regex(/href=.*genshingothic[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
   end
 
   font "GenShinGothic-Bold.ttf"

--- a/Casks/font/font-g/font-genshingothic.rb
+++ b/Casks/font/font-g/font-genshingothic.rb
@@ -1,11 +1,15 @@
 cask "font-genshingothic" do
-  version "20150607,8.637"
+  version "20150607"
   sha256 "b8e00f00a6e2517bfe75ceb2a732b596fe002457b89c05c181d6b71373aada58"
 
-  url "https://osdn.dl.osdn.jp/users/#{version.csv.second.major}/#{version.csv.second.no_dots}/genshingothic-#{version.csv.first}.zip",
-      verified: "osdn.jp/"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/users/8/8637/genshingothic-#{version}.zip",
+      verified: "ftp.iij.ad.jp/pub/osdn.jp/users/"
   name "Gen Shin Gothic"
   homepage "http://jikasei.me/font/genshin/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   font "GenShinGothic-Bold.ttf"
   font "GenShinGothic-ExtraLight.ttf"

--- a/Casks/font/font-m/font-migmix-1m.rb
+++ b/Casks/font/font-m/font-migmix-1m.rb
@@ -2,7 +2,8 @@ cask "font-migmix-1m" do
   version "20150712"
   sha256 "ac91394f3687315fb2727f8ee2b8ef70c6801d0b674dfc991912400eb3e7a344"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63544/migmix-1m-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-1m-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "MigMix 1M"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix1m"
 

--- a/Casks/font/font-m/font-migmix-1m.rb
+++ b/Casks/font/font-m/font-migmix-1m.rb
@@ -1,14 +1,18 @@
 cask "font-migmix-1m" do
-  version "20150712"
-  sha256 "ac91394f3687315fb2727f8ee2b8ef70c6801d0b674dfc991912400eb3e7a344"
+  version "2020.0307"
+  sha256 "5b662021765d5a091cdbe6b09dd464710fbc42fb20c544d28795b3e0580a216e"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-1m-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migmix-1m-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "MigMix 1M"
-  homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix1m"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migmix/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migmix-1m-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migmix-1m-#{version}/migmix-1m-bold.ttf"

--- a/Casks/font/font-m/font-migmix-1m.rb
+++ b/Casks/font/font-m/font-migmix-1m.rb
@@ -15,8 +15,8 @@ cask "font-migmix-1m" do
     end
   end
 
-  font "migmix-1m-#{version}/migmix-1m-bold.ttf"
-  font "migmix-1m-#{version}/migmix-1m-regular.ttf"
+  font "migmix-1m-#{version.no_dots}/migmix-1m-bold.ttf"
+  font "migmix-1m-#{version.no_dots}/migmix-1m-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migmix-1m.rb
+++ b/Casks/font/font-m/font-migmix-1m.rb
@@ -7,6 +7,10 @@ cask "font-migmix-1m" do
   name "MigMix 1M"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix1m"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migmix-1m-#{version}/migmix-1m-bold.ttf"
   font "migmix-1m-#{version}/migmix-1m-regular.ttf"
 

--- a/Casks/font/font-m/font-migmix-1m.rb
+++ b/Casks/font/font-m/font-migmix-1m.rb
@@ -10,7 +10,7 @@ cask "font-migmix-1m" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migmix-1m-(\d*)\.zip}i)
+      page.scan(/href=.*migmix-1m[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migmix-1p.rb
+++ b/Casks/font/font-m/font-migmix-1p.rb
@@ -10,7 +10,7 @@ cask "font-migmix-1p" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migmix-1p-(\d*)\.zip}i)
+      page.scan(/href=.*migmix-1p[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migmix-1p.rb
+++ b/Casks/font/font-m/font-migmix-1p.rb
@@ -7,6 +7,10 @@ cask "font-migmix-1p" do
   name "MigMix 1P"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix1p"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migmix-1p-#{version}/migmix-1p-bold.ttf"
   font "migmix-1p-#{version}/migmix-1p-regular.ttf"
 

--- a/Casks/font/font-m/font-migmix-1p.rb
+++ b/Casks/font/font-m/font-migmix-1p.rb
@@ -2,7 +2,8 @@ cask "font-migmix-1p" do
   version "20150712"
   sha256 "d71aa59146c600bc2f22de87495fe0127741fbb692736be0e1fe454e128c9d76"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63544/migmix-1p-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-1p-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "MigMix 1P"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix1p"
 

--- a/Casks/font/font-m/font-migmix-1p.rb
+++ b/Casks/font/font-m/font-migmix-1p.rb
@@ -1,14 +1,18 @@
 cask "font-migmix-1p" do
-  version "20150712"
-  sha256 "d71aa59146c600bc2f22de87495fe0127741fbb692736be0e1fe454e128c9d76"
+  version "2020.0307"
+  sha256 "586660e48dc24f95c6fed49852eedb0185485ffc731cc4128acd10fd98813b8c"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-1p-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migmix-1p-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "MigMix 1P"
-  homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix1p"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migmix/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migmix-1p-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migmix-1p-#{version}/migmix-1p-bold.ttf"

--- a/Casks/font/font-m/font-migmix-1p.rb
+++ b/Casks/font/font-m/font-migmix-1p.rb
@@ -15,8 +15,8 @@ cask "font-migmix-1p" do
     end
   end
 
-  font "migmix-1p-#{version}/migmix-1p-bold.ttf"
-  font "migmix-1p-#{version}/migmix-1p-regular.ttf"
+  font "migmix-1p-#{version.no_dots}/migmix-1p-bold.ttf"
+  font "migmix-1p-#{version.no_dots}/migmix-1p-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migmix-2m.rb
+++ b/Casks/font/font-m/font-migmix-2m.rb
@@ -15,8 +15,8 @@ cask "font-migmix-2m" do
     end
   end
 
-  font "migmix-2m-#{version}/migmix-2m-bold.ttf"
-  font "migmix-2m-#{version}/migmix-2m-regular.ttf"
+  font "migmix-2m-#{version.no_dots}/migmix-2m-bold.ttf"
+  font "migmix-2m-#{version.no_dots}/migmix-2m-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migmix-2m.rb
+++ b/Casks/font/font-m/font-migmix-2m.rb
@@ -10,7 +10,7 @@ cask "font-migmix-2m" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migmix-2m-(\d*)\.zip}i)
+      page.scan(/href=.*migmix-2m[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migmix-2m.rb
+++ b/Casks/font/font-m/font-migmix-2m.rb
@@ -7,6 +7,10 @@ cask "font-migmix-2m" do
   name "MigMix 2M"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix2m"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migmix-2m-#{version}/migmix-2m-bold.ttf"
   font "migmix-2m-#{version}/migmix-2m-regular.ttf"
 

--- a/Casks/font/font-m/font-migmix-2m.rb
+++ b/Casks/font/font-m/font-migmix-2m.rb
@@ -1,14 +1,18 @@
 cask "font-migmix-2m" do
-  version "20150712"
-  sha256 "a8639f277f5a2a2c78c20d05d2a6fb0977116193dcb708997a04080e9615882d"
+  version "2023.1123"
+  sha256 "187486f875a980eb5c68751e2df86d7ed3c376c8ffd6fe3c5d2e5d79257b207b"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-2m-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migmix-2m-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "MigMix 2M"
-  homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix2m"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migmix/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migmix-2m-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migmix-2m-#{version}/migmix-2m-bold.ttf"

--- a/Casks/font/font-m/font-migmix-2m.rb
+++ b/Casks/font/font-m/font-migmix-2m.rb
@@ -2,7 +2,8 @@ cask "font-migmix-2m" do
   version "20150712"
   sha256 "a8639f277f5a2a2c78c20d05d2a6fb0977116193dcb708997a04080e9615882d"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63544/migmix-2m-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-2m-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "MigMix 2M"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix2m"
 

--- a/Casks/font/font-m/font-migmix-2p.rb
+++ b/Casks/font/font-m/font-migmix-2p.rb
@@ -1,14 +1,18 @@
 cask "font-migmix-2p" do
-  version "20150712"
-  sha256 "b9289b61661ed2c158230651a963724618620607b060ae9701f1c5bbedfdee7f"
+  version "2023.1123"
+  sha256 "be93ac23840224586b58bdd7a468d22e28affa6e49f4e2812bb03961706ac278"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-2p-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migmix-2p-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "MigMix 2P"
-  homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix2p"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migmix/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migmix-2p-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migmix-2p-#{version}/migmix-2p-bold.ttf"

--- a/Casks/font/font-m/font-migmix-2p.rb
+++ b/Casks/font/font-m/font-migmix-2p.rb
@@ -10,7 +10,7 @@ cask "font-migmix-2p" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migmix-2p-(\d*)\.zip}i)
+      page.scan(/href=.*migmix-2p[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migmix-2p.rb
+++ b/Casks/font/font-m/font-migmix-2p.rb
@@ -2,7 +2,8 @@ cask "font-migmix-2p" do
   version "20150712"
   sha256 "b9289b61661ed2c158230651a963724618620607b060ae9701f1c5bbedfdee7f"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63544/migmix-2p-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63544/migmix-2p-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "MigMix 2P"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix2p"
 

--- a/Casks/font/font-m/font-migmix-2p.rb
+++ b/Casks/font/font-m/font-migmix-2p.rb
@@ -15,8 +15,8 @@ cask "font-migmix-2p" do
     end
   end
 
-  font "migmix-2p-#{version}/migmix-2p-bold.ttf"
-  font "migmix-2p-#{version}/migmix-2p-regular.ttf"
+  font "migmix-2p-#{version.no_dots}/migmix-2p-bold.ttf"
+  font "migmix-2p-#{version.no_dots}/migmix-2p-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migmix-2p.rb
+++ b/Casks/font/font-m/font-migmix-2p.rb
@@ -7,6 +7,10 @@ cask "font-migmix-2p" do
   name "MigMix 2P"
   homepage "https://mix-mplus-ipa.osdn.jp/migmix/#migmix2p"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migmix-2p-#{version}/migmix-2p-bold.ttf"
   font "migmix-2p-#{version}/migmix-2p-regular.ttf"
 

--- a/Casks/font/font-m/font-migu-1c.rb
+++ b/Casks/font/font-m/font-migu-1c.rb
@@ -7,6 +7,10 @@ cask "font-migu-1c" do
   name "Migu 1C"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1c"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migu-1c-#{version}/migu-1c-bold.ttf"
   font "migu-1c-#{version}/migu-1c-regular.ttf"
 

--- a/Casks/font/font-m/font-migu-1c.rb
+++ b/Casks/font/font-m/font-migu-1c.rb
@@ -1,14 +1,18 @@
 cask "font-migu-1c" do
-  version "20150712"
-  sha256 "62aba11af4e5343b5437c866e3747366d084b63885539c92636222d2978999f1"
+  version "2020.0307"
+  sha256 "de18e4558495ab2860e01a218e43274c49660ab882085f4b803bfd9f0ccde02b"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-1c-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migu-1c-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "Migu 1C"
-  homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1c"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migu-1c-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migu-1c-#{version}/migu-1c-bold.ttf"

--- a/Casks/font/font-m/font-migu-1c.rb
+++ b/Casks/font/font-m/font-migu-1c.rb
@@ -10,7 +10,7 @@ cask "font-migu-1c" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migu-1c-(\d*)\.zip}i)
+      page.scan(/href=.*migu-1c[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migu-1c.rb
+++ b/Casks/font/font-m/font-migu-1c.rb
@@ -2,7 +2,8 @@ cask "font-migu-1c" do
   version "20150712"
   sha256 "62aba11af4e5343b5437c866e3747366d084b63885539c92636222d2978999f1"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63545/migu-1c-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-1c-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "Migu 1C"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1c"
 

--- a/Casks/font/font-m/font-migu-1c.rb
+++ b/Casks/font/font-m/font-migu-1c.rb
@@ -15,8 +15,8 @@ cask "font-migu-1c" do
     end
   end
 
-  font "migu-1c-#{version}/migu-1c-bold.ttf"
-  font "migu-1c-#{version}/migu-1c-regular.ttf"
+  font "migu-1c-#{version.no_dots}/migu-1c-bold.ttf"
+  font "migu-1c-#{version.no_dots}/migu-1c-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migu-1m.rb
+++ b/Casks/font/font-m/font-migu-1m.rb
@@ -10,7 +10,7 @@ cask "font-migu-1m" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migu-1m-(\d*)\.zip}i)
+      page.scan(/href=.*migu-1m[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migu-1m.rb
+++ b/Casks/font/font-m/font-migu-1m.rb
@@ -2,7 +2,8 @@ cask "font-migu-1m" do
   version "20150712"
   sha256 "d4c38664dd57bc5927abe8f4fbea8f06a8ece3fea49ea02354d4e03ac6d15006"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63545/migu-1m-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-1m-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "Migu 1M"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1m"
 

--- a/Casks/font/font-m/font-migu-1m.rb
+++ b/Casks/font/font-m/font-migu-1m.rb
@@ -15,8 +15,8 @@ cask "font-migu-1m" do
     end
   end
 
-  font "migu-1m-#{version}/migu-1m-bold.ttf"
-  font "migu-1m-#{version}/migu-1m-regular.ttf"
+  font "migu-1m-#{version.no_dots}/migu-1m-bold.ttf"
+  font "migu-1m-#{version.no_dots}/migu-1m-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migu-1m.rb
+++ b/Casks/font/font-m/font-migu-1m.rb
@@ -1,14 +1,18 @@
 cask "font-migu-1m" do
-  version "20150712"
-  sha256 "d4c38664dd57bc5927abe8f4fbea8f06a8ece3fea49ea02354d4e03ac6d15006"
+  version "2020.0307"
+  sha256 "e4806d297e59a7f9c235b0079b2819f44b8620d4365a8955cb612c9ff5809321"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-1m-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migu-1m-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "Migu 1M"
-  homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1m"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migu-1m-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migu-1m-#{version}/migu-1m-bold.ttf"

--- a/Casks/font/font-m/font-migu-1m.rb
+++ b/Casks/font/font-m/font-migu-1m.rb
@@ -7,6 +7,10 @@ cask "font-migu-1m" do
   name "Migu 1M"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1m"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migu-1m-#{version}/migu-1m-bold.ttf"
   font "migu-1m-#{version}/migu-1m-regular.ttf"
 

--- a/Casks/font/font-m/font-migu-1p.rb
+++ b/Casks/font/font-m/font-migu-1p.rb
@@ -7,6 +7,10 @@ cask "font-migu-1p" do
   name "Migu 1P"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1p"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migu-1p-#{version}/migu-1p-bold.ttf"
   font "migu-1p-#{version}/migu-1p-regular.ttf"
 

--- a/Casks/font/font-m/font-migu-1p.rb
+++ b/Casks/font/font-m/font-migu-1p.rb
@@ -15,8 +15,8 @@ cask "font-migu-1p" do
     end
   end
 
-  font "migu-1p-#{version}/migu-1p-bold.ttf"
-  font "migu-1p-#{version}/migu-1p-regular.ttf"
+  font "migu-1p-#{version.no_dots}/migu-1p-bold.ttf"
+  font "migu-1p-#{version.no_dots}/migu-1p-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migu-1p.rb
+++ b/Casks/font/font-m/font-migu-1p.rb
@@ -1,14 +1,18 @@
 cask "font-migu-1p" do
-  version "20150712"
-  sha256 "9406399eeb94bb98f0844c2cd6bc94c390d994e6705af56e550d27f2a30b4bd5"
+  version "2020.0307"
+  sha256 "2e632832e7984400654bf666775c0fba14e18191765b64b6477e65b14c3a624a"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-1p-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migu-1p-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "Migu 1P"
-  homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1p"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migu-1p-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migu-1p-#{version}/migu-1p-bold.ttf"

--- a/Casks/font/font-m/font-migu-1p.rb
+++ b/Casks/font/font-m/font-migu-1p.rb
@@ -2,7 +2,8 @@ cask "font-migu-1p" do
   version "20150712"
   sha256 "9406399eeb94bb98f0844c2cd6bc94c390d994e6705af56e550d27f2a30b4bd5"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63545/migu-1p-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-1p-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "Migu 1P"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu1p"
 

--- a/Casks/font/font-m/font-migu-1p.rb
+++ b/Casks/font/font-m/font-migu-1p.rb
@@ -10,7 +10,7 @@ cask "font-migu-1p" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migu-1p-(\d*)\.zip}i)
+      page.scan(/href=.*migu-1p[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-migu-2m.rb
+++ b/Casks/font/font-m/font-migu-2m.rb
@@ -1,14 +1,18 @@
 cask "font-migu-2m" do
-  version "20150712"
-  sha256 "659a6a121dadb6eac78369b9d129e2ec77a09fa292ca20932e42a5c753874297"
+  version "2023.1123"
+  sha256 "e7845f148772c984064c325eba70ed4dfb9a27084c2011a3a1b6194be6e439e5"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-2m-#{version}.zip",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
+  url "https://github.com/itouhiro/mixfont-mplus-ipa/releases/download/v#{version}/migu-2m-#{version.no_dots}.zip",
+      verified: "github.com/itouhiro/mixfont-mplus-ipa/"
   name "Migu 2M"
-  homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu2m"
+  homepage "https://itouhiro.github.io/mixfont-mplus-ipa/migu/"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    strategy :page_match do |page|
+      page.scan(%r{href=.*?/migu-2m-(\d*)\.zip}i)
+          .map { |match| match[0].insert(4, ".") }
+    end
   end
 
   font "migu-2m-#{version}/migu-2m-bold.ttf"

--- a/Casks/font/font-m/font-migu-2m.rb
+++ b/Casks/font/font-m/font-migu-2m.rb
@@ -7,6 +7,10 @@ cask "font-migu-2m" do
   name "Migu 2M"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu2m"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "migu-2m-#{version}/migu-2m-bold.ttf"
   font "migu-2m-#{version}/migu-2m-regular.ttf"
 

--- a/Casks/font/font-m/font-migu-2m.rb
+++ b/Casks/font/font-m/font-migu-2m.rb
@@ -15,8 +15,8 @@ cask "font-migu-2m" do
     end
   end
 
-  font "migu-2m-#{version}/migu-2m-bold.ttf"
-  font "migu-2m-#{version}/migu-2m-regular.ttf"
+  font "migu-2m-#{version.no_dots}/migu-2m-bold.ttf"
+  font "migu-2m-#{version.no_dots}/migu-2m-regular.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-migu-2m.rb
+++ b/Casks/font/font-m/font-migu-2m.rb
@@ -2,7 +2,8 @@ cask "font-migu-2m" do
   version "20150712"
   sha256 "659a6a121dadb6eac78369b9d129e2ec77a09fa292ca20932e42a5c753874297"
 
-  url "https://osdn.dl.osdn.jp/mix-mplus-ipa/63545/migu-2m-#{version}.zip"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/63545/migu-2m-#{version}.zip",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mix-mplus-ipa/"
   name "Migu 2M"
   homepage "https://mix-mplus-ipa.osdn.jp/migu/#migu2m"
 

--- a/Casks/font/font-m/font-migu-2m.rb
+++ b/Casks/font/font-m/font-migu-2m.rb
@@ -10,7 +10,7 @@ cask "font-migu-2m" do
   livecheck do
     url :homepage
     strategy :page_match do |page|
-      page.scan(%r{href=.*?/migu-2m-(\d*)\.zip}i)
+      page.scan(/href=.*migu-2m[._-]v?(\d+(?:\.\d+)*)\.zip"/i)
           .map { |match| match[0].insert(4, ".") }
     end
   end

--- a/Casks/font/font-m/font-mplus.rb
+++ b/Casks/font/font-m/font-mplus.rb
@@ -7,6 +7,10 @@ cask "font-mplus" do
   name "M+ FONTS"
   homepage "https://mplusfonts.github.io"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-black.ttf"
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-bold.ttf"
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-heavy.ttf"

--- a/Casks/font/font-m/font-mplus.rb
+++ b/Casks/font/font-m/font-mplus.rb
@@ -2,9 +2,10 @@ cask "font-mplus" do
   version "063a"
   sha256 "44eb973b4b6aff574de454db105ddc23e6749c2294734bd9cb1e0d734e4cdd79"
 
-  url "https://osdn.dl.osdn.jp/mplus-fonts/62344/mplus-TESTFLIGHT-#{version}.tar.xz"
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/mplus-fonts/62344/mplus-TESTFLIGHT-#{version}.tar.xz",
+    verified: "ftp.iij.ad.jp/pub/osdn.jp/mplus-fonts/"
   name "M+ FONTS"
-  homepage "https://mplus-fonts.osdn.jp/about-en.html"
+  homepage "https://mplusfonts.github.io"
 
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-black.ttf"
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-bold.ttf"

--- a/Casks/font/font-o/font-ocr.rb
+++ b/Casks/font/font-o/font-ocr.rb
@@ -8,7 +8,7 @@ cask "font-ocr" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/ocr-(\d+(?:\.\d+)*)\.zip}i)
+    regex(/href=.*ocr[._-]v?(\d+(?:\.\d+)*)\.zip/i)
   end
 
   font "ocr-#{version}/OCRA.otf"

--- a/Casks/font/font-o/font-ocr.rb
+++ b/Casks/font/font-o/font-ocr.rb
@@ -2,7 +2,7 @@ cask "font-ocr" do
   version "0.2"
   sha256 "39289c641520265ecedbade99f01600f316f8196ec57f71c8402d3ba09438666"
 
-  url "https://osdn.dl.osdn.jp/tsukurimashou/56948/ocr-#{version}.zip",
+  url "https://ftp.iij.ad.jp/pub/osdn.jp/tsukurimashou/56948/ocr-#{version}.zip",
       verified: "osdn.dl.osdn.jp/tsukurimashou/"
   name "OCR"
   homepage "https://ansuz.sooke.bc.ca/page/fonts#ocra"

--- a/Casks/font/font-o/font-ocr.rb
+++ b/Casks/font/font-o/font-ocr.rb
@@ -3,7 +3,7 @@ cask "font-ocr" do
   sha256 "39289c641520265ecedbade99f01600f316f8196ec57f71c8402d3ba09438666"
 
   url "https://ftp.iij.ad.jp/pub/osdn.jp/tsukurimashou/56948/ocr-#{version}.zip",
-      verified: "osdn.dl.osdn.jp/tsukurimashou/"
+      verified: "ftp.iij.ad.jp/pub/osdn.jp/tsukurimashou/"
   name "OCR"
   homepage "https://ansuz.sooke.bc.ca/page/fonts#ocra"
 

--- a/Casks/font/font-o/font-ocr.rb
+++ b/Casks/font/font-o/font-ocr.rb
@@ -1,11 +1,10 @@
 cask "font-ocr" do
-  version "0.2"
-  sha256 "39289c641520265ecedbade99f01600f316f8196ec57f71c8402d3ba09438666"
+  version "0.3.1"
+  sha256 "58136fccfdee0923cc83a20996a067b98bae054570ee41bf896d7ca8224399bf"
 
-  url "https://ftp.iij.ad.jp/pub/osdn.jp/tsukurimashou/56948/ocr-#{version}.zip",
-      verified: "ftp.iij.ad.jp/pub/osdn.jp/tsukurimashou/"
+  url "https://tsukurimashou.org/files/ocr-#{version}.zip"
   name "OCR"
-  homepage "https://ansuz.sooke.bc.ca/page/fonts#ocra"
+  homepage "https://tsukurimashou.org/ocr.php.en"
 
   livecheck do
     skip "No version information available"

--- a/Casks/font/font-o/font-ocr.rb
+++ b/Casks/font/font-o/font-ocr.rb
@@ -7,6 +7,10 @@ cask "font-ocr" do
   name "OCR"
   homepage "https://ansuz.sooke.bc.ca/page/fonts#ocra"
 
+  livecheck do
+    skip "No version information available"
+  end
+
   font "ocr-#{version}/OCRA.otf"
   font "ocr-#{version}/OCRB.otf"
   font "ocr-#{version}/OCRBE.otf"

--- a/Casks/font/font-o/font-ocr.rb
+++ b/Casks/font/font-o/font-ocr.rb
@@ -7,7 +7,8 @@ cask "font-ocr" do
   homepage "https://tsukurimashou.org/ocr.php.en"
 
   livecheck do
-    skip "No version information available"
+    url :homepage
+    regex(%r{href=.*?/ocr-(\d+(?:\.\d+)*)\.zip}i)
   end
 
   font "ocr-#{version}/OCRA.otf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR changes Casks with osdn.dl.osdn.jp/ urls to use ftp.iij.ad.jp/pub/osdn.jp/ mirrors or GitHub repos.

Questions with some Casks:
- `font-mplus`
  - Changed homepage to github.io
  - Duplicate of `font-m-plus-1-code` `font-m-plus-1` `font-m-plus-1p` `font-m-plus-2` `font-m-plus-code-latin`
  - Alternative sources
    - https://github.com/coz-m/MPLUS_FONTS (is the upstream repo of the fonts mentioned above)
