### PR TITLE
Remove throttling from Rewind livecheck

### DIFF
--- a/Casks/r/rewind.rb
+++ b/Casks/r/rewind.rb
@@ -1,5 +1,5 @@
 cask "rewind" do
-  version "15284.1,dcd0176,20240504"
+  version "15284.1,dcd0176"
   sha256  "2848f2381152e4e8cb592a239e812b257ef0d80790f5e606bb67aa476f0c3d4d"
 
   url "https://updates.rewind.ai/builds/main/b#{version.csv.first}-main-#{version.csv.second}.zip"
@@ -10,10 +10,7 @@ cask "rewind" do
   livecheck do
     url "https://updates.rewind.ai/appcasts/main.xml"
     strategy :sparkle do |item|
-      # Throttle updates to one every 3 days.
-      next version if DateTime.parse(version.csv.third) + 3 > Date.today
-
-      "#{item.version},#{item.url.match(/[._-](\w+)\.zip/i)[1]},#{item.pub_date.strftime("%Y%m%d")}"
+      "#{item.version},#{item.url.match(/[._-](\w+)\.zip/i)[1]}"
     end
   end
 


### PR DESCRIPTION
Rewind no longer receives regular updates so it doesn't need to be throttled anymore. This also simplifies the cask's version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.