### PR TITLE
calibrite-profiler: move livecheck to GithubLatest

### DIFF
--- a/Casks/c/calibrite-profiler.rb
+++ b/Casks/c/calibrite-profiler.rb
@@ -1,6 +1,6 @@
 cask "calibrite-profiler" do
-  version "1.3.1"
-  sha256 "8adce527e8aeb9d271405a4c9fc865e24498494eae282f32268ed3a495982691"
+  version "1.3.2"
+  sha256 "ac3ef76116de2efec11fbe67c68b1ba0ba225fa3108831788df5985d3a6dca50"
 
   url "https://github.com/LUMESCA/calibrite-profiler-releases/releases/download/v#{version}/calibrite-PROFILER-#{version}.dmg",
       verified: "github.com/LUMESCA/calibrite-profiler-releases/"

--- a/Casks/c/calibrite-profiler.rb
+++ b/Casks/c/calibrite-profiler.rb
@@ -8,6 +8,11 @@ cask "calibrite-profiler" do
   desc "Display calibration software for Calibrite, ColorChecker and X-Rite devices"
   homepage "https://calibrite.com/calibrite-profiler/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   auto_updates true
   depends_on macos: ">= :high_sierra"
 

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -3,7 +3,6 @@
   "alcom": "all",
   "altdeploy": "all",
   "bitbar": "all",
-  "calibrite-profiler": "all",
   "cleartext": "all",
   "comma-chameleon": "all",
   "crypter": "all",


### PR DESCRIPTION
The associated repo uses pre-releasesleading to audit failures.