### PR TITLE
Change Ankerwork sha256 for arm

### DIFF
--- a/Casks/a/ankerwork.rb
+++ b/Casks/a/ankerwork.rb
@@ -2,7 +2,7 @@ cask "ankerwork" do
   arch arm: "arm64", intel: "x64"
 
   version "3.0.4"
-  sha256 arm:   "d56a3b64f25daec7f4d4d41b42c14087e90244949ec520bfbd7defcb2faa143d",
+  sha256 arm:   "4c229125ccc1374cc409462d15218e22e96ff784eade63a36b097bd4900c0f24",
          intel: "3a99ddf50cc6594adf783a5f1b241fd8491295a2a719d61fec4ab1a1c59191d9"
 
   url "https://ankerwork.s3.us-west-2.amazonaws.com/electron/AnkerWork-Setup-#{arch}.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `ankerwork` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The sha256 introduced in https://github.com/Homebrew/homebrew-cask/pull/175618 is not correct. Homebrew shows following error on my machine:

```sh
Error: ankerwork: SHA256 mismatch
Expected: d56a3b64f25daec7f4d4d41b42c14087e90244949ec520bfbd7defcb2faa143d
  Actual: 4c229125ccc1374cc409462d15218e22e96ff784eade63a36b097bd4900c0f24
    File: /Users/me/Library/Caches/Homebrew/downloads/d9aaa2a8a47dea662a47edf01618d526b636fe409245bfaa45833c41a8ccaa80--AnkerWork-Setup-arm64.dmg
To retry an incomplete download, remove the file above.
```
