### PR TITLE
vpn-by-google-one: disable

### DIFF
--- a/Casks/v/vpn-by-google-one.rb
+++ b/Casks/v/vpn-by-google-one.rb
@@ -7,10 +7,7 @@ cask "vpn-by-google-one" do
   desc "VPN provided by Google One"
   homepage "https://one.google.com/about/vpn"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-06-20", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
Service is being formally discontinued per Google [announcement](https://support.google.com/googleone/answer/14806901)
