### PR TITLE
opencore-patcher: switch to pkg installer

### DIFF
--- a/Casks/o/opencore-patcher.rb
+++ b/Casks/o/opencore-patcher.rb
@@ -1,22 +1,34 @@
 cask "opencore-patcher" do
   version "1.5.0"
-  sha256 "1339b694899a0aec51dd32b20f9e7b84df6be08aac56837a94d2bfaf806c155e"
+  sha256 "15f70a148a5490331a4b9f2b3cb7403b594a049250edd537f95a4b083e9efa9d"
 
-  url "https://github.com/dortania/OpenCore-Legacy-Patcher/releases/download/#{version}/OpenCore-Patcher-GUI.app.zip",
+  url "https://github.com/dortania/OpenCore-Legacy-Patcher/releases/download/#{version}/OpenCore-Patcher.pkg",
       verified: "github.com/dortania/OpenCore-Legacy-Patcher/"
-  name "OpenCore Legacy Patcher GUI"
+  name "OpenCore Legacy Patcher"
   desc "Boot loader to inject/patch current features for unsupported Macs"
   homepage "https://dortania.github.io/OpenCore-Legacy-Patcher/"
 
-  app "OpenCore-Patcher.app"
+  pkg "OpenCore-Patcher.pkg"
 
-  uninstall delete: "/Library/LaunchAgents/com.dortania.opencore-legacy-patcher.auto-patch.plist"
+  uninstall launchctl: [
+              "com.dortania.opencore-legacy-patcher.auto-patch",
+              "com.dortania.opencore-legacy-patcher.macos-update",
+            ],
+            pkgutil:   "com.dortania.opencore-legacy-patcher",
+            delete:    "/Applications/OpenCore-Patcher.app"
 
   zap trash: [
+    "/Library/Logs/DiagnosticReports/OpenCore-Patcher_*.*_resource.diag",
     "/Users/Shared/.com.dortania.opencore-legacy-patcher.plist",
+    "/Users/Shared/.OCLP-AutoPatcher-Log-*.txt",
+    "/Users/Shared/.OCLP-System-Log-*.txt",
+    "/Users/Shared/OpenCore-Patcher_*.log",
     "~/Library/Application Support/CrashReporter/OpenCore-Patcher*",
+    "~/Library/Caches/com.dortania.opencore-legacy-patcher",
+    "~/Library/Logs/Dortania",
     "~/Library/Preferences/com.dortania.opencore-legacy-patcher-wxpython.plist",
     "~/Library/Saved Application State/com.dortania.opencore-legacy-patcher-wxpython.savedState",
     "~/Library/Saved Application State/com.dortania.opencore-legacy-patcher.savedState",
+    "~/Library/WebKit/com.dortania.opencore-legacy-patcher",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
Revises `opencore-patcher` to use the new package installer, which [replaces the direct app download as of v1.5.0](https://github.com/dortania/OpenCore-Legacy-Patcher/releases/tag/1.5.0).