### PR TITLE
chore(flox): Move removal of nix cache to zap section

### DIFF
--- a/Casks/f/flox.rb
+++ b/Casks/f/flox.rb
@@ -26,22 +26,23 @@ cask "flox" do
               sudo:         true,
               must_succeed: false,
             },
-            launchctl:    [
-              "org.nixos.darwin-store",
-              "org.nixos.nix-daemon",
-            ],
-            quit:         [
-              "org.nixos.darwin-store",
-              "org.nixos.nix-daemon",
-            ],
-            script:       {
-              executable: "/usr/local/share/flox/scripts/uninstall",
-              sudo:       true,
-            },
-            pkgutil:      "com.floxdev.flox"
+            delete:       "/usr/local/bin/flox"
 
-  zap trash: [
-    "~/.cache/flox",
-    "~/.config/flox",
-  ]
+  zap launchctl: [
+        "org.nixos.darwin-store",
+        "org.nixos.nix-daemon",
+      ],
+      quit:      [
+        "org.nixos.darwin-store",
+        "org.nixos.nix-daemon",
+      ],
+      script:    {
+        executable: "/usr/local/share/flox/scripts/uninstall",
+        sudo:       true,
+      },
+      pkgutil:   "com.floxdev.flox",
+      trash:     [
+        "~/.cache/flox",
+        "~/.config/flox",
+      ]
 end


### PR DESCRIPTION
Previously, during upgrades, users of flox would end up in a broken state since all of the flox caches relied upon caches in the nix store to work properly. This meant that we'd have symlinks pointing to nothing after upgrades in many scenarios. This changes moves removal of the nix store to be grouped with the other caches and thus accessible through zap.

In the event a future feature of homebrew cask has distinct upgrade options, we'd revisit this to be cleaner.


After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

