### PR TITLE
loopback 2.4.1 + split into ARK & ACE versions

### DIFF
--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -1,21 +1,38 @@
 cask "loopback" do
-  version "2.4.0"
   sha256 :no_check
 
-  url "https://rogueamoeba.com/loopback/download/Loopback.zip"
+  macosversion_no_dots = "145"
+  audio_engine = "ark"
+
+  on_ventura :or_older do
+    # macOS 11.0 is oldest supported version
+    macosversion_no_dots = "110"
+    audio_engine = "ace"
+
+    version "2.3.3"
+
+    depends_on macos: ">= :big_sur"
+  end
+  on_sonoma :or_newer do
+    version "2.4.0"
+
+    depends_on macos: ">= :sonoma"
+
+    # NOTE: see https://weblog.rogueamoeba.com/2024/06/07/now-you-can-install-loopback-in-under-one-minute/#fn1-2024-06-loopback
+    caveats "Loopback 2.4.0 requires macOS 14.5 or newer."
+  end
+
+  url "https://rogueamoeba.com/loopback/download-#{audio_engine}.php"
   name "Loopback"
   desc "Cable-free audio router"
   homepage "https://rogueamoeba.com/loopback/"
 
-  # NOTE: The `system` value will need to be kept up to date with the latest
-  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=145&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{macosversion_no_dots}&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "Loopback.app"
 
@@ -27,9 +44,10 @@ cask "loopback" do
 
   zap trash: [
     "~/Library/Application Support/Loopback",
-    "~/Library/Caches/com.rogueamoeba.loop*",
-    "~/Library/HTTPStorages/com.rogueamoeba.loop*",
-    "~/Library/Preferences/com.rogueamoeba.loop*.plist",
+    "~/Library/Caches/com.rogueamoeba.Loopback",
+    "~/Library/HTTPStorages/com.rogueamoeba.[Ll]oopback*",
+    "~/Library/Preferences/com.rogueamoeba.[Ll]oopback*.plist",
+    "~/Library/Saved Application State/com.rogueamoeba.Loopback.savedState",
     "~/Library/WebKit/com.rogueamoeba.Loopback",
   ]
 end

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -14,12 +14,12 @@ cask "loopback" do
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
-    version "2.4.0"
+    version "2.4.1"
 
     depends_on macos: ">= :sonoma"
 
     # NOTE: see https://weblog.rogueamoeba.com/2024/06/07/now-you-can-install-loopback-in-under-one-minute/#fn1-2024-06-loopback
-    caveats "Loopback 2.4.0 requires macOS 14.5 or newer."
+    caveats "Loopback #{version} requires macOS 14.5 or newer."
   end
 
   url "https://rogueamoeba.com/loopback/download-#{audio_engine}.php"


### PR DESCRIPTION
Similar to `audio-hijack` and other apps from this developer.

More info: https://weblog.rogueamoeba.com/2024/06/07/now-you-can-install-loopback-in-under-one-minute/#fn1-2024-06-loopback

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
