### PR TITLE
dash: remove legacy version

### DIFF
--- a/Casks/d/dash.rb
+++ b/Casks/d/dash.rb
@@ -1,12 +1,6 @@
 cask "dash" do
-  on_high_sierra :or_older do
-    version "4.6.7"
-    sha256 "e2b5eb996645b25f12ccae15e24b1b0d8007bc5fed925e14ce7be45a2b693fb6"
-  end
-  on_mojave :or_newer do
-    version "7.2.1"
-    sha256 "815a11f6efd7701830d321918274c36a768c643003f52079a6bb331dd41202f5"
-  end
+  version "7.2.1"
+  sha256 "815a11f6efd7701830d321918274c36a768c643003f52079a6bb331dd41202f5"
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
   name "Dash"
@@ -20,7 +14,7 @@ cask "dash" do
 
   auto_updates true
   conflicts_with cask: "dash@6"
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :mojave"
 
   app "Dash.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
Seems odd to keep this around when [dash@6](https://formulae.brew.sh/cask/dash@6) exists.