### PR TITLE
Disable font-mplus

### DIFF
--- a/Casks/font/font-m/font-mplus.rb
+++ b/Casks/font/font-m/font-mplus.rb
@@ -3,13 +3,11 @@ cask "font-mplus" do
   sha256 "44eb973b4b6aff574de454db105ddc23e6749c2294734bd9cb1e0d734e4cdd79"
 
   url "https://ftp.iij.ad.jp/pub/osdn.jp/mplus-fonts/62344/mplus-TESTFLIGHT-#{version}.tar.xz",
-    verified: "ftp.iij.ad.jp/pub/osdn.jp/mplus-fonts/"
+      verified: "ftp.iij.ad.jp/pub/osdn.jp/mplus-fonts/"
   name "M+ FONTS"
-  homepage "https://mplusfonts.github.io"
+  homepage "https://mplusfonts.github.io/"
 
-  livecheck do
-    skip "No version information available"
-  end
+  disable! date: "2024-06-09", because: "is moved to font-m-plus-1, font-m-plus-2..."
 
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-black.ttf"
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-bold.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`font-mplus` is now on Google Fonts, and can be downloaded separately from `font-m-plus-1-code`, `font-m-plus-1`, `font-m-plus-1p`, `font-m-plus-2` and `font-m-plus-code-latin`.