### PR TITLE
batteries 2.2.8

### DIFF
--- a/Casks/b/batteries.rb
+++ b/Casks/b/batteries.rb
@@ -8,6 +8,11 @@ cask "batteries" do
   desc "Track all your devices' batteries"
   homepage "https://www.fadel.io/batteries/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :catalina"
 
   app "Batteries.app"

--- a/Casks/b/batteries.rb
+++ b/Casks/b/batteries.rb
@@ -1,6 +1,6 @@
 cask "batteries" do
-  version "2.2.9"
-  sha256 "9f67e1451bb406e9a14d514cd8a032252ef671d359cbffd3a47d4b80f015a9f6"
+  version "2.2.8"
+  sha256 "f7fce2db2466fa46afd30fcc09ca0269ee7727583776355b376aa409fb39c191"
 
   url "https://github.com/ronyfadel/BatteriesReleases/releases/download/v#{version}/Batteries.dmg",
       verified: "github.com/ronyfadel/BatteriesReleases/"


### PR DESCRIPTION
Batteries 2.2.9 does not appear in the upstream release repo: https://github.com/ronyfadel/BatteriesReleases/releases/

This leads to:

```
❯ brew upgrade batteries
==> Upgrading 1 outdated package:
batteries 2.2.8 -> 2.2.9
==> Upgrading batteries
==> Downloading https://github.com/ronyfadel/BatteriesReleases/releases/download/v2.2.9/Batteries.dmg
curl: (22) The requested URL returned error: 404

==> Purging files for version 2.2.9 of Cask batteries
Error: batteries: Download failed on Cask 'batteries' with message: Download failed: https://github.com/ronyfadel/BatteriesReleases/releases/download/v2.2.9/Batteries.dmg
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
