### PR TITLE
jalview: fix sha256

### DIFF
--- a/Casks/j/jalview.rb
+++ b/Casks/j/jalview.rb
@@ -2,8 +2,8 @@ cask "jalview" do
   arch arm: "aarch64", intel: "x64"
 
   version "2.11.3.3"
-  sha256 arm:   "63c3b141ca5b60b5d05a4cb68c17310b4b46144fee4a574f29f4bdac90d777e5",
-         intel: "a9c6bd5885cceb99e8d56a38b8038c62f6b89c9c03181cb0c181ed96dc47cdc3"
+  sha256 arm:   "b2414604e75ed029c7b520f1442ff3e3df00f677d88dd7068141ea8126a24423",
+         intel: "47bb1f11b5fc2b94479818ae615b2752cc4286684fd8a5f5f5619a0728fb99e0"
 
   url "https://www.jalview.org/downloads/installers/release/Jalview-#{version.dots_to_underscores}-macos-#{arch}-java_8.dmg"
   name "Jalview"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

See updated SHA256 checksums on the [download page](https://www.jalview.org/download/macos/).