### PR TITLE
webplotdigitizer: deprecate 

### DIFF
--- a/Casks/w/webplotdigitizer.rb
+++ b/Casks/w/webplotdigitizer.rb
@@ -1,8 +1,11 @@
 cask "webplotdigitizer" do
-  version "4.7"
-  sha256 "1175eb93a78844e6cb9153856bb3a648c190eebc20347250eb23c4d049507fbf"
+  arch arm: "apple-silicon", intel: "darwin-x64"
 
-  url "https://automeris.io/downloads/WebPlotDigitizer-#{version}-darwin-x64.zip"
+  version "4.7"
+  sha256 arm:   "e5ea8537c7809cce52c4d841ae0be89436f651924c10ab944507bb0ccd3febdb",
+         intel: "1175eb93a78844e6cb9153856bb3a648c190eebc20347250eb23c4d049507fbf"
+
+  url "https://apps.automeris.io/downloads/WebPlotDigitizer-#{version}-#{arch}.zip"
   name "WebPlotDigitizer"
   desc "Extract numerical data from plot images"
   homepage "https://automeris.io/WebPlotDigitizer.html"
@@ -12,5 +15,18 @@ cask "webplotdigitizer" do
     regex(%r{href=.*?/WebPlotDigitizer-(\d+(?:\.\d+)*)-darwin-x64\.zip}i)
   end
 
-  app "WebPlotDigitizer-#{version}-darwin-x64/WebPlotDigitizer-#{version}.app"
+  depends_on macos: ">= :catalina"
+
+  on_arm do
+    app "WebPlotDigitizer.app"
+  end
+  on_intel do
+    app "WebPlotDigitizer-#{version}-#{arch}/WebPlotDigitizer-#{version}.app"
+  end
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.webplotdigitizer.sfl*",
+    "~/Library/Application Support/WebPlotDigitizer",
+    "~/Library/Preferences/com.electron.webplotdigitizer.plist",
+  ]
 end

--- a/Casks/w/webplotdigitizer.rb
+++ b/Casks/w/webplotdigitizer.rb
@@ -10,10 +10,7 @@ cask "webplotdigitizer" do
   desc "Extract numerical data from plot images"
   homepage "https://automeris.io/WebPlotDigitizer.html"
 
-  livecheck do
-    url "https://automeris.io/download.html"
-    regex(%r{href=.*?/WebPlotDigitizer-(\d+(?:\.\d+)*)-darwin-x64\.zip}i)
-  end
+  deprecate! date: "2024-06-10", because: :discontinued
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The development of WebPlotDigitizer has been stopped (see [announcement](https://automeris.io/v4/)).
