### PR TITLE
slicer@preview: remove `url do`

### DIFF
--- a/Casks/s/slicer@preview.rb
+++ b/Casks/s/slicer@preview.rb
@@ -2,11 +2,7 @@ cask "slicer@preview" do
   version :latest
   sha256 :no_check
 
-  url "https://download.slicer.org/find?os=macosx&stability=nightly" do |page|
-    require "json"
-    file_path = JSON.parse(page)["download_url"]
-    URI.join(page.url, file_path)
-  end
+  url "https://download.slicer.org/download?os=macosx&stability=nightly"
   name "3D Slicer"
   desc "Medical image processing and visualization system"
   homepage "https://www.slicer.org/"


### PR DESCRIPTION
The `url do` block should generally be avoided and seems unnecessary here.