### PR TITLE
dolphin@beta: remove `url do`, switch to versioned downloads

### DIFF
--- a/Casks/d/dolphin@beta.rb
+++ b/Casks/d/dolphin@beta.rb
@@ -1,13 +1,21 @@
 cask "dolphin@beta" do
-  version :latest
-  sha256 :no_check
+  version "5.0-21460,0b,8c"
+  sha256 "eea2cc9248bea9279bf895469e624c015ecb628017a4bfc6debf01c649e15dcf"
 
-  url "https://dolphin-emu.org/download/" do |page|
-    page[/href="([^"]+\.dmg)"/, 1]
-  end
+  url "https://dl.dolphin-emu.org/builds/#{version.csv.second}/#{version.csv.third}/dolphin-master-#{version.csv.first}-universal.dmg"
   name "Dolphin Beta"
   desc "Emulator to play GameCube and Wii games"
   homepage "https://dolphin-emu.org/"
+
+  livecheck do
+    url "https://dolphin-emu.org/update/latest/beta/"
+    regex(%r{/builds/([^/]+)/([^/]+)/dolphin-master-v?(\d+(?:[.-]\d+)+)-universal.dmg}i)
+    strategy :json do |json|
+      macos_artifact = json["artifacts"].find { |artifact| artifact["system"].include?("macOS") }
+      match = macos_artifact["url"].match(regex)
+      "#{match[3]},#{match[1]},#{match[2]}"
+    end
+  end
 
   conflicts_with cask: [
     "dolphin",


### PR DESCRIPTION
Beta releases are monthly so both grabbing them via `url do` and marking as `version :latest` seems unnecessary.

We should also consider whether we want to make the beta the main `dolphin` cask. It is the version promoted on the homepage and the stable versions are now called "legacy" versions.