### PR TITLE
awa: update livecheck

### DIFF
--- a/Casks/a/awa.rb
+++ b/Casks/a/awa.rb
@@ -11,7 +11,7 @@ cask "awa" do
   livecheck do
     url "https://contents.awa.io/pc_update.json"
     strategy :json do |json|
-      json["version"]&.split("-").first
+      json["version"]&.split("-")&.first
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This is a quick follow-up to #176341. The `livecheck` block for `awa` was recently updated but the `strategy` block uses an ordinary method call after one using the safe navigation operator. This updates the second call to also use the safe navigation operator, addressing the style issue.

Fwiw, I would have thought that this would be caught by CI (i.e., `brew style awa` gives an offense).