### PR TITLE
code-composer-studio: update livecheck, url

### DIFF
--- a/Casks/c/code-composer-studio.rb
+++ b/Casks/c/code-composer-studio.rb
@@ -1,19 +1,19 @@
 cask "code-composer-studio" do
   version "12.7.1.00001"
-  sha256 "1cc449d01820ce7c8c2c6ed398e4f4bb59eca4c1e37aa6ae5cc2f90c8655f378"
+  sha256 "3207eede8be13378318ff725de4dcb95ef3a97e5befaeb05e83b44e45d5f5cd7"
 
-  url "https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-J1VdearkvK/#{version.major_minor_patch}/CCS#{version}_osx.zip"
+  url "https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-J1VdearkvK/#{version.major_minor_patch}/ccs_installer_osx_#{version}.dmg"
   name "Code Composer Studio (CCS)"
   desc "Integrated development environment"
   homepage "https://www.ti.com/tool/CCSTUDIO"
 
   livecheck do
     url :homepage
-    regex(/href=.*?CCS[._-]?v?(\d+(?:\.\d+)+)[._-]osx\.zip/i)
+    regex(/href=.*?ccs[._-]installer[._-]osx[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   installer script: {
-    executable: "CCS#{version}_osx/ccs_setup_#{version}.app/Contents/MacOS/installbuilder.sh",
+    executable: "ccs_setup_#{version}.app/Contents/MacOS/installbuilder.sh",
     args:       ["--mode", "unattended", "--prefix", "/Applications/TI"],
   }
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream seems to have changed their `url` structure and packaging, as the previous links are no longer on the homepage. Version hasn't changed.