### PR TITLE
logitech-options: improve livecheck, fix legacy versions

### DIFF
--- a/Casks/l/logitech-options.rb
+++ b/Casks/l/logitech-options.rb
@@ -3,8 +3,8 @@ cask "logitech-options" do
     version "7.14.77"
     sha256 "e4df55642e04139fc93d955e949bf736196a404ed067d87f8de7eb9ac9117ece"
 
-    url "https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
-        verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
+    url "https://web.archive.org/web/20220113114711/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
+        verified: "web.archive.org/web/20220113114711/https://download01.logi.com/web/ftp/pub/techsupport/options/"
 
     livecheck do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.12"
@@ -17,8 +17,8 @@ cask "logitech-options" do
     version "8.30.293"
     sha256 "db5f2cd94960223bdf74f0db6fc009f82f80928fe2ce849202754bbdb720eb87"
 
-    url "https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
-        verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
+    url "https://web.archive.org/web/20210208002741/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
+        verified: "web.archive.org/web/20210208002741/https://download01.logi.com/web/ftp/pub/techsupport/options/"
 
     livecheck do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.13"
@@ -31,8 +31,8 @@ cask "logitech-options" do
     version "8.54.147"
     sha256 "7b7a8d7a498d868c90b4ffe7dfc50a7a39c25e1f61350702e87d4c771b3d6459"
 
-    url "https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
-        verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
+    url "https://web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
+        verified: "web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/"
 
     livecheck do
       url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.14"
@@ -41,7 +41,21 @@ cask "logitech-options" do
 
     pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
   end
-  on_catalina :or_newer do
+  on_catalina do
+    version "8.54.147"
+    sha256 "7b7a8d7a498d868c90b4ffe7dfc50a7a39c25e1f61350702e87d4c771b3d6459"
+
+    url "https://web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
+        verified: "web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/"
+
+    livecheck do
+      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.14"
+      regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
+    end
+
+    pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"
+  end
+  on_big_sur :or_newer do
     version "10.20.4"
     sha256 :no_check
 
@@ -49,8 +63,12 @@ cask "logitech-options" do
         verified: "download01.logi.com/web/ftp/pub/techsupport/options/"
 
     livecheck do
-      url "https://download01.logi.com/web/ftp/pub/techsupport/options/options_installer.zip"
-      strategy :extract_plist
+      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-11.0"
+      regex(/Software Version: .*?v?(\d+(?:\.\d+)+)/i)
+      strategy :json do |json, regex|
+        json["articles"].select { |item| item["name"] == "Logitech Options" }
+                        .map { |item| item["body"][regex, 1] }
+      end
     end
 
     pkg "LogiMgr Installer #{version}.app/Contents/Resources/LogiMgr.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
The last version for 10.15 is 9.70.29, but that wasn't found on archive.org and it and every older version has been scrubbed from the source.