### PR TITLE
Remove #readme from GitHub homepage URLs

### DIFF
--- a/Casks/m/manila.rb
+++ b/Casks/m/manila.rb
@@ -5,7 +5,7 @@ cask "manila" do
   url "https://github.com/neilsardesai/Manila/releases/download/v#{version}/Manila.zip"
   name "Manila"
   desc "Finder extension for changing folder colours"
-  homepage "https://github.com/neilsardesai/Manila#readme"
+  homepage "https://github.com/neilsardesai/Manila"
 
   livecheck do
     url :url


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

While working on something else, I noticed that some GitHub homepage URLs have a fragment identifier at the end (`#readme`). The overwhelming majority (~1000) don't have a fragment identifier, so this removes it from the casks in this PR (similar to https://github.com/Homebrew/homebrew-core/pull/174323).

I've created a tentative `brew style` rule to fix this issue for formulae (only for GitHub homepage URLs) but the cask rules are separate. I'll probably look into adding this style rule for casks as well before I create a brew PR but I figured I would bring these URLs in line in the interim time.