### PR TITLE
githubpulse: remove livecheck due to deprecation

### DIFF
--- a/Casks/g/githubpulse.rb
+++ b/Casks/g/githubpulse.rb
@@ -9,10 +9,5 @@ cask "githubpulse" do
 
   deprecate! date: "2024-06-12", because: :unmaintained
 
-  livecheck do
-    url :homepage
-    strategy :github
-  end
-
   app "GithubPulse.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Follow-up to #176563