### PR TITLE
yandex-cloud-cli: fix install

### DIFF
--- a/Casks/y/yandex-cloud-cli.rb
+++ b/Casks/y/yandex-cloud-cli.rb
@@ -19,10 +19,6 @@ cask "yandex-cloud-cli" do
     executable: "install.sh",
     args:       ["-i", "#{staged_path}/#{token}", "-r", "/dev/null"],
   }
-  installer script: {
-    executable: "yandex-cloud-cli/bin/yc",
-    args:       ["components", "post-update"],
-  }
   binary "yandex-cloud-cli/bin/docker-credential-yc"
   binary "yandex-cloud-cli/bin/yc"
   binary "yandex-cloud-cli/completion.zsh.inc",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Closes https://github.com/Homebrew/homebrew-cask/issues/175038

There is currently no logic to handle the order of `install script` stanzas despite it being an option to add multiple. In this case, the second command is dependent on the first, so if they run out of order they will fail. From what I can see in the upstream docs, the second command is probably no longer required.

This should fix the installation issue, and we can see if there are any subsequent issues with dropping the secondary command.
