### PR TITLE
wine@staging: remove `caveats`, update `livecheck`

### DIFF
--- a/Casks/w/wine@staging.rb
+++ b/Casks/w/wine@staging.rb
@@ -11,10 +11,24 @@ cask "wine@staging" do
   desc "Compatibility layer to run Windows applications"
   homepage "https://wiki.winehq.org/MacOS"
 
+  # Not every GitHub release provides a `wine-staging` file, so we check multiple
+  # recent releases instead of only the "latest" release.
   livecheck do
     url :url
-    strategy :github_latest
     regex(/^v?((?:\d+(?:\.\d+)+)(?:-RC\d)?)$/i)
+    strategy :github_releases do |json, regex|
+      file_regex = /^wine[._-]staging[._-].*?$/i
+
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+        next unless release["assets"]&.any? { |asset| asset["name"]&.match?(file_regex) }
+
+        match = release["tag_name"].match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   conflicts_with cask: [
@@ -60,16 +74,4 @@ cask "wine@staging" do
         "~/.local/share/icons",
         "~/.local/share/mime",
       ]
-
-  caveats <<~EOS
-    #{token} supports both 32-bit and 64-bit. It is compatible with an existing
-    32-bit wine prefix, but it will now default to 64-bit when you create a new
-    wine prefix. The architecture can be selected using the WINEARCH environment
-    variable which can be set to either win32 or win64.
-
-    To create a new pure 32-bit prefix, you can run:
-      $ WINEARCH=win32 WINEPREFIX=~/.wine32 winecfg
-
-    See the Wine FAQ for details: https://wiki.winehq.org/FAQ#Wineprefixes
-  EOS
 end


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-cask/pull/176693.

Currently:
```
|-> brew livecheck wine@staging
Error: wine@staging: Unable to get versions
```