### PR TITLE
various casks: fix macOS version requirements

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -12,8 +12,6 @@ cask "airfoil" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1366&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.12.1"
@@ -26,8 +24,6 @@ cask "airfoil" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :sonoma"
   end
 
   name "Airfoil"
@@ -35,6 +31,7 @@ cask "airfoil" do
   homepage "https://rogueamoeba.com/airfoil/mac/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Airfoil/Airfoil Satellite.app"
   app "Airfoil/Airfoil.app"

--- a/Casks/a/appcleaner.rb
+++ b/Casks/a/appcleaner.rb
@@ -31,7 +31,6 @@ cask "appcleaner" do
   homepage "https://freemacsoft.net/appcleaner/"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "AppCleaner.app"
 

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -12,8 +12,6 @@ cask "audio-hijack" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1366&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "4.4.2"
@@ -26,8 +24,6 @@ cask "audio-hijack" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :sonoma"
   end
 
   name "Audio Hijack"
@@ -35,6 +31,7 @@ cask "audio-hijack" do
   homepage "https://rogueamoeba.com/audiohijack/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Audio Hijack.app"
 

--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -54,8 +54,6 @@ cask "calibre" do
   desc "E-books management software"
   homepage "https://calibre-ebook.com/"
 
-  depends_on macos: ">= :catalina"
-
   app "calibre.app"
   binary "#{appdir}/calibre.app/Contents/MacOS/calibre"
   binary "#{appdir}/calibre.app/Contents/MacOS/calibre-complete"

--- a/Casks/c/cave-story.rb
+++ b/Casks/c/cave-story.rb
@@ -61,7 +61,5 @@ cask "cave-story" do
   desc "Action-adventure game reminiscent of classic 8- and 16-bit games"
   homepage "https://www.cavestory.org/"
 
-  depends_on macos: ">= :catalina"
-
   zap trash: "~/Library/Preferences/com.nakiwo.Doukutsu.plist"
 end

--- a/Casks/c/cd-to.rb
+++ b/Casks/c/cd-to.rb
@@ -6,8 +6,6 @@ cask "cd-to" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :mojave"
   end
   on_monterey :or_newer do
     version "3.1.3"
@@ -17,14 +15,14 @@ cask "cd-to" do
       url :url
       strategy :github_latest
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   url "https://github.com/jbtule/cdto/releases/download/v#{version}/cdto_#{version.dots_to_underscores}.zip"
   name "cd to"
   desc "Finder Toolbar app to open the current directory in the Terminal"
   homepage "https://github.com/jbtule/cdto"
+
+  depends_on macos: ">= :mojave"
 
   app "cd to.app"
 

--- a/Casks/c/choosy.rb
+++ b/Casks/c/choosy.rb
@@ -58,8 +58,6 @@ cask "choosy" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :big_sur"
-
     pkg "Choosy.pkg"
   end
 

--- a/Casks/c/contexts.rb
+++ b/Casks/c/contexts.rb
@@ -17,8 +17,6 @@ cask "contexts" do
         item.version.chars.join(".")
       end
     end
-
-    depends_on macos: ">= :catalina"
   end
 
   url "https://contexts.co/releases/Contexts-#{version}.dmg"

--- a/Casks/c/coteditor.rb
+++ b/Casks/c/coteditor.rb
@@ -72,7 +72,6 @@ cask "coteditor" do
   homepage "https://coteditor.com/"
 
   auto_updates true
-  depends_on macos: ">= :ventura"
 
   app "CotEditor.app"
   binary "#{appdir}/CotEditor.app/Contents/SharedSupport/bin/cot"

--- a/Casks/d/deepl.rb
+++ b/Casks/d/deepl.rb
@@ -17,8 +17,6 @@ cask "deepl" do
         end
       end
     end
-
-    depends_on macos: ">= :catalina"
   end
   on_big_sur do
     version "24.2.1798840"
@@ -29,8 +27,6 @@ cask "deepl" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_monterey :or_newer do
     version "24.4.2912025"
@@ -50,8 +46,6 @@ cask "deepl" do
         end
       end
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   name "DeepL"
@@ -59,6 +53,7 @@ cask "deepl" do
   homepage "https://www.deepl.com/"
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "DeepL.app"
 

--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -13,8 +13,6 @@ cask "docker" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :catalina"
   end
   on_big_sur do
     version "4.24.2,124339"
@@ -24,8 +22,6 @@ cask "docker" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: :big_sur
   end
   on_monterey :or_newer do
     version "4.31.0,153195"
@@ -36,8 +32,6 @@ cask "docker" do
       url "https://desktop.docker.com/mac/main/#{arch}/appcast.xml"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :monterey"
 
     binary "Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
            target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
@@ -61,6 +55,7 @@ cask "docker" do
     docker-compose
     docker-credential-helper-ecr
   ]
+  depends_on macos: ">= :catalina"
 
   app "Docker.app"
   binary "#{appdir}/Docker.app/Contents/Resources/bin/com.docker.cli",

--- a/Casks/i/ireal-pro.rb
+++ b/Casks/i/ireal-pro.rb
@@ -9,8 +9,6 @@ cask "ireal-pro" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :high_sierra"
   end
   on_big_sur :or_newer do
     version "2024.6,20240614"
@@ -23,8 +21,6 @@ cask "ireal-pro" do
       url "https://ireal-pro.s3.amazonaws.com/appcast.xml"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
 
   name "iReal Pro"
@@ -32,6 +28,7 @@ cask "ireal-pro" do
   homepage "https://irealpro.com/"
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "iReal Pro.app"
 

--- a/Casks/i/iterm2.rb
+++ b/Casks/i/iterm2.rb
@@ -40,7 +40,7 @@ cask "iterm2" do
     "iterm2@beta",
     "iterm2@nightly",
   ]
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :sierra"
 
   app "iTerm.app"
 

--- a/Casks/i/itsycal.rb
+++ b/Casks/i/itsycal.rb
@@ -45,8 +45,6 @@ cask "itsycal" do
       url "https://itsycal.s3.amazonaws.com/itsycal.xml"
       strategy :sparkle, &:short_version
     end
-
-    depends_on macos: ">= :big_sur"
   end
 
   url "https://itsycal.s3.amazonaws.com/Itsycal-#{version}.zip",

--- a/Casks/j/jamulus.rb
+++ b/Casks/j/jamulus.rb
@@ -1,13 +1,13 @@
 cask "jamulus" do
   version "3.10.0"
 
-  on_mojave :or_older do
+  on_catalina :or_older do
     sha256 "1407619a136e5d2094cdad1e65cf51e9029a36232db4e83b6e48c6b987374a56"
 
     url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac_legacy.dmg",
         verified: "downloads.sourceforge.net/llcon/"
   end
-  on_catalina :or_newer do
+  on_big_sur :or_newer do
     sha256 "c4f15729706e7ba6a93b1226c33cbeb4dc95d8aee64c9fbdc4443c9d8687b9b6"
 
     url "https://downloads.sourceforge.net/llcon/jamulus_#{version}_mac.dmg",
@@ -17,8 +17,6 @@ cask "jamulus" do
   name "Jamulus"
   desc "Play music online with friends"
   homepage "https://jamulus.io/"
-
-  depends_on macos: ">= :catalina"
 
   app "Jamulus.app"
   app "JamulusServer.app"

--- a/Casks/k/kid3.rb
+++ b/Casks/k/kid3.rb
@@ -7,21 +7,19 @@ cask "kid3" do
 
     url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin-Qt5.dmg",
         verified: "downloads.sourceforge.net/kid3/"
-
-    depends_on macos: "<= :high_sierra"
   end
   on_mojave :or_newer do
     sha256 "1154c252cbc1b70dccebf6e1f48e00e16eb87e7cc8302d700db2236f1de5ed8e"
 
     url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin-amd64.dmg",
         verified: "downloads.sourceforge.net/kid3/"
-
-    depends_on macos: ">= :mojave"
   end
 
   name "Kid3"
   desc "Audio tagger focusing on efficiency"
-  homepage "https://kid3.sourceforge.io/"
+  homepage "https://kid3.kde.org/"
+
+  depends_on macos: ">= :high_sierra"
 
   app "kid3.app"
   binary "#{appdir}/kid3.app/Contents/MacOS/kid3-cli"

--- a/Casks/l/launchcontrol.rb
+++ b/Casks/l/launchcontrol.rb
@@ -15,8 +15,6 @@ cask "launchcontrol" do
       url "https://www.soma-zone.com/LaunchControl/a/appcast-update-#{version.major}.xml"
       strategy :sparkle, &:short_version
     end
-
-    depends_on macos: ">= :big_sur"
   end
 
   url "https://www.soma-zone.com/download/files/LaunchControl-#{version}.tar.xz"

--- a/Casks/l/libreoffice-still.rb
+++ b/Casks/l/libreoffice-still.rb
@@ -6,13 +6,6 @@ cask "libreoffice-still" do
   sha256 arm:   "17686aff42734ea4feef08e1189bab3011220000f7784061314c1ae9e5942531",
          intel: "42d2eeaeee7bcb0e76e9decdcb8f5a4beebf133ad31f7d42a5e96ea770860110"
 
-  on_arm do
-    depends_on macos: ">= :big_sur"
-  end
-  on_intel do
-    depends_on macos: ">= :catalina"
-  end
-
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"
   name "LibreOffice Still"
@@ -34,6 +27,7 @@ cask "libreoffice-still" do
   end
 
   conflicts_with cask: "libreoffice"
+  depends_on macos: ">= :catalina"
 
   app "LibreOffice.app"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"

--- a/Casks/l/lightkey.rb
+++ b/Casks/l/lightkey.rb
@@ -19,8 +19,6 @@ cask "lightkey" do
         end
       end
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_ventura :or_newer do
     version "4.8.3"
@@ -36,8 +34,6 @@ cask "lightkey" do
         items.map(&:version)
       end
     end
-
-    depends_on macos: ">= :ventura"
   end
 
   url "https://lightkeyapp.com/download/Lightkey-#{version.dots_to_hyphens}/LightkeyInstaller.zip"
@@ -46,6 +42,7 @@ cask "lightkey" do
   homepage "https://lightkeyapp.com/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   pkg "LightkeyInstaller.pkg"
 

--- a/Casks/m/macupdater.rb
+++ b/Casks/m/macupdater.rb
@@ -2,14 +2,10 @@ cask "macupdater" do
   on_monterey :or_older do
     version "2.3.15"
     sha256 "9d6775c99b2a76d3f3be0e3d23c27305666341be16d38a0661c8d9cfa50e5256"
-
-    depends_on macos: ">= :mojave"
   end
   on_ventura :or_newer do
     version "3.3.1"
     sha256 "3052da96d7f09416dfebac43f5579c5fdb8789df2e35c85f0870c12634c83d8c"
-
-    depends_on macos: ">= :ventura"
 
     binary "#{appdir}/MacUpdater.app/Contents/Resources/macupdater_install"
   end
@@ -25,6 +21,7 @@ cask "macupdater" do
   end
 
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   app "MacUpdater.app"
   binary "#{appdir}/MacUpdater.app/Contents/Resources/macupdater_client"

--- a/Casks/m/microsoft-auto-update.rb
+++ b/Casks/m/microsoft-auto-update.rb
@@ -28,7 +28,6 @@ cask "microsoft-auto-update" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   pkg "Microsoft_AutoUpdate_#{version}_Updater.pkg"
 

--- a/Casks/m/mixxx.rb
+++ b/Casks/m/mixxx.rb
@@ -5,13 +5,6 @@ cask "mixxx" do
   sha256 arm:   "c9ad0bd7c02ac02a70d1d36a30f197945bdde2073b5dbf1e67badb310e3abd95",
          intel: "b4d43050b9462b510218c75a730e8c46f059ed9d723caf7fedae469e519d1c7e"
 
-  on_arm do
-    depends_on macos: ">= :big_sur"
-  end
-  on_intel do
-    depends_on macos: ">= :sierra"
-  end
-
   url "https://downloads.mixxx.org/releases/#{version}/mixxx-#{version}-macos#{arch}.dmg"
   name "Mixxx"
   desc "Open-source DJ software"
@@ -23,6 +16,7 @@ cask "mixxx" do
   end
 
   conflicts_with cask: "mixxx@snapshot"
+  depends_on macos: ">= :sierra"
 
   app "Mixxx.app"
 

--- a/Casks/m/mixxx@snapshot.rb
+++ b/Casks/m/mixxx@snapshot.rb
@@ -5,13 +5,6 @@ cask "mixxx@snapshot" do
   sha256 arm:   "1437171d62a92b8a2c81638e3270c9875d5a2994b6d4147085efdfeb84ddfba6",
          intel: "648f12c477143d72586445a6c5ebfcfca1849e425622b64b7b0887ffd22bcac5"
 
-  on_arm do
-    depends_on macos: ">= :big_sur"
-  end
-  on_intel do
-    depends_on macos: ">= :catalina"
-  end
-
   url "https://downloads.mixxx.org/snapshots/main/mixxx-#{version}-macos#{arch}.dmg"
   name "Mixxx"
   desc "Open-source DJ software"
@@ -23,6 +16,7 @@ cask "mixxx@snapshot" do
   end
 
   conflicts_with cask: "mixxx"
+  depends_on macos: ">= :catalina"
 
   app "Mixxx.app"
 

--- a/Casks/m/mmhmm-studio.rb
+++ b/Casks/m/mmhmm-studio.rb
@@ -6,8 +6,6 @@ cask "mmhmm-studio" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_ventura :or_newer do
     version "2.6.3,1703105000"
@@ -22,8 +20,6 @@ cask "mmhmm-studio" do
         items.map(&:nice_version)
       end
     end
-
-    depends_on macos: ">= :ventura"
   end
 
   url "https://updates.mmhmm.app/mac/production/mmhmmStudio_#{version.csv.first}.zip"
@@ -32,6 +28,7 @@ cask "mmhmm-studio" do
   homepage "https://www.mmhmm.app/product"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "mmhmm Studio.app"
 

--- a/Casks/m/motion.rb
+++ b/Casks/m/motion.rb
@@ -5,13 +5,6 @@ cask "motion" do
   sha256 arm:   "309f8ac04211305186f1fe4a23284837e0c0396904c0bc6c8f4ff1dafa07bdef",
          intel: "78f887abed9039e61c273dd969cecd44de0592fdebc7c230abd5ef06da134e44"
 
-  on_arm do
-    depends_on macos: ">= :big_sur"
-  end
-  on_intel do
-    depends_on macos: ">= :catalina"
-  end
-
   url "https://github.com/usemotion/desktopapp/releases/download/#{version}/motion-#{version}-mac-#{arch}.zip",
       verified: "github.com/usemotion/desktopapp/"
   name "Motion"
@@ -24,6 +17,7 @@ cask "motion" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Motion.app"
 

--- a/Casks/n/nextcloud.rb
+++ b/Casks/n/nextcloud.rb
@@ -6,8 +6,6 @@ cask "nextcloud" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :mojave"
   end
   on_monterey :or_newer do
     version "3.13.0"
@@ -34,6 +32,7 @@ cask "nextcloud" do
   homepage "https://nextcloud.com/"
 
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   pkg "Nextcloud-#{version}.pkg"
   binary "/Applications/Nextcloud.app/Contents/MacOS/nextcloudcmd"

--- a/Casks/o/omnifocus.rb
+++ b/Casks/o/omnifocus.rb
@@ -1,5 +1,5 @@
 cask "omnifocus" do
-  on_el_capitan do
+  on_el_capitan :or_older do
     version "2.10"
     sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
 

--- a/Casks/o/omnigraffle.rb
+++ b/Casks/o/omnigraffle.rb
@@ -69,8 +69,6 @@ cask "omnigraffle" do
       url "https://www.omnigroup.com/download/latest/omnigraffle/"
       strategy :header_match
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   name "OmniGraffle"

--- a/Casks/o/openemu@experimental.rb
+++ b/Casks/o/openemu@experimental.rb
@@ -22,7 +22,6 @@ cask "openemu@experimental" do
 
   auto_updates true
   conflicts_with cask: "openemu"
-  depends_on macos: ">= :mojave"
 
   app "OpenEmu.app"
 

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -5,15 +5,11 @@ cask "piezo" do
     version "1.8.2"
 
     url "https://rogueamoeba.com/piezo/download/Piezo.zip"
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "1.9.2"
 
     url "https://rogueamoeba.com/piezo/download/Piezo-ARK.zip"
-
-    depends_on macos: ">= :sonoma"
   end
 
   name "Piezo"
@@ -26,6 +22,7 @@ cask "piezo" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Piezo.app"
 

--- a/Casks/p/powerphotos.rb
+++ b/Casks/p/powerphotos.rb
@@ -71,8 +71,6 @@ cask "powerphotos" do
         items.find { |item| item.channel.nil? }&.short_version
       end
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   name "PowerPhotos"

--- a/Casks/p/propresenter.rb
+++ b/Casks/p/propresenter.rb
@@ -13,8 +13,6 @@ cask "propresenter" do
         end
       end
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_monterey :or_newer do
     version "7.16.3,118489862"
@@ -30,8 +28,6 @@ cask "propresenter" do
         end
       end
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   url "https://renewedvision.com/downloads/propresenter/mac/ProPresenter_#{version.csv.first}_#{version.csv.second}.zip"
@@ -41,6 +37,7 @@ cask "propresenter" do
 
   auto_updates true
   conflicts_with cask: "propresenter@beta"
+  depends_on macos: ">= :big_sur"
 
   app "ProPresenter.app"
 

--- a/Casks/p/propresenter@beta.rb
+++ b/Casks/p/propresenter@beta.rb
@@ -13,8 +13,6 @@ cask "propresenter@beta" do
         end
       end
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_monterey :or_newer do
     version "7.16.3,118489862"
@@ -30,8 +28,6 @@ cask "propresenter@beta" do
         end
       end
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   url "https://renewedvision.com/downloads/propresenter/mac/ProPresenter_#{version.csv.first}_#{version.csv.second}.zip"
@@ -41,6 +37,7 @@ cask "propresenter@beta" do
 
   auto_updates true
   conflicts_with cask: "propresenter"
+  depends_on macos: ">= :big_sur"
 
   app "ProPresenter.app"
 

--- a/Casks/r/raycast.rb
+++ b/Casks/r/raycast.rb
@@ -8,8 +8,6 @@ cask "raycast" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_monterey :or_newer do
     arch arm: "arm", intel: "x86_64"
@@ -27,8 +25,6 @@ cask "raycast" do
       regex(/Raycast[._-]v?(\d+(?:\.\d+)+)(?:[._-](\h+))[._-]#{livecheck_arch}\.dmg/i)
       strategy :header_match
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   name "Raycast"
@@ -36,6 +32,7 @@ cask "raycast" do
   homepage "https://raycast.com/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Raycast.app"
 

--- a/Casks/s/silentknight.rb
+++ b/Casks/s/silentknight.rb
@@ -6,8 +6,6 @@ cask "silentknight" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :el_capitan"
   end
   on_catalina :or_newer do
     version "2.9,2024.06"
@@ -27,8 +25,6 @@ cask "silentknight" do
         "#{version},#{match[1]}.#{match[2]}"
       end
     end
-
-    depends_on macos: ">= :catalina"
   end
 
   # Upstream zero-pads the minor version in the no-dot filename version to two

--- a/Casks/s/sketch.rb
+++ b/Casks/s/sketch.rb
@@ -8,8 +8,6 @@ cask "sketch" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_monterey :or_newer do
     version "100.1,180159"
@@ -21,8 +19,6 @@ cask "sketch" do
       url "https://download.sketch.com/sketch-versions.xml"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :monterey"
   end
 
   name "Sketch"
@@ -30,6 +26,7 @@ cask "sketch" do
   homepage "https://www.sketch.com/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Sketch.app"
 

--- a/Casks/s/sourcetree.rb
+++ b/Casks/s/sourcetree.rb
@@ -9,8 +9,6 @@ cask "sourcetree" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :el_capitan"
   end
   on_high_sierra do
     version "3.2.1,225"
@@ -45,8 +43,6 @@ cask "sourcetree" do
       url "https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcast.xml"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :catalina"
   end
 
   name "Atlassian SourceTree"

--- a/Casks/t/tripmode.rb
+++ b/Casks/t/tripmode.rb
@@ -30,8 +30,6 @@ cask "tripmode" do
         end
       end
     end
-
-    depends_on macos: ">= :big_sur"
   end
 
   name "TripMode"

--- a/Casks/t/tunnelbear.rb
+++ b/Casks/t/tunnelbear.rb
@@ -6,8 +6,6 @@ cask "tunnelbear" do
     livecheck do
       skip "Legacy version"
     end
-
-    depends_on macos: ">= :sierra"
   end
   on_big_sur :or_newer do
     version "5.3.1"
@@ -21,8 +19,6 @@ cask "tunnelbear" do
         items.map(&:short_version)
       end
     end
-
-    depends_on macos: ">= :big_sur"
   end
 
   url "https://tunnelbear.s3.amazonaws.com/downloads/mac/TunnelBear-#{version}.zip",
@@ -32,6 +28,7 @@ cask "tunnelbear" do
   homepage "https://www.tunnelbear.com/"
 
   auto_updates true
+  depends_on macos: ">= :sierra"
 
   app "TunnelBear.app"
 

--- a/Casks/v/vitamin-r.rb
+++ b/Casks/v/vitamin-r.rb
@@ -2,14 +2,10 @@ cask "vitamin-r" do
   on_high_sierra :or_older do
     version "3.31"
     sha256 "6c5ce3926060b7e3616527fc3c1f0d2a5cd8a0be4d9f5496c099a33be993312b"
-
-    depends_on macos: ">= :el_capitan"
   end
   on_mojave :or_newer do
     version "4.18"
     sha256 "3ad3a2ccb1402b6f4870154653df42110ac1b5b9954a9f28cd45b503992402b1"
-
-    depends_on macos: ">= :mojave"
   end
 
   url "https://www.publicspace.net/download/signedVitamin#{version.major}.zip"

--- a/Casks/w/wireshark.rb
+++ b/Casks/w/wireshark.rb
@@ -3,17 +3,8 @@ cask "wireshark" do
   livecheck_arch = on_arch_conditional arm: "arm", intel: "x86-"
 
   version "4.2.5"
-
-  on_arm do
-    sha256 "72d670ad068ac46c1d16ffb5fc8e6b582136a0eed6fc278b9f36877311e4e4af"
-
-    depends_on macos: ">= :big_sur"
-  end
-  on_intel do
-    sha256 "67a1ea88226c2f5699c3c6c36fb0006d84c62bdbfe5474dccff30860fd9f81b7"
-
-    depends_on macos: ">= :mojave"
-  end
+  sha256 arm:   "72d670ad068ac46c1d16ffb5fc8e6b582136a0eed6fc278b9f36877311e4e4af",
+         intel: "67a1ea88226c2f5699c3c6c36fb0006d84c62bdbfe5474dccff30860fd9f81b7"
 
   url "https://2.na.dl.wireshark.org/osx/Wireshark%20#{version}%20#{arch}%2064.dmg"
   name "Wireshark"
@@ -33,6 +24,7 @@ cask "wireshark" do
   auto_updates true
   conflicts_with cask:    "wireshark-chmodbpf",
                  formula: "wireshark"
+  depends_on macos: ">= :mojave"
 
   app "Wireshark.app"
   pkg "Add Wireshark to the system path.pkg"

--- a/Casks/x/xit.rb
+++ b/Casks/x/xit.rb
@@ -9,8 +9,6 @@ cask "xit" do
       skip "Legacy version"
     end
 
-    depends_on macos: ">= :mojave"
-
     app "Xit.app"
   end
   on_monterey :or_newer do
@@ -27,14 +25,14 @@ cask "xit" do
       regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
     end
 
-    depends_on macos: ">= :monterey"
-
     app "Xit#{arch} #{version}/Xit.app"
   end
 
   name "Xit"
   desc "GUI for the git version control system"
   homepage "https://github.com/Uncommon/Xit"
+
+  depends_on macos: ">= :mojave"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.uncommonplace.xit.sfl*",

--- a/Casks/x/xsplit-vcam.rb
+++ b/Casks/x/xsplit-vcam.rb
@@ -3,17 +3,8 @@ cask "xsplit-vcam" do
   livecheck_arch = on_arch_conditional arm: "arm64", intel: "x86_64"
 
   version "4.0.2206.0801"
-
-  on_arm do
-    sha256 "164002714041f5e94427c227bc1eb21b11a95490cce65e613746128d02fc055e"
-
-    depends_on macos: ">= :big_sur"
-  end
-  on_intel do
-    sha256 "5c4f9b77e47c1938140deccf21f56dc7643eb7f622c99ac52aa4501bbf073591"
-
-    depends_on macos: ">= :mojave"
-  end
+  sha256 arm:   "164002714041f5e94427c227bc1eb21b11a95490cce65e613746128d02fc055e",
+         intel: "5c4f9b77e47c1938140deccf21f56dc7643eb7f622c99ac52aa4501bbf073591"
 
   url "https://cdn2.xsplit.com/download/vc/macos/builds/#{version}/XSplit_VCam_#{version}_#{arch}.pkg"
   name "XSplit VCam"
@@ -26,6 +17,7 @@ cask "xsplit-vcam" do
   end
 
   auto_updates true
+  depends_on macos: ">= :mojave"
 
   pkg "XSplit_VCam_#{version}_#{arch}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
- removes minimum macOS version requirements that were preventing installations on older versions
- consolidates on_system-specific macOS version requirements to a single declaration for the cask, allowing its formulae.brew.sh entry to display all available versions