### PR TITLE
idafree 8.4.240527: fix SHA256

### DIFF
--- a/Casks/i/idafree.rb
+++ b/Casks/i/idafree.rb
@@ -2,8 +2,8 @@ cask "idafree" do
   arch arm: "arm_"
 
   version "8.4.240527"
-  sha256 arm:   "db5c0184a84ee2ed4fd534b3c2d657fbc8b27c79ccfae8921e3e8faa64f9d923",
-         intel: "e47b0513709fffc3616ca5319ca82dcbc03b705b5950b18c6252aa05ff41b9a9"
+  sha256 arm:   "dec15875d871a398088a05320ac45e1971940de279abb8e2cd57054833da18f6",
+         intel: "c4cf8b35d02b217351cad738c8aadaf0bb17aacc3e7421e6b420c5fe2451e6f5"
 
   url "https://out7.hex-rays.com/files/#{arch}idafree#{version.major_minor.no_dots}_mac.app.zip"
   name "IDA Free"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Hello!

For some reason, the current SHA256 for `idafree` `8.4.240527` cask is incorrect:

```shell
dmitry in ~ λ brew update-reset && brew update
#...
==> Updating Homebrew...
Already up-to-date.
dmitry in ~ λ brew install idafree            
==> Downloading https://out7.hex-rays.com/files/idafree84_mac.app.zip
############################################################################################################################################### 100.0%
Error: SHA256 mismatch
Expected: e47b0513709fffc3616ca5319ca82dcbc03b705b5950b18c6252aa05ff41b9a9
  Actual: c4cf8b35d02b217351cad738c8aadaf0bb17aacc3e7421e6b420c5fe2451e6f5
    File: /Users/dmitry/Library/Caches/Homebrew/downloads/6771ee936daa0606e3617bfb08fa457c57d1f358e41c63b3bebf4802536992a8--idafree84_mac.app.zip
To retry an incomplete download, remove the file above.
```

But according to IDA official website actual SHA256 checksums for IDA [v8.4.240527sp2](https://hex-rays.com/products/ida/news/8_4sp2/) are correct:

<img width="635" alt="ida_free_cheksums" src="https://github.com/Homebrew/homebrew-cask/assets/36661032/5328194c-6415-4fba-892f-748220d8d00d">

Firstly, I have tried
```shell
dmitry in ~ λ brew bump --open-pr idafree                                                                 
Warning: A newer `curl` is required for Repology queries.
==> idafree is up to date!
Current cask version:     8.4.240527
Latest livecheck version: 8.4.240527
Open pull requests:       none
Closed pull requests:     idafree 8.4.240527 (https://github.com/Homebrew/homebrew-cask/pull/175006)
```

But it doesn't work because IDA Free version is up to date. So I've created this pull request manually.