### PR TITLE
Add swi-prolog (GUI)

### DIFF
--- a/Casks/s/swi-prolog.rb
+++ b/Casks/s/swi-prolog.rb
@@ -1,0 +1,34 @@
+cask "swi-prolog" do
+  version "9.2.5"
+  sha256 "123d97bf225a1b2433969fc1d3541dfccb17de860075bbbbd0f136088751adae"
+
+  url "https://www.swi-prolog.org/download/stable/bin/swipl-#{version.major_minor_patch}-1.fat.dmg"
+  name "SWI-Prolog"
+  desc "ISO/Edinburgh-style Prolog interpreter with GUI support"
+  homepage "https://www.swi-prolog.org/"
+
+  livecheck do
+    url "https://www.swi-prolog.org/download/stable"
+    regex(%r{href=.*?/swipl-(\d+(?:\.\d+)+)(?:-\d+)?\.fat\.dmg}i)
+  end
+
+  conflicts_with formula: "swi-prolog"
+  depends_on cask: "xquartz"
+  depends_on macos: ">= :mojave"
+
+  app "SWI-Prolog.app"
+  binary "#{appdir}/SWI-Prolog.app/Contents/MacOS/swipl"
+  binary "#{appdir}/SWI-Prolog.app/Contents/MacOS/swipl-ld"
+  binary "#{appdir}/SWI-Prolog.app/Contents/MacOS/swipl-win"
+  manpage "#{appdir}/SWI-Prolog.app/Contents/man/swipl.1"
+  manpage "#{appdir}/SWI-Prolog.app/Contents/man/swipl-ld.1"
+
+  uninstall quit: "org.swi-prolog.app"
+
+  zap trash: [
+    "~/.config/swi-prolog",
+    "~/.local/share/swi-prolog",
+    "~/Library/Preferences/com.swi-prolog.pqConsole.plist",
+    "~/Library/Saved Application State/org.swi-prolog.app.savedState",
+  ]
+end

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -45,7 +45,6 @@
   "srclib": "homebrew/core",
   "sshfs": "homebrew/core",
   "sslmate": "homebrew/core",
-  "swi-prolog": "homebrew/core",
   "terraform": "homebrew/core",
   "vault": "homebrew/core",
   "vfuse": "homebrew/core",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online swi-prolog` is error-free.
- [x] `brew style --fix swi-prolog` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token `reference](https://docs.brew.sh/Cask-Cookbook#token-reference).`

    There is already a core package named `swi-prolog`, but as far as I can tell from this document, the cast should also be named `swi-prolog` (though I originally was calling it `swi-prolog-gui`).

    To make this work I had remove `swi-prolog` from `tap_migrations.json`. I'm thinking this should be safe, as this migration happend on Aug 22, 2016: https://github.com/Homebrew/homebrew-cask/commit/bf9a703a887c9faff8ed36fff16bcafece06c74a

    I'm thinking a caveat should also be added to `core/swi-prolog` similar to `core/wireshark` (I can open a PR for that to!):

    ```
    This formula only installs the command-line utilities by default.

    Install Wireshark.app with Homebrew Cask:
      brew install --cask wireshark
    ```

- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new swi-prolog` worked successfully.

  I get two errors:

  ```
  audit for swi-prolog: failed
  - Signature verification failed:
  /private/tmp/cask-audit20240614-43570-3g36p6/SWI-Prolog.app: rejected

  macOS on ARM requires software to be signed.
  Please contact the upstream developer to let them know they should sign and notarize their software.

  - possible duplicate, cask token conflicts with Homebrew core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/swi-prolog.rb
  swi-prolog
  * line 5, col 2: Signature verification failed:
      /private/tmp/cask-audit20240614-43570-3g36p6/SWI-Prolog.app: rejected

      macOS on ARM requires software to be signed.
      Please contact the upstream developer to let them know they should sign and notarize their software.
  * possible duplicate, cask token conflicts with Homebrew core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/s/swi-prolog.rb
  Error: 2 problems in 1 cask detected.
  ```

  I'm not sure what to do about the unsigned issue, it is from the offical swi-prolog site though! Maybe open an issue for them to get it signed?

  And for the name conflict, it seems like I should name it as `swi-prolog` the same as `wireshark`.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask swi-prolog` worked successfully.
- [x] `brew uninstall --cask swi-prolog` worked successfully.
- [x] `brew livecheck --cask swi-prolog` worked successfully.

---

Hello all!  The reason I'm adding this is the `swi-prolog` formula doesn't have GUI support!  So you can't use the [graphical debugger](https://www.swi-prolog.org/gtrace.html) `gtrace.` (it's very nice!)

There are some issues though (commented about), that I would love help resolving:
- It should be named `swi-prolog` even though there is a formula `swi-prolog`?  Or should it be something like `swi-prolog`?  Currently audit is giving a duplicate name error. 😢 
- It's ok to remove from `tap_migrations.json`?
- Need help, the official binary from SWI Prolog is unsigned.

Thanks y'all!
