### PR TITLE
xquartz: Add caveat to relogin, and close the app when uninstalling

### DIFF
--- a/Casks/x/xquartz.rb
+++ b/Casks/x/xquartz.rb
@@ -20,6 +20,7 @@ cask "xquartz" do
   pkg "XQuartz-#{version}.pkg"
 
   uninstall launchctl: "org.xquartz.privileged_startx",
+            quit:      "org.xquartz.X11",
             pkgutil:   "org.xquartz.X11"
 
   zap trash: [
@@ -38,4 +39,8 @@ cask "xquartz" do
         "~/.fonts",
         "~/Library/Logs/X11",
       ]
+
+  caveats <<~EOS
+    Logout and log back in to update your DISPLAY environment variable.
+  EOS
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online xquartz` is error-free.
- [x] `brew style --fix xquartz` reports no offenses.
    ```
    1 file inspected, no offenses detected
    ```

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --cask --new xquartz` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask xquartz` worked successfully.
- [x] `brew uninstall --cask xquartz` worked successfully.
  - [x] And it also succesfully closed XQuartz app when I had it running 😄 

---

I'm adding a caveat that you have to login and log back out again, which may not be obvious to some people (me), otherwise you get:

```
$ xeyes
Error: Can't open display: 
```

Caveat for XQuartz is also mentioned here: https://www.xquartz.org/releases/XQuartz-2.1.3.html

Also added `quit: "org.xquartz.X11"` so it closes the XQuartz app if it's running!