### PR TITLE
chore: update beekeeper-studio.rb to version 4.3.4

### DIFF
--- a/Casks/b/beekeeper-studio.rb
+++ b/Casks/b/beekeeper-studio.rb
@@ -1,9 +1,9 @@
 cask "beekeeper-studio" do
   arch arm: "-arm64"
 
-  version "4.4.0"
-  sha256 arm:   "6fa98064114e7666ef52a6ec9c9ac031dfd61e0ebe88f3442b5a0f4f884344f3",
-         intel: "50829e925a34e7b4a5c9d46047edbd0812a4c60ad25cd670177d275bc05a1aed"
+  version "4.3.4"
+  sha256 arm:   "deffc9551488f4f77449af45f9700f68a2cf2efdc1c2a6dfc7661655e9e61045",
+         intel: "ae6440b40c749d9787039375595a31af568bda114019a2a47c8879eaf91cf79b"
 
   url "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v#{version}/Beekeeper-Studio-#{version}#{arch}.dmg",
       verified: "github.com/beekeeper-studio/beekeeper-studio/"


### PR DESCRIPTION
it seems the version 4.4.0 is removed

<img width="1440" alt="Screenshot 2024-06-16 at 03 36 31" src="https://github.com/Homebrew/homebrew-cask/assets/48643295/205b79fb-21c0-4a7c-9b20-1878eb696ebe">
<img width="1140" alt="Screenshot 2024-06-16 at 03 36 53" src="https://github.com/Homebrew/homebrew-cask/assets/48643295/843ce96c-3eaa-4e4b-91ac-4a679a0fc970">

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
