### PR TITLE
getoutline 1.3.1 (new cask)

### DIFF
--- a/Casks/g/getoutline.rb
+++ b/Casks/g/getoutline.rb
@@ -1,8 +1,9 @@
 cask "getoutline" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.3.1"
-  sha256 :no_check
+  version "1.3.1,240227x80f4vacd"
+  sha256 arm:   "5178207301ee32ff0540dba762af9a8c64d61c42bbc64bdfbee4f058e9953ad4",
+         intel: "8409afc5d0433084d9aacbd6decb3bb387c343a75aa37acdf5ba29d145a229f6"
 
   url "https://download.todesktop.com/2211128hgkdcltv/Outline%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}.dmg",
       verified: "download.todesktop.com/2211128hgkdcltv/"

--- a/Casks/g/getoutline.rb
+++ b/Casks/g/getoutline.rb
@@ -4,21 +4,25 @@ cask "getoutline" do
   version "1.3.1"
   sha256 :no_check
 
-    url "https://desktop.getoutline.com/mac/dmg/#{arch}"
+  url "https://desktop.getoutline.com/mac/dmg/#{arch}"
   name "Outline"
-  desc "Fast, collaborative, knowledge base for your team built using React and Node.js"
+  desc "Knowledge management tool"
   homepage "https://getoutline.com/"
+
+  livecheck do
+    url :url
+    regex(/outline\s?(\d+(?:\.\d+)*)/i)
+    strategy :header_match
+  end
 
   depends_on macos: ">= :catalina"
 
   app "Outline.app"
 
-  # locations to zap (uninstall)
   zap trash: [
-    "/Applications/Outline.app",
-    "/Volumes/Outline 1.3.1-arm64/",
-    "/Volumes/Outline 1.3.1/",
-    "~/Library/Application Support/Outline/",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.generaloutline.outline.sfl*",
+    "~/Library/Application Support/Outline",
+    "~/Library/Logs/Outline",
     "~/Library/Preferences/com.generaloutline.outline.plist",
     "~/Library/Saved Application State/com.generaloutline.outline.savedState",
   ]

--- a/Casks/g/getoutline.rb
+++ b/Casks/g/getoutline.rb
@@ -1,0 +1,33 @@
+cask "getoutline" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.3.1"
+  sha256 :no_check
+
+  # arm64 (apple-silicon)
+  on_arm do
+    url "https://desktop.getoutline.com/mac/dmg/arm64"
+  end
+  # x64 (intel)
+  on_intel do
+    url "https://desktop.getoutline.com/mac/dmg/x64"
+  end
+
+  name "Outline"
+  desc "Fast, collaborative, knowledge base for your team built using React and Node.js"
+  homepage "https://getoutline.com/"
+
+  depends_on macos: ">= :catalina"
+
+  app "Outline.app"
+
+  # locations to zap (uninstall)
+  zap trash: [
+    "/Applications/Outline.app",
+    "/Volumes/Outline 1.3.1-arm64/",
+    "/Volumes/Outline 1.3.1/",
+    "~/Library/Application Support/Outline/",
+    "~/Library/Preferences/com.generaloutline.outline.plist",
+    "~/Library/Saved Application State/com.generaloutline.outline.savedState",
+  ]
+end

--- a/Casks/g/getoutline.rb
+++ b/Casks/g/getoutline.rb
@@ -4,15 +4,7 @@ cask "getoutline" do
   version "1.3.1"
   sha256 :no_check
 
-  # arm64 (apple-silicon)
-  on_arm do
-    url "https://desktop.getoutline.com/mac/dmg/arm64"
-  end
-  # x64 (intel)
-  on_intel do
-    url "https://desktop.getoutline.com/mac/dmg/x64"
-  end
-
+    url "https://desktop.getoutline.com/mac/dmg/#{arch}"
   name "Outline"
   desc "Fast, collaborative, knowledge base for your team built using React and Node.js"
   homepage "https://getoutline.com/"

--- a/Casks/g/getoutline.rb
+++ b/Casks/g/getoutline.rb
@@ -4,15 +4,21 @@ cask "getoutline" do
   version "1.3.1"
   sha256 :no_check
 
-  url "https://desktop.getoutline.com/mac/dmg/#{arch}"
+  url "https://download.todesktop.com/2211128hgkdcltv/Outline%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}.dmg",
+      verified: "download.todesktop.com/2211128hgkdcltv/"
   name "Outline"
   desc "Knowledge management tool"
   homepage "https://getoutline.com/"
 
   livecheck do
-    url :url
-    regex(/outline\s?(\d+(?:\.\d+)*)/i)
-    strategy :header_match
+    url "https://download.todesktop.com/2211128hgkdcltv/latest-mac.yml"
+    regex(/Build[ ._-]([^-]+)[._-]/i)
+    strategy :electron_builder do |item, regex|
+      build = item["files"].first["url"][regex, 1]
+      next if build.blank?
+
+      "#{item["version"]},#{build}"
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
I made a new cask for the outline desktop app (built from the .dmg installer). 
I verified everything is brew-conform and neither errors nor warnings do show-up. 
https://getoutline.com
https://github.com/outline/outline

- [*] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [*] `brew audit --cask --online <cask>` is error-free.
- [*] `brew style --fix <cask>` reports no offenses.
- [*] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [*] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [*] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [*] `brew audit --cask --new <cask>` worked successfully.
- [*] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [*] `brew uninstall --cask <cask>` worked successfully.

---
