### PR TITLE
mochi-diffusion: update depends_on

### DIFF
--- a/Casks/m/mochi-diffusion.rb
+++ b/Casks/m/mochi-diffusion.rb
@@ -8,7 +8,7 @@ cask "mochi-diffusion" do
   homepage "https://github.com/godly-devotion/MochiDiffusion"
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: ">= :sonoma"
   depends_on arch: :arm64
 
   app "Mochi Diffusion.app"

--- a/Casks/m/mochi-diffusion.rb
+++ b/Casks/m/mochi-diffusion.rb
@@ -9,6 +9,7 @@ cask "mochi-diffusion" do
 
   auto_updates true
   depends_on macos: ">= :ventura"
+  depends_on arch: :arm64
 
   app "Mochi Diffusion.app"
 


### PR DESCRIPTION
Mochi Diffusion can't run on x86 mac

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
