### PR TITLE
cloudtabs: deprecate

### DIFF
--- a/Casks/c/cloudytabs.rb
+++ b/Casks/c/cloudytabs.rb
@@ -7,6 +7,8 @@ cask "cloudytabs" do
   desc "Menu bar application that lists iCloud Tabs"
   homepage "https://github.com/josh-/CloudyTabs/"
 
+  deprecate! date: "2024-06-16", because: :repo_archived
+
   depends_on macos: ">= :high_sierra"
 
   app "CloudyTabs.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The GitHub repository for `cloudytabs` was archived on 2024-03-17. The most recent release was on 2020-09-29 and the most recent commit was on 2020-09-30. The `README` wasn't updated to explain the project status but this presumably means that the project isn't developed anymore. There's also an [issue from 2022-2023](https://github.com/josh-/CloudyTabs/issues/71) asking about the project status that didn't receive a response. This deprecates the cask accordingly.