### PR TITLE
developer/bin/import_google_fonts: skip `desc` in font cask generation

### DIFF
--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -52,9 +52,6 @@ class FontCask:
       only_path: "{{folder}}"
 {% endif %}
   name "{{font_name}}"
-{% if desc %}
-  desc "{{desc}}"
-{% endif %}
   homepage "{{homepage}}"
 
 {% for file in files %}


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes the addition of the `desc` stanza to the font-cask generation script for Google Fonts.
I have kept the description creation functions for now, in case we decide to add them back in at some point. But they could be removed in a future PR.