### PR TITLE
sitesucker-pro: update livecheck

### DIFF
--- a/Casks/s/sitesucker-pro.rb
+++ b/Casks/s/sitesucker-pro.rb
@@ -20,8 +20,10 @@ cask "sitesucker-pro" do
     sha256 "189f4e60238dbc81d87abd278bc286952aed83cc6b6d94906a5470decd90e94e"
 
     livecheck do
-      url "https://ricks-apps.com/osx/sitesucker/history.html"
-      regex(/Version\s*(\d+(?:\.\d+)+)/i)
+      url "https://ricks-apps.com/osx/sitesucker/pro-versions.plist"
+      strategy :xml do |xml|
+        xml.elements["//dict/key[text()='App Version']"]&.next_element&.text&.strip
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This aligns the `livecheck` block with the in-app updater, which will hopefully prove to more reliable than upstream "release notes" web page.
The issue with the release notes is that while a release is being drafted/tested, the new version is in the HTML, but hidden using CSS, so it is returned by `livecheck` as a false positive.