### PR TITLE
cmd/lib/ci_matrix: remove intel runner

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -9,7 +9,6 @@ module CiMatrix
 
   # Weight for each arch must add up to 1.0.
   INTEL_RUNNERS = {
-    { symbol: :big_sur,  name: "macos-11", arch: :intel } => 0.0,
     { symbol: :monterey, name: "macos-12", arch: :intel } => 0.0,
     { symbol: :ventura,  name: "macos-13", arch: :intel } => 1.0,
   }.freeze


### PR DESCRIPTION
GitHub's Intel Big Sur runners are being deprecated and are currently experiencing their first brown out.
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal

Let's remove it now so we don't see CI failures.

Noticed in: https://github.com/Homebrew/homebrew-cask/pull/176959