### PR TITLE
.workflows/cache: remove GitHub Big Sur runner

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-11
           - macos-12
           - macos-13
           - macos-14


### PR DESCRIPTION
Big Sur runners are being deprecated by GitHub.
https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal