### PR TITLE
Use github org for overlayed

### DIFF
--- a/Casks/o/overlayed.rb
+++ b/Casks/o/overlayed.rb
@@ -2,8 +2,8 @@ cask "overlayed" do
   version "0.3.0"
   sha256 "85284c4cceb49663cf7d474da1a9efad9b0465aec5018df00f3e302385723845"
 
-  url "https://github.com/Hacksore/overlayed/releases/download/v#{version}/overlayed_#{version}_universal.dmg",
-      verified: "github.com/Hacksore/overlayed/"
+  url "https://github.com/overlayeddev/overlayed/releases/download/v#{version}/overlayed_#{version}_universal.dmg",
+      verified: "github.com/overlayeddev/overlayed/"
   name "Overlayed"
   desc "Modern, open-source, and free voice chat overlay for Discord"
   homepage "https://overlayed.dev/"


### PR DESCRIPTION
I used the `gh` cli, sorry about that but once all checks pass and I'll mark for review.

Updated the [overlayed.dev](https://overlayed.dev) cask to use the new github org URL.