### PR TITLE
falcon-sql-client: deprecate

### DIFF
--- a/Casks/f/falcon-sql-client.rb
+++ b/Casks/f/falcon-sql-client.rb
@@ -8,6 +8,8 @@ cask "falcon-sql-client" do
   desc "Free, open-source SQL client"
   homepage "https://plot.ly/free-sql-client-download/"
 
+  deprecate! date: "2024-06-17", because: :repo_archived
+
   app "Falcon SQL Client.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The GitHub repository for `falcon-sql-client` was archived on 2024-06-04. The most recent release (v4.1.0) was on 2018-12-21 and the most recent commit was on 2020-04-16. The `README` wasn't updated to explain the project status before the repository was archived but it does contain an older note explaining that the company is focusing on their Dash project instead.

Since Falcon hasn't been updated in years and the repository is now archived, it seems like the project isn't being developed further, so this deprecates the cask accordingly.