### PR TITLE
cmd/lib/ci_matrix: use arm-14 runner for CI syntax jobs

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -85,9 +85,9 @@ module CiMatrix
     end
   end
 
-  def self.random_runner(avalible_runners = INTEL_RUNNERS)
-    avalible_runners.max_by { |(_, weight)| rand ** (1.0 / weight) }
-                    .first
+  def self.random_runner(available_runners = ARM_RUNNERS)
+    available_runners.max_by { |(_, weight)| rand ** (1.0 / weight) }
+                     .first
   end
 
   def self.runners(cask_content:)


### PR DESCRIPTION
This PR switches our CI Matrix to use the macos-14 arm runners for CI's syntax job, to see if we receive any performance benefit.

And fix a typo in the ci_matrix while we are here.