### PR TITLE
.github/workflows/remove-disabled-packages.yml add action

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -1,0 +1,89 @@
+name: Remove disabled packages
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/remove-disabled-packages.yml
+  schedule:
+    # Once every day at midnight UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: remove-disabled-packages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  remove-disabled-packages:
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
+    env:
+      REMOVAL_BRANCH: remove-disabled-packages
+    permissions:
+      contents: write # for Homebrew/actions/git-try-push
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: true
+          test-bot: false
+
+      - name: Configure Git user
+        id: git-user-config
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
+      - name: Checkout removal branch
+        run: git checkout -b "$REMOVAL_BRANCH" origin/master
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+
+      - name: Remove disabled packages
+        id: remove_disabled
+        uses: Homebrew/actions/remove-disabled-packages@master
+        env:
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+          HOMEBREW_EVAL_ALL: 1
+
+      - name: Push commits
+        if: fromJson(steps.remove_disabled.outputs.packages-removed)
+        uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+          branch: ${{ env.REMOVAL_BRANCH }}
+        env:
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+
+      - name: Create pull request
+        id: pr-create
+        if: fromJson(steps.remove_disabled.outputs.packages-removed)
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          PR_BODY: >
+            This pull request was created automatically by the
+            [`remove-disabled-packages`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/.github/workflows/remove-disabled-packages.yml)
+            workflow.
+        run: |
+          gh pr create \
+            --base master \
+            --body "$PR_BODY" \
+            --head "$REMOVAL_BRANCH" \
+            --title 'Remove disabled packages'


### PR DESCRIPTION
This PR adds a new workflow that checks for disabled packages and opens a PR to remove them.
We could probably get away with running this once/week instead of daily.

There's no real way to test it here until a package has been disabled for 12-months, unless we add something to test that it works correctly.