### PR TITLE
workflows/ci: run syntax check on master push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
     inputs:
@@ -57,6 +60,9 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]
           then
             brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" ${{ github.event.inputs.skip_install  && '--skip-install' }} ${{ github.event.inputs.new_cask  && '--new' }} --casks=${{ github.event.inputs.casks }}
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]
+          then
+            brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" --syntax-only
           else
             brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" --url="${{ github.event.pull_request.url }}"
           fi

--- a/cmd/lib/generate-matrix.rb
+++ b/cmd/lib/generate-matrix.rb
@@ -22,8 +22,14 @@ module Homebrew
                description: "Skip installing casks"
         switch "--new",
                description: "Run new cask checks"
+        switch "--syntax-only",
+               description: "Only run syntax checks"
 
         conflicts "--url", "--casks"
+        conflicts "--syntax-only", "--url"
+        conflicts "--syntax-only", "--casks"
+        conflicts "--syntax-only", "--skip-install"
+        conflicts "--syntax-only", "--new"
       end
 
       def run
@@ -50,7 +56,7 @@ module Homebrew
 
         matrix = [syntax_job]
 
-        unless labels&.include?("ci-syntax-only")
+        if !args.syntax_only? && !labels&.include?("ci-syntax-only")
           cask_jobs = if args.casks&.any?
             CiMatrix.generate(tap, labels:, cask_names: casks, skip_install:, new_cask:)
           else


### PR DESCRIPTION
Benefits:

* Populates the style cache so PRs can use them (otherwise caches wouldn't share between PRs)
* Follows CI practice used in most other Homebrew repos
* May be used as a building block for a future merge queue if such use case arises