### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,6 @@ Additionally, **if adding a new cask**:
 
 - [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
 - [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
-- [ ] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
 - [ ] `brew audit --cask --new <cask>` worked successfully.
 - [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
 - [ ] `brew uninstall --cask <cask>` worked successfully.


### PR DESCRIPTION
This checkbox isn't relevant anymore now that `homebrew-cask-fonts`, `homebrew-cask-drivers`, and `homebrew-cask-versions` have been deprecated.
