### PR TITLE
productive 1.11.0 (new cask)

### DIFF
--- a/Casks/p/productive.rb
+++ b/Casks/p/productive.rb
@@ -1,0 +1,31 @@
+cask "productive" do
+  arch arm: "-arm64"
+
+  version "1.12.0"
+  sha256 arm:   "6a8fdcfe18b506ba55c9787da9959bc7b908719179ff872d484f93c182241667",
+         intel: "c85ef5495edbb50511bd11cacee8d77370293e7a1627b833d0017ecc4be2c430"
+
+  url "https://download.productive.io/desktop/electron/Productive-#{version}#{arch}.dmg"
+  name "Productive"
+  desc "Agency management system"
+  homepage "https://productive.io/"
+
+  livecheck do
+    url "https://download.productive.io/desktop/electron/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Productive.app"
+
+  zap trash: [
+    "~/Library/Application Support/productive",
+    "~/Library/Caches/io.productive",
+    "~/Library/Caches/io.productive.ShipIt",
+    "~/Library/Caches/productive-updater",
+    "~/Library/Preferences/io.productive.plist",
+    "~/Library/Saved Application State/io.productive.savedState",
+  ]
+end


### PR DESCRIPTION

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Description

Add formulae for https://productive.io/apps/