### PR TITLE
bbc-iplayer-downloads: disable

### DIFF
--- a/Casks/b/bbc-iplayer-downloads.rb
+++ b/Casks/b/bbc-iplayer-downloads.rb
@@ -7,10 +7,7 @@ cask "bbc-iplayer-downloads" do
   desc "Download programmes from the BBC iPlayer website"
   homepage "https://www.bbc.co.uk/iplayer/install"
 
-  livecheck do
-    url "https://downloads-app.iplayer.api.bbc.co.uk/stable/darwin-x64"
-    strategy :header_match
-  end
+  disable! date: "2024-06-21", because: :no_longer_available
 
   depends_on macos: ">= :el_capitan"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Desktop support has ended ([source](https://www.bbc.co.uk/iplayer/help/questions/recent-changes-to-iplayer/ipd-closure)).
