### PR TITLE
Bump scroll reverser to 1.9 and other brewfile updates

### DIFF
--- a/Casks/s/scroll-reverser.rb
+++ b/Casks/s/scroll-reverser.rb
@@ -1,6 +1,6 @@
 cask "scroll-reverser" do
-  version "1.8.2"
-  sha256 "afe125b05ef1740f9a95101233006453b0e02bd71b6195608414bab5fb5d2c6a"
+  version "1.9"
+  sha256 "0961dbb6f8ef4e5edd432bf0dd6e7cdd4219d8bac8b3baa3f576af9a42bbf585"
 
   url "https://pilotmoon.com/downloads/ScrollReverser-#{version}.zip"
   name "Scroll Reverser"

--- a/Casks/s/scroll-reverser.rb
+++ b/Casks/s/scroll-reverser.rb
@@ -17,7 +17,7 @@ cask "scroll-reverser" do
   app "Scroll Reverser.app"
 
   zap trash: [
-    "~/Library/Caches/com.pilotmoon.scroll-reverser",    
+    "~/Library/Caches/com.pilotmoon.scroll-reverser",
     "~/Library/Preferences/com.pilotmoon.scroll-reverser.plist",
   ]
 end

--- a/Casks/s/scroll-reverser.rb
+++ b/Casks/s/scroll-reverser.rb
@@ -8,18 +8,16 @@ cask "scroll-reverser" do
   homepage "https://pilotmoon.com/scrollreverser/"
 
   livecheck do
-    url "https://pilotmoon.com/appcast/sr.xml"
+    url "https://softwareupdate.pilotmoon.com/update/scrollreverser/appcast.xml"
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :ventura"
 
   app "Scroll Reverser.app"
 
-  zap trash: [
-    "~/Library/Application Scripts/com.pilotmoon.scroll-reverser.launcher",
-    "~/Library/Caches/com.pilotmoon.scroll-reverser",
-    "~/Library/Containers/com.pilotmoon.scroll-reverser.launcher",
+  zap trash: [    
+    "~/Library/Caches/com.pilotmoon.scroll-reverser",    
     "~/Library/Preferences/com.pilotmoon.scroll-reverser.plist",
   ]
 end

--- a/Casks/s/scroll-reverser.rb
+++ b/Casks/s/scroll-reverser.rb
@@ -16,7 +16,7 @@ cask "scroll-reverser" do
 
   app "Scroll Reverser.app"
 
-  zap trash: [    
+  zap trash: [
     "~/Library/Caches/com.pilotmoon.scroll-reverser",    
     "~/Library/Preferences/com.pilotmoon.scroll-reverser.plist",
   ]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free **no: I ran the audit, but it fails because livecheck returns v1.9. this pr, of course, fixes that.**
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
First commit created with brew bump-cask-pr.
Second commit created manually to update cask file as follows:

- Change `livecheck` url to `https://softwareupdate.pilotmoon.com/update/scrollreverser/appcast.xml`. This is the canonical URL for Scroll Reverser's appcast. The other URL does currently work, but should not be relied upon
- Change `depends_on` stanza to indicate macOS Ventura, which is the new minimum requirements as of Scroll Reverser 1.9.
- Remove the launcher artifacts from the `zap` stanza. The launcher component no longer exists as of Scroll Reverser 1.9.

Third commit fixes a whitespace linter error