### PR TITLE
onyx: update Sequoia handling

### DIFF
--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -41,10 +41,15 @@ cask "onyx" do
 
     url "https://www.titanium-software.fr/download/13/OnyX.dmg"
   end
-  on_sonoma :or_newer do
+  on_sonoma do
     version "4.5.9"
 
     url "https://www.titanium-software.fr/download/14/OnyX.dmg"
+  end
+  on_sequoia :or_newer do
+    version "4.6.5"
+
+    url "https://www.titanium-software.fr/download/15/OnyX.dmg"
   end
 
   name "OnyX"
@@ -66,6 +71,7 @@ cask "onyx" do
     :monterey,
     :ventura,
     :sonoma,
+    :sequoia,
   ]
 
   app "OnyX.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
This PR adds handling to the OnyX cask for macOS Sequoia. Livecheck is currently returning the latest version on Sonoma as the upcoming version for Sequoia.

There is no existing release for Sequoia, but the releases only run on their specified OS, so this should be fine.