### PR TITLE
operator: disable

### DIFF
--- a/Casks/o/operator.rb
+++ b/Casks/o/operator.rb
@@ -8,10 +8,7 @@ cask "operator" do
   desc "Prelude Operator is a desktop adversary emulation platform"
   homepage "https://www.prelude.org/"
 
-  livecheck do
-    url "https://s3.amazonaws.com/operator.versions/dist/latest-mac.yml"
-    strategy :electron_builder
-  end
+  disable! date: "2024-06-23", because: :no_longer_available
 
   app "Operator.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The homepage for Prelude Operator now redirects to Prelude Detect, and repositories for [resources](https://github.com/preludeorg/community) and [support](https://github.com/preludeorg/operator-support) outlined in the deprecated [documentation](https://docs.preludesecurity.com/v1/docs/basic) no longer exist.

https://github.com/Homebrew/homebrew-cask/issues/172732#issuecomment-2184311376
