### PR TITLE
yuna: disable

### DIFF
--- a/Casks/y/yuna.rb
+++ b/Casks/y/yuna.rb
@@ -8,6 +8,8 @@ cask "yuna" do
   desc "Anime player and list manager"
   homepage "https://yuna.moe/"
 
+  disable! date: "2024-06-24", because: :no_longer_available
+
   app "Yuna.app"
 
   zap trash: "~/Library/Application Support/yuna"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The GitHub repository for `yuna` was archived on 2024-03-21. The most recent version was v1.4.23 on 2021-03-28 and the most recent commit (outside of a recent `README` tweak) was on 2021-05-25.

Any existing releases have been removed at this point, so this all seems to suggest that the project isn't being developed further. This sets the cask as disabled, as the cask `url` is a release asset that no longer exists.