### PR TITLE
citra: deprecate

### DIFF
--- a/Casks/c/citra.rb
+++ b/Casks/c/citra.rb
@@ -8,6 +8,8 @@ cask "citra" do
   desc "Nintendo 3DS emulator"
   homepage "https://citra-emu.org/"
 
+  deprecate! date: "2024-06-25", because: :repo_archived
+
   installer manual: "citra-setup-mac.app"
 
   uninstall delete: "/Applications/Citra"


### PR DESCRIPTION
Repository was archived on 2024-03-04, and all repository items appear to be deleted except for the release artifacts.
