### PR TITLE
megazeux: update livecheck

### DIFF
--- a/Casks/m/megazeux.rb
+++ b/Casks/m/megazeux.rb
@@ -8,8 +8,8 @@ cask "megazeux" do
   homepage "https://www.digitalmzx.com/"
 
   livecheck do
-    url "https://github.com/AliceLR/megazeux"
-    strategy :git
+    url "https://www.digitalmzx.com/megazeux.php"
+    regex(/href=["'][^"' >]*?download\.php\?latest=osx["' ][^>]*?>\s*v?(\d+(?:\.\d+)+)\s*</im)
   end
 
   app "MegaZeux.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `megazeux` checks the tags in a related GitHub repository, presumably because the cask `url` gives a response with a `Content-Disposition` header where the `filename` value uses a dotless version (293 for 2.93). This updates the `livecheck` block to match the version of the macOS file from the link text on the first-party download page.

This change aligns the check with the cask `url` source (since we're not using an asset from GitHub) and addresses the redundant `#strategy` call in the process (i.e., livecheck already used the `Git` strategy by default for the GitHub URL).