### PR TITLE
Allow third-party taps to include both casks and formulae.

### DIFF
--- a/cmd/lib/changed_files.rb
+++ b/cmd/lib/changed_files.rb
@@ -24,6 +24,7 @@ module ChangedFiles
     modified_command_files = modified_files.select { |path| path.ascend.to_a.last.to_s == "cmd" }
     modified_github_actions_files = modified_files.select { |path| path.to_s.start_with?(".github/actions/") }
     modified_cask_files = modified_files.select { |path| cask_file?(path) }
+    modified_formula_files = modified_files.select { |path| formula_file?(path) }
 
     {
       modified_files:,
@@ -32,6 +33,7 @@ module ChangedFiles
       modified_command_files:,
       modified_github_actions_files:,
       modified_cask_files:,
+      modified_formula_files:,
     }
   end
 end

--- a/cmd/lib/changed_files.rb
+++ b/cmd/lib/changed_files.rb
@@ -20,20 +20,11 @@ module ChangedFiles
       "git", args: ["diff", "--name-only", "--diff-filter=A", commit_range], chdir: path
     ).stdout.split("\n").map { |path| Pathname(path) }
 
-    modified_ruby_files = modified_files.select { |path| path.extname == ".rb" }
-    modified_command_files = modified_files.select { |path| path.ascend.to_a.last.to_s == "cmd" }
-    modified_github_actions_files = modified_files.select { |path| path.to_s.start_with?(".github/actions/") }
     modified_cask_files = modified_files.select { |path| cask_file?(path) }
-    modified_formula_files = modified_files.select { |path| formula_file?(path) }
 
     {
-      modified_files:,
       added_files:,
-      modified_ruby_files:,
-      modified_command_files:,
-      modified_github_actions_files:,
       modified_cask_files:,
-      modified_formula_files:,
     }
   end
 end

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -124,6 +124,8 @@ module CiMatrix
     ruby_files_in_wrong_directory =
       changed_files[:modified_ruby_files] - (
       changed_files[:modified_cask_files] +
+      # Allow third-party taps to include both formulae/casks.
+      (tap.official? ? changed_files[:modified_formula_files] : []) +
       changed_files[:modified_command_files] +
       changed_files[:modified_github_actions_files]
     )

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -121,23 +121,6 @@ module CiMatrix
 
     changed_files = tap.changed_files
 
-    ruby_files_in_wrong_directory =
-      changed_files[:modified_ruby_files] - (
-      changed_files[:modified_cask_files] +
-      # Allow third-party taps to include both formulae/casks.
-      (tap.official? ? changed_files[:modified_formula_files] : []) +
-      changed_files[:modified_command_files] +
-      changed_files[:modified_github_actions_files]
-    )
-
-    if ruby_files_in_wrong_directory.any?
-      ruby_files_in_wrong_directory.each do |path|
-        puts "::error file=#{path}::File is in wrong directory."
-      end
-
-      odie "Found Ruby files in wrong directory:\n#{ruby_files_in_wrong_directory.join("\n")}"
-    end
-
     cask_files_to_check = if cask_names.any?
       cask_names.map do |cask_name|
         Cask::CaskLoader.find_cask_in_tap(cask_name, tap).relative_path_from(tap.path)


### PR DESCRIPTION
I have formulae and casks in my personal tap and I'm syncing the CI config from here, which is failing due to this workflow flagging formula files, so allow formula files in third party taps.