### PR TITLE
redisinsight: update livecheck

### DIFF
--- a/Casks/r/redisinsight.rb
+++ b/Casks/r/redisinsight.rb
@@ -15,7 +15,7 @@ cask "redisinsight" do
   # GitHub releases as a best guess of when a new version is released.
   livecheck do
     url "https://github.com/RedisInsight/RedisInsight"
-    strategy :git
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `redisinsight` checks the Git tags from the related GitHub repository, as the first-party website doesn't publish version information. livecheck already uses the `Git` strategy for the GitHub URL by default, so this `#strategy` call isn't necessary.

This resolves the redundancy by updating the call to use the `GithubLatest` strategy instead, as that is more likely to align with releases on the first-party website. Besides that, it should also omit unstable versions like `2.0.2-preview`, `2.0.2-preview-rc1`, etc. that the existing approach is matching (without a strict regex).