### PR TITLE
espanso: remove unsigned caveat

### DIFF
--- a/Casks/e/espanso.rb
+++ b/Casks/e/espanso.rb
@@ -28,8 +28,4 @@ cask "espanso" do
     "~/Library/Preferences/espanso.plist",
     "~/Library/Saved Application State/com.federicoterzi.espanso.savedState",
   ]
-
-  caveats do
-    unsigned_accessibility
-  end
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The app is signed now so the caveat `unsigned_accessibility` should no longer apply, as far as I am aware.

Note: there is only one cask left using this caveat now: `copyq`