### PR TITLE
Add missing rosetta caveats

### DIFF
--- a/Casks/4/4k-stogram.rb
+++ b/Casks/4/4k-stogram.rb
@@ -18,4 +18,8 @@ cask "4k-stogram" do
   app "4K Stogram.app"
 
   zap trash: "~/Pictures/4K Stogram"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/4/4k-video-downloader.rb
+++ b/Casks/4/4k-video-downloader.rb
@@ -23,4 +23,8 @@ cask "4k-video-downloader" do
     "~/Library/Preferences/com.openmedia.4kvideodownloader.plist",
     "~/Library/Saved Application State/com.openmedia.4kvideodownloader.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/activitywatch.rb
+++ b/Casks/a/activitywatch.rb
@@ -20,4 +20,8 @@ cask "activitywatch" do
     "~/Library/Caches/activitywatch",
     "~/Library/Logs/activitywatch",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/adoptopenjdk.rb
+++ b/Casks/a/adoptopenjdk.rb
@@ -21,6 +21,7 @@ cask "adoptopenjdk" do
   ]
 
   caveats do
+    requires_rosetta
     <<~EOS
       Temurin is the official successor to this software:
 

--- a/Casks/a/airpass.rb
+++ b/Casks/a/airpass.rb
@@ -9,4 +9,8 @@ cask "airpass" do
   homepage "https://airpass.tiagoalves.me/"
 
   app "Airpass.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/amazon-luna.rb
+++ b/Casks/a/amazon-luna.rb
@@ -28,4 +28,8 @@ cask "amazon-luna" do
     "~/Library/Preferences/Amazon.SpiderPorkClientMac.plist",
     "~/Library/WebKit/Amazon.SpiderPorkClientMac",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/amazon-music.rb
+++ b/Casks/a/amazon-music.rb
@@ -39,12 +39,15 @@ cask "amazon-music" do
     "~/Library/Saved Application State/com.amazon.music.savedState",
   ]
 
-  caveats <<~EOS
-    If the app will not launch after installation, try
+  caveats do
+    requires_rosetta
+    <<~EOS
+      If the app will not launch after installation, try
 
-      brew uninstall --zap --cask #{token}
-      brew install --cask #{token}
+        brew uninstall --zap --cask #{token}
+        brew install --cask #{token}
 
-    then re-launch the app.
-  EOS
+      then re-launch the app.
+    EOS
+  end
 end

--- a/Casks/a/ampps.rb
+++ b/Casks/a/ampps.rb
@@ -19,4 +19,8 @@ cask "ampps" do
   uninstall_preflight do
     set_permissions "#{appdir}/AMPPS", "0777"
   end
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/android-file-transfer.rb
+++ b/Casks/a/android-file-transfer.rb
@@ -23,4 +23,8 @@ cask "android-file-transfer" do
         "~/Library/Preferences/com.google.android.mtpviewer.plist",
       ],
       rmdir: "~/Library/Application Support/Google"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/apache-directory-studio.rb
+++ b/Casks/a/apache-directory-studio.rb
@@ -18,6 +18,7 @@ cask "apache-directory-studio" do
 
   caveats do
     depends_on_java "11+"
+    requires_rosetta
     <<~EOS
       To set the Java VM to use:
 

--- a/Casks/a/apptrap.rb
+++ b/Casks/a/apptrap.rb
@@ -18,4 +18,8 @@ cask "apptrap" do
   uninstall login_item: "AppTrap"
 
   zap trash: "~/Library/Preferences/com.KumaranVijayan.AppTrap.prefpanel.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/ariang.rb
+++ b/Casks/a/ariang.rb
@@ -15,4 +15,8 @@ cask "ariang" do
     "~/Library/Preferences/net.mayswind.ariang.plist",
     "~/Library/Saved Application State/net.mayswind.ariang.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/ark-desktop-wallet.rb
+++ b/Casks/a/ark-desktop-wallet.rb
@@ -11,4 +11,8 @@ cask "ark-desktop-wallet" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "Ark Desktop Wallet.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/atom.rb
+++ b/Casks/a/atom.rb
@@ -32,4 +32,8 @@ cask "atom" do
     "~/Library/Saved Application State/com.github.atom.savedState",
     "~/Library/WebKit/com.github.atom",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/atomic-wallet.rb
+++ b/Casks/a/atomic-wallet.rb
@@ -17,4 +17,8 @@ cask "atomic-wallet" do
   app "Atomic Wallet.app"
 
   zap trash: "~/Library/Application Support/atomic"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/authy.rb
+++ b/Casks/a/authy.rb
@@ -21,4 +21,8 @@ cask "authy" do
     "~/Library/Preferences/com.authy.authy-mac.helper.plist",
     "~/Library/Preferences/com.authy.authy-mac.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/backlog.rb
+++ b/Casks/b/backlog.rb
@@ -15,4 +15,8 @@ cask "backlog" do
   app "Backlog-darwin-x64/Backlog.app"
 
   zap trash: "~/Library/Application Support/Backlog"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/banshee.rb
+++ b/Casks/b/banshee.rb
@@ -11,4 +11,8 @@ cask "banshee" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "Banshee.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/baretorrent.rb
+++ b/Casks/b/baretorrent.rb
@@ -18,4 +18,8 @@ cask "baretorrent" do
     "~/Library/Application Support/baretorrent",
     "~/Library/Saved Application State/baretorrent.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/baritone.rb
+++ b/Casks/b/baritone.rb
@@ -9,4 +9,8 @@ cask "baritone" do
   homepage "https://tma02.github.io/baritone/"
 
   app "Baritone-darwin-x64/Baritone.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/battle-net.rb
+++ b/Casks/b/battle-net.rb
@@ -41,8 +41,11 @@ cask "battle-net" do
       ],
       rmdir: "~/Blizzard"
 
-  caveats <<~EOS
-    If your installation directory is not /Applications, you will need to
-    uninstall this cask manually.
-  EOS
+  caveats do
+    requires_rosetta
+    <<~EOS
+      If your installation directory is not /Applications, you will need to
+      uninstall this cask manually.
+    EOS
+  end
 end

--- a/Casks/b/betwixt.rb
+++ b/Casks/b/betwixt.rb
@@ -38,4 +38,8 @@ cask "betwixt" do
     "~/Library/Preferences/com.electron.betwixt.plist",
     "~/Library/Saved Application State/com.electron.betwixt.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/beyond-compare.rb
+++ b/Casks/b/beyond-compare.rb
@@ -27,4 +27,8 @@ cask "beyond-compare" do
     "~/Library/Preferences/com.ScooterSoftware.BeyondCompare.plist",
     "~/Library/Saved Application State/com.ScooterSoftware.BeyondCompare.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/bisq.rb
+++ b/Casks/b/bisq.rb
@@ -19,4 +19,8 @@ cask "bisq" do
     "~/Library/Application Support/Bisq",
     "~/Library/Saved Application State/io.bisq.CAT.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/bluestacks.rb
+++ b/Casks/b/bluestacks.rb
@@ -33,4 +33,8 @@ cask "bluestacks" do
         "~/Library/Preferences/com.bluestacks.BlueStacks.plist",
       ],
       rmdir: "~/Library/Caches/KSCrashReports"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/bonitastudiocommunity.rb
+++ b/Casks/b/bonitastudiocommunity.rb
@@ -26,4 +26,8 @@ cask "bonitastudiocommunity" do
     "/Library/Caches/org.bonitasoft.studio.product",
     "~/Library/Preferences/org.bonitasoft.studio.product.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/brackets.rb
+++ b/Casks/b/brackets.rb
@@ -16,4 +16,8 @@ cask "brackets" do
     "~/Library/Application Support/Brackets",
     "~/Library/Preferences/io.brackets.appshell.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/btcpayserver-vault.rb
+++ b/Casks/b/btcpayserver-vault.rb
@@ -16,4 +16,8 @@ cask "btcpayserver-vault" do
   depends_on macos: ">= :high_sierra"
 
   app "BTCPayServer Vault.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/b/buttercup.rb
+++ b/Casks/b/buttercup.rb
@@ -26,4 +26,8 @@ cask "buttercup" do
     "~/Library/Preferences/pw.buttercup.desktop.plist",
     "~/Library/Saved Application State/pw.buttercup.desktop.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/camed.rb
+++ b/Casks/c/camed.rb
@@ -14,4 +14,8 @@ cask "camed" do
   end
 
   app "CAMEd-#{version}/CAMed.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/chiaki.rb
+++ b/Casks/c/chiaki.rb
@@ -17,4 +17,8 @@ cask "chiaki" do
     "~/Library/Application Support/Chiaki",
     "~/Library/Preferences/com.chiaki.Chiaki.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/chrome-devtools.rb
+++ b/Casks/c/chrome-devtools.rb
@@ -17,4 +17,8 @@ cask "chrome-devtools" do
     "~/Library/Preferences/com.auchenberg.chrome-devtools-app.plist",
     "~/Library/Saved Application State/com.auchenberg.chrome-devtools-app.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/codeql.rb
+++ b/Casks/c/codeql.rb
@@ -10,4 +10,8 @@ cask "codeql" do
   binary "#{staged_path}/codeql/codeql"
 
   # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/coin-wallet.rb
+++ b/Casks/c/coin-wallet.rb
@@ -19,4 +19,8 @@ cask "coin-wallet" do
     "~/Library/Preferences/com.coinspace.wallet*.plist",
     "~/Library/Saved Application State/com.coinspace.wallet.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/coinomi-wallet.rb
+++ b/Casks/c/coinomi-wallet.rb
@@ -24,4 +24,8 @@ cask "coinomi-wallet" do
     "~/Library/Caches/Coinomi",
     "~/Library/Saved Application State/com.coinomi.desktop.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/colorsnapper.rb
+++ b/Casks/c/colorsnapper.rb
@@ -29,4 +29,8 @@ cask "colorsnapper" do
     "~/Library/Cookies/com.koolesache.ColorSnapper2.binarycookies",
     "~/Library/Preferences/com.koolesache.ColorSnapper2.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/comictagger.rb
+++ b/Casks/c/comictagger.rb
@@ -13,4 +13,8 @@ cask "comictagger" do
   end
 
   app "ComicTagger.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/comma-chameleon.rb
+++ b/Casks/c/comma-chameleon.rb
@@ -8,4 +8,8 @@ cask "comma-chameleon" do
   homepage "https://comma-chameleon.io/"
 
   app "Comma Chameleon-darwin-x64/Comma Chameleon.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/convert3dgui.rb
+++ b/Casks/c/convert3dgui.rb
@@ -19,4 +19,8 @@ cask "convert3dgui" do
   binary "#{appdir}/Convert3DGUI.app/Contents/bin/c4d"
 
   zap trash: "~/Library/Saved Application State/org.itksnap.c3dgui.savedState"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/couchbase-server-community.rb
+++ b/Casks/c/couchbase-server-community.rb
@@ -25,4 +25,8 @@ cask "couchbase-server-community" do
     "~/Library/Preferences/com.couchbase.couchbase-server.plist",
     "~/Library/Preferences/couchbase-server.ini",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/couchbase-server-enterprise.rb
+++ b/Casks/c/couchbase-server-enterprise.rb
@@ -25,4 +25,8 @@ cask "couchbase-server-enterprise" do
     "~/Library/Preferences/com.couchbase.couchbase-server.plist",
     "~/Library/Preferences/couchbase-server.ini",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/couchpotato.rb
+++ b/Casks/c/couchpotato.rb
@@ -13,4 +13,8 @@ cask "couchpotato" do
   app "CouchPotato.app"
 
   zap trash: "~/Library/Application Support/CouchPotato"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/daedalus-mainnet.rb
+++ b/Casks/d/daedalus-mainnet.rb
@@ -28,4 +28,8 @@ cask "daedalus-mainnet" do
     "~/Library/Preferences/com.electron.daedalus-mainnet.plist",
     "~/Library/Saved Application State/com.electron.daedalus-mainnet.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/deezer.rb
+++ b/Casks/d/deezer.rb
@@ -27,4 +27,8 @@ cask "deezer" do
     "~/Library/Preferences/com.deezer.deezer-desktop.plist",
     "~/Library/Saved Application State/com.deezer.deezer-desktop.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/deluge.rb
+++ b/Casks/d/deluge.rb
@@ -20,4 +20,8 @@ cask "deluge" do
     "~/Library/Preferences/org.deluge.plist",
     "~/Library/Saved Application State/org.deluge.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/denemo.rb
+++ b/Casks/d/denemo.rb
@@ -13,4 +13,8 @@ cask "denemo" do
   end
 
   app "Denemo.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/detexify.rb
+++ b/Casks/d/detexify.rb
@@ -16,4 +16,8 @@ cask "detexify" do
   app "Detexify.app"
 
   zap trash: "~/Library/Preferences/org.kirelabs.Detexify-Mac.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/devilutionx.rb
+++ b/Casks/d/devilutionx.rb
@@ -21,4 +21,8 @@ cask "devilutionx" do
         "~/Library/Application Support/diasurgical/devilution",
       ],
       rmdir: "~/Library/Application Support/diasurgical"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/diffmerge.rb
+++ b/Casks/d/diffmerge.rb
@@ -21,4 +21,8 @@ cask "diffmerge" do
     "~/Library/Preferences/SourceGear DiffMerge Preferences",
     "~/Library/Saved Application State/com.sourcegear.DiffMerge.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/digikam.rb
+++ b/Casks/d/digikam.rb
@@ -31,4 +31,8 @@ cask "digikam" do
     "~/Library/Preferences/digikamrc",
     "~/Library/Saved Application State/digikam.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/disk-inventory-x.rb
+++ b/Casks/d/disk-inventory-x.rb
@@ -18,4 +18,8 @@ cask "disk-inventory-x" do
   app "Disk Inventory X.app"
 
   zap trash: "~/Library/Preferences/com.derlien.DiskInventoryX.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/dogecoin.rb
+++ b/Casks/d/dogecoin.rb
@@ -20,4 +20,8 @@ cask "dogecoin" do
   end
 
   zap trash: "~/Library/com.dogecoin.Dogecoin-Qt.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/dolphin.rb
+++ b/Casks/d/dolphin.rb
@@ -24,4 +24,8 @@ cask "dolphin" do
     "~/Library/Application Support/Dolphin",
     "~/Library/Preferences/org.dolphin-emu.dolphin.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/doomsday-engine.rb
+++ b/Casks/d/doomsday-engine.rb
@@ -14,4 +14,8 @@ cask "doomsday-engine" do
 
   app "Doomsday.app"
   app "Doomsday Shell.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/douyin-chat.rb
+++ b/Casks/d/douyin-chat.rb
@@ -32,4 +32,8 @@ cask "douyin-chat" do
     "~/Library/Preferences/com.bytedance.awemeim.desktop.plist",
     "~/Library/Saved Application State/com.bytedance.awemeim.desktop.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/dropbox-dash.rb
+++ b/Casks/d/dropbox-dash.rb
@@ -24,4 +24,8 @@ cask "dropbox-dash" do
     "~/Library/Group Containers/com.dash",
     "~/Library/Preferences/io.hypertools.Dropbox-Dash.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/duckietv.rb
+++ b/Casks/d/duckietv.rb
@@ -19,4 +19,8 @@ cask "duckietv" do
               "/Applications/duckieTV.app",
               "~/Library/Application Support/DuckieTV-Standalone",
             ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/dwarf-fortress-lmp.rb
+++ b/Casks/d/dwarf-fortress-lmp.rb
@@ -20,4 +20,8 @@ cask "dwarf-fortress-lmp" do
     "~/Library/Preferences/Lazy Mac Pack.plist",
     "~/Library/Saved Application State/Lazy Mac Pack.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/d/dwarf-fortress.rb
+++ b/Casks/d/dwarf-fortress.rb
@@ -27,6 +27,7 @@ cask "dwarf-fortress" do
   end
 
   caveats do
+    requires_rosetta
     <<~EOS
       During uninstall, your save data will be copied to /tmp/dwarf-fortress-save
     EOS

--- a/Casks/e/easyeda.rb
+++ b/Casks/e/easyeda.rb
@@ -21,4 +21,8 @@ cask "easyeda" do
     "~/Library/Preferences/com.easyeda.editor.plist",
     "~/Library/Saved Application State/com.easyeda.editor.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/eclipse-javascript.rb
+++ b/Casks/e/eclipse-javascript.rb
@@ -11,4 +11,8 @@ cask "eclipse-javascript" do
 
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse JavaScript.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/eclipse-testing.rb
+++ b/Casks/e/eclipse-testing.rb
@@ -11,4 +11,8 @@ cask "eclipse-testing" do
 
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Testing.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/edex-ui.rb
+++ b/Casks/e/edex-ui.rb
@@ -16,4 +16,8 @@ cask "edex-ui" do
     "~/Library/Preferences/com.edex.ui.plist",
     "~/Library/Saved Application State/com.edex.ui.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/electrocrud.rb
+++ b/Casks/e/electrocrud.rb
@@ -19,4 +19,8 @@ cask "electrocrud" do
     "~/Library/Preferences/com.garrylachman.electrocrud.plist",
     "~/Library/Saved Application State/com.garrylachman.electrocrud.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/electronic-wechat.rb
+++ b/Casks/e/electronic-wechat.rb
@@ -20,4 +20,8 @@ cask "electronic-wechat" do
     "~/Library/Preferences/com.electron.electronic-wechat.plist",
     "~/Library/Saved Application State/com.electron.electronic-wechat.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/electrum-grs.rb
+++ b/Casks/e/electrum-grs.rb
@@ -18,4 +18,8 @@ cask "electrum-grs" do
     "~/Library/Preferences/org.org.pythonmac.unspecified.Electrum-GRS.plist",
     "~/Library/Saved Application State/Electrum-GRS.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/electrum-ltc.rb
+++ b/Casks/e/electrum-ltc.rb
@@ -15,4 +15,8 @@ cask "electrum-ltc" do
   app "Electrum-LTC.app"
 
   zap trash: "~/.electrum-ltc"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/electrum.rb
+++ b/Casks/e/electrum.rb
@@ -22,4 +22,8 @@ cask "electrum" do
     "~/Library/Preferences/org.org.pythonmac.unspecified.Electrum.plist",
     "~/Library/Saved Application State/Electrum.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/electrumsv.rb
+++ b/Casks/e/electrumsv.rb
@@ -14,4 +14,8 @@ cask "electrumsv" do
   end
 
   app "ElectrumSV.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/embyserver.rb
+++ b/Casks/e/embyserver.rb
@@ -18,4 +18,8 @@ cask "embyserver" do
   app "EmbyServer.app"
 
   zap trash: "~/.config/emby-server"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/enclave.rb
+++ b/Casks/e/enclave.rb
@@ -22,4 +22,8 @@ cask "enclave" do
     "/etc/enclave",
     "/var/log/enclave",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/envkey.rb
+++ b/Casks/e/envkey.rb
@@ -23,4 +23,8 @@ cask "envkey" do
     "~/Library/Logs/EnvKey",
     "~/Library/Preferences/com.envkey.EnvKeyApp.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/epic-games.rb
+++ b/Casks/e/epic-games.rb
@@ -27,4 +27,8 @@ cask "epic-games" do
     "~/Library/Logs/Unreal Engine/EpicGamesLauncher",
     "~/Library/Preferences/Unreal Engine/EpicGamesLauncher",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/espresso.rb
+++ b/Casks/e/espresso.rb
@@ -23,4 +23,8 @@ cask "espresso" do
     "~/Library/Preferences/com.kanagacode.espresso.plist",
     "~/Library/WebKit/com.kanagacode.espresso",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/ethereum-wallet.rb
+++ b/Casks/e/ethereum-wallet.rb
@@ -17,4 +17,8 @@ cask "ethereum-wallet" do
     "~/Library/Preferences/com.ethereum.wallet.helper.plist",
     "~/Library/Preferences/com.ethereum.wallet.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/e/exist-db.rb
+++ b/Casks/e/exist-db.rb
@@ -14,5 +14,6 @@ cask "exist-db" do
 
   caveats do
     depends_on_java "8"
+    requires_rosetta
   end
 end

--- a/Casks/e/explorer.rb
+++ b/Casks/e/explorer.rb
@@ -13,4 +13,8 @@ cask "explorer" do
     "~/Library/Application Support/Explorer",
     "~/Library/Caches/Explorer",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/factor.rb
+++ b/Casks/f/factor.rb
@@ -16,5 +16,6 @@ cask "factor" do
 
   caveats do
     path_environment_variable "#{appdir}/factor"
+    requires_rosetta
   end
 end

--- a/Casks/f/fastclicker.rb
+++ b/Casks/f/fastclicker.rb
@@ -10,4 +10,8 @@ cask "fastclicker" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "FastClicker.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/favro.rb
+++ b/Casks/f/favro.rb
@@ -20,4 +20,8 @@ cask "favro" do
     "~/Library/Preferences/com.favro.desktop-app.plist",
     "~/Library/Saved Application State/com.favro.desktop-app.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/fightcade.rb
+++ b/Casks/f/fightcade.rb
@@ -23,4 +23,8 @@ cask "fightcade" do
     "~/Library/Preferences/com.fightcade*.plist",
     "~/Library/Saved Application State/com.fightcade*.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/final-fantasy-xiv-online.rb
+++ b/Casks/f/final-fantasy-xiv-online.rb
@@ -25,4 +25,8 @@ cask "final-fantasy-xiv-online" do
     "~/Library/HTTPStorages/com.square-enix.finalfantasyxiv",
     "~/Library/Preferences/com.square-enix.finalfantasyxiv.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/firestorm.rb
+++ b/Casks/f/firestorm.rb
@@ -26,13 +26,16 @@ cask "firestorm" do
     "~/Library/Preferences/Firestorm.plist",
   ]
 
-  caveats <<~EOS
-    This version does not contain the Havok engine (does not matter if
-    you are not a content creator).
+  caveats do
+    requires_rosetta
+    <<~EOS
+      This version does not contain the Havok engine (does not matter if
+      you are not a content creator).
 
-    Most problems that crop up during updates can be resolved or fixed by
-    performing a clean install. For instructions, see:
+      Most problems that crop up during updates can be resolved or fixed by
+      performing a clean install. For instructions, see:
 
-      https://wiki.phoenixviewer.com/doku.php?id=fs_clean_reinstall
-  EOS
+        https://wiki.phoenixviewer.com/doku.php?id=fs_clean_reinstall
+    EOS
+  end
 end

--- a/Casks/f/flow.rb
+++ b/Casks/f/flow.rb
@@ -21,4 +21,8 @@ cask "flow" do
     "~/Library/HTTPStorages/com.metalab.flow-mac",
     "~/Library/Preferences/com.metalab.flow-mac.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/fly.rb
+++ b/Casks/f/fly.rb
@@ -10,4 +10,8 @@ cask "fly" do
   binary "fly"
 
   # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/foldit.rb
+++ b/Casks/f/foldit.rb
@@ -19,4 +19,8 @@ cask "foldit" do
   app "Foldit.app"
 
   zap trash: "~/Library/Saved Application State/edu.washington.foldit.savedState"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/freesurfer.rb
+++ b/Casks/f/freesurfer.rb
@@ -17,6 +17,7 @@ cask "freesurfer" do
   zap trash: "~/Library/Preferences/edu.harvard.mgh.nmr.FreeView.plist"
 
   caveats do
+    requires_rosetta
     free_license "https://surfer.nmr.mgh.harvard.edu/registration.html"
   end
 end

--- a/Casks/f/functionflip.rb
+++ b/Casks/f/functionflip.rb
@@ -13,4 +13,8 @@ cask "functionflip" do
   end
 
   prefpane "FunctionFlip.prefPane"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/f/fvim.rb
+++ b/Casks/f/fvim.rb
@@ -20,4 +20,8 @@ cask "fvim" do
   app "FVim.app"
 
   zap trash: "~/Library/Saved Application State/com.fvim.www.savedState"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/git-it.rb
+++ b/Casks/g/git-it.rb
@@ -14,4 +14,8 @@ cask "git-it" do
     "~/Library/Preferences/com.electron.git-it.helper.plist",
     "~/Library/Preferences/com.electron.git-it.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gitblade.rb
+++ b/Casks/g/gitblade.rb
@@ -13,4 +13,8 @@ cask "gitblade" do
   end
 
   app "GitBlade.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gittyup.rb
+++ b/Casks/g/gittyup.rb
@@ -31,4 +31,8 @@ cask "gittyup" do
     "~/Library/Preferences/com.Murmele.Gittyup.plist",
     "~/Library/Saved Application State/com.Murmele.Gittyup.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gmvault.rb
+++ b/Casks/g/gmvault.rb
@@ -8,4 +8,8 @@ cask "gmvault" do
   homepage "http://gmvault.org/"
 
   binary "gmvault-v#{version}/gmvault"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gnucash.rb
+++ b/Casks/g/gnucash.rb
@@ -28,4 +28,8 @@ cask "gnucash" do
     "~/Library/Preferences/org.gnucash.Gnucash.plist",
     "~/Library/Saved Application State/org.gnucash.Gnucash.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gog-galaxy.rb
+++ b/Casks/g/gog-galaxy.rb
@@ -32,4 +32,8 @@ cask "gog-galaxy" do
     "~/Library/Preferences/com.gog.galaxy.plist",
     "~/Library/Saved Application State/com.gog.galaxy.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/goldencheetah.rb
+++ b/Casks/g/goldencheetah.rb
@@ -14,4 +14,8 @@ cask "goldencheetah" do
   end
 
   app "GoldenCheetah.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/goofy.rb
+++ b/Casks/g/goofy.rb
@@ -20,4 +20,8 @@ cask "goofy" do
     "~/Library/Preferences/cc.buechele.Goofy.plist",
     "~/Library/Saved Application State/cc.buechele.Goofy.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/google-chat.rb
+++ b/Casks/g/google-chat.rb
@@ -19,4 +19,8 @@ cask "google-chat" do
     "~/Library/Preferences/com.google.chat*",
     "~/Library/Saved Application State/com.google.chat.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/google-earth-pro.rb
+++ b/Casks/g/google-earth-pro.rb
@@ -35,4 +35,8 @@ cask "google-earth-pro" do
         "~/Library/Caches/com.Google.GoogleEarthPro",
         "~/Library/Caches/Google Earth",
       ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gplates.rb
+++ b/Casks/g/gplates.rb
@@ -9,4 +9,8 @@ cask "gplates" do
   homepage "https://www.gplates.org/"
 
   app "GPlates-#{version}.0/GPlates.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/g/gridtracker.rb
+++ b/Casks/g/gridtracker.rb
@@ -22,4 +22,8 @@ cask "gridtracker" do
     "~/Library/Preferences/org.gridtracker.gridtracker.plist",
     "~/Library/Saved Application State/org.gridtracker.gridtracker.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/h/harmony.rb
+++ b/Casks/h/harmony.rb
@@ -24,4 +24,8 @@ cask "harmony" do
     "~/Library/Preferences/com.vincelwt.harmony.plist",
     "~/Library/Saved Application State/com.vincelwt.harmony.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/h/haroopad.rb
+++ b/Casks/h/haroopad.rb
@@ -10,4 +10,8 @@ cask "haroopad" do
   app "Haroopad.app"
 
   zap trash: "~/Library/Application Support/Haroopad"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/h/html-mangareader.rb
+++ b/Casks/h/html-mangareader.rb
@@ -14,4 +14,8 @@ cask "html-mangareader" do
     "~/Library/Preferences/HTML Mangareader.plist",
     "~/Library/Saved Application State/HTML Mangareader.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/h/hyperbackupexplorer.rb
+++ b/Casks/h/hyperbackupexplorer.rb
@@ -18,4 +18,8 @@ cask "hyperbackupexplorer" do
     "~/Library/Preferences/com.synology.HyperBackupExplorer.plist",
     "~/Library/Saved Application State/com.synology.HyperBackupExplorer.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/i/ibm-aspera-connect.rb
+++ b/Casks/i/ibm-aspera-connect.rb
@@ -30,4 +30,8 @@ cask "ibm-aspera-connect" do
     "~/Library/Preferences/com.aspera.connect.plist",
     "~/Library/Saved Application State/com.aspera.connect.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/i/icestudio.rb
+++ b/Casks/i/icestudio.rb
@@ -18,4 +18,8 @@ cask "icestudio" do
     "~/Library/Preferences/com.nw-builder.icestudio.plist",
     "~/Library/Saved Application State/com.nw-builder.icestudio.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/i/icons.rb
+++ b/Casks/i/icons.rb
@@ -10,4 +10,8 @@ cask "icons" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "Icons.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/i/icq.rb
+++ b/Casks/i/icq.rb
@@ -21,4 +21,8 @@ cask "icq" do
     "~/Library/Preferences/com.icq.macicq.plist",
     "~/Library/Saved Application State/com.icq.macicq.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/i/ivideonserver.rb
+++ b/Casks/i/ivideonserver.rb
@@ -16,4 +16,8 @@ cask "ivideonserver" do
   app "IvideonServer.app"
 
   zap trash: "~/Library/Saved Application State/com.ivideon.IvideonServer.savedState"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/j/jad.rb
+++ b/Casks/j/jad.rb
@@ -15,6 +15,7 @@ cask "jad" do
   manpage "jad.1"
 
   caveats do
+    requires_rosetta
     <<~EOS
       Instructions on using jad are available in
 

--- a/Casks/j/jet.rb
+++ b/Casks/j/jet.rb
@@ -16,4 +16,8 @@ cask "jet" do
   binary "jet"
 
   # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/j/jitsi.rb
+++ b/Casks/j/jitsi.rb
@@ -23,4 +23,8 @@ cask "jitsi" do
     "~/Library/Logs/Jitsi",
     "~/Library/Preferences/org.jitsi.jitsi.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/j/julia@lts.rb
+++ b/Casks/j/julia@lts.rb
@@ -16,4 +16,8 @@ cask "julia@lts" do
   binary "#{appdir}/Julia-#{version.major_minor}.app/Contents/Resources/julia/bin/julia", target: "julia-lts"
 
   zap trash: "~/.julia"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/kid3.rb
+++ b/Casks/k/kid3.rb
@@ -25,4 +25,8 @@ cask "kid3" do
   binary "#{appdir}/kid3.app/Contents/MacOS/kid3-cli"
 
   zap trash: "~/Library/Preferences/com.kid3.Kid3.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/komodo-edit.rb
+++ b/Casks/k/komodo-edit.rb
@@ -10,4 +10,8 @@ cask "komodo-edit" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "Komodo Edit #{version.major}.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/komodo-ide.rb
+++ b/Casks/k/komodo-ide.rb
@@ -10,4 +10,8 @@ cask "komodo-ide" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "Komodo IDE #{version.major}.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/launchrocket.rb
+++ b/Casks/l/launchrocket.rb
@@ -12,4 +12,8 @@ cask "launchrocket" do
   prefpane "LaunchRocket.prefPane"
 
   zap trash: "~/Library/Preferences/com.joshbutts.launchrocket.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/laverna.rb
+++ b/Casks/l/laverna.rb
@@ -12,4 +12,8 @@ cask "laverna" do
   deprecate! date: "2024-01-01", because: :unmaintained
 
   app "laverna.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/lazarus.rb
+++ b/Casks/l/lazarus.rb
@@ -25,4 +25,8 @@ cask "lazarus" do
             delete:  "/Applications/Lazarus.app"
 
   zap trash: "~/.lazarus"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/librepcb.rb
+++ b/Casks/l/librepcb.rb
@@ -19,4 +19,8 @@ cask "librepcb" do
     "~/Library/Saved Application State/com.yourcompany.librepcb.savedState",
     "~/Library/Saved Application State/org.librepcb.LibrePCB.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/liclipse.rb
+++ b/Casks/l/liclipse.rb
@@ -25,4 +25,8 @@ cask "liclipse" do
     "~/Library/Preferences/com.brainwy.liclipse.rcp.product.plist",
     "~/Library/Saved Application State/com.brainwy.liclipse.rcp.product.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/lidarr.rb
+++ b/Casks/l/lidarr.rb
@@ -18,4 +18,8 @@ cask "lidarr" do
   app "Lidarr.app"
 
   zap trash: "~/.config/Lidarr/"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/litecoin.rb
+++ b/Casks/l/litecoin.rb
@@ -31,4 +31,8 @@ cask "litecoin" do
     "~/Library/Preferences/org.litecoin.Litecoin-Qt.plist",
     "~/Library/Saved Application State/org.litecoin.Litecoin-Qt.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/l/lunasea.rb
+++ b/Casks/l/lunasea.rb
@@ -24,4 +24,8 @@ cask "lunasea" do
     "~/Library/Application Scripts/app.lunasea.lunasea",
     "~/Library/Containers/app.lunasea.lunasea",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mater.rb
+++ b/Casks/m/mater.rb
@@ -14,4 +14,8 @@ cask "mater" do
     "~/Library/Preferences/com.electron.mater.plist",
     "~/Library/Saved Application State/com.electron.mater.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mbcord.rb
+++ b/Casks/m/mbcord.rb
@@ -8,4 +8,8 @@ cask "mbcord" do
   homepage "https://github.com/oonqt/MBCord"
 
   app "MBCord.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/meld.rb
+++ b/Casks/m/meld.rb
@@ -29,4 +29,8 @@ cask "meld" do
     "~/Library/Preferences/org.gnome.meld.plist",
     "~/Library/Saved Application State/org.gnome.meld.savedState/",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mendeley.rb
+++ b/Casks/m/mendeley.rb
@@ -20,6 +20,7 @@ cask "mendeley" do
   ]
 
   caveats do
+    requires_rosetta
     <<~EOS
       mendeley-reference-manager is the successor to this software:
 

--- a/Casks/m/messenger-native.rb
+++ b/Casks/m/messenger-native.rb
@@ -8,4 +8,8 @@ cask "messenger-native" do
   homepage "https://github.com/gastonmorixe/MessengerNative"
 
   app "osx64/Messenger Native.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/metasploit.rb
+++ b/Casks/m/metasploit.rb
@@ -40,4 +40,8 @@ cask "metasploit" do
             rmdir:  "/opt/metasploit-framework"
 
   zap trash: "~/.msf4"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/miktex-console.rb
+++ b/Casks/m/miktex-console.rb
@@ -13,4 +13,8 @@ cask "miktex-console" do
   end
 
   app "MiKTeX Console.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mindforger.rb
+++ b/Casks/m/mindforger.rb
@@ -22,4 +22,8 @@ cask "mindforger" do
   end
 
   app "mindforger.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/minecraft.rb
+++ b/Casks/m/minecraft.rb
@@ -22,4 +22,8 @@ cask "minecraft" do
     "~/Library/Caches/com.mojang.minecraftlauncher",
     "~/Library/Caches/com.mojang.minecraftlauncherupdater",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/minecraftpe.rb
+++ b/Casks/m/minecraftpe.rb
@@ -28,4 +28,8 @@ cask "minecraftpe" do
     "~/Library/Saved Application State/com.microsoft.minecraftpe.savedState",
     "~/Library/WebKit/com.microsoft.minecraftpe",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/minishift.rb
+++ b/Casks/m/minishift.rb
@@ -9,4 +9,8 @@ cask "minishift" do
   binary "minishift-#{version}-darwin-amd64/minishift"
 
   zap trash: "~/.minishift"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/modelio.rb
+++ b/Casks/m/modelio.rb
@@ -11,4 +11,8 @@ cask "modelio" do
   app "Modelio #{version.major_minor}.app"
 
   zap trash: "~/.modelio"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mojibar.rb
+++ b/Casks/m/mojibar.rb
@@ -10,4 +10,8 @@ cask "mojibar" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "Mojibar-darwin-x64/Mojibar.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mongodbpreferencepane.rb
+++ b/Casks/m/mongodbpreferencepane.rb
@@ -10,4 +10,8 @@ cask "mongodbpreferencepane" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   prefpane "MongoDB.prefPane"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mongotron.rb
+++ b/Casks/m/mongotron.rb
@@ -21,4 +21,8 @@ cask "mongotron" do
     "~/Library/Application Support/Mongotron",
     "~/Library/Caches/Mongotron",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/multibit-hd.rb
+++ b/Casks/m/multibit-hd.rb
@@ -11,4 +11,8 @@ cask "multibit-hd" do
   app "MultiBit HD.app"
 
   uninstall quit: "com.install4j.6925-4794-5772-4956.24"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mumble.rb
+++ b/Casks/m/mumble.rb
@@ -25,4 +25,8 @@ cask "mumble" do
     "~/Library/Preferences/net.sourceforge.mumble.Mumble.plist",
     "~/Library/Saved Application State/net.sourceforge.mumble.Mumble.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/m/mumble@snapshot.rb
+++ b/Casks/m/mumble@snapshot.rb
@@ -29,4 +29,8 @@ cask "mumble@snapshot" do
     "~/Library/Preferences/net.sourceforge.mumble.Mumble.plist",
     "~/Library/Saved Application State/net.sourceforge.mumble.Mumble.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/natron.rb
+++ b/Casks/n/natron.rb
@@ -30,4 +30,8 @@ cask "natron" do
   end
 
   app "Natron.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/nfov.rb
+++ b/Casks/n/nfov.rb
@@ -17,4 +17,8 @@ cask "nfov" do
     "~/Library/Preferences/com.electron.nfov.plist",
     "~/Library/Saved Application State/com.electron.nfov.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/nocturn.rb
+++ b/Casks/n/nocturn.rb
@@ -10,4 +10,8 @@ cask "nocturn" do
   deprecate! date: "2024-01-11", because: :discontinued
 
   app "Nocturn-darwin-x64/Nocturn.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/nodeclipse.rb
+++ b/Casks/n/nodeclipse.rb
@@ -20,4 +20,8 @@ cask "nodeclipse" do
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/8183
   app "Eclipse.app", target: "Nodeclipse.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/nuclear.rb
+++ b/Casks/n/nuclear.rb
@@ -21,4 +21,8 @@ cask "nuclear" do
     "~/Library/Preferences/nuclear.plist",
     "~/Library/Saved Application State/nuclear.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/nuclino.rb
+++ b/Casks/n/nuclino.rb
@@ -21,4 +21,8 @@ cask "nuclino" do
     "~/Library/Logs/Nuclino",
     "~/Library/Preferences/com.nuclino.desktop.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/nulloy.rb
+++ b/Casks/n/nulloy.rb
@@ -16,4 +16,8 @@ cask "nulloy" do
   app "Nulloy.app"
 
   zap trash: "~/Library/Saved Application State/com.nulloy.savedState"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/oclint.rb
+++ b/Casks/o/oclint.rb
@@ -14,4 +14,8 @@ cask "oclint" do
   binary "oclint-#{version}/include/c++/v1", target: "#{HOMEBREW_PREFIX}/include/c++/v1"
   binary "oclint-#{version}/lib/clang", target: "#{HOMEBREW_PREFIX}/lib/clang"
   binary "oclint-#{version}/lib/oclint", target: "#{HOMEBREW_PREFIX}/lib/oclint"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/olive.rb
+++ b/Casks/o/olive.rb
@@ -20,4 +20,8 @@ cask "olive" do
     "~/Library/Preferences/com.*.Olive.plist",
     "~/Library/Preferences/olivevideoeditor.org",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openemu.rb
+++ b/Casks/o/openemu.rb
@@ -59,4 +59,8 @@ cask "openemu" do
     "~/Library/Preferences/org.openemu.VisualBoyAdvance.plist",
     "~/Library/Saved Application State/org.openemu.OpenEmu.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openemu@experimental.rb
+++ b/Casks/o/openemu@experimental.rb
@@ -36,4 +36,8 @@ cask "openemu@experimental" do
     "~/Library/Preferences/org.openemu.*.plist",
     "~/Library/Saved Application State/org.openemu.OpenEmu.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openmsx.rb
+++ b/Casks/o/openmsx.rb
@@ -9,4 +9,8 @@ cask "openmsx" do
   homepage "https://openmsx.org/"
 
   app "openMSX.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openoffice.rb
+++ b/Casks/o/openoffice.rb
@@ -43,4 +43,8 @@ cask "openoffice" do
   app "OpenOffice.app"
 
   zap trash: "~/Library/Application Support/OpenOffice"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openpht.rb
+++ b/Casks/o/openpht.rb
@@ -14,4 +14,8 @@ cask "openpht" do
     "~/Library/Logs/OpenPHT.log",
     "~/Library/Saved Application State/tv.openpht.openpht.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/opensesame.rb
+++ b/Casks/o/opensesame.rb
@@ -19,4 +19,8 @@ cask "opensesame" do
     "~/.opensesame",
     "~/Library/Preferences/com.cogscinl.default.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openshot-video-editor.rb
+++ b/Casks/o/openshot-video-editor.rb
@@ -23,4 +23,8 @@ cask "openshot-video-editor" do
     "~/Library/Application Support/openshot",
     "~/Library/Preferences/openshot-qt.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/openshot-video-editor@daily.rb
+++ b/Casks/o/openshot-video-editor@daily.rb
@@ -26,4 +26,8 @@ cask "openshot-video-editor@daily" do
     "~/Library/Application Support/openshot",
     "~/Library/Preferences/openshot-qt.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/operator.rb
+++ b/Casks/o/operator.rb
@@ -20,4 +20,8 @@ cask "operator" do
     "~/Library/Preferences/com.prelude.operator.plist",
     "~/Library/Saved Application State/com.prelude.operator.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/origin.rb
+++ b/Casks/o/origin.rb
@@ -24,4 +24,8 @@ cask "origin" do
     "~/Library/LaunchAgents/com.ea.origin.WebHelper.plist",
     "~/Library/Saved Application State/com.ea.Origin.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/oss-browser.rb
+++ b/Casks/o/oss-browser.rb
@@ -22,4 +22,8 @@ cask "oss-browser" do
     "~/Library/Preferences/com.electron.oss-browser.plist",
     "~/Library/Saved Application State/com.electron.oss-browser.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/o/osxfuse.rb
+++ b/Casks/o/osxfuse.rb
@@ -30,6 +30,7 @@ cask "osxfuse" do
 
   caveats do
     reboot
+    requires_rosetta
     <<~EOS
       `#{token}` has been succeeded by `macfuse` as of version 4.0.0.
 

--- a/Casks/p/pd-l2ork.rb
+++ b/Casks/p/pd-l2ork.rb
@@ -26,4 +26,8 @@ cask "pd-l2ork" do
     "~/Library/Logs/Purr-Data",
     "~/Library/Purr-Data",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/plex-media-player.rb
+++ b/Casks/p/plex-media-player.rb
@@ -22,6 +22,7 @@ cask "plex-media-player" do
   ]
 
   caveats do
+    requires_rosetta
     <<~EOS
       #{token} has been deprecated in favor of Plex for Desktop and Plex HTPC.
 

--- a/Casks/p/plover.rb
+++ b/Casks/p/plover.rb
@@ -18,8 +18,11 @@ cask "plover" do
 
   zap trash: "~/Library/Application Support/plover/"
 
-  caveats <<~EOS
-    Version 4 is a major change and the configuration file it creates is not
-    compatible with Plover 3 or earlier. Please backup your plover.cfg.
-  EOS
+  caveats do
+    requires_rosetta
+    <<~EOS
+      Version 4 is a major change and the configuration file it creates is not
+      compatible with Plover 3 or earlier. Please backup your plover.cfg.
+    EOS
+  end
 end

--- a/Casks/p/polkadot-js.rb
+++ b/Casks/p/polkadot-js.rb
@@ -33,4 +33,8 @@ cask "polkadot-js" do
     "~/Library/Preferences/com.polkadotjs.polkadotjs-apps.plist",
     "~/Library/Saved Application State/com.polkadotjs.polkadotjs-apps.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/postbox.rb
+++ b/Casks/p/postbox.rb
@@ -29,4 +29,8 @@ cask "postbox" do
     "~/Library/Preferences/com.postbox-inc.postbox.plist",
     "~/Library/Saved Application State/com.postbox-inc.postbox.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/pronterface.rb
+++ b/Casks/p/pronterface.rb
@@ -23,4 +23,8 @@ cask "pronterface" do
   depends_on macos: ">= :big_sur"
 
   app "pronterface.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/protonmail-import-export.rb
+++ b/Casks/p/protonmail-import-export.rb
@@ -21,4 +21,8 @@ cask "protonmail-import-export" do
     "~/Library/Caches/protonmail/importExport",
     "~/Library/Preferences/com.protonmail.import-export.ProtonMail Import-Export app.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/psi-plus.rb
+++ b/Casks/p/psi-plus.rb
@@ -24,4 +24,8 @@ cask "psi-plus" do
     "~/Library/Caches/Psi+",
     "~/Library/Saved Application State/com.psi-plus.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/pyzo.rb
+++ b/Casks/p/pyzo.rb
@@ -11,4 +11,8 @@ cask "pyzo" do
   app "pyzo.app"
 
   zap trash: "~/Library/Application Support/pyzo"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qdslrdashboard.rb
+++ b/Casks/q/qdslrdashboard.rb
@@ -23,4 +23,8 @@ cask "qdslrdashboard" do
     "~/Library/Application Support/DslrDashboard/qDslrDashboard",
     "~/Library/Saved Application State/info.dslrdashboard.qDslrDashboard.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qownnotes.rb
+++ b/Casks/q/qownnotes.rb
@@ -22,4 +22,8 @@ cask "qownnotes" do
     "~/Library/Preferences/com.pbe.QOwnNotes.plist",
     "~/Library/Saved Application State/com.PBE.QOwnNotes.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qt-creator.rb
+++ b/Casks/q/qt-creator.rb
@@ -36,4 +36,8 @@ cask "qt-creator" do
     "~/Library/Preferences/org.qt-project.qtcreator.plist",
     "~/Library/Saved Application State/org.qt-project.qtcreator.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qt-creator@dev.rb
+++ b/Casks/q/qt-creator@dev.rb
@@ -32,4 +32,8 @@ cask "qt-creator@dev" do
     "~/Library/Preferences/org.qt-project.qtcreator.plist",
     "~/Library/Saved Application State/org.qt-project.qtcreator.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qt3dstudio.rb
+++ b/Casks/q/qt3dstudio.rb
@@ -22,4 +22,8 @@ cask "qt3dstudio" do
   installer manual: "qt-3dstudio-opensource-mac-x64-#{version}.app"
 
   uninstall delete: "~/Applications/qt3dstudio-#{version}"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qtox.rb
+++ b/Casks/q/qtox.rb
@@ -16,4 +16,8 @@ cask "qtox" do
     "~/Library/Preferences/chat.tox.qtox.plist",
     "~/Library/Saved Application State/chat.tox.qtox.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/q/qv2ray.rb
+++ b/Casks/q/qv2ray.rb
@@ -20,4 +20,8 @@ cask "qv2ray" do
     "~/Library/Preferences/qv2ray",
     "~/Library/Saved Application State/com.github.qv2ray.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/r/readmoreading.rb
+++ b/Casks/r/readmoreading.rb
@@ -20,4 +20,8 @@ cask "readmoreading" do
     "~/Library/Preferences/com.readmoo.electron.plist",
     "~/Library/Saved Application State/com.readmoo.electron.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/r/redream.rb
+++ b/Casks/r/redream.rb
@@ -18,4 +18,8 @@ cask "redream" do
     "~/Library/Application Support/redream",
     "~/Library/Saved Application State/io.recompiled.redream.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/r/retroarch.rb
+++ b/Casks/r/retroarch.rb
@@ -23,4 +23,8 @@ cask "retroarch" do
     "~/Library/Application Support/RetroArch",
     "~/Library/Saved Application State/com.libretro.RetroArch.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/r/robo-3t.rb
+++ b/Casks/r/robo-3t.rb
@@ -22,4 +22,8 @@ cask "robo-3t" do
     "~/Library/Saved Application State/com.3tsoftwarelabs.robo3t.savedState",
     "~/Library/Saved Application State/Robo 3T.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/r/rq.rb
+++ b/Casks/r/rq.rb
@@ -13,4 +13,8 @@ cask "rq" do
   end
 
   binary "rq"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/scala-ide.rb
+++ b/Casks/s/scala-ide.rb
@@ -22,4 +22,8 @@ cask "scala-ide" do
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/2731
   app "eclipse.app", target: "Scala IDE.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/scidvsmac.rb
+++ b/Casks/s/scidvsmac.rb
@@ -19,4 +19,8 @@ cask "scidvsmac" do
     "~/Library/Preferences/net.sf.scid.plist",
     "~/Library/Saved Application State/net.sf.scid.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/second-life-viewer.rb
+++ b/Casks/s/second-life-viewer.rb
@@ -25,4 +25,8 @@ cask "second-life-viewer" do
     "~/Library/Application Support/SecondLife",
     "~/Library/Caches/SecondLife",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/semeru-jdk-open@8.rb
+++ b/Casks/s/semeru-jdk-open@8.rb
@@ -21,4 +21,8 @@ cask "semeru-jdk-open@8" do
   uninstall pkgutil: "net.ibm-semeru-open.8.jdk"
 
   # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/sensiblesidebuttons.rb
+++ b/Casks/s/sensiblesidebuttons.rb
@@ -11,4 +11,8 @@ cask "sensiblesidebuttons" do
   app "SensibleSideButtons.app"
 
   zap trash: "~/Library/Preferences/net.archagon.sensible-side-buttons.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/sequel-pro.rb
+++ b/Casks/s/sequel-pro.rb
@@ -20,6 +20,7 @@ cask "sequel-pro" do
   ]
 
   caveats do
+    requires_rosetta
     <<~EOS
       #{token} has been deprecated in favor of Sequel Ace.
         brew install --cask sequel-ace

--- a/Casks/s/session.rb
+++ b/Casks/s/session.rb
@@ -21,4 +21,8 @@ cask "session" do
     "~/Library/Preferences/com.loki-project.messenger-desktop.plist",
     "~/Library/Saved Application State/com.loki-project.messenger-desktop.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/shades.rb
+++ b/Casks/s/shades.rb
@@ -12,4 +12,8 @@ cask "shades" do
   end
 
   prefpane "Shades Preferences.prefPane"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/shiba.rb
+++ b/Casks/s/shiba.rb
@@ -8,4 +8,8 @@ cask "shiba" do
   homepage "https://github.com/rhysd/Shiba/"
 
   app "Shiba-darwin-x64/Shiba.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/shiftit.rb
+++ b/Casks/s/shiftit.rb
@@ -18,4 +18,8 @@ cask "shiftit" do
     "~/Library/Caches/org.shiftitapp.ShiftIt",
     "~/Library/Preferences/org.shiftitapp.ShiftIt.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/sigdigger.rb
+++ b/Casks/s/sigdigger.rb
@@ -14,4 +14,8 @@ cask "sigdigger" do
   end
 
   app "SigDigger.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/singularity.rb
+++ b/Casks/s/singularity.rb
@@ -17,4 +17,8 @@ cask "singularity" do
   end
 
   app "SingularityAlpha.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/skychart.rb
+++ b/Casks/s/skychart.rb
@@ -24,4 +24,8 @@ cask "skychart" do
     "~/Library/Preferences/net.ap-i.skychart.plist",
     "~/Library/Saved Application State/net.ap-i.skychart.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/slippi-dolphin.rb
+++ b/Casks/s/slippi-dolphin.rb
@@ -19,4 +19,8 @@ cask "slippi-dolphin" do
     "~/Library/Application Support/Dolphin",
     "~/Library/Preferences/com.project-slippi.dolphin.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/socket-io-tester.rb
+++ b/Casks/s/socket-io-tester.rb
@@ -9,4 +9,8 @@ cask "socket-io-tester" do
   deprecate! date: "2023-12-17", because: :discontinued
 
   app "socket-io-tester-darwin-x64/socket-io-tester.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/spaceradar.rb
+++ b/Casks/s/spaceradar.rb
@@ -22,4 +22,8 @@ cask "spaceradar" do
     "~/Library/Preferences/com.electron.spaceradar.plist",
     "~/Library/Saved Application State/com.electron.spaceradar.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/sqlexplorer.rb
+++ b/Casks/s/sqlexplorer.rb
@@ -13,4 +13,8 @@ cask "sqlexplorer" do
   end
 
   app "SQLExplorer/sqlexplorer.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/steam.rb
+++ b/Casks/s/steam.rb
@@ -34,4 +34,8 @@ cask "steam" do
     "~/Library/Preferences/com.valvesoftware.steam.helper.plist",
     "~/Library/Saved Application State/com.valvesoftware.steam.savedState/",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/steamcmd.rb
+++ b/Casks/s/steamcmd.rb
@@ -40,4 +40,8 @@ cask "steamcmd" do
         "~/Library/Application Support/Steam",
         "~/Library/Application Support/Steam/logs",
       ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/steelseries-engine.rb
+++ b/Casks/s/steelseries-engine.rb
@@ -39,4 +39,8 @@ cask "steelseries-engine" do
     "~/Library/Preferences/com.steelseries.SteelSeries-Engine-#{version.major}.plist",
     "~/Library/Saved Application State/com.steelseries.ssenext.client.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/steelseries-gg.rb
+++ b/Casks/s/steelseries-gg.rb
@@ -44,4 +44,8 @@ cask "steelseries-gg" do
     "~/Library/Saved Application State/com.steelseries.gg.client.savedState",
     "~/Library/Saved Application State/com.steelseries.gg.uninstaller.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/studiolinkstandalone.rb
+++ b/Casks/s/studiolinkstandalone.rb
@@ -24,4 +24,8 @@ cask "studiolinkstandalone" do
   end
 
   app "StudioLinkStandalone.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/subsync.rb
+++ b/Casks/s/subsync.rb
@@ -26,4 +26,8 @@ cask "subsync" do
   end
 
   zap trash: "~/Library/Preferences/subsync/"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/swiftdefaultappsprefpane.rb
+++ b/Casks/s/swiftdefaultappsprefpane.rb
@@ -11,4 +11,8 @@ cask "swiftdefaultappsprefpane" do
   prefpane "SwiftDefaultApps.prefpane"
 
   # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/syncmate.rb
+++ b/Casks/s/syncmate.rb
@@ -14,4 +14,8 @@ cask "syncmate" do
   end
 
   app "SyncMate.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/s/synology-note-station-client.rb
+++ b/Casks/s/synology-note-station-client.rb
@@ -20,4 +20,8 @@ cask "synology-note-station-client" do
     "~/Library/Preferences/synology.note.station.plist",
     "~/Library/Saved Application State/synology.note.station.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/tachidesk-sorayomi.rb
+++ b/Casks/t/tachidesk-sorayomi.rb
@@ -15,4 +15,8 @@ cask "tachidesk-sorayomi" do
     "~/Library/Application Scripts/com.suwayomi.tachideskSorayomi",
     "~/Library/Containers/com.suwayomi.tachideskSorayomi",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/teambition.rb
+++ b/Casks/t/teambition.rb
@@ -20,4 +20,8 @@ cask "teambition" do
     "~/Library/Preferences/com.teambition.teambition.plist",
     "~/Library/Saved Application State/com.teambition.teambition.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/temurin@8.rb
+++ b/Casks/t/temurin@8.rb
@@ -26,4 +26,8 @@ cask "temurin@8" do
   uninstall pkgutil: "net.temurin.#{version.csv.first}.jdk"
 
   # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/texmaker.rb
+++ b/Casks/t/texmaker.rb
@@ -18,4 +18,8 @@ cask "texmaker" do
     "~/Library/Preferences/texmaker.plist",
     "~/Library/Saved Application State/texmaker.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/tla-plus-toolbox.rb
+++ b/Casks/t/tla-plus-toolbox.rb
@@ -14,4 +14,8 @@ cask "tla-plus-toolbox" do
   end
 
   app "TLA+ Toolbox.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/tortoisehg.rb
+++ b/Casks/t/tortoisehg.rb
@@ -16,4 +16,8 @@ cask "tortoisehg" do
   app "TortoiseHg.app"
 
   zap trash: "~/.config/tortoisehg.org"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/trilium-notes.rb
+++ b/Casks/t/trilium-notes.rb
@@ -20,4 +20,8 @@ cask "trilium-notes" do
     "~/Library/Preferences/com.electron.trilium-notes.plist",
     "~/Library/Saved Application State/com.electron.trilium-notes.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/t/tvrenamer.rb
+++ b/Casks/t/tvrenamer.rb
@@ -17,5 +17,6 @@ cask "tvrenamer" do
 
   caveats do
     depends_on_java
+    requires_rosetta
   end
 end

--- a/Casks/u/ubports-installer.rb
+++ b/Casks/u/ubports-installer.rb
@@ -21,4 +21,8 @@ cask "ubports-installer" do
     "~/Library/Preferences/com.ubports.installer.plist",
     "~/Library/Saved Application State/com.ubports.installer.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/u/udig.rb
+++ b/Casks/u/udig.rb
@@ -15,7 +15,7 @@ cask "udig" do
 
   caveats do
     depends_on_java "8"
-
+    requires_rosetta
     <<~EOS
       #{token} will fail to launch unless java 1.8 is installed as the system’s default. Point #{token} to java 1.8 by editing:
 

--- a/Casks/u/uncolored.rb
+++ b/Casks/u/uncolored.rb
@@ -14,4 +14,8 @@ cask "uncolored" do
   end
 
   app "Uncolored.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/u/unipro-ugene.rb
+++ b/Casks/u/unipro-ugene.rb
@@ -14,4 +14,8 @@ cask "unipro-ugene" do
     "~/Library/Preferences/com.unipro.UGENE.plist",
     "~/Library/Preferences/net.ugene.ugene.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/u/unity-hub.rb
+++ b/Casks/u/unity-hub.rb
@@ -23,4 +23,8 @@ cask "unity-hub" do
         "~/Library/Preferences/com.unity3d.unityhub.plist",
       ],
       rmdir: "/Applications/Unity/Hub"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/v2ray-unofficial.rb
+++ b/Casks/v/v2ray-unofficial.rb
@@ -18,4 +18,8 @@ cask "v2ray-unofficial" do
     "~/Library/Preferences/V2Ray-Desktop",
     "~/Library/Saved Application State/com.yourcompany.V2Ray-Desktop.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/vagrant-manager.rb
+++ b/Casks/v/vagrant-manager.rb
@@ -15,4 +15,8 @@ cask "vagrant-manager" do
     "~/Library/Caches/lanayo.Vagrant-Manager",
     "~/Library/Preferences/lanayo.Vagrant-Manager.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/valentina-studio.rb
+++ b/Casks/v/valentina-studio.rb
@@ -23,4 +23,8 @@ cask "valentina-studio" do
     "~/Library/Preferences/com.paradigmasoft.vstudio.plist",
     "~/Library/Saved Application State/com.paradigmasoft.vstudio.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/visualboyadvance-m.rb
+++ b/Casks/v/visualboyadvance-m.rb
@@ -19,4 +19,8 @@ cask "visualboyadvance-m" do
     "~/Library/Application Support/visualboyadvance-m",
     "~/Library/Preferences/visualboyadvance-m.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/vmpk.rb
+++ b/Casks/v/vmpk.rb
@@ -22,4 +22,8 @@ cask "vmpk" do
     "~/Library/Preferences/net.sourceforge.vmpk.VMPK.plist",
     "~/Library/Saved Application State/net.sourceforge.vmpk.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/vnote.rb
+++ b/Casks/v/vnote.rb
@@ -15,4 +15,8 @@ cask "vnote" do
     "~/Library/Preferences/com.vnotex.vnote.plist",
     "~/Library/Preferences/VNote",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/v/vox-preferences-pane.rb
+++ b/Casks/v/vox-preferences-pane.rb
@@ -16,4 +16,8 @@ cask "vox-preferences-pane" do
   prefpane "Vox Preferences.prefPane"
 
   zap trash: "~/Library/Preferences/com.coppertino.VoxPrefs.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/webcamoid.rb
+++ b/Casks/w/webcamoid.rb
@@ -27,4 +27,8 @@ cask "webcamoid" do
     "~/Library/Preferences/org.webcamoid.cmio.AkVCam.Assistant.plist",
     "~/Library/Saved Application State/com.webcamoidprj.webcamoid.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/weiyun.rb
+++ b/Casks/w/weiyun.rb
@@ -21,4 +21,8 @@ cask "weiyun" do
     "~/Library/Preferences/com.tencent.MacWeiyun.plist",
     "~/Library/Saved Application State/com.tencent.MacWeiyun.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/wey.rb
+++ b/Casks/w/wey.rb
@@ -18,4 +18,8 @@ cask "wey" do
     "~/Library/Saved Application State/org.yue.wey.savedState",
     "~/Library/WebKit/org.yue.wey",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/wine-stable.rb
+++ b/Casks/w/wine-stable.rb
@@ -70,4 +70,8 @@ cask "wine-stable" do
         "~/.local/share/icons",
         "~/.local/share/mime",
       ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/wine@devel.rb
+++ b/Casks/w/wine@devel.rb
@@ -74,4 +74,8 @@ cask "wine@devel" do
         "~/.local/share/icons",
         "~/.local/share/mime",
       ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/wine@staging.rb
+++ b/Casks/w/wine@staging.rb
@@ -74,4 +74,8 @@ cask "wine@staging" do
         "~/.local/share/icons",
         "~/.local/share/mime",
       ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/w/wombat.rb
+++ b/Casks/w/wombat.rb
@@ -10,4 +10,8 @@ cask "wombat" do
   app "Wombat.app"
 
   zap trash: "~/Library/Application Support/Wombat"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/x/xiaomi-cloud.rb
+++ b/Casks/x/xiaomi-cloud.rb
@@ -25,4 +25,8 @@ cask "xiaomi-cloud" do
     "~/Library/Preferences/micloud.pc.xiaomi.helper.plist",
     "~/Library/Preferences/micloud.pc.xiaomi.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/z/zecwallet-lite.rb
+++ b/Casks/z/zecwallet-lite.rb
@@ -16,4 +16,8 @@ cask "zecwallet-lite" do
     "~/Library/Application Support/Zcash/zecwallet-light-wallet.debug.log",
     "~/Library/Application Support/Zecwallet Lite",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/z/zotero.rb
+++ b/Casks/z/zotero.rb
@@ -24,4 +24,8 @@ cask "zotero" do
     "~/Library/Preferences/org.zotero.zotero.plist",
     "~/Library/Saved Application State/org.zotero.zotero.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Added the `requires_rosetta` caveat to many casks with only intel builds available. I'm sure I missed some but tried to cover the most popular and most obvious ones.

Methodologies used:
- grep for relevant `url` substrings such as: intel, x86, x64, amd64
- manual inspection via `file` command and Info box for apps

Potential issues: some casks might get updated in the future with arm builds so then a maintainer will need to notice and remove the caveat, especially for universal builds. Note in particular there are some casks with arm builds for development versions but not for the stable version.
- examples: beyond-compare (beta), virtualbox (beta), dolphin (beta/dev), retroarch/metal

Related problem: I identified some casks that are only built for 32-bit intel, so they do not work with Rosetta. Not sure what is the right way to handle these -- require intel arch? Can make a separate PR for this.
- examples: pgadmin3, nightingale, mame, gameranger