### PR TITLE
jtool2: deprecate

### DIFF
--- a/Casks/j/jtool2.rb
+++ b/Casks/j/jtool2.rb
@@ -8,9 +8,7 @@ cask "jtool2" do
   desc "Tool to help out reverse engineering, security researchers, and tweak developers"
   homepage "https://newosxbook.com/tools/jtool.html"
 
-  livecheck do
-    skip "version available by running `jtool2 --version` when installed"
-  end
+  deprecate! date: "2024-06-27", because: :discontinued
 
   binary "jtool2"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

jtool2 is no longer supported ([source](https://www.newosxbook.com/tools/jtool.html)).
