### PR TITLE
positron 2024.06.1-27 (new cask)

### DIFF
--- a/Casks/p/positron.rb
+++ b/Casks/p/positron.rb
@@ -1,0 +1,20 @@
+cask "positron" do
+  version "2024.06.1-27"
+  sha256 "74ae5bbcb6818dc3c6bbd41ce7a6e32ebef8aa67daa42eafbb4e059ab5d68caa"
+
+  url "https://github.com/posit-dev/positron/releases/download/#{version}/Positron-#{version}.dmg"
+  name "Positron"
+  desc "VScode-based data science IDE"
+  homepage "https://github.com/posit-dev/positron"
+
+  depends_on macos: ">= :catalina"
+
+  app "Positron.app"
+
+  zap trash: [
+    "~/.positron",
+    "~/Library/Application Support/Positron",
+    "~/Library/Preferences/com.rstudio.positron.plist",
+    "~/Library/Saved Application State/com.rstudio.positron.savedState",
+  ]
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -36,6 +36,7 @@
   "openshot-video-editor@daily": "all",
   "plugdata": "all",
   "pock": "all",
+  "positron": "all",
   "powershell@preview": "all",
   "profilecreator": "all",
   "qdesktop": "all",


### PR DESCRIPTION
add [Positron](https://github.com/posit-dev/positron) public preview

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Comments:

- [Positron](https://github.com/posit-dev/positron) is a new IDE that might eventually replace [RStudio](https://posit.co/products/open-source/rstudio/)

- brew audit warns that this is pre-release (so not ticking the checkboxes), but so is [rstudio@daily](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/r/rstudio%40daily.rb)
