### PR TITLE
bluegriffon: deprecate

### DIFF
--- a/Casks/b/bluegriffon.rb
+++ b/Casks/b/bluegriffon.rb
@@ -7,10 +7,11 @@ cask "bluegriffon" do
   desc "Web and EPUB editor"
   homepage "http://bluegriffon.org/"
 
-  livecheck do
-    url "http://bluegriffon.org/freshmeat/?C=M;O=D"
-    regex(%r{href=['"]?(\d+(?:\.\d+)+)/}i)
-  end
+  deprecate! date: "2024-06-28", because: :discontinued
 
   app "BlueGriffon.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

BlueGriffon has been discontinued ([source](http://bluegriffon.org/)).
