### PR TITLE
firefox@developer-edition: update download `url` and `livecheck`

### DIFF
--- a/Casks/f/firefox@developer-edition.rb
+++ b/Casks/f/firefox@developer-edition.rb
@@ -70,15 +70,17 @@ cask "firefox@developer-edition" do
     "zh-CN"
   end
 
-  url "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=osx&lang=#{language}"
+  url "https://download-installer.cdn.mozilla.net/pub/devedition/releases/#{version}/mac/#{language}/Firefox%20#{version}.dmg",
+      verified: "download-installer.cdn.mozilla.net/pub/devedition/releases/"
   name "Mozilla Firefox Developer Edition"
   desc "Web browser"
   homepage "https://www.mozilla.org/firefox/developer/"
 
   livecheck do
-    url "https://archive.mozilla.org/pub/devedition/releases/"
-    regex %r{href=.*?/releases/(\d+(?:\.\d+)+b?\d*)/}i
-    strategy :page_match
+    url "https://product-details.mozilla.org/1.0/firefox_versions.json"
+    strategy :json do |json|
+      json["FIREFOX_DEVEDITION"]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Follow-up to comments from @Bo98 to update the download url to be versioned, and use the `firefox_versions.json` file over scanning the releases page for the latest.