### PR TITLE
jettison 1.8.8: update sha256

### DIFF
--- a/Casks/j/jettison.rb
+++ b/Casks/j/jettison.rb
@@ -1,6 +1,6 @@
 cask "jettison" do
   version "1.8.8"
-  sha256 "29537fb43a753ad0091580f87515dc7601e7923ec1ac468a546a72bcdc93eb92"
+  sha256 "e8306aeb0fe3942c8b0ab4527682406f9ccb7c5605bf9b8004dee8ab255e4139"
 
   url "https://stclairsoft.com/download/Jettison-#{version}.dmg"
   name "Jettison"


### PR DESCRIPTION
Updated the sha256 value so it matches the new disk image file

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
