### PR TITLE
ghost-browser 2.3.0.4 (arm)

### DIFF
--- a/Casks/g/ghost-browser.rb
+++ b/Casks/g/ghost-browser.rb
@@ -17,7 +17,7 @@ cask "ghost-browser" do
   homepage "https://ghostbrowser.com/"
 
   livecheck do
-    url "http://ghostbrowser.s3.amazonaws.com/updates/macosx/manifest#{arch}"
+    url "https://ghostbrowser.s3.amazonaws.com/updates/macosx/manifest#{arch}"
     regex(/^(\d+(?:\.\d+)+)\n/i)
   end
 

--- a/Casks/g/ghost-browser.rb
+++ b/Casks/g/ghost-browser.rb
@@ -1,19 +1,27 @@
 cask "ghost-browser" do
   arch arm: "_arm64"
 
-  version "2.3.0.3"
-  sha256 arm:   "9e74fc6416df60f7dea22e14d41ab0670d11304a1b3ba4e9d6b6e5d33935d304",
+  sha256 arm:   "60c2d73bab0784b69675697e1a233a5021419b7431156da256758e9344b9662e",
          intel: "63dc9782cdadd80f240071385d4698acd4fd69bf3bec8a0a768a65188de32046"
+
+  on_arm do
+    version "2.3.0.4"
+  end
+  on_intel do
+    version "2.3.0.3"
+  end
 
   url "https://downloads.ghostbrowser.com/GhostBrowser-#{version}#{arch}.dmg"
   name "Ghost Browser"
   desc "Web browser"
-  homepage "https://ghostbrowser.com/download/"
+  homepage "https://ghostbrowser.com/"
 
   livecheck do
-    url "https://ghostbrowser.s3.amazonaws.com/updates/changelog.html"
-    regex(/>\s*Version\s*(\d+(?:\.\d+)+)/i)
+    url "http://ghostbrowser.s3.amazonaws.com/updates/macosx/manifest#{arch}"
+    regex(/^(\d+(?:\.\d+)+)\n/i)
   end
+
+  auto_updates true
 
   app "Ghost Browser.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Check the manifest from the in-app updater. The intel and arm versions are currently out of sync. Update the `homepage` to point to the actual homepage, not the download page.