### PR TITLE
Update ARM image checksum for Ueli

### DIFF
--- a/Casks/u/ueli.rb
+++ b/Casks/u/ueli.rb
@@ -3,7 +3,7 @@ cask "ueli" do
 
   version "9.0.1"
   sha256 intel: "4c17bdee3365ebd76801fbfbc45e9895119aeff604f53059cba2d930c9ed3b5d",
-         arm:   "3ea010fe3d8d7c91c310bc601260cb4f7bc33ad647039657da0d33ce3ff4d60a"
+         arm:   "7e81deb4815f7d9b4904ca02572202ca0d5af6da3f356d49606ead43d72f75cb"
 
   url "https://github.com/oliverschwendener/ueli/releases/download/v#{version}/Ueli-#{version}#{arch}.dmg",
       verified: "github.com/oliverschwendener/ueli/"


### PR DESCRIPTION
[Ueli 9.0.1](https://github.com/oliverschwendener/ueli/releases/tag/v9.0.1) release has updated ARM macOS binaries without incrementing the release number.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
