### PR TITLE
fix putio-adder shasum

### DIFF
--- a/Casks/p/putio-adder.rb
+++ b/Casks/p/putio-adder.rb
@@ -1,6 +1,6 @@
 cask "putio-adder" do
   version "3.0.5"
-  sha256 "58a772804ea8509e302376838c9ed71f8b3820263843cb65421ec8bfebd5092e"
+  sha256 "0a95a144a2ff43dc8d3bd34229235c6efcc194b20812ce1c1dd2987d709c83a5"
 
   url "https://github.com/nicoSWD/put.io-adder/releases/download/v#{version}/put.io-adder-v#{version}.zip"
   name "Put.IO Adder"


### PR DESCRIPTION
Installing/upgrading this leads to:

```
==> Upgrading 1 outdated package:
putio-adder 3.0.4 -> 3.0.5
==> Upgrading putio-adder
==> Downloading https://github.com/nicoSWD/put.io-adder/releases/download/v3.0.5/put.io-adder-v3.0.5.zip
Already downloaded: /Users/jan/Library/Caches/Homebrew/downloads/2c68843b57f1b306940695c46c0807186476795bccae61f3b9d13fb93ee4dc99--put.io-adder-v3.0.5.zip
==> Purging files for version 3.0.5 of Cask putio-adder
Error: putio-adder: SHA256 mismatch
Expected: 58a772804ea8509e302376838c9ed71f8b3820263843cb65421ec8bfebd5092e
  Actual: 0a95a144a2ff43dc8d3bd34229235c6efcc194b20812ce1c1dd2987d709c83a5
    File: /Users/jan/Library/Caches/Homebrew/downloads/2c68843b57f1b306940695c46c0807186476795bccae61f3b9d13fb93ee4dc99--put.io-adder-v3.0.5.zip
To retry an incomplete download, remove the file above.
```

The shasum either was never correct or got updated on the host after the [previous PR](https://github.com/Homebrew/homebrew-cask/pull/175639/files):

```
curl -s https://github.com/nicoSWD/put.io-adder/releases/download/v3.0.5/put.io-adder-v3.0.5.zip -Lo - | shasum -a 256
0a95a144a2ff43dc8d3bd34229235c6efcc194b20812ce1c1dd2987d709c83a5  -
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

