### PR TITLE
botc 3.29.0 (new cask)

### DIFF
--- a/Casks/b/botc.rb
+++ b/Casks/b/botc.rb
@@ -1,0 +1,25 @@
+cask "botc" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "3.29.0"
+  sha256 arm:   "36ec407dccc09d01851f317a2069d427663014dc636bdaf2628c8cbbcbd66af5",
+         intel: "3bfdfdbd7fe2277263e57fd1c27e55caf59d79385aa955a52f0c8a077add7d58"
+
+  url "https://github.com/ThePandemoniumInstitute/botc-release/releases/download/v#{version}/Blood.on.the.Clocktower.Online_#{version}_#{arch}.dmg",
+      verified: "github.com/ThePandemoniumInstitute/botc-release/"
+  name "Blood on the Clocktower Online"
+  desc "Online client for the popular social deduction game Blood on the Clocktower"
+  homepage "https://bloodontheclocktower.com/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Blood on the Clocktower Online.app"
+
+  zap trash: [
+    "~/Library/Application Support/botc-app",
+    "~/Library/Application Support/com.thepandemoniuminstitute.botc.app",
+    "~/Library/Caches/com.thepandemoniuminstitute.botc.app",
+    "~/Library/Saved Application State/com.thepandemoniuminstitute.botc.app.savedState",
+    "~/Library/WebKit/com.thepandemoniuminstitute.botc.app",
+  ]
+end


### PR DESCRIPTION
Adding a cask for blood on the clocktower (botc)

This *fails* the audit due to the repository not having enough stars/watches. This software is an online client for a very popular social deduction game called blood on the clocktower and is available at https://botc.app and given a lot of people use the web app it makes sense that this distribution isn't as watched. 

I was also a little unsure if being on the official cask was suitable for a game like this, but after looking at other software I thought I would give it a try. 

I submitted after failing the audit due to it possibly falling under the definitions here https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold

BOTC was chosen over blood on the clocktower as it is closer to the website url. 

Happy to hear any and all feedback, even if it is just a "Nope, this should be on a third party tap"



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
