### PR TITLE
k8studio 1.0.11-beta (new cask)

### DIFF
--- a/Casks/k/k8studio.rb
+++ b/Casks/k/k8studio.rb
@@ -1,0 +1,32 @@
+cask "k8studio" do
+  arch arm: "-arm64"
+
+  version "1.0.11-beta"
+  sha256 arm:   "77f5e0b4fb2d74070ef9b3a8d55e11fed326e9a4941ae855272a412983bd843b",
+         intel: "c78651df1b92abd9a55dfb4c89129d046b04d19cda634759af204c59b102373e"
+
+  url "https://github.com/guiqui/k8Studio/releases/download/v#{version}/K8Studio-#{version}#{arch}.dmg",
+      verified: "github.com/guiqui/k8Studio/"
+  name "K8studio"
+  desc "Kubernetes GUI"
+  homepage "https://k8studio.io/"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?k8studio[._-]v?(\d+(?:\.\d+)+(?:[._-]beta)?)\.dmg/i)
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "K8Studio.app"
+
+  zap trash: [
+    "~/Library/Application Support/K8Studio",
+    "~/Library/Caches/ide.k8studio.io",
+    "~/Library/Caches/ide.k8studio.io.ShipIt",
+    "~/Library/Caches/k8studio-updater",
+    "~/Library/Logs/K8Studio",
+    "~/Library/Preferences/ide.k8studio.io.plist",
+    "~/Library/Saved Application State/ide.k8studio.io.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
### Add K8studio Cask

**Cask details:**

- **Name:** K8studio
- **Version:** 1.0.11
- **Description:** K8studio Kubernetes GUI
- **Homepage:** https://k8studio.io

**Notes:**

This Cask includes conditional logic to handle both Intel and ARM architectures, ensuring users on both platforms can install the appropriate version of K8studio.
