### PR TITLE
dolphin 2407

### DIFF
--- a/Casks/d/dolphin.rb
+++ b/Casks/d/dolphin.rb
@@ -1,15 +1,15 @@
 cask "dolphin" do
-  version "5.0"
-  sha256 "1e7127cf9b110c5d7feabc0d05f620bad31d0f47a1d16e1f46e2e402d0ec233c"
+  version "2407"
+  sha256 "bc9e4646c71f653874b2c17c0261475f0caaae8b50886300927c521c2843694c"
 
-  url "https://dl-mirror.dolphin-emu.org/#{version}/dolphin-#{version}.dmg"
+  url "https://dl.dolphin-emu.org/releases/#{version}/dolphin-#{version}-universal.dmg"
   name "Dolphin"
   desc "Emulator to play GameCube and Wii games"
   homepage "https://dolphin-emu.org/"
 
   livecheck do
     url "https://dolphin-emu.org/download/"
-    regex(/href=.*?dolphin[._-]v?(\d+(?:\.\d+)+)(?:[._-]universal)?\.dmg/i)
+    regex(/href=.*?dolphin[._-]v?(\d+(?:\.\d+)*)(?:[._-]universal)?\.dmg/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

@EricFromCanada mentioned that Dolphin has switched to a [rolling release cycle](https://dolphin-emu.org/blog/2024/07/02/dolphin-releases-announcement/) going forward and they will now be using versions like 2407 instead of 5.0. This updates `dolphin` to 2407 and tweaks the `livecheck` block regex to match the new version format.

Based on our [internal] discussion, `dolphin@beta` shouldn't be necessary going forward (as upstream has replaced beta builds with releases). From the upstream announcement:

> Beta builds are being replaced by releases. All users in the beta update track will be moved to the new release track.

Do we have a way of migrating `dolphin@beta` users to `dolphin` (e.g., would a cask rename be appropriate)?