### PR TITLE
dolphin: update livecheck

### DIFF
--- a/Casks/d/dolphin.rb
+++ b/Casks/d/dolphin.rb
@@ -9,7 +9,7 @@ cask "dolphin" do
 
   livecheck do
     url "https://dolphin-emu.org/download/"
-    regex(/href=.*?dolphin[._-]v?(\d+(?:\.\d+)*)(?:[._-]universal)?\.dmg/i)
+    regex(/href=.*?dolphin[._-]v?(\d+(?:\.\d+)*[a-z]?)(?:[._-]universal)?\.dmg/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I recently updated the `dolphin` cask's `livecheck` block (#178353) to handle the new version format but I overlooked [the bit about an optional hotfix suffix](https://dolphin-emu.org/blog/2024/07/02/dolphin-releases-announcement/#announcement):

> Hotfix releases will have the addition of a suffix. For example, a
> single hotfix to Dolphin 2409 would be "Dolphin 2409a".

This updates the `livecheck` block regex to account for an optional suffix character like `2409a`.