### PR TITLE
quickhue: deprecate

### DIFF
--- a/Casks/q/quickhue.rb
+++ b/Casks/q/quickhue.rb
@@ -7,10 +7,7 @@ cask "quickhue" do
   desc "Menu bar utility for controlling the Philips Hue lighting system"
   homepage "https://github.com/danparsons/QuickHue"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-04", because: :discontinued
 
   app "QuickHue.app"
 
@@ -19,4 +16,8 @@ cask "quickhue" do
     "~/Library/Caches/cat.moo.QuickHue",
     "~/Library/Preferences/cat.moo.QuickHue.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app is no longer up-to-date as per the author ([source](https://github.com/danparsons/QuickHue/issues/8)) and has not seen updates since then.

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
