### PR TITLE
dwgsee: disable

### DIFF
--- a/Casks/d/dwgsee.rb
+++ b/Casks/d/dwgsee.rb
@@ -7,10 +7,7 @@ cask "dwgsee" do
   desc "DWG viewer and editor"
   homepage "https://www.dwgsee.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-07-05", because: :no_longer_available
 
   app "DWGSee.app"
 end


### PR DESCRIPTION
Upstream no longer appears to be serving a valid macOS application.