### PR TITLE
zoho-workdrive: update livecheck

### DIFF
--- a/Casks/z/zoho-workdrive.rb
+++ b/Casks/z/zoho-workdrive.rb
@@ -1,6 +1,6 @@
 cask "zoho-workdrive" do
   version "2.7.39"
-  sha256 :no_check
+  sha256 "59eb1d050fd5dea1e05c6cb422c1f8ab2fccc3ce68bd404362425759584f704e"
 
   url "https://files-accl.zohopublic.com/public/wdbin/download/46f971e4fc4a32b68ad5d7dade38a7d2",
       verified: "files-accl.zohopublic.com/"
@@ -9,8 +9,17 @@ cask "zoho-workdrive" do
   homepage "https://www.zoho.com/workdrive/desktop-sync.html"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://teamsync.zoho.com/wd/checksum"
+    strategy :json do |json|
+      checksum_match = json["mac"]
+      next if checksum_match.blank?
+
+      cask = CaskLoader.load(__FILE__)
+      next cask.version if cask.sha256 == checksum_match
+
+      url = cask.url.to_s
+      Homebrew::Livecheck::Strategy::ExtractPlist.find_versions(cask:, url:)[:matches].values
+    end
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Zoho WorkDrive does not seem to publish any version information, only the checksum for the binary.

This proposal reduces the effective use of the `ExtractPlist` strategy except for actual version bumps. However, this would require using the `sha256` stanza without a versioned `url`, which seems to fail the audit.

I am looking forward to your thoughts on this.

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
