### PR TITLE
routeconverter: update livecheck, use versioned url

### DIFF
--- a/Casks/r/routeconverter.rb
+++ b/Casks/r/routeconverter.rb
@@ -1,17 +1,15 @@
 cask "routeconverter" do
-  version "3.0.379"
-  sha256 :no_check
+  version "3.0"
+  sha256 "308d86626c30d24456dbca433610d0785ab946990d46f84756121b21f4961cb2"
 
-  url "https://static.routeconverter.com/download/RouteConverterMac.app.zip"
+  url "https://static.routeconverter.com/download/previous-releases/#{version}/RouteConverterMacOpenSource.app.zip"
   name "RouteConverter"
   desc "GPS tool to display, edit, enrich and convert routes, tracks and waypoints"
   homepage "https://www.routeconverter.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist do |versions|
-      versions.values.filter_map(&:short_version).first
-    end
+    url "https://static.routeconverter.com/download/previous-releases/"
+    regex(/href=.*?v?(\d+(?:\.\d+)+)/i)
   end
 
   auto_updates true
@@ -19,4 +17,8 @@ cask "routeconverter" do
   app "RouteConverter.app"
 
   zap trash: "~/.routeconverter"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The download path is `previous-releases,` but the `CFBundleShortVersionString` of the latest release corresponds to the currently extracted version String.

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
