### PR TITLE
8x8-work: add `requires_rosetta`, update `depends_on` min OS

### DIFF
--- a/Casks/8/8x8-work.rb
+++ b/Casks/8/8x8-work.rb
@@ -12,9 +12,13 @@ cask "8x8-work" do
     regex(/work[._-]dmg[._-]v(\d+(?:[.-]\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "8x8 Work.app"
 
   zap trash: "~/Library/Application Support/8x8 Work"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Add `requires_rosetta` to the Cask, and updates the minimum required OS in the `depends_on` stanza.