### PR TITLE
continuity-activation-tool: deprecate

### DIFF
--- a/Casks/c/continuity-activation-tool.rb
+++ b/Casks/c/continuity-activation-tool.rb
@@ -7,12 +7,7 @@ cask "continuity-activation-tool" do
   desc "Enable continuity features on compatible hardware"
   homepage "https://github.com/dokterdok/Continuity-Activation-Tool/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["org.dokterdok.ContinuityActivationTool"].short_version
-    end
-  end
+  deprecate! date: "2024-07-06", because: :unmaintained
 
   app "Continuity-Activation-Tool-master/Continuity Activation Tool.app"
 end


### PR DESCRIPTION
Application has not seen any updates since 2016, has not moved from version 1.0, and is unsigned.