### PR TITLE
pokemon-trading-card-game-online: disable

### DIFF
--- a/Casks/p/pokemon-trading-card-game-online.rb
+++ b/Casks/p/pokemon-trading-card-game-online.rb
@@ -8,10 +8,7 @@ cask "pokemon-trading-card-game-online" do
   desc "Play the Pokemon TCG online"
   homepage "https://www.pokemon.com/us/pokemon-tcg/play-online/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-07-07", because: :no_longer_available
 
   app "Pokemon Trading Card Game Online.app"
 
@@ -20,4 +17,8 @@ cask "pokemon-trading-card-game-online" do
     "~/Library/Caches/com.plausiblelabs.crashreporter.data/unity.The Pokémon Company International.Pokemon Trading Card Game Online",
     "~/Library/Preferences/unity.The Pokémon Company International.Pokemon Trading Card Game Online.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app is superseded by `pokemon-tcg-live` ([source](https://www.pokemon.com/us/pokemon-news/pokemon-trading-card-game-online-will-sunset-on-june-5)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
