### PR TITLE
cmd/*: fix `cmd_args` usage

### DIFF
--- a/cmd/find-appcast.rb
+++ b/cmd/find-appcast.rb
@@ -14,17 +14,15 @@ module Homebrew
   module Cmd
     class FindAppcastCmd < AbstractCommand
       cmd_args do
-        Homebrew::CLI::Parser.new do
-          usage_banner <<~EOS
-            `find-appcast` <app_path>
+        usage_banner <<~EOS
+          `find-appcast` <app_path>
 
-            Finds the appcast for a given app when a path is provided to the .app bundle.
-          EOS
+          Finds the appcast for a given app when a path is provided to the .app bundle.
+        EOS
 
-          named_args :app_path, min: 1
+        named_args :app_path, min: 1
 
-          hide_from_man_page!
-        end
+        hide_from_man_page!
       end
 
       sig { override.void }

--- a/cmd/font-casker.rb
+++ b/cmd/font-casker.rb
@@ -8,17 +8,15 @@ module Homebrew
   module Cmd
     class FontCaskerCmd < AbstractCommand
       cmd_args do
-        Homebrew::CLI::Parser.new do
-          usage_banner <<~EOS
-            `font-casker` <archive_path>
+        usage_banner <<~EOS
+          `font-casker` <archive_path>
 
-            Generates cask stanzas from OTF/TTF files within <archive_path>.
-          EOS
+          Generates cask stanzas from OTF/TTF files within <archive_path>.
+        EOS
 
-          named_args :archive_path, min: 1, max: 1
+        named_args :archive_path, min: 1, max: 1
 
-          hide_from_man_page!
-        end
+        hide_from_man_page!
       end
 
       FONT_EXT_PATTERN = /.(otf|ttf)\Z/i


### PR DESCRIPTION
So that arguments to these commands can again be recognised properly.

See also: https://github.com/Homebrew/homebrew-core/pull/176608

Better viewed with https://github.com/Homebrew/homebrew-cask/pull/178806/files?w=1 (whitespace changes hidden).
