### PR TITLE
logmein-hamachi: deprecate

### DIFF
--- a/Casks/l/logmein-hamachi.rb
+++ b/Casks/l/logmein-hamachi.rb
@@ -8,12 +8,7 @@ cask "logmein-hamachi" do
   desc "Hosted VPN service that lets you securely extend LAN-like networks"
   homepage "https://vpn.net/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.logmein.hamachiinstaller"].short_version
-    end
-  end
+  deprecate! date: "2024-07-07", because: :unmaintained
 
   installer manual: "LogMeInHamachiInstaller.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app is unsupported on recent macOS versions ([source](https://community.logmein.com/t5/Hamachi-Discussions/Hamachi-vpn-app-won-t-start-on-macOS-with-M2-processor-How-can-I/m-p/300493/highlight/true#M20385)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
