### PR TITLE
mullvadvpn: Cleanup shell completions

### DIFF
--- a/Casks/m/mullvadvpn.rb
+++ b/Casks/m/mullvadvpn.rb
@@ -23,6 +23,9 @@ cask "mullvadvpn" do
             delete:    [
               "/Library/Caches/mullvad-vpn",
               "/Library/LaunchDaemons/net.mullvad.daemon.plist",
+              "/opt/homebrew/share/fish/vendor_completions.d/mullvad.fish",
+              "/usr/local/share/fish/vendor_completions.d/mullvad.fish",
+              "/usr/local/share/zsh/site-functions/_mullvad",
               "/var/log/mullvad-vpn",
             ]
 


### PR DESCRIPTION
After uninstalling Mullvad VPN, it leaves behind invalid symlinks for zsh and fish shell completions. The linked file in the `Mullvad VPN.app` is deleted but the symlink is not. This causes errors when running compinit in zsh

<details><summary>Error in compinit</summary>
<p>

`compinit:527: no such file or directory: /usr/local/share/zsh/site-functions/_mullvad`

</p>
</details> 

I have created a bug in mullvad's repo as well, I dunno if they can fix it on their side if the app is installed/uninstalled with brew https://github.com/mullvad/mullvadvpn-app/issues/6450

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

