### PR TITLE
seadrive 3.0.10

### DIFF
--- a/Casks/s/seadrive.rb
+++ b/Casks/s/seadrive.rb
@@ -1,19 +1,38 @@
 cask "seadrive" do
-  version "2.0.26"
-  sha256 "e43c5711510f578be9346e09bd35df8926cd4eb980330acf2d266d7cf70aff22"
+  on_monterey :or_newer do
+    version "3.0.10"
+    sha256 "efd129f10cb34b7349889363484670f204ab47728ce979d36661b180ce52c578"
 
-  url "https://download.seadrive.org/seadrive-#{version}.dmg",
-      verified: "download.seadrive.org/"
+    url "https://download.seadrive.org/seadrive-#{version}.pkg",
+        verified: "download.seadrive.org/"
+
+    livecheck do
+      url "https://www.seafile.com/en/download/"
+      regex(%r{href=.*?/seadrive[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+    end
+
+    pkg "seadrive-#{version}.pkg"
+
+    # TODO: : add unistall stanza
+  end
+  on_ventura :or_older do
+    version "2.0.26"
+    sha256 "e43c5711510f578be9346e09bd35df8926cd4eb980330acf2d266d7cf70aff22"
+
+    url "https://download.seadrive.org/seadrive-#{version}.dmg",
+        verified: "download.seadrive.org/"
+
+    livecheck do
+      url "https://www.seafile.com/en/download/"
+      regex(%r{href=.*?/seadrive[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    end
+
+    app "SeaDrive.app"
+  end
+
   name "Seadrive"
   desc "Manual for Seafile server"
   homepage "https://www.seafile.com/en/home/"
 
-  livecheck do
-    url "https://www.seafile.com/en/download/"
-    regex(%r{href=.*?/seadrive[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   depends_on macos: ">= :high_sierra"
-
-  app "SeaDrive.app"
 end


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online seadrive` is error-free.
- [x] `brew style --fix seadrive` reports no offenses.

- [ ] `brew uninstall --cask seadrive` worked successfully.

---

Update Seadrive Cask for MacOs Monterey and newer, as recommended at [seadrive.com](https://www.seafile.com/en/download/)

This is my first try to contribute to homebrew. I hope, that I did not make to many mistakes.

I did not manage to add the uninstall stanza and would be happy if someone could help me with that.
