### PR TITLE
mythic@alpha 0.3.1

### DIFF
--- a/Casks/m/mythic@alpha.rb
+++ b/Casks/m/mythic@alpha.rb
@@ -1,0 +1,23 @@
+cask "mythic@alpha" do
+  version "0.3.1"
+  sha256 "b6ca8a014b19730275a97b232a0fecbafc8d868e5a3cdcecd891966d878d9aae"
+
+  url "https://github.com/MythicApp/Mythic/releases/download/v#{version}/Mythic.zip",
+      verified: "github.com/MythicApp/Mythic/"
+  name "Mythic"
+  desc "Unique open-source game launcher with the ability to run Windows games"
+  homepage "https://getmythic.app/"
+
+  depends_on macos: ">= :sonoma"
+  depends_on arch: :arm64
+
+  app "Mythic.app"
+
+  zap trash: [
+    "~/Library/Application Support/Mythic",
+    "~/Library/Caches/xyz.blackxfiied.Mythic.plist",
+    "~/Library/HTTPStorages/xyz.blackxfiied.Mythic",
+    "~/Library/HTTPStorages/xyz.blackxfiied.Mythic.binarycookies",
+    "~/Library/Preferences/xyz.blackxfiied.Mythic.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Initial add of a relatively new open-source Epic Games-supporting launcher. There are some issues however when verifying a new cask listed below.

`brew audit --cask --online <cask>` and `brew audit --cask --new <cask>` return
```
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
audit for mythic@alpha: failed
 - exception while auditing mythic@alpha: Not Found
mythic@alpha
  * exception while auditing mythic@alpha: Not Found
Error: 1 problem in 1 cask detected.
```

`--verbose` flag adds nothing but `/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.3.3/bin/bundle clean` at the beginning of the output.