### PR TITLE
Crashplan 11.3.1 (new cask)

### DIFF
--- a/Casks/c/crashplan.rb
+++ b/Casks/c/crashplan.rb
@@ -1,0 +1,30 @@
+cask "crashplan" do
+  version "11.3.1,3"
+  sha256 "d4c1f96a7d207536f6a6877da717f282778610b7961fb41c60ccb467120ce5fc"
+
+  url "https://download.crashplan.com/installs/agent/cloud/#{version.csv.first}/#{version.csv.second}/install/CrashPlan_#{version.csv.first}_#{version.csv.second}_Mac.dmg"
+  name "CrashPlan"
+  desc "Backup and recovery software"
+  homepage "https://www.crashplan.com/"
+
+  livecheck do
+    skip "No version information available"
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  pkg "Install CrashPlan.pkg"
+
+  uninstall launchctl: "com.crashplan.engine",
+            quit:      "com.crashplan.app",
+            script:    {
+              executable: "Uninstall.app/Contents/Resources/uninstall.sh",
+              sudo:       true,
+            },
+            pkgutil:   "com.crashplan.app.pkg"
+
+  zap trash: [
+    "~/Library/Application Support/CrashPlan",
+    "~/Library/Preferences/com.crashplan.desktop.plist",
+  ]
+end

--- a/Casks/c/crashplan.rb
+++ b/Casks/c/crashplan.rb
@@ -8,7 +8,11 @@ cask "crashplan" do
   homepage "https://www.crashplan.com/"
 
   livecheck do
-    skip "No version information available"
+    url "https://download.crashplan.com/installs/agent/latest-mac.dmg"
+    strategy :header_match do |headers|
+      match = headers["location"].match(%r{/(\d+(?:\.\d+)+)/(\d+)/})
+      "#{match[1]},#{match[2]}" if match
+    end
   end
 
   depends_on macos: ">= :sonoma"

--- a/Casks/c/crashplan.rb
+++ b/Casks/c/crashplan.rb
@@ -9,9 +9,12 @@ cask "crashplan" do
 
   livecheck do
     url "https://download.crashplan.com/installs/agent/latest-mac.dmg"
-    strategy :header_match do |headers|
-      match = headers["location"].match(%r{/(\d+(?:\.\d+)+)/(\d+)/})
-      "#{match[1]},#{match[2]}" if match
+    regex(/CrashPlan[._-]v?(\d+(?:[._]\d+)+)/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      match[1].tr("_", ",")
     end
   end
 


### PR DESCRIPTION
This is the new Crashplan cloud app since the old "code42-crashplan" on-premise app was deprecated a while ago (#133123).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
