### PR TITLE
various casks: update livecheck to use json.dig

### DIFF
--- a/Casks/1/115.rb
+++ b/Casks/1/115.rb
@@ -12,7 +12,7 @@ cask "115" do
   livecheck do
     url "https://appversion.115.com/1/web/1.0/api/chrome"
     strategy :json do |json|
-      json["data"]["mac_115"]["version_code"]
+      json.dig("data", "mac_115", "version_code")
     end
   end
 

--- a/Casks/1/115browser.rb
+++ b/Casks/1/115browser.rb
@@ -14,7 +14,7 @@ cask "115browser" do
   livecheck do
     url "https://appversion.115.com/1/web/1.0/api/chrome"
     strategy :json do |json|
-      json["data"]["mac"]["version_code"]
+      json.dig("data", "mac", "version_code")
     end
   end
 

--- a/Casks/a/accurics.rb
+++ b/Casks/a/accurics.rb
@@ -14,7 +14,7 @@ cask "accurics" do
     url "https://www.tenable.com/downloads/api/v2/pages/cloud-security"
     regex(/Accurics\sv?(\d+(?:\.\d+)+)/i)
     strategy :json do |json|
-      json["releases"]["latest"].keys.map do |item|
+      json.dig("releases", "latest")&.keys&.map do |item|
         item.match(regex) { |match| match[1] }
       end
     end

--- a/Casks/a/audiorelay.rb
+++ b/Casks/a/audiorelay.rb
@@ -24,4 +24,8 @@ cask "audiorelay" do
     "~/Library/Logs/AudioRelay",
     "~/Library/Preferences/com.azefsw.audioconnect.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/a/audiorelay.rb
+++ b/Casks/a/audiorelay.rb
@@ -10,7 +10,7 @@ cask "audiorelay" do
   livecheck do
     url "https://api.audiorelay.net/Downloads"
     strategy :json do |json|
-      json["macOs"]["version"]
+      json.dig("macOs", "version")
     end
   end
 

--- a/Casks/b/boop.rb
+++ b/Casks/b/boop.rb
@@ -11,7 +11,7 @@ cask "boop" do
   livecheck do
     url "https://boop.okat.best/version.json"
     strategy :json do |json|
-      json["standalone"]["version"]
+      json.dig("standalone", "version")
     end
   end
 

--- a/Casks/b/burp-suite-professional.rb
+++ b/Casks/b/burp-suite-professional.rb
@@ -14,7 +14,7 @@ cask "burp-suite-professional" do
   livecheck do
     url "https://portswigger.net/burp/releases/data"
     strategy :json do |json|
-      all_versions = json["ResultSet"]["Results"]
+      all_versions = json.dig("ResultSet", "Results")
       next if all_versions.blank?
 
       all_versions.filter_map do |item|

--- a/Casks/b/burp-suite.rb
+++ b/Casks/b/burp-suite.rb
@@ -14,7 +14,7 @@ cask "burp-suite" do
   livecheck do
     url "https://portswigger.net/burp/releases/data"
     strategy :json do |json|
-      all_versions = json["ResultSet"]["Results"]
+      all_versions = json.dig("ResultSet", "Results")
       next if all_versions.blank?
 
       all_versions.filter_map do |item|

--- a/Casks/c/carbide-create.rb
+++ b/Casks/c/carbide-create.rb
@@ -11,7 +11,7 @@ cask "carbide-create" do
   livecheck do
     url "https://carbide-downloads.website-us-east-1.linodeobjects.com/builds.json"
     strategy :json do |json|
-      json["cc"]["stable"]["osx"]["build"].to_s
+      json.dig("cc", "stable", "osx", "build")&.to_s
     end
   end
 

--- a/Casks/c/chromedriver.rb
+++ b/Casks/c/chromedriver.rb
@@ -15,7 +15,7 @@ cask "chromedriver" do
     url "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
     regex(/v?(\d+(?:\.\d+)+)/i)
     strategy :json do |json, regex|
-      json["channels"]["Stable"]["version"]&.scan(regex) { |match| match[0] }
+      json.dig("channels", "Stable", "version")&.scan(regex) { |match| match[0] }
     end
   end
 

--- a/Casks/c/chromedriver@beta.rb
+++ b/Casks/c/chromedriver@beta.rb
@@ -15,7 +15,7 @@ cask "chromedriver@beta" do
     url "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
     regex(/v?(\d+(?:\.\d+)+)/i)
     strategy :json do |json, regex|
-      json["channels"]["Beta"]["version"]&.scan(regex) { |match| match[0] }
+      json.dig("channels", "Beta", "version")&.scan(regex) { |match| match[0] }
     end
   end
 

--- a/Casks/c/creality-slicer.rb
+++ b/Casks/c/creality-slicer.rb
@@ -23,4 +23,8 @@ cask "creality-slicer" do
     "~/Library/Preferences/com.creality.crealityslicer.plist",
     "~/Library/Saved Application State/com.creality.crealityslicer.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/c/creality-slicer.rb
+++ b/Casks/c/creality-slicer.rb
@@ -10,7 +10,7 @@ cask "creality-slicer" do
   livecheck do
     url "https://file-cdn.creality.com/ota-sz/crealityslicer/last.json"
     strategy :json do |json|
-      v = json["cura"]["Darwin"]
+      v = json.dig("cura", "Darwin")
       "#{v["major"]}.#{v["minor"]}.#{v["revision"]}"
     end
   end

--- a/Casks/e/epilogue-playback.rb
+++ b/Casks/e/epilogue-playback.rb
@@ -11,7 +11,7 @@ cask "epilogue-playback" do
   livecheck do
     url "https://www.epilogue.co/v2/api/update"
     strategy :json do |json|
-      v = json["operator-app"]["osx"]["version"]
+      v = json.dig("operator-app", "osx", "version")
       "#{v["major"]}.#{v["minor"]}.#{v["patch"]}"
     end
   end

--- a/Casks/f/fig.rb
+++ b/Casks/f/fig.rb
@@ -10,7 +10,7 @@ cask "fig" do
   livecheck do
     url "https://repo.fig.io/generic/stable/index.json"
     strategy :json do |json|
-      json["hints"]["livecheck"]
+      json.dig("hints", "livecheck")
     end
   end
 

--- a/Casks/f/fme.rb
+++ b/Casks/f/fme.rb
@@ -15,8 +15,8 @@ cask "fme" do
     url "https://engage.safe.com/api/downloads/"
     regex(/fme[._-]form[._-]v?(\d+(?:\.\d+)+)[._-]b(\d+)[._-]macosx[._-]#{arch}\.pkg/i)
     strategy :json do |json, regex|
-      json["official"]["desktop"]["mac"].select { |item| item["url"]&.match?(regex) }
-                                        .map { |item| "#{item["url"][regex, 1]},#{item["url"][regex, 2]}" }
+      json.dig("official", "desktop", "mac")&.select { |item| item["url"]&.match?(regex) }
+          &.map { |item| "#{item["url"][regex, 1]},#{item["url"][regex, 2]}" }
     end
   end
 

--- a/Casks/g/grids.rb
+++ b/Casks/g/grids.rb
@@ -10,7 +10,7 @@ cask "grids" do
   livecheck do
     url "https://gridsapp.net/appcast.json"
     strategy :json do |json|
-      json["version"]["mac"]
+      json.dig("version", "mac")
     end
   end
 

--- a/Casks/k/kdrive.rb
+++ b/Casks/k/kdrive.rb
@@ -11,7 +11,7 @@ cask "kdrive" do
     url "https://www.infomaniak.com/drive/latest"
     regex(/kDrive[._-](\d+(?:\.\d+)+)\.pkg/i)
     strategy :json do |json|
-      json["macos"]["downloadurl"]&.scan(regex)&.map { |match| (match[0]).to_s }
+      json.dig("macos", "downloadurl")&.scan(regex)&.map { |match| (match[0]).to_s }
     end
   end
 

--- a/Casks/m/mockplus.rb
+++ b/Casks/m/mockplus.rb
@@ -12,7 +12,7 @@ cask "mockplus" do
   livecheck do
     url "https://api.mockplus.com/v6/software/checkNewerVersionForMockupV2?name=MockplusClassic&version=latest&platform=mac"
     strategy :json do |json|
-      json["value"]["version"]
+      json.dig("value", "version")
     end
   end
 

--- a/Casks/m/mockplus.rb
+++ b/Casks/m/mockplus.rb
@@ -25,4 +25,8 @@ cask "mockplus" do
     "~/Library/Mockplus2",
     "~/Library/Saved Application State/com.mockplus.desktop.chinese.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/n/naver-whale.rb
+++ b/Casks/n/naver-whale.rb
@@ -13,7 +13,7 @@ cask "naver-whale" do
   livecheck do
     url "https://cv.whale.naver.com/version/latest_version"
     strategy :json do |json|
-      json["message"]["@version"]
+      json.dig("message", "@version")
     end
   end
 

--- a/Casks/r/rode-central.rb
+++ b/Casks/r/rode-central.rb
@@ -10,7 +10,7 @@ cask "rode-central" do
   livecheck do
     url "https://update.rode.com/rode-devices-manifest.json"
     strategy :json do |json|
-      json["rode-central-manifest"]["macos"]["main-version"]["update-version"]
+      json.dig("rode-central-manifest", "macos", "main-version", "update-version")
     end
   end
 

--- a/Casks/r/rstudio@daily.rb
+++ b/Casks/r/rstudio@daily.rb
@@ -11,8 +11,8 @@ cask "rstudio@daily" do
   livecheck do
     url "https://dailies.rstudio.com/rstudio/latest/index.json"
     strategy :json do |json|
-      json["products"]["electron"]["platforms"]["macos"]["version"]
-        &.tr("+", "-")
+      json.dig("products", "electron", "platforms", "macos", "version")
+          &.tr("+", "-")
     end
   end
 

--- a/Casks/w/warp.rb
+++ b/Casks/w/warp.rb
@@ -10,7 +10,7 @@ cask "warp" do
   livecheck do
     url "https://releases.warp.dev/channel_versions.json"
     strategy :json do |json|
-      json["stable"]["version"][1..]
+      json.dig("stable", "version")&.delete_prefix("v")
     end
   end
 

--- a/Casks/w/wetype.rb
+++ b/Casks/w/wetype.rb
@@ -12,7 +12,7 @@ cask "wetype" do
     url "https://z.weixin.qq.com/web/api/app_info"
     regex(/WeTypeInstaller[._-]v?(\d+(?:.\d+)+)[._-](\d+).zip/i)
     strategy :json do |json, regex|
-      match = json["data"]["mac"]["download_link"].match(regex)
+      match = json.dig("data", "mac", "download_link")&.match(regex)
       "#{match[1]},#{match[2]}"
     end
   end

--- a/Casks/x/xiaomi-cloud.rb
+++ b/Casks/x/xiaomi-cloud.rb
@@ -12,7 +12,7 @@ cask "xiaomi-cloud" do
   livecheck do
     url "https://update-server.micloud.xiaomi.net/api/v1/releases"
     strategy :json do |json|
-      json["data"]["version"]
+      json.dig("data", "version")
     end
   end
 

--- a/Casks/y/yealink-meeting.rb
+++ b/Casks/y/yealink-meeting.rb
@@ -10,7 +10,7 @@ cask "yealink-meeting" do
   livecheck do
     url "https://www.ylyun.com/portal/front/appPackageInfo?type=macos"
     strategy :json do |json|
-      "#{json["data"]["packageVersion"]},#{json["data"]["md5"]}"
+      "#{json.dig("data", "packageVersion")},#{json.dig("data", "md5")}"
     end
   end
 

--- a/Casks/z/zspace.rb
+++ b/Casks/z/zspace.rb
@@ -22,7 +22,7 @@ cask "zspace" do
     url "https://upgrade.zenithspace.net/upgrade_server/v2/check_upgrade?app_id=APP_ZSPACE_DESKTOP_MAC#{folder}&app_version=V0.0.0&nas_id=&plat=app&channel=zspace&skip_app_sync_upgrade=1"
     regex(%r{v?(\d+(?:\.\d+)+)/zspace/(\d+)/zspace[._-]mac[._-]#{arch}[._-](?:\d+(?:\.\d+)+)[._-](\d+)\.dmg}i)
     strategy :json do |json, regex|
-      json["data"]["download_url"]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
+      json.dig("data", "download_url")&.scan(regex)&.map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This modifies a number of casks to use `json.dig` instead of `json[*][*]`, and additional adds safe operators to chained functions.