### PR TITLE
[a] Casks: disable 32-bit applications

### DIFF
--- a/Casks/a/anonym.rb
+++ b/Casks/a/anonym.rb
@@ -12,5 +12,7 @@ cask "anonym" do
     regex(%r{href=.*?/anonym[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 
+  disable! date: "2024-07-09", because: "is 32-bit only"
+
   app "Anonym.app"
 end

--- a/Casks/a/arrsync.rb
+++ b/Casks/a/arrsync.rb
@@ -12,5 +12,7 @@ cask "arrsync" do
     regex(/arrsync-(\d+(?:\.\d+)+)\.dmg/i)
   end
 
+  disable! date: "2024-07-09", because: "is 32-bit only"
+
   app "arRsync.app"
 end

--- a/Casks/a/audioslicer.rb
+++ b/Casks/a/audioslicer.rb
@@ -7,5 +7,7 @@ cask "audioslicer" do
   desc "Finds all silences in an audio file"
   homepage "https://audioslicer.sourceforge.net/"
 
+  disable! date: "2024-07-09", because: "is 32-bit only"
+
   app "AudioSlicer.app"
 end

--- a/Casks/a/awareness.rb
+++ b/Casks/a/awareness.rb
@@ -12,6 +12,8 @@ cask "awareness" do
     regex(%r{/Awareness-(\d+(?:\.\d+)+)\.dmg}i)
   end
 
+  disable! date: "2024-07-09", because: "is 32-bit only"
+
   app "Awareness.app"
 
   zap trash: "~/Library/Preferences/com.futureproof.awareness.plist"


### PR DESCRIPTION
Disables a handful of [a] Casks that are 32-bit only and do not run on modern macOS.

---
