### PR TITLE
various: [b] casks: disable 32-bit applications

### DIFF
--- a/Casks/b/bonjour-browser.rb
+++ b/Casks/b/bonjour-browser.rb
@@ -7,7 +7,7 @@ cask "bonjour-browser" do
   desc "Display all the bonjour services on your local network"
   homepage "https://www.tildesoft.com/"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2023-12-17", because: "is 32-bit only."
 
   depends_on macos: "<= :mojave"
 

--- a/Casks/b/bootxchanger.rb
+++ b/Casks/b/bootxchanger.rb
@@ -8,7 +8,7 @@ cask "bootxchanger" do
   desc "Utility to change the boot logo on old Macs"
   homepage "https://namedfork.net/bootxchanger/"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "BootXChanger.app"
 end

--- a/Casks/b/brain-workshop.rb
+++ b/Casks/b/brain-workshop.rb
@@ -11,5 +11,7 @@ cask "brain-workshop" do
     regex(%r{url=.*?/brainworkshop[._-]v?(\d+(?:\.\d+)+)-MacOSX\.zip}i)
   end
 
+  disable! date: "2024-07-09", because: "is 32-bit only"
+
   app "Brain Workshop.app"
 end


### PR DESCRIPTION
Small number of 32-bit applications starting with [b] to mark as disabled as they do not run on any modern macOS.
