### PR TITLE
various [c] casks: disable 32-bit applications

### DIFF
--- a/Casks/c/clonk.rb
+++ b/Casks/c/clonk.rb
@@ -8,7 +8,7 @@ cask "clonk" do
   desc "Single player and multiplayer action game"
   homepage "http://www.clonk.de/cr.php"
 
-  disable! date: "2024-07-05", because: :unmaintained
+  disable! date: "2024-07-05", because: "is 32-bit only"
 
   app "Clonk.app"
 end

--- a/Casks/c/colortester.rb
+++ b/Casks/c/colortester.rb
@@ -7,10 +7,7 @@ cask "colortester" do
   desc "Colour accessibility and contrast tester"
   homepage "https://alfasado.net/apps/colortester.html"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "ColorTester/ColorTester.app"
 

--- a/Casks/c/cronnix.rb
+++ b/Casks/c/cronnix.rb
@@ -7,7 +7,7 @@ cask "cronnix" do
   name "CronniX"
   homepage "https://code.google.com/archive/p/cronnix/"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "CronniX.app"
 end


### PR DESCRIPTION
Disable casks beginning with [c] that are 32-bit applications and are no longer functional on modern macOS.

---
