### PR TITLE
brl-cad-mged: disable

### DIFF
--- a/Casks/b/brl-cad-mged.rb
+++ b/Casks/b/brl-cad-mged.rb
@@ -8,13 +8,13 @@ cask "brl-cad-mged" do
   desc "Solid modelling system"
   homepage "https://brlcad.org/"
 
-  livecheck do
-    url "https://sourceforge.net/projects/brlcad/rss?path=/BRL-CAD%20for%20Mac%20OS%20X"
-    regex(%r{url=.*?/BRL-CAD(?:[._-]|%20)v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :page_match
-  end
+  disable! date: "2024-07-09", because: :discontinued
 
   depends_on cask: "xquartz"
 
   app "BRL-CAD : MGED #{version}.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Marking the Cask as disabled, as there has not been a formal release in excess of 10 years, and the below issue indicates the application is non-functional on macOS.

https://github.com/BRL-CAD/brlcad/issues/84