### PR TITLE
beardedspice: deprecate

### DIFF
--- a/Casks/b/beardedspice.rb
+++ b/Casks/b/beardedspice.rb
@@ -4,7 +4,10 @@ cask "beardedspice" do
 
   url "https://github.com/beardedspice/beardedspice/releases/download/v#{version}/BeardedSpice-#{version}.zip"
   name "BeardedSpice"
+  desc "Control web-based media players with media keys"
   homepage "https://github.com/beardedspice/beardedspice/"
+
+  deprecate! date: "2024-07-09", because: :unmaintained
 
   auto_updates true
 
@@ -14,4 +17,8 @@ cask "beardedspice" do
     "~/Library/Caches/com.beardedspice.BeardedSpice",
     "~/Library/Preferences/com.beardedspice.BeardedSpice.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not had a release since 2017.

---

Also see https://github.com/beardedspice/beardedspice/issues/899