### PR TITLE
baudline: disable

### DIFF
--- a/Casks/b/baudline.rb
+++ b/Casks/b/baudline.rb
@@ -7,10 +7,7 @@ cask "baudline" do
   desc "Time-frequency browser"
   homepage "https://www.baudline.com/"
 
-  livecheck do
-    url "https://www.baudline.com/download.html"
-    regex(/href=.*?baudline_(\d+(?:\.\d+)+)_macosx_universal\.dmg/i)
-  end
+  disable! date: "2024-07-09", because: :no_longer_meets_criteria
 
   app "baudline.app"
 end


### PR DESCRIPTION
The version in this Cask (1.08) does not appear to be available upstream anymore, and the next version is only available via subscription model.

<img width="1404" alt="baudline" src="https://github.com/Homebrew/homebrew-cask/assets/39449589/7b641524-defe-4390-b3b1-ffa4302b0518">
