### PR TITLE
classroom-assistant: disable

### DIFF
--- a/Casks/c/classroom-assistant.rb
+++ b/Casks/c/classroom-assistant.rb
@@ -7,7 +7,7 @@ cask "classroom-assistant" do
   desc "Tool to clone student repositories in bulk"
   homepage "https://classroom.github.com/assistant"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2023-12-17", because: :discontinued
 
   app "Classroom Assistant.app"
 


### PR DESCRIPTION
Moving from deprecated to disabled as the upstream repository does not exist.