### PR TITLE
fix: asciidocfx 1.8.10 checksum mismatch

### DIFF
--- a/Casks/a/asciidocfx.rb
+++ b/Casks/a/asciidocfx.rb
@@ -3,7 +3,7 @@ cask "asciidocfx" do
 
   version "1.8.10"
   sha256 arm:   "aa3790f8d250136ef8025a4862d64a188640bc4b835ec3857401d2b5eec95b79",
-         intel: "81fbb4ea8fd781a62e1e92fd936d038c919d337cdfb0509f24f91d27a29db146"
+         intel: "eb4510935a93df580633a7508be2c719f827a889ea6ded72f2a5956ba3b1a9a8"
 
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac#{arch}.dmg",
       verified: "github.com/asciidocfx/AsciidocFX/"

--- a/Casks/a/asciidocfx.rb
+++ b/Casks/a/asciidocfx.rb
@@ -2,8 +2,8 @@ cask "asciidocfx" do
   arch arm: "_M1"
 
   version "1.8.10"
-  sha256 arm:   "aa3790f8d250136ef8025a4862d64a188640bc4b835ec3857401d2b5eec95b79",
-         intel: "eb4510935a93df580633a7508be2c719f827a889ea6ded72f2a5956ba3b1a9a8"
+  sha256 arm:   "eb4510935a93df580633a7508be2c719f827a889ea6ded72f2a5956ba3b1a9a8",
+         intel: "2b50145239ee80c7adf053bbfc5df481580da14e5e5fb0703a4adc8c2fdb45ea"
 
   url "https://github.com/asciidocfx/AsciidocFX/releases/download/v#{version}/AsciidocFX_Mac#{arch}.dmg",
       verified: "github.com/asciidocfx/AsciidocFX/"


### PR DESCRIPTION
This MR fixes the sha256 checksum mismatch for asciidocfx 1.8.10

```
asciidocfx 1.8.9 -> 1.8.10
==> Upgrading asciidocfx
==> Downloading https://github.com/asciidocfx/AsciidocFX/releases/download/v1.8.10/AsciidocFX_Mac.dmg
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/19916900/91669695-7804-4f02-9073-2d28d6f56ce5?X-A
############################################################################################################################################ 100.0%
==> Purging files for version 1.8.10 of Cask asciidocfx
Error: asciidocfx: SHA256 mismatch
Expected: 81fbb4ea8fd781a62e1e92fd936d038c919d337cdfb0509f24f91d27a29db146
  Actual: 2b50145239ee80c7adf053bbfc5df481580da14e5e5fb0703a4adc8c2fdb45ea
```

- introduced with b6a1c8d last week, when updating asciidocfx 1.8.9 -> 1.8.10
- vendor updated the app (in-place?) 4 days ago: https://github.com/asciidocfx/AsciidocFX/releases/tag/v1.8.10

This is my first contribution here, please double-check carefully. 
