### PR TITLE
doubletwist: disable 32-bit application

### DIFF
--- a/Casks/d/doubletwist.rb
+++ b/Casks/d/doubletwist.rb
@@ -7,10 +7,7 @@ cask "doubletwist" do
   desc "Sync your music, videos and pictures over USB or WiFi"
   homepage "https://www.doubletwist.com/desktop"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-07-10", because: "is 32-bit only"
 
   app "doubleTwist.app"
 


### PR DESCRIPTION
Disable casks beginning with [d] that are 32-bit applications and are no longer functional on modern macOS.
