### PR TITLE
devbook: disable

### DIFF
--- a/Casks/d/devbook.rb
+++ b/Casks/d/devbook.rb
@@ -11,10 +11,7 @@ cask "devbook" do
   desc "Search engine for developers"
   homepage "https://usedevbook.com/"
 
-  livecheck do
-    url "https://download.todesktop.com/2102273jsy18baz/latest-mac.yml"
-    strategy :electron_builder
-  end
+  disable! date: "2024-07-10", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
Formally noted as deprecated here - https://github.com/devbookhq/devbook-palette, but the servers appear to be offline and downloads are unreachable.
