### PR TITLE
droidid: deprecate

### DIFF
--- a/Casks/d/droidid.rb
+++ b/Casks/d/droidid.rb
@@ -6,10 +6,11 @@ cask "droidid" do
   name "DroidID"
   homepage "https://www.suyashsrijan.com/droidid/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-10", because: :unmaintained
 
   app "DroidID.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Last update was maybe in 2020, as that was the switch from using version :latest to a numbered version.  Probable the last update was much earlier, as far back as 2016.  Cask has not seen any real updates since being added.