### PR TITLE
dwihn0r-keepassx: disable

### DIFF
--- a/Casks/d/dwihn0r-keepassx.rb
+++ b/Casks/d/dwihn0r-keepassx.rb
@@ -6,5 +6,11 @@ cask "dwihn0r-keepassx" do
   name "KeePassX"
   homepage "https://github.com/dwihn0r/keepassx/"
 
+  disable! date: "2024-07-10", because: :unmaintained
+
   app "KeePassX.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application is a 0-fork, couple star repo that hasn't been updated since 2014.  Possibly should not have been in the repository.