### PR TITLE
bluej: update livecheck

### DIFF
--- a/Casks/b/bluej.rb
+++ b/Casks/b/bluej.rb
@@ -8,15 +8,7 @@ cask "bluej" do
   homepage "https://www.bluej.org/"
 
   livecheck do
-    url "https://www.bluej.org"
-    regex(%r{href=.*?/BlueJ-mac-(\d+)(\d+)(\d+)(a)?\.dmg}i)
-    strategy :page_match do |page|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]}.#{match[2]}.#{match[3]}" unless match[4]
-      "#{match[1]}.#{match[2]}.#{match[3]}#{match[4]}"
-    end
+    url "https://github.com/k-pet-group/BlueJ-Greenfoot"
   end
 
   depends_on macos: ">= :sierra"

--- a/Casks/b/bluej.rb
+++ b/Casks/b/bluej.rb
@@ -8,7 +8,8 @@ cask "bluej" do
   homepage "https://www.bluej.org/"
 
   livecheck do
-    url "https://github.com/k-pet-group/BlueJ-Greenfoot"
+    url :homepage
+    regex(/Version\s*v?(\d+(?:\.\d+)+)/i)
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
As of v5.2.0, the source code for this application is available on GitHub, but not precompiled binaries. The [latest PR to update Rubocop](https://github.com/Homebrew/brew/pull/17671) does not like the current livecheck, so let's just check these tags to simply.