### PR TITLE
various: [f] and [g] casks: disable 32-bit applications

### DIFF
--- a/Casks/f/flash-decompiler-trillix.rb
+++ b/Casks/f/flash-decompiler-trillix.rb
@@ -8,7 +8,7 @@ cask "flash-decompiler-trillix" do
   desc "Convert SWF files to editable FLA projects"
   homepage "https://www.flash-decompiler.com/mac.html"
 
-  disable! date: "2024-07-03", because: :unmaintained
+  disable! date: "2024-07-03", because: "is 32-bit only"
 
   app "Flash Decompiler Trillix.app"
 end

--- a/Casks/g/gameranger.rb
+++ b/Casks/g/gameranger.rb
@@ -6,7 +6,7 @@ cask "gameranger" do
   name "GameRanger"
   homepage "https://gameranger.com/"
 
-  disable! date: "2024-07-05", because: :unmaintained
+  disable! date: "2024-07-05", because: "is 32-bit only"
 
   app "GameRanger.app"
 

--- a/Casks/g/gulp.rb
+++ b/Casks/g/gulp.rb
@@ -6,7 +6,7 @@ cask "gulp" do
   name "gulp-app"
   homepage "https://github.com/sindresorhus/gulp-app"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-07-11", because: "is 32-bit only"
 
   app "gulp.app"
 


### PR DESCRIPTION
Updates the `disable` reason for `flash-decompiler-trillix` and `gameranger` to reflect 32-bit application.  Additionally, moves `gulp` from `deprecate` to `disable` due to being a 32-bit app.