### PR TITLE
gopass-ui: deprecate

### DIFF
--- a/Casks/g/gopass-ui.rb
+++ b/Casks/g/gopass-ui.rb
@@ -7,7 +7,13 @@ cask "gopass-ui" do
   desc "Password manager for teams"
   homepage "https://github.com/codecentric/gopass-ui"
 
+  deprecate! date: "2024-07-11", because: :unmaintained
+
   app "Gopass UI.app"
 
   zap trash: "~/.config/gopass"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Maintainer has mentioned re-writing the application using Tauri, no releases since 2021 or commit activity suggests this is no longer being actively worked on.

https://github.com/codecentric/gopass-ui/issues/103


