### PR TITLE
gitnote: deprecate

### DIFF
--- a/Casks/g/gitnote.rb
+++ b/Casks/g/gitnote.rb
@@ -7,5 +7,11 @@ cask "gitnote" do
   name "gitnote"
   homepage "https://gitnoteapp.com/"
 
+  deprecate! date: "2024-07-11", because: :unmaintained
+
   app "GitNote.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2019, and repository is bare.  Note exists that a new version will be developed, suggesting this is no longer maintained.

https://github.com/zhaopengme/gitnote

```
In order to better serve everyone, from the recent collection of a large number of issues, 
many issues need to be modified at the bottom, so decided to start a new version of the development, 
issues will be resolved in the new version. Recently, concentrated time development.

2023-01-12 17:51:39
```