### PR TITLE
g-desktop-suite: deprecate

### DIFF
--- a/Casks/g/g-desktop-suite.rb
+++ b/Casks/g/g-desktop-suite.rb
@@ -6,5 +6,11 @@ cask "g-desktop-suite" do
   name "G Desktop Suite"
   homepage "https://github.com/alexkim205/g-desktop-suite"
 
+  deprecate! date: "2024-07-11", because: :unmaintained
+
   app "G Desktop Suite.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application is no longer maintained.

https://github.com/alexkim205/g-desktop-suite#thank-you-everyone-who-gave-this-app-a-shot-its-been-a-great-learning-opportunity-for-me

```
Thank you everyone who gave this app a shot, it's been a great learning opportunity for me!
Unfortunately, I won't be able to continue maintaining G-Desktop-Suite due to time constraints. However, this repository is open to new lead maintainers!
```