### PR TITLE
crashplan: support macOS Monterey and Ventura

### DIFF
--- a/Casks/c/crashplan.rb
+++ b/Casks/c/crashplan.rb
@@ -18,7 +18,7 @@ cask "crashplan" do
     end
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: ">= :monterey"
 
   pkg "Install CrashPlan.pkg"
 


### PR DESCRIPTION
The CrashPlan app supports macOS 12-14,[^1] but the cask requires macOS 14 or later. I have lowered the minimum required version to macOS 12.

[^1]: https://support.crashplan.com/hc/en-us/articles/9160162474765-Supported-operating-systems#01GFBK9PWFMQK72Z7SW922N466

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - I received an error that the cask is for an outdated version, but that is orthogonal to the problem I have trying to solve. I was able to successfully install the cask without and errors using `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask crashplan`. The new release only happened a couple of hours ago ([CrashPlan app version 11.4 release notes](https://support.crashplan.com/hc/en-us/articles/28340113326733-CrashPlan-app-version-11-4-release-notes)), and I'm not even sure it's entirely rolled out yet.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.