### PR TITLE
font-cantarell: Use the version from the Gnome project

### DIFF
--- a/Casks/font/font-c/font-cantarell.rb
+++ b/Casks/font/font-c/font-cantarell.rb
@@ -1,18 +1,16 @@
 cask "font-cantarell" do
-  version :latest
-  sha256 :no_check
+  version "0.303"
+  sha256 "54f644b5edf5da9a48a942452e38ff1bc2382aa25cabb8742222247944f1dc3a"
 
-  url "https://github.com/google/fonts.git",
-      verified:  "github.com/google/fonts",
-      branch:    "main",
-      only_path: "ofl/cantarell"
+  url "https://cantarell.gnome.org/releases/cantarell-fonts-#{version}.tar.xz"
   name "Cantarell"
-  homepage "https://fonts.google.com/specimen/Cantarell"
+  homepage "https://cantarell.gnome.org/"
 
-  font "Cantarell-Bold.ttf"
-  font "Cantarell-BoldItalic.ttf"
-  font "Cantarell-Italic.ttf"
-  font "Cantarell-Regular.ttf"
+  livecheck do
+    url "https://gitlab.gnome.org/GNOME/cantarell-fonts.git"
+  end
+
+  font "cantarell-fonts-#{version}/prebuilt/Cantarell-VF.otf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
Use the version from Gnome project rather than outdated version host by Google Fonts.

Fixes https://github.com/Homebrew/homebrew-cask/issues/179369

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
