### PR TITLE
workflows: input handling improvements

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,7 +29,5 @@ jobs:
           squash-commit-message: '\n'
           do-not-merge-labels: automerge-skip,do not merge
           required-labels: bump-cask-pr
-          pull-request: ${{ github.event.inputs.pull-request }}
           pull-request-author-associations: MEMBER,OWNER
-          review: ${{ github.event.inputs.review }}
           review-author-associations: MEMBER,OWNER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]
           then
-            brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" ${{ github.event.inputs.skip_install  && '--skip-install' }} ${{ github.event.inputs.new_cask  && '--new' }} --casks=${{ github.event.inputs.casks }}
+            brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" ${{ github.event.inputs.skip_install && '--skip-install' }} ${{ github.event.inputs.new_cask && '--new' }} --casks="$INPUT_CASKS"
           elif [[ "${GITHUB_EVENT_NAME}" == "push" ]]
           then
             brew ruby -- "$(brew --repository homebrew/cask)/cmd/lib/generate-matrix.rb" --syntax-only
@@ -126,7 +126,6 @@ jobs:
              ! sudo pkgutil --forget com.xamarin.mono-MDK.pkg; then
             echo '::warning::Uninstalling Mono is no longer necessary.'
           fi
-        
 
       - name: Cache Homebrew Gems
         id: cache


### PR DESCRIPTION
- workflows/automerge: remove unused inputs
  The ability to run this workflow with inputs (i.e., via `workflow_dispatch`) was removed in #143999.
- workflows/ci: better handle input strings
  This is to avoid code injection through the `casks` input. The boolean inputs are fine.
