### PR TITLE
gitkraken-on-premise-serverless 10.1.1 (new cask)

### DIFF
--- a/Casks/g/gitkraken-on-premise-serverless.rb
+++ b/Casks/g/gitkraken-on-premise-serverless.rb
@@ -1,4 +1,4 @@
-cask "gitkraken-serverless" do
+cask "gitkraken-on-premise-serverless" do
   arch arm: "darwin-arm64", intel: "darwin"
 
   version "10.1.1"

--- a/Casks/g/gitkraken-serverless.rb
+++ b/Casks/g/gitkraken-serverless.rb
@@ -1,0 +1,40 @@
+cask "gitkraken-serverless" do
+  arch arm: "darwin-arm64", intel: "darwin"
+
+  version "10.1.1"
+  sha256 arm:   "fc5cd736682b86e134567c82bf3b474c5c0e90f9ada797a53ad7c66e0639affe",
+         intel: "bf1be6a44f1861d28c1b066eff286c2fded42cb182407d4c365932bae4be0bf0"
+
+  url "https://release.axocdn.com/#{arch}-standalone/GitKraken-v#{version}.zip",
+      verified: "release.axocdn.com/"
+  name "GitKraken Serverless"
+  desc "Git client focusing on productivity"
+  homepage "https://www.gitkraken.com/git-client/on-premise"
+
+  livecheck do
+    url "https://www.gitkraken.com/download-on-premise-serverless"
+    regex(/Latest\srelease:\s(\d+(?:\.\d+)+)/i)
+  end
+
+  auto_updates true
+  conflicts_with cask: "gitkraken"
+  depends_on macos: ">= :el_capitan"
+
+  app "GitKraken.app"
+
+  uninstall quit: "com.axosoft.gitkraken"
+
+  zap trash: [
+    "~/.gitkraken",
+    "~/Library/Application Support/com.axosoft.gitkraken.ShipIt",
+    "~/Library/Application Support/GitKraken",
+    "~/Library/Caches/com.axosoft.gitkraken",
+    "~/Library/Caches/com.axosoft.gitkraken.ShipIt",
+    "~/Library/Caches/GitKraken",
+    "~/Library/Cookies/com.axosoft.gitkraken.binarycookies",
+    "~/Library/HTTPStorages/com.axosoft.gitkraken",
+    "~/Library/Preferences/com.axosoft.gitkraken.helper.plist",
+    "~/Library/Preferences/com.axosoft.gitkraken.plist",
+    "~/Library/Saved Application State/com.axosoft.gitkraken.savedState",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online gitkraken-serverless` is error-free.
- [x] `brew style --fix gitkraken-serverless` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new gitkraken-serverless` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask gitkraken-serverless` worked successfully.
- [x] `brew uninstall --cask gitkraken-serverless` worked successfully.
