### PR TITLE
Update Tailscale cask to use .pkg installer

### DIFF
--- a/Casks/t/tailscale.rb
+++ b/Casks/t/tailscale.rb
@@ -1,10 +1,10 @@
 cask "tailscale" do
-  version "1.68.2"
-  sha256 "7dad62fa1787d1439ae9ccceaff72156b515a5b8b1a2b91d91b17c04b80b4600"
+  version "1.70.0"
+  sha256 "15134284147db110de12a87f33d0b617f02e85b176580fc5e30cdf33468923c9"
 
-  url "https://pkgs.tailscale.com/stable/Tailscale-#{version}-macos.zip"
+  url "https://pkgs.tailscale.com/stable/Tailscale-#{version}-macos.pkg"
   name "Tailscale"
-  desc "Mesh VPN based on Wireguard"
+  desc "Mesh VPN based on WireGuard"
   homepage "https://tailscale.com/"
 
   livecheck do
@@ -16,7 +16,7 @@ cask "tailscale" do
   conflicts_with formula: "tailscale"
   depends_on macos: ">= :catalina"
 
-  app "Tailscale.app"
+  pkg "Tailscale-#{version}-macos.pkg"
   # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/tailscale.wrapper.sh"
   binary shimscript, target: "tailscale"
@@ -29,17 +29,28 @@ cask "tailscale" do
   end
 
   uninstall quit:       "io.tailscale.ipn.macsys",
-            login_item: "Tailscale"
+            login_item: "Tailscale",
+            pkgutil:    "com.tailscale.ipn.macsys"
 
   zap trash: [
     "~/Library/Application Scripts/*.io.tailscale.ipn.macsys",
     "~/Library/Application Scripts/io.tailscale.ipn.macsys",
+    "~/Library/Application Scripts/io.tailscale.ipn.macsys.login-item-helper",
     "~/Library/Application Scripts/io.tailscale.ipn.macsys.share-extension",
+    "~/Library/Caches/io.tailscale.ipn.macsys",
     "~/Library/Containers/io.tailscale.ipn.macos.network-extension",
     "~/Library/Containers/io.tailscale.ipn.macsys",
+    "~/Library/Containers/io.tailscale.ipn.macsys.login-item-helper",
     "~/Library/Containers/io.tailscale.ipn.macsys.share-extension",
     "~/Library/Containers/Tailscale",
     "~/Library/Group Containers/*.io.tailscale.ipn.macsys",
+    "~/Library/HTTPStorages/io.tailscale.ipn.macsys",
+    "~/Library/Preferences/io.tailscale.ipn.macsys.plist",
     "~/Library/Tailscale",
   ]
+
+  caveats do
+    kext
+    license "https://tailscale.com/terms"
+  end
 end


### PR DESCRIPTION
For the past few months, Tailscale has been distributed [on its official website](https://pkgs.tailscale.com/stable/#macos) using a .pkg installer. Using the .pkg installer is preferred over the .zip file that Homebrew is currently using as source for the application, because the installer includes a preinstall script that disables the VPN tunnel before performing the installation. This reduces the chance of conflicts between versions when performing upgrades. 

This PR updates the cask to use the .pkg installer, fixes a capitalization typo in the `desc`, adds new paths to the `zap` stanza, and adds two caveats relevant to Tailscale: `kext` and `license`.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.