### PR TITLE
various: [i] casks: disable 32-bit applications

### DIFF
--- a/Casks/i/ibackup.rb
+++ b/Casks/i/ibackup.rb
@@ -7,10 +7,7 @@ cask "ibackup" do
   desc "Backup utility"
   homepage "https://www.grapefruit.ch/iBackup/"
 
-  livecheck do
-    url "https://www.grapefruit.ch/iBackup/downloads.html"
-    regex(%r{href=.*?/iBackup\s*v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "iBackup.app"
 end

--- a/Casks/i/icefloor.rb
+++ b/Casks/i/icefloor.rb
@@ -7,10 +7,7 @@ cask "icefloor" do
   desc "Firewall tool"
   homepage "https://www.hanynet.com/icefloor/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/icefloor[._-]v?(\d+(?:\.\d+)+)\.zip}i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "IceFloor.app"
 end

--- a/Casks/i/image-tool.rb
+++ b/Casks/i/image-tool.rb
@@ -7,7 +7,7 @@ cask "image-tool" do
   desc "Scale images and convert image file formats"
   homepage "https://archive.org/details/jimmcgowan-2000s-software"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   depends_on macos: "<= :mojave"
 

--- a/Casks/i/ireadfast.rb
+++ b/Casks/i/ireadfast.rb
@@ -7,10 +7,7 @@ cask "ireadfast" do
   desc "Speed reading program"
   homepage "https://www.gengis.net/prodotti/iReadFast_Mac/en/index.php"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/iReadFast\s*v?(\d+(?:\.\d+)+)\.dmg}i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   depends_on macos: "<= :mojave"
 

--- a/Casks/i/ishowu.rb
+++ b/Casks/i/ishowu.rb
@@ -7,7 +7,7 @@ cask "ishowu" do
   desc "Screen recorder"
   homepage "https://www.shinywhitebox.com/ishowu"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "iShowU.app"
 end

--- a/Casks/i/isolator.rb
+++ b/Casks/i/isolator.rb
@@ -7,10 +7,7 @@ cask "isolator" do
   desc "Menu bar app that hides desktop, inactive windows, etc."
   homepage "https://www.willmore.eu/software/isolator/"
 
-  livecheck do
-    url "https://www.willmore.eu/software/isolator/allversions.xml"
-    strategy :sparkle
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "Isolator.app"
 end

--- a/Casks/i/isteg.rb
+++ b/Casks/i/isteg.rb
@@ -7,10 +7,7 @@ cask "isteg" do
   desc "Encryption tool"
   homepage "https://www.hanynet.com/isteg/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/isteg[._-]v?(\d+(?:\.\d+)+)\.zip}i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "iSteg.app"
 end


### PR DESCRIPTION
Disables the casks starting with [i] which are 32-bit applications and do not run on any modern macOS version.