### PR TITLE
various: [l] casks: disable 32-bit applications

### DIFF
--- a/Casks/l/launchy.rb
+++ b/Casks/l/launchy.rb
@@ -7,10 +7,7 @@ cask "launchy" do
   desc "Utility desktop shortcut utility"
   homepage "https://www.launchy.net/"
 
-  livecheck do
-    url "https://www.launchy.net/download.php"
-    regex(%r{href=.*?/Launchy(\d+(?:\.\d+)*)\.dmg}i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "Launchy.app"
 end

--- a/Casks/l/logicalshift-zoom.rb
+++ b/Casks/l/logicalshift-zoom.rb
@@ -7,10 +7,7 @@ cask "logicalshift-zoom" do
   desc "Player for Z-Code, TADS, and HUGO stories or games"
   homepage "https://www.logicalshift.co.uk/unix/zoom/"
 
-  livecheck do
-    url "https://www.logicalshift.co.uk/unix/zoom/older.html"
-    regex(%r{href=.*?/Zoom-(\d+(?:\.\d+)*)\.dmg}i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "Zoom.app"
 end

--- a/Casks/l/lynxlet.rb
+++ b/Casks/l/lynxlet.rb
@@ -7,10 +7,7 @@ cask "lynxlet" do
   desc "Launch Lynx in a Terminal window"
   homepage "https://habilis.net/lynxlet/"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?Lynxlet_(\d+(?:\.\d+)*)\.dmg/i)
-  end
+  disable! date: "2024-07-14", because: "is 32-bit only"
 
   app "Lynxlet.app"
 end


### PR DESCRIPTION
Disables the casks starting with [l] which are 32-bit applications and do not run on any modern macOS version.