### PR TITLE
rightzoom: revert to 3.0, update livecheck

### DIFF
--- a/Casks/r/rightzoom.rb
+++ b/Casks/r/rightzoom.rb
@@ -8,8 +8,8 @@ cask "rightzoom" do
   homepage "https://www.blazingtools.com/right_zoom_mac.html"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url :homepage
+    regex(/Right\s*Zoom.*v?(\d+(?:\.\d+)+)\s+for\s+macOS/i)
   end
 
   app "RightZoom.app"

--- a/Casks/r/rightzoom.rb
+++ b/Casks/r/rightzoom.rb
@@ -1,5 +1,5 @@
 cask "rightzoom" do
-  version "3.1"
+  version "3.0"
   sha256 :no_check
 
   url "https://www.blazingtools.com/mac/RightZoom.zip"
@@ -13,4 +13,6 @@ cask "rightzoom" do
   end
 
   app "RightZoom.app"
+
+  # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Version 3.0 is the latest release available on the download page ([source](https://www.blazingtools.com/right_zoom_mac.html)).

```text
Version '3.1' differs from '3.0' retrieved by livecheck.
```
