### PR TITLE
macx-dvd-ripper-mac-free-edition: disable 32-bit application

### DIFF
--- a/Casks/m/macx-dvd-ripper-mac-free-edition.rb
+++ b/Casks/m/macx-dvd-ripper-mac-free-edition.rb
@@ -4,12 +4,10 @@ cask "macx-dvd-ripper-mac-free-edition" do
 
   url "https://www.macxdvd.com/download/converter_ripper_org/macx-dvd-ripper-mac-free-edition.dmg"
   name "MacX DVD Ripper Mac Free Edition"
+  desc "DVD ripping application"
   homepage "https://www.macxdvd.com/dvd-ripper-mac-free/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2024-07-15", because: "is 32-bit only"
 
   app "MacX DVD Ripper Mac Free Edition.app"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
