### PR TITLE
nextcloud-vfs 3.13.2 (new cask)

### DIFF
--- a/Casks/n/nextcloud-vfs.rb
+++ b/Casks/n/nextcloud-vfs.rb
@@ -1,0 +1,59 @@
+cask "nextcloud-vfs" do
+  version "3.13.2"
+  sha256 "5141dfcea9dd4d08faa86d4a2fd88f558e6d6a16e9dab2b5942533130153b0e3"
+
+  url "https://github.com/nextcloud-releases/desktop/releases/download/v#{version}/Nextcloud-#{version}-macOS-vfs.pkg",
+      verified: "github.com/nextcloud-releases/desktop/"
+  name "Nextcloud Virtual Files"
+  desc "Desktop sync client for Nextcloud software products"
+  homepage "https://nextcloud.com/"
+
+  # Upstream publishes releases for multiple different minor versions and the
+  # "latest" release is sometimes a lower version. Until the "latest" release
+  # is reliably the highest version, we have to check multiple releases.
+  livecheck do
+    url :url
+    regex(/^Nextcloud[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]vfs\.pkg$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "nextcloud"
+  depends_on macos: ">= :monterey"
+
+  pkg "Nextcloud-#{version}-macOS-vfs.pkg"
+  binary "/Applications/Nextcloud.app/Contents/MacOS/nextcloudcmd"
+
+  uninstall launchctl: "com.nextcloud.desktopclient",
+            quit:      "com.nextcloud.desktopclient",
+            pkgutil:   "com.nextcloud.desktopclient",
+            delete:    "/Applications/Nextcloud.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.nextcloud.desktopclient.FileProviderExt",
+    "~/Library/Application Scripts/com.nextcloud.desktopclient.FileProviderUIExt",
+    "~/Library/Application Scripts/com.nextcloud.desktopclient.FinderSyncExt",
+    "~/Library/Application Support/Nextcloud",
+    "~/Library/Caches/Nextcloud",
+    "~/Library/Containers/Nextcloud Extensions",
+    "~/Library/Containers/Nextcloud File Provider Extension",
+    "~/Library/Containers/Nextcloud File Provider UI Extension",
+    "~/Library/Group Containers/com.nextcloud.desktopclient",
+    "~/Library/HTTPStorages/com.nextcloud.desktopclient",
+    "~/Library/LaunchAgents/com.nextcloud.desktopclient.plist",
+    "~/Library/Preferences/com.nextcloud.desktopclient",
+    "~/Library/Preferences/com.nextcloud.desktopclient.plist",
+    "~/Library/Preferences/Nextcloud",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

`brew audit --cask --new <cask>` fails, because of 'GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)'

Nextcloud started to offer a separate package with virtual file system.

If you find another way, to have both versions of nextcloud Desktop available, please feel free to do so.
If you have any questions, feel free to comment.
