### PR TITLE
joinme: deprecate

### DIFF
--- a/Casks/j/joinme.rb
+++ b/Casks/j/joinme.rb
@@ -7,10 +7,7 @@ cask "joinme" do
   desc "Online conferencing software"
   homepage "https://www.join.me/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-16", because: :discontinued
 
   app "join.me.app"
 
@@ -23,4 +20,8 @@ cask "joinme" do
     "~/Library/Preferences/com.logmein.join.me.plist",
     "~/Library/Saved Application State/com.logmein.join.me.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Join.Me is now part of GoTo Meeting and discontinued as a free product ([source](https://support.goto.com/joinme/help/joinme-is-no-longer-free-what-happens-now)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
