### PR TITLE
Update nuclear.rb SHA256

### DIFF
--- a/Casks/n/nuclear.rb
+++ b/Casks/n/nuclear.rb
@@ -2,8 +2,8 @@ cask "nuclear" do
   arch arm: "arm64", intel: "x64"
 
   version "0.6.31"
-  sha256 arm:   "0618fbe8dff0dc3ab862dcc3afe93e76bb34afa073b0440c956778bfaa699841",
-         intel: "2679bb823ce9043d3685c0d6323afec3be9e91aaa5a3a898c5b65309e34c8240"
+  sha256 arm:   "68ca9faa7093b881b84d2fd707854e8b048ece1b999ea93c5f0b48f4a7d3cabb",
+         intel: "b24d3de9126c4c7ac833d23169c193c70151618021c2627e2c60a0d74bbc695b"
 
   url "https://github.com/nukeop/nuclear/releases/download/v#{version}/nuclear-v#{version}-#{arch}.dmg",
       verified: "github.com/nukeop/nuclear/"


### PR DESCRIPTION
Both checksums for arm and Intel were incorrect, these are the verified SHA256 checksums for the current 0.6.31 downloads

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
