### PR TITLE
Remove livecheck from casks that won't have a new version

### DIFF
--- a/Casks/a/anonym.rb
+++ b/Casks/a/anonym.rb
@@ -7,11 +7,6 @@ cask "anonym" do
   desc "Network access anonymiser"
   homepage "https://www.hanynet.com/anonym/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/anonym[._-]v?(\d+(?:\.\d+)+)\.zip}i)
-  end
-
   disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "Anonym.app"

--- a/Casks/a/arrsync.rb
+++ b/Casks/a/arrsync.rb
@@ -7,11 +7,6 @@ cask "arrsync" do
   desc "Graphical front end for the utility rsync"
   homepage "https://arrsync.sourceforge.net/"
 
-  livecheck do
-    url :homepage
-    regex(/arrsync-(\d+(?:\.\d+)+)\.dmg/i)
-  end
-
   disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "arRsync.app"

--- a/Casks/a/awareness.rb
+++ b/Casks/a/awareness.rb
@@ -7,11 +7,6 @@ cask "awareness" do
   desc "Time tracking application"
   homepage "http://iamfutureproof.com/tools/awareness/"
 
-  livecheck do
-    url "http://iamfutureproof.com/javascripts/tools/awareness.js"
-    regex(%r{/Awareness-(\d+(?:\.\d+)+)\.dmg}i)
-  end
-
   disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "Awareness.app"

--- a/Casks/b/brain-workshop.rb
+++ b/Casks/b/brain-workshop.rb
@@ -6,11 +6,6 @@ cask "brain-workshop" do
   name "Brain Workshop"
   homepage "https://brainworkshop.sourceforge.net/"
 
-  livecheck do
-    url :url
-    regex(%r{url=.*?/brainworkshop[._-]v?(\d+(?:\.\d+)+)-MacOSX\.zip}i)
-  end
-
   disable! date: "2024-07-09", because: "is 32-bit only"
 
   app "Brain Workshop.app"

--- a/Casks/c/command-x.rb
+++ b/Casks/c/command-x.rb
@@ -8,14 +8,6 @@ cask "command-x" do
   desc "Cut and paste files in Finder"
   homepage "https://sindresorhus.com/command-x"
 
-  livecheck do
-    url :homepage
-    regex(%r{href.*?/scl/fi/(\w+)/Command-X-([\d.-]+)\.zip\?rlkey=(\w+)}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]},#{match[2]}" }
-    end
-  end
-
   deprecate! date: "2024-07-09", because: :moved_to_mas
 
   depends_on macos: ">= :ventura"

--- a/Casks/m/microsoft-teams@classic.rb
+++ b/Casks/m/microsoft-teams@classic.rb
@@ -8,21 +8,6 @@ cask "microsoft-teams@classic" do
   desc "Meet, chat, call, and collaborate in just one place"
   homepage "https://www.microsoft.com/en-us/microsoft-teams/group-chat-software"
 
-  # Microsoft releases multiple versions and builds of Teams, as listed here:
-  #   https://raw.githubusercontent.com/ItzLevvie/MicrosoftTeams-msinternal/master/defconfig
-  # and here:
-  #   https://raw.githubusercontent.com/ItzLevvie/MicrosoftTeams-msinternal/master/defconfig2
-  #
-  # We only track the "production build"/"Public (R4) build" version,
-  # which agrees with the version reported by `livecheck`.
-  #
-  # Any pull request that updates this Cask to a version that
-  # differs from the `livecheck` version will be closed.
-  livecheck do
-    url "https://aka.ms/teamsmac"
-    strategy :header_match
-  end
-
   deprecate! date: "2024-07-03", because: :discontinued
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This removes `livecheck` blocks from some casks where there won't be a new version. The casks in this PR are all deprecated/disabled, so livecheck will automatically skip these casks after the `livecheck` block is removed.

Since these are all deprecated/disabled, I'm running this as syntax-only for the sake of efficiency and to make sure this won't get hung up by unrelated failures. Feel free to re-run it if it shouldn't be syntax-only.