### PR TITLE
[various Rogue Amoeba casks]: new urls, refactor livechecks

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -4,14 +4,14 @@ cask "airfoil" do
   on_ventura :or_older do
     version "5.11.8"
 
-    url "https://rogueamoeba.com/airfoil/mac/download-ace.php"
+    url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil-ACE.zip"
 
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.12.1"
 
-    url "https://rogueamoeba.com/airfoil/mac/download-ark.php"
+    url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
 
     depends_on macos: ">= :sonoma"
 

--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -4,34 +4,31 @@ cask "airfoil" do
   on_ventura :or_older do
     version "5.11.8"
 
-    url "https://rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
+    url "https://rogueamoeba.com/airfoil/mac/download-ace.php"
 
-    # NOTE: The `system` value will need to be kept up to date with the latest
-    # macOS Ventura version (e.g. 1366 for 13.6.6).
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1366&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
+    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.12.1"
 
-    url "https://rogueamoeba.com/airfoil/mac/download/Airfoil-ARK.zip"
+    url "https://rogueamoeba.com/airfoil/mac/download-ark.php"
 
-    # NOTE: The `system` value will need to be kept up to date with the latest
-    # macOS version (e.g. 1441 for 14.4.1).
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
+    depends_on macos: ">= :sonoma"
+
+    # NOTE: see https://rogueamoeba.com/airfoil/mac/
+    caveats "Airfoil #{version} requires macOS 14.4 or higher."
   end
 
   name "Airfoil"
   desc "Sends audio from computer to outputs"
   homepage "https://rogueamoeba.com/airfoil/mac/"
 
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+    strategy :sparkle
+  end
+
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "Airfoil/Airfoil Satellite.app"
   app "Airfoil/Airfoil.app"

--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -15,7 +15,7 @@ cask "airfoil" do
 
     depends_on macos: ">= :sonoma"
 
-    # NOTE: see https://rogueamoeba.com/airfoil/mac/
+    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Airfoil+for+Mac
     caveats "Airfoil #{version} requires macOS 14.4 or higher."
   end
 

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -15,8 +15,8 @@ cask "audio-hijack" do
 
     depends_on macos: ">= :sonoma"
 
-    # NOTE: see https://weblog.rogueamoeba.com/2024/04/05/our-new-installer-free-setup-comes-to-audio-hijack/#fn1-2024-04-audiohijack
-    caveats "Loopback #{version} requires macOS 14.5 or higher."
+    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Audio+Hijack
+    caveats "Audio Hijack #{version} requires macOS 14.5 or higher."
   end
 
   name "Audio Hijack"

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -4,14 +4,14 @@ cask "audio-hijack" do
   on_ventura :or_older do
     version "4.3.3"
 
-    url "https://rogueamoeba.com/audiohijack/download-ace.php"
+    url "https://cdn.rogueamoeba.com/audiohijack/download/AudioHijack-ACE.zip"
 
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "4.4.2"
 
-    url "https://rogueamoeba.com/audiohijack/download-ark.php"
+    url "https://cdn.rogueamoeba.com/audiohijack/download/AudioHijack.zip"
 
     depends_on macos: ">= :sonoma"
 

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -4,34 +4,31 @@ cask "audio-hijack" do
   on_ventura :or_older do
     version "4.3.3"
 
-    url "https://rogueamoeba.com/audiohijack/download/AudioHijack.zip"
+    url "https://rogueamoeba.com/audiohijack/download-ace.php"
 
-    # NOTE: The `system` value will need to be kept up to date with the latest
-    # macOS Ventura version (e.g. 1366 for 13.6.6).
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1366&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
+    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "4.4.2"
 
-    url "https://rogueamoeba.com/audiohijack/download/AudioHijack-ARK.zip"
+    url "https://rogueamoeba.com/audiohijack/download-ark.php"
 
-    # NOTE: The `system` value will need to be kept up to date with the latest
-    # macOS version (e.g. 1441 for 14.4.1).
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
+    depends_on macos: ">= :sonoma"
+
+    # NOTE: see https://weblog.rogueamoeba.com/2024/04/05/our-new-installer-free-setup-comes-to-audio-hijack/#fn1-2024-04-audiohijack
+    caveats "Loopback #{version} requires macOS 14.5 or higher."
   end
 
   name "Audio Hijack"
   desc "Records audio from any application"
   homepage "https://rogueamoeba.com/audiohijack/"
 
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
+    strategy :sparkle
+  end
+
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "Audio Hijack.app"
 

--- a/Casks/f/farrago.rb
+++ b/Casks/f/farrago.rb
@@ -2,7 +2,7 @@ cask "farrago" do
   version "2.0.7"
   sha256 :no_check
 
-  url "https://rogueamoeba.com/farrago/download/Farrago.zip"
+  url "https://cdn.rogueamoeba.com/farrago/download/Farrago.zip"
   name "Farrago"
   desc "Audio playback"
   homepage "https://rogueamoeba.com/farrago/"

--- a/Casks/f/farrago.rb
+++ b/Casks/f/farrago.rb
@@ -7,10 +7,8 @@ cask "farrago" do
   desc "Audio playback"
   homepage "https://rogueamoeba.com/farrago/"
 
-  # NOTE: The `system` value will need to be kept up to date with the latest
-  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.farrago&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.farrago&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 

--- a/Casks/f/fission.rb
+++ b/Casks/f/fission.rb
@@ -2,7 +2,7 @@ cask "fission" do
   version "2.8.5"
   sha256 :no_check
 
-  url "https://rogueamoeba.com/fission/download/Fission.zip"
+  url "https://cdn.rogueamoeba.com/fission/download/Fission.zip"
   name "Fission"
   desc "Audio editor"
   homepage "https://rogueamoeba.com/fission/"

--- a/Casks/f/fission.rb
+++ b/Casks/f/fission.rb
@@ -7,10 +7,8 @@ cask "fission" do
   desc "Audio editor"
   homepage "https://rogueamoeba.com/fission/"
 
-  # NOTE: The `system` value will need to be kept up to date with the latest
-  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.fission&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.fission&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -4,14 +4,14 @@ cask "loopback" do
   on_ventura :or_older do
     version "2.3.3"
 
-    url "https://rogueamoeba.com/loopback/download-ace.php"
+    url "https://cdn.rogueamoeba.com/loopback/download/Loopback.zip"
 
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "2.4.1"
 
-    url "https://rogueamoeba.com/loopback/download-ark.php"
+    url "https://cdn.rogueamoeba.com/loopback/download/Loopback-ARK.zip"
 
     depends_on macos: ">= :sonoma"
 

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -1,20 +1,17 @@
 cask "loopback" do
   sha256 :no_check
 
-  macosversion_no_dots = "145"
-  audio_engine = "ark"
-
   on_ventura :or_older do
-    # macOS 11.0 is oldest supported version
-    macosversion_no_dots = "110"
-    audio_engine = "ace"
-
     version "2.3.3"
+
+    url "https://rogueamoeba.com/loopback/download-ace.php"
 
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "2.4.1"
+
+    url "https://rogueamoeba.com/loopback/download-ark.php"
 
     depends_on macos: ">= :sonoma"
 
@@ -22,13 +19,12 @@ cask "loopback" do
     caveats "Loopback #{version} requires macOS 14.5 or newer."
   end
 
-  url "https://rogueamoeba.com/loopback/download-#{audio_engine}.php"
   name "Loopback"
   desc "Cable-free audio router"
   homepage "https://rogueamoeba.com/loopback/"
 
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{macosversion_no_dots}&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -15,7 +15,7 @@ cask "loopback" do
 
     depends_on macos: ">= :sonoma"
 
-    # NOTE: see https://weblog.rogueamoeba.com/2024/06/07/now-you-can-install-loopback-in-under-one-minute/#fn1-2024-06-loopback
+    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Loopback
     caveats "Loopback #{version} requires macOS 14.5 or newer."
   end
 

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -4,14 +4,14 @@ cask "piezo" do
   on_ventura :or_older do
     version "1.8.2"
 
-    url "https://rogueamoeba.com/piezo/download-ace.php"
+    url "https://cdn.rogueamoeba.com/piezo/download/Piezo-ACE.zip"
 
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "1.9.2"
 
-    url "https://rogueamoeba.com/piezo/download-ark.php"
+    url "https://cdn.rogueamoeba.com/piezo/download/Piezo.zip"
 
     depends_on macos: ">= :sonoma"
 

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -15,7 +15,7 @@ cask "piezo" do
 
     depends_on macos: ">= :sonoma"
 
-    # NOTE: see https://weblog.rogueamoeba.com/2024/03/13/piezo-ark-update-launches/
+    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Piezo
     caveats "Piezo #{version} requires macOS 14.4 or higher."
   end
 

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -4,12 +4,19 @@ cask "piezo" do
   on_ventura :or_older do
     version "1.8.2"
 
-    url "https://rogueamoeba.com/piezo/download/Piezo.zip"
+    url "https://rogueamoeba.com/piezo/download-ace.php"
+
+    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "1.9.2"
 
-    url "https://rogueamoeba.com/piezo/download/Piezo-ARK.zip"
+    url "https://rogueamoeba.com/piezo/download-ark.php"
+
+    depends_on macos: ">= :sonoma"
+
+    # NOTE: see https://weblog.rogueamoeba.com/2024/03/13/piezo-ark-update-launches/
+    caveats "Piezo #{version} requires macOS 14.4 or higher."
   end
 
   name "Piezo"
@@ -22,7 +29,6 @@ cask "piezo" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
 
   app "Piezo.app"
 

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -2,7 +2,7 @@ cask "soundsource" do
   version "5.6.3"
   sha256 :no_check
 
-  url "https://rogueamoeba.com/soundsource/download/SoundSource.zip"
+  url "https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip"
   name "SoundSource"
   desc "Sound and audio controller"
   homepage "https://rogueamoeba.com/soundsource/"

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -7,8 +7,6 @@ cask "soundsource" do
   desc "Sound and audio controller"
   homepage "https://rogueamoeba.com/soundsource/"
 
-  # NOTE: The `system` value will need to be kept up to date with the latest
-  # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
     url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -10,7 +10,7 @@ cask "soundsource" do
   # NOTE: The `system` value will need to be kept up to date with the latest
   # macOS version (e.g. 1441 for 14.4.1).
   livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
     strategy :sparkle
   end
 


### PR DESCRIPTION
Rogue Amoeba is splitting most of their software into two parallel version tracks: Audio Routing Kit (ARK) for macOS 14.4 (sometimes 14.5) and above, and ACE (Audio Capture Engine) for older. ARK features a much more streamlined and less permission-greedy install process.

`airfoil`, `piezo`, and `audio-hijack` are currently broken as their URLs have changed for the split versions. The current URLs now give 404s.

For the other 5 casks by the same developer, this PR standardizes formatting and improves formula readability.

Shoutout to @samford for the much nicer way to get the current macOS version with no dots (needed for all Rogue Amoeba livecheck URLs): https://github.com/Homebrew/homebrew-cask/commit/48d317e6566a00136fa2400e8fb5167125a2eba8

- **airfoil: new urls, refactor livecheck**
- **audio-hijack: new urls, refactor livecheck**
- **farrago: smarter livecheck**
- **fission: smarter livecheck**
- **loopback: refactor livecheck**
- **piezo: new urls, differentiate macos dependencies**
- **soundsource: smarter livecheck**

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
