### PR TITLE
time-lapse-assembler: deprecate

### DIFF
--- a/Casks/t/time-lapse-assembler.rb
+++ b/Casks/t/time-lapse-assembler.rb
@@ -7,10 +7,7 @@ cask "time-lapse-assembler" do
   desc "Tool to create movies from a sequence of images"
   homepage "https://www.dayofthenewdan.com/projects/time-lapse-assembler-1/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-17", because: :unmaintained
 
   app "Time Lapse Assembler.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

[Author remark](https://github.com/dbridges/cocoa-tlassemble/issues/6#issuecomment-1296333802) in an issue of the underlying command line application:
> I'm actually pretty surprised this even works as it uses now deprecated Quicktime frameworks. Consider using ffmpeg as a replacement.

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
