### PR TITLE
various: [s] casks: disable 32-bit applications

### DIFF
--- a/Casks/s/serial-tools.rb
+++ b/Casks/s/serial-tools.rb
@@ -6,7 +6,7 @@ cask "serial-tools" do
   name "Serial Tools"
   homepage "https://www.w7ay.net/site/Applications/Serial%20Tools/"
 
-  disable! date: "2024-07-06", because: :unmaintained
+  disable! date: "2024-07-06", because: "is 32-bit only"
 
   app "Serial Tools.app"
 end

--- a/Casks/s/shimeike-formulatepro.rb
+++ b/Casks/s/shimeike-formulatepro.rb
@@ -7,10 +7,7 @@ cask "shimeike-formulatepro" do
   desc "Overlays text and graphics on PDF documents"
   homepage "https://github.com/shimeike/formulatepro/"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)[a-z]?$/i)
-  end
+  disable! date: "2024-07-17", because: "is 32-bit only"
 
   app "FormulatePro.app"
 end

--- a/Casks/s/shupapan.rb
+++ b/Casks/s/shupapan.rb
@@ -6,15 +6,7 @@ cask "shupapan" do
   name "Shupapan"
   homepage "http://sunsky3s.s41.xrea.com/shupapan/"
 
-  livecheck do
-    url "http://sunsky3s.s41.xrea.com/shupapan/download/index.html"
-    regex(%r{href=.*?/Shupapan_v(\d+)(\d+)(\d+)(\d+)\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[0]}.#{match[1]}.#{match[2]}.#{match[3]}"
-      end
-    end
-  end
+  disable! date: "2024-07-17", because: "is 32-bit only"
 
   app "Shupapan.app"
 end

--- a/Casks/s/simplesynth.rb
+++ b/Casks/s/simplesynth.rb
@@ -8,5 +8,7 @@ cask "simplesynth" do
   desc "Small and fast synth"
   homepage "https://github.com/notahat/simplesynth"
 
+  disable! date: "2024-07-17", because: "is 32-bit only"
+
   app "SimpleSynth.app"
 end

--- a/Casks/s/sqlexplorer.rb
+++ b/Casks/s/sqlexplorer.rb
@@ -7,10 +7,7 @@ cask "sqlexplorer" do
   desc "SQL Client for JDBC compliant databases"
   homepage "https://eclipsesql.sourceforge.net/"
 
-  livecheck do
-    url "https://sourceforge.net/projects/eclipsesql/rss?path=/SQL%20Explorer%20RCP%20%28exc%20JRE%29"
-    regex(%r{url=.*?/sqlexplorer[._-]rcp[._-]v?(\d+(?:\.\d+)+)[._-]macosx?[^"' ]*?\.(?:t|zip)}i)
-  end
+  disable! date: "2024-07-17", because: "is 32-bit only"
 
   app "SQLExplorer/sqlexplorer.app"
 end

--- a/Casks/s/stepmania.rb
+++ b/Casks/s/stepmania.rb
@@ -8,10 +8,7 @@ cask "stepmania" do
   desc "Advanced rhythm game designed for both home and arcade use"
   homepage "https://www.stepmania.com/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  disable! date: "2024-07-17", because: "is 32-bit only"
 
   app "StepMania-#{version}/Stepmania.app"
 end

--- a/Casks/s/subtitle-master.rb
+++ b/Casks/s/subtitle-master.rb
@@ -7,10 +7,7 @@ cask "subtitle-master" do
   desc "Search for subtitles"
   homepage "https://github.com/subtitle-master/subtitlemaster"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)(?:-SNAPSHOT)?$/i)
-  end
+  disable! date: "2024-07-17", because: "is 32-bit only"
 
   app "Subtitle Master.app"
 end


### PR DESCRIPTION
Disable various casks starting with [s] that are 32-bit only and do not run on modern versions of macOS.