### PR TITLE
various: [k] casks: deprecate

### DIFF
--- a/Casks/k/kakapo.rb
+++ b/Casks/k/kakapo.rb
@@ -2,11 +2,16 @@ cask "kakapo" do
   version "1.3.0"
   sha256 "4f89f2d651b88e7c13bce3cccefc4929e83a5f509dae102f071ecd80aab9d524"
 
-  url "https://github.com/bluedaniel/Kakapo-app/releases/download/v#{version}/Kakapo-#{version}-Mac.zip",
-      verified: "github.com/bluedaniel/Kakapo-app/"
+  url "https://github.com/bluedaniel/Kakapo-app/releases/download/v#{version}/Kakapo-#{version}-Mac.zip"
   name "Kakapo"
   desc "Open-source ambient sound mixer"
-  homepage "http://www.kakapo.co/app.html"
+  homepage "https://github.com/bluedaniel/Kakapo-app"
+
+  deprecate! date: "2024-07-17", because: :unmaintained
 
   app "Kakapo.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/kaku.rb
+++ b/Casks/k/kaku.rb
@@ -7,5 +7,11 @@ cask "kaku" do
   name "Kaku"
   homepage "https://kaku.rocks/"
 
+  deprecate! date: "2024-07-17", because: :unmaintained
+
   app "Kaku.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/kapitainsky-rclone-browser.rb
+++ b/Casks/k/kapitainsky-rclone-browser.rb
@@ -7,20 +7,13 @@ cask "kapitainsky-rclone-browser" do
   desc "GUI for rclone"
   homepage "https://github.com/kapitainsky/RcloneBrowser"
 
-  livecheck do
-    url :url
-    regex(/^rclone-browser[._-]v?(\d+(?:\.\d+)+)-([0-9a-f]+)-macos\.dmg/i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
-
-        "#{match[1]},#{match[2]}"
-      end
-    end
-  end
+  deprecate! date: "2024-07-17", because: :unmaintained
 
   depends_on formula: "rclone"
 
   app "Rclone Browser.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/kawa.rb
+++ b/Casks/k/kawa.rb
@@ -7,5 +7,11 @@ cask "kawa" do
   desc "Alternative input source switcher"
   homepage "https://github.com/utatti/kawa"
 
+  deprecate! date: "2024-07-17", because: :unmaintained
+
   app "Kawa.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/kmbmpdc.rb
+++ b/Casks/k/kmbmpdc.rb
@@ -7,8 +7,14 @@ cask "kmbmpdc" do
   name "kawaii menu bar music player daemon controller"
   homepage "https://github.com/arttuperala/kmbmpdc"
 
+  deprecate! date: "2024-07-17", because: :unmaintained
+
   auto_updates true
   depends_on macos: ">= :el_capitan"
 
   app "kmbmpdc.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/koala.rb
+++ b/Casks/k/koala.rb
@@ -7,10 +7,11 @@ cask "koala" do
   name "Koala"
   homepage "http://koala-app.com/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-07-17", because: :unmaintained
 
   app "Koala.app"
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/k/kube-forwarder.rb
+++ b/Casks/k/kube-forwarder.rb
@@ -7,5 +7,12 @@ cask "kube-forwarder" do
   name "Kube Forwarder"
   homepage "https://kube-forwarder.pixelpoint.io/"
 
+  # https://github.com/pixel-point/kube-forwarder/issues/100#issuecomment-1065111816
+  deprecate! date: "2024-07-17", because: :unmaintained
+
   app "Kube Forwarder.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Deprecates various [k] casks which do not appear to be maintained any longer.

`kakapo` - last update 2016
`kaku` - last update 2019
`kapitainsky-rclone-browser` - last update 2020
`kawa` - last update 2017
`kmbmpdc` - last update 2017
`koala` - last update 2017
`kube-forwarder` - see https://github.com/pixel-point/kube-forwarder/issues/100#issuecomment-1065111816