### PR TITLE
aptanastudio: deprecate

### DIFF
--- a/Casks/a/aptanastudio.rb
+++ b/Casks/a/aptanastudio.rb
@@ -5,12 +5,10 @@ cask "aptanastudio" do
   url "https://github.com/aptana/studio3/releases/download/#{version}/Aptana_Studio_#{version.major}.dmg",
       verified: "github.com/aptana/studio3/"
   name "Aptana Studio"
+  desc "IDE for web development"
   homepage "https://www.aptana.com/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-07-17", because: :unmaintained
 
   app "AptanaStudio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Aptana Studio is no longer being maintained ([source](https://www.axway.com/en/aptana)):

> Aptana Studio 3 is an open-source web development IDE, and while we are no longer actively maintaining the repository, it is still open-source and public so if you wish to download Aptana Studio 3 you can do so on GitHub.
