### PR TITLE
black-light-pro: deprecate

### DIFF
--- a/Casks/b/black-light-pro.rb
+++ b/Casks/b/black-light-pro.rb
@@ -7,10 +7,7 @@ cask "black-light-pro" do
   desc "Colour effects on a schedule"
   homepage "https://michelf.ca/software/black-light-pro/"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?black[._-]light[._-]pro[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-  end
+  deprecate! date: "2024-07-17", because: :discontinued
 
   app "BLack Light Pro.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Black Light Pro has been discontinued ([source](https://michelf.ca/software/black-light-pro/)):

> Black Light Pro is no longer. Its functionalities have been merged into [Black Light 3](https://michelf.ca/projects/black-light/).
