### PR TITLE
cord: deprecate

### DIFF
--- a/Casks/c/cord.rb
+++ b/Casks/c/cord.rb
@@ -7,10 +7,7 @@ cask "cord" do
   desc "Remote desktop client"
   homepage "https://cord.sourceforge.net/"
 
-  livecheck do
-    url "https://cord.sourceforge.net/sparkle.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2024-07-17", because: :discontinued
 
   app "CoRD.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

CoRD has been discontinued ([source](https://cord.sourceforge.net/)):

> 2020-04-13: This project is defunct.
