### PR TITLE
Fix shasums for sapmachine-jdk.rb

### DIFF
--- a/Casks/s/sapmachine-jdk.rb
+++ b/Casks/s/sapmachine-jdk.rb
@@ -2,8 +2,8 @@ cask "sapmachine-jdk" do
   arch arm: "aarch64", intel: "x64"
 
   version "22.0.2"
-  sha256 arm:   "d0119abdd5d625fa7d353fb7bf80faf791ca74569fece4db3db84685817477fb",
-         intel: "5e5568e5080ca531150e855780e0552cb68fd45476dab4ce1ef1c78d28c2cda0"
+  sha256 arm:   "acfc48c89def275753cfb93f683929c9987ecd27fc12189d7e176dec7f2f7c13",
+         intel: "2efeba61d8bc752c28ab79303c41cdc4e54576d21d0e7bdac00985706fbfc160"
 
   url "https://github.com/SAP/SapMachine/releases/download/sapmachine-#{version}/sapmachine-jdk-#{version}_macos-#{arch}_bin.dmg",
       verified: "github.com/SAP/SapMachine/"


### PR DESCRIPTION
The binaries for release sapmachine-22.0.2 have been updated so it needs to be reflected in the cask's sha256 sums.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
