### PR TITLE
ivacy 7.0.0,8 (new cask)

### DIFF
--- a/Casks/i/ivacy.rb
+++ b/Casks/i/ivacy.rb
@@ -1,0 +1,24 @@
+cask "ivacy" do
+  version "7.0.0,8"
+  sha256 :no_check
+
+  url "https://apps-ivacy.s3.amazonaws.com/mac/Ivacy.dmg",
+      verified: "apps-ivacy.s3.amazonaws.com/"
+  name "Ivacy"
+  desc "VPN client"
+  homepage "https://www.ivacy.com/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Ivacy.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.ivacy.mac",
+    "~/Library/Containers/com.ivacy.mac",
+  ]
+end


### PR DESCRIPTION
Unfortunately I was unable to find any reference to any versions anywhere on the site and have had to use the extract_plist strategy.

Link to download - https://www.ivacy.com/download-vpn/vpn-for-mac/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
