### PR TITLE
logi-options-plus: add legacy versions

### DIFF
--- a/Casks/l/logi-options-plus.rb
+++ b/Casks/l/logi-options-plus.rb
@@ -1,17 +1,42 @@
 cask "logi-options-plus" do
-  version "1.78.588966"
-  sha256 :no_check
+  on_catalina do
+    version "1.44.415778"
+    sha256 "c38b38aada01a296d32dcebb61200b53977e876089b8502b7f8453d1efa3a3f6"
 
-  url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip",
-      verified: "download01.logi.com/web/ftp/pub/techsupport/optionsplus/"
+    url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_#{version}.zip",
+        verified: "download01.logi.com/web/ftp/pub/techsupport/optionsplus/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur do
+    version "1.60.495862"
+    sha256 "711d64f48b9dc2ed48f50dccc8610e64b3ce437383ed6ff3da6e220380271434"
+
+    url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_#{version}.zip",
+        verified: "download01.logi.com/web/ftp/pub/techsupport/optionsplus/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_monterey :or_newer do
+    version "1.78.588966"
+    sha256 :no_check
+
+    url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip",
+        verified: "download01.logi.com/web/ftp/pub/techsupport/optionsplus/"
+
+    livecheck do
+      url "https://support.logi.com/hc/en-gb/articles/1500005516462"
+      regex(/version\D*?(\d+(?:\.\d+)+)/i)
+    end
+  end
+
   name "Logitech Options+"
   desc "Software for Logitech devices"
   homepage "https://www.logitech.com/en-us/software/logi-options-plus.html"
-
-  livecheck do
-    url "https://support.logi.com/hc/en-gb/articles/1500005516462"
-    regex(/version\D*?(\d+(?:\.\d+)+)/i)
-  end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
Rather than just increasing the minimum version required, I have added some legacy versions. 

Not sure if there is a more efficient method of specifing the url as unfortunately `https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer_#{version}.zip` doesn't seem to exist when the most recent version is provided.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
