### PR TITLE
binary-ninja: update livecheck

### DIFF
--- a/Casks/b/binary-ninja.rb
+++ b/Casks/b/binary-ninja.rb
@@ -8,10 +8,15 @@ cask "binary-ninja" do
   homepage "https://binary.ninja/"
 
   livecheck do
-    url :url
-    regex(/(\d+(?:\.\d+)+)/)
-    strategy :extract_plist do |items|
-      items["com.vector35.binaryninja"].short_version[regex, 1]
+    url "https://binary.ninja/js/changelog.json"
+    regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :json do |json, regex|
+      json.map do |item|
+        match = item["version"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the `livecheck` block for `binary-ninja` to check the version information from the `changelog.json` file that's used as the content of the https://binary.ninja/changelog/ page. This allows us to move away from using the `ExtractPlist` strategy here, as we only use it when there isn't another usable source of version information.

Related to https://github.com/Homebrew/homebrew-cask/issues/171006