### PR TITLE
gitkraken conflict

### DIFF
--- a/Casks/g/gitkraken.rb
+++ b/Casks/g/gitkraken.rb
@@ -17,6 +17,7 @@ cask "gitkraken" do
   end
 
   auto_updates true
+  conflicts_with cask: "gitkraken-on-premise-serverless"
   depends_on macos: ">= :el_capitan"
 
   app "GitKraken.app"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online gitkraken` is error-free.
- [x] `brew style --fix gitkraken` reports no offenses.

Add conflict for new cask `gitkraken-on-premise-serverless` added in https://github.com/Homebrew/homebrew-cask/pull/179504