### PR TITLE
monofocus: update livecheck, use versioned url

### DIFF
--- a/Casks/m/monofocus.rb
+++ b/Casks/m/monofocus.rb
@@ -1,17 +1,16 @@
 cask "monofocus" do
   version "1.0.beta36"
-  sha256 :no_check
+  sha256 "17a885fcba482c23e26539275f8bb75812d00675ac26e78879848bded435f69e"
 
-  url "https://updates.monofocus.app/MonoFocus.latest.dmg"
+  url "https://updates.monofocus.app/MonoFocus.#{version}.dmg"
   name "MonoFocus"
   desc "Keep all tasks from your todo apps on your menu bar"
   homepage "https://monofocus.app/"
 
   livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+\S*)/i)
-    strategy :extract_plist do |items, regex|
-      items["com.zbudniewek.WorkingOn"]&.short_version&.scan(regex)&.map { |match| match[0] }
+    url "https://sparkle.monofocus.app/feeds/beta"
+    strategy :sparkle do |item|
+      item.short_version&.split&.first
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
