### PR TITLE
db-browser-for-sqlite: Bump version from 3.12.2 to 3.13.0

### DIFF
--- a/Casks/d/db-browser-for-sqlite.rb
+++ b/Casks/d/db-browser-for-sqlite.rb
@@ -1,11 +1,8 @@
 cask "db-browser-for-sqlite" do
-  arch arm: "-arm64"
+  version "3.13.0"
+  sha256 "dfa72811ab9faa522586a31bf680db1604442e35a2725f0aed77d5f66388724b"
 
-  version "3.12.2"
-  sha256 arm:   "0c2076e4479cb9db5c85123cfe9750641f92566694ff9f6c99906321a2c424e8",
-         intel: "546d57b6c88c2be7517759c016c0bf0313dfcc14adfcb43967f3c5d24657f366"
-
-  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite#{arch}-#{version}.dmg",
+  url "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v#{version}/DB.Browser.for.SQLite-v#{version}.dmg",
       verified: "github.com/sqlitebrowser/sqlitebrowser/"
   name "DB Browser for SQLite"
   desc "Browser for SQLite databases"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
We released a new version. Thank you.
Related:
- https://github.com/sqlitebrowser/sqlitebrowser/releases/tag/v3.13.0
- https://github.com/sqlitebrowser/sqlitebrowser/discussions/3689