### PR TITLE
topcat java dependency removed

### DIFF
--- a/Casks/t/topcat.rb
+++ b/Casks/t/topcat.rb
@@ -17,8 +17,4 @@ cask "topcat" do
   binary "#{appdir}/TOPCAT.app/Contents/Resources/app/stilts"
 
   # No zap stanza required
-
-  caveats do
-    depends_on_java "8+"
-  end
 end


### PR DESCRIPTION
The topcat DMG file that is downloaded for installation now bundles a JRE, so there is no additional dependency on an external java package.

I (topcat author) have therefore removed the caveats stanza containing depends_on_java.  I presume that's the right thing to do, but I have minimal ruby/homebrew experience, so mistakes are not impossible.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
