### PR TITLE
amazon-luna: deprecate

### DIFF
--- a/Casks/a/amazon-luna.rb
+++ b/Casks/a/amazon-luna.rb
@@ -7,12 +7,7 @@ cask "amazon-luna" do
   desc "Play your favorite games straight from the cloud"
   homepage "https://www.amazon.com/luna/"
 
-  # amazon-luna does use an appcast.xml for auto-updates, but
-  # the appcast uses an authentication token and is not easily accessible
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-23", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
Doesn't appear on Amazon's website anymore, also found this news article - https://9to5google.com/2023/06/05/amazon-luna-windows-pc-mac-apps/

Can also be removed from #171006

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
