### PR TITLE
amazon-workdocs-drive: deprecate

### DIFF
--- a/Casks/a/amazon-workdocs-drive.rb
+++ b/Casks/a/amazon-workdocs-drive.rb
@@ -4,21 +4,10 @@ cask "amazon-workdocs-drive" do
   on_arm do
     version "1.0.11931.0"
     sha256 :no_check
-
-    livecheck do
-      url :url
-      strategy :extract_plist
-    end
   end
   on_intel do
     version "1.0.10729.0"
     sha256 :no_check
-
-    livecheck do
-      strategy :extract_plist do |items|
-        items["com.Amazon.WorkDocs.Drive"].short_version
-      end
-    end
   end
 
   url "https://d3f2hupz96ggz3.cloudfront.net/#{arch}/AmazonWorkDocsDrive.pkg",
@@ -26,6 +15,8 @@ cask "amazon-workdocs-drive" do
   name "Amazon WorkDocs Drive"
   desc "Fully managed, secure enterprise storage and sharing service"
   homepage "https://aws.amazon.com/workdocs/"
+
+  deprecate! date: "2024-07-24", because: :discontinued
 
   depends_on macos: ">= :el_capitan"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Amazon is ending support for the WorkDocs service:
> Notice: New customer sign-ups and account upgrades are no longer available for Amazon WorkDocs. Learn about migration steps [here](https://aws.amazon.com/blogs/business-productivity/how-to-migrate-content-from-amazon-workdocs/).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
