### PR TITLE
mamp@6 6.9 (new cask)

### DIFF
--- a/Casks/m/mamp@6.rb
+++ b/Casks/m/mamp@6.rb
@@ -1,0 +1,48 @@
+cask "mamp" do
+  arch arm: "M1-arm", intel: "Intel-x86"
+
+  version "6.9"
+  sha256 arm:   "e66a67fad914a065c882ffa137c9c9dc5ae8c24de53320d560b6b5cc0f4a890a",
+         intel: "7a3ff488c9c8d3f8f6730edfb06822e2640303cfcd03d75d14bb977d85518570"
+
+  url "https://downloads.mamp.info/MAMP-PRO/releases/#{version}/MAMP_MAMP_PRO_#{version}-#{arch}.pkg"
+  name "MAMP"
+  desc "Web development solution with Apache, Nginx, PHP & MySQL"
+  homepage "https://www.mamp.info/"
+
+  livecheck do
+    url "https://www.mamp.info/en/downloads/"
+    regex(%r{href=.*?/MAMP[._-]MAMP[._-]PRO[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.pkg}i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sierra"
+
+  pkg "MAMP_MAMP_PRO_#{version}-#{arch}.pkg"
+
+  postflight do
+    set_ownership ["/Applications/MAMP", "/Applications/MAMP PRO"]
+  end
+
+  uninstall pkgutil: "de.appsolute.installer.(mamp|mampacticon|mampendinstall|mamppro).pkg",
+            delete:  "/Applications/MAMP"
+
+  zap delete: [
+        "/Library/Application Support/appsolute",
+        "/Library/LaunchDaemons/de.appsolute.mampprohelper.plist",
+        "/Library/PrivilegedHelperTools/de.appsolute.mampprohelper",
+      ],
+      trash:  [
+        "~/Library/Application Support/appsolute",
+        "~/Library/Application Support/de.appsolute.MAMP",
+        "~/Library/Application Support/de.appsolute.mamppro",
+        "~/Library/Caches/de.appsolute.MAMP",
+        "~/Library/Caches/de.appsolute.mamppro",
+        "~/Library/HTTPStorages/de.appsolute.MAMP",
+        "~/Library/HTTPStorages/de.appsolute.mamppro",
+        "~/Library/Preferences/de.appsolute.MAMP.plist",
+        "~/Library/Preferences/de.appsolute.mamppro.plist",
+        "~/Library/Saved Application State/de.appsolute.MAMP.savedState",
+        "~/Library/Saved Application State/de.appsolute.mamppro.savedState",
+      ]
+end

--- a/Casks/m/mamp@6.rb
+++ b/Casks/m/mamp@6.rb
@@ -1,4 +1,4 @@
-cask "mamp" do
+cask "mamp@6" do
   arch arm: "M1-arm", intel: "Intel-x86"
 
   version "6.9"


### PR DESCRIPTION
With MAMP Pro 7 being a paid for update, support should be kept for MAMP Pro 6.

Ref: https://github.com/Homebrew/homebrew-cask/commit/7481fac97ed14ef2387379b5f7979ac9e3f6b42b

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
