### PR TITLE
115: disabled

### DIFF
--- a/Casks/1/115.rb
+++ b/Casks/1/115.rb
@@ -9,12 +9,7 @@ cask "115" do
   desc "Client for the 115 cloud storage service"
   homepage "https://pc.115.com/index.html#mac"
 
-  livecheck do
-    url "https://appversion.115.com/1/web/1.0/api/chrome"
-    strategy :json do |json|
-      json.dig("data", "mac_115", "version_code")
-    end
-  end
+  disable! date: "2024-07-25", because: :no_longer_available
 
   auto_updates true
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
115 can not login anymore because of deprecation. And it recommends another official product `115browser`.

<img width="770" alt="Xnip2024-07-26_13-32-25" src="https://github.com/user-attachments/assets/46b61ec4-9694-4353-8ca3-28e17f8ca92f">
