### PR TITLE
box-sync: deprecate

### DIFF
--- a/Casks/b/box-sync.rb
+++ b/Casks/b/box-sync.rb
@@ -8,12 +8,9 @@ cask "box-sync" do
   desc "Cloud based collaboration and management platform focusing on security"
   homepage "https://www.box.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.box.sync"].version
-    end
-  end
+  deprecate! date: "2024-07-26", because: :discontinued
+
+  conflicts_with cask: "box-drive"
 
   app "Box Sync.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Box Sync is superseded by Box Drive ([source](https://support.box.com/hc/en-us/articles/16778168894995-Box-Sync-and-Apple-Silicon-devices-are-not-supported/)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
