### PR TITLE
Disable the cask Tuist

### DIFF
--- a/Casks/t/tuist.rb
+++ b/Casks/t/tuist.rb
@@ -1,4 +1,5 @@
 cask "tuist" do
+  disable! date: "2024-07-26", because: "It's distributed through the tap https://github.com/tuist/homebrew-tuist"
   version "4.21.2"
   sha256 "7c00de9e0d45de9b1071b84d81a4cb95010c807733676e065a2926db45e4fc88"
 


### PR DESCRIPTION
We are maintaining the Tuist formula in our own [tap](https://github.com/tuist/homebrew-tuist) so I'm disabling the cask to point people to our formula.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
