### PR TITLE
cloudflare-warp: update livecheck

### DIFF
--- a/Casks/c/cloudflare-warp.rb
+++ b/Casks/c/cloudflare-warp.rb
@@ -12,7 +12,7 @@ cask "cloudflare-warp" do
     # :sparkle strategy using appcenter url cannot be used - see below link
     # https://github.com/Homebrew/homebrew-cask/pull/109118#issuecomment-887184248
     url "https://1111-releases.cloudflareclient.com/mac/latest"
-    regex(%r{/Cloudflare[._-]WARP[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+    regex(/Cloudflare[._-]WARP[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
     strategy :header_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `cloudflare-warp` is currently giving an `Unable to get versions` error. I assume that the regex was originally intended to match a `location` header URL but the server now gives the filename in a `content-disposition` header and there's no leading forward slash in that context.

This addresses the issue by updating the `livecheck` block regex to remove the leading forward slash, which will work in either scenario.