### PR TITLE
fl-studio: update url, livecheck

### DIFF
--- a/Casks/f/fl-studio.rb
+++ b/Casks/f/fl-studio.rb
@@ -2,14 +2,34 @@ cask "fl-studio" do
   version "24.1.1.3888"
   sha256 "5dea7153764f3f4a3c19099c79d7b790993335728600e05e890efac699a00ab5"
 
-  url "https://demodownload.image-line.com/flstudio/flstudio_mac_#{version}.dmg"
+  url "https://install.image-line.com/flstudio/flstudio_mac_#{version}.dmg",
+      referer:    "https://www.image-line.com/fl-studio-download/",
+      user_agent: :browser
   name "FL Studio"
   desc "Digital audio production application"
   homepage "https://www.image-line.com/flstudio/"
 
+  # The macOS link on the download page redirects to the latest dmg file but
+  # livecheck is blocked by Cloudflare unless we use a `:browser` user agent
+  # and set the download page as the referer. We can't set the referer in
+  # livecheck yet, so this works around the issue by parsing the version from
+  # the URL that the download page uses to fetch version information.
   livecheck do
-    url "https://support.image-line.com/redirect/flstudio20_mac_installer"
-    strategy :header_match
+    url "https://support.image-line.com/api.php?call=get_version_info&callback=il_get_version_info_cb"
+    strategy :page_match do |page|
+      # Extract the JSON text from the JavaScript
+      match = page.match(/il_get_version_info_cb\("(.+?)"\);/i)
+      next if match.blank?
+
+      # Unescape the JSON text and parse it
+      json = Homebrew::Livecheck::Strategy::Json.parse_json(match[1].gsub(/\\+"/, '"'))
+      json["prod"]&.filter_map do |_id, prod|
+        next unless (prod_mac = prod["mac"])
+        next unless prod_mac["name"]&.include?("FL Studio")
+
+        prod_mac["version"]
+      end
+    end
   end
 
   pkg "Install FL Studio.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The cask URL for `fl-studio` doesn't work locally or on CI, so this updates it to the current URL from the redirecting macOS link on the download page. Even with this change, it was still necessary to use a `:browser` user agent and add a referer to get this to work.

The existing `livecheck` block for `fl-studio` returns an `Unable to get versions` error, as the request is blocked by Cloudflare. As with the dmg URL, we have to set a `:browser` user agent and referer for this to work. We can't set the referer in livecheck yet (though I have some forthcoming work to enable this), so we have to work around this for now.

This addresses the issue by updating the `livecheck` block to parse the version from the URL that the download page uses to fetch version information. Unfortunately the server returns JavaScript, so we have to extract the JSON data from the content, unescape the string, and parse it. The data only contains FL Studio releases at the moment but I added some safeguards to help ensure we only return appropriate versions if the data changes in the future.