### PR TITLE
font-goorm-sans-code 1.0.1 (new cask)

### DIFF
--- a/Casks/font/font-g/font-goorm-sans-code.rb
+++ b/Casks/font/font-g/font-goorm-sans-code.rb
@@ -8,7 +8,7 @@ cask "font-goorm-sans-code" do
 
   livecheck do
     url :homepage
-    regex(/href=.*?goorm[._-]sans[._-]code[._-](\d+(?:\.\d+)*)\.zip/i)
+    regex(/href=.*?goorm[._-]sans[._-]code[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   font "goorm sans code 2/Public/goorm_Sans_Code_400.ttf"

--- a/Casks/font/font-g/font-goorm-sans-code.rb
+++ b/Casks/font/font-g/font-goorm-sans-code.rb
@@ -1,0 +1,17 @@
+cask "font-goorm-sans-code" do
+  version "1.0.1"
+  sha256 "ddf93e59558509f2b62959fb553461b0b03cd00a186e61d21f410428c5ee76ba"
+
+  url "https://statics.goorm.io/fonts/GoormSansCode/v#{version}/goorm-sans-code-#{version}.zip"
+  name "goorm Sans Code"
+  homepage "https://goorm-sans.goorm.io/"
+
+  livecheck do
+    url "https://goorm-sans.goorm.io"
+    strategy :page_match do |page|
+      page.scan(/href=.*?goorm[._-]sans[._-]code[._-](\d+(?:\.\d+)*)\.zip/i).map { |match| match[0] }
+    end
+  end
+
+  font "goorm sans code 2/Public/goorm_Sans_Code_400.ttf"
+end

--- a/Casks/font/font-g/font-goorm-sans-code.rb
+++ b/Casks/font/font-g/font-goorm-sans-code.rb
@@ -7,11 +7,11 @@ cask "font-goorm-sans-code" do
   homepage "https://goorm-sans.goorm.io/"
 
   livecheck do
-    url "https://goorm-sans.goorm.io"
-    strategy :page_match do |page|
-      page.scan(/href=.*?goorm[._-]sans[._-]code[._-](\d+(?:\.\d+)*)\.zip/i).map { |match| match[0] }
-    end
+    url :homepage
+    regex(/href=.*?goorm[._-]sans[._-]code[._-](\d+(?:\.\d+)*)\.zip/i)
   end
 
   font "goorm sans code 2/Public/goorm_Sans_Code_400.ttf"
+
+  # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Additional Information

This font, "goorm Sans Code (구름 산스 코드)", is developed by goorm Inc. It is specifically designed for codebases that include Korean characters. The official homepage is [goorm-sans.goorm.io](https://goorm-sans.goorm.io/), and it is distributed under the SIL Open Font License.

As a personal note, I am pleased to see another coding font optimized for Korean characters, as the primary option until now has been NAVER's [D2Coding](https://github.com/naver/d2codingfont). This new font provides an additional choice for developers.

Please note that I am not affiliated with goorm Inc., and this PR does not represent the company's official opinion. Since redistribution is explicitly allowed according to their homepage, my goal is simply to facilitate easier installation via Homebrew.

