### PR TITLE
criptext: deprecate

### DIFF
--- a/Casks/c/criptext.rb
+++ b/Casks/c/criptext.rb
@@ -5,12 +5,9 @@ cask "criptext" do
   url "http://cdn.criptext.com/Criptext-Email-Desktop/mac/Criptext-latest.dmg"
   name "Criptext"
   desc "Email service that's built around privacy"
-  homepage "http://criptext.com/"
+  homepage "https://criptext.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-27", because: :unmaintained
 
   app "Criptext.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app has not seen an update since 2020 and upstream does not respond to issues for any of the client implementations:

* https://github.com/Criptext/Criptext-Email-React-Client/issues
* https://github.com/Criptext/Android-Email-Client/issues
* https://github.com/Criptext/iOS-Email-Client/issues

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
