### PR TITLE
font-goorm-sans 1.0.0 (new cask)

### DIFF
--- a/Casks/font/font-g/font-goorm-sans.rb
+++ b/Casks/font/font-g/font-goorm-sans.rb
@@ -7,13 +7,13 @@ cask "font-goorm-sans" do
   homepage "https://goorm-sans.goorm.io/"
 
   livecheck do
-    url "https://goorm-sans.goorm.io"
-    strategy :page_match do |page|
-      page.scan(/href=.*?goorm-sans-(\d+(?:\.\d+)*)\.zip/i).map { |match| match[0] }
-    end
+    url :homepage
+    regex(/href=.*?goorm-sans-(\d+(?:\.\d+)*)\.zip/i)
   end
 
   font "goorm sans/Public/TTF/goorm-sans-regular.ttf"
   font "goorm sans/Public/TTF/goorm-sans-medium.ttf"
   font "goorm sans/Public/TTF/goorm-sans-bold.ttf"
+
+  # No zap stanza required
 end

--- a/Casks/font/font-g/font-goorm-sans.rb
+++ b/Casks/font/font-g/font-goorm-sans.rb
@@ -1,0 +1,19 @@
+cask "font-goorm-sans" do
+  version "1.0.0"
+  sha256 "c59219d6ef005aa7035fa0ddd13612a36179bd59463b3f3b9ca960e44451dc52"
+
+  url "https://statics.goorm.io/fonts/goorm-sans/goorm-sans-#{version}.zip"
+  name "goorm Sans"
+  homepage "https://goorm-sans.goorm.io/"
+
+  livecheck do
+    url "https://goorm-sans.goorm.io"
+    strategy :page_match do |page|
+      page.scan(/href=.*?goorm-sans-(\d+(?:\.\d+)*)\.zip/i).map { |match| match[0] }
+    end
+  end
+
+  font "goorm sans/Public/TTF/goorm-sans-regular.ttf"
+  font "goorm sans/Public/TTF/goorm-sans-medium.ttf"
+  font "goorm sans/Public/TTF/goorm-sans-bold.ttf"
+end

--- a/Casks/font/font-g/font-goorm-sans.rb
+++ b/Casks/font/font-g/font-goorm-sans.rb
@@ -8,7 +8,7 @@ cask "font-goorm-sans" do
 
   livecheck do
     url :homepage
-    regex(/href=.*?goorm-sans-(\d+(?:\.\d+)*)\.zip/i)
+    regex(/href=.*?goorm[._-]sans[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   font "goorm sans/Public/TTF/goorm-sans-regular.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Additional Information

This font, "goorm Sans (구름 산스)", is developed by goorm Inc. It is designed for Korean characters. The official homepage is [goorm-sans.goorm.io](https://goorm-sans.goorm.io/), and it is distributed under the SIL Open Font License.

Please note that I am not affiliated with goorm Inc., and this PR does not represent the company's official opinion. Since redistribution is explicitly allowed according to their homepage, my goal is simply to facilitate easier installation via Homebrew.

Additionally, see https://github.com/Homebrew/homebrew-cask/pull/180787 for `font-goorm-sans-code`. It is from the same company.