### PR TITLE
mplayerx: deprecate

### DIFF
--- a/Casks/m/mplayerx.rb
+++ b/Casks/m/mplayerx.rb
@@ -8,10 +8,7 @@ cask "mplayerx" do
   desc "Media player"
   homepage "http://mplayerx.org/"
 
-  livecheck do
-    url "https://raw.githubusercontent.com/niltsh/MPlayerX-Deploy/master/appcast.xml"
-    strategy :sparkle
-  end
+  deprecate! date: "2024-07-27", because: :unmaintained
 
   auto_updates true
 
@@ -24,4 +21,8 @@ cask "mplayerx" do
     "~/Library/Preferences/org.niltsh.MPlayerX.LSSharedFileList.plist",
     "~/Library/Preferences/org.niltsh.MPlayerX.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2018, only has a few forks and stars.