### PR TITLE
nvalt: deprecate

### DIFF
--- a/Casks/n/nvalt.rb
+++ b/Casks/n/nvalt.rb
@@ -8,10 +8,7 @@ cask "nvalt" do
   desc "Note taking app"
   homepage "https://brettterpstra.com/projects/nvalt/"
 
-  livecheck do
-    url "https://updates.designheresy.com/nvalt/updates.xml"
-    strategy :sparkle
-  end
+  deprecate! date: "2024-07-27", because: :unmaintained
 
   app "nvALT.app"
 
@@ -19,4 +16,8 @@ cask "nvalt" do
     "~/Library/Application Support/Notational Velocity",
     "~/Library/Preferences/net.elasticthreads.nv.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2017, is being [superseded by another application](https://brettterpstra.com/projects/nvalt/)