### PR TITLE
oolite: deprecate

### DIFF
--- a/Casks/o/oolite.rb
+++ b/Casks/o/oolite.rb
@@ -8,10 +8,11 @@ cask "oolite" do
   desc "Space trading and combat simulator"
   homepage "https://www.oolite.space/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-07-27", because: :discontinued
 
   app "Oolite.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Last stable release in 2020, any other releases have not included macOS.