### PR TITLE
processing@3: deprecate

### DIFF
--- a/Casks/p/processing@3.rb
+++ b/Casks/p/processing@3.rb
@@ -8,13 +8,7 @@ cask "processing@3" do
   desc "Flexible software sketchbook and a language for learning how to code"
   homepage "https://processing.org/"
 
-  livecheck do
-    url :url
-    regex(/^processing[._-](\d+(?:\.\d+)*)[@_-](3(?:\.\d+)+)$/i)
-    strategy :github_latest do |json, regex|
-      json["tag_name"]&.scan(regex)&.map { |match| "#{match[1]},#{match[0]}" }
-    end
-  end
+  deprecate! date: "2024-07-28", because: :unmaintained
 
   conflicts_with cask: "processing"
 
@@ -27,4 +21,8 @@ cask "processing@3" do
     "~/Preferences/org.processing.app.plist",
     "~/Preferences/processing.app.tools.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2020 and author is no longer providing updates to Processing 3, instead focusing efforts on Processing 4 which is [in the repo](https://github.com/Homebrew/homebrew-cask/blob/432b5476a88711a075b0ff127f65e2ddf0db57aa/Casks/p/processing.rb), supports Apple Silicon, etc.