### PR TITLE
qsyncthingtray: deprecate

### DIFF
--- a/Casks/q/qsyncthingtray.rb
+++ b/Casks/q/qsyncthingtray.rb
@@ -7,7 +7,13 @@ cask "qsyncthingtray" do
   desc "Tray app for Syncthing"
   homepage "https://github.com/sieren/QSyncthingTray"
 
+  deprecate! date: "2024-07-28", because: :unmaintained
+
   app "QSyncthingTray.app"
 
   zap trash: "~/Library/Preferences/com.sieren.QSyncthingTray.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not seen any updated release since 2017, is currently noted as [no longer being maintained.](https://github.com/sieren/QSyncthingTray)