### PR TITLE
camera-live: deprecate

### DIFF
--- a/Casks/c/camera-live.rb
+++ b/Casks/c/camera-live.rb
@@ -7,11 +7,7 @@ cask "camera-live" do
   desc "Syphon server for connected Canon DSLR cameras"
   homepage "https://github.com/v002/v002-Camera-Live"
 
-  livecheck do
-    url :url
-    regex(/v?(\d+)/i)
-    strategy :github_latest
-  end
+  deprecate! date: "2024-07-28", because: :repo_archived
 
   app "Camera Live.app"
 


### PR DESCRIPTION
[Repo](https://github.com/v002/v002-Camera-Live) was archived on 2024-07-18