### PR TITLE
fix(devtunnel): incorrect sha256 checksum

### DIFF
--- a/Casks/d/devtunnel.rb
+++ b/Casks/d/devtunnel.rb
@@ -2,7 +2,7 @@ cask "devtunnel" do
   arch arm: "arm64", intel: "x64"
 
   version "1.0.1338+932252c8a1"
-  sha256 arm:   "fc5a7ac8aaf0ac7efa7754478f55bafd73b21cb614d283e609aa41df3db14201",
+  sha256 arm:   "a0db69bd6f16bbda78a941aee19b13b9af0415859d114bb23ec3240d49484773",
          intel: "9b2a798c02c7bc68e644c809cc06f10d245c1ba6ea4d1f921f201cd262f75cf8"
 
   url "https://tunnelsassetsprod.blob.core.windows.net/cli/#{version}/osx-#{arch}-devtunnel-zip",

--- a/Casks/d/devtunnel.rb
+++ b/Casks/d/devtunnel.rb
@@ -3,7 +3,7 @@ cask "devtunnel" do
 
   version "1.0.1338+932252c8a1"
   sha256 arm:   "a0db69bd6f16bbda78a941aee19b13b9af0415859d114bb23ec3240d49484773",
-         intel: "9b2a798c02c7bc68e644c809cc06f10d245c1ba6ea4d1f921f201cd262f75cf8"
+         intel: "648e13e2c4eebeb411a68f6912dc7b4cf222ef85b14700089011f88b7c13a8cb"
 
   url "https://tunnelsassetsprod.blob.core.windows.net/cli/#{version}/osx-#{arch}-devtunnel-zip",
       verified: "tunnelsassetsprod.blob.core.windows.net/cli/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The sha256 checksum for the devtunnel cask seems to be incorrect. I tried installing the cask using `brew install devtunnel` and got 
```sh
Error: SHA256 mismatch
Expected: fc5a7ac8aaf0ac7efa7754478f55bafd73b21cb614d283e609aa41df3db14201
Actual: a0db69bd6f16bbda78a941aee19b13b9af0415859d114bb23ec3240d49484773
```
I downloaded the cask for both arm (https://tunnelsassetsprod.blob.core.windows.net/cli/1.0.1338+932252c8a1/osx-arm64-devtunnel-zip) and x64 (https://tunnelsassetsprod.blob.core.windows.net/cli/1.0.1338+932252c8a1/osx-x64-devtunnel-zip) manually and checked the sha256 with `openssl sha256 <archive>`. The values were indeed different, and in the case of arm (which I use) showed the checksum listed above in "Actual".

I understand that updating version & checksum is a task usually performed by a bot (see https://github.com/Homebrew/homebrew-cask/commit/31382329ed31d4371227ca8a17b2bd6282dded5c), but in this case something went wrong and brew users cannot install the update. I also understand that changing the checksums opens up the possibility of getting insecure code onto users' machines, but since the source is not changed, I see no harm.