### PR TITLE
google-cloud-sdk: delete stale caveats

### DIFF
--- a/Casks/g/google-cloud-sdk.rb
+++ b/Casks/g/google-cloud-sdk.rb
@@ -60,19 +60,4 @@ cask "google-cloud-sdk" do
     "#{google_cloud_sdk_root}.staging",
     google_cloud_sdk_root,
   ]
-
-  caveats <<~EOS
-    To add gcloud components to your PATH, add this to your profile:
-
-      for bash users
-        source "$(brew --prefix)/share/google-cloud-sdk/path.bash.inc"
-
-      for zsh users
-        source "$(brew --prefix)/share/google-cloud-sdk/path.zsh.inc"
-        source "$(brew --prefix)/share/google-cloud-sdk/completion.zsh.inc"
-
-      for fish users
-        source "$(brew --prefix)/share/google-cloud-sdk/path.fish.inc"
-
-  EOS
 end


### PR DESCRIPTION
To the best of my knowledge:

- all binaries installed by the `google-cloud-sdk` cask are
  symlinked into `$(brew --prefix)/bin`
- all shell completions are installed into Homebrew's standard
  locations for their respective shells

and these two observations make that cask's caveats unnecessary.

Preserving them for `zsh` notably harms shell startup times because `compinit` will be called twice unnecessarily, which AFAICT interferes with `zcompdump`'s caching mechanism because `source`-ing the suggested file adds another `zcompdump` entry in between `compinit` invocations. This observation can be confirmed by profiling `zsh` startup using that shell's `zprof` utility.

I have not tested the performance implications on startup of other shells.

~~I have run `brew audit --cask google-cloud-sdk` and it is error-free. I have also run `brew audit --cask --online google-cloud-sdk` and the only error is that "Version '485.0.0' differs from '486.0.0' retrieved by livecheck.". If maintainers prefer, I can also update the `google-cloud-sdk` version in this pull request; my original intent in omitting the version update was to focus on the issue of removing caveats.~~

**EDIT:** After rebasing on `master` as of commit 27823d1f7319d6179348f9b6f060b01bd683e4ca, `brew audit --online google-cloud-sdk` passes.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
