### PR TITLE
virtualbuddy@beta 2.0 beta 1

### DIFF
--- a/Casks/v/virtualbuddy@beta.rb
+++ b/Casks/v/virtualbuddy@beta.rb
@@ -1,19 +1,34 @@
 cask "virtualbuddy@beta" do
-  version "1.3,100"
-  sha256 "599b848a8d2dd13e1bde0785f2fd68e60ab795d98e5f1fa3d8ea70f28b3a42d9"
+  version "2.0,200,b1"
+  sha256 "7ba42e15eeb9e6563c6df75d6ceaa5a6ec18692b6cea9797f6d3fee9b929ad37"
 
-  url "https://github.com/insidegui/VirtualBuddy/releases/download/#{version.csv.first}-beta/VirtualBuddy_v#{version.csv.first}-#{version.csv.second}.dmg"
+  url "https://github.com/insidegui/VirtualBuddy/releases/download/#{version.csv.first}#{"-#{version.csv.third}" if version.csv.third}/VirtualBuddy_v#{version.csv.first}-#{version.csv.second}.dmg"
   name "VirtualBuddy"
   desc "Virtualization tool"
   homepage "https://github.com/insidegui/VirtualBuddy"
 
   livecheck do
-    skip "No reliable way to get version info"
+    url :url
+    regex(/^VirtualBuddy[._-]v?(\d+(?:[.-]\d+)+)\.dmg$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        tag_suffix = release["tag_name"][/-(.+)$/i, 1]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          tag_suffix ? "#{match[1].tr("-", ",")},#{tag_suffix}" : match[1].tr("-", ",")
+        end
+      end.flatten
+    end
   end
 
   conflicts_with cask: "virtualbuddy"
   depends_on arch: :arm64
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :ventura"
 
   app "VirtualBuddy.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `virtualbuddy@beta` to the newest beta version, 2.0 beta 1.

This also updates the `livecheck` block to check releases (including pre-release), matching the full version from the filename and any unstable suffix from the tag (e.g., `-b1`).