### PR TITLE
opera-neon: deprecate

### DIFF
--- a/Casks/o/opera-neon.rb
+++ b/Casks/o/opera-neon.rb
@@ -4,12 +4,10 @@ cask "opera-neon" do
 
   url "https://get.geo.opera.com/.private/OperaNeon.dmg"
   name "Opera Neon"
+  desc "Web browser"
   homepage "https://www.opera.com/computer/neon"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2024-07-29", because: :unmaintained
 
   app "Opera Neon.app"
 
@@ -17,4 +15,8 @@ cask "opera-neon" do
     "~/Library/Application Support/Opera Neon",
     "~/Library/Caches/Opera Neon",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Opera Neon is a concept browser that will not receive further updates ([source](https://forums.opera.com/topic/18833/new-opera-neon-concept-browser/)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
