### PR TITLE
 fix(wakatime): incorrect sha256 checksum

### DIFF
--- a/Casks/w/wakatime.rb
+++ b/Casks/w/wakatime.rb
@@ -1,6 +1,6 @@
 cask "wakatime" do
   version "5.17.0"
-  sha256 "b7172d260d2cb39d49afced2703d9ea1f31a77c9fe65484df0e7f099a1853a26"
+  sha256 "1749e4bc7b68a0da7635cc09b390b1950b8935d1e0fae5d6149fd86e33209d5d"
 
   url "https://github.com/wakatime/macos-wakatime/releases/download/v#{version}/macos-wakatime.zip",
       verified: "github.com/wakatime/macos-wakatime/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
The sha256 checksum for the wakatime cask seems to be incorrect. I tried installing the cask using brew install wakatime and got
```shell
Error: wakatime: SHA256 mismatch
Expected: b7172d260d2cb39d49afced2703d9ea1f31a77c9fe65484df0e7f099a1853a26
  Actual: 1749e4bc7b68a0da7635cc09b390b1950b8935d1e0fae5d6149fd86e33209d5d
```
I downloaded the cask for (https://github.com/wakatime/macos-wakatime/releases/download/v5.17.0/macos-wakatime.zip) manually and checked the sha256 with shasum -a 256<archive>. The values were indeed different, and in the case of arm (which I use) showed the checksum listed above in "Actual".

I understand that updating version & checksum is a task usually performed by a bot (see https://github.com/Homebrew/homebrew-cask/pull/180968/commits/401bb55de338450a2f3626c9b6f9de9758a53efb), but in this case something went wrong and brew users cannot install the update. I also understand that changing the checksums opens up the possibility of getting insecure code onto users' machines, but since the source is not changed, I see no harm.