### PR TITLE
toontown-rewritten: update livecheck, use versioned url

### DIFF
--- a/Casks/t/toontown-rewritten.rb
+++ b/Casks/t/toontown-rewritten.rb
@@ -1,19 +1,30 @@
 cask "toontown-rewritten" do
-  version "1.5.0"
-  sha256 :no_check
+  version "1.5.1"
+  sha256 "c88cd534c903ffc0a5e8696de4f18455e1193b18afa607db54689283c951b4df"
 
-  url "https://cdn.toontownrewritten.com/launcher/mac/Toontown%20Rewritten.dmg"
+  url "https://download.toontownrewritten.com/launcher/mac/updates/#{version}/ttr_launcher_#{version}.zip"
   name "Toontown Rewritten"
   name "Toontown Launcher"
   desc "Fan-made revival of Disney's Toontown Online"
   homepage "https://www.toontownrewritten.com/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://download.toontownrewritten.com/launcher/mac/Toontown%20Rewritten.xml"
+    strategy :sparkle
   end
+
+  auto_updates true
+  depends_on macos: ">= :mojave"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/8037
   app "Toontown Launcher.app", target: "Toontown Rewritten.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.toontownrewritten.toontown-launcher.sfl*",
+    "~/Library/Caches/com.toontownrewritten.Toontown-Launcher",
+    "~/Library/HTTPStorages/com.toontownrewritten.Toontown-Launcher",
+    "~/Library/Preferences/com.toontownrewritten.Toontown-Launcher.plist",
+    "~/Library/Saved Application State/com.toontownrewritten.Toontown-Launcher.savedState",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
