### PR TITLE
headlamp 0.25.0-1

### DIFF
--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -1,15 +1,19 @@
 cask "headlamp" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.25.0"
+  version "0.25.0-1"
   sha256 arm:   "b65e0d0a795dac7deeb0bb4547e46a585d9df4f95bf6f2ef654428ab31237ad9",
          intel: "b3a4586df03e5a45af7c2eeebb63fba2eeb08373374189c3adf51212210a2e62"
 
-  url "https://github.com/kinvolk/headlamp/releases/download/v#{version}/Headlamp-#{version}-mac-#{arch}-1.dmg",
+  url "https://github.com/kinvolk/headlamp/releases/download/v0.25.0/Headlamp-0.25.0-1-mac-#{arch}.dmg",
       verified: "github.com/kinvolk/headlamp/"
   name "Headlamp"
   desc "UI for Kubernetes"
   homepage "https://kinvolk.github.io/headlamp"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   app "Headlamp.app"
 

--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -5,15 +5,26 @@ cask "headlamp" do
   sha256 arm:   "b65e0d0a795dac7deeb0bb4547e46a585d9df4f95bf6f2ef654428ab31237ad9",
          intel: "b3a4586df03e5a45af7c2eeebb63fba2eeb08373374189c3adf51212210a2e62"
 
-  url "https://github.com/kinvolk/headlamp/releases/download/v0.25.0/Headlamp-0.25.0-1-mac-#{arch}.dmg",
-      verified: "github.com/kinvolk/headlamp/"
+  url "https://github.com/headlamp-k8s/headlamp/releases/download/v#{version.sub(/-\d+/, "")}/Headlamp-#{version}-mac-#{arch}.dmg",
+      verified: "github.com/headlamp-k8s/headlamp/"
   name "Headlamp"
   desc "UI for Kubernetes"
-  homepage "https://kinvolk.github.io/headlamp"
+  homepage "https://headlamp.dev/"
 
   livecheck do
-    skip "No version information available"
+    url :url
+    regex(/Headlamp[._-]v?(\d+(?:[.-]\d+)+)-mac-#{arch}/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
+
+  depends_on macos: ">= :catalina"
 
   app "Headlamp.app"
 


### PR DESCRIPTION
In the last fix to 0.25.0, we didn't bump the version, so current installations of that version are kept with the broken binaries. Having this new build version should force the update for those users.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
