### PR TITLE
Add versioned livecheck blocks

### DIFF
--- a/Casks/k/keepassxc@beta.rb
+++ b/Casks/k/keepassxc@beta.rb
@@ -11,6 +11,11 @@ cask "keepassxc@beta" do
   desc "Password manager app"
   homepage "https://keepassxc.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   conflicts_with cask: "keepassxc"
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/o/openemu@experimental.rb
+++ b/Casks/o/openemu@experimental.rb
@@ -10,6 +10,11 @@ cask "openemu@experimental" do
   on_mojave :or_newer do
     version "2.4.1"
     sha256 "57b6f2b6005119efecb566e8cf611e12f1d0171dcd1f96797a0e9b4c33d3cdb4"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
   end
 
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}-experimental.zip",

--- a/Casks/u/utm@beta.rb
+++ b/Casks/u/utm@beta.rb
@@ -8,8 +8,22 @@ cask "utm@beta" do
   desc "Virtual machines UI using QEMU"
   homepage "https://mac.getutm.app/"
 
-  # Use the default livecheck strategy to return the "latest" release
-  # regardless of how it is tagged. https://github.com/Homebrew/homebrew-cask-versions/pull/18839#issuecomment-1874765632
+  # This uses the `GithubReleases` strategy and includes releases marked as
+  # "pre-release", so this will use both unstable and stable releases.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+.*)$/i)
+    strategy :github_releases do |json|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
 
   conflicts_with cask: "utm"
   depends_on macos: ">= :big_sur"

--- a/Casks/v/vscodium@insiders.rb
+++ b/Casks/v/vscodium@insiders.rb
@@ -12,6 +12,12 @@ cask "vscodium@insiders" do
   desc "Code editor"
   homepage "https://vscodium.com/"
 
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+.*)$/i)
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :catalina"
 
   app "VSCodium - Insiders.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Looking through versioned casks, only four did not have a `livecheck` block (`keepassxc@beta`, `openemu@experimental`, `utm@beta`, and `vscodium@insiders`). These use the `Git` strategy to check Git repository tags by default but these will be automatically skipped as versioned if/when [a recent brew change](https://github.com/Homebrew/brew/pull/17925) is merged (to skip versioned casks without a `livecheck` block, like we do for versioned formulae). This preemptively adds a `livecheck` block to these casks, so they will continue to be checked for new version information.

Based on feedback, the aforementioned brew PR also tweaks the `livecheck_version` audit to ensure that versioned casks will continue to have the livecheck version checked, to ensure that a working `livecheck` block is added. Any versioned casks that don't need to be checked for version information (e.g., legacy versions) can simply use a `livecheck` block using `#skip`. This PR ensures that all versioned casks have a `livecheck` block.

-----

The only one of these that may be unusual is `utm@beta`, as there was [previous discussion](https://github.com/Homebrew/homebrew-cask-versions/pull/18839#issuecomment-1874765632) around which versions to use. We seem to have settled on using the latest version, whether unstable or stable, so this isn't an unusual situation for unstable casks.