### PR TITLE
meta-quest-developer-hub 4.8.0 (new cask)

### DIFF
--- a/Casks/m/meta-quest-developer-hub.rb
+++ b/Casks/m/meta-quest-developer-hub.rb
@@ -8,8 +8,8 @@ cask "meta-quest-developer-hub" do
   homepage "https://developer.oculus.com/meta-quest-developer-hub/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://www.oculus.com/electron-updates/mqdh/latest-mac.yml"
+    strategy :electron_builder
   end
 
   depends_on macos: ">= :catalina"

--- a/Casks/m/meta-quest-developer-hub.rb
+++ b/Casks/m/meta-quest-developer-hub.rb
@@ -1,0 +1,24 @@
+cask "meta-quest-developer-hub" do
+  version "4.8.0"
+  sha256 :no_check
+
+  url "https://securecdn.oculus.com/binaries/download/?id=26027232766892142"
+  name "meta-quest-developer-hub"
+  desc "VR development tool"
+  homepage "https://developer.oculus.com/meta-quest-developer-hub/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Meta Quest Developer Hub.app"
+
+  # No zap stanza required
+
+  caveats do
+    license "https://developer.oculus.com/licenses/oculussdk"
+  end
+end

--- a/Casks/m/meta-quest-developer-hub.rb
+++ b/Casks/m/meta-quest-developer-hub.rb
@@ -1,8 +1,8 @@
 cask "meta-quest-developer-hub" do
   version "4.8.0"
-  sha256 :no_check
+  sha256 "c32c569b0d2a803d122de2a2a281df041d368586aa7c61d18fda9821622ed89b"
 
-  url "https://securecdn.oculus.com/binaries/download/?id=26027232766892142"
+  url "https://www.oculus.com/x2asset/electron-apps/odh/d7fbf9110e4200cae75755db8cff6d5f/Meta%20Quest%20Developer%20Hub-#{version}.zip"
   name "meta-quest-developer-hub"
   desc "VR development tool"
   homepage "https://developer.oculus.com/meta-quest-developer-hub/"

--- a/Casks/m/meta-quest-developer-hub.rb
+++ b/Casks/m/meta-quest-developer-hub.rb
@@ -16,7 +16,13 @@ cask "meta-quest-developer-hub" do
 
   app "Meta Quest Developer Hub.app"
 
-  # No zap stanza required
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.oculus.odh.sfl*",
+    "~/Library/Application Support/Meta Quest Developer Hub",
+    "~/Library/Application Support/odh",
+    "~/Library/Preferences/com.oculus.odh.plist",
+    "~/Library/Saved Application State/com.oculus.odh.savedState",
+  ]
 
   caveats do
     license "https://developer.oculus.com/licenses/oculussdk"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
Hello there! For notability, this cask is the official tool for Meta Quest development provided by Meta.

Unfortunately, I could not figure out a livecheck, the [download page](https://developer.oculus.com/downloads/package/oculus-developer-hub-mac/) provides version numbers but I think it dynamically fetches the data and populates the page because a regex search does not seem to work.

The download URL is a direct link to a binary, and I'm not sure whether Meta replaces the download URL with a new one for each version or uses the same download URL, but it doesn't seem to be personalized as I could reproduce the download on another machine. It did include a `&access_token=######` url parameter in the original download link that when stripped does not appear to affect the download.