### PR TITLE
onyx: fix Sequoia URL

### DIFF
--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -49,7 +49,7 @@ cask "onyx" do
   on_sequoia do
     version "4.7.0"
 
-    url "https://www.titanium-software.fr/download/15/OnyX.dmg"
+    url "https://www.titanium-software.fr/download/beta/OnyX.dmg"
   end
 
   name "OnyX"


### PR DESCRIPTION
This is using a different URL until Sequoia is officially released.