### PR TITLE
fig: deprecate

### DIFF
--- a/Casks/f/fig.rb
+++ b/Casks/f/fig.rb
@@ -7,12 +7,7 @@ cask "fig" do
   desc "Reimagine your terminal"
   homepage "https://fig.io/"
 
-  livecheck do
-    url "https://repo.fig.io/generic/stable/index.json"
-    strategy :json do |json|
-      json.dig("hints", "livecheck")
-    end
-  end
+  deprecate! date: "2024-08-03", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Fig is shutting down and will disable access to its service on September 1, 2024.
