### PR TITLE
fix: update Busycal sha256 sum for v2024.3.3

### DIFF
--- a/Casks/b/busycal.rb
+++ b/Casks/b/busycal.rb
@@ -1,6 +1,6 @@
 cask "busycal" do
   version "2024.3.3"
-  sha256 "dc8e0c77deb79ff06dd490a9a7b144268646f29e312e3904110d654858615b5b"
+  sha256 "dfb8e10532ebc5f84e3f2973e94c2feae11f1972e70e3b2db2e65da4b8f51b5b"
 
   url "https://www.busymac.com/download/bcl-#{version}.zip"
   name "BusyCal"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
