### PR TITLE
ultracopier: deprecate

### DIFF
--- a/Casks/u/ultracopier.rb
+++ b/Casks/u/ultracopier.rb
@@ -8,10 +8,9 @@ cask "ultracopier" do
   desc "Replacement for files copy dialogs"
   homepage "https://ultracopier.herman-brule.com/"
 
-  livecheck do
-    url "https://ultracopier.herman-brule.com/#download"
-    regex(/ultracopier[._-]mac[._-]os[._-]x[._-](\d+(?:\.\d+)+)\.dmg/i)
-  end
+  deprecate! date: "2024-08-04", because: :discontinued
+
+  depends_on macos: ">= :high_sierra"
 
   app "ultracopier.app"
 
@@ -20,4 +19,8 @@ cask "ultracopier" do
     "~/Library/Preferences/com.yourcompany.ultracopier.plist",
     "~/Library/Saved Application State/com.yourcompany.ultracopier.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream is lacking the infrastructure to provide macOS builds for new releases ([source](https://github.com/alphaonex86/Ultracopier/issues/106)).
