### PR TITLE
clix: disable

### DIFF
--- a/Casks/c/clix.rb
+++ b/Casks/c/clix.rb
@@ -13,6 +13,8 @@ cask "clix" do
     end
   end
 
+  disable! date: "2024-08-05", because: :no_longer_available
+
   app "CLIX/CLIX.app"
 
   preflight do


### PR DESCRIPTION
The upstream website has been unavailable for a couple of weeks now, and the application has not been updated for many years.