### PR TITLE
lazy: disable

### DIFF
--- a/Casks/l/lazy.rb
+++ b/Casks/l/lazy.rb
@@ -7,12 +7,7 @@ cask "lazy" do
   desc "Control your environment from your keyboard"
   homepage "https://www.lazy-app.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.ahmedmen.Bob"].short_version
-    end
-  end
+  disable! date: "2024-08-05", because: :no_longer_available
 
   pkg "lazy.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The homepage and source are no longer available (see [web.archive.org](http://web.archive.org/web/20240518095751/https://www.lazy-app.com/)). The app is now marketed as an AI tool on https://lazy.so/ without any publicly available release.

<img width="580" alt="image" src="https://github.com/user-attachments/assets/20782b28-ebaa-4a1d-9d8e-4c8295f26233">

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.