### PR TITLE
sony-ps-remote-play: remove Rosetta caveat

### DIFF
--- a/Casks/s/sony-ps-remote-play.rb
+++ b/Casks/s/sony-ps-remote-play.rb
@@ -27,8 +27,4 @@ cask "sony-ps-remote-play" do
     "~/Library/Preferences/com.playstation.RemotePlay.plist",
     "~/Library/WebKit/com.playstation.RemotePlay",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
Installing this Cask shows this caveat:
```
sony-ps-remote-play is built for Intel macOS and so requires Rosetta 2 to be installed.
You can install Rosetta 2 with:
  softwareupdate --install-rosetta --agree-to-license
Note that it is very difficult to remove Rosetta 2 once it is installed.
```
However, this no longer seems to be necessary:
```
~> file /Applications/RemotePlay.app/Contents/MacOS/RemotePlay
/Applications/RemotePlay.app/Contents/MacOS/RemotePlay: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
/Applications/RemotePlay.app/Contents/MacOS/RemotePlay (for architecture x86_64):	Mach-O 64-bit executable x86_64
/Applications/RemotePlay.app/Contents/MacOS/RemotePlay (for architecture arm64):	Mach-O 64-bit executable arm64
```
and
```
~> system_profiler SPApplicationsDataType | grep -A 7 "PS Remote Play" | grep Kind
      Kind: Universal
```
Sony's [website](https://www.playstation.com/en-us/support/games/playstation-remote-play-on-pc-and-mac/#min) also shows no Intel requirement