### PR TITLE
BetterDisplay v3.x is macOS Ventura or newer only

### DIFF
--- a/Casks/b/betterdisplay.rb
+++ b/Casks/b/betterdisplay.rb
@@ -7,7 +7,7 @@ cask "betterdisplay" do
       skip "Legacy version"
     end
   end
-  on_monterey do    
+  on_monterey do
     version "2.3.9"
     sha256 "3ee043fd5893ab354efbc4c9a92295a21b365e55af34cc64612255878b746722"
 

--- a/Casks/b/betterdisplay.rb
+++ b/Casks/b/betterdisplay.rb
@@ -7,7 +7,15 @@ cask "betterdisplay" do
       skip "Legacy version"
     end
   end
-  on_monterey :or_newer do
+  on_monterey do    
+    version "2.3.9"
+    sha256 "3ee043fd5893ab354efbc4c9a92295a21b365e55af34cc64612255878b746722"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_ventura :or_newer do
     version "3.0.1"
     sha256 "72bf6238c8fca6becb38a6a5b3d7b66860cefc1cded7b1592e321b3b08ddd382"
 


### PR DESCRIPTION
BetterDisplay v3.x is compatible with Ventura and newer. Monterey should get v2.3.9.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
