### PR TITLE
flux: update livecheck

### DIFF
--- a/Casks/f/flux.rb
+++ b/Casks/f/flux.rb
@@ -7,12 +7,9 @@ cask "flux" do
   desc "Screen colour temperature controller"
   homepage "https://justgetflux.com/"
 
-  # The sparkle feed "https://justgetflux.com/mac/macflux.xml" is currently
-  # unstable and often outputs the older version 40.1 as the latest release.
-  # As a workaround, we extract the version from plist of unversioned download.
   livecheck do
-    url "https://justgetflux.com/mac/Flux.zip"
-    strategy :extract_plist
+    url "https://justgetflux.com/mac/macflux.xml"
+    strategy :sparkle
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The Sparkle feed was removed in https://github.com/Homebrew/homebrew-cask/pull/100442 due to reliability issues. However, f.lux has since listed fixes for the Sparkle updater in their release notes ([source](https://justgetflux.com/news/pages/mac/)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
