### PR TITLE
soundboosterlite: deprecate

### DIFF
--- a/Casks/s/soundboosterlite.rb
+++ b/Casks/s/soundboosterlite.rb
@@ -7,12 +7,7 @@ cask "soundboosterlite" do
   desc "App for an enhanced audio experience"
   homepage "https://froyosoft.com/soundbooster.php"
 
-  livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.froyosoft.SoundBoosterLite"].short_version
-    end
-  end
+  deprecate! date: "2024-08-11", because: :unmaintained
 
   pkg "SoundBoosterLite.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app was last updated in 2016, and reviews for the Mac App Store variant indicate issues on recent macOS versions ([source](https://apps.apple.com/us/app/sound-booster/id923008988?see-all=reviews)).

Related to https://github.com/Homebrew/homebrew-cask/issues/171006.
