### PR TITLE
Add Thumb Host 3MF

### DIFF
--- a/Casks/t/thumb-host-3mf.rb
+++ b/Casks/t/thumb-host-3mf.rb
@@ -4,8 +4,8 @@ cask "thumb-host-3mf" do
        
   url "https://github.com/DavidPhillipOster/ThumbHost3mf/releases/download/#{version}/ThumbHost3mfVersion#{version}.zip"
   name "ThumbHost3mf"
-  desc "Menu bar status indicator"
-  homepage "A macOS app that hosts a thumbnail provider that makes the Finder displays the thumbnails built in to some .gcode, .bgcode, and .3mf files."
+  desc "A macOS app that hosts a thumbnail provider that makes the Finder displays the thumbnails built in to some .gcode, .bgcode, and .3mf files."
+  homepage "https://github.com/DavidPhillipOster/ThumbHost3mf/"
 
   app "ThumbHost3mf.app"
 end

--- a/Casks/t/thumb-host-3mf.rb
+++ b/Casks/t/thumb-host-3mf.rb
@@ -1,4 +1,4 @@
-cask "anybar" do
+cask "thumb-host-3mf" do
   version "1.4"
   sha256 "ed18f842c065fc1bf92ffb1d8111647efb28c1d56ba457017a5c81e22bc3f4c2"
        

--- a/Casks/t/thumb-host-3mf.rb
+++ b/Casks/t/thumb-host-3mf.rb
@@ -1,0 +1,11 @@
+cask "anybar" do
+  version "1.4"
+  sha256 "ed18f842c065fc1bf92ffb1d8111647efb28c1d56ba457017a5c81e22bc3f4c2"
+       
+  url "https://github.com/DavidPhillipOster/ThumbHost3mf/releases/download/#{version}/ThumbHost3mfVersion#{version}.zip"
+  name "ThumbHost3mf"
+  desc "Menu bar status indicator"
+  homepage "A macOS app that hosts a thumbnail provider that makes the Finder displays the thumbnails built in to some .gcode, .bgcode, and .3mf files."
+
+  app "ThumbHost3mf.app"
+end


### PR DESCRIPTION
A macOS app that hosts a thumbnail provider that makes the Finder displays the thumbnails built in to some .gcode, .bgcode, and .3mf files.

See https://github.com/DavidPhillipOster/ThumbHost3mf/issues/9 for the corresponding discussion

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
