### PR TITLE
macupdater: remove checksum

### DIFF
--- a/Casks/m/macupdater.rb
+++ b/Casks/m/macupdater.rb
@@ -5,7 +5,8 @@ cask "macupdater" do
   end
   on_ventura :or_newer do
     version "3.3.2"
-    sha256 "4552c9bc51737d90c12ee68cc53c05b561583f5d02b46f36ad7c8a6a976bcdde"
+    # required as upstream package is regularly updated in-place https://github.com/Homebrew/homebrew-cask/pull/182188#issuecomment-2284199515
+    sha256 :no_check
 
     binary "#{appdir}/MacUpdater.app/Contents/Resources/macupdater_install"
   end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew style --fix macupdater` reports no offenses.

- [ ] `brew audit --cask --online macupdater` failed:
```
audit for macupdater: failed
 - download not possible: SHA256 mismatch
Expected: 4552c9bc51737d90c12ee68cc53c05b561583f5d02b46f36ad7c8a6a976bcdde
  Actual: 9e315082e91adc99e47f28659b0bd7a4952147edcb269d8823c5e54526854f05
    File: /Users/unleftie/Library/Caches/Homebrew/downloads/10165f5e69c39e724191d09e01bdbd406027f93c05a613816687e08dba70136b--macupdater_3.3.2.dmg
To retry an incomplete download, remove the file above.

 - exception while auditing macupdater: SHA256 mismatch
Expected: 4552c9bc51737d90c12ee68cc53c05b561583f5d02b46f36ad7c8a6a976bcdde
  Actual: 9e315082e91adc99e47f28659b0bd7a4952147edcb269d8823c5e54526854f05
    File: /Users/unleftie/Library/Caches/Homebrew/downloads/10165f5e69c39e724191d09e01bdbd406027f93c05a613816687e08dba70136b--macupdater_3.3.2.dmg
To retry an incomplete download, remove the file above.
unleftie/cask/macupdater
  * line 13, col 2: download not possible: SHA256 mismatch
    Expected: 4552c9bc51737d90c12ee68cc53c05b561583f5d02b46f36ad7c8a6a976bcdde
      Actual: 9e315082e91adc99e47f28659b0bd7a4952147edcb269d8823c5e54526854f05
        File: /Users/unleftie/Library/Caches/Homebrew/downloads/10165f5e69c39e724191d09e01bdbd406027f93c05a613816687e08dba70136b--macupdater_3.3.2.dmg
    To retry an incomplete download, remove the file above.
  * exception while auditing macupdater: SHA256 mismatch
    Expected: 4552c9bc51737d90c12ee68cc53c05b561583f5d02b46f36ad7c8a6a976bcdde
      Actual: 9e315082e91adc99e47f28659b0bd7a4952147edcb269d8823c5e54526854f05
        File: /Users/unleftie/Library/Caches/Homebrew/downloads/10165f5e69c39e724191d09e01bdbd406027f93c05a613816687e08dba70136b--macupdater_3.3.2.dmg
    To retry an incomplete download, remove the file above.
Error: 2 problems in 1 cask detected.
```