### PR TITLE
labplot 2.11.1 (new cask)

### DIFF
--- a/Casks/l/labplot.rb
+++ b/Casks/l/labplot.rb
@@ -1,0 +1,27 @@
+cask "labplot" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "2.11.1"
+  sha256 arm:   "61af87d94f83f9e254b2ada3ae801c9fdc9c034047c13aa7dd10dfc24b846380",
+         intel: "59180a91db2661dc1f0bd52a684213b8ea8f449be3fe108636f96e1438411650"
+
+  url "https://download.kde.org/stable/labplot/labplot-#{version}-#{arch}.dmg"
+  name "LabPlot"
+  desc "Data visualization and analysis software"
+  homepage "https://labplot.kde.org/"
+
+  livecheck do
+    url "https://download.kde.org/stable/labplot/"
+    regex(/href=.*?labplot[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}.dmg/i)
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "labplot#{version.major}.app"
+
+  zap trash: [
+    "~/Library/Preferences/labplot#{version.major}rc",
+    "~/Library/Preferences/org.kde.UserFeedback.org.kde.labplot*.plist",
+    "~/Library/Saved Application State/org.kde.labplot.SavedState",
+  ]
+end


### PR DESCRIPTION
This commit adds a new cask for LabPlot (version 2.11.1)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
