### PR TITLE
Prepare CI workflow for Cask::Artifact::Installer refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,14 @@ jobs:
             cask = Cask::CaskLoader.load('${{ matrix.cask.path }}')
 
             was_installed = cask.installed?
-            manual_installer = cask.artifacts.any? { |artifact|
-              artifact.is_a?(Cask::Artifact::Installer::ManualInstaller)
-            }
+            manual_installer = cask.artifacts.any? do |artifact|
+              if defined?(artifact.manual_install)
+                artifact.manual_install
+              else
+                # TODO: Remove this branch when ManualInstaller is removed from brew
+                artifact.is_a?(Cask::Artifact::Installer::ManualInstaller)
+              end
+            end
 
             macos_requirement_satisfied = if macos_requirement = cask.depends_on.macos
               macos_requirement.satisfied?


### PR DESCRIPTION
Updates the CI workflow to un-revert https://github.com/Homebrew/brew/pull/18020 (per GH search, this is the only reference to that PR's removed modules in the Homebrew org, outside of the `brew` repo)