### PR TITLE
hhkb, hhkb-studio: update livecheck

### DIFF
--- a/Casks/h/hhkb-studio.rb
+++ b/Casks/h/hhkb-studio.rb
@@ -10,11 +10,7 @@ cask "hhkb-studio" do
 
   livecheck do
     url "https://happyhackingkb.com/download/"
-    regex(/macOS\s+:\s+Version\s+(\d+(?:\.\d+)+)/i)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      (match[1]).to_s
-    end
+    regex(%r{macOS\s*</td>.*?HHKBStudiokeymapTool[._-]v?\d+(?:\.\d+)*[^.]*?\.dmg.*?>\s*v?(\d+(?:\.\d+)+)\s*<}im)
   end
 
   depends_on macos: ">= :big_sur"

--- a/Casks/h/hhkb.rb
+++ b/Casks/h/hhkb.rb
@@ -10,7 +10,7 @@ cask "hhkb" do
 
   livecheck do
     url "https://happyhackingkb.com/download/"
-    regex(/macOS\s+:\s+Version\s+(\d+(?:\.\d+)+)/i)
+    regex(%r{macOS\s*</td>.*?HHKBkeymapTool[._-]v?\d+(?:\.\d+)*[^.]*?\.dmg.*?>\s*v?(\d+(?:\.\d+)+)\s*<}im)
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` blocks for `hhkb` and `hhkb-studio` are currently giving an `Unable to get versions` error, as the regexes aren't matching the current version text.

This updates the regexes to match the relevant versions for macOS. This works for now but the regexes are loose and can potentially lead to unexpected matches if the page structure changes in the future. Unfortunately, this may be the best we can do for the moment (as the filenames don't use dots in the version).