### PR TITLE
wine*: update sha256

### DIFF
--- a/Casks/w/wine@devel.rb
+++ b/Casks/w/wine@devel.rb
@@ -1,6 +1,6 @@
 cask "wine@devel" do
   version "9.15"
-  sha256 "01ba00edc08e82edc1dd9200e138c3709d93418d4e3f2edcf94d70539ce10b38"
+  sha256 "5c3f36827477eff1fcda45892ca4ebe6206d7ae161de0441dfcfa66b1aff7c6c"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.

--- a/Casks/w/wine@staging.rb
+++ b/Casks/w/wine@staging.rb
@@ -1,6 +1,6 @@
 cask "wine@staging" do
   version "9.15"
-  sha256 "9a86dcdfe80fbc4f4a55a5c8668e7a6610c04a89a9b34c67a7c9175657885b78"
+  sha256 "32c741742ddb88a75cc87a69b88df69f328015a7c35c52f9032167b76fabe2d1"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.


### PR DESCRIPTION
The latest `wine@devel` and `wine@staging` shipped with a broken library path leading to a crash when launched. See issue Gcenx/macOS_Wine_builds#104.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
