### PR TITLE
updating sha256 hash for mural 3.0.1 to match for a clean installation

### DIFF
--- a/Casks/m/mural.rb
+++ b/Casks/m/mural.rb
@@ -1,6 +1,6 @@
 cask "mural" do
   version "3.0.1"
-  sha256 "2bf4ac7c2bbf7c8d98708ffde37763b118667908e7b6c45bfbe5251ef85a2e55"
+  sha256 "634e07489d9ea1c7383a6a6cc58096556008c1d287c5f49986859d95c4a62f2d"
 
   url "https://download.mural.co/mac-app/Mural-#{version}.dmg"
   name "MURAL"


### PR DESCRIPTION
This pull request updates the sha256 hash on a mural cask to match the one directly from the source. 

When attempting to upgrade mural from an older version to 3.0.1 the following error is returned due to a sha256 hashing mismatch: 
```bash
% brew update && brew upgrade 

==> Upgrading 1 outdated package:
mural 2.0.0 -> 3.0.1
==> Upgrading mural
==> Downloading https://download.mural.co/mac-app/Mural-3.0.1.dmg
Already downloaded: /Users/redacted/Library/Caches/Homebrew/downloads/91db7487681552cd9b8bf2654a5d69f1ab30c3a941a5522855f0ee0031a233e0--Mural-3.0.1.dmg
==> Purging files for version 3.0.1 of Cask mural
Error: mural: SHA256 mismatch
Expected: 2bf4ac7c2bbf7c8d98708ffde37763b118667908e7b6c45bfbe5251ef85a2e55
  Actual: 634e07489d9ea1c7383a6a6cc58096556008c1d287c5f49986859d95c4a62f2d
    File: /Users/redacted/Library/Caches/Homebrew/downloads/91db7487681552cd9b8bf2654a5d69f1ab30c3a941a5522855f0ee0031a233e0--Mural-3.0.1.dmg
To retry an incomplete download, remove the file above.
```

Rather than simply ignoring the mismatch I downloaded the file directly from Mural and ran a hash against it to ensure it's accuracy: 
```bash
% wget https://download.mural.co/mac-app/Mural-3.0.1.dmg  

--2024-08-16 12:04:46--  https://download.mural.co/mac-app/Mural-3.0.1.dmg
Resolving download.mural.co (download.mural.co)... 13.107.253.40, 2620:1ec:29:1::40
Connecting to download.mural.co (download.mural.co)|13.107.253.40|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 180296479 (172M) [application/x-apple-diskimage]
Saving to: ‘Mural-3.0.1.dmg’

Mural-3.0.1.dmg                                                100%[=================================================================================================================================================>] 171.94M  25.2MB/s    in 6.4s    

2024-08-16 12:04:53 (26.7 MB/s) - ‘Mural-3.0.1.dmg’ saved [180296479/180296479]

% shasum -a 256 Mural-3.0.1.dmg 

634e07489d9ea1c7383a6a6cc58096556008c1d287c5f49986859d95c4a62f2d  Mural-3.0.1.dmg
```