### PR TITLE
font-gilbert: update livecheck

### DIFF
--- a/Casks/font/font-g/font-gilbert.rb
+++ b/Casks/font/font-g/font-gilbert.rb
@@ -2,10 +2,9 @@ cask "font-gilbert" do
   version "1.005,alpha"
   sha256 "d3ac3075efe00bf4302264b2e626f548e3549740d359a43991605b2a180d8cbe"
 
-  url "https://github.com/Fontself/TypeWithPride/releases/download/#{version.csv.first}/Gilbert_#{version.csv.first}_#{version.csv.second}.zip",
-      verified: "github.com/Fontself/TypeWithPride/"
+  url "https://github.com/Fontself/TypeWithPride/releases/download/#{version.csv.first}/Gilbert_#{version.csv.first}_#{version.csv.second}.zip"
   name "Gilbert"
-  homepage "https://typewithpride.com/"
+  homepage "https://github.com/Fontself/TypeWithPride"
 
   # This uses the `GithubReleases` strategy because all releases are marked as
   # pre-release on GitHub. We should be able to switch to the `GithubLatest`


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `font-gilbert` is returning an `Unable to get versions` error, as the GitHub releases HTML no longer contains asset links but this hasn't been updated to use the `GithubLatest` or `GithubReleases` strategy.

This updates the `livecheck` block to use the `GithubReleases` strategy and matches the version information from asset filenames. It's currently necessary to use `GithubReleases`, as all releases are marked as "pre-release" (i.e., there's no "latest" release). We should be able to switch to the `GithubLatest` strategy if/when there's a "latest" release in the future.