### PR TITLE
xamarin-*: deprecate

### DIFF
--- a/Casks/x/xamarin-android.rb
+++ b/Casks/x/xamarin-android.rb
@@ -7,10 +7,7 @@ cask "xamarin-android" do
   desc "Gives .NET developers complete access to Android SDK's"
   homepage "https://www.xamarin.com/platform"
 
-  livecheck do
-    url "https://software.xamarin.com/Service/Updates?v=2&pvd1ec039f-f3db-468b-a508-896d7c382999=0"
-    regex(%r{/xamarin\.android[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
-  end
+  deprecate! date: "2024-08-20", because: :discontinued
 
   pkg "xamarin.android-#{version}.pkg"
 

--- a/Casks/x/xamarin-ios.rb
+++ b/Casks/x/xamarin-ios.rb
@@ -7,15 +7,7 @@ cask "xamarin-ios" do
   desc "Gives .NET developers complete access to iOS, watchOS, and tvOS SDK's"
   homepage "https://dotnet.microsoft.com/en-us/apps/xamarin"
 
-  livecheck do
-    url "https://software.xamarin.com/Service/Updates?v=2&pv4569c276-1397-4adb-9485-82a7696df22e=0"
-    regex(%r{/download/pr/([^/]+)/([^/]+)/xamarin[._-]ios[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2]},#{match[0]},#{match[1]}"
-      end
-    end
-  end
+  deprecate! date: "2024-08-20", because: :discontinued
 
   pkg "xamarin.ios-#{version.csv.first}.pkg"
 

--- a/Casks/x/xamarin-mac.rb
+++ b/Casks/x/xamarin-mac.rb
@@ -7,15 +7,7 @@ cask "xamarin-mac" do
   desc "Gives C# and .NET developers access to Objective-C and Swift API's"
   homepage "https://dotnet.microsoft.com/en-us/apps/xamarin"
 
-  livecheck do
-    url "https://software.xamarin.com/Service/Updates?v=2&pv0ab364ff-c0e9-43a8-8747-3afb02dc7731=0"
-    regex(%r{/download/pr/([^/]+)/([^/]+)/xamarin[._-]mac[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[2]},#{match[0]},#{match[1]}"
-      end
-    end
-  end
+  deprecate! date: "2024-08-20", because: :discontinued
 
   depends_on cask: "mono-mdk-for-visual-studio"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> As of May 1, 2024, Xamarin is no longer supported or updated by Microsoft.
