### PR TITLE
Remove rosetta caveat from WISO casks

### DIFF
--- a/Casks/w/wiso-steuer-2022.rb
+++ b/Casks/w/wiso-steuer-2022.rb
@@ -34,8 +34,4 @@ cask "wiso-steuer-2022" do
     "~/Library/Saved Application State/com.BuhlData.WISOsteuerMac2022.savedState",
     "~/Library/WebKit/com.BuhlData.WISOsteuerMac2022",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/w/wiso-steuer-2023.rb
+++ b/Casks/w/wiso-steuer-2023.rb
@@ -34,8 +34,4 @@ cask "wiso-steuer-2023" do
     "~/Library/Saved Application State/com.BuhlData.WISOsteuerMac2023.savedState",
     "~/Library/WebKit/com.BuhlData.WISOsteuerMac2023",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/w/wiso-steuer-2024.rb
+++ b/Casks/w/wiso-steuer-2024.rb
@@ -34,8 +34,4 @@ cask "wiso-steuer-2024" do
     "~/Library/Saved Application State/com.BuhlData.WISOsteuerMac2024.savedState",
     "~/Library/WebKit/com.BuhlData.WISOsteuerMac2024",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Just tested the WISO Steuer Apps on ARM machines and they don't require rosetta, as the shipped apps are all universal binaries

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
