### PR TITLE
rstudio@daily 2024.08.0-351

### DIFF
--- a/Casks/r/rstudio@daily.rb
+++ b/Casks/r/rstudio@daily.rb
@@ -1,6 +1,6 @@
 cask "rstudio@daily" do
   version "2024.08.0-351"
-  sha256 "9680c56b7de713133044f42c420e579b55841d22530384cc12bf7ebf5ed70495"
+  sha256 "cf748fcdceb4fe479a33a9b5eb020d693aedac8f019182dcbc081db752c32ebb"
 
   url "https://rstudio-ide-build.s3.amazonaws.com/electron/macos/RStudio-#{version}.dmg",
       verified: "rstudio-ide-build.s3.amazonaws.com/electron/macos/"


### PR DESCRIPTION
This PR updates only the SHA256 for rstudio@daily 2024.08.0-351. The current formula returns a SHA256 mismatch error.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
