### PR TITLE
mambaforge: deprecate

### DIFF
--- a/Casks/m/mambaforge.rb
+++ b/Casks/m/mambaforge.rb
@@ -10,11 +10,7 @@ cask "mambaforge" do
   desc "Minimal installer for conda with preinstalled support for Mamba"
   homepage "https://github.com/conda-forge/miniforge"
 
-  livecheck do
-    url :url
-    regex(/v?(\d+(?:[._-]\d+)+)/i)
-    strategy :github_latest
-  end
+  deprecate! date: "2024-07-30", because: :discontinued
 
   auto_updates true
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
> Mambaforge (Deprecated as of July 2024) 🚨
With the [release](https://github.com/conda-forge/miniforge/releases/tag/23.3.1-0) of Miniforge3-23.3.1-0, that incorporated the changes in https://github.com/conda-forge/miniforge/pull/277, the packages and configuration of Mambaforge and Miniforge3 are now identical. The only difference between the two is the name of the installer and, subsequently, the default installation directory.

See also https://github.com/conda-forge/miniforge/issues/602 and [Sunsetting Mambaforge](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/).