### PR TITLE
new cask: probhat-keyboard-layout 1.0.1

### DIFF
--- a/Casks/p/probhat-keyboard-layout.rb
+++ b/Casks/p/probhat-keyboard-layout.rb
@@ -1,0 +1,16 @@
+cask "probhat-keyboard-layout" do
+  version "1.0.1"
+  sha256 "c80d71e19447c36b543eda78eb05807945d7991339b3e392cbdd6ba0e9528caa"
+
+  url "https://github.com/bdeshi/probhat-mac-osx/archive/refs/tags/v#{version}.tar.gz"
+  name "probhat-keyboard-layout"
+  desc "Bangla Probhat keyboard layout bundle"
+  homepage "https://github.com/bdeshi/probhat-mac-osx/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  keyboard_layout "probhat-mac-osx-#{version}/ProbhatKeyboardLayout.bundle"
+end


### PR DESCRIPTION
"[Probhat](https://en.wikipedia.org/wiki/Bengali_input_methods#Probhat)" is one of the most popular keyboard layouts for the Bangla (aka Bengali) language. This cask provides Probhat as a Mac OS native keyboard layout bundle.

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online probhat-keyboard-layout` is error-free.
- [x] `brew style --fix probhat-keyboard-layout ` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new probhat-keyboard-layout` worked successfully.
  ```log
    * line 5, col 2: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
  Error: 1 problem in 1 cask detected.
  ```
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask probhat-keyboard-layout` worked successfully.
- [x] `brew uninstall --cask probhat-keyboard-layout` worked successfully.
