### PR TITLE
cmd/font-casker: Bump to Sorbet `typed: true`

### DIFF
--- a/cmd/font-casker.rb
+++ b/cmd/font-casker.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "abstract_command"


### PR DESCRIPTION
- Part of https://github.com/Homebrew/brew/issues/17297.

```shell
$ brew typecheck homebrew/cask
No errors! Great job.
```