### PR TITLE
retroactive: deprecate

### DIFF
--- a/Casks/r/retroactive.rb
+++ b/Casks/r/retroactive.rb
@@ -1,13 +1,21 @@
 cask "retroactive" do
   version "2.1"
-  sha256 "5ef0aac063ab4f20579325481a0c75d14ed3d95576991c0c0767334ebabc38ca"
+  sha256 "bb1db2b54880164d577e2bc5e083046c2d3c6749de511652a84c5f7d2ce14142"
 
   url "https://github.com/cormiertyshawn895/Retroactive/releases/download/#{version}/Retroactive.#{version}.zip"
   name "Retroactive"
   desc "Run Apple apps on incompatible OS versions"
   homepage "https://github.com/cormiertyshawn895/Retroactive"
 
-  app "Retroactive #{version}/Retroactive (right click to open).app"
+  deprecate! date: "2024-08-21", because: :discontinued
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Retroactive #{version}/Retroactive.app"
 
   zap delete: "~/Library/Caches/com.retroactive.Retroactive"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The [GitHub repository](https://github.com/cormiertyshawn895/Retroactive) has been archived on Aug 11, 2024:

> Retroactive has been discontinued, and does not support macOS Sequoia or later.
