### PR TITLE
Update sha256 for unite v5.2.1

### DIFF
--- a/Casks/u/unite.rb
+++ b/Casks/u/unite.rb
@@ -1,6 +1,6 @@
 cask "unite" do
   version "5.2.1"
-  sha256 "4d392c105452c51edd5f70baa3bf5c97559a4eb7db2cf2c1adf080e3ca7cda53"
+  sha256 "817be1209d467c36ea2d3c6e4c3d9dffbe798d3fde021e3ac529175cbdf4f2a2"
 
   url "https://bzgdownloads.s3.amazonaws.com/Unite/Unite+#{version}.zip",
       verified: "bzgdownloads.s3.amazonaws.com/Unite/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

(deleted the new cask section of checkboxes since they do not apply)

The audit fails right now because the sha256 is now incorrect. This commit fixes this. 
---
