### PR TITLE
font-lexend-deca: update url and homepage

### DIFF
--- a/Casks/font/font-l/font-lexend-deca.rb
+++ b/Casks/font/font-l/font-lexend-deca.rb
@@ -2,11 +2,12 @@ cask "font-lexend-deca" do
   version :latest
   sha256 :no_check
 
-  url "https://github.com/ThomasJockin/lexend/raw/master/fonts/ttf/LexendDeca-Regular.ttf"
+  url "https://github.com/google/fonts/raw/main/ofl/lexenddeca/LexendDeca%5Bwght%5D.ttf",
+      verified: "github.com/google/fonts/"
   name "Lexend Deca"
-  homepage "https://github.com/ThomasJockin/lexend"
+  homepage "https://fonts.google.com/specimen/Lexend+Deca"
 
-  font "LexendDeca-Regular.ttf"
+  font "LexendDeca[wght].ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR updates the `url` and `homepage` stanzas to align with other Lexend font family casks.

Related to https://github.com/Homebrew/homebrew-cask/issues/172732#issuecomment-2303424906.
