### PR TITLE
joshjon-nocturnal: deprecate

### DIFF
--- a/Casks/j/joshjon-nocturnal.rb
+++ b/Casks/j/joshjon-nocturnal.rb
@@ -7,9 +7,15 @@ cask "joshjon-nocturnal" do
   desc "Dimness and night shift menu bar app"
   homepage "https://github.com/joshjon/nocturnal"
 
+  deprecate! date: "2024-08-22", because: :repo_archived
+
   depends_on macos: ">= :high_sierra"
 
   app "Nocturnal.app"
 
   zap trash: "~/Library/Preferences/com.joshua.jon.Nocturnal.plist"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Repository [archived](https://github.com/joshjon/nocturnal) on 2024-08-05