### PR TITLE
font-d2coding: update livecheck

### DIFF
--- a/Casks/font/font-d/font-d2coding.rb
+++ b/Casks/font/font-d/font-d2coding.rb
@@ -2,15 +2,20 @@ cask "font-d2coding" do
   version "1.3.2,20180524"
   sha256 "0f1c9192eac7d56329dddc620f9f1666b707e9c8ed38fe1f988d0ae3e30b24e6"
 
-  url "https://github.com/naver/d2codingfont/releases/download/VER#{version.csv.first}/D2Coding-Ver#{version.csv.first}-#{version.csv.second}.zip"
+  url "https://github.com/naver/d2codingfont/releases/download/VER#{version.csv.first}/D2Coding-Ver#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}.zip"
   name "D2 Coding"
   homepage "https://github.com/naver/d2codingfont"
 
   livecheck do
-    url "https://github.com/naver/d2codingfont/releases/latest"
-    strategy :page_match do |page|
-      page.scan(/href=.*?D2Coding[._-](?:Ver)?(\d+(?:\.\d+)+)[_-](\d+)\.zip/i)
-          .map { |matches| "#{matches[0]},#{matches[1]}" }
+    url :url
+    regex(/D2Coding[._-](?:Ver|v)?v?(\d+(?:\.\d+)+)(?:-(v?(\d+(?:\.\d+)*)))?\.zip/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
+
+        match[2] ? "#{match[1]},#{match[2]}" : match[1]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `font-d2coding` is returning an `Unable to get versions` error, as the GitHub releases HTML no longer contains asset links but this hasn't been updated to use the `GithubLatest` or `GithubReleases` strategy.

This updates the `livecheck` block to use the `GithubLatest` strategy and matches the version information from the asset filename. This also updates the `url` and `livecheck` block to make the date suffix optional, as there has been at least one release where the filename didn't have a suffix (D2Coding-1.2.zip).