### PR TITLE
mamp: update sha256

### DIFF
--- a/Casks/m/mamp.rb
+++ b/Casks/m/mamp.rb
@@ -2,8 +2,8 @@ cask "mamp" do
   arch arm: "Apple-chip", intel: "Intel-x86"
 
   version "7.0"
-  sha256 arm:   "2f0c89c0682247c5543706911513af17304bd39d3a324473f8f919acad3a7fdd",
-         intel: "80b680cb002fdfeccd43bb4de8f73ea071d21544e9a024ffd0bab21eb2e8ecca"
+  sha256 arm:   "86dc72fc8ebf7a7506396d824e018c082d57abb9d1db673a8d0c76a22d20472c",
+         intel: "d0dae20f8bd7ea1571e563e78140dcf70c0f91481deb11e6558abd1476ee883d"
 
   url "https://downloads.mamp.info/MAMP-PRO/macOS/MAMP-PRO/MAMP-MAMP-PRO-#{version}-#{arch}.pkg"
   name "MAMP"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
**Additional Information:**
- I have left the checkboxes unchecked because I was unsure how to run the commands with my branch's changes reflected.
- I downloaded the pkg files from the official MAMP website at https://www.mamp.info/en/downloads/ and verified the hashes locally.
```bash
$ find . -type f -exec shasum -a 256 {} \; -exec shasum -a 512 {} \; 
86dc72fc8ebf7a7506396d824e018c082d57abb9d1db673a8d0c76a22d20472c  ./MAMP-MAMP-PRO-7.0-Apple-chip.pkg
5b425760f837977c7ba374abf8f20847113d2fde55cef196500e2fbd9bde848dc5d9963222daab3595ba9aed26cf4e560e2b0679e9c123d3ecb7deb2e8b511e6  ./MAMP-MAMP-PRO-7.0-Apple-chip.pkg
d0dae20f8bd7ea1571e563e78140dcf70c0f91481deb11e6558abd1476ee883d  ./MAMP-MAMP-PRO-7.0-Intel-x86.pkg
3c5c0efc8bbf87b3b0602a007aaefdd805b9046f13e4b8aaddf81eeca9941bf423449f263b03254fca86a4b931b0e888e882df9c713379b1cc63bbf38ce3e753  ./MAMP-MAMP-PRO-7.0-Intel-x86.pkg
```