### PR TITLE
wolfram-engine: livecheck and download url update

### DIFF
--- a/Casks/w/wolfram-engine.rb
+++ b/Casks/w/wolfram-engine.rb
@@ -1,6 +1,6 @@
 cask "wolfram-engine" do
-  version "14.0.0.0"
-  sha256 "6f281cc645d63e98180327f084fda3becd78ae5c977e2026f71ed48e2999d381"
+  version "14.1.0.0"
+  sha256 "8c5f7ea938316c20d8627a9ffafa13b084d4b6b583c6e18b425971da13b0c5ec"
 
   url "https://files.wolframcdn.com/packages/Homebrew/#{version}/WolframEngine_#{version.major_minor_patch}_MAC.dmg",
       verified: "files.wolframcdn.com/packages/Homebrew/"
@@ -9,11 +9,12 @@ cask "wolfram-engine" do
   homepage "https://www.wolfram.com/engine/"
 
   livecheck do
-    url "https://files.wolframcdn.com/packages/Homebrew/latest.txt"
-    regex(/^(\d+(?:\.\d+)+)$/i)
+    url "https://account.wolfram.com/dl/WolframEngine?platform=Mac"
+    regex(%r{WolframEngine/(\d+(?:\.\d+)+)}i)
+    strategy :header_match
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Wolfram Engine.app"
   binary "#{appdir}/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents/MacOS/wolframscript"


### PR DESCRIPTION
Update download and livecheck url, because the previous livecheck is not updated automatically.
Download url is now same as the web page.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [] `brew style --fix <cask>` reports no offenses.

---
