### PR TITLE
r-name: deprecate

### DIFF
--- a/Casks/r/r-name.rb
+++ b/Casks/r/r-name.rb
@@ -6,10 +6,7 @@ cask "r-name" do
   name "R-Name"
   homepage "https://www.jacek-dom.net/software/R-Name/"
 
-  livecheck do
-    url :homepage
-    regex(/version\s+.*?(\d+(?:\.\d+)+)/i)
-  end
+  deprecate! date: "2024-08-25", because: :unmaintained
 
   app "R-Name.app"
 


### PR DESCRIPTION
Application does not appear to have been updated since it was introduced in 2013 -- still contains i386 and ppc binaries.
