### PR TITLE
shuttle: deprecate

### DIFF
--- a/Casks/s/shuttle.rb
+++ b/Casks/s/shuttle.rb
@@ -8,7 +8,13 @@ cask "shuttle" do
   desc "Simple shortcut menu"
   homepage "https://fitztrev.github.io/shuttle/"
 
+  deprecate! date: "2024-08-25", because: :unmaintained
+
   app "Shuttle.app"
 
   zap trash: "~/.shuttle.json"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
No updates since 2016 and is unsigned.