### PR TITLE
oxygen-xml-*: remove checksum

### DIFF
--- a/Casks/o/oxygen-xml-developer.rb
+++ b/Casks/o/oxygen-xml-developer.rb
@@ -1,6 +1,6 @@
 cask "oxygen-xml-developer" do
   version "26.1,2024073008"
-  sha256 "d55faf6ecc28fa28ac62bc69887cf509bbbbf8f2efb917383d1ae0a0de6c4d0e"
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://archives.oxygenxml.com/Oxygen/Developer/InstData#{version.csv.first}/MacOSX/VM/oxygenDeveloper-openjdk.dmg"
   name "oXygen XML Developer"

--- a/Casks/o/oxygen-xml-editor.rb
+++ b/Casks/o/oxygen-xml-editor.rb
@@ -1,6 +1,6 @@
 cask "oxygen-xml-editor" do
   version "26.1,2024073008"
-  sha256 "f46650473d0adcb6dbaf5ec800bd34e6d8487ed3325d631d41817980c5708eb9"
+  sha256 :no_check # required as upstream package is updated in-place
 
   url "https://archives.oxygenxml.com/Oxygen/Editor/InstData#{version.csv.first}/MacOSX/VM/oxygen-openjdk.dmg"
   name "oXygen XML Editor"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

For both `oxygen-xml-developer` and `oxygen-xml-editor` a checksum cannot be used as the download `url` only includes the version number, and not the build number. Within versions, the binary is updated in place when the build number is incremented.

See https://github.com/Homebrew/homebrew-cask/commit/ddc1a1b00f31dac5a97748851d87afa1f2637071 and https://github.com/Homebrew/homebrew-cask/commit/9141e9b81ed90d17cae39b21b036560efddc93c1