### PR TITLE
Added msft openjdk21 as an explicit version option

### DIFF
--- a/Casks/m/microsoft-openjdk@21.rb
+++ b/Casks/m/microsoft-openjdk@21.rb
@@ -1,0 +1,27 @@
+cask "microsoft-openjdk" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "21.0.4"
+  sha256 arm:   "147f73d0f97a7ce885ae0e582f7afe38b5af817ddb62a84584d9636024b17e90",
+         intel: "18306c3e485c31f513b15bcdfb76840f9bdf008d264dd8a7f13633b4e6b22bf6"
+
+  url "https://aka.ms/download-jdk/microsoft-jdk-#{version}-macos-#{arch}.pkg",
+      verified: "aka.ms/download-jdk/"
+  name "Microsoft Build of OpenJDK"
+  desc "OpenJDK distribution from Microsoft"
+  homepage "https://microsoft.com/openjdk"
+
+  livecheck do
+    url "https://docs.microsoft.com/java/openjdk/download"
+    regex(%r{href=.*?/microsoft[._-]jdk[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]#{arch}\.pkg}i)
+  end
+
+  pkg "microsoft-jdk-#{version}-macOS-#{arch}.pkg"
+
+  uninstall pkgutil: "com.microsoft.#{version.major}.jdk"
+
+  zap trash: [
+    "~/Library/Preferences/net.java.openjdk.java.plist",
+    "~/Library/Saved Application State/net.java.openjdk.java.savedState",
+  ]
+end

--- a/Casks/m/microsoft-openjdk@21.rb
+++ b/Casks/m/microsoft-openjdk@21.rb
@@ -13,7 +13,7 @@ cask "microsoft-openjdk@21" do
 
   livecheck do
     url "https://docs.microsoft.com/java/openjdk/download"
-    regex(%r{href=.*?/microsoft[._-]jdk[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]#{arch}\.pkg}i)
+    regex(%r{href=.*?/microsoft[._-]jdk[._-]v?(21(?:\.\d+)+)[._-]macOS[._-]#{arch}\.pkg}i)
   end
 
   pkg "microsoft-jdk-#{version}-macOS-#{arch}.pkg"

--- a/Casks/m/microsoft-openjdk@21.rb
+++ b/Casks/m/microsoft-openjdk@21.rb
@@ -1,4 +1,4 @@
-cask "microsoft-openjdk" do
+cask "microsoft-openjdk@21" do
   arch arm: "aarch64", intel: "x64"
 
   version "21.0.4"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
