### PR TITLE
musescore 4.4.0.242390800

### DIFF
--- a/Casks/m/musescore.rb
+++ b/Casks/m/musescore.rb
@@ -1,6 +1,6 @@
 cask "musescore" do
-  version "4.3.2.241630832"
-  sha256 "d61562a8397040a4b2a50c4a68e44469483b40362decec2222e162c89cef0f8d"
+  version "4.4.0.242390800"
+  sha256 "889298a47bfe54b9b8b005783cd59d8b3aaab48b2e1eaf137bd2cead6a4ad956"
 
   url "https://github.com/musescore/MuseScore/releases/download/v#{version.major_minor_patch}/MuseScore-Studio-#{version}.dmg",
       verified: "github.com/musescore/MuseScore/"
@@ -43,8 +43,4 @@ cask "musescore" do
     "~/Library/Preferences/org.musescore.MuseScore*.plist",
     "~/Library/Saved Application State/org.musescore.MuseScore.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

There is no Rosetta requirement now, see: [MuseScore 4.4 Release](https://github.com/musescore/MuseScore/releases/tag/v4.4.0)

> macOS builds have moved to universal binary, providing native support for both Intel and Apple Silicon chips.


```bash
audit for musescore: failed
 - Artifacts does not require Rosetta 2 but the caveats say otherwise!
musescore
  * line 5, col 2: Artifacts does not require Rosetta 2 but the caveats say otherwise!
Error: 1 problem in 1 cask detected.
Error: `brew audit` failed!
```
