### PR TITLE
neo-network-utility 1.1 (new cask)

### DIFF
--- a/Casks/n/neo-network-utility.rb
+++ b/Casks/n/neo-network-utility.rb
@@ -1,0 +1,25 @@
+cask "neo-network-utility" do
+  version "1.1"
+  sha256 "8bc8c1bdf78ec4e7622c8e812bc0a5ceee86a4c5899c17f88244f033642f970e"
+
+  url "https://download.devontechnologies.com/download/freeware/networkutility/#{version}/Neo_Network_Utility.dmg.zip"
+  name "Neo Network Utility"
+  desc "Network information and diagnostics utility"
+  homepage "https://www.devontechnologies.com/apps/freeware"
+
+  livecheck do
+    url "https://api.devontechnologies.com/1/apps/sparkle/sparkle.php?id=900000089"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "Network Utility.app"
+
+  zap trash: [
+    "~/Library/HTTPStorages/com.devon-technologies.network-utility",
+    "~/Library/Preferences/com.devon-technologies.network-utility.plist",
+    "~/Library/Saved Application State/com.devon-technologies.network-utility.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
> All similarities with an application of the same name that was once bundled with legacy versions of Mac OS X and OSX are, of course, [purely coincidental](https://www.devontechnologies.com/blog/20240711-network-utility-10).