### PR TITLE
yaak: fix shasums

### DIFF
--- a/Casks/y/yaak.rb
+++ b/Casks/y/yaak.rb
@@ -2,8 +2,8 @@ cask "yaak" do
   arch arm: "aarch64", intel: "x64"
 
   version "2024.8.2"
-  sha256 arm:   "aa6c9ff7a2a7287604a598421826209dfb78ca4108b9f4da57d3594b72ac6f9b",
-         intel: "b83a752c30dba856758dc32d8a6e20eb216642c6fd2de2466eaa1b8ff0a13331"
+  sha256 arm:   "d8c359e2444e7b94f18e1bc56d6cd8b630cde2d49ecbff3f4cbbb70c4544dcd0",
+         intel: "8432a2d4b426b3b885e6061cfc4709303e73513c031ce955eade36236f8b8401"
 
   url "https://releases.yaak.app/releases/#{version}/Yaak_#{version}_#{arch}.dmg"
   name "Yaak"


### PR DESCRIPTION
Worth investigating why/how, but somehow the SHA256s have changed since @BrewTestBot's autobump #183658

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
