### PR TITLE
lib/changed_files: fix `cask_file?` call

### DIFF
--- a/cmd/lib/changed_files.rb
+++ b/cmd/lib/changed_files.rb
@@ -23,7 +23,7 @@ module ChangedFiles
     modified_ruby_files = modified_files.select { |path| path.extname == ".rb" }
     modified_command_files = modified_files.select { |path| path.ascend.to_a.last.to_s == "cmd" }
     modified_github_actions_files = modified_files.select { |path| path.to_s.start_with?(".github/actions/") }
-    modified_cask_files = modified_files.select { |path| cask_file?(path) }
+    modified_cask_files = modified_files.select { |path| cask_file?(path.to_s) }
 
     {
       modified_files:,


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Fixes a failure in the `generate-matrix` job.

