### PR TITLE
zen 1.0.0 (new cask)

### DIFF
--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -1,0 +1,35 @@
+cask "zen" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "1.0.0-a.32"
+  sha256 arm:   "3b9ab978317a780f2f8f23976f95f190dafc258144cbfe9e45dba6589aad5faa",
+         intel: "defde5572cb6310c57dbfb09f1e9bd00283498b538623545b797096b2b1bc7a7"
+
+  url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-#{arch}.dmg"
+  name "Zen"
+  desc "Firefox based browser with a focus on privacy and customization"
+  homepage "https://github.com/zen-browser/desktop"
+
+  livecheck do
+    url :url
+    strategy :github_latest do |json|
+      json["tag_name"].match(/^v?(\d+(?:\.\d+)+(-a\.\d+)?)$/i)[0]
+    end
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Zen Browser.app"
+
+  zap trash: [
+    "~/Library/Application Support/zen",
+    "~/Library/Caches/Mozilla/updates/Applications/Zen Browser/",
+    "~/Library/Caches/zen",
+    "~/Library/Preferences/org.mozilla.com.zen.browser.plist",
+    "~/Library/Saved Application State/org.mozilla.com.zen.browser.savedState",
+  ]
+
+  caveats do
+    "bypass gatekeeper: 'xattr -d com.apple.quarantine '/Applications/Zen Browser.app/'"
+  end
+end


### PR DESCRIPTION
Hi, I added a new cask for the zen browser. Because it is still in Alpha and doesnt have an Apple Developer License yet, I added a caveat with the user info to bypass gatekeeper.
What's weird is that, when I tried to use the official homepage as 'homepage' I received an error
`The homepage URL https://www.zen-browser.app/ is not reachable (HTTP status code 403)`
so I just changed it to the zen desktop github repo.
Hope that is alright.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
