### PR TITLE
cursor: fix binary path & target

### DIFF
--- a/Casks/c/cursor.rb
+++ b/Casks/c/cursor.rb
@@ -26,7 +26,7 @@ cask "cursor" do
   depends_on macos: ">= :catalina"
 
   app "Cursor.app"
-  binary "#{appdir}/Cursor.app/Contents/Resources/app/bin/cursor"
+  binary "#{appdir}/Cursor.app/Contents/Resources/app/bin/code", target: "cursor"
 
   zap trash: [
     "~/.cursor",


### PR DESCRIPTION
Current path causes this error:

grep: /proc/version: No such file or directory
/opt/homebrew/bin/cursor: line 62: /Applications/Cursor.app/Contents/Resources/app/bin/../cursor: No such file or directory

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
