### PR TITLE
winbox 4.0beta3 (new cask)

### DIFF
--- a/Casks/w/winbox.rb
+++ b/Casks/w/winbox.rb
@@ -1,0 +1,24 @@
+cask "winbox" do
+  version "4.0beta3"
+  sha256 "1c798996b466a3e89310d9065beb7f5d450cfedc4cfee925ff8f8a11cf01431c"
+
+  url "https://download.mikrotik.com/routeros/winbox/#{version}/WinBox.dmg"
+  name "WinBox"
+  desc "Administration tool for MikroTik RouterOS"
+  homepage "https://mikrotik.com/"
+
+  livecheck do
+    url "https://upgrade.mikrotik.com/routeros/winbox/LATEST.#{version.major}"
+    regex(/v?(\d+(?:\.\d+)+(?:beta\d+)?)/i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "WinBox.app"
+
+  zap trash: [
+    "~/Library/Application Support/MikroTik/WinBox",
+    "~/Library/Caches/MikroTik/WinBox",
+    "~/Library/Saved Application State/my.example.com.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
This PR adds WinBox 4 (Beta). This is the first WinBox release that natively supports macOS (see https://forum.mikrotik.com/viewtopic.php?t=210505).
After the stable version has been released this Cask could drop the `@beta` and take the `winbox` handle (see https://github.com/Homebrew/homebrew-cask/pull/40510).
A livecheck is currently unavailable, but I expected it do be available with the stable release (https://mikrotik.com/download still points to 3.41, which is not available for macOS).