### PR TITLE
typcn-bilibili: deprecate

### DIFF
--- a/Casks/t/typcn-bilibili.rb
+++ b/Casks/t/typcn-bilibili.rb
@@ -7,6 +7,8 @@ cask "typcn-bilibili" do
   desc "Unofficial bilibili client"
   homepage "https://github.com/typcn/bilibili-mac-client/"
 
+  deprecate! date: "2024-08-30", because: :unmaintained
+
   auto_updates true
 
   app "Bilibili.app"
@@ -16,4 +18,8 @@ cask "typcn-bilibili" do
     "~/Library/Application Support/com.typcn.bilibili",
     "~/Library/WebKit/com.typcn.bilibili",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Cask has not been updated since 2018.

---
