### PR TITLE
trojanx: deprecate

### DIFF
--- a/Casks/t/trojanx.rb
+++ b/Casks/t/trojanx.rb
@@ -7,6 +7,8 @@ cask "trojanx" do
   desc "Mechanism to bypass the Great Firewall"
   homepage "https://github.com/JimLee1996/TrojanX"
 
+  deprecate! date: "2024-08-30", because: :unmaintained
+
   depends_on macos: ">= :el_capitan"
 
   app "TrojanX.app"
@@ -18,4 +20,8 @@ cask "trojanx" do
     "~/Library/Application Support/TrojanX",
     "~/Library/Preferences/TrojanX.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application appears to have issues running on the latest macOS -- no updates since 2020.
