### PR TITLE
frappe-books: bump arm version only

### DIFF
--- a/Casks/f/frappe-books.rb
+++ b/Casks/f/frappe-books.rb
@@ -1,8 +1,16 @@
 cask "frappe-books" do
-  version "0.21.2"
-  sha256 "9fd0a360f35d9c0745ca43b459d133b7da555122005499a8372eb6fa90719723"
+  arch arm: "-arm64"
 
-  url "https://github.com/frappe/books/releases/download/v#{version}/Frappe-Books-#{version}.dmg",
+  on_arm do
+    version "0.22.0"
+    sha256 "06ca67133f11f20b7aaff28f968d028db53b3e8483967493ff09a464c53fbbc6"
+  end
+  on_intel do
+    version "0.21.2"
+    sha256 "9fd0a360f35d9c0745ca43b459d133b7da555122005499a8372eb6fa90719723"
+  end
+
+  url "https://github.com/frappe/books/releases/download/v#{version}/Frappe-Books-#{version}#{arch}.dmg",
       verified: "github.com/frappe/books/"
   name "Frappe Books"
   desc "Book-keeping software for small businesses and freelancers"
@@ -10,8 +18,20 @@ cask "frappe-books" do
 
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/^Frappe[._-]Books[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
+
+  depends_on macos: ">= :high_sierra"
 
   app "Frappe Books.app"
 
@@ -20,8 +40,4 @@ cask "frappe-books" do
     "~/Library/Preferences/io.frappe.books.plist",
     "~/Library/Saved Application State/io.frappe.books.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
It seems that the intel version is not supported from this version. So I split the livecheck, versions for each arch.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
