### PR TITLE
zdoom: disable 32-bit application

### DIFF
--- a/Casks/z/zdoom.rb
+++ b/Casks/z/zdoom.rb
@@ -7,7 +7,7 @@ cask "zdoom" do
   desc "Source port of Doom"
   homepage "https://zdoom.org/index"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  disable! date: "2024-09-01", because: "is 32-bit only"
 
   app "ZDoom.app"
 end


### PR DESCRIPTION
Moves `zdoom` from deprecated to disabled due to being a 32-bit application.