### PR TITLE
yippy: add Rosetta caveat, fix homepage

### DIFF
--- a/Casks/y/yippy.rb
+++ b/Casks/y/yippy.rb
@@ -2,13 +2,16 @@ cask "yippy" do
   version "2.8.1"
   sha256 "89d8c2c628637cc72ff6f8a3ca0d07484479a1becb66cedaa67a12062d148131"
 
-  url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip",
-      verified: "github.com/mattDavo/Yippy/"
+  url "https://github.com/mattDavo/Yippy/releases/download/#{version}/Yippy.zip"
   name "Yippy"
   desc "Open source clipboard manager"
-  homepage "https://yippy.mattdavo.com/"
+  homepage "https://github.com/mattDavo/Yippy"
 
   app "Yippy.app"
 
   zap trash: "~/Library/Application Support/MatthewDavidson.Yippy"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
App needs Rosetta, and updated homepage since it now appears to have been squatted by an online gambling site.