### PR TITLE
nodeclipse: deprecate

### DIFF
--- a/Casks/n/nodeclipse.rb
+++ b/Casks/n/nodeclipse.rb
@@ -8,16 +8,14 @@ cask "nodeclipse" do
   desc "Node.js tooling with Eclipse"
   homepage "https://nodeclipse.github.io/"
 
-  livecheck do
-    url "https://nodeclipse.github.io/updates/"
-    regex(%r{/Enide-(\d+)-(\d+)-macosx-x64-(\d+)\.zip})
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}.#{match[1]},#{match[2]}" }
-    end
-  end
+  deprecate! date: "2024-09-01", because: :unmaintained
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/8183
   app "Eclipse.app", target: "Nodeclipse.app"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2015 and no longer appears to be maintained.