### PR TITLE
cuda-z: deprecate

### DIFF
--- a/Casks/c/cuda-z.rb
+++ b/Casks/c/cuda-z.rb
@@ -7,14 +7,9 @@ cask "cuda-z" do
   desc "Show basic information about CUDA-enabled GPUs and GPGPUs"
   homepage "https://cuda-z.sourceforge.net/"
 
-  livecheck do
-    url :homepage
-    regex(/CUDA-Z-(\d+(?:\.\d+)+)\.dmg/i)
-  end
+  deprecate! date: "2024-09-01", because: :unmaintained
+
+  depends_on arch: :x86_64
 
   app "CUDA-Z.app"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Application has not been updated since 2015 and does not run on Apple Silicon.