### PR TITLE
metavideo: add auto_update true

### DIFF
--- a/Casks/m/metavideo.rb
+++ b/Casks/m/metavideo.rb
@@ -12,6 +12,7 @@ cask "metavideo" do
     strategy :sparkle, &:short_version
   end
 
+  auto_updates true
   depends_on macos: ">= :big_sur"
 
   app "MetaVideo.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Update according to issue https://github.com/Homebrew/homebrew-cask/issues/170994#issue-2234458666
- Livecheck returns the latest version.
- MetaVideo provides the option to enable automatic updates in the pop-up window, when a new version is available.

Although this cask is not on the list, it matches the criteria of the issue. The app is from the [NeededApps](https://neededapps.com) and metaimage, gluemotion, snapmotion and photsrevive are also apps from this publisher and are on the list. Please consider adding MetaVideo to the list.

Screenshot:
<img width="1282" alt="metavideo-auto-update" src="https://github.com/user-attachments/assets/37bfadd1-32b8-4a72-bc91-bb3d5b184d77">

