### PR TITLE
ci: make space on runners

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -26,6 +26,14 @@ jobs:
           cask: true
           test-bot: false
 
+      - name: Clean up CI Xcode Versions
+        run: |
+          df -hI /dev/disk3s1s1
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.app
+          df -hI /dev/disk3s1s1
+
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,15 @@ jobs:
             echo '::warning::Uninstalling Mono is no longer necessary.'
           fi
 
+      - name: Clean up CI Xcode Versions
+        if: matrix.runner == 'macos-14'
+        run: |
+          df -hI /dev/disk3s1s1
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.app
+          df -hI /dev/disk3s1s1
+
       - name: Cache Homebrew Gems
         id: cache
         uses: actions/cache@v4


### PR DESCRIPTION
There are additional superfluous versions, but it takes some time to remove them, so only remove 3.