### PR TITLE
Blood-on-the-clocktower 3.31.0 (new cask)

### DIFF
--- a/Casks/b/blood-on-the-clocktower-online.rb
+++ b/Casks/b/blood-on-the-clocktower-online.rb
@@ -1,4 +1,4 @@
-cask "blood-on-the-clocktower" do
+cask "blood-on-the-clocktower-online" do
   arch arm: "aarch64", intel: "x64"
 
   version "3.31.0"
@@ -8,7 +8,7 @@ cask "blood-on-the-clocktower" do
   url "https://github.com/ThePandemoniumInstitute/botc-release/releases/download/v#{version}/Blood.on.the.Clocktower.Online_#{version}_#{arch}.dmg",
       verified: "github.com/ThePandemoniumInstitute/botc-release/"
   name "Blood on the Clocktower Online"
-  desc "Client for the popular social deduction game Blood on the Clocktower"
+  desc "Client for the game Blood on the Clocktower"
   homepage "https://bloodontheclocktower.com/"
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/b/blood-on-the-clocktower.rb
+++ b/Casks/b/blood-on-the-clocktower.rb
@@ -1,0 +1,25 @@
+cask "blood-on-the-clocktower" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "3.31.0"
+  sha256 arm:   "cae25b9e2f7f858decfd1108f358c46b6d6a3b6a08d78f0fc776896b050e28f0",
+         intel: "019da8bf6a4be77f89acd92df3621837ab5c95fc91428d1dac5ceed904d8f769"
+
+  url "https://github.com/ThePandemoniumInstitute/botc-release/releases/download/v#{version}/Blood.on.the.Clocktower.Online_#{version}_#{arch}.dmg",
+      verified: "github.com/ThePandemoniumInstitute/botc-release/"
+  name "Blood on the Clocktower Online"
+  desc "Client for the popular social deduction game Blood on the Clocktower"
+  homepage "https://bloodontheclocktower.com/"
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Blood on the Clocktower Online.app"
+
+  zap trash: [
+    "~/Library/Application Support/botc-app",
+    "~/Library/Application Support/com.thepandemoniuminstitute.botc.app",
+    "~/Library/Caches/com.thepandemoniuminstitute.botc.app",
+    "~/Library/Saved Application State/com.thepandemoniuminstitute.botc.app.savedState",
+    "~/Library/WebKit/com.thepandemoniuminstitute.botc.app",
+  ]
+end


### PR DESCRIPTION
Adding a cask for blood on the clocktower 

This fails the audit due to the repository not having enough stars/watches. This software is an online client for a very popular social deduction game called blood on the clocktower and is available at https://botc.app/ and given a lot of people use the web app it makes sense that this distribution isn't as watched.

Follow up from #178297 

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
