### PR TITLE
spotify 1.2.45.454

### DIFF
--- a/Casks/s/spotify.rb
+++ b/Casks/s/spotify.rb
@@ -1,14 +1,8 @@
 cask "spotify" do
   arch arm: "ARM64"
 
+  version "1.2.45.454"
   sha256 :no_check
-
-  on_arm do
-    version "1.2.44.405,81fd6352,3712"
-  end
-  on_intel do
-    version "1.2.44.405,81fd6352,3707"
-  end
 
   url "https://download.scdn.co/Spotify#{arch}.dmg",
       verified: "download.scdn.co/"
@@ -18,12 +12,7 @@ cask "spotify" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |items|
-      match = items["com.spotify.client"].version.match(/^(\d+(?:\.\d+)+)[._-]g(\h+)[._-](\d+)$/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]},#{match[3]}"
-    end
+    strategy :extract_plist
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Besides updating `spotify` to the latest version, this updates the `livecheck` block to remove the `strategy` block. The regex in the existing `strategy` block no longer matches, as the version format is now simply `1.2.45.454`. The `ExtractPlist` strategy will automatically use the plist version, so a `strategy` block shouldn't be necessary now.