### PR TITLE
Update actual with new info

### DIFF
--- a/Casks/a/actual.rb
+++ b/Casks/a/actual.rb
@@ -1,25 +1,26 @@
 cask "actual" do
-  arch arm: "-arm64"
+  arch arm: "arm64", intel: "x64"
 
-  version "0.0.148"
-  sha256 arm:   "df9e2139a3a5b1355f1ed1a28863115ac574eb15ec856d6e95de13b02bc26ae0",
-         intel: "95159e54c011aba02f64b0d126a497b99544e1086429a11e67587e3ffc0533d4"
+  version "24.9.0"
+  sha256 arm:   "43346a77d58390119d69b70e86e66416558e9679f7f5907aa2e15ceb49e2422a",
+         intel: "cf384e663216fc953c9b1990639f2a53c662970117497dfa9aac7f0c8083f039"
 
-  url "https://github.com/actualbudget/releases/releases/download/#{version}/Actual-#{version}#{arch}.dmg",
-      verified: "github.com/actualbudget/releases/"
+  url "https://github.com/actualbudget/actual/releases/download/v#{version}/Actual-mac-#{arch}.dmg",
+      verified: "github.com/actualbudget/actual/"
   name "Actual"
   desc "Privacy-focused app for managing your finances"
   homepage "https://actualbudget.com/"
 
-  deprecate! date: "2023-12-17", because: :discontinued
+  depends_on macos: ">= :catalina"
 
   app "Actual.app"
 
   zap trash: [
     "~/Documents/Actual",
     "~/Library/Application Support/Actual",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.actualbudget.actual.sfl*",
     "~/Library/Logs/Actual",
-    "~/Library/Preferences/com.shiftreset.actual.plist",
-    "~/Library/Saved Application State/com.shiftreset.actual.savedState",
+    "~/Library/Preferences/com.actualbudget.actual.plist",
+    "~/Library/Saved Application State/com.actualbudget.actual.savedState",
   ]
 end


### PR DESCRIPTION
I'm not actually sure if this is desirable or not, but figured it'd be worth discussing.  I don't use the software (yet?) but ran across it again recently.

Basically, this was deprecated in #160816 about a year or so ago, but things appear to have changed a bit per <https://actualbudget.com/open-source>.  There's a new repo (<https://github.com/actualbudget/actual>) with the same url (<https://actualbudget.org>).  The owner of the original repo appears to have released it to the community, so this seems like it supersedes the original.

I'm not sure that the best way is to replace this whole-hog; `brew info --analytics actual` gives 19/40/108.  I have no idea what this PR would do to them.

----

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.