### PR TITLE
yubico-authenticator: update livecheck

### DIFF
--- a/Casks/y/yubico-authenticator.rb
+++ b/Casks/y/yubico-authenticator.rb
@@ -8,6 +8,27 @@ cask "yubico-authenticator" do
   desc "Application for generating TOTP and HOTP codes"
   homepage "https://developers.yubico.com/yubioath-flutter/"
 
+  # Releases sometimes don't have a macOS build, so we check multiple
+  # recent releases instead of only the "latest" release. NOTE: We should be
+  # able to use `strategy :github_latest` when subsequent releases provide
+  # files for macOS again.
+  livecheck do
+    url :url
+    regex(/^yubico[._-]authenticator[._-]v?(\d+(?:\.\d+)+)[._-]mac\.(?:dmg|pkg)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
   depends_on macos: ">= :big_sur"
 
   app "Yubico Authenticator.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Fixes a long standing issue where the latest `yubico-authenticator` release is only for Android, so this scans for the latest macOS release.

This can probably be removed in the future once releases are back on regular cadence.