### PR TITLE
snes9x: update livecheck

### DIFF
--- a/Casks/s/snes9x.rb
+++ b/Casks/s/snes9x.rb
@@ -8,6 +8,29 @@ cask "snes9x" do
   desc "Video game console emulator"
   homepage "https://www.snes9x.com/"
 
+  # Releases sometimes don't have a macOS build, so we check multiple
+  # recent releases instead of only the "latest" release. NOTE: We should be
+  # able to use `strategy :github_latest` or drop livecheck altogether
+  # when subsequent releases provide files for macOS again.
+  livecheck do
+    url :url
+    regex(/^snes9x[._-]v?(\d+(?:\.\d+)+)[._-]Mac\.zip$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
+  depends_on macos: ">= :sierra"
+
   app "Snes9x.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Fixes long standing livecheck issue where the latest release does not contain files for macOS, so scans releases to find the latest macOS release.