### PR TITLE
zenmate-vpn: disable

### DIFF
--- a/Casks/z/zenmate-vpn.rb
+++ b/Casks/z/zenmate-vpn.rb
@@ -7,12 +7,7 @@ cask "zenmate-vpn" do
   desc "VPN client"
   homepage "https://zenmate.com/products/vpn-for-osx/"
 
-  livecheck do
-    url "https://download.zenmate.com/mac/zenmate.xml"
-    strategy :sparkle do |item|
-      item.url[%r{/zm_(\d+(?:\.\d+)*)\.dmg}i, 1]
-    end
-  end
+  disable! date: "2024-09-07", because: :discontinued
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Since March 16th, 2023 the VPN service has been provided by CyberGhost VPN’s mobile and desktop apps ([source](https://zenmate.com/blog/zenmate-changes)).
