### PR TITLE
lando, lando@edge: deprecate

### DIFF
--- a/Casks/l/lando.rb
+++ b/Casks/l/lando.rb
@@ -11,15 +11,7 @@ cask "lando" do
   desc "Local development environment and DevOps tool built on Docker"
   homepage "https://lando.dev/"
 
-  # Upstream doesn't label all unstable releases (e.g. alpha, beta, rc) as
-  # pre-release on GitHub, so the "latest" release is sometimes an unstable
-  # version. Until this changes we have to use the `GithubReleases` strategy
-  # with a regex to only match stable versions.
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :github_releases
-  end
+  deprecate! date: "2024-09-07", because: "no longer distributing an install package"
 
   conflicts_with cask: "lando@edge"
   depends_on cask: "docker"

--- a/Casks/l/lando@edge.rb
+++ b/Casks/l/lando@edge.rb
@@ -11,10 +11,7 @@ cask "lando@edge" do
   desc "Local development environment and DevOps tool built on Docker"
   homepage "https://docs.lando.dev/"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
+  deprecate! date: "2024-09-07", because: "no longer distributing an install package"
 
   conflicts_with cask: "lando"
   depends_on cask: "docker"


### PR DESCRIPTION
`lando` (and by extension, `lando@edge`) is no longer being distributed as a package by upstream, so this EOL's the packages.

Current install instructions are here for obtaining the software: https://docs.lando.dev/install/macos.html