### PR TITLE
katrain: update livecheck

### DIFF
--- a/Casks/k/katrain.rb
+++ b/Casks/k/katrain.rb
@@ -11,6 +11,26 @@ cask "katrain" do
   desc "Tool for analyzing games and playing go with AI feedback from KataGo"
   homepage "https://github.com/sanderland/katrain"
 
+  # Most recent release doesn't provide a file forr macOS, so we check multiple
+  # recent releases instead of only the "latest" release. NOTE: We should be
+  # able to remove this next release when upstream provides a file for macOS again.
+  livecheck do
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/KaTrainOSX\.(?:dmg|pkg)$}i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
   app "KaTrain.app"
 
   zap trash: "~/.katrain"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The latest release is a hotfix release for Windows, so using the default strategy breaks since there is no macOS version.  This updates the livecheck to check all releases for the last macOS version and use that accordingly.

Likely can be removed on the next release.