### PR TITLE
horndis: disable

### DIFF
--- a/Casks/h/horndis.rb
+++ b/Casks/h/horndis.rb
@@ -7,6 +7,8 @@ cask "horndis" do
   desc "Android USB tethering driver"
   homepage "https://github.com/jwise/HoRNDIS"
 
+  disable! date: "2024-09-08", because: :unmaintained
+
   depends_on macos: [
     :el_capitan,
     :sierra,
@@ -18,4 +20,8 @@ cask "horndis" do
 
   uninstall kext:    "com.joshuawise.kexts.HoRNDIS",
             pkgutil: "com.joshuawise.*"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2018 and is no longer updated by the maintainer.

Additionally, this loads 3rd party kexts and requires disabling SIP, making it broadly incompatible with Apple Silicon machines.