### PR TITLE
audioscrobbler: disable

### DIFF
--- a/Casks/a/audioscrobbler.rb
+++ b/Casks/a/audioscrobbler.rb
@@ -7,6 +7,8 @@ cask "audioscrobbler" do
   desc "Minimal, robust iTunes scrobbling"
   homepage "https://github.com/mxcl/Audioscrobbler.app"
 
+  disable! date: "2024-09-08", because: :unmaintained
+
   app "Audioscrobbler.app"
 
   zap trash: [


### PR DESCRIPTION
Application has not been updated since 2014, does not appear to work with Apple Music.