### PR TITLE
shortcuts: disable

### DIFF
--- a/Casks/s/shortcuts.rb
+++ b/Casks/s/shortcuts.rb
@@ -6,5 +6,11 @@ cask "shortcuts" do
   name "Restart/Sleep/Logout/Shutdown/Lock Shortcuts"
   homepage "https://github.com/siong1987/shortcuts/"
 
+  disable! date: "2024-09-08", because: :unmaintained
+
   suite "system", target: "Shortcuts"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Application has not been updated since 2017, seems to cause issues on [Apple Silicon](https://github.com/siong1987/shortcuts/issues/20)