### PR TITLE
tuxguitar 1.6.4

### DIFF
--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -1,13 +1,17 @@
 cask "tuxguitar" do
-  version "1.5.6"
-  sha256 "fa53ebd78fa507bbb2a654e17efb6913957cf5eb8cceeb6da3423c82ff6e18ff"
+  version "1.6.4"
+  sha256 "1d16a97b313f7968773b3f677a8ce086f6cc78ac8999bc68f02e4e53f03a2ef6"
 
-  url "https://downloads.sourceforge.net/tuxguitar/tuxguitar-#{version}-macosx-cocoa-64.app.tar.gz"
+  url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz",
+      verified: "github.com/helge17/tuxguitar/"
   name "TuxGuitar"
   desc "Multitrack guitar tablature editor and player"
-  homepage "https://sourceforge.net/projects/tuxguitar/"
+  homepage "https://www.tuxguitar.app/"
 
-  deprecate! date: "2024-06-21", because: :discontinued
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
-  app "tuxguitar-#{version}-macosx-cocoa-64.app"
+  app "tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app"
 end

--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -14,4 +14,6 @@ cask "tuxguitar" do
   end
 
   app "tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app"
+
+  zap trash: "~/Library/Application Support/tuxguitar"
 end


### PR DESCRIPTION
This cask was marked as deprecated / out of date, because the original maintainer has stopped contributing to Tuxguitar on SourceForge. However, the maintenance was picked up by other people, and, currently, the most recent stable version is 1.6.4. It's now hosted on GitHub, not anymore on SourceForge, and the there is also a new website.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ x ] `brew audit --cask --online <cask>` is error-free.
- [ x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
