### PR TITLE
parallels*: update `conflicts_with`, deprecate outdated casks

### DIFF
--- a/Casks/p/parallels.rb
+++ b/Casks/p/parallels.rb
@@ -24,6 +24,7 @@ cask "parallels" do
     "parallels@16",
     "parallels@17",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: ">= :monterey"
 

--- a/Casks/p/parallels@12.rb
+++ b/Casks/p/parallels@12.rb
@@ -7,13 +7,7 @@ cask "parallels@12" do
   desc "Desktop virtualization software"
   homepage "https://www.parallels.com/products/desktop/"
 
-  livecheck do
-    url "https://kb.parallels.com/123948"
-    regex(/(\d+(?:\.\d+)+)(?:\s*|&nbsp;)\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]}" }
-    end
-  end
+  deprecate! date: "2024-09-11", because: :discontinued
 
   conflicts_with cask: [
     "parallels",

--- a/Casks/p/parallels@12.rb
+++ b/Casks/p/parallels@12.rb
@@ -23,6 +23,7 @@ cask "parallels@12" do
     "parallels@16",
     "parallels@17",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: "<= :sierra"
 

--- a/Casks/p/parallels@13.rb
+++ b/Casks/p/parallels@13.rb
@@ -23,6 +23,7 @@ cask "parallels@13" do
     "parallels@16",
     "parallels@17",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: "<= :high_sierra"
 

--- a/Casks/p/parallels@13.rb
+++ b/Casks/p/parallels@13.rb
@@ -7,13 +7,7 @@ cask "parallels@13" do
   desc "Desktop virtualization software"
   homepage "https://www.parallels.com/products/desktop/"
 
-  livecheck do
-    url "https://kb.parallels.com/124262"
-    regex(/(\d+(?:\.\d+)+)(?:\s*|&nbsp;)\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]}" }
-    end
-  end
+  deprecate! date: "2024-09-11", because: :discontinued
 
   conflicts_with cask: [
     "parallels",

--- a/Casks/p/parallels@14.rb
+++ b/Casks/p/parallels@14.rb
@@ -24,6 +24,7 @@ cask "parallels@14" do
     "parallels@16",
     "parallels@17",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: [
     :el_capitan,

--- a/Casks/p/parallels@14.rb
+++ b/Casks/p/parallels@14.rb
@@ -7,13 +7,7 @@ cask "parallels@14" do
   desc "Desktop virtualization software"
   homepage "https://www.parallels.com/products/desktop/"
 
-  livecheck do
-    url "https://kb.parallels.com/124521"
-    regex(/(\d+(?:\.\d+)+)(?:\s*|&nbsp;)\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]}" }
-    end
-  end
+  deprecate! date: "2024-09-11", because: :discontinued
 
   auto_updates true
   conflicts_with cask: [

--- a/Casks/p/parallels@15.rb
+++ b/Casks/p/parallels@15.rb
@@ -24,6 +24,7 @@ cask "parallels@15" do
     "parallels@16",
     "parallels@17",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: ">= :sierra"
 

--- a/Casks/p/parallels@15.rb
+++ b/Casks/p/parallels@15.rb
@@ -7,13 +7,7 @@ cask "parallels@15" do
   desc "Desktop virtualization software"
   homepage "https://www.parallels.com/products/desktop/"
 
-  livecheck do
-    url "https://kb.parallels.com/124724"
-    regex(/(\d+(?:\.\d+)+)(?:\s*|&nbsp;)\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]}" }
-    end
-  end
+  deprecate! date: "2024-09-11", because: :discontinued
 
   auto_updates true
   conflicts_with cask: [

--- a/Casks/p/parallels@16.rb
+++ b/Casks/p/parallels@16.rb
@@ -7,13 +7,7 @@ cask "parallels@16" do
   desc "Desktop virtualization software"
   homepage "https://www.parallels.com/products/desktop/"
 
-  livecheck do
-    url "https://kb.parallels.com/125053"
-    regex(/(\d+(?:\.\d+)+)(?:\s*|&nbsp;)\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]}" }
-    end
-  end
+  deprecate! date: "2024-09-11", because: :discontinued
 
   auto_updates true
   conflicts_with cask: [

--- a/Casks/p/parallels@16.rb
+++ b/Casks/p/parallels@16.rb
@@ -24,6 +24,7 @@ cask "parallels@16" do
     "parallels@15",
     "parallels@17",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/p/parallels@17.rb
+++ b/Casks/p/parallels@17.rb
@@ -7,13 +7,7 @@ cask "parallels@17" do
   desc "Desktop virtualization software"
   homepage "https://www.parallels.com/products/desktop/"
 
-  livecheck do
-    url "https://kb.parallels.com/125552"
-    regex(/(\d+(?:\.\d+)+)(?:\s*|&nbsp;)\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]}-#{match[1]}" }
-    end
-  end
+  deprecate! date: "2024-09-11", because: :discontinued
 
   auto_updates true
   conflicts_with cask: [

--- a/Casks/p/parallels@17.rb
+++ b/Casks/p/parallels@17.rb
@@ -24,6 +24,7 @@ cask "parallels@17" do
     "parallels@15",
     "parallels@16",
     "parallels@18",
+    "parallels@19",
   ]
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/p/parallels@18.rb
+++ b/Casks/p/parallels@18.rb
@@ -24,6 +24,7 @@ cask "parallels@18" do
     "parallels@15",
     "parallels@16",
     "parallels@17",
+    "parallels@19",
   ]
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Update `conflicts_with` stanzas.
Parallels@12-17 no longer have knowledgebase articles, so let's deprecate them. Also remove the non-functional livechecks.
