### PR TITLE
Remove `auto_updates` from ente-auth

### DIFF
--- a/Casks/e/ente-auth.rb
+++ b/Casks/e/ente-auth.rb
@@ -14,7 +14,6 @@ cask "ente-auth" do
     strategy :github_releases
   end
 
-  auto_updates true
   depends_on macos: ">= :mojave"
 
   app "Ente Auth.app"


### PR DESCRIPTION
The app doesn't actually auto-update—its update dialog just has a download button that opens the GitHub releases page.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.