### PR TITLE
font-andron-scriptor-web: add livecheck

### DIFF
--- a/Casks/font/font-a/font-andron-scriptor-web.rb
+++ b/Casks/font/font-a/font-andron-scriptor-web.rb
@@ -6,6 +6,11 @@ cask "font-andron-scriptor-web" do
   name "Andron Scriptor Web"
   homepage "https://folk.uib.no/hnooh/mufi/fonts/"
 
+  livecheck do
+    url :homepage
+    regex(/AND[._-]SCR[._-]WEB[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
   font "AND_SCR_WEB_#{version}/Andron Scriptor Web.ttf"
 
   # No zap stanza required


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

livecheck is unable to identify versions for
`font-andron-scriptor-web` by default. This adds a `livecheck` block that checks the homepage, which links to the zip file.