### PR TITLE
floorp: remove livecheck

### DIFF
--- a/Casks/f/floorp.rb
+++ b/Casks/f/floorp.rb
@@ -8,11 +8,6 @@ cask "floorp" do
   desc "Privacy-focused Firefox-based browser"
   homepage "https://floorp.app/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   auto_updates true
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Floorp does not use pre-releases, so the livecheck block can be dropped to instead use the default strategy.