### PR TITLE
proton-mail: change download url

### DIFF
--- a/Casks/p/proton-mail.rb
+++ b/Casks/p/proton-mail.rb
@@ -1,15 +1,22 @@
 cask "proton-mail" do
-  arch arm: "arm64", intel: "x64"
+  version "1.1.0"
+  sha256 "9d49c5833c3ddec408e62e898a73d89500d9865cb85f42067e8a2fc1d334c3ee"
 
-  version "1.0.6"
-  sha256 arm:   "4206e235c99f432e6b8d654bc925b4a1b6b91ea91e2fc15c239ad539c21bc499",
-         intel: "4206e235c99f432e6b8d654bc925b4a1b6b91ea91e2fc15c239ad539c21bc499"
-
-  url "https://github.com/ProtonMail/inbox-desktop/releases/download/#{version}/Proton.Mail-#{version}-#{arch}.dmg",
-      verified: "github.com/ProtonMail/inbox-desktop/"
+  url "https://proton.me/download/mail/macos/ProtonMail-desktop.dmg"
   name "Proton Mail"
   desc "Client for Proton Mail and Proton Calendar"
   homepage "https://proton.me/mail"
+
+  livecheck do
+    url "https://proton.me/download/mail/macos/version.json"
+    strategy :json do |json|
+      json["Releases"]&.map do |item|
+        next unless item["CategoryName"]&.match?("Stable")
+
+        item["Version"]
+      end
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :catalina"

--- a/Casks/p/proton-mail.rb
+++ b/Casks/p/proton-mail.rb
@@ -1,6 +1,6 @@
 cask "proton-mail" do
   version "1.1.0"
-  sha256 "9d49c5833c3ddec408e62e898a73d89500d9865cb85f42067e8a2fc1d334c3ee"
+  sha256 :no_check
 
   url "https://proton.me/download/mail/macos/ProtonMail-desktop.dmg"
   name "Proton Mail"


### PR DESCRIPTION
Since the Proton Mail desktop app is now on version 1.1.0 and GitHub releases only show versions up to 1.0.6, I thought it would be good to change the download url to the non-versioned one which is hosted on proton.me
Unfortunately, there is no versioned url available.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
