### PR TITLE
replaywebpage 2.1.4 (new cask)

### DIFF
--- a/Casks/r/replaywebpage.rb
+++ b/Casks/r/replaywebpage.rb
@@ -1,4 +1,4 @@
-cask "webrecorder-replaywebpage" do
+cask "replaywebpage" do
   version "2.1.4"
   sha256 "e67db03fc107879c3fe4a028d421a4a48b09d26463ec88fc4a339af3ed196eef"
 

--- a/Casks/w/webrecorder-replaywebpage.rb
+++ b/Casks/w/webrecorder-replaywebpage.rb
@@ -1,0 +1,27 @@
+cask "webrecorder-replaywebpage" do
+  version "2.1.4"
+  sha256 "e67db03fc107879c3fe4a028d421a4a48b09d26463ec88fc4a339af3ed196eef"
+
+  url "https://github.com/webrecorder/replayweb.page/releases/download/v#{version}/ReplayWeb.page-#{version}.dmg",
+      verified: "github.com/webrecorder/replayweb.page/"
+  name "ReplayWeb.page"
+  desc "Web archive viewer for WARC and WACZ files"
+  homepage "https://replayweb.page"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "ReplayWeb.page.app"
+
+  zap trash: [
+    "~/Library/Application Support/ReplayWeb.page",
+    "~/Library/Logs/ReplayWeb.page",
+    "~/Library/Saved Application State/net.webrecorder.replaywebpage.savedState",
+    "~/Library/Preferences/net.webrecorder.replaywebpage.plst",
+  ]
+
+end

--- a/Casks/w/webrecorder-replaywebpage.rb
+++ b/Casks/w/webrecorder-replaywebpage.rb
@@ -6,7 +6,7 @@ cask "webrecorder-replaywebpage" do
       verified: "github.com/webrecorder/replayweb.page/"
   name "ReplayWeb.page"
   desc "Web archive viewer for WARC and WACZ files"
-  homepage "https://replayweb.page"
+  homepage "https://replayweb.page/"
 
   livecheck do
     url :url
@@ -20,8 +20,7 @@ cask "webrecorder-replaywebpage" do
   zap trash: [
     "~/Library/Application Support/ReplayWeb.page",
     "~/Library/Logs/ReplayWeb.page",
-    "~/Library/Saved Application State/net.webrecorder.replaywebpage.savedState",
     "~/Library/Preferences/net.webrecorder.replaywebpage.plst",
+    "~/Library/Saved Application State/net.webrecorder.replaywebpage.savedState",
   ]
-
 end


### PR DESCRIPTION
### Review Process

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
  - ~~I've prefixed it with the company name to match `webrecorder-player` (deprecated in favour of [ReplayWeb.page](https://github.com/webrecorder/replayweb.page))~~
  - ~~Assuming this gets added, I'll likely also add ArchiveWeb.page (our other macOS app) also prefixed with the company name~~
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.