### PR TITLE
Add Universal Desktop companion app (with beta version)

### DIFF
--- a/Casks/u/universal-desktop.rb
+++ b/Casks/u/universal-desktop.rb
@@ -14,6 +14,7 @@ cask "universal-desktop" do
   end
 
   auto_updates true
+  conflicts_with cask: "universal-desktop@beta"
   depends_on macos: ">= :ventura"
 
   app "Universal Desktop.app"

--- a/Casks/u/universal-desktop.rb
+++ b/Casks/u/universal-desktop.rb
@@ -1,0 +1,25 @@
+cask "universal-desktop" do
+  version "1.0.8"
+  sha256 "5502501767cb445237f57da2a68604897b0d53c91530b28bcf9895ee1cb73af9"
+
+  url "https://github.com/adrianjagielak/universal-desktop-website/releases/download/v#{version}/Universal.Desktop.dmg",
+      verified: "github.com/adrianjagielak/universal-desktop-website/"
+  name "Universal Desktop"
+  desc "Stream Mac apps to Apple Vision Pro as native visionOS windows"
+  homepage "https://universaldesktop.app/"
+
+  livecheck do
+    url "https://www.universaldesktop.app/macos_host_appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "Universal Desktop.app"
+
+  zap trash: [
+    "~/Library/Preferences/dev.adrianjagielak.UniversalDesktop.plist",
+    "~/Library/HTTPStorages/dev.adrianjagielak.UniversalDesktop",
+  ]
+end

--- a/Casks/u/universal-desktop.rb
+++ b/Casks/u/universal-desktop.rb
@@ -5,7 +5,7 @@ cask "universal-desktop" do
   url "https://github.com/adrianjagielak/universal-desktop-website/releases/download/v#{version}/Universal.Desktop.dmg",
       verified: "github.com/adrianjagielak/universal-desktop-website/"
   name "Universal Desktop"
-  desc "Stream Mac apps to Apple Vision Pro as native visionOS windows"
+  desc "Stream apps to Vision Pro as native visionOS windows"
   homepage "https://universaldesktop.app/"
 
   livecheck do
@@ -19,7 +19,7 @@ cask "universal-desktop" do
   app "Universal Desktop.app"
 
   zap trash: [
-    "~/Library/Preferences/dev.adrianjagielak.UniversalDesktop.plist",
     "~/Library/HTTPStorages/dev.adrianjagielak.UniversalDesktop",
+    "~/Library/Preferences/dev.adrianjagielak.UniversalDesktop.plist",
   ]
 end

--- a/Casks/u/universal-desktop@beta.rb
+++ b/Casks/u/universal-desktop@beta.rb
@@ -14,6 +14,7 @@ cask "universal-desktop@beta" do
   end
 
   auto_updates true
+  conflicts_with cask: "universal-desktop"
   depends_on macos: ">= :monterey"
 
   app "Universal Desktop.app"

--- a/Casks/u/universal-desktop@beta.rb
+++ b/Casks/u/universal-desktop@beta.rb
@@ -5,7 +5,7 @@ cask "universal-desktop@beta" do
   url "https://github.com/adrianjagielak/universal-desktop-website/releases/download/v#{version.csv.first}-#{version.csv.second}/Universal.Desktop.dmg",
       verified: "github.com/adrianjagielak/universal-desktop-website/"
   name "Universal Desktop (Beta)"
-  desc "Stream Mac apps to Apple Vision Pro as native visionOS windows"
+  desc "Stream apps to Vision Pro as native visionOS windows"
   homepage "https://universaldesktop.app/"
 
   livecheck do
@@ -19,7 +19,7 @@ cask "universal-desktop@beta" do
   app "Universal Desktop.app"
 
   zap trash: [
-    "~/Library/Preferences/dev.adrianjagielak.UniversalDesktop.plist",
     "~/Library/HTTPStorages/dev.adrianjagielak.UniversalDesktop",
+    "~/Library/Preferences/dev.adrianjagielak.UniversalDesktop.plist",
   ]
 end

--- a/Casks/u/universal-desktop@beta.rb
+++ b/Casks/u/universal-desktop@beta.rb
@@ -1,0 +1,25 @@
+cask "universal-desktop@beta" do
+  version "1.1,65"
+  sha256 "fec78328bfd7afd613d636dd1d60b4ba75a745080a814f16c45c15dbb4c4ec9f"
+
+  url "https://github.com/adrianjagielak/universal-desktop-website/releases/download/v#{version.csv.first}-#{version.csv.second}/Universal.Desktop.dmg",
+      verified: "github.com/adrianjagielak/universal-desktop-website/"
+  name "Universal Desktop (Beta)"
+  desc "Stream Mac apps to Apple Vision Pro as native visionOS windows"
+  homepage "https://universaldesktop.app/"
+
+  livecheck do
+    url "https://www.universaldesktop.app/macos_host_beta_appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Universal Desktop.app"
+
+  zap trash: [
+    "~/Library/Preferences/dev.adrianjagielak.UniversalDesktop.plist",
+    "~/Library/HTTPStorages/dev.adrianjagielak.UniversalDesktop",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - There is a warning about "desktop" being in the name, but "Universal Desktop" is the app's full name and I think `universal-desktop` makes the most sense as the name
  - There is also a warning about the GitHub repo not being notable enough, but the repo isn't advertised anywhere publicly and is just to host the app's website and downloads. The app is pretty popular on Vision Pro (see [App Store Page](https://apps.apple.com/us/app/universal-desktop/id6479523407))
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

I added the beta version of the companion app too, since it's a complete rewrite and reverses the sides of client and server. So the beta client app won't work with the stable companion app and vice versa. But if it should be just the stable version let me know and I'll remove it. (And yes, for some reason stable needs Ventura and beta needs Monterey)

I also used Sparkle instead of GitHub releases as that's what the app uses to auto-update. But again let me know if I should use GH releases instead.