### PR TITLE
autobump: add `threema` and `threema-work`

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -807,6 +807,8 @@ texshop
 texstudio
 thangs-sync
 theiaide
+threema
+threema-work
 threema@beta
 ths
 thunderbird


### PR DESCRIPTION
Noticed during the autobump run we were auto-updating `threema@beta` but not `threema` and `threema-work`, so adding those to the list.