### PR TITLE
pieces-cli 1.6.2 

### DIFF
--- a/Casks/p/pieces-cli.rb
+++ b/Casks/p/pieces-cli.rb
@@ -20,5 +20,5 @@ cask "pieces-cli" do
 
   binary "pieces"
 
-  # No zap stanza required
+  zap trash: "~/Library/Application Support/cli-agent"
 end

--- a/Casks/p/pieces-cli.rb
+++ b/Casks/p/pieces-cli.rb
@@ -13,8 +13,12 @@ cask "pieces-cli" do
 
   livecheck do
     url "https://builds.pieces.app/stages/production/pieces_cli/version"
-    regex(/"version":\s*"(\d+\.\d+\.\d+)"/i)
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   binary "pieces"
+
+  # No zap stanza required
 end

--- a/Casks/p/pieces-cli.rb
+++ b/Casks/p/pieces-cli.rb
@@ -1,23 +1,20 @@
 cask "pieces-cli" do
-  version "1.2.4"
-  sha256 "8c3f210254221b5dcef1a0f0798e0a1f3883758089b1017d4495e7181ef20781"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://storage.googleapis.com/app-releases-59612ba/pieces-cli/release/pieces-mac-#{version}.tar.gz",
-      verified: "storage.googleapis.com/app-releases-59612ba/pieces-cli/release/"
+  version "1.6.2"
+  sha256 arm:   "b19ae0529e2bdd49d8243c2c8bae27690ce87c4738e1a709cbbefda440197bc8",
+         intel: "687cd1864669e8b837b19e1df3b326a73222a6cad2adb93dc598e62ebb8a0567"
+
+  url "https://storage.googleapis.com/app-releases-production/pieces_cli/release/pieces-cli-mac_#{arch}-#{version}.zip",
+      verified: "storage.googleapis.com/app-releases-production/pieces_cli/release/"
   name "Pieces CLI"
   desc "Command-line tool for Pieces.app"
-  homepage "https://code.pieces.app/"
+  homepage "https://pieces.app/"
 
   livecheck do
-    url "https://code.pieces.app/cli-version"
-    regex(/pieces[._-]cli[._-]v?(\d+(?:\.\d+)+)/i)
+    url "https://builds.pieces.app/stages/production/pieces_cli/version"
+    regex(/"version":\s*"(\d+\.\d+\.\d+)"/i)
   end
 
   binary "pieces"
-
-  zap trash: "~/Library/.piecescli-cache"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Our team at Pieces.app has completely redone our CLI tool and replaced all the existing URLs

This cask file should reflect all of those changes.

However, I am having issues running `brew audit --cask --online pieces-cli` as it seems to pull the one that is currently in homebrew-cask.

I have attempted to clear all caches, tap/untap my forked repo but alas, I cannot seem to get it to audit our new version. Help with this would be much appreciated if there are issues with our new CLI and/or the cask file.

I am also not aware of any cached resources at this moment that need to be zapped.

Thanks in advance! 
