### PR TITLE
ocenaudio: update livecheck

### DIFF
--- a/Casks/o/ocenaudio.rb
+++ b/Casks/o/ocenaudio.rb
@@ -22,8 +22,8 @@ cask "ocenaudio" do
   homepage "https://www.ocenaudio.com/en"
 
   livecheck do
-    url "https://www.ocenaudio.com/changelog"
-    regex(/download\?version=v?(\d+(?:\.\d+)+)/i)
+    url :url
+    strategy :header_match
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `ocenaudio` checks the upstream changelog page and parses the version links in the HTML. This works but each of the cask `url`s return a 200 response that has a `Content-Disposition` header with a versioned filename, so it makes more sense to check that instead. These files use the same version at the moment but using `HeaderMatch` to identify the version from the `url` response ensures that we're checking each upstream file version instead of assuming that they will always be the same.