### PR TITLE
tuxera-ntfs: fix livecheck

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -844,6 +844,7 @@ tunnelbear
 tunnelblick@beta
 tuple
 tuta-mail
+tuxera-ntfs
 twine
 typeface
 typora

--- a/Casks/t/tuxera-ntfs.rb
+++ b/Casks/t/tuxera-ntfs.rb
@@ -8,8 +8,8 @@ cask "tuxera-ntfs" do
   homepage "https://ntfsformac.tuxera.com/"
 
   livecheck do
-    url "https://ntfsformac.tuxera.com/support/"
-    regex(/Release\s*?v?(\d+(?:\.\d+)*)/i)
+    url "https://download.tuxera.com/mac/tuxerantfs_latest.dmg"
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Previous `livecheck` checks a url that is no longer available. The download link from the `homepage` includes a redirect to the file, so we can use the `header_match` strategy.
