### PR TITLE
readmoreading 1.1.0

### DIFF
--- a/Casks/r/readmoreading.rb
+++ b/Casks/r/readmoreading.rb
@@ -1,27 +1,32 @@
 cask "readmoreading" do
-  version "0.14.13"
-  sha256 "119f6ee475f1b7040d26cf97b675be6c08fc1e226f12ec9375ae84ddd5077ecc"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://cdn.readmoo.com/download/apps/desktop/osx64/el/Readmoo_Desktop-#{version}.dmg"
+  version "1.1.0"
+  sha256 arm:   "8dcee6ab5a9a75de1dbca57f013d12fefaeeec2434a53e338327462d82317087",
+         intel: "9e52b7645e88ed57835b142b854fd3053473dc0ff1bc952dedc6e75b1d3c486b"
+
+  url "https://github.com/eCrowdMedia/remake/releases/download/v#{version}/Readmoo.-#{version}-#{arch}.dmg",
+      verified: "github.com/eCrowdMedia/remake/"
   name "Readmo Reading"
   desc "Traditional Chinese eBook service"
   homepage "https://readmoo.com/"
 
   livecheck do
-    url "https://readmoo.com/download/osx"
-    strategy :header_match
+    url :url
+    strategy :github_latest
   end
+
+  depends_on macos: ">= :catalina"
 
   app "Readmoo看書.app"
 
   zap trash: [
     "~/Library/Application Support/Readmoo看書",
+    "~/Library/Caches/com.electron.readmoo",
+    "~/Library/Caches/com.electron.readmoo.ShipIt",
+    "~/Library/HTTPStorages/com.electron.readmoo",
     "~/Library/Logs/Readmoo看書",
-    "~/Library/Preferences/com.readmoo.electron.plist",
-    "~/Library/Saved Application State/com.readmoo.electron.savedState",
+    "~/Library/Preferences/com.electron.readmoo.plist",
+    "~/Library/Saved Application State/com.electron.readmoo.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
I have fixed the download url, livecheck.
It looks like the app is built with electron, but I cannot check the livecheck url because I am behind of company proxy.

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
