### PR TITLE
citrix-workspace: set homepage to product homepage

### DIFF
--- a/Casks/c/citrix-workspace.rb
+++ b/Casks/c/citrix-workspace.rb
@@ -5,7 +5,7 @@ cask "citrix-workspace" do
   url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/Receiver/Mac/CitrixWorkspaceAppUniversal#{version}.pkg"
   name "Citrix Workspace"
   desc "Managed desktop virtualization solution"
-  homepage "https://www.citrix.com/"
+  homepage "https://docs.citrix.com/en-us/citrix-workspace"
 
   livecheck do
     url "https://downloadplugins.citrix.com/ReceiverUpdates/Prod/catalog_macos2.xml"


### PR DESCRIPTION
This is the best entry point for the Citrix Workspace Application, rather than the Citrix company homepage.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online citrix-workspace` is error-free.
- [x] `brew style --fix  citrix-workspace` reports no offenses.