### PR TITLE
archivewebpage 0.12.7 (new cask)

### DIFF
--- a/Casks/a/archivewebpage.rb
+++ b/Casks/a/archivewebpage.rb
@@ -1,0 +1,30 @@
+cask "archivewebpage" do
+  version "0.12.7"
+  sha256 "75d94de545daa43bc01899fddbfe1dbde4589e595a4b09eb35825bf2959fbc49"
+
+  url "https://github.com/webrecorder/archiveweb.page/releases/download/v#{version}/ArchiveWeb.page-#{version}.dmg",
+      verified: "github.com/webrecorder/archiveweb.page/"
+  name "ArchiveWeb.page"
+  desc "Archive webpages manually to WARC or WACZ files as you browse the web"
+  homepage "https://archiveweb.page/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "ArchiveWeb.page.app"
+
+  zap trash: [
+    "~/Library/Application Support/ArchiveWeb.page",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/net.webrecorder.archivewebpage.sfl*",
+    "~/Library/Caches/net.webrecorder.archivewebpage",
+    "~/Library/Caches/net.webrecorder.archivewebpage.ShipIt",
+    "~/Library/HTTPStorages/net.webrecorder.archivewebpage",
+    "~/Library/Logs/ArchiveWeb.page",
+    "~/Library/Preferences/net.webrecorder.archivewebpage.plst",
+    "~/Library/Saved Application State/net.webrecorder.archivewebpage.savedState",
+  ]
+end


### PR DESCRIPTION
## Checks

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Previous discussion here: https://github.com/Homebrew/homebrew-cask/pull/185735 (accidentally force pushed and messed up the commit history, figured this was cleaner!)
