### PR TITLE
busycontacts 2024.3.1-2024-09-18-11-17

### DIFF
--- a/Casks/b/busycontacts.rb
+++ b/Casks/b/busycontacts.rb
@@ -1,6 +1,6 @@
 cask "busycontacts" do
   version "2024.3.1"
-  sha256 "fba998ab3612ed96bd31f4b9ec50e65f5d7973e9db7478a013ded2b8cc8a0602"
+  sha256 "0c1eee64ffb10e98e45b2a405b6f3800227cfb9da577f25c7b8317f26ec6d59d"
 
   url "https://www.busymac.com/download/bct-#{version}.zip"
   name "BusyContacts"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Hey, it's my first PR to Homebrew so let me know if anything is wrong.

I tried doing `brew bump --open-pr busycontacts` and I got a response that the cask was up to date because the major version number matches. (I also got an API error since I don't have a Homebrew access token set up, but I assumed it would not create a PR because it thinks the cask is up to date, so I made one manually.) As of the time of this PR, the link https://www.busymac.com/download/bct-2024.3.1.zip now downloads a file `bct-2024.3.1-2024-09-18-11-17.zip` with a different hash that I've updated.

I've also made the changes on my machine and everything seems to work well.