### PR TITLE
omnidisksweeper 1.15.1b

### DIFF
--- a/Casks/o/omnidisksweeper.rb
+++ b/Casks/o/omnidisksweeper.rb
@@ -40,8 +40,8 @@ cask "omnidisksweeper" do
     end
   end
   on_big_sur :or_newer do
-    version "1.15"
-    sha256 "6006cfc0ab6d1a8fc04564d35608bb6d30a89d8d64d4c2769879f99ccc72007a"
+    version "1.15.1b"
+    sha256 "e079d644e8c0d64a4926d4b426bb0e4932a1b25707901a07c3a227cfdf7574f0"
 
     url "https://downloads.omnigroup.com/software/macOS/11/OmniDiskSweeper-#{version}.dmg"
 

--- a/Casks/o/omnidisksweeper.rb
+++ b/Casks/o/omnidisksweeper.rb
@@ -47,7 +47,7 @@ cask "omnidisksweeper" do
 
     livecheck do
       url "https://update.omnigroup.com/appcast/com.omnigroup.OmniDiskSweeper"
-      regex(/OmniDiskSweeper[._-](\d+(?:\.\d+)+)\.dmg/i)
+      regex(/OmniDiskSweeper[._-](\d+(?:\.\d+)+b?)\.dmg/i)
     end
   end
 


### PR DESCRIPTION
I could not run `brew audit --cask --online omnidisksweeper`. It gives me

```
Error: Cask 'omnidisksweeper' is unavailable: No Cask with this name exists.
```

although the Cask exists 🤷🏼 

Note: the download for the previous version `1.15` is broken. It seems the DMG was removed from the server.

<hr>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
