### PR TITLE
busycontacts: don't check sha256

### DIFF
--- a/Casks/b/busycontacts.rb
+++ b/Casks/b/busycontacts.rb
@@ -1,6 +1,13 @@
 cask "busycontacts" do
   version "2024.3.1"
-  sha256 "0c1eee64ffb10e98e45b2a405b6f3800227cfb9da577f25c7b8317f26ec6d59d"
+  # The `bct-2024.3.1.zip` URL redirects to a file with a date at the end
+  # (e.g. `bct-2024.3.1-2024-09-19-12-11.zip`) and this changes over time.
+  # Upstream appears to delete the previous file when switching to a file with
+  # a newer date, so we can't use the full URL with the date (the file may
+  # eventually disappear and break cask installation) but we also can't use a
+  # `sha256` with the redirecting version-only URL because the checksum will
+  # change when the redirected date/file changes.
+  sha256 :no_check
 
   url "https://www.busymac.com/download/bct-#{version}.zip"
   name "BusyContacts"
@@ -8,10 +15,9 @@ cask "busycontacts" do
   homepage "https://www.busymac.com/busycontacts/index.html"
 
   livecheck do
-    url "https://versioncheck.busymac.com/busycontacts/news.plist"
-    strategy :xml do |xml|
-      xml.elements["//dict/key[text()='current']"]&.next_element&.text&.strip
-    end
+    url "https://www.busymac.com/download/BusyContacts.zip"
+    regex(/bct[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This is a follow-up to #185945, where the `busycontacts` `sha256` was updated.

The `url` for the `busycontacts` cask redirects to a file that includes a trailing date (`bct-2024.3.1-2024-09-19-12-11.zip`) and uses downloads.busymac.com. This would be fine if the redirection was static but the date/file changes over time, so the `sha256` is now different than when this cask was last updated. Unfortunately, upstream appears to delete the previous file when switching to one with a newer date, so using the full URL would cause the cask to break as well.

With that in mind, we can either use `sha256 :no_check` with the redirecting version-only URL or use the full URL and accept that it may break between updates. There was only a day between the last change and now, so using `:no_check` instead would keep the cask in a working state for longer. Users wouldn't know what iteration of a given version that they're getting but this is no worse than downloading the file from the upstream website.