### PR TITLE
autobump: add replaywebpage

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -686,6 +686,7 @@ rekordbox
 remote-desktop-manager
 remotehamradio
 removebg
+replaywebpage
 replit
 reqable
 resolume-arena


### PR DESCRIPTION
Adds Webrecorder's [ReplayWeb.page](https://github.com/webrecorder/replayweb.page) (published through GitHub releases like ArchiveWeb.page https://github.com/Homebrew/homebrew-cask/commit/6a209341a6fd4baa3829898b1b2e8a2af0c4ab65) to the autobump file.

Happy to report that ArchiveWeb.page bumped correctly! :)