### PR TITLE
Revert "northern-softworks-cache-cleaner: add legacy versions"

### DIFF
--- a/Casks/n/northern-softworks-cache-cleaner.rb
+++ b/Casks/n/northern-softworks-cache-cleaner.rb
@@ -1,62 +1,20 @@
 cask "northern-softworks-cache-cleaner" do
+  version "20.0"
   sha256 :no_check
 
-  on_mojave :or_older do
-    version "12.0.6"
+  # Homepage, livecheck regex, and app change with major macOS releases
 
-    url "https://www.northernsoftworks.com/legacy/mcc.dmg"
-  end
-  on_catalina do
-    version "15.0.6"
-
-    url "https://www.northernsoftworks.com/legacy/ccc-final.dmg"
-  end
-  on_big_sur do
-    version "16.1.7"
-
-    url "https://www.northernsoftworks.com/legacy/bscc-final.dmg"
-  end
-  on_monterey do
-    version "17.0.5"
-
-    url "https://www.northernsoftworks.com/legacy/mcc2022.dmg"
-  end
-  on_ventura do
-    version "18.0.7"
-
-    url "https://www.northernsoftworks.com/legacy/vcc180007.dmg"
-  end
-  on_sonoma do
-    version "19.0.6"
-
-    url "https://www.northernsoftworks.com/legacy/nscc190006.dmg"
-  end
-  on_sequoia :or_newer do
-    version "20.0"
-
-    url "https://www.northernsoftworks.com/downloads/nscc.dmg"
-  end
-
+  url "https://www.northernsoftworks.com/downloads/nscc.dmg"
   name "Northern Softworks Cache Cleaner"
   desc "General purpose system maintenance tool"
-  homepage "https://www.northernsoftworks.com/cachecleanerfeatures.html"
+  homepage "https://www.northernsoftworks.com/sequoiacachecleaner.html"
 
   livecheck do
-    url "https://www.northernsoftworks.com/support.html"
-    regex(/#{MacOS.version.pretty_name}\s*Cache\s*Cleaner\s*v?(\d+(?:\.\d+)+)/i)
+    url :homepage
+    regex(/Download\s*Sequoia\s*Cache\s*Cleaner\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: [
-    :mojave,
-    :catalina,
-    :big_sur,
-    :monterey,
-    :ventura,
-    :sonoma,
-    :sequoia,
-  ]
-
-  app "#{MacOS.version.pretty_name} Cache Cleaner.app"
+  app "Sequoia Cache Cleaner.app"
 
   zap trash: [
     "~/Library/Application Support/com.northernsw.nswCacheCleaner",


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#186118

@khipp Sorry, I should have re-read the upstream support page before merging the other PR, and I remembered something about this cask. Although the name changes for each MacOS version, it still continues to support the old ones (I think it's just a marketing thing).

![Screenshot 2024-09-20 at 11 33 14 pm](https://github.com/user-attachments/assets/476dc10c-7f1d-4e83-9d87-23b1193b7dc6)
