### PR TITLE
ruffle (new cask)

### DIFF
--- a/Casks/r/ruffle.rb
+++ b/Casks/r/ruffle.rb
@@ -1,0 +1,28 @@
+cask "ruffle" do
+  version "2024-09-21"
+  sha256 "c6f1f4e230600a75117cdba61139a6deabfe2e12e80d40c43aa6fa9dc11f2d0f"
+
+  url "https://github.com/ruffle-rs/ruffle/releases/download/nightly-#{version}/ruffle-nightly-#{version.hyphens_to_underscores}-macos-universal.tar.gz",
+      verified: "github.com/ruffle-rs/ruffle/"
+  name "ruffle"
+  desc "Flash Player emulator"
+  homepage "https://ruffle.rs"
+
+  livecheck do
+    url :url
+    regex(/(nightly-?)(\d+(?:\.-_\d+)+)/i)
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Ruffle.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/rs.ruffle.ruffle",
+    "~/Library/Application Scripts/rs.ruffle.ruffle.extension",
+    "~/Library/Application Support/ruffle",
+    "~/Library/Containers/rs.ruffle.ruffle",
+    "~/Library/Containers/rs.ruffle.ruffle.extension",
+  ]
+end


### PR DESCRIPTION
Ruffle team is gearing up for its [first stable release](https://ruffle.rs/blog/2024/09/12/optimisations-text-more)!

Preparing this Cask formula so we're ready to go. Right now, desktop app is built nightly with Pre-Release tags in GitHub.

Note I wrote and maintain the [ruffle-rs/ruffle/ruffle](http://github.com/ruffle-rs/homebrew-ruffle) Tap, which has been a formula for the CLI tool, but we have a whole GUI now.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
