### PR TITLE
peakhour: deprecate

### DIFF
--- a/Casks/p/peakhour.rb
+++ b/Casks/p/peakhour.rb
@@ -5,12 +5,9 @@ cask "peakhour" do
   url "https://updates.peakhourapp.com/releases/PeakHour%20#{version}.zip"
   name "PeakHour"
   desc "Network bandwidth and network quality visualiser"
-  homepage "https://www.peakhourapp.com/"
+  homepage "https://old.peakhourapp.com/"
 
-  livecheck do
-    url "https://updates.peakhourapp.com/PeakHour#{version.major}Appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2024-09-21", because: :moved_to_mas
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> PeakHour is available now, exclusively in the Mac Appstore.
