### PR TITLE
impel: disable

### DIFF
--- a/Casks/i/impel.rb
+++ b/Casks/i/impel.rb
@@ -8,10 +8,7 @@ cask "impel" do
   desc "AI Companion"
   homepage "https://www.tryimpel.com/"
 
-  livecheck do
-    url "https://impel-sparkle-updater.fly.dev/appcast.xml"
-    strategy :sparkle, &:version
-  end
+  disable! date: "2024-09-22", because: :no_longer_available
 
   auto_updates true
   depends_on macos: ">= :sonoma"


### PR DESCRIPTION
Upstream appears to have completely gone offline - homepage, livecheck, downloads.

Can be re-enabled in the future.
