### PR TITLE
ideamaker: update livecheck

### DIFF
--- a/Casks/i/ideamaker.rb
+++ b/Casks/i/ideamaker.rb
@@ -1,5 +1,6 @@
 cask "ideamaker" do
   arch arm: "-arm64"
+  livecheck_arch = on_arch_conditional arm: "apple-silicon", intel: "intel"
 
   version "5.0.6.8380"
   sha256 arm:   "11d2f2a8af237e047cdd1c28875dc59f5643d41d8314dda27d34185fe6a8eb7a",
@@ -11,8 +12,8 @@ cask "ideamaker" do
   homepage "https://www.raise3d.com/ideamaker/"
 
   livecheck do
-    url "https://www.raise3d.com/download/"
-    regex(%r{href=.*?/install[._-]ideaMaker[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    url "https://www.raise3d.com/download-ideamaker-mac-#{livecheck_arch}/"
+    regex(/install[._-]ideaMaker[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `ideamaker` is giving an `Unable to get versions` error, as the existing download page no longer links to dmg files. Instead, the download page links to separate pages for Apple Silicon and Intel.

This addresses the issue by updating the `livecheck` block to account for this new setup.