### PR TITLE
fujifilm-tether-app 1.30.0,vvr6ik27 (new cask)

### DIFF
--- a/Casks/f/fujifilm-tether-app.rb
+++ b/Casks/f/fujifilm-tether-app.rb
@@ -11,10 +11,10 @@ cask "fujifilm-tether-app" do
     url :homepage
     regex(%r{Mac\sVersion:\s(\d+(?:\.\d+)+).*href=.*?tether-app-mac\d+-([a-zA-Z0-9]+)/}im)
     strategy :page_match do |page, regex|
-      match = page.match(regex)\
+      match = page.match(regex)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}" if match
+      "#{match[1]},#{match[2]}"
     end
   end
 

--- a/Casks/f/fujifilm-tether-app.rb
+++ b/Casks/f/fujifilm-tether-app.rb
@@ -1,0 +1,29 @@
+cask "fujifilm-tether-app" do
+  version "1.30.0,vvr6ik27"
+  sha256 "613e43b3688b6a362a661a767c43b22db87fe574ba41f2cecb88e07c56154437"
+
+  url "https://dl.fujifilm-x.com/support/software/tether-app-mac#{version.csv.first.no_dots}-#{version.csv.second}/FUJIFILM_TetherApp_Mac#{version.csv.first.no_dots}.pkg"
+  name "FUJIFILM TETHER APP"
+  desc "For Fujifilm GFX/X series camera tether shooting"
+  homepage "https://fujifilm-x.com/en-us/support/download/software/tether-app/"
+
+  livecheck do
+    url :homepage
+    regex(%r{Mac\sVersion:\s(\d+(?:\.\d+)+).*href=.*?tether-app-mac\d+-([a-zA-Z0-9]+)/}im)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      "#{match[1]},#{match[2]}" if match
+    end
+  end
+
+  depends_on macos: ">= :catalina"
+
+  pkg "FUJIFILM_TetherApp_Mac#{version.csv.first.no_dots}.pkg"
+
+  uninstall pkgutil: "com.fujifilm.FUJIFILM_TetherApp_Mac"
+
+  zap trash: [
+    "~/Library/Application Support/com.fujifilm.denji/FUJIFILM TetherApp",
+    "~/Library/Preferences/com.fujifilm.FUJIFILM-TETHER-APP.plist",
+  ]
+end

--- a/Casks/f/fujifilm-tether-app.rb
+++ b/Casks/f/fujifilm-tether-app.rb
@@ -11,7 +11,9 @@ cask "fujifilm-tether-app" do
     url :homepage
     regex(%r{Mac\sVersion:\s(\d+(?:\.\d+)+).*href=.*?tether-app-mac\d+-([a-zA-Z0-9]+)/}im)
     strategy :page_match do |page, regex|
-      match = page.match(regex)
+      match = page.match(regex)\
+      next if match.blank?
+
       "#{match[1]},#{match[2]}" if match
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This app is a recently released software for tether-shooting Fujifilm GFX/X series cameras. The version number consist two part, the first part is the actual version, the second part is for downloading the file (and it will change over time, similar to [FUJIFILM X RAW STUDIO](https://github.com/Homebrew/homebrew-cask/blob/77a80fad401352cfa7b235c0fdc629bae09607b3/Casks/f/fujifilm-x-raw-studio.rb). First time contribution, any suggestions are welcome! Thanks.