### PR TITLE
ccstudio 1.1.4 (new cask)

### DIFF
--- a/Casks/c/ccstudio.rb
+++ b/Casks/c/ccstudio.rb
@@ -1,0 +1,31 @@
+cask "ccstudio" do
+  version "1.1.4"
+  sha256 "090ea91ebd83d360e9e32cc519067f0924d3e1dfe90967e9cbcc99a7fbc7773a"
+
+  url "https://downloads.xrite.com/Downloads/Software/ccStudio/v#{version}/mac/ccStudio.zip",
+      verified: "downloads.xrite.com/Downloads/Software/ccStudio/"
+  name "ccStudio"
+  desc "Color management tool for accurate monitor and printer calibration"
+  homepage "https://calibrite.com/us/software-downloads/"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/mac/ccStudio\.zip}i)
+  end
+
+  depends_on macos: ">= :catalina"
+
+  pkg "ccStudio.pkg"
+
+  uninstall launchctl: "com.xrite.device.xrdd (com.xrite.device.xrdd.plist)",
+            pkgutil:   [
+              "com.xrite.xritedeviceservices.installer.pkg",
+              "X-Rite.com.i1studio.ccStudio.pkg",
+            ]
+
+  zap trash: [
+    "/Library/Application Support/Calibrite/ccStudio",
+    "~/Library/Preferences/com.calibrite.ccStudio.plist",
+    "~/Library/Preferences/com.x-rite.ccStudio.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This software is the one and the only software that supports the ColorChecker Studio, X-Rite i1Studio, and ColorMunki Photo/Design. Although similar to X-rite's i1Studio, X-rite's version is no longer maintained, and thus not recognizing the above mentioned devices when connected. The new [calibrite-profiler](https://formulae.brew.sh/cask/calibrite-profiler) cannot replace it, as it is not compatible with these devices.