### PR TITLE
megazeux 2.93b

### DIFF
--- a/Casks/m/megazeux.rb
+++ b/Casks/m/megazeux.rb
@@ -1,5 +1,5 @@
 cask "megazeux" do
-  version "2.93"
+  version "2.93b"
   sha256 :no_check
 
   url "https://www.digitalmzx.com/download.php?latest=osx"
@@ -9,7 +9,7 @@ cask "megazeux" do
 
   livecheck do
     url "https://www.digitalmzx.com/megazeux.php"
-    regex(/href=["'][^"' >]*?download\.php\?latest=osx["' ][^>]*?>\s*v?(\d+(?:\.\d+)+)\s*</im)
+    regex(/href=["'][^"' >]*?download\.php\?latest=osx["' ][^>]*?>\s*v?(\d+(?:\.\d+)+[a-z]?)\s*</im)
   end
 
   app "MegaZeux.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `megazeux` returns an `Unable to get versions` error, as the regex will match 2.93 but not 2.93b. This updates the regex to match either format and updates the cask version.