### PR TITLE
shotcut 24.09.19

### DIFF
--- a/Casks/s/shotcut.rb
+++ b/Casks/s/shotcut.rb
@@ -1,8 +1,8 @@
 cask "shotcut" do
-  version "24.09.13"
-  sha256 "60ac07ccf48617ca3c344175a651698f80cd73068aa3b5a3c1cfb8c2831d2177"
+  version "24.09.19"
+  sha256 "fa05e60dfe7be6c78155c3ce9aae18ceb7882c40baa66770badf2dbb7c54a4ce"
 
-  url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-#{version.no_dots}.dmg",
+  url "https://github.com/mltframework/shotcut/releases/download/v24.09.13/shotcut-macos-#{version.no_dots}.dmg",
       verified: "github.com/mltframework/shotcut/"
   name "Shotcut"
   desc "Video editor"


### PR DESCRIPTION
URL path has temp hack as newer version saved in old path only for MacOS.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
