### PR TITLE
Remove `url do` blocks

### DIFF
--- a/Casks/d/dolphin@dev.rb
+++ b/Casks/d/dolphin@dev.rb
@@ -1,13 +1,16 @@
 cask "dolphin@dev" do
-  version :latest
-  sha256 :no_check
+  version "2409-45"
+  sha256 "17046a69f8cceda3a239f6b19e306545988a9c10e16429d355d648cfc2f8891a"
 
-  url "https://dolphin-emu.org/download/list/master/1/" do |page|
-    page[/href="([^"]+\.dmg)"/, 1]
-  end
+  url "https://dl.dolphin-emu.org/builds/d5/33/dolphin-master-#{version}-universal.dmg"
   name "Dolphin Dev"
   desc "Emulator to play GameCube and Wii games"
   homepage "https://dolphin-emu.org/"
+
+  livecheck do
+    url "https://dolphin-emu.org/download/list/master/1/"
+    regex(/href=.*?dolphin[._-]master[._-]v?(\d+(?:[._-]\d+)+)-universal\.dmg/i)
+  end
 
   conflicts_with cask: [
     "dolphin",

--- a/Casks/d/dolphin@dev.rb
+++ b/Casks/d/dolphin@dev.rb
@@ -1,15 +1,18 @@
 cask "dolphin@dev" do
-  version "2409-45"
-  sha256 "17046a69f8cceda3a239f6b19e306545988a9c10e16429d355d648cfc2f8891a"
+  version "2409-48,4c,e6"
+  sha256 "6a720704035b5b80bd9da8354456ef5dc0a0b629752bebafa986adbe61f08703"
 
-  url "https://dl.dolphin-emu.org/builds/d5/33/dolphin-master-#{version}-universal.dmg"
+  url "https://dl.dolphin-emu.org/builds/#{version.csv.second}/#{version.csv.third}/dolphin-master-#{version.csv.first}-universal.dmg"
   name "Dolphin Dev"
   desc "Emulator to play GameCube and Wii games"
   homepage "https://dolphin-emu.org/"
 
   livecheck do
-    url "https://dolphin-emu.org/download/list/master/1/"
-    regex(/href=.*?dolphin[._-]master[._-]v?(\d+(?:[._-]\d+)+)-universal\.dmg/i)
+    url "https://dolphin-emu.org/download/"
+    regex(%r{href=.*?/builds/([^/]+?)/([^/]+?)/dolphin[._-]master[._-]v?(\d+(?:[.-]\d+)+)-universal\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }
+    end
   end
 
   conflicts_with cask: [

--- a/Casks/k/keepassxc@snapshot.rb
+++ b/Casks/k/keepassxc@snapshot.rb
@@ -1,14 +1,16 @@
 cask "keepassxc@snapshot" do
-  version :latest
-  sha256 :no_check
+  version "2.8.0"
+  sha256 "bde7044cc2b7bb30c01d3991dcc756da052d2ce5538d56a789323f3168426221"
 
-  url "https://snapshot.keepassxc.org/latest/" do |page|
-    file_path = page[/href="([^"]+-snapshot\.dmg)"/, 1]
-    URI.join(page.url, file_path)
-  end
+  url "https://snapshot.keepassxc.org/latest/KeePassXC-#{version}-snapshot.dmg"
   name "KeePassXC"
   desc "Password manager app"
   homepage "https://keepassxc.org/"
+
+  livecheck do
+    url "https://snapshot.keepassxc.org/latest/"
+    regex(/href=.*?KeePassXC[._-]v?(\d+(?:[._-]\d+)+)-snapshot\.dmg/i)
+  end
 
   deprecate! date: "2025-05-01", because: :unsigned
 

--- a/Casks/k/keepassxc@snapshot.rb
+++ b/Casks/k/keepassxc@snapshot.rb
@@ -1,15 +1,32 @@
 cask "keepassxc@snapshot" do
-  version "2.8.0"
+  version "2.8.0,252895"
   sha256 "bde7044cc2b7bb30c01d3991dcc756da052d2ce5538d56a789323f3168426221"
 
-  url "https://snapshot.keepassxc.org/latest/KeePassXC-#{version}-snapshot.dmg"
+  url "https://snapshot.keepassxc.org/build-#{version.csv.second}/KeePassXC-#{version.csv.first}-snapshot.dmg"
   name "KeePassXC"
   desc "Password manager app"
   homepage "https://keepassxc.org/"
 
   livecheck do
-    url "https://snapshot.keepassxc.org/latest/"
-    regex(/href=.*?KeePassXC[._-]v?(\d+(?:[._-]\d+)+)-snapshot\.dmg/i)
+    url "https://snapshot.keepassxc.org/"
+    regex(/href=.*?KeePassXC[._-]v?(\d+(?:\.\d+)+)-snapshot\.dmg/i)
+    strategy :page_match do |page, regex|
+      # Identify build numbers from directories like `build-123456`
+      newest_build = page.scan(%r{href=["']?build[._-]v?(\d+(?:\.\d+)*)/?["' >]}i)
+                         .flatten
+                         .uniq
+                         .max
+      next if newest_build.blank?
+
+      # Fetch the directory listing page for newest build
+      build_response = Homebrew::Livecheck::Strategy.page_content("https://snapshot.keepassxc.org/build-#{newest_build}/")
+      next if (build_page = build_response[:content]).blank?
+
+      match = build_page.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{newest_build}"
+    end
   end
 
   deprecate! date: "2025-05-01", because: :unsigned

--- a/Casks/t/transmission@nightly.rb
+++ b/Casks/t/transmission@nightly.rb
@@ -1,19 +1,21 @@
 cask "transmission@nightly" do
-  version :latest
-  sha256 :no_check
+  version "ed2c6c4085"
+  sha256 "7b705f4fcad1a200f6327c363c8ce8cdb923dd7ac08dbb22a87260f9199282a0"
 
-  url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/" do |page|
-    file_path = page[/href="([^"]+.dmg)"/, 1]
-    URI.join(page.url, file_path)
-  end
+  url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/Transmission-#{version}.dmg"
   name "Transmission"
   desc "Open-source BitTorrent client"
   homepage "https://transmissionbt.com/"
 
+  livecheck do
+    url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/"
+    regex(/href=.*?Transmission[._-]([a-f0-9]+)\.dmg/i)
+  end
+
   deprecate! date: "2025-05-01", because: :unsigned
 
   conflicts_with cask: "transmission"
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :big_sur"
 
   app "Transmission.app"
 

--- a/Casks/t/transmission@nightly.rb
+++ b/Casks/t/transmission@nightly.rb
@@ -1,15 +1,18 @@
 cask "transmission@nightly" do
-  version "ed2c6c4085"
+  version "9662,ed2c6c4085"
   sha256 "7b705f4fcad1a200f6327c363c8ce8cdb923dd7ac08dbb22a87260f9199282a0"
 
-  url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/Transmission-#{version}.dmg"
+  url "https://build.transmissionbt.com/job/trunk-mac/#{version.csv.first}/artifact/release/Transmission-#{version.csv.second}.dmg"
   name "Transmission"
   desc "Open-source BitTorrent client"
   homepage "https://transmissionbt.com/"
 
   livecheck do
     url "https://build.transmissionbt.com/job/trunk-mac/lastSuccessfulBuild/artifact/release/"
-    regex(/href=.*?Transmission[._-]([a-f0-9]+)\.dmg/i)
+    regex(/>\s*\#(\d+)\s*<.+?href=.*?Transmission[._-](\h+)\.dmg/im)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
   deprecate! date: "2025-05-01", because: :unsigned

--- a/Casks/v/vlc@nightly.rb
+++ b/Casks/v/vlc@nightly.rb
@@ -1,19 +1,32 @@
 cask "vlc@nightly" do
   arch arm: "arm64", intel: "x86_64"
 
-  version :latest
-  sha256 :no_check
+  on_arm do
+    version "20240924-0413,daab68e6"
+    sha256 "4ce9455a08682876d8a9660883d305d74e6edb144e9d830d5b81f8489babd6f2"
 
-  url "https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/" do |page|
-    folder_path = page[%r{\d+-\d+/}]
-    url URI.join(page.url, folder_path) do |version_page|
-      file_path = version_page[/href="([^"]+.dmg)"/, 1]
-      URI.join(version_page.url, file_path)
-    end
+    url "https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/#{version.csv.first}/vlc-4.0.0-dev-arm64-#{version.csv.second}.dmg"
   end
+  on_intel do
+    version "20240924-0416,daab68e6"
+    sha256 "f617a21edee78c509a8dbb31dbac8cd27705a48188adec88a2e53c2615c1a6e8"
+
+    url "https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/#{version.csv.first}/vlc-4.0.0-dev-intel64-#{version.csv.second}.dmg"
+  end
+
   name "VLC media player"
   desc "Open-source cross-platform multimedia player"
   homepage "https://www.videolan.org/vlc/"
+
+  livecheck do
+    url "https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/"
+    strategy :page_match do |page|
+      date = page[%r{href="(\d+-\d+)/"}, 1]
+      filename_arch = (arch == "x86_64") ? "intel64" : arch
+      version_page = Homebrew::Livecheck::Strategy.page_content("https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/#{date}/")
+      "#{date},#{version_page[:content].scan(/href=.*?vlc-4\.0\.0-dev-#{filename_arch}-([0-9a-f]+)\.dmg/i).flatten.first}"
+    end
+  end
 
   deprecate! date: "2025-05-01", because: :unsigned
 


### PR DESCRIPTION
This PR removes the `url do` blocks that remain in homebrew/cask. These will be disallowed in official taps soon. See <https://github.com/Homebrew/brew/pull/18390> for more context, but essentially we want these removed for formulae.brew.sh API generation.

To be honest, this is the first time I've really played with livechecks, so let me know if those aren't correct.
