### PR TITLE
label-live 3.2.3 (new cask)

### DIFF
--- a/Casks/l/label-live.rb
+++ b/Casks/l/label-live.rb
@@ -1,0 +1,24 @@
+cask "label-live" do
+  version "3.2.3"
+  sha256 "e5cf6eb208c37982afb5452160cd0d5d0380b7da7edf6b8ee7b629709ea91bf1"
+
+  url "https://download.label.live/Label-LIVE-#{version}.dmg"
+  name "Label LIVE"
+  desc "Label design and printer software"
+  homepage "https://label.live/"
+
+  livecheck do
+    url "https://label.live/thank-you"
+    regex(/"VERSION"\s*:\s*"(\d+(:?\.\d+)+)"/i)
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Label LIVE.app"
+
+  zap trash: [
+    "~/Library/Application Support/Label LIVE",
+    "~/Library/Logs/Label LIVE",
+    "~/Library/Saved Application State/com.semireg.LabelLIVE.savedState",
+  ]
+end

--- a/Casks/l/label-live.rb
+++ b/Casks/l/label-live.rb
@@ -19,6 +19,7 @@ cask "label-live" do
   zap trash: [
     "~/Library/Application Support/Label LIVE",
     "~/Library/Logs/Label LIVE",
+    "~/Library/Preferences/com.semireg.LabelLIVE.plist",
     "~/Library/Saved Application State/com.semireg.LabelLIVE.savedState",
   ]
 end

--- a/Casks/l/label-live.rb
+++ b/Casks/l/label-live.rb
@@ -8,8 +8,8 @@ cask "label-live" do
   homepage "https://label.live/"
 
   livecheck do
-    url "https://label.live/thank-you"
-    regex(/"VERSION"\s*:\s*"(\d+(:?\.\d+)+)"/i)
+    url "https://s3.amazonaws.com/labellive.semireg.com/latest-mac.yml"
+    strategy :electron_builder
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
  Added Label LIVE which is a label design
  and printing software for thermal printers.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
