### PR TITLE
keybase: remove Mark of the Web from the FUSE bundle

### DIFF
--- a/Casks/k/keybase.rb
+++ b/Casks/k/keybase.rb
@@ -32,6 +32,10 @@ cask "keybase" do
   postflight do
     system_command "#{appdir}/Keybase.app/Contents/SharedSupport/bin/keybase",
                    args: ["install-auto"]
+    system_command "/usr/bin/xattr",
+                   args: ["-c",
+                          "#{appdir}/Keybase.app/Contents/Resources" \
+                          "/KeybaseInstaller.app/Contents/Resources/kbfuse.bundle"]
   end
 
   uninstall launchctl: "keybase.Helper",


### PR DESCRIPTION
If the end user decides to enable KBFS feature, they will get the challenge from macOS to open the "application" manually using Finder using Open in context menu.
Unfortunately, the offending "application" is a FUSE bundle and not a regular executable application bundle.
So one cannot simply enable KBFS.

Removing Mark of the Web helps, though.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
