### PR TITLE
wave 0.8.3

### DIFF
--- a/Casks/w/wave.rb
+++ b/Casks/w/wave.rb
@@ -1,8 +1,11 @@
 cask "wave" do
-  version "0.7.6"
-  sha256 "6fbe5e42752d790efaefe72b55efa059f05fecfaeb123a0d1554f1f2cfe34d73"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://dl.waveterm.dev/releases/Wave-darwin-universal-#{version}.dmg"
+  version "0.8.3"
+  sha256 arm:   "b1e7e440e3e9d5ed49caa54e3585bec796a69ccc36636b754105e75661475f73",
+         intel: "83d060ba32b4b42932d131235a423aa9826dbe8815cb88c240c9d3286a3d4ffc"
+
+  url "https://dl.waveterm.dev/releases-w2/Wave-darwin-#{arch}-#{version}.dmg"
   name "Wave Terminal"
   name "WaveTerm"
   desc "Terminal emulator"


### PR DESCRIPTION
This change updates the release url to our new temporary releases path. We are planning to move back to the old releases path in the future, but we are giving our users time to migrate to our new architecture first. This also separates out intel and arm builds into separate versions and bumps the version manually. The auto-updates should be able to pick up the changes going forward.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
