### PR TITLE
krita 5.2.5

### DIFF
--- a/Casks/k/krita.rb
+++ b/Casks/k/krita.rb
@@ -1,8 +1,8 @@
 cask "krita" do
-  version "5.2.3"
-  sha256 "1e9014edfd8cef1bf618b6db06ebf6e727a9ce8f92cada2a78bfce15ff96b88a"
+  version "5.2.5"
+  sha256 "b1a84c3b0a83ef00b7099401976e12f86656dac2ae6f368c353a125c77093a56"
 
-  url "https://download.kde.org/stable/krita/#{version}/krita-#{version}.dmg",
+  url "https://download.kde.org/stable/krita/#{version}/krita-#{version}-signed.dmg",
       verified: "download.kde.org/stable/krita/"
   name "Krita"
   desc "Free and open-source painting and sketching program"
@@ -10,10 +10,10 @@ cask "krita" do
 
   livecheck do
     url "https://krita.org/en/download/"
-    regex(/href=.*?krita[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(/href=.*?krita[._-]v?(\d+(?:\.\d+)+)(?:-signed)?\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :high_sierra"
 
   app "krita.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `krita` to the latest release, 5.2.5.

The existing `livecheck` block for `krita` is returning an `Unable to get versions` error, as the dmg file URL now includes a `-signed` suffix. This updates the regex to account for this suffix, fixing the check.