### PR TITLE
font-libertinus 7.051

### DIFF
--- a/Casks/font/font-l/font-libertinus.rb
+++ b/Casks/font/font-l/font-libertinus.rb
@@ -1,6 +1,6 @@
 cask "font-libertinus" do
-  version "7.050"
-  sha256 "cbb54c4c482376eb17bb6397494489baacff0755d3864f9b5c772e2f3d43d429"
+  version "7.051"
+  sha256 "250677c929d3775a30913643594379af264ac2ef2801035aa1dcbe30b9be23a6"
 
   url "https://github.com/alerque/libertinus/releases/download/v#{version}/Libertinus-#{version}.tar.zst"
   name "Libertinus"


### PR DESCRIPTION
https://github.com/alerque/libertinus/releases/tag/v7.051

----

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

----
