### PR TITLE
vienna-assistant 1.1.433 (new cask)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -889,6 +889,7 @@ vamiga
 vbrokers
 vcam
 vellum
+vienna-assistant
 vimr
 virtualbox@beta
 virtualbuddy

--- a/Casks/v/vienna-assistant.rb
+++ b/Casks/v/vienna-assistant.rb
@@ -1,0 +1,30 @@
+cask "vienna-assistant" do
+  version "1.1.433"
+  sha256 :no_check
+
+  url "https://www.vsl.co.at/service/vamac",
+      verified:   "vsl.co.at",
+      user_agent: :fake
+  name "Vienna Assistant"
+  desc "Manager for Vienna Symphonic Library sound samples"
+  homepage "https://www.vsl.info/en/manuals/vienna-assistant/introduction"
+
+  livecheck do
+    url "https://api.vsl.co.at/data/.well-known/dataservice-configuration"
+    strategy :json do |json|
+      json["vaLatestVersionReadable"]
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  pkg "Vienna Assistant #{version}.pkg"
+
+  uninstall pkgutil: "at.co.vsl.viassistant.*"
+
+  zap trash: [
+    "~/Library/Preferences/at.co.vsl.Vienna Assistant.plist",
+    "~/Library/Preferences/at.co.vsl.viennaassistant.plist",
+    "~/Library/Saved Application State/at.co.vsl.viennaassistant.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
1. `brew audit --cask --new vienna-assistant` failed because of the auditor did not find the pkg file when trying to verifiy the signature. This is due to the auditor did not catch the pkg rename in `preflight`. Similar cask: [flrig](https://github.com/Homebrew/homebrew-cask/blob/eb41e6e5977c0d035904ea7b1cff3cefe62564ad/Casks/f/flrig.rb#L28). I don't know if it's a bug of the auditor or should I do it in another way, any suggestions are welcome! The software itself does have signature though.
2. There's two way of `livecheck`, one is through download header, which may give immediate feedback of the versioning information but a bit slower. Another is through the release log (currently used), which is faster (API call) but I don't know will they push this information immediately after a new release. Which way do you think it's better?
3. I'm not sure should I version this cask as `latest` or the identified version. On one hand, the download URL doesn't give the version info (the download URL will redirect to an AWS link that expires in 24hr), but through either header or downloaded pkg, the version could be identified. On the other hand, I can't use this version info in my `pkg` stanza as if they release a new version and this cask is not updated simultaneously, the installation would fail due to the wrong version info, so it seems `:latest` works too. I would appreciate some feedback on this.

Sorry for so many questions. Still learning about contributing for homebrew. Thanks!
