### PR TITLE
Revert shotcut to 24.08.29

### DIFF
--- a/Casks/s/shotcut.rb
+++ b/Casks/s/shotcut.rb
@@ -1,6 +1,6 @@
 cask "shotcut" do
-  version "24.09.13"
-  sha256 "60ac07ccf48617ca3c344175a651698f80cd73068aa3b5a3c1cfb8c2831d2177"
+  version "24.08.29"
+  sha256 "24c7da67038cc701bc921f899413e30762d84b36c39a6518b82caa983eba8466"
 
   url "https://github.com/mltframework/shotcut/releases/download/v#{version}/shotcut-macos-#{version.no_dots}.dmg",
       verified: "github.com/mltframework/shotcut/"


### PR DESCRIPTION
Revert the changes from #185387 to bump back shortcut from `24.09.13` to `24.08.29`.

The `shotcut` software has an issue on the `24.09.13` release and the DMG binary does not have that version number:

- https://github.com/mltframework/shotcut/releases/tag/v24.09.13

The DMG binary should be `shotcut-macos-240913.dmg`, but it was overwritten as `shotcut-macos-240919.dmg` (`240913` was overwritten to `240919`)

The `24.09.19` version is currently marked as pre-release, so the checks fail because it is not "stable".

- https://github.com/mltframework/shotcut/releases/tag/v24.09.19

This issue has been reported to the upstream repository, but the maintainer stated that it might get fixed in homebrew, rather than upstream.

- https://github.com/mltframework/shotcut/issues/1583

There were efforts to manually patch the Cask file to allow for this situation to be handled. However, the PRs were closed for a variety of reasons and the CI checks were not passing.

- #186672
- #186553
- #186487

This PR is an attempt to revert the changes created on #185387 and fall back to the last version that passed the checks.

This might not be he ideal solution, but we can create another PR to update to the next stable branch where the version numbers match after things have settled.

- https://github.com/mltframework/shotcut/releases

--------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

<!--
Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
-->

--------

Fixes:

- #186969
