### PR TITLE
Incorrect checksum in the update of Shottr 1.8.0

### DIFF
--- a/Casks/s/shottr.rb
+++ b/Casks/s/shottr.rb
@@ -1,6 +1,6 @@
 cask "shottr" do
   version "1.8.0"
-  sha256 "811788bc0c8244af54c5f5e13f60e4e16f16523eaad5d6443fb4b00e576de632"
+  sha256 "c3f60ed65223303bd40532ae6036349778988360bd7820294a8672f5c9e22514"
 
   url "https://shottr.cc/dl/Shottr-#{version}.dmg"
   name "Shottr"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The new update uses a different hash compared to the DMG file downloaded from the Shottr site

<img width="715" alt="image" src="https://github.com/user-attachments/assets/de6b6005-7098-436a-a931-49ec70f67b74">

The correct hash of file is this:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/4c6f3233-78d6-4a2b-a57f-97d1190c8765">

