### PR TITLE
disable deprecated casks

### DIFF
--- a/Casks/a/auryo.rb
+++ b/Casks/a/auryo.rb
@@ -8,7 +8,7 @@ cask "auryo" do
   desc "Unofficial desktop app for Soundcloud"
   homepage "https://auryo.com/"
 
-  deprecate! date: "2021-02-10", because: :discontinued
+  disable! date: "2021-02-10", because: :discontinued
 
   app "Auryo.app"
 end

--- a/Casks/c/colorpicker-skalacolor.rb
+++ b/Casks/c/colorpicker-skalacolor.rb
@@ -7,7 +7,7 @@ cask "colorpicker-skalacolor" do
   desc "Colour picker"
   homepage "https://bjango.com/help/skalacolor/gettingstarted/"
 
-  deprecate! date: "2023-06-25", because: :unmaintained
+  disable! date: "2023-06-25", because: :unmaintained
 
   colorpicker "Skala Color Installer.app/Contents/Resources/SkalaColor.colorPicker"
 end

--- a/Casks/t/tusk.rb
+++ b/Casks/t/tusk.rb
@@ -8,7 +8,7 @@ cask "tusk" do
   homepage "https://github.com/klaudiosinani/tusk"
 
   # https://github.com/klaudiosinani/tusk/issues/381
-  deprecate! date: "2023-01-15", because: :unmaintained
+  disable! date: "2023-01-15", because: :unmaintained
 
   app "Tusk.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Casks have been deprecated for over 12 months.