### PR TITLE
Revert "lw-scanner 0.25.0"

### DIFF
--- a/Casks/l/lw-scanner.rb
+++ b/Casks/l/lw-scanner.rb
@@ -1,8 +1,8 @@
 cask "lw-scanner" do
-  version "0.25.0"
-  sha256 "b8bbe30c59561bd189b9090a0b95cdc06db7beef7bc9f9de47f347106a371a16"
+  version "0.24.0"
+  sha256 "a2bbd9b615143ca1f63824fa335d49da9dd2744a58776bff1c9a85e6bcd3c34e"
 
-  url "https://github.com/lacework/lacework-vulnerability-scanner/releases/download/#{version}/lw-scanner-darwin-amd64",
+  url "https://github.com/lacework/lacework-vulnerability-scanner/releases/download/v#{version}/lw-scanner-darwin-amd64",
       verified: "github.com/lacework/lacework-vulnerability-scanner/"
   name "Lacework vulnerability scanner"
   desc "Lacework inline scanner"
@@ -13,7 +13,7 @@ cask "lw-scanner" do
     strategy :github_latest
   end
 
-  binary "lw-scanner-darwin_amd64", target: "lw-scanner"
+  binary "lw-scanner-darwin-amd64", target: "lw-scanner"
 
   zap trash: "~/.config/lw-scanner"
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#185832 as there is no release `0.25.0` in the https://github.com/lacework/lacework-vulnerability-scanner/releases, so `brew upgrade lw-scanner` fails with:
```
==> Downloading https://github.com/lacework/lacework-vulnerability-scanner/releases/download/0.25.0/lw-scanner-darwin-amd64
curl: (56) The requested URL returned error: 404

==> Purging files for version 0.25.0 of Cask lw-scanner
Error: lw-scanner: Download failed on Cask 'lw-scanner' with message: Download failed: https://github.com/lacework/lacework-vulnerability-scanner/releases/download/0.25.0/lw-scanner-darwin-amd64
```
The last released version is still `0.24.0`.