### PR TITLE
pixel-shift-combiner 1.5.0,1050,sgwn5e23 (new cask)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -639,6 +639,7 @@ pieces
 pieces-os
 pile
 pitch
+pixel-shift-combiner
 plasticscm-cloud-edition
 playdate-simulator
 plex

--- a/Casks/p/pixel-shift-combiner.rb
+++ b/Casks/p/pixel-shift-combiner.rb
@@ -1,20 +1,20 @@
 cask "pixel-shift-combiner" do
-  version "1.5.0,sgwn5e23"
+  version "1.5.0,1050,sgwn5e23"
   sha256 "4e734f66062e19c7272abd06e6d21b5bdc222090631e2691ce8b847975e5fce1"
 
-  url "https://dl.fujifilm-x.com/support/software/pixel-shift-combiner-mac#{version.csv.first.major}#{version.csv.first.minor.rjust(2, "0")}#{version.csv.first.patch}-#{version.csv.second}/FUJIFILM_PixelShiftCombiner#{version.csv.first.major}#{version.csv.first.minor.rjust(2, "0")}#{version.csv.first.patch}.dmg"
+  url "https://dl.fujifilm-x.com/support/software/pixel-shift-combiner-mac#{version.csv.second}-#{version.csv.third}/FUJIFILM_PixelShiftCombiner#{version.csv.second}.dmg"
   name "Fujifilm Pixel Shift Combiner"
   desc "Tool to tether and combine photos for Fujifilm cameras with IBIS function"
   homepage "https://fujifilm-x.com/en-us/support/download/software/pixel-shift-combiner/"
 
   livecheck do
     url :homepage
-    regex(%r{Mac\sVersion:\s(\d+(?:\.\d+)+).*href=.*?pixel-shift-combiner-mac\d+-([a-zA-Z0-9]+)/}im)
+    regex(%r{Mac\sVersion:\s(\d+(?:\.\d+)+).*href=.*?pixel-shift-combiner-mac(\d+)[._-]([a-zA-Z0-9]+)/}im)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?
 
-      "#{match[1]},#{match[2]}"
+      "#{match[1]},#{match[2]},#{match[3]}"
     end
   end
 

--- a/Casks/p/pixel-shift-combiner.rb
+++ b/Casks/p/pixel-shift-combiner.rb
@@ -1,0 +1,29 @@
+cask "pixel-shift-combiner" do
+  version "1.5.0,sgwn5e23"
+  sha256 "4e734f66062e19c7272abd06e6d21b5bdc222090631e2691ce8b847975e5fce1"
+
+  url "https://dl.fujifilm-x.com/support/software/pixel-shift-combiner-mac#{version.csv.first.major}#{version.csv.first.minor.rjust(2, "0")}#{version.csv.first.patch}-#{version.csv.second}/FUJIFILM_PixelShiftCombiner#{version.csv.first.major}#{version.csv.first.minor.rjust(2, "0")}#{version.csv.first.patch}.dmg"
+  name "Fujifilm Pixel Shift Combiner"
+  desc "Tool to tether and combine photos for Fujifilm cameras with IBIS function"
+  homepage "https://fujifilm-x.com/en-us/support/download/software/pixel-shift-combiner/"
+
+  livecheck do
+    url :homepage
+    regex(%r{Mac\sVersion:\s(\d+(?:\.\d+)+).*href=.*?pixel-shift-combiner-mac\d+-([a-zA-Z0-9]+)/}im)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "Pixel Shift Combiner.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.fujifilm.denji/*Pixel Shift Combiner",
+    "~/Library/Preferences/com.fujifilm.denji.PIXEL-SHIFT-COMBINER.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
1. The `url` is quite long because of the weird versioning by Fujifilm (1.5.0 -> ...1050.dmg), have to `rjust` the minor version so that it match. Don't know if there's a better way of doing it, is it allowed to introduce variable to the cask file?
2. I added this cask to auto-bump. Is there a rule of what should be added and what shouldn't? This doesn't update that frequent, is it ok to add to auto-bump?
3. The last line of the zap trash contained a weird hidden unicode character in the path ([U+2068]). This cannot be removed or zap won't work just FYI. -- Solved by using `*`

Thanks!