### PR TITLE
various casks: add depends_on

### DIFF
--- a/Casks/n/naver-whale.rb
+++ b/Casks/n/naver-whale.rb
@@ -18,6 +18,7 @@ cask "naver-whale" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Whale.app"
 

--- a/Casks/y/yandex.rb
+++ b/Casks/y/yandex.rb
@@ -21,6 +21,7 @@ cask "yandex" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Yandex.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
These browsers are based on Chromium 128, and as such require macOS 10.15 or later; this adds the missing `depends_on` stanza.