### PR TITLE
various casks: update depends_on

### DIFF
--- a/Casks/b/brave-browser.rb
+++ b/Casks/b/brave-browser.rb
@@ -18,7 +18,7 @@ cask "brave-browser" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Brave Browser.app"
 

--- a/Casks/b/brave-browser@beta.rb
+++ b/Casks/b/brave-browser@beta.rb
@@ -18,7 +18,7 @@ cask "brave-browser@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Brave Browser Beta.app"
 

--- a/Casks/b/brave-browser@nightly.rb
+++ b/Casks/b/brave-browser@nightly.rb
@@ -18,7 +18,7 @@ cask "brave-browser@nightly" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Brave Browser Nightly.app"
 

--- a/Casks/c/chromium.rb
+++ b/Casks/c/chromium.rb
@@ -14,7 +14,7 @@ cask "chromium" do
     "eloston-chromium",
     "freesmug-chromium",
   ]
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "chrome-mac/Chromium.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/e/eloston-chromium.rb
+++ b/Casks/e/eloston-chromium.rb
@@ -26,7 +26,7 @@ cask "eloston-chromium" do
     "chromium",
     "freesmug-chromium",
   ]
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Chromium.app"
 

--- a/Casks/g/google-chrome.rb
+++ b/Casks/g/google-chrome.rb
@@ -15,7 +15,7 @@ cask "google-chrome" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Google Chrome.app"
 

--- a/Casks/g/google-chrome@beta.rb
+++ b/Casks/g/google-chrome@beta.rb
@@ -13,7 +13,7 @@ cask "google-chrome@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Google Chrome Beta.app"
 

--- a/Casks/g/google-chrome@canary.rb
+++ b/Casks/g/google-chrome@canary.rb
@@ -13,7 +13,7 @@ cask "google-chrome@canary" do
   #   regex(/"version":\s*"v?(\d+(?:\.\d+)+)"/i)
   # end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Google Chrome Canary.app"
 

--- a/Casks/g/google-chrome@dev.rb
+++ b/Casks/g/google-chrome@dev.rb
@@ -13,7 +13,7 @@ cask "google-chrome@dev" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Google Chrome Dev.app"
 

--- a/Casks/m/microsoft-edge.rb
+++ b/Casks/m/microsoft-edge.rb
@@ -24,6 +24,7 @@ cask "microsoft-edge" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   pkg "MicrosoftEdge-#{version.csv.first}.pkg",
       choices: [

--- a/Casks/m/microsoft-edge@beta.rb
+++ b/Casks/m/microsoft-edge@beta.rb
@@ -24,6 +24,7 @@ cask "microsoft-edge@beta" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   pkg "MicrosoftEdgeBeta-#{version.csv.first}.pkg",
       choices: [

--- a/Casks/m/microsoft-edge@dev.rb
+++ b/Casks/m/microsoft-edge@dev.rb
@@ -24,6 +24,7 @@ cask "microsoft-edge@dev" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   pkg "MicrosoftEdgeDev-#{version.csv.first}.pkg",
       choices: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
These browsers are now based on Chromium 129 (or later), and as such [require macOS 11 or later](https://support.google.com/chrome/answer/95346?visit_id=638271258484999533-1844643546&p=unsupported_mac&rd=1#sysreq_mac&zippy=%2Cmac); this updates the `depends_on` stanza (and adds it to the microsoft-edge casks, where it was missing).