### PR TITLE
brave-browser@dev: deprecate

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -103,7 +103,6 @@ boltai
 box-drive
 brave-browser
 brave-browser@beta
-brave-browser@dev
 brave-browser@nightly
 brewtarget
 bricklink-studio

--- a/Casks/b/brave-browser@dev.rb
+++ b/Casks/b/brave-browser@dev.rb
@@ -12,10 +12,7 @@ cask "brave-browser@dev" do
   desc "Web browser focusing on privacy"
   homepage "https://brave.com/download-dev/"
 
-  livecheck do
-    url "https://updates.bravesoftware.com/sparkle/Brave-Browser/#{folder}/appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2023-12-04", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The dev channel has been dropped by Brave and no longer receiving any updates. Sources:
* [Drop the dev channel](https://github.com/brave/brave-browser/issues/25248)
* [How do I migrate my Brave "Dev" data to another channel (Nightly, Beta, Release)?
](https://support.brave.com/hc/en-us/articles/17924707453581-How-do-I-migrate-my-Brave-Dev-data-to-another-channel-Nightly-Beta-Release)