### PR TITLE
drawpile 2.2.1

### DIFF
--- a/Casks/d/drawpile.rb
+++ b/Casks/d/drawpile.rb
@@ -3,21 +3,37 @@ cask "drawpile" do
     version "2.1.7"
     sha256 "820ec2837d3c7ea4e190a64cbb1d0fdecb3797bf968277b3b7ca0cc5d758987f"
 
+    url "https://github.com/drawpile/Drawpile/releases/download/#{version}/Drawpile.#{version}.dmg",
+        verified: "github.com/drawpile/Drawpile"
+
     livecheck do
       skip "Legacy version"
     end
   end
-  on_sierra :or_newer do
+  on_sierra do
     version "2.1.20"
     sha256 "fe7f93c2f3ec9505b8a4f044093b67bae0c80fc8d6613ba2d0dfad5243cfdf44"
 
+    url "https://github.com/drawpile/Drawpile/releases/download/#{version}/Drawpile.#{version}.dmg",
+        verified: "github.com/drawpile/Drawpile"
+
     livecheck do
-      url "https://drawpile.net/files/osx/"
-      regex(/href=.*?Drawpile[ ._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+      skip "Legacy version"
+    end
+  end
+  on_high_sierra :or_newer do
+    version "2.2.1"
+    sha256 "d4b29c78da9a64eb8a5526c464f9647b48a99b60cace0ce3eaf06a4e484dec60"
+
+    url "https://github.com/drawpile/Drawpile/releases/download/#{version}/Drawpile-#{version}.dmg",
+        verified: "github.com/drawpile/Drawpile"
+
+    livecheck do
+      url :url
+      strategy :github_latest
     end
   end
 
-  url "https://drawpile.net/files/osx/Drawpile%20#{version}.dmg"
   name "Drawpile"
   desc "Collaborative drawing app"
   homepage "https://drawpile.net/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Homebrew currently points to the old 2.1.20 version, which is not forward-compatible, causing troubles for our users. Livecheck didn't catch it because we moved stuff out of our own servers in the meantime.

I don't own a Mac, so it doesn't look like I can run `brew audit` sensibly.