### PR TITLE
drawpile@beta

### DIFF
--- a/Casks/d/drawpile.rb
+++ b/Casks/d/drawpile.rb
@@ -38,6 +38,8 @@ cask "drawpile" do
   desc "Collaborative drawing app"
   homepage "https://drawpile.net/"
 
+  conflicts_with cask: "drawpile@beta"
+
   app "Drawpile.app"
 
   zap trash: [

--- a/Casks/d/drawpile@beta.rb
+++ b/Casks/d/drawpile@beta.rb
@@ -1,0 +1,30 @@
+cask "drawpile@beta" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "2.2.2-beta.3"
+  sha256 arm:   "a161834d7dd28e1edebee1c490c3dd02bb82a55167ac192150387e6aa347b4b0",
+         intel: "f79327ebc102ca17f536aacee0e0dc3a129df4ec9c2f91096a24a0967c96db7c"
+
+  url "https://github.com/drawpile/Drawpile/releases/download/#{version}/Drawpile-#{version}-#{arch}.dmg",
+      verified: "github.com/drawpile/Drawpile/"
+  name "Drawpile"
+  desc "Collaborative drawing app"
+  homepage "https://drawpile.net/"
+
+  livecheck do
+    url :url
+    regex(/^(\d+(?:\.\d+)+(?:-beta\.\d+)?)$/)
+  end
+
+  conflicts_with cask: "drawpile"
+  depends_on macos: ">= :big_sur"
+
+  app "Drawpile.app"
+
+  zap trash: [
+    "~/Library/Application Support/drawpile",
+    "~/Library/Preferences/net.drawpile.drawpile.plist",
+    "~/Library/Preferences/net.drawpile.DrawpileClient.plist",
+    "~/Library/Saved Application State/net.drawpile.DrawpileClient.savedState",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This adds a drawpile@beta, pointing at Drawpile 2.2.2-beta.3. That release adds Apple Silicon support.

As mentioned in #187333, I don't have a Mac, so I can't run `audit`, `install` or `uninstall` myself.