### PR TITLE
vivaldi@snapshot: update depends_on

### DIFF
--- a/Casks/v/vivaldi@snapshot.rb
+++ b/Casks/v/vivaldi@snapshot.rb
@@ -13,7 +13,7 @@ cask "vivaldi@snapshot" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Vivaldi Snapshot.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The latest version (released [yesterday](https://vivaldi.com/blog/new-look-new-feature-vivaldi-browser-snapshot-3483-4/#:~:text=macOS,no%20longer%20supported.%20%E2%9A%A0%EF%B8%8F)), now requires macOS 11 or later.