### PR TITLE
Update stolendata-mpv cask to include Arm64 build

### DIFF
--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -1,23 +1,38 @@
 cask "stolendata-mpv" do
-  on_catalina :or_older do
-    version "0.35.0"
-    sha256 "376415c787aef391a3927cdecd5bb0dac9f21ef9d7742516b8cd8d8ce502e7b6"
+  arch arm: "-arm64", intel: ""
 
-    livecheck do
-      skip "Legacy version"
+  on_arm do
+    on_sonoma :or_newer do
+      version "0.39.0"
+      sha256 "9c81c5cf2e756cf9c2fef97a00627140ea7c6b46079469ce3b1a13b4cd4f5b2b"
+
+      livecheck do
+        url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
+        regex(/mpv-arm64-(\d+(?:\.\d+)+)\.t/i)
+      end
     end
   end
-  on_big_sur :or_newer do
-    version "0.39.0"
-    sha256 "35ec81ad86a97b24956a8d0f4fa1ba2690b44ae7741c920e923620bcd7bd402a"
+  on_intel do
+    on_catalina :or_older do
+      version "0.35.0"
+      sha256 "376415c787aef391a3927cdecd5bb0dac9f21ef9d7742516b8cd8d8ce502e7b6"
 
-    livecheck do
-      url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
-      regex(/mpv[._-]v?(\d+(?:\.\d+)+)\.t/i)
+      livecheck do
+        skip "Legacy version"
+      end
+    end
+    on_big_sur :or_newer do
+      version "0.39.0"
+      sha256 "35ec81ad86a97b24956a8d0f4fa1ba2690b44ae7741c920e923620bcd7bd402a"
+
+      livecheck do
+        url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
+        regex(/mpv-(\d+(?:\.\d+)+)\.t/i)
+      end
     end
   end
 
-  url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv-#{version}.tar.gz",
+  url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv#{arch}-#{version}.tar.gz",
       verified: "laboratory.stolendata.net/~djinn/mpv_osx/"
   name "mpv"
   desc "Media player based on MPlayer and mplayer2"
@@ -36,8 +51,4 @@ cask "stolendata-mpv" do
     "~/Library/Preferences/io.mpv.plist",
     "~/Library/Preferences/mpv.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -1,16 +1,15 @@
 cask "stolendata-mpv" do
-  arch arm: "-arm64", intel: ""
+  arch arm: "-arm64"
 
   on_arm do
-    on_sonoma :or_newer do
-      version "0.39.0"
-      sha256 "9c81c5cf2e756cf9c2fef97a00627140ea7c6b46079469ce3b1a13b4cd4f5b2b"
+    version "0.39.0"
+    sha256 "9c81c5cf2e756cf9c2fef97a00627140ea7c6b46079469ce3b1a13b4cd4f5b2b"
 
-      livecheck do
-        url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
-        regex(/mpv-arm64-(\d+(?:\.\d+)+)\.t/i)
-      end
+    livecheck do
+      url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
+      regex(/mpv-arm64-(\d+(?:\.\d+)+)\.t/i)
     end
+
     depends_on macos: ">= :sonoma"
   end
   on_intel do

--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -11,6 +11,7 @@ cask "stolendata-mpv" do
         regex(/mpv-arm64-(\d+(?:\.\d+)+)\.t/i)
       end
     end
+    depends_on macos: ">= :sonoma"
   end
   on_intel do
     on_catalina :or_older do
@@ -39,7 +40,6 @@ cask "stolendata-mpv" do
   homepage "https://mpv.io/"
 
   conflicts_with formula: "mpv"
-  depends_on macos: ">= :mojave"
 
   app "mpv.app"
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

---

Apologies in advance if this is erroneous. I don't really know how the cask formulas work, or how to test local cask edits, and I merely skimmed the documentation to produce these changes.