### PR TITLE
yubico-authenticator: remove livecheck block

### DIFF
--- a/Casks/y/yubico-authenticator.rb
+++ b/Casks/y/yubico-authenticator.rb
@@ -8,27 +8,6 @@ cask "yubico-authenticator" do
   desc "Application for generating TOTP and HOTP codes"
   homepage "https://developers.yubico.com/yubioath-flutter/"
 
-  # Releases sometimes don't have a macOS build, so we check multiple
-  # recent releases instead of only the "latest" release. NOTE: We should be
-  # able to use `strategy :github_latest` when subsequent releases provide
-  # files for macOS again.
-  livecheck do
-    url :url
-    regex(/^yubico[._-]authenticator[._-]v?(\d+(?:\.\d+)+)[._-]mac\.(?:dmg|pkg)$/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        release["assets"]&.map do |asset|
-          match = asset["name"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end.flatten
-    end
-  end
-
   depends_on macos: ">= :big_sur"
 
   app "Yubico Authenticator.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

A livecheck was added in #184640 as the application had a one-off release for Android that resulted in a version bump only for that platform.  The livecheck then returned incorrect values as the macOS version wasn't updated.

With the latest version, the application is now back on a standard update cadence.

This reverts the livecheck back to the default `git` strategy instead of making a now unnecessary API call.