### PR TITLE
ajour: deprecate

### DIFF
--- a/Casks/a/ajour.rb
+++ b/Casks/a/ajour.rb
@@ -7,10 +7,7 @@ cask "ajour" do
   desc "World of Warcraft addon manager"
   homepage "https://github.com/casperstorm/ajour"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
+  deprecate! date: "2024-10-04", because: :unmaintained
 
   app "Ajour.app"
 


### PR DESCRIPTION
Repository was archived on 2024-09-17.