### PR TITLE
cryptr: deprecate

### DIFF
--- a/Casks/c/cryptr.rb
+++ b/Casks/c/cryptr.rb
@@ -7,10 +7,7 @@ cask "cryptr" do
   desc "GUI for Hashicorp's Vault"
   homepage "https://github.com/adobe/cryptr"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-10-04", because: :unmaintained
 
   app "Cryptr.app"
 


### PR DESCRIPTION
Repository was archived on 2024-09-30.