### PR TITLE
Remove "~/Screen Studio Projects" from zap in screen-studio.rb

### DIFF
--- a/Casks/s/screen-studio.rb
+++ b/Casks/s/screen-studio.rb
@@ -31,6 +31,5 @@ cask "screen-studio" do
     "~/Library/HTTPStorages/com.timpler.screenstudio",
     "~/Library/Preferences/com.timpler.screenstudio.plist",
     "~/Library/Saved Application State/com.timpler.screenstudio.savedState",
-    "~/Screen Studio Projects",
   ]
 end

--- a/Casks/s/screen-studio.rb
+++ b/Casks/s/screen-studio.rb
@@ -31,5 +31,8 @@ cask "screen-studio" do
     "~/Library/HTTPStorages/com.timpler.screenstudio",
     "~/Library/Preferences/com.timpler.screenstudio.plist",
     "~/Library/Saved Application State/com.timpler.screenstudio.savedState",
+  ],
+  rmdir: [
+    "~/Screen Studio Projects",
   ]
 end

--- a/Casks/s/screen-studio.rb
+++ b/Casks/s/screen-studio.rb
@@ -24,15 +24,13 @@ cask "screen-studio" do
   app "Screen Studio.app"
 
   zap trash: [
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.timpler.screenstudio.sfl*",
-    "~/Library/Application Support/Screen Studio",
-    "~/Library/Caches/com.timpler.screenstudio",
-    "~/Library/Caches/com.timpler.screenstudio.ShipIt",
-    "~/Library/HTTPStorages/com.timpler.screenstudio",
-    "~/Library/Preferences/com.timpler.screenstudio.plist",
-    "~/Library/Saved Application State/com.timpler.screenstudio.savedState",
-  ],
-  rmdir: [
-    "~/Screen Studio Projects",
-  ]
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.timpler.screenstudio.sfl*",
+        "~/Library/Application Support/Screen Studio",
+        "~/Library/Caches/com.timpler.screenstudio",
+        "~/Library/Caches/com.timpler.screenstudio.ShipIt",
+        "~/Library/HTTPStorages/com.timpler.screenstudio",
+        "~/Library/Preferences/com.timpler.screenstudio.plist",
+        "~/Library/Saved Application State/com.timpler.screenstudio.savedState",
+      ],
+      rmdir: "~/Screen Studio Projects"
 end


### PR DESCRIPTION
`~/Screen Studio Projects` is the default directory for all recording files, not preferences. Someone can accidentally zap screen-studio and lost all of their works.

Reference: https://www.screen.studio/guide/saving-your-project#how-to-change-the-default-folder-for-all-new-projects

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
