### PR TITLE
requestly: add livecheck for `:github_latest`

### DIFF
--- a/Casks/r/requestly.rb
+++ b/Casks/r/requestly.rb
@@ -11,6 +11,11 @@ cask "requestly" do
   desc "Intercept and modify HTTP requests"
   homepage "https://requestly.com/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :high_sierra"
 
   app "Requestly.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Adding strategy `:github_latest` to livecheck as tags without binary releases are being picked up as new versions