### PR TITLE
nrlquaker-winbox: add compat check for Sequoia

### DIFF
--- a/Casks/n/nrlquaker-winbox.rb
+++ b/Casks/n/nrlquaker-winbox.rb
@@ -12,6 +12,8 @@ cask "nrlquaker-winbox" do
     strategy :github_latest
   end
 
+  depends_on macos: "<= :sonoma"
+
   app "Winbox-mac.app"
 
   zap trash: "~/Library/Application Support/com.mikrotik.winbox"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Hey folks. First time doing an update to a cask with a case like this, so appreciate any guidance on what I may have messed up here. 

We have a confirmed compatibility issue with Winbox-mac (nrlquaker-winbox) where new permission entitlements in macOS Sequoia are required to access the local network, but due to how the project is built, we do not have a straight forward go-ahead path to add this entitlement. Until we have a solution (or the project is retired, see https://github.com/nrlquaker/winbox-mac/issues/155), I feel it's valuable to prevent net new installations on Sequoia systems.   

In reading the cask and version documentation, I'm not sure if I also need to update the cask version or not to make this take effect. Appreciate any guidance on that. Thanks!
