### PR TITLE
windows-app: remove auto_updates

### DIFF
--- a/Casks/w/windows-app.rb
+++ b/Casks/w/windows-app.rb
@@ -13,7 +13,6 @@ cask "windows-app" do
     strategy :header_match
   end
 
-  auto_updates true
   conflicts_with cask: "microsoft-remote-desktop"
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
Microsoft AutoUpdate (MAU) still doesn't offer updates for this app for more than two weeks after its introduction, so let's tune the cask code accordingly.

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

See https://github.com/Homebrew/homebrew-cask/pull/186284#issuecomment-2400850023