### PR TITLE
jellyfin-media-player: Fix Monterey & Ventura installation with Rosetta

### DIFF
--- a/Casks/j/jellyfin-media-player.rb
+++ b/Casks/j/jellyfin-media-player.rb
@@ -1,9 +1,20 @@
 cask "jellyfin-media-player" do
-  arch arm: "AppleSilicon", intel: "Intel"
-
   version "1.11.1"
-  sha256 arm:   "6d5478a7eb457c0c842e3b4265f254d9504fe8e4c8bc5e49e59bf8c68d3cdfcd",
-         intel: "2683c358606d8b3196c890759331a29f204438e53408640429e832ca3d92ffe0"
+
+  on_ventura :or_older do
+    arch arm: "Intel", intel: "Intel"
+
+    sha256 "2683c358606d8b3196c890759331a29f204438e53408640429e832ca3d92ffe0"
+    caveats do
+      requires_rosetta
+    end
+  end
+  on_sonoma :or_newer do
+    arch arm: "AppleSilicon", intel: "Intel"
+
+    sha256 arm:   "6d5478a7eb457c0c842e3b4265f254d9504fe8e4c8bc5e49e59bf8c68d3cdfcd",
+           intel: "2683c358606d8b3196c890759331a29f204438e53408640429e832ca3d92ffe0"
+  end
 
   url "https://github.com/jellyfin/jellyfin-media-player/releases/download/v#{version}/JellyfinMediaPlayer-#{version}-#{arch}.dmg",
       verified: "github.com/jellyfin/jellyfin-media-player/"
@@ -15,6 +26,8 @@ cask "jellyfin-media-player" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Jellyfin Media Player.app"
 

--- a/Casks/j/jellyfin-media-player.rb
+++ b/Casks/j/jellyfin-media-player.rb
@@ -2,9 +2,11 @@ cask "jellyfin-media-player" do
   version "1.11.1"
 
   on_ventura :or_older do
+    # Monterey and Ventura require Rosetta on Apple Silicon
     arch arm: "Intel", intel: "Intel"
 
     sha256 "2683c358606d8b3196c890759331a29f204438e53408640429e832ca3d92ffe0"
+
     caveats do
       requires_rosetta
     end


### PR DESCRIPTION
* Up until a couple months ago, Jellyfin Media Player did not support Apple Silicon explicitly
* jellyfin-media-player 1.10.0 and later versions have added separate Apple Silicon builds, but the Intel build requires 12+ (Monterey or later) while the Apple Silicon build requires 14+ (Sonoma or later) (jellyfin/jellyfin-media-player#699)
* #173856 added jellyfin-media-player 1.10.0 support to `brew`, but didn't encode the above system arch restrictions
* As a result, anyone on Monterey or Ventura who did a `brew upgrade` would get immediate crashes on startup as in jellyfin/jellyfin-media-player#681 and jellyfin/jellyfin-media-player#668
* Now, we use the Intel build via Rosetta on Apple Silicon devices for pre-Sonoma releases, which fixes the above crashes, making this program usable
* We now also encode the minimum supported release as macOS Monterey

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
