### PR TITLE
luxmark: deprecate

### DIFF
--- a/Casks/l/luxmark.rb
+++ b/Casks/l/luxmark.rb
@@ -8,10 +8,7 @@ cask "luxmark" do
   desc "OpenCL benchmark"
   homepage "http://www.luxmark.info/"
 
-  livecheck do
-    url :url
-    regex(/^luxmark[._-]v?(\d+(?:\.\d+)+)$/i)
-  end
+  deprecate! date: "2024-10-12", because: :unmaintained
 
   app "LuxMark.app"
 

--- a/Casks/l/luxmark.rb
+++ b/Casks/l/luxmark.rb
@@ -2,11 +2,10 @@ cask "luxmark" do
   version "3.1"
   sha256 "eb103ac1bbee170c9fdecb2cd2bc6b70662a0a5f74bcf8e8edf1057d695291c0"
 
-  url "https://github.com/LuxCoreRender/LuxMark/releases/download/luxmark_v#{version}/luxmark-macos64-v#{version}.zip",
-      verified: "github.com/LuxCoreRender/LuxMark/"
+  url "https://github.com/LuxCoreRender/LuxMark/releases/download/luxmark_v#{version}/luxmark-macos64-v#{version}.zip"
   name "LuxMark"
   desc "OpenCL benchmark"
-  homepage "http://www.luxmark.info/"
+  homepage "https://github.com/LuxCoreRender/LuxMark/"
 
   deprecate! date: "2024-10-12", because: :unmaintained
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The application has not been updated since 2017.
