### PR TITLE
nasas-eyes: deprecate

### DIFF
--- a/Casks/n/nasas-eyes.rb
+++ b/Casks/n/nasas-eyes.rb
@@ -5,12 +5,9 @@ cask "nasas-eyes" do
   url "https://eyes.jpl.nasa.gov/server/engine/osx/NASA's%20Eyes.dmg"
   name "NASA's Eyes"
   desc "Learn about the earth, solar system, universe and the spacecraft exploring them"
-  homepage "https://eyes.jpl.nasa.gov/eyes-on-exoplanets.html"
+  homepage "https://science.nasa.gov/eyes/"
 
-  livecheck do
-    url :url
-    skip "unversioned application"
-  end
+  deprecate! date: "2024-10-12", because: :discontinued
 
   app "NASA's Eyes.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> NASA’s Eyes products have completely transitioned to a new web browser-based 3D application to be accessible worldwide. [...] If you have the downloadable versions of NASA’s Eyes installed on your computer, they will continue to run, but are no longer supported by NASA or the NASA Eyes team.
