### PR TITLE
sparkleshare: deprecate

### DIFF
--- a/Casks/s/sparkleshare.rb
+++ b/Casks/s/sparkleshare.rb
@@ -8,11 +8,7 @@ cask "sparkleshare" do
   desc "Tool to sync with any Git repository instantly"
   homepage "https://sparkleshare.org/"
 
-  livecheck do
-    url "https://github.com/hbons/SparkleShare/releases/"
-    regex(/sparkleshare[._-]?mac[._-]?(\d+(?:\.\d+)*)\.zip/i)
-    strategy :page_match
-  end
+  deprecate! date: "2024-10-14", because: :discontinued
 
   app "SparkleShare.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> The final release tag will be 3.38.1. Though I will not produce any binaries for it. [...] I will put this repository into public archive mode probably by next year. If someone wants to fork and rebrand the project, you have my blessing.
