### PR TITLE
functionflip: deprecate

### DIFF
--- a/Casks/f/functionflip.rb
+++ b/Casks/f/functionflip.rb
@@ -7,10 +7,7 @@ cask "functionflip" do
   desc "Function key control"
   homepage "https://kevingessner.com/software/functionflip/"
 
-  livecheck do
-    url "https://kevingessner.com/update/functionflip/"
-    regex(/v?(\d+(?:\.\d+)+)/i)
-  end
+  deprecate! date: "2024-10-14", because: :unmaintained
 
   prefpane "FunctionFlip.prefPane"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The application has not been updated since 2017 and reportedly does not work on macOS Big Sur: https://github.com/kevingessner/FunctionFlip/issues/17.
