### PR TITLE
gzdoom 4.13.0a

### DIFF
--- a/Casks/g/gzdoom.rb
+++ b/Casks/g/gzdoom.rb
@@ -1,16 +1,26 @@
 cask "gzdoom" do
-  version "4.12.2"
-  sha256 "3903827fcd8a81053f504fc1bfc55d4eba16b2651029b85b4284e51f0709bff6"
+  version "4.13.0a,4.13.0"
+  sha256 "1411e9bebf27a16bd71806d1750a122b491ac258d7b261c698ef5d39c064af93"
 
-  url "https://github.com/ZDoom/gzdoom/releases/download/g#{version}/gzdoom-#{version.dots_to_hyphens}-macOS.zip"
+  url "https://github.com/ZDoom/gzdoom/releases/download/g#{version.csv.second || version.csv.first}/gzdoom-#{version.csv.first.dots_to_hyphens}-macOS.zip"
   name "GZDoom"
   desc "Adds an OpenGL renderer to the ZDoom source port"
   homepage "https://github.com/ZDoom/gzdoom"
 
   livecheck do
     url :url
-    regex(/^g?(\d+(?:\.\d+)+)$/i)
+    regex(%r{/g?(\d+(?:\.\d+)+)/gzdoom(?:-bin)?[._-]v?(\d+(?:[.-]\d+)+[a-z]?)(?:(?:-macOS)?\.dmg|-macOS\.zip)}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        (match[2] == match[1]) ? match[1] : "#{match[2].tr("-", ".")},#{match[1]}"
+      end
+    end
   end
+
+  depends_on macos: ">= :catalina"
 
   app "GZDoom.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `gzdoom` to 4.13.0a. The latest release on GitHub uses a `g4.13.0` tag but the release asset for macOS is
`gzdoom-4-13-0a-macos.zip`, so the tag version and filename version differ. This adds a `livecheck` block to account for this potential mismatch and updates the cask `url` to adapt based on the number of `version` parts.