### PR TITLE
intune-company-portal: update livecheck, use versioned url

### DIFF
--- a/Casks/i/intune-company-portal.rb
+++ b/Casks/i/intune-company-portal.rb
@@ -1,16 +1,21 @@
 cask "intune-company-portal" do
   version "5.2409.1"
-  sha256 :no_check
+  sha256 "5fc90f74ffd980c0d696a5698a8df6743743b8882e7ad99b58f61eb050476e6c"
 
-  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal-Installer.pkg"
+  url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Upgrade.pkg"
   name "Company Portal"
   desc "App to manage access to corporate apps, data, and resources"
   homepage "https://docs.microsoft.com/en-us/mem/intune/user-help/enroll-your-device-in-intune-macos-cp"
 
   livecheck do
-    url :url
-    strategy :extract_plist do |items|
-      items["com.microsoft.CompanyPortalMac"].short_version
+    url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409IMCP01.xml"
+    regex(/^CompanyPortal[._-]v?(\d+(?:\.+\d+)+)[._-]Upgrade\.pkg$/i)
+    strategy :xml do |xml, regex|
+      filename = xml.elements["//key[text()='Payload']"]&.next_element&.text&.strip
+      match = filename&.match(regex)
+      next if match.blank?
+
+      match[1]
     end
   end
 
@@ -18,7 +23,7 @@ cask "intune-company-portal" do
   depends_on cask: "microsoft-auto-update"
   depends_on macos: ">= :mojave"
 
-  pkg "CompanyPortal-Installer.pkg",
+  pkg "CompanyPortal_#{version}-Upgrade.pkg",
       choices: [
         {
           "choiceIdentifier" => "com.microsoft.package.Microsoft_AutoUpdate.app", # Office16_autoupdate_updater.pkg


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Related to #171006.
