### PR TITLE
omnidb: deprecate

### DIFF
--- a/Casks/o/omnidb.rb
+++ b/Casks/o/omnidb.rb
@@ -2,16 +2,12 @@ cask "omnidb" do
   version "2.17.0"
   sha256 "8fdd482d45d1b2d4d330074d94238d91cc91242239a3ebb62ccc3319bacd5d16"
 
-  url "https://github.com/OmniDB/OmniDB/releases/download/#{version}/omnidb-app_#{version}-mac.dmg",
-      verified: "github.com/OmniDB/OmniDB/"
+  url "https://github.com/OmniDB/OmniDB/releases/download/#{version}/omnidb-app_#{version}-mac.dmg"
   name "OmniDB"
   desc "Web tool for database management"
-  homepage "https://omnidb.org/"
+  homepage "https://github.com/OmniDB/OmniDB/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-10-15", because: :unmaintained
 
   app "OmniDB.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The company behind OmniDB ended customer support in 2021 (see https://github.com/OmniDB/OmniDB/issues/1289#issuecomment-1020807589), and the website is no longer available.
