### PR TITLE
metabase: deprecate

### DIFF
--- a/Casks/m/metabase.rb
+++ b/Casks/m/metabase.rb
@@ -8,10 +8,7 @@ cask "metabase" do
   desc "Business intelligence and analytics"
   homepage "https://www.metabase.com/"
 
-  livecheck do
-    url "https://s3.amazonaws.com/downloads.metabase.com/appcast.xml"
-    strategy :sparkle
-  end
+  deprecate! date: "2024-10-15", because: :discontinued
 
   app "Metabase.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> We’ve decided to sunset the Mac App Store version of Metabase. [...] Since maintaining the Mac version demands resources, this (0.41) is the last release we’ll publish, and will remove it from the app store after that.
