### PR TITLE
stella: add livecheck

### DIFF
--- a/Casks/s/stella.rb
+++ b/Casks/s/stella.rb
@@ -2,11 +2,24 @@ cask "stella" do
   version "7.0"
   sha256 "dcd6de1baf5b2fdcf655478eb04d3fb8e65e3cdaed2e04cd6c5347b3149c1eed"
 
-  url "https://github.com/stella-emu/stella/releases/download/#{version}/Stella-#{version}-macos.dmg",
+  url "https://github.com/stella-emu/stella/releases/download/#{version.csv.second || version.csv.first}/Stella-#{version.csv.first}-macos.dmg",
       verified: "github.com/stella-emu/stella/"
   name "Stella"
   desc "Multi-platform Atari 2600 Emulator"
   homepage "https://stella-emu.github.io/"
+
+  livecheck do
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/Stella[._-]v?(\d+(?:\.\d+)+[a-z]?)(?:-macos)?\.dmg}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        (match[2] == match[1]) ? match[1] : "#{match[2]},#{match[1]}"
+      end
+    end
+  end
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `stella` but upstream tagged `7.0a` and `7.0b` versions after 7.0 that appear to only apply to Windows, so livecheck is reporting 7.0b as newest. We use the dmg release asset in the cask and that's still 7.0.

This adds a `livecheck` block that matches the version from the dmg file in the "latest" release on GitHub. Since the tag version and filename version can differ, I've set up the `livecheck` block and cask `url` to be able to handle a mismatch.