### PR TITLE
Add Unraid USB Creator Next

### DIFF
--- a/Casks/unraid-usb-creator-next.rb
+++ b/Casks/unraid-usb-creator-next.rb
@@ -1,0 +1,19 @@
+cask "unraid-usb-creator-next" do
+   version "1.0.1"
+   sha256 "403cbfb11c6072f197fccf74a0c061e0d60561274bc8cd531b8de9db2019959d"
+
+   url "https://github.com/unraid/usb-creator-next/releases/download/v#{version}/unraid-usb-creator-#{version}.dmg",
+       verified: "github.com/unraid/usb-creator-next/"
+   name "Unraid USB Creator"
+   desc "Home of the Next-Gen Unraid USB Creator, a fork of the Raspberry Pi Imager"
+   homepage "https://unraid.net/download/"
+
+   livecheck do
+     url :url
+     strategy :github_latest
+   end
+
+   app "Unraid USB Creator.app"
+
+   zap trash: "~/Library/Preferences/net.unraid.Unraid USB Creator.plist"
+ end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Unraid has officially updated their next generation usb-creator on [usb-creator-next](https://github.com/unraid/usb-creator-next)