### PR TITLE
sound-control: update livecheck

### DIFF
--- a/Casks/s/sound-control.rb
+++ b/Casks/s/sound-control.rb
@@ -10,12 +10,9 @@ cask "sound-control" do
 
   livecheck do
     url :homepage
-    regex(%r{/download/(\d+)}i)
-    strategy :page_match do |page, _regex|
-      version = page[/Sound Control v?(\d+(?:\.\d+)+) Release Notes/i, 1]
-      next if version.blank?
-
-      version.to_s
+    regex(/Sound\s+Control\s+v?(\d+(?:\.\d+)+)\s+Release\s+Notes/im)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0] }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `sound-control` inlines a regex in the `strategy` block and isn't using the regex from the `#regex` call. This updates the `livecheck` block to move the inline regex from the `strategy` block into the `#regex` call. In the process, I've replaced the literal spaces with `\s+` (which won't break if the whitespace changes a bit) and to use the `m` (multiline) flag, since we're matching loose text that may span multiple lines.

This also updates the `strategy` block logic to use the `scan`/`map` approach, which will work with all matches on the page instead of assuming that the first match will always be what we want.

[For what it's worth, the original goal behind this was to remove the unnecessary `#to_s` call on the `version` string but this brings the check up to standard while we're working on it.]