### PR TITLE
Remove redundant `#to_s` calls in `strategy` blocks

### DIFF
--- a/Casks/d/darwindumper.rb
+++ b/Casks/d/darwindumper.rb
@@ -10,7 +10,7 @@ cask "darwindumper" do
   livecheck do
     url "https://bytebucket.org/blackosx/darwindumper/wiki/DD_AppCast.xml"
     strategy :sparkle do |item|
-      item.short_version.delete_prefix("r").to_s
+      item.short_version.delete_prefix("r")
     end
   end
 

--- a/Casks/d/duet.rb
+++ b/Casks/d/duet.rb
@@ -22,7 +22,7 @@ cask "duet" do
       regex(/duet[._-]dd[._-]v?(\d+(?:-\d+)+)\.zip/i)
       strategy :header_match do |headers, regex|
         headers["location"].scan(regex).map do |match|
-          match[0].tr("-", ".").to_s
+          match[0].tr("-", ".")
         end
       end
     end

--- a/Casks/f/faxbot.rb
+++ b/Casks/f/faxbot.rb
@@ -9,8 +9,9 @@ cask "faxbot" do
 
   livecheck do
     url "https://www.hosy.de/faxer/version.xml"
-    strategy :sparkle do |item|
-      item.title[/Version (\d+(?:\.\d+)*)/i, 1].to_s
+    regex(/Version\s+(\d+(?:\.\d+)*)/i)
+    strategy :sparkle do |item, regex|
+      item.title[regex, 1]
     end
   end
 

--- a/Casks/i/ilok-license-manager.rb
+++ b/Casks/i/ilok-license-manager.rb
@@ -10,7 +10,7 @@ cask "ilok-license-manager" do
   livecheck do
     url "https://updates.ilok.com/iloklicensemanager/LicenseSupportInstallerMacAppcast.xml"
     strategy :sparkle do |item|
-      item.short_version.split.first.to_s
+      item.short_version.split.first
     end
   end
 

--- a/Casks/o/opencat.rb
+++ b/Casks/o/opencat.rb
@@ -10,7 +10,7 @@ cask "opencat" do
   livecheck do
     url "https://opencat.app/releases/versions.xml"
     strategy :sparkle do |item|
-      short_version = (item.short_version.split(".").length < 3) ? "#{item.short_version}.0" : item.short_version.to_s
+      short_version = (item.short_version.split(".").length < 3) ? "#{item.short_version}.0" : item.short_version
       "#{short_version},#{item.version}"
     end
   end

--- a/Casks/r/realforce.rb
+++ b/Casks/r/realforce.rb
@@ -11,7 +11,7 @@ cask "realforce" do
     url "https://www.realforce.co.jp/support/download/software/"
     regex(%r{href=.*?/REALFORCE\s*?CONNECT\s*?Software[._-](\d+(?:-\d+)+)\.pkg})
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match[0].tr("-", ".").to_s }
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/s/scrolla.rb
+++ b/Casks/s/scrolla.rb
@@ -9,9 +9,7 @@ cask "scrolla" do
 
   livecheck do
     url "https://scrolla.app/releases/appcast.xml"
-    strategy :sparkle do |item|
-      item.version.to_s
-    end
+    strategy :sparkle, &:version
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This removes `#to_s` calls in `strategy` blocks where the variable is already a string.