### PR TITLE
various: replace `:stable` with `:url` in livecheck

### DIFF
--- a/Casks/s/semeru-jdk-open@11.rb
+++ b/Casks/s/semeru-jdk-open@11.rb
@@ -12,7 +12,7 @@ cask "semeru-jdk-open@11" do
   homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^jdk[._-](\d+(?:[.+]\d+)*)[._-](.+?)$/i)
     strategy :github_latest do |json, regex|
       json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }

--- a/Casks/s/semeru-jdk-open@17.rb
+++ b/Casks/s/semeru-jdk-open@17.rb
@@ -12,7 +12,7 @@ cask "semeru-jdk-open@17" do
   homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^jdk[._-](\d+(?:[.+]\d+)*)[._-](.+?)$/i)
     strategy :github_latest do |json, regex|
       json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }

--- a/Casks/s/semeru-jdk-open@21.rb
+++ b/Casks/s/semeru-jdk-open@21.rb
@@ -12,7 +12,7 @@ cask "semeru-jdk-open@21" do
   homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^jdk[._-](\d+(?:[.+]\d+)*)[._-](.+?)$/i)
     strategy :github_latest do |json, regex|
       json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]},#{match[1]}" }

--- a/Casks/s/semeru-jdk-open@8.rb
+++ b/Casks/s/semeru-jdk-open@8.rb
@@ -9,7 +9,7 @@ cask "semeru-jdk-open@8" do
   homepage "https://developer.ibm.com/languages/java/semeru-runtimes"
 
   livecheck do
-    url :stable
+    url :url
     regex(/^(?:jdk)?(\d+u\d+)[._-](b\d+)[._-](.+?)$/i)
     strategy :github_latest do |json, regex|
       json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]}-#{match[1]},#{match[2]}" }

--- a/Casks/u/utm@beta.rb
+++ b/Casks/u/utm@beta.rb
@@ -11,7 +11,7 @@ cask "utm@beta" do
   # This uses the `GithubReleases` strategy and includes releases marked as
   # "pre-release", so this will use both unstable and stable releases.
   livecheck do
-    url :stable
+    url :url
     regex(/^v?(\d+(?:\.\d+)+.*)$/i)
     strategy :github_releases do |json|
       json.map do |release|


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Use `:url` instead of `:stable` for `livecheck` urls.