### PR TITLE
epilogue-playback: checksum update

### DIFF
--- a/Casks/e/epilogue-playback.rb
+++ b/Casks/e/epilogue-playback.rb
@@ -1,6 +1,6 @@
 cask "epilogue-playback" do
   version "1.5.0"
-  sha256 "fa28b163993d78acd9f7b012b9ac51a06f2c87a2a990f39bcc96e307a6c3d380"
+  sha256 "4748e80b8102527560019748311ff74244bc2e71c62e45e78fa343b80ae16543"
 
   url "https://epilogue.nyc3.digitaloceanspaces.com/releases/software/Playback/version/#{version}/release/mac/Playback.dmg",
       verified: "epilogue.nyc3.digitaloceanspaces.com/releases/software/Playback/version/"


### PR DESCRIPTION
I have submitted a request to check that this checksum change is intended or not.

> 3 days ago, I have checked that the sha256 checksum of Epilogue Playback is fa28b163993d78acd9f7b012b9ac51a06f2c87a2a990f39bcc96e307a6c3d380 and now it is changed into 4748e80b8102527560019748311ff74244bc2e71c62e45e78fa343b80ae16543.
>
>Download url is 
>
>https://epilogue.nyc3.digitaloceanspaces.com/releases/software/Playback/version/1.5.0/release/mac/Playback.dmg
>
>Can you check that the change of artifact with the same version intended? I am trying to update homebrew cask.
>
>https://github.com/Homebrew/homebrew-cask/commit/f006961bf464b448f650ba4b446c63e91eaaa1ef#diff-86966485203070ae47b8238831825fc6928342e536345439c364c39c211a625eL15
>
>Thanks,

----

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
