### PR TITLE
triage: fix `extract_plist livecheck` label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -43,11 +43,11 @@ jobs:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           def: |
             - label: cask deprecated
-              path: Cask/.+
+              path: Casks/.+
               content: \n  deprecate!.*\n
 
             - label: cask disabled
-              path: Cask/.+
+              path: Casks/.+
               content: \n  disable!.*\n
 
             - label: new cask

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -72,7 +72,7 @@ jobs:
 
             - label: extract_plist livecheck
               path: Casks/.+
-              content: \n  strategy :extract_plist.*\n
+              content: strategy :extract_plist
 
             - label: missing zap
               path: Casks/.+


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This label was never being applied because the regex only matched `strategy :extract_plist` when indented by 2 spaces, this is always at least 4 spaces because it is nested inside of a `livecheck do` block. The newline check shouldn't be necessary regardless, and removing it causes this to also match in the case that the `livecheck` is nested within another block, ie. `on_arm do`.