### PR TITLE
Downgrade google-cloud-sdk dependency to python@3.11

### DIFF
--- a/Casks/g/google-cloud-sdk.rb
+++ b/Casks/g/google-cloud-sdk.rb
@@ -16,7 +16,7 @@ cask "google-cloud-sdk" do
   end
 
   auto_updates true
-  depends_on formula: "python@3.12"
+  depends_on formula: "python@3.11"
 
   google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 


### PR DESCRIPTION
`gsutil`, which is part of `google-cloud-sdk`, still does not support python@3.12:

```
Error: gsutil requires Python version 2.7 or 3.5-3.11, but a different version is installed.
You are currently running Python 3.12
Follow the steps below to resolve this issue:
	1. Switch to Python 3.5-3.11 using your Python version manager or install an appropriate version.
	2. If you are unsure how to manage Python versions, visit [https://cloud.google.com/storage/docs/gsutil_install#specifications] for detailed instructions.
```