### PR TITLE
tuta-mail 246.241008.0

### DIFF
--- a/Casks/t/tuta-mail.rb
+++ b/Casks/t/tuta-mail.rb
@@ -2,7 +2,7 @@ cask "tuta-mail" do
   version "246.241008.0"
   sha256 "52c74c46436b6dc2ecb782457c770a9287b1e540376f485c38b47e171622dc71"
 
-  url "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-#{version}/tutanota-desktop-mac.dmg",
+  url "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-hotfix-#{version}/tutanota-desktop-mac.dmg",
       verified: "github.com/tutao/tutanota/"
   name "Tuta Mail"
   desc "Email client"


### PR DESCRIPTION
The [latest release of tuta-mail](https://github.com/tutao/tutanota/releases/tag/tutanota-desktop-hotfix-246.241008.0) was the first `hotfix` released and it's using `hotfix-<version>` in the tag instead of the usual `release-<version>`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
