### PR TITLE
font-oppo-sans: disable

### DIFF
--- a/Casks/font/font-o/font-oppo-sans.rb
+++ b/Casks/font/font-o/font-oppo-sans.rb
@@ -6,6 +6,8 @@ cask "font-oppo-sans" do
   name "OPPO Sans"
   homepage "https://www.coloros.com/index/newsDetail?id=72"
 
+  disable! date: "2024-10-23", because: "terms specified no redistribution"
+
   font "3.0 Designer_分级/OPlusSans3-ExtraLight.ttf"
   font "3.0 Designer_分级/OPlusSans3-Light.ttf"
   font "3.0 Designer_分级/OPlusSans3-Regular.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
Checked the homepage of the font and found out Oppo Sans's terms explicitly stated that no alternative download methods shall be provided.

Original Chinese:

* OPPO Sans（含中文及西文，3 款字重）允许个人或企业免费使用，含商业用途，版权归 OPPO 广东移动通信有限公司所有。

您应遵守以下条款，违者将会被追究法律责任：

1. 不对字体进行改编或二次开发；
2. 不对外售卖字体；
3. 不向他方提供其他下载渠道；
4. 不用于违法用途。

Machine translated:

* OPPO Sans (including Chinese and Spanish, 3 weights) is allowed to be used by individuals or enterprises free of charge, including commercial use. The copyright belongs to OPPO Guangdong Mobile Communications Co., Ltd.

You should abide by the following terms, and violators will be investigated for legal responsibility:

1. Do not adapt or re-develop fonts;
2. Do not sell fonts to the outside world;
3. Do not provide other download channels to others;
4. It is not used for illegal purposes.