### PR TITLE
vivaldi: update depends_on

### DIFF
--- a/Casks/v/vivaldi.rb
+++ b/Casks/v/vivaldi.rb
@@ -13,7 +13,7 @@ cask "vivaldi" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Vivaldi.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Version 7.0, which just released, now [requires macOS 11 or later](https://vivaldi.com/os-support-notice-10-15/).

`brew audit` gave me this error:
```
audit for vivaldi: failed
 - Version '6.9.3447.55' differs from '7.0.3495.6' retrieved by livecheck.
```

But I think it should be resolved once #189582 is merged.