### PR TITLE
lm-studio: fix sha256

### DIFF
--- a/Casks/l/lm-studio.rb
+++ b/Casks/l/lm-studio.rb
@@ -1,6 +1,6 @@
 cask "lm-studio" do
   version "0.3.5"
-  sha256 "e5f7d0af329490c22a15df68c55f31d6f8623ad32acd51f3f3deee19e5cee1cf"
+  sha256 "5cf69721677f5e5de2e5d4bee5663d384201f4f3567b9cbd0b5330a1930386dd"
 
   url "https://releases.lmstudio.ai/darwin/arm64/#{version}/LM-Studio-#{version}-arm64.dmg"
   name "LM Studio"


### PR DESCRIPTION
The sha256sum for the version 0.3.5 of LM Studio is wrong.

Expected: e5f7d0af329490c22a15df68c55f31d6f8623ad32acd51f3f3deee19e5cee1cf
     Actual: 5cf69721677f5e5de2e5d4bee5663d384201f4f3567b9cbd0b5330a1930386dd

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
