### PR TITLE
various: replace livecheck url with symbol

### DIFF
--- a/Casks/a/adobe-air.rb
+++ b/Casks/a/adobe-air.rb
@@ -12,7 +12,7 @@ cask "adobe-air" do
   # Since the <number> is not fixed in the filename, the current JavaScript
   # file needs to be extracted from the download page.
   livecheck do
-    url "https://airsdk.harman.com/"
+    url :homepage
     regex(%r{/v?(\d+(?:\.\d+)+)/AdobeAIR\.dmg}i)
     strategy :page_match do |page, regex|
       js_file = page[/src=["']?(main.+\.js)\??["' >]/i, 1]

--- a/Casks/a/arm-performance-libraries.rb
+++ b/Casks/a/arm-performance-libraries.rb
@@ -9,7 +9,7 @@ cask "arm-performance-libraries" do
   homepage "https://developer.arm.com/downloads/-/arm-performance-libraries"
 
   livecheck do
-    url "https://developer.arm.com/downloads/-/arm-performance-libraries"
+    url :homepage
     regex(/Version[._-]v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/e/elecom-mouse-util.rb
+++ b/Casks/e/elecom-mouse-util.rb
@@ -8,7 +8,7 @@ cask "elecom-mouse-util" do
   homepage "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
 
   livecheck do
-    url "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/"
+    url :homepage
     regex(/ELECOM[._-]Mouse[._-]Installer[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 

--- a/Casks/n/notesollama.rb
+++ b/Casks/n/notesollama.rb
@@ -8,7 +8,7 @@ cask "notesollama" do
   homepage "https://smallest.app/notesollama/"
 
   livecheck do
-    url "https://smallest.app/notesollama/"
+    url :homepage
     regex(/NotesOllama-(\d+(?:\.\d+)*)\.zip/i)
   end
 

--- a/Casks/w/wins.rb
+++ b/Casks/w/wins.rb
@@ -9,7 +9,7 @@ cask "wins" do
   homepage "https://wins.cool/"
 
   livecheck do
-    url "https://wins.cool/"
+    url :homepage
     regex(/href=.*?Wins[._-]latest[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This replaces `url` strings in `livecheck` blocks that clearly duplicate a URL that can be referenced (e.g., `:url`, `:homepage`).