### PR TITLE
fellow: add auto_updates true, minimum macos

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -295,6 +295,7 @@ fbreader
 fedistar
 feed-the-beast
 feishu
+fellow
 ferdium
 ff-works
 fightcade

--- a/Casks/f/fellow.rb
+++ b/Casks/f/fellow.rb
@@ -12,6 +12,9 @@ cask "fellow" do
     strategy :header_match
   end
 
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
   app "Fellow.app"
 
   zap trash: [


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Adds `auto_updates true` to Fellow and adds it to the autobump