### PR TITLE
lyn: update `sha256`

### DIFF
--- a/Casks/l/lyn.rb
+++ b/Casks/l/lyn.rb
@@ -1,6 +1,6 @@
 cask "lyn" do
   version "2.4"
-  sha256 "0d52a48a636b2adc80cbac166af85af1d2c2be06c055333ee80d3d89f10be8e1"
+  sha256 "e71467942da444c2004ed0208d80ef6694c9d8c3926f2f9092e89c0d57cbdeb1"
 
   url "https://www.lynapp.com/downloads/Lyn-#{version}.dmg"
   name "Lyn"


### PR DESCRIPTION
Hash mismatch when installing. According to author the SHA256 for v2.4 should be `e71467942da444c2004ed0208d80ef6694c9d8c3926f2f9092e89c0d57cbdeb1`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

![lyn@2x](https://github.com/user-attachments/assets/20e70491-9f96-4e33-b2e8-16b3a6856562)
