### PR TITLE
various: use case insensitive regex in livecheck blocks

### DIFF
--- a/Casks/b/beeper.rb
+++ b/Casks/b/beeper.rb
@@ -13,7 +13,7 @@ cask "beeper" do
 
   livecheck do
     url "https://download.todesktop.com/2003241lzgn20jd/latest-mac.yml"
-    regex(/Beeper\sv?(\d+(?:\.\d+)+)(?:\s-\sBuild\s([a-z\d]+?))?-#{arch}-mac\.zip/)
+    regex(/Beeper\sv?(\d+(?:\.\d+)+)(?:\s-\sBuild\s([a-z\d]+?))?-#{arch}-mac\.zip/i)
     strategy :electron_builder do |yaml, regex|
       yaml["files"]&.map do |item|
         match = item["url"]&.match(regex)

--- a/Casks/b/bluestacks.rb
+++ b/Casks/b/bluestacks.rb
@@ -9,7 +9,7 @@ cask "bluestacks" do
 
   livecheck do
     url "https://cloud.bluestacks.com/api/getdownloadnow?platform=mac&mac_version=#{MacOS.full_version}"
-    regex(%r{/(\d+(?:\.\d+)*)/([^/]+)/})
+    regex(%r{/(\d+(?:\.\d+)*)/([^/]+)/}i)
     strategy :header_match do |headers, regex|
       headers["location"].scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end

--- a/Casks/e/epoccam.rb
+++ b/Casks/e/epoccam.rb
@@ -9,7 +9,7 @@ cask "epoccam" do
 
   livecheck do
     url "https://help.elgato.com/api/v2/help_center/en-us/articles/360052826852.json"
-    regex(/EpocCam[._-]Installer[._-]v?(\d+(?:[._]\d+)+)\.pkg/)
+    regex(/EpocCam[._-]Installer[._-]v?(\d+(?:[._]\d+)+)\.pkg/i)
     strategy :json do |json, regex|
       match = json.dig("article", "body")&.match(regex)
       next if match.blank?

--- a/Casks/font/font-a/font-aileron.rb
+++ b/Casks/font/font-a/font-aileron.rb
@@ -8,7 +8,7 @@ cask "font-aileron" do
 
   livecheck do
     url :homepage
-    regex(/Version\s+(\d+(?:\.\d+)*)/)
+    regex(/Version\s+(\d+(?:\.\d+)*)/i)
   end
 
   font "Aileron-Black.otf"

--- a/Casks/font/font-c/font-computer-modern.rb
+++ b/Casks/font/font-c/font-computer-modern.rb
@@ -9,7 +9,7 @@ cask "font-computer-modern" do
 
   livecheck do
     url "https://sourceforge.net/projects/cm-unicode/rss?path=/cm-unicode"
-    regex(%r{url=.*?/cm-unicode/v?(\d+(?:\.\d+)+[a-z]?)/})
+    regex(%r{url=.*?/cm-unicode/v?(\d+(?:\.\d+)+[a-z]?)/}i)
   end
 
   font "cm-unicode-#{version}/cmunbbx.ttf"

--- a/Casks/font/font-f/font-free-mono-tengwar.rb
+++ b/Casks/font/font-f/font-free-mono-tengwar.rb
@@ -8,7 +8,7 @@ cask "font-free-mono-tengwar" do
 
   livecheck do
     url "https://sourceforge.net/projects/freetengwar/rss?path=/TengwarFont"
-    regex(/FreeMonoTengwar\.(\d+(?:-\d+)*)/)
+    regex(/FreeMonoTengwar\.(\d+(?:-\d+)*)/i)
   end
 
   font "FreeMonoTengwar.#{version}/FreeMonoTengwar-embedding.ttf"

--- a/Casks/font/font-r/font-ricty-diminished.rb
+++ b/Casks/font/font-r/font-ricty-diminished.rb
@@ -8,7 +8,7 @@ cask "font-ricty-diminished" do
 
   livecheck do
     url :homepage
-    regex(%r{/ricty_diminished-(\d+(?:\.\d+)*)\.t})
+    regex(%r{/ricty_diminished-(\d+(?:\.\d+)*)\.t}i)
   end
 
   font "RictyDiminished-Bold.ttf"

--- a/Casks/l/linear-linear.rb
+++ b/Casks/l/linear-linear.rb
@@ -13,7 +13,7 @@ cask "linear-linear" do
 
   livecheck do
     url "https://download.todesktop.com/200315glz2793v6/latest-mac.yml"
-    regex(/Linear\sv?(\d+(?:\.\d+)+)(?:\s-\sBuild\s([a-z\d]+?))?-#{arch}-mac\.zip/)
+    regex(/Linear\sv?(\d+(?:\.\d+)+)(?:\s-\sBuild\s([a-z\d]+?))?-#{arch}-mac\.zip/i)
     strategy :electron_builder do |yaml, regex|
       yaml["files"]&.map do |item|
         match = item["url"]&.match(regex)

--- a/Casks/l/little-snitch.rb
+++ b/Casks/l/little-snitch.rb
@@ -9,7 +9,7 @@ cask "little-snitch" do
 
   livecheck do
     url "https://sw-update.obdev.at/update-feeds/littlesnitch#{version.major}.plist"
-    regex(/LittleSnitch[._-]v?(\d+(?:\.\d+)+)\.dmg/)
+    regex(/LittleSnitch[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :xml do |xml, regex|
       xml.get_elements("//key[text()='DownloadURL']").map do |item|
         match = item.next_element&.text&.match(regex)

--- a/Casks/l/local.rb
+++ b/Casks/l/local.rb
@@ -12,7 +12,7 @@ cask "local" do
 
   livecheck do
     url "https://cdn.localwp.com/stable/latest/mac#{arch}"
-    regex(%r{/(\d+(?:\.\d+)+)\+(\d+)/})
+    regex(%r{/(\d+(?:\.\d+)+)\+(\d+)/}i)
     strategy :header_match do |headers|
       match = headers["location"].match(regex)
       next if match.blank?

--- a/Casks/o/outfox.rb
+++ b/Casks/o/outfox.rb
@@ -10,7 +10,7 @@ cask "outfox" do
 
   livecheck do
     url :url
-    regex(%r{/([^/]+?)/([^/]+)-v?(\d+(?:\.\d+)+[^/]*?)-(MacOSX?[^/]*)\.dmg$})
+    regex(%r{/([^/]+?)/([^/]+)-v?(\d+(?:\.\d+)+[^/]*?)-(MacOSX?[^/]*)\.dmg$}i)
     strategy :github_releases do |json, regex|
       # Temporarily restrict the ten newest releases, to work around older
       # versions using a 4.13.0 version scheme instead of the newer 0.4.14.

--- a/Casks/p/parallels-client.rb
+++ b/Casks/p/parallels-client.rb
@@ -9,7 +9,7 @@ cask "parallels-client" do
 
   livecheck do
     url "https://download.parallels.com/website_links/ras/#{version.csv.first.major}/builds-en_US.json"
-    regex(/RasClient[._-]Mac[._-]Notarized[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.pkg/)
+    regex(/RasClient[._-]Mac[._-]Notarized[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.pkg/i)
     strategy :json do |json, regex|
       client_json = json.select { |item| item.dig("category", "name")&.start_with?("Client") }&.first
       mac_client_json = client_json&.dig("contents")&.select { |item| item["subcategory"] == "Mac" }&.first

--- a/Casks/r/realforce.rb
+++ b/Casks/r/realforce.rb
@@ -9,7 +9,7 @@ cask "realforce" do
 
   livecheck do
     url "https://www.realforce.co.jp/support/download/software/"
-    regex(%r{href=.*?/REALFORCE\s*?CONNECT\s*?Software[._-](\d+(?:-\d+)+)\.pkg})
+    regex(%r{href=.*?/REALFORCE\s*?CONNECT\s*?Software[._-](\d+(?:-\d+)+)\.pkg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match[0].tr("-", ".") }
     end

--- a/Casks/s/salt.rb
+++ b/Casks/s/salt.rb
@@ -12,7 +12,7 @@ cask "salt" do
 
   livecheck do
     url "https://repo.saltproject.io/salt/py3/macos/latest/"
-    regex(/salt[._-]v?(\d+(?:\.\d+)+)-py3-#{arch}\.pkg/)
+    regex(/salt[._-]v?(\d+(?:\.\d+)+)-py3-#{arch}\.pkg/i)
   end
 
   pkg "salt-#{version}-py3-#{arch}.pkg"

--- a/Casks/s/snowflake-snowsql.rb
+++ b/Casks/s/snowflake-snowsql.rb
@@ -13,7 +13,7 @@ cask "snowflake-snowsql" do
 
   livecheck do
     url "https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/#{version.major_minor}/darwin_#{arch}/index.html"
-    regex(%r{">snowsql-(\d+(?:\.\d+)+)-darwin_#{arch}.pkg</a>})
+    regex(%r{">snowsql-(\d+(?:\.\d+)+)-darwin_#{arch}.pkg</a>}i)
   end
 
   pkg "snowsql-#{version}-darwin_#{arch}.pkg"

--- a/Casks/t/telegram.rb
+++ b/Casks/t/telegram.rb
@@ -9,7 +9,7 @@ cask "telegram" do
 
   livecheck do
     url "https://osx.telegram.org/updates/versions.xml"
-    regex(/Telegram[._-]v?(\d+(?:\.\d+)+)\.(\d{4,})\.app\.zip/)
+    regex(/Telegram[._-]v?(\d+(?:\.\d+)+)\.(\d{4,})\.app\.zip/i)
     strategy :sparkle do |items, regex|
       items.map do |item|
         match = item.url.match(regex)

--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -10,7 +10,7 @@ cask "treesheets" do
 
   livecheck do
     url :url
-    regex(/^(\d+)$/)
+    regex(/^(\d+)$/i)
     strategy :github_latest
   end
 

--- a/Casks/v/voov-meeting.rb
+++ b/Casks/v/voov-meeting.rb
@@ -19,7 +19,7 @@ cask "voov-meeting" do
 
   livecheck do
     url %Q(https://voovmeeting.com/web-service/query-download-info?q=[{"package-type":"app","channel":"1410000198","platform":"mac","arch":"#{arch}","decorators":["intl"]}]&nonce=1234567890123456)
-    regex(%r{/cos/(\h+)/VooVMeeting[._-].+?v?(\d+(?:\.\d+)+)})
+    regex(%r{/cos/(\h+)/VooVMeeting[._-].+?v?(\d+(?:\.\d+)+)}i)
     strategy :json do |json, regex|
       json["info-list"]&.map do |item|
         match = item["url"]&.match(regex)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates regexes in `livecheck` blocks to make them case insensitive (using the `i` flag), as we use this by default unless case sensitivity is specifically needed to make a match work. This is usually enforced by a RuboCop but the livecheck cops don't apply to casks yet. I'm currently working on that and these bulk style PRs are part of related fixes.

I'm running this as syntax-only to go easy on CI, as there's a fairly large number of casks involved and I've verified that these checks continue to work the same locally.