### PR TITLE
obs-ndi: deprecate

### DIFF
--- a/Casks/o/obs-ndi.rb
+++ b/Casks/o/obs-ndi.rb
@@ -7,10 +7,7 @@ cask "obs-ndi" do
   desc "NDI integration for OBS Studio"
   homepage "https://github.com/obs-ndi/obs-ndi"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2024-10-27", because: :discontinued
 
   depends_on cask: "libndi"
 


### PR DESCRIPTION
- https://github.com/DistroAV/DistroAV/releases/tag/4.14.1

The package is now changed their name with the new version. So the `obs-ndi` is no longer continued.


---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
