### PR TITLE
macterm: deprecate

### DIFF
--- a/Casks/m/macterm.rb
+++ b/Casks/m/macterm.rb
@@ -7,10 +7,7 @@ cask "macterm" do
   desc "Terminal emulator"
   homepage "https://www.macterm.net/"
 
-  livecheck do
-    url "https://www.macterm.net/updates/daily.html"
-    regex(/macterm[._-](\d+(?:\.\d+)+)\.dmg/i)
-  end
+  deprecate! date: "2024-10-27", because: :unmaintained
 
   depends_on macos: "<= :mojave"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The application has not been updated since 2018 and does not run on macOS Catalina or later.
