### PR TITLE
ci_matrix: Rework depends_on array macos handling

### DIFF
--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -18,18 +18,14 @@ module CiMatrix
   }.freeze
   RUNNERS = INTEL_RUNNERS.merge(ARM_RUNNERS).freeze
 
-  # This string uses regex syntax and is intended to be interpolated into
-  # `Regexp` literals, so the backslashes must be escaped to be preserved.
-  DEPENDS_ON_MACOS_ARRAY_MEMBER = '\\s*"?:([^\\s",]+)"?,?\\s*'
-
   def self.filter_runners(cask_content)
     # Retrieve arguments from `depends_on macos:`
     required_macos = case cask_content
-    when /depends_on\s+macos:\s+\[((?:#{DEPENDS_ON_MACOS_ARRAY_MEMBER})+)\]/o
-      Regexp.last_match(1).scan(/#{DEPENDS_ON_MACOS_ARRAY_MEMBER}/o).flatten.map(&:to_sym).map do |v|
+    when /depends_on\s+macos:\s+\[([^\]]+)\]/
+      Regexp.last_match(1).scan(/\s*(?:"([=<>]=)\s+)?:([^\s",]+)"?,?\s*/).map do |match|
         {
-          version:    v,
-          comparator: "==",
+          version:    match[1].to_sym,
+          comparator: match[0] || "==",
         }
       end
     when /depends_on\s+macos:\s+"?:([^\s"]+)"?/ # e.g. `depends_on macos: :big_sur`


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

CodeQL complains about parts of the `DEPENDS_ON_MACOS_ARRAY_MEMBER` regex snippet: `This part of the regular expression may cause exponential backtracking on strings starting with 'depends_on macos: [:' and containing many repetitions of '!:'.` This error occurs in relation to the repeating `[^\\s",]` and trailing `\s` parts of this regex.

I'm not very familiar with the issue CodeQL is flagging but this reworks handling of `depends_on macos:` arrays in such a way that CodeQL doesn't return any errors. In the process of addressing this, I updated the array member regex so it's also capable of matching strings with a leading comparator (e.g., `">= :big_sur"`) instead of only symbols like `:big_sur`. If we only ever need to match symbols, I'll update this to use the existing `.flatten.map(&:to_sym).map` approach.

I also opted to simplify the case condition regex and inline the array member regex, as it may be easier to understand compared to having a separate regex constant.

I'll mark this as ready for review in the morning but I've set it as a draft for now, as I didn't want to risk messing up CI while I'm asleep. I manually tested the logic but better safe than sorry.

Related to https://github.com/Homebrew/brew/pull/18594