### PR TITLE
perimeter81: update livecheck

### DIFF
--- a/Casks/p/perimeter81.rb
+++ b/Casks/p/perimeter81.rb
@@ -3,19 +3,19 @@ cask "perimeter81" do
   version "11.0.10.2696"
   sha256 "7b9774866a38040fbce5750bd2bba05e644fa6568bbc5b9f44a2651b38ced2e1"
 
-  url "https://static.perimeter81.com/agents/mac/Perimeter81_#{version}.pkg"
+  url "https://static.perimeter81.com/agents/mac/Harmony_SASE_#{version}.pkg"
   name "Perimeter 81"
   desc "Zero trust network as a service client"
   homepage "https://perimeter81.com/"
 
   livecheck do
-    url "https://support.perimeter81.com/v1/docs/en/downloading-the-agent"
-    regex(/href=.*?Perimeter81[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    url "https://support.perimeter81.com/v1/docs/downloading-the-agent"
+    regex(/href=.*?Harmony[._-]SASE[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
   depends_on macos: ">= :big_sur"
 
-  pkg "Perimeter81_#{version}.pkg"
+  pkg "Harmony_SASE_#{version}.pkg"
 
   uninstall launchctl: [
               "com.perimeter81.osx.HelperTool",


### PR DESCRIPTION
> Mac agent 11.0.10.2696
> October 21st, 2024
>
> Enhancements:
>
> Added support for wildcards in URL filtering rules (feature to be released gradually)
> Renamed installation file from Perimeter81_10.x.x.xxxx.pkg to Harmony_SASE_11.x.x.xxxx.pkg

So, the livecheck and download url are changed.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
