### PR TITLE
avidcodecsle: disable due to being 32-bit only

### DIFF
--- a/Casks/a/avidcodecsle.rb
+++ b/Casks/a/avidcodecsle.rb
@@ -8,9 +8,7 @@ cask "avidcodecsle" do
   desc "Use QuickTime movies using Avid codecs on systems without Media Composer"
   homepage "https://avid.secure.force.com/pkb/articles/en_US/download/Avid-QuickTime-Codecs-LE"
 
-  livecheck do
-    skip "No version information available"
-  end
+  disable! date: "2024-10-28", because: "is 32-bit only"
 
   pkg "AvidCodecsLE.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Application is 32 bit only