### PR TITLE
deeper 3.1.1

### DIFF
--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -47,7 +47,7 @@ cask "deeper" do
     url "https://www.titanium-software.fr/download/14/Deeper.dmg"
   end
   on_sequoia :or_newer do
-    version "3.1.0"
+    version "3.1.1"
 
     url "https://www.titanium-software.fr/download/15/Deeper.dmg"
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `deeper` to the latest version, 3.1.1. This is also intended as a test for [recent changes to `ci_matrix.rb`](https://github.com/Homebrew/homebrew-cask/pull/189969) related to casks that use a `depends_on macos:` array value (instead of a symbol or string).