### PR TITLE
lyrics-master: update livecheck

### DIFF
--- a/Casks/l/lyrics-master.rb
+++ b/Casks/l/lyrics-master.rb
@@ -9,7 +9,7 @@ cask "lyrics-master" do
 
   livecheck do
     url :homepage
-    regex(/href=.*?LyricsMaster[._-]?v?(\d+(?:\.\d+)*)\.dmg/)
+    regex(/href=.*?LyricsMaster[._-]?v?(\d+(?:\.\d+)*)\.dmg/i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The [`livecheck` block for `lyrics-master` was recently updated](https://github.com/Homebrew/homebrew-cask/pull/189901) but in the process the case-insensitive regex flag was mistakenly removed. We enforce case sensitive regexes by default in livecheck RuboCops (and provide a file to opt a package out when case sensitivity is necessary) but they don't apply to casks yet.

I'm currently working on making that happen but I'm cleaning up style offenses in the interim time. I recently did a pass to address regexes that don't have the `i` flag but this instance was introduced after the most recent pass. Thankfully `brew style` will catch this in the future and prevent regressions but we're not there yet.