### PR TITLE
post-haste: update livecheck

### DIFF
--- a/Casks/p/post-haste.rb
+++ b/Casks/p/post-haste.rb
@@ -7,13 +7,16 @@ cask "post-haste" do
   desc "Digital media project management tool"
   homepage "https://www.digitalrebellion.com/posthaste/"
 
+  # Upstream filenames use a version without dots, so we check the support page
+  # that displays version history.
   livecheck do
-    url "https://www.digitalrebellion.com/download/posthaste"
-    strategy :header_match do |headers|
-      match = headers["location"].match(/_((\d+)(\d+)(\d+)\d+)\.dmg/)
-      next if match.blank?
-
-      "#{match[2]}.#{match[3]}.#{match[4]},#{match[1]}"
+    url "https://www.digitalrebellion.com/support/posthaste"
+    regex(%r{
+      href=.*?/download/posthaste\?version=(\d+(?:\.\d+)*)[^>]*?>
+      \s*Post\s+Haste\s+for\s+Mac\s+v?(\d+(?:\.\d+)+)
+    }imx)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `post-haste` naively inserts dots into a dotless version string. This approach only works as expected if all the version parts are a single digit (i.e., a version like `1.23.4` would be incorrectly parsed as `1.2.3`). It may be that upstream is careful to only use versions where each numeric part is a single digit but this can't be maintained forever, as there are a finite number of available versions before having to add another digit (e.g., a 10+ major version, more than four numeric parts, etc.).

This avoids the issue by matching versions with dots from the "Version History" section of the Post Haste support page. This provides both the dotted and dotless version (which has more numbers), so we don't have to make assumptions about the difference between the two.

I'm running this as syntax-only, as the upstream server returns a 403 (Forbidden) response when run on CI (or using a VPN).

Related to https://github.com/Homebrew/homebrew-cask/pull/190292.