### PR TITLE
qbittorrent: update on_<system> blocks

### DIFF
--- a/Casks/q/qbittorrent.rb
+++ b/Casks/q/qbittorrent.rb
@@ -7,7 +7,23 @@ cask "qbittorrent" do
       skip "Legacy version"
     end
   end
-  on_mojave :or_newer do
+  on_mojave do
+    version "4.3.9"
+    sha256 "c43323a625a937383da68e50a99d823d56e6843580dc8550dd4942683467c3ed"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_catalina do
+    version "4.6.7"
+    sha256 "0b1051af73562fc3f7c0c71abd27c3433ad238fbca0c4612f554db35be3eba6e"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur :or_newer do
     version "5.0.1"
     sha256 "e0d52860cc41929bdab42df6c3405c1fb867d8dad514e4295df1eadcd64580f1"
 
@@ -18,7 +34,7 @@ cask "qbittorrent" do
   end
 
   url "https://downloads.sourceforge.net/qbittorrent/qbittorrent-mac/qbittorrent-#{version}/qbittorrent-#{version}.dmg",
-      verified: "sourceforge.net/qbittorrent/"
+      verified: "downloads.sourceforge.net/qbittorrent/qbittorrent-mac/"
   name "qBittorrent"
   desc "Peer to peer Bitorrent client"
   homepage "https://www.qbittorrent.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Version 5.0.0 and onwards [requires macOS 11 or later](https://www.qbittorrent.org/news#sun-aug-18th-2024---qbittorrent-v4.6.6-and-v5.0.0rc1-releases).

Additionally, this PR also modifies `verified` to be in line with [`qbittorrent@lt20`](https://github.com/Homebrew/homebrew-cask/blob/f68ab91181518a611e485a375fd0d0a7c4613311/Casks/q/qbittorrent%40lt20.rb#L6)

---
~I'm not really sure what policy you have in place for maintaining legacy versions; the [updating software documentation](https://docs.brew.sh/Updating-Software-in-Homebrew) says nothing about them and hence why I removed it from this cask. Most casks I've seen usually just offer the latest version after all.~

~The only documentation that I _could_ find about legacy versions was from [acceptable casks](https://docs.brew.sh/Acceptable-Casks#beta-unstable-development-nightly-or-legacy), which is not very clear about them; in relation to new casks, it says that legacy versions are accepted, but does not specify if as separate casks like @beta/@dev/@nightly/@<other_label> labeled ones, or as is being currently done in this cask.~

~If removing that legacy version was wrong though, I'd be more than ok with redoing this PR to keep using the `on_<system>` blocks.~