### PR TITLE
various: replace `[a-f0-9]` with `\h` in regexes

### DIFF
--- a/Casks/c/cura-lulzbot.rb
+++ b/Casks/c/cura-lulzbot.rb
@@ -10,7 +10,7 @@ cask "cura-lulzbot" do
 
   livecheck do
     url "https://gitlab.com/api/v4/projects/15405668/releases"
-    regex(%r{/uploads/([0-9a-f]+)/cura[._-]?lulzbot[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    regex(%r{/uploads/(\h+)/cura[._-]?lulzbot[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end

--- a/Casks/d/draw-things.rb
+++ b/Casks/d/draw-things.rb
@@ -9,7 +9,7 @@ cask "draw-things" do
 
   livecheck do
     url "https://drawthings.ai/releases/"
-    regex(/href=.*?DrawThings[._-]v?(\d+(?:\.\d+)+(?:-[\da-f]*)?)\.zip/i)
+    regex(/href=.*?DrawThings[._-]v?(\d+(?:\.\d+)+(?:-\h+)?)\.zip/i)
   end
 
   app "Draw Things.app"

--- a/Casks/e/emacs@nightly.rb
+++ b/Casks/e/emacs@nightly.rb
@@ -11,7 +11,7 @@ cask "emacs@nightly" do
 
   livecheck do
     url "https://emacsformacosx.com/atom/daily"
-    regex(/href=.*?Emacs[._-](\d+-\d+-\d+_\d+-\d+-\d+)[._-]([a-f0-9]+)[._-]universal\.dmg/i)
+    regex(/href=.*?Emacs[._-]v?(\d+-\d+-\d+_\d+-\d+-\d+)[._-](\h+)[._-]universal\.dmg/i)
     strategy :page_match do |page|
       match = page.match(regex)
       next if match.blank?

--- a/Casks/e/evernote.rb
+++ b/Casks/e/evernote.rb
@@ -37,7 +37,7 @@ cask "evernote" do
 
     livecheck do
       url "https://updates.desktop.evernote.com/mac/public/latest-mac.yml"
-      regex(/Evernote[._-](\d+(?:\.\d+)+)-mac-ddl-stage-(\d+(?:\.\d+)*)-([0-9a-f]+)\.dmg/i)
+      regex(/Evernote[._-]v?(\d+(?:\.\d+)+)-mac-ddl-stage-(\d+(?:\.\d+)*)-(\h+)\.dmg/i)
       strategy :electron_builder do |yaml, regex|
         yaml["files"]&.map do |file|
           match = file["url"]&.match(regex)

--- a/Casks/f/fontforge.rb
+++ b/Casks/f/fontforge.rb
@@ -10,7 +10,7 @@ cask "fontforge" do
 
   livecheck do
     url :url
-    regex(/^FontForge[._-]v?(\d+(?:-\d+)+)-([0-9a-f]+)\.app\.dmg/i)
+    regex(/^FontForge[._-]v?(\d+(?:-\d+)+)-(\h+)\.app\.dmg/i)
     strategy :github_latest do |json, regex|
       json["assets"]&.map do |asset|
         match = asset["name"]&.match(regex)

--- a/Casks/u/ui.rb
+++ b/Casks/u/ui.rb
@@ -10,9 +10,9 @@ cask "ui" do
 
   livecheck do
     url "https://api-gw.uid.alpha.ui.com:443/location/api/v1/public/fw/download/latest/?app=UI-DESKTOP-MACOS"
-    regex(/(\w+)[._-]macOS[._-](\d+(?:\.\d+)+)[._-]([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/i)
+    regex(/(\w+)[._-]macOS[._-](\d+(?:\.\d+)+)[._-](\h{8}-\h{4}-\h{4}-\h{4}-\h{12})/i)
     strategy :header_match do |headers, regex|
-      match = headers["location"].match(regex)
+      match = headers["location"]&.match(regex)
       next if match.blank?
 
       "#{match[2]},#{match[3]},#{match[1]}"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This replaces usage of `[a-f0-9]` in `livecheck` block regexes with `\h`, which is the same thing but less verbose. We've informally standardized on `\h` for this reason, so this brings these in line.

Besides that, this also includes some minor changes:

* `draw-things`: Use `+` instead of `*` in `(?:-\h*)?`, as the group should be optional but not the hash (i.e., this would match `-` with nothing after it, which shouldn't happen).
* `ui`: Use safe navigation operator after `headers["location"]`, as the `Location` header isn't guaranteed to exist.

I've set this as syntax-only, simply due to the number of casks being modified. I've tested all these locally and they continue to work as expected.