### PR TITLE
doxie: update livecheck

### DIFF
--- a/Casks/d/doxie.rb
+++ b/Casks/d/doxie.rb
@@ -8,8 +8,8 @@ cask "doxie" do
   homepage "https://www.getdoxie.com/"
 
   livecheck do
-    url "https://r.getdoxie.com/app/doxie/release-notes-latest.html"
-    regex(/Doxie.(\d+(?:\.\d+)+)/i)
+    url "https://r.getdoxie.com/app/download_mac/"
+    strategy :header_match
   end
 
   app "Doxie.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `doxie` checks the release notes page and matches text like `Doxie 3.3`. That works but we have better options.

The support pages for the various Doxie models each link to the same download URL (https://r.getdoxie.com/app/download_mac/), which redirects (using a `Location` header) to the latest dmg file, so we can check that using the `HeaderMatch` strategy.

This better aligns the check with the download URL, so the cask will [only] be updated when the version from the download URL changes. This will both ensure that the cask isn't updated too early (if the release notes are updated before the dmg file is available) or later than necessary (if the release notes aren't updated in a timely manner or at all).