### PR TITLE
gifox: update livecheck

### DIFF
--- a/Casks/g/gifox.rb
+++ b/Casks/g/gifox.rb
@@ -9,12 +9,10 @@ cask "gifox" do
   homepage "https://gifox.io/"
 
   livecheck do
-    url "https://gifox.io/download/latest"
-    regex(%r{/(\d(\d)\d(\d)\d(\d).\d\d)\.dmg}i)
-    strategy :header_match do |headers, regex|
-      headers["location"].scan(regex).map do |match|
-        "#{match[1]}.#{match[2]}.#{match[3]},#{match[0]}"
-      end
+    url "https://gifox.app/changelog/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)\.dmg.*?Version\s+v?(\d+(?:\.\d+)+)}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `gifox` checks a URL that redirects to the latest dmg file but it uses a dotless version format, so this check naively inserts dots to create a dotted version. We avoid this type of approach whenever possible, as the assumptions of how to split the numbers may not hold up over time. This check won't work as expected if any of the version parts are more than one digit, as this regex only captures the last digit of every two digits.

This resolves the issue by checking the [upstream changelog page](https://gifox.app/changelog/), which links to the dmg files and also provides versions with dots.