### PR TITLE
various: use numeric `match` addressing

### DIFF
--- a/Casks/a/aviatrix-vpn-client.rb
+++ b/Casks/a/aviatrix-vpn-client.rb
@@ -12,7 +12,7 @@ cask "aviatrix-vpn-client" do
     url "https://docs.aviatrix.com/documentation/latest/release-notes/vpn-client/vpn-release-notes.html"
     regex(/href=.*?aviatrix[._-]vpn[._-]client[._-]v?(\d+(?:[.-]\d+)+)[ "<]/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.tr("-", ".") }
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/font/font-a/font-anonymous-pro.rb
+++ b/Casks/font/font-a/font-anonymous-pro.rb
@@ -10,7 +10,7 @@ cask "font-anonymous-pro" do
     url :homepage
     regex(/href=.*?AnonymousPro[._-]v?(\d+(?:[._]\d+)+)\.zip/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match.first.tr("_", ".") }
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/i/imagej.rb
+++ b/Casks/i/imagej.rb
@@ -12,11 +12,11 @@ cask "imagej" do
 
   livecheck do
     url "https://imagej.net/ij/download.html"
-    regex(%r{href=.*?/ij(\d+(?:\.\d+)*)[._-]osx[._-]java\d+\.zip}i)
+    regex(%r{href=.*?/ij[._-]?v?(\d+(?:\.\d+)*)[._-]osx[._-]java\d+\.zip}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
-        text = match.first
-        text.include?(".") ? text : text.sub(/(\d)(\d+)/, '\1.\2')
+        version = match[0]
+        version.include?(".") ? version : version.sub(/(\d)(\d+)/, '\1.\2')
       end
     end
   end

--- a/Casks/p/pages-data-merge.rb
+++ b/Casks/p/pages-data-merge.rb
@@ -12,7 +12,7 @@ cask "pages-data-merge" do
     url :homepage
     regex(/href=.*?data[._-]merge[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.tr("-", ".") }
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
     end
   end
 

--- a/Casks/p/pym-player.rb
+++ b/Casks/p/pym-player.rb
@@ -11,7 +11,7 @@ cask "pym-player" do
     url "https://pym.uce.pl/downloads/"
     regex(/href=.*?PYMPlayer[._-]?v?([^.]+)\.dmg.*v[^\d]*(\d+(?:\.\d+)+)["< ]/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match.second},#{match.first}" }
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 

--- a/Casks/q/qcad.rb
+++ b/Casks/q/qcad.rb
@@ -19,7 +19,7 @@ cask "qcad" do
     url "https://www.qcad.org/en/download"
     regex(/qcad[._-]v?(\d+(?:\.\d+)+)[._-]trial[._-]macos[._-](\d+(?:[._-]\d+)+(?:[._-]qt\d)?)#{arch}\.dmg/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match.first},#{match.second}" }
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 

--- a/Casks/r/rekordbox.rb
+++ b/Casks/r/rekordbox.rb
@@ -11,7 +11,7 @@ cask "rekordbox" do
     url "https://rekordbox.com/en/download/"
     regex(%r{data-url=.*?/(\d+)/Install[._-]rekordbox[._-]v?(\d+(?:[._]\d+)+)[^"'< ]+\.zip}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match.second.tr("_", ".")},#{match.first}" }
+      page.scan(regex).map { |match| "#{match[1].tr("_", ".")},#{match[0]}" }
     end
   end
 

--- a/Casks/s/smartsvn.rb
+++ b/Casks/s/smartsvn.rb
@@ -12,9 +12,9 @@ cask "smartsvn" do
 
   livecheck do
     url "https://www.smartsvn.com/download/"
-    strategy :page_match do |page|
-      page.scan(/smartsvn[._-]#{arch}[._-](\d+(?:_\d+)+).dmg/i)
-          .map { |match| match&.first&.tr("_", ".") }
+    regex(/smartsvn[._-]#{arch}[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Casks/s/sqlight.rb
+++ b/Casks/s/sqlight.rb
@@ -7,8 +7,8 @@ cask "sqlight" do
   desc "Database management tool"
   homepage "https://www.aurvan.com/sqlight/"
 
-  # The download page is rendered using JavaScript with the download links obtained
-  # from https://www.aurvan.com/com-aurvan-satva-ui-reactjs-release/static/js/main.<hash>.chunk.js
+  # The download page is rendered using JavaScript with the download links
+  # obtained from https://www.aurvan.com/com-aurvan-satva-ui-reactjs-release/static/js/main.<hash>.chunk.js
   # Since the <hash> is not fixed in the filename, the current JavaScript file
   # needs to be extracted from the download page.
   livecheck do
@@ -16,12 +16,12 @@ cask "sqlight" do
     regex(/sqlight[._-]v?(\d+(?:[._]\d+)+)[._-]app\.dmg/i)
     strategy :page_match do |page, regex|
       js_file = page[%r{src=["']?(/com-aurvan-satva-ui-reactjs-release/static/js/main\.\w+\.chunk\.js)["' >]}i, 1]
-      next [] if js_file.blank?
+      next if js_file.blank?
 
       js_file_data = Homebrew::Livecheck::Strategy.page_content("https://www.aurvan.com/#{js_file}")
-      next [] if js_file_data[:content].blank?
+      next if js_file_data[:content].blank?
 
-      js_file_data[:content].scan(regex).map { |match| match&.first&.tr("_", ".") }
+      js_file_data[:content].scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates instances of `match.first`, `match.second`, etc. in `livecheck` blocks to use numeric addressing instead (e.g., `match[0]`, `match[1]`, etc.). This brings these instances in line with the prevailing standard.

For what it's worth, it's not necessary to use the safe navigation operator with the `match` variable when using the `#scan`/`#map` approach, as we're only iterating over matches in this context. So long as the regex has the expected capture groups, `match[0]`, etc. will always exist when the regex matches.

I'm running this as syntax-only, due to the number of casks involved. I've tested these checks locally to confirm that they continue to work as expected.