### PR TITLE
various: omit unnecessary `strategy` block return values

### DIFF
--- a/Casks/a/appgate-sdp-client.rb
+++ b/Casks/a/appgate-sdp-client.rb
@@ -26,7 +26,7 @@ cask "appgate-sdp-client" do
         support_versions =
           page.scan(%r{href=["']?([^"' >]*?/software-defined-perimeter-support/sdp[._-]v?(\d+(?:[.-]\d+)+))["' >]}i)
               .sort_by { |match| Version.new(match[1]) }
-        next [] if support_versions.blank?
+        next if support_versions.blank?
 
         # Assume the last-sorted version is newest
         version_page_path, = support_versions.last
@@ -36,7 +36,7 @@ cask "appgate-sdp-client" do
         version_page = Homebrew::Livecheck::Strategy.page_content(
           URI.join("https://www.appgate.com/", version_page_path).to_s,
         )
-        next [] if version_page[:content].blank?
+        next if version_page[:content].blank?
 
         version_page[:content].scan(regex).map(&:first)
       end

--- a/Casks/b/blender@lts.rb
+++ b/Casks/b/blender@lts.rb
@@ -29,7 +29,7 @@ cask "blender@lts" do
       next if lts_versions.blank?
 
       version_page = Homebrew::Livecheck::Strategy.page_content("https://www.blender.org/download/lts/#{lts_versions.max}/")
-      next [] if version_page[:content].blank?
+      next if version_page[:content].blank?
 
       # If the version page has a download link, return it as the livecheck version
       matched_versions = version_page[:content].scan(regex).flatten


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

It used to be necessary to use an explicit value with every early return in a `strategy` block (e.g., `next [] if ...`) but I updated the related logic years ago to allow for a `nil` value, so we can simply do `next if ...`. There are times when it makes sense to return a value for an early return but returning a blank value (e.g., `[]`, `""`) isn't necessary.

This removes unnecessary values for early returns in `strategy` blocks.