### PR TITLE
packetsender: revert to 8.7.1

### DIFF
--- a/Casks/p/packetsender.rb
+++ b/Casks/p/packetsender.rb
@@ -1,12 +1,17 @@
 cask "packetsender" do
-  version "8.8.2"
-  sha256 "0487a888652f2693ebb1333a97475dc1c676710de5c5f607cb988636fb88dc94"
+  version "8.7.1"
+  sha256 "6ad44e1a1fff5bd1ff1d23036820d6859c4137a0efd0048718308bfa10bc9e98"
 
   url "https://github.com/dannagle/PacketSender/releases/download/v#{version}/PacketSender_v#{version}.dmg",
       verified: "github.com/dannagle/PacketSender/"
   name "Packet Sender"
   desc "Network utility for sending / receiving TCP, UDP, SSL"
   homepage "https://packetsender.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   auto_updates true
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.


---
IMPORTANT NOTE: This doesn't pass the tests since 8.8.9 is marked as a pre-release. But the 8.8.2 version has been deleted, so the current version fails right now. The 8.8.9 version is marked as a rerelease of 8.8.2 with a few fixes. If this is not merged we'll probably get a lot of fails on that cask.