### PR TITLE
specter: update livecheck

### DIFF
--- a/Casks/s/specter.rb
+++ b/Casks/s/specter.rb
@@ -8,10 +8,12 @@ cask "specter" do
   desc "Desktop GUI for Bitcoin Core optimised to work with hardware wallets"
   homepage "https://specter.solutions/"
 
+  # Upstream doesn't reliably mark unstable versions as pre-release on GitHub.
+  # We check the upstream download page, which links to the latest stable files
+  # on GitHub.
   livecheck do
-    url "https://github.com/cryptoadvance/specter-desktop/releases/"
-    regex(%r{v?(\d+(?:\.\d+)+)/Specter.*?\.dmg}i)
-    strategy :page_match
+    url "https://specter.solutions/downloads/"
+    regex(/href=.*?Specter[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `specter` uses the `PageMatch` strategy to check the GitHub releases page and matches dmg filenames in the HTML. This only works because upstream includes links in the release description text, as GitHub doesn't include release asset links in the HTML anymore.

Unfortunately, upstream doesn't reliably mark unstable releases as pre-release on GitHub, so the latest version is currently v2.1.0-pre3. This is presumably why this isn't using the `GithubLatest` strategy. We can use the `GithubReleases` strategy to identify releases with a stable version format that provide a dmg release asset but it's simpler to just check the upstream download page, as that links to the latest stable dmg on GitHub (v2.0.5). This also means that we don't have to worry about unstable releases pushing the latest stable release out of the GitHub API response (due to pagination).