### PR TITLE
themeengine: deprecate

### DIFF
--- a/Casks/t/themeengine.rb
+++ b/Casks/t/themeengine.rb
@@ -7,15 +7,7 @@ cask "themeengine" do
   desc "App to edit compiled .car files"
   homepage "https://github.com/alexzielenski/ThemeEngine/"
 
-  livecheck do
-    url :url
-    strategy :git do |tags|
-      tags.filter_map do |tag|
-        match = tag.match(/^(\d+(?:\.\d+)*)\((\d+)\)$/i)
-        "#{match[1]},#{match[2]}" if match
-      end
-    end
-  end
+  deprecate! date: "2024-10-31", because: :unmaintained
 
   app "ThemeEngine.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The application hasn't been updated since 2016 and is still marked as a pre-release.
