### PR TITLE
claude 0.4.8 (new cask)

### DIFF
--- a/Casks/c/claude.rb
+++ b/Casks/c/claude.rb
@@ -10,7 +10,7 @@ cask "claude" do
 
   livecheck do
     url "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/update_manifest.json"
-    regex(/release[-_.](\d+(?:\.\d+)+)[-_.]artifact[-_.](\h+)\.zip$/i)
+    regex(/release[._-]v?(\d+(?:\.\d+)+)[._-]artifact[._-](\h+)\.zip/i)
     strategy :json do |json, regex|
       json["releases"]&.map do |item|
         match = item.dig("updateTo", "url")&.match(regex)

--- a/Casks/c/claude.rb
+++ b/Casks/c/claude.rb
@@ -1,17 +1,23 @@
 cask "claude" do
-  version "0.4.8"
+  version "0.4.8,abfc4944184bdf344113a54b0fcaddfc8040176b"
   sha256 "6e3cc0dfdb145128790855aee8ed08b76a32e0f01827fddf86a0f27836c4da73"
 
-  url "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/release-#{version}-artifact-abfc4944184bdf344113a54b0fcaddfc8040176b.zip",
+  url "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/release-#{version.csv.first}-artifact-#{version.csv.second}.zip",
       verified: "storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/"
-  name "claude"
-  desc "AI partner on desktop"
-  homepage "https://claude.ai/"
+  name "Claude"
+  desc "Anthropic's official Claude AI desktop app"
+  homepage "https://claude.ai/download"
 
   livecheck do
     url "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/update_manifest.json"
-    strategy :json do |json|
-      json["currentRelease"]
+    regex(/release[-_.](\d+(?:\.\d+)+)[-_.]artifact[-_.](\h+)\.zip$/i)
+    strategy :json do |json, regex|
+      json["releases"]&.map do |item|
+        match = item.dig("updateTo", "url")&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/c/claude.rb
+++ b/Casks/c/claude.rb
@@ -1,0 +1,32 @@
+cask "claude" do
+  version "0.4.8"
+  sha256 "6e3cc0dfdb145128790855aee8ed08b76a32e0f01827fddf86a0f27836c4da73"
+
+  url "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/release-#{version}-artifact-abfc4944184bdf344113a54b0fcaddfc8040176b.zip",
+      verified: "storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/"
+  name "claude"
+  desc "AI partner on desktop"
+  homepage "https://claude.ai/"
+
+  livecheck do
+    url "https://storage.googleapis.com/osprey-downloads-c02f6a0d-347c-492b-a752-3e0651722e97/nest/update_manifest.json"
+    strategy :json do |json|
+      json["currentRelease"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Claude.app"
+
+  zap trash: [
+    "~/Library/Application Support/Claude",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.anthropic.claudefordesktop.sfl*",
+    "~/Library/Caches/com.anthropic.claudefordesktop",
+    "~/Library/Caches/com.anthropic.claudefordesktop.ShipIt",
+    "~/Library/HTTPStorages/com.anthropic.claudefordesktop",
+    "~/Library/Preferences/com.anthropic.claudefordesktop.plist",
+    "~/Library/Saved Application State/com.anthropic.claudefordesktop.savedState",
+  ]
+end


### PR DESCRIPTION
This PR adds a cask for the new Claude desktop app found at https://claude.ai/download

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
