### PR TITLE
dropbox-passwords: deprecate

### DIFF
--- a/Casks/d/dropbox-passwords.rb
+++ b/Casks/d/dropbox-passwords.rb
@@ -8,10 +8,7 @@ cask "dropbox-passwords" do
   desc "Password manager that syncs across devices"
   homepage "https://www.dropbox.com/features/security/passwords"
 
-  livecheck do
-    url "https://www.dropbox.com/dropbox-passwords-download/mac/stable"
-    strategy :sparkle
-  end
+  deprecate! date: "2024-11-01", because: :discontinued
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The Dropbox Passwords app for desktop has been deprecated (see [support statement](https://www.dropboxforum.com/t5/Apps-and-Installations/Dropbox-Passwords-going-away/m-p/658639/highlight/true#M50543)).
