### PR TITLE
scala-ide: deprecate

### DIFF
--- a/Casks/s/scala-ide.rb
+++ b/Casks/s/scala-ide.rb
@@ -7,16 +7,7 @@ cask "scala-ide" do
   name "Scala IDE"
   homepage "https://scala-ide.org/"
 
-  livecheck do
-    url "https://scala-ide.org/download/sdk.html"
-    regex(%r{prefix:.*?(\d+(?:\.\d+)+)-vfinal-[a-z]+-\d+-(\d+)/scala-SDK-\1-vfinal-(\d+(?:\.\d+)+)["']}i)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[3]},#{match[2]}"
-    end
-  end
+  deprecate! date: "2024-11-01", because: :unmaintained
 
   # Renamed for clarity: app name is inconsistent with its branding.
   # Also renamed to avoid conflict with other eclipse Casks.


### PR DESCRIPTION
Livecheck failed and noticed that the eclipse version is not supported anymore.
Their repo is also stop to develop but no-where to find deprecation message.
- https://github.com/scala-ide/scala-ide

--- 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
