### PR TITLE
xtool-creative-space 2.2.23

### DIFF
--- a/Casks/x/xtool-creative-space.rb
+++ b/Casks/x/xtool-creative-space.rb
@@ -1,26 +1,25 @@
 cask "xtool-creative-space" do
-  arch arm: "arm64", intel: "x64"
-  livecheck_arch = on_arch_conditional arm: "apple", intel: "intel"
+  arch arm: "-arm64"
 
   on_arm do
-    version "1.7.8,28,bef4f224-d24e-4f63-b111-8670b86dcd49,2023-11-27-17-54-11"
-    sha256  "d98539f34f0b2efe1326065ea61b0c638ba2653a55a194935bdd47a79bae577b"
+    version "2.2.23,28,2e1bddec-0d1a-4dab-bfd5-de1b68cacd35,2024-10-11-11-50-02"
+    sha256  "d928d3e71e25ded28b208547167dd1ab8753f1a1e8935fc19091d6a8fec38097"
   end
   on_intel do
-    version "1.7.8,16,16d09ac8-b6d6-4335-ae2a-c51788a6acaf,2023-11-27-17-55-01"
-    sha256 "854b9e4c5397a6aa3a958b03dd3bec6c7665393132924fdedc913eefbd85056d"
+    version "2.2.23,16,0fbeb19a-b594-4f86-a200-e5e736e6f038,2024-10-11-11-24-25"
+    sha256 "4bdd6b51d35974590b75bc9409bbb422fad85f76474923669a8d5524058198bb"
   end
 
-  url "https://storage-us.xtool.com/resource/efficacy/xcs/production/packages/#{version.csv.second}/#{version.csv.third}/xTool%20Creative%20Space-#{version.csv.first}-#{version.csv.fourth}-#{arch}.dmg"
+  url "https://storage-us.xtool.com/resource/efficacy/xcs/prod-us/packages/#{version.csv.second}/#{version.csv.third}/xTool-Creative-Space-#{version.csv.first}-#{version.csv.fourth}#{arch}.dmg"
   name "xTool Creative Space"
   desc "Design and control software for xTool laser machines"
   homepage "https://www.xtool.com/pages/software"
 
   livecheck do
-    url "https://s.xtool.com/software/download/macos-#{livecheck_arch}-chip"
-    regex(%r{/([^/]+)/([^/]+)/xTool.*Creative.*Space[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:-\d+)+)[._-]#{arch}\.dmg}i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
+    url :homepage
+    regex(%r{/([^/]+)/([^/]+)/xTool[._-]Creative[._-]Space[._-]v?(\d+(?:\.\d+)+)[._-](\d+(?:-\d+)+)#{arch}\.dmg}i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
       next if match.blank?
 
       "#{match[3]},#{match[1]},#{match[2]},#{match[4]}"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

Livecheck needs update to use :homepage and PageMatch, but I am not sure how to handle the missing arch part for intel.
