### PR TITLE
remotix-agent: deprecate

### DIFF
--- a/Casks/r/remotix-agent.rb
+++ b/Casks/r/remotix-agent.rb
@@ -8,15 +8,7 @@ cask "remotix-agent" do
   desc "Remote desktop and monitoring solution"
   homepage "https://remotixcloud.com/"
 
-  livecheck do
-    url "https://remotix.com/downloads-mac/"
-    strategy :page_match do |page|
-      match = page.match(/Remotix\sAgent.*Current\sversion:\s<b>(\d+(?:\.\d+)+)\s\((\d+)\)/i)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
+  deprecate! date: "2024-11-01", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Remotix has been replaced by Acronis Cyber Protect Connect (see [support article](https://care.acronis.com/s/article/70487-Acronis-Cyber-Protect-Connect-formerly-Remotix-What-s-new-in-Licensing-and-how-to-use?language=en_US)).
