### PR TITLE
Fix panoply.rb SHA256 value for v5.5.4

### DIFF
--- a/Casks/p/panoply.rb
+++ b/Casks/p/panoply.rb
@@ -2,8 +2,8 @@ cask "panoply" do
   arch arm: "arm64-"
 
   version "5.5.4"
-  sha256 arm:   "5207a99eed154e8805c8e5749492c4c7efd6dabf49c225c85fd746e7c767a23e",
-         intel: "b497aed3c21830fa1cfb419286a5662790d139418187b4ff30939d90e6fa17f8"
+  sha256 arm:   "e687d518a31da07c2cc56d0abcdd45f7a2d3241e72a526373ef3bba5e90897a6",
+         intel: "db3cd87d1b60fae7382f523095368b2c547dec6f341a1125225b2c76f7874dc4"
 
   url "https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-#{arch}#{version}.dmg"
   name "Panoply netCDF, HDF and GRIB Data Viewer"


### PR DESCRIPTION
https://www.giss.nasa.gov/tools/panoply/download/Panoply-5.5.4.sha256.txt

	SHA256(PanoplyJ-5.5.4.tgz)= ac2daf41c69a9cada73520ed897361c81895d1237742ab7053c58d05cec3fcdc
	SHA256(PanoplyJ-5.5.4.zip)= e2925659bf5660ba2c8d0df5e4710747c43490493a47202ac58e4e40bf7dab5a
	SHA256(PanoplyMacOS-5.5.4.dmg)= db3cd87d1b60fae7382f523095368b2c547dec6f341a1125225b2c76f7874dc4
	SHA256(PanoplyMacOS-jfc-5.5.4.dmg)= b2504c14dc7455c9e23cdbc2e179202804a149cf22456ddf186532fa0cd6ad24
	SHA256(PanoplyMacOS-arm64-5.5.4.dmg)= e687d518a31da07c2cc56d0abcdd45f7a2d3241e72a526373ef3bba5e90897a6
	SHA256(PanoplyWin-5.5.4.zip)= f2e03766af8dfd9fc19e1789e01108f3c4ca827731d6c9a1f4793b59eeac68d1

---

Background, copy from https://github.com/Homebrew/homebrew-cask/pull/190257

I tried to use `brew upgrade` but failed:

![CleanShot 2024-11-02 at 23 13 27@2x](https://github.com/user-attachments/assets/88f41d37-c538-47ed-a671-0d8461e8aaa9)

```console
➜  ~ brew upgrade
==> Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them.
==> Upgrading 1 outdated package:
panoply 5.5.3 -> 5.5.4
==> Upgrading panoply
==> Caveats
panoply requires Java 11+. You can install the latest version with:
  brew install --cask temurin

==> Downloading https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-arm64-5.5.4.dmg
######################################################################################################################################################### 100.0%
==> Purging files for version 5.5.4 of Cask panoply
Error: panoply: SHA256 mismatch
Expected: 5207a99eed154e8805c8e5749492c4c7efd6dabf49c225c85fd746e7c767a23e
  Actual: e687d518a31da07c2cc56d0abcdd45f7a2d3241e72a526373ef3bba5e90897a6
    File: /Users/ringsaturn/Library/Caches/Homebrew/downloads/7f6897c3ec81a32c182c7ff177e30c121140ce5bd601a8d6e63d93c7c9a2fb35--PanoplyMacOS-arm64-5.5.4.dmg
To retry an incomplete download, remove the file above.
```

Then I download the dmg file from https://www.giss.nasa.gov/tools/panoply/download/PanoplyMacOS-arm64-5.5.4.dmg

And found the SHA256 changed:

```bash
shasum -a 256  PanoplyMacOS-arm64-5.5.4.dmg
e687d518a31da07c2cc56d0abcdd45f7a2d3241e72a526373ef3bba5e90897a6  PanoplyMacOS-arm64-5.5.4.dmg
```

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
