### PR TITLE
pallotron-yubiswitch: Bump SHA256 for re-released version

### DIFF
--- a/Casks/p/pallotron-yubiswitch.rb
+++ b/Casks/p/pallotron-yubiswitch.rb
@@ -1,6 +1,6 @@
 cask "pallotron-yubiswitch" do
   version "0.17"
-  sha256 "48787eadef7df2383a508587ff93932f35800c146c808269def5db99f6dc869c"
+  sha256 "da18d8059e42dfe71abaa7211d7da80f4b5f7f0c1c18bad104bd11a0885b633f"
 
   url "https://github.com/pallotron/yubiswitch/releases/download/v#{version}/yubiswitch_#{version}.dmg"
   name "Yubiswitch"


### PR DESCRIPTION
Version was re-released due to code-signing issues without a new version number.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

n/a

---
