### PR TITLE
`lm-studio`: Restore `auto_updates true`; require `high_sierra`

### DIFF
--- a/Casks/l/lm-studio.rb
+++ b/Casks/l/lm-studio.rb
@@ -14,7 +14,9 @@ cask "lm-studio" do
     end
   end
 
+  auto_updates true
   depends_on arch: :arm64
+  depends_on macos: ">= :high_sierra"
 
   app "LM Studio.app"
 


### PR DESCRIPTION
Following up on a comment:

- https://github.com/Homebrew/homebrew-cask/pull/184462#pullrequestreview-2411194821

... on #184462 where `auto_updates` was removed.

---

## Changes

- [x] restore `auto_updates true`
    - slightly speculatively, because you might have removed it for a good reason; it wasn't discussed in that PR though 
    - it can also update itself on a beta channel
- [x] require High Sierra, because a first run of `brew audit --cask --online lm-studio` produced an error

---

## Evidence LM Studio autoupdates

<img width="813" alt="image" src="https://github.com/user-attachments/assets/cf9bb501-089d-4310-a64b-69a5647701a5">

---

## Evidence LM Studio needs High Sierra

```terminal
$ brew audit --strict --online lm-studio

==> Downloading and extracting artifacts

...

audit for lm-studio: failed
 - Upstream defined :high_sierra as the minimum OS version but the cask declared no minimum OS version
lm-studio
  * Upstream defined :high_sierra as the minimum OS version but the cask declared no minimum OS version
Error: 1 problem in 1 cask detected.
```

---

## Testing

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online lm-studio` is error-free.
- [x] `brew style --fix lm-studio` reports no offences.

And from the 'new cask' list, why not:

- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask lm-studio` worked successfully.
- [x] `brew uninstall --cask lm-studio` worked successfully.
