### PR TITLE
acronis-true-image 41592

### DIFF
--- a/Casks/a/acronis-true-image.rb
+++ b/Casks/a/acronis-true-image.rb
@@ -1,16 +1,22 @@
 cask "acronis-true-image" do
-  version "2021"
-  sha256 :no_check # required as upstream package is updated in-place
+  version "41592"
+  sha256 "304335d0e8e26bc46571e6926baf20da0f2d694f20a8728c7f220236d1ed29c2"
 
-  url "https://dl.acronis.com/u/AcronisTrueImage#{version}.dmg"
+  url "https://dl.acronis.com/u/AcronisTrueImage_#{version}.dmg"
   name "Acronis True Image"
   desc "Full image backup and cloning software"
-  homepage "https://www.acronis.com/personal/computer-backup/"
+  homepage "https://www.acronis.com/products/true-image/"
 
-  deprecate! date: "2024-02-07", because: :discontinued
+  livecheck do
+    url "https://www.acronis.com/en-us/support/updates/changes.html?p=42798"
+    regex(/Build.*?>\s*v?(\d+(?:\.\d+)*)\s*</)
+  end
 
-  pkg "Install Acronis True Image.pkg"
+  auto_updates true
+  depends_on macos: ">= :big_sur"
 
-  uninstall pkgutil: "com.acronis.trueimageformac",
+  pkg "Installer.pkg"
+
+  uninstall pkgutil: "com.acronis.CyberProtectHomeOffice",
             delete:  "/Applications/Acronis True Image.app"
 end


### PR DESCRIPTION
Acronis True Image wasn't deprecated, it was just temporarily rebranded as Acronis Cyber Protect Home Office. Now it's back!

TODO: define zap procedure.
At the moment, the official uninstaller is an app on the distribution image (DMG). It needs to be somehow preserved at the installation time. However, such an uninstaller matching the current installed version is not guaranteed as the user can upgrade Acronis True Image via a built-in upgrade feature.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
