### PR TITLE
various: remove `macos-12` from Actions

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         runner:
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
           - ubuntu-latest
     runs-on: ${{ matrix.runner }}
     steps:

--- a/cmd/lib/ci_matrix.rb
+++ b/cmd/lib/ci_matrix.rb
@@ -9,7 +9,6 @@ module CiMatrix
 
   # Weight for each arch must add up to 1.0.
   INTEL_RUNNERS = {
-    { symbol: :monterey, name: "macos-12", arch: :intel } => 0.0,
     { symbol: :ventura,  name: "macos-13", arch: :intel } => 1.0,
   }.freeze
   ARM_RUNNERS = {


### PR DESCRIPTION
`macOS-12` is deprecated: https://github.com/actions/runner-images/issues/10721

Noticed this due to the brownout.