### PR TITLE
google-cloud-sdk: use system Python 3

### DIFF
--- a/Casks/g/google-cloud-sdk.rb
+++ b/Casks/g/google-cloud-sdk.rb
@@ -16,7 +16,6 @@ cask "google-cloud-sdk" do
   end
 
   auto_updates true
-  depends_on formula: "python@3.11"
 
   google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 
@@ -42,6 +41,7 @@ cask "google-cloud-sdk" do
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_google_cloud_sdk"
 
   preflight do
+    FileUtils.mkdir_p google_cloud_sdk_root
     FileUtils.cp_r staged_path/"google-cloud-sdk/.", google_cloud_sdk_root, remove_destination: true
     FileUtils.rm_r(staged_path/"google-cloud-sdk")
     FileUtils.ln_s google_cloud_sdk_root, (staged_path/"google-cloud-sdk")


### PR DESCRIPTION
Python 3.13 is unsupported and Python 3.12 is unsupported by some tools.

At the same time, Google Cloud SDK works just fine with the Python 3.9
provided by Command-Line Tools which are assumed to be present.

In reality, `gcloud` is a shell script that probes Python executables:
* `python3` has the highest precedence: 3.13 by Homebrew (skipped) and
  3.9 by Command-Line Tools
* `python` is next, but should not match anything
* `python3.11`..`python3.8`: either a compatible Homebrew distribution or
  3.9 by Command-Line Tools
* Problematic `python3.12` has the lowest precedence

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
