### PR TITLE
acronis-true-image-cleanup-tool 41561 (new cask)

### DIFF
--- a/Casks/a/acronis-true-image-cleanup-tool.rb
+++ b/Casks/a/acronis-true-image-cleanup-tool.rb
@@ -1,0 +1,22 @@
+cask "acronis-true-image-cleanup-tool" do
+  version "41561"
+  sha256 "aae4d79ea1324941d67857f1ab81efdc8b680dd4dd14380f78bf7c5b9320a5bd"
+
+  url "https://dl.acronis.com/u/support/KB/cleanup_tool%20Mac?version=#{version}"
+  name "Acronis True Image Cleanup Utility"
+  desc "Uninstaller for Acronis True Image"
+  homepage "https://care.acronis.com/s/article/48668-Acronis-Cyber-Protect-Home-Office-Acronis-True-Image-Cleanup-Utility"
+
+  livecheck do
+    url :url
+    regex(/\x00cleanup_tool_mac_macarm64_(.+?)\x00/)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/lib/acronis-true-image"
+
+  binary "#{staged_path}/cleanup_tool%20Mac", target: "#{google_cloud_sdk_root}/cleanup_tool"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
Acronis True Image Cleanup Utility

Unfortunately, it must be downloaded separately.
To be used by `acronis-true-image`'s zap stanza.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
