### PR TITLE
acronis-true-image 41592: improve uninstall and implement zap

### DIFF
--- a/Casks/a/acronis-true-image.rb
+++ b/Casks/a/acronis-true-image.rb
@@ -14,13 +14,51 @@ cask "acronis-true-image" do
 
   auto_updates true
   depends_on macos: ">= :big_sur"
+  depends_on cask: "acronis-true-image-cleanup-tool"
 
   pkg "Installer.pkg"
 
-  uninstall pkgutil: "com.acronis.CyberProtectHomeOffice",
-            delete:  "/Applications/Acronis True Image.app"
+  uninstall launchctl: [
+              "com.acronis.aakore",
+              "com.acronis.acep",
+              "com.acronis.acroprld_client",
+              "com.acronis.active_protection",
+              "com.acronis.cyber-protect-service",
+              "com.acronis.escyberprotect",
+              "com.acronis.helpertool",
+              "com.acronis.mms_mini",
+              "com.acronis.mobile_backup_server",
+              "com.acronis.mobile_backup_status_server",
+              "com.acronis.monitor",
+              "com.acronis.scheduler",
+            ],
+            quit:      [
+              "com.acronis.CyberProtectHomeOffice",
+              "com.acronis.CyberProtectHomeOffice.FinderSyncExt",
+              "com.acronis.CyberProtectHomeOffice.help",
+              "com.acronis.CyberProtectHomeOffice.monitor",
+              "com.acronis.escyberprotect",
+            ],
+            signal:    [
+              ["TERM", "com.acronis.CyberProtectHomeOffice"],
+              ["TERM", "com.acronis.CyberProtectHomeOffice.FinderSyncExt"],
+              ["TERM", "com.acronis.CyberProtectHomeOffice.help"],
+              ["TERM", "com.acronis.CyberProtectHomeOffice.monitor"],
+              ["TERM", "com.acronis.escyberprotect"],
+              ["KILL", "com.acronis.CyberProtectHomeOffice"],
+              ["KILL", "com.acronis.CyberProtectHomeOffice.FinderSyncExt"],
+              ["KILL", "com.acronis.CyberProtectHomeOffice.help"],
+              ["KILL", "com.acronis.CyberProtectHomeOffice.monitor"],
+              ["KILL", "com.acronis.escyberprotect"],
+            ],
+            pkgutil:   "com.acronis.CyberProtectHomeOffice",
+            delete:    "/Applications/Acronis True Image.app"
 
-  zap delete: [
+  zap script: {
+        executable: "#{HOMEBREW_PREFIX}/lib/acronis-true-image/cleanup_tool",
+        sudo:       true,
+      },
+      delete: [
         "/Library/Application Support/Acronis",
         "/Library/Application Support/BackupClient",
         "/Library/PrivilegedHelperTools/com.acronis.helpertool",


### PR DESCRIPTION
Uses `acronis-true-image-cleanup-tool`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
