### PR TITLE
Livecheck style generic tarball extension

### DIFF
--- a/Casks/d/denemo.rb
+++ b/Casks/d/denemo.rb
@@ -9,7 +9,7 @@ cask "denemo" do
 
   livecheck do
     url "https://denemo.org/downloads/"
-    regex(/href=.*?denemo[._-]v?(\d+(?:\.\d+)+)[._-]darwin[._-]x64.tar\.bz2/i)
+    regex(/href=.*?denemo[._-]v?(\d+(?:\.\d+)+)[._-]darwin[._-]x64\.t/i)
   end
 
   app "Denemo.app"

--- a/Casks/j/jdk-mission-control.rb
+++ b/Casks/j/jdk-mission-control.rb
@@ -12,7 +12,7 @@ cask "jdk-mission-control" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/(\d+)/binaries/jmc[._-]v?(\d+(?:\.\d+)*)[._-]macos[._-]#{arch}\.tar\.gz}i)
+    regex(%r{href=.*?/(\d+)/binaries/jmc[._-]v?(\d+(?:\.\d+)*)[._-]macos[._-]#{arch}\.t}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end

--- a/Casks/p/papyrus.rb
+++ b/Casks/p/papyrus.rb
@@ -9,7 +9,7 @@ cask "papyrus" do
 
   livecheck do
     url "https://eclipse.dev/papyrus/download.html"
-    regex(%r{href=.*?/papyrus-(\d+(?:-\d+)*)-(\d+(?:\.\d+)*)-macosx64\.tar\.gz}i)
+    regex(%r{href=.*?/papyrus-(\d+(?:-\d+)*)-(\d+(?:\.\d+)*)-macosx64\.t}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end

--- a/Casks/w/worldpainter.rb
+++ b/Casks/w/worldpainter.rb
@@ -9,7 +9,7 @@ cask "worldpainter" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/files/worldpainter[._-]v?(\d+(?:\.\d+)+)\.tgz}i)
+    regex(%r{href=.*?/files/worldpainter[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates regexes that use a specific tarball extension to use the generic `\.t` pattern instead. We currently enforce this with a RuboCop for formulae and the same will apply to casks when I finish that work.