### PR TITLE
Fix `SafeNavigationChainLength` style offenses

### DIFF
--- a/Casks/a/alfred.rb
+++ b/Casks/a/alfred.rb
@@ -10,11 +10,11 @@ cask "alfred" do
   livecheck do
     url "https://www.alfredapp.com/app/update#{version.major}/general.xml"
     strategy :xml do |xml|
-      version = xml.elements["//key[text()='version']"]&.next_element&.text&.strip
-      build = xml.elements["//key[text()='build']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='version']"]&.next_element&.text
+      build = xml.elements["//key[text()='build']"]&.next_element&.text
       next if version.blank? || build.blank?
 
-      "#{version},#{build}"
+      "#{version.strip},#{build.strip}"
     end
   end
 

--- a/Casks/a/alfred@4.rb
+++ b/Casks/a/alfred@4.rb
@@ -10,11 +10,11 @@ cask "alfred@4" do
   livecheck do
     url "https://www.alfredapp.com/app/update#{version.major}/general.xml"
     strategy :xml do |xml|
-      version = xml.elements["//key[text()='version']"]&.next_element&.text&.strip
-      build = xml.elements["//key[text()='build']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='version']"]&.next_element&.text
+      build = xml.elements["//key[text()='build']"]&.next_element&.text
       next if version.blank? || build.blank?
 
-      "#{version},#{build}"
+      "#{version.strip},#{build.strip}"
     end
   end
 

--- a/Casks/a/apparency.rb
+++ b/Casks/a/apparency.rb
@@ -38,11 +38,11 @@ cask "apparency" do
     livecheck do
       url "https://www.mothersruin.com/software/Apparency/data/ApparencyVersionInfo.plist"
       strategy :xml do |xml|
-        short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
-        version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+        short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text
+        version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
         next if short_version.blank? || version.blank?
 
-        "#{short_version},#{version}"
+        "#{short_version.strip},#{version.strip}"
       end
     end
   end

--- a/Casks/a/archaeology.rb
+++ b/Casks/a/archaeology.rb
@@ -10,11 +10,11 @@ cask "archaeology" do
   livecheck do
     url "https://www.mothersruin.com/software/Archaeology/data/ArchaeologyVersionInfo.plist"
     strategy :xml do |xml|
-      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
-      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
       next if short_version.blank? || version.blank?
 
-      "#{short_version},#{version}"
+      "#{short_version.strip},#{version.strip}"
     end
   end
 

--- a/Casks/c/cirrus.rb
+++ b/Casks/c/cirrus.rb
@@ -15,11 +15,12 @@ cask "cirrus" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Cirrus']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/c/colemak-dh.rb
+++ b/Casks/c/colemak-dh.rb
@@ -11,7 +11,10 @@ cask "colemak-dh" do
   livecheck do
     url "https://raw.githubusercontent.com/ColemakMods/mod-dh/master/macOS/Colemak%20DH.bundle/Contents/Info.plist"
     strategy :xml do |xml|
-      xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/c/colemak-dhk.rb
+++ b/Casks/c/colemak-dhk.rb
@@ -11,7 +11,10 @@ cask "colemak-dhk" do
   livecheck do
     url "https://raw.githubusercontent.com/ColemakMods/mod-dh/master/macOS/Colemak%20DHk.bundle/Contents/Info.plist"
     strategy :xml do |xml|
-      xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/d/dintch.rb
+++ b/Casks/d/dintch.rb
@@ -15,11 +15,12 @@ cask "dintch" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Dintch']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/e/easyfind.rb
+++ b/Casks/e/easyfind.rb
@@ -10,7 +10,10 @@ cask "easyfind" do
   livecheck do
     url "https://api.devontechnologies.com/1/apps/updates.plist.php?product=EasyFind&version=#{version}"
     strategy :xml do |xml|
-      xml.elements["//key[text()='EasyFind']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='EasyFind']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/e/etrecheckpro.rb
+++ b/Casks/e/etrecheckpro.rb
@@ -10,7 +10,10 @@ cask "etrecheckpro" do
   livecheck do
     url "https://cdn.etrecheck.com/EtreCheckProUpdates.plist"
     strategy :xml do |xml|
-      xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/f/flickr-uploadr.rb
+++ b/Casks/f/flickr-uploadr.rb
@@ -10,11 +10,11 @@ cask "flickr-uploadr" do
   livecheck do
     url "https://downloads.flickr.com/uploadr/DEVBRANCH94103_FlickrUploadr-Info.plist"
     strategy :xml do |xml|
-      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
-      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
       next if short_version.blank? || version.blank?
 
-      "#{short_version},#{version}"
+      "#{short_version.strip},#{version.strip}"
     end
   end
 

--- a/Casks/i/intune-company-portal.rb
+++ b/Casks/i/intune-company-portal.rb
@@ -11,8 +11,8 @@ cask "intune-company-portal" do
     url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/0409IMCP01.xml"
     regex(/^CompanyPortal[._-]v?(\d+(?:\.+\d+)+)[._-]Upgrade\.pkg$/i)
     strategy :xml do |xml, regex|
-      filename = xml.elements["//key[text()='Payload']"]&.next_element&.text&.strip
-      match = filename&.match(regex)
+      filename = xml.elements["//key[text()='Payload']"]&.next_element&.text
+      match = filename.strip.match(regex) if filename
       next if match.blank?
 
       match[1]

--- a/Casks/l/lockrattler.rb
+++ b/Casks/l/lockrattler.rb
@@ -15,11 +15,12 @@ cask "lockrattler" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='LockRattler']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/m/metamer.rb
+++ b/Casks/m/metamer.rb
@@ -15,11 +15,12 @@ cask "metamer" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Metamer']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/m/mints.rb
+++ b/Casks/m/mints.rb
@@ -15,11 +15,12 @@ cask "mints" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Mints']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/o/obs.rb
+++ b/Casks/o/obs.rb
@@ -15,7 +15,11 @@ cask "obs" do
     url "https://obsproject.com/osx_update/updates_#{livecheck_folder}_v2.xml"
     regex(/obs[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
     strategy :sparkle do |items, regex|
-      items.find { |item| item.channel == "stable" }&.url&.scan(regex)&.flatten
+      items.map do |item|
+        next if item.channel != "stable"
+
+        item.url&.[](regex, 1)
+      end
     end
   end
 

--- a/Casks/o/obs@beta.rb
+++ b/Casks/o/obs@beta.rb
@@ -15,7 +15,11 @@ cask "obs@beta" do
     url "https://obsproject.com/osx_update/updates_#{livecheck_folder}_v2.xml"
     regex(/obs[._-]studio[._-](\d+(?:[.-]\d+)+(?:(?:-beta)|(?:-rc))\d+)[._-]macos/i)
     strategy :sparkle do |items, regex|
-      items.find { |item| item.channel == "beta" }&.url&.scan(regex)&.flatten
+      items.map do |item|
+        next if item.channel != "beta"
+
+        item.url&.[](regex, 1)
+      end
     end
   end
 

--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -59,7 +59,10 @@ cask "onyx" do
   livecheck do
     url "https://www.titanium-software.fr/download/#{MacOS.version}/OnyX.plist"
     strategy :xml do |xml|
-      xml.elements["//key[text()='Version']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='Version']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/o/openvanilla.rb
+++ b/Casks/o/openvanilla.rb
@@ -11,11 +11,11 @@ cask "openvanilla" do
   livecheck do
     url "https://raw.githubusercontent.com/openvanilla/openvanilla/master/Source/Mac/OpenVanilla-Info.plist"
     strategy :xml do |xml|
-      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
-      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+      short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text
+      version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
       next if short_version.blank? || version.blank?
 
-      "#{short_version},#{version}"
+      "#{short_version.strip},#{version.strip}"
     end
   end
 

--- a/Casks/p/photostickies.rb
+++ b/Casks/p/photostickies.rb
@@ -10,7 +10,10 @@ cask "photostickies" do
   livecheck do
     url "https://api.devontechnologies.com/1/apps/updates.plist.php?product=PhotoStickies&version=#{version}"
     strategy :xml do |xml|
-      xml.elements["//key[text()='PhotoStickies']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='PhotoStickies']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/s/signet.rb
+++ b/Casks/s/signet.rb
@@ -15,11 +15,12 @@ cask "signet" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Signet']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/s/silentknight.rb
+++ b/Casks/s/silentknight.rb
@@ -18,11 +18,12 @@ cask "silentknight" do
         item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='SilentKnight#{version.major}']]"]
         next unless item
 
-        version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-        match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+        version = item.elements["key[text()='Version']"]&.next_element&.text
+        url = item.elements["key[text()='URL']"]&.next_element&.text
+        match = url.strip.match(regex) if url
         next if version.blank? || match.blank?
 
-        "#{version},#{match[1]}.#{match[2]}"
+        "#{version.strip},#{match[1]}.#{match[2]}"
       end
     end
   end

--- a/Casks/s/sitesucker-pro.rb
+++ b/Casks/s/sitesucker-pro.rb
@@ -22,7 +22,10 @@ cask "sitesucker-pro" do
     livecheck do
       url "https://ricks-apps.com/osx/sitesucker/pro-versions.plist"
       strategy :xml do |xml|
-        xml.elements["//dict/key[text()='App Version']"]&.next_element&.text&.strip
+        version = xml.elements["//dict/key[text()='App Version']"]&.next_element&.text
+        next if version.blank?
+
+        version.strip
       end
     end
   end

--- a/Casks/s/smultron.rb
+++ b/Casks/s/smultron.rb
@@ -10,11 +10,11 @@ cask "smultron" do
   livecheck do
     url "https://www.peterborgapps.com/updates/smultron#{version.major}.plist"
     strategy :xml do |xml|
-      version = xml.elements["//key[text()='version']"]&.next_element&.text&.strip
-      build = xml.elements["//key[text()='build']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='version']"]&.next_element&.text
+      build = xml.elements["//key[text()='build']"]&.next_element&.text
       next if version.blank? || build.blank?
 
-      "#{version},#{build}"
+      "#{version.strip},#{build.strip}"
     end
   end
 

--- a/Casks/s/spundle.rb
+++ b/Casks/s/spundle.rb
@@ -15,11 +15,12 @@ cask "spundle" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Spundle']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/s/suspicious-package.rb
+++ b/Casks/s/suspicious-package.rb
@@ -58,11 +58,11 @@ cask "suspicious-package" do
     livecheck do
       url "https://www.mothersruin.com/software/SuspiciousPackage/data/SuspiciousPackageVersionInfo.plist"
       strategy :xml do |xml|
-        short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text&.strip
-        version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text&.strip
+        short_version = xml.elements["//key[text()='CFBundleShortVersionString']"]&.next_element&.text
+        version = xml.elements["//key[text()='CFBundleVersion']"]&.next_element&.text
         next if short_version.blank? || version.blank?
 
-        "#{short_version},#{version}"
+        "#{short_version.strip},#{version.strip}"
       end
     end
   end

--- a/Casks/t/taccy.rb
+++ b/Casks/t/taccy.rb
@@ -15,11 +15,12 @@ cask "taccy" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Taccy']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/t/thetimemachinemechanic.rb
+++ b/Casks/t/thetimemachinemechanic.rb
@@ -16,11 +16,12 @@ cask "thetimemachinemechanic" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='T2M22']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/t/thumbsup.rb
+++ b/Casks/t/thumbsup.rb
@@ -10,7 +10,10 @@ cask "thumbsup" do
   livecheck do
     url "https://api.devontechnologies.com/1/apps/updates.plist.php?product=ThumbsUp&version=#{version}"
     strategy :xml do |xml|
-      xml.elements["//key[text()='ThumbsUp']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='ThumbsUp']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/u/ulbow.rb
+++ b/Casks/u/ulbow.rb
@@ -15,11 +15,12 @@ cask "ulbow" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='Ulbow']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/x/xattred.rb
+++ b/Casks/x/xattred.rb
@@ -15,11 +15,12 @@ cask "xattred" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='xattred']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 

--- a/Casks/x/xmenu.rb
+++ b/Casks/x/xmenu.rb
@@ -10,7 +10,10 @@ cask "xmenu" do
   livecheck do
     url "https://api.devontechnologies.com/1/apps/updates.plist.php?product=XMenu&version=#{version}"
     strategy :xml do |xml|
-      xml.elements["//key[text()='XMenu']"]&.next_element&.text&.strip
+      version = xml.elements["//key[text()='XMenu']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
     end
   end
 

--- a/Casks/x/xprocheck.rb
+++ b/Casks/x/xprocheck.rb
@@ -14,11 +14,12 @@ cask "xprocheck" do
       item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='XProCheck']]"]
       next unless item
 
-      version = item.elements["key[text()='Version']"]&.next_element&.text&.strip
-      match = item.elements["key[text()='URL']"]&.next_element&.text&.strip&.match(regex)
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]}.#{match[2]}"
+      "#{version.strip},#{match[1]}.#{match[2]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This reworks safe navigation chains that are longer than two, as this will be surfaced as a style offense after https://github.com/Homebrew/brew/pull/18682 is merged. These all happen to occur in `livecheck` block `strategy` blocks, mostly in relation to the `Xml` strategy.

These changes are fairly straightforward but feel free to suggest alternative approaches if you can think of anything nicer than this.

I'm running this as syntax-only due to the number of casks involved. I've tested these locally and the livecheck output is identical to before these changes.