### PR TITLE
expo-orbit: update sha256

### DIFF
--- a/Casks/e/expo-orbit.rb
+++ b/Casks/e/expo-orbit.rb
@@ -1,6 +1,6 @@
 cask "expo-orbit" do
   version "1.2.0"
-  sha256 "164ddb618577508ce34b33ce61a3bb3c11fb0697f2c4de8268ff2a78f9d73fb8"
+  sha256 "ea6a4f644feabbb4cc3963a333b3a1edc832538aa056c0cfe1f117eaa71811f4"
 
   url "https://github.com/expo/orbit/releases/download/expo-orbit-v#{version}/expo-orbit.v#{version}.zip"
   name "Expo Orbit"


### PR DESCRIPTION
Update `sha256` for expo-orbit 1.2.0. Due to internal issues, we had to update the orbit executable leading a change in the sha256

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

