### PR TITLE
tablecruncher 1.7.0

### DIFF
--- a/Casks/t/tablecruncher.rb
+++ b/Casks/t/tablecruncher.rb
@@ -1,15 +1,18 @@
 cask "tablecruncher" do
-  version "1.6.0.1"
-  sha256 "897f9fabcabdd902343dad66e67ea2c68b911cf44d383e32adb94ea2908c87de"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://tablecruncher.com/download/Tablecruncher-#{version}.zip"
+  version "1.7.0"
+  sha256 arm:   "11dfed89498a9f30ce323ce16159aa9a24b4665634f4bea293682f40eb07cdab",
+         intel: "316ae70fd1b34f9ab59c1bfcde7b0ae3c1a6000c3b0a433ca3b7963d28b1a080"
+
+  url "https://tablecruncher.com/download/Tablecruncher-#{version}-#{arch}.zip"
   name "Tablecruncher"
   desc "Lightweight CSV editor"
   homepage "https://tablecruncher.com/"
 
   livecheck do
     url "https://tablecruncher.com/download/"
-    regex(/Tablecruncher-(\d+(?:\.\d+)+)\.zip/i)
+    regex(/href=.*?Tablecruncher[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.zip/i)
   end
 
   app "Tablecruncher.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `tablecruncher` to the latest stable version, 1.7.0. Upstream assets are now split between arm64 and x86_64, so this updates the cask setup accordingly. Besides that, this also tweaks the `livecheck` block regex to bring it in line with prevailing standards.