### PR TITLE
various: update urls to resolve redirections

### DIFF
--- a/Casks/d/dcv-viewer.rb
+++ b/Casks/d/dcv-viewer.rb
@@ -9,7 +9,7 @@ cask "dcv-viewer" do
       verified: "d1uj6qtbmh3dt5.cloudfront.net/"
   name "NICE DCV Viewer"
   desc "Client for NICE DCV remote display protocol"
-  homepage "https://www.nice-dcv.com/"
+  homepage "https://www.amazondcv.com/"
 
   livecheck do
     url :homepage

--- a/Casks/font/font-a/font-anonymous-pro.rb
+++ b/Casks/font/font-a/font-anonymous-pro.rb
@@ -4,7 +4,7 @@ cask "font-anonymous-pro" do
 
   url "https://www.marksimonson.com/assets/content/fonts/AnonymousPro-#{version.dots_to_underscores}.zip"
   name "Anonymous Pro"
-  homepage "https://www.marksimonson.com/fonts/view/anonymous-pro"
+  homepage "https://www.marksimonson.com/fonts/view/anonymous-pro/"
 
   livecheck do
     url :homepage

--- a/Casks/k/keeper-password-manager.rb
+++ b/Casks/k/keeper-password-manager.rb
@@ -8,7 +8,7 @@ cask "keeper-password-manager" do
   homepage "https://keepersecurity.com/"
 
   livecheck do
-    url "https://docs.keeper.io/en/v/release-notes/desktop"
+    url "https://docs.keeper.io/en/release-notes/desktop"
     regex(/Release\s+v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/r/receipts.rb
+++ b/Casks/r/receipts.rb
@@ -2,13 +2,13 @@ cask "receipts" do
   version "1.16-762"
   sha256 "76349f6602c457ed490b43187df36b118822deb76130abb1f2a440612485445d"
 
-  url "https://www.receipts-app.com/update/download/Receipts-#{version}.zip"
+  url "https://receipts-app.com/update/download/Receipts-#{version}.zip"
   name "Receipts"
   desc "Document management"
-  homepage "https://www.receipts-app.com/"
+  homepage "https://receipts-app.com/"
 
   livecheck do
-    url "https://www.receipts-app.com/updater.php"
+    url "https://receipts-app.com/updater.php"
     regex(/href=.*?Receipts[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
   end
 

--- a/Casks/s/screen-studio.rb
+++ b/Casks/s/screen-studio.rb
@@ -9,10 +9,10 @@ cask "screen-studio" do
       verified: "screenstudioassets.com/"
   name "Screen Studio"
   desc "Screen recorder and editor"
-  homepage "https://www.screen.studio/"
+  homepage "https://screen.studio/"
 
   livecheck do
-    url "https://www.screen.studio/api/trpc/appInfo.latestVersionInfo?input=%7B%22isBeta%22%3Afalse%7D"
+    url "https://screen.studio/api/trpc/appInfo.latestVersionInfo?input=%7B%22isBeta%22%3Afalse%7D"
     strategy :json do |json|
       json.dig("result", "data", "version")
     end

--- a/Casks/u/usb-overdrive.rb
+++ b/Casks/u/usb-overdrive.rb
@@ -8,7 +8,7 @@ cask "usb-overdrive" do
   homepage "https://www.usboverdrive.com/"
 
   livecheck do
-    url "https://www.usboverdrive.com/index.php/download/"
+    url "https://www.usboverdrive.com/downloads/"
     regex(/>USB\s+Overdrive\s+v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/v/vox-preferences-pane.rb
+++ b/Casks/v/vox-preferences-pane.rb
@@ -9,7 +9,7 @@ cask "vox-preferences-pane" do
   homepage "https://vox.rocks/mac-music-player/control-extension-download"
 
   livecheck do
-    url "http://updateinfo.devmate.com/com.coppertino.VoxPrefs/updates.xml"
+    url "https://updateinfo.devmate.com/com.coppertino.VoxPrefs/updates.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates various URLs to resolve simple redirections where there isn't a benefit to using the existing URL. There may be some others that we can safely update but these are the straightforward ones.

To be clear, we retain some redirecting URLs in `livecheck` blocks when they redirect to mirrors, cloud providers, etc. (e.g., `affinity-designer`). In those cases, upstream may point the URL to something else in the future (e.g., a different cloud provider), so checking the generic URL helps to ensure that the check won't break. For example, sometimes a source can change location and the existing URL can return outdated information until someone manually identifies a new version outside of livecheck and updates the cask, so using the generic, redirecting URL can help to avoid that type of situation.