### PR TITLE
Upgrade Headlamp version to 0.26.0

### DIFF
--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -1,9 +1,9 @@
 cask "headlamp" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.25.1"
-  sha256 arm:   "3292bd47a9e880753d9550520ff153bfdcdd17e4444f2ff6f1af6b02846e372a",
-         intel: "d840939f86a325779df22b8e00e9d8b108fe80bd603ef5433b4dbcef9073b1ea"
+  version "0.26.0"
+  sha256 arm:   "5786bf7333c70fd27a350993bc7f0fab81d36ce6165070c38998cdbe2b192d71",
+         intel: "2d88bc3693f70a09c33258f5c4c4c7558a9d6509615031394fa3a94e95e6bd0a"
 
   url "https://github.com/headlamp-k8s/headlamp/releases/download/v#{version.sub(/-\d+/, "")}/Headlamp-#{version}-mac-#{arch}.dmg",
       verified: "github.com/headlamp-k8s/headlamp/"


### PR DESCRIPTION
Upgrade Headlamp version to 0.26.0
  cc: @joaquimrocha