### PR TITLE
mochi-diffusion: update sha256

### DIFF
--- a/Casks/m/mochi-diffusion.rb
+++ b/Casks/m/mochi-diffusion.rb
@@ -1,6 +1,6 @@
 cask "mochi-diffusion" do
   version "5.2"
-  sha256 "fbb7ec461bb2f4056e4ace50758307d7a622cdc04b70ef01148f1f521386681c"
+  sha256 "81d35c1d5e0c9cf83173681ca830a882c857de3531e7c744d5c7588cd0e38a26"
 
   url "https://github.com/godly-devotion/MochiDiffusion/releases/download/v#{version}/MochiDiffusion_v#{version}.dmg"
   name "Mochi Diffusion"


### PR DESCRIPTION
```
Error: mochi-diffusion: SHA256 mismatch
Expected: fbb7ec461bb2f4056e4ace50758307d7a622cdc04b70ef01148f1f521386681c
  Actual: 81d35c1d5e0c9cf83173681ca830a882c857de3531e7c744d5c7588cd0e38a26
    File: /Users/mayx/Library/Caches/Homebrew/downloads/57b4a9167c21e72132ed5f25c9cc11321eef4526a8b9cb591b768277169f60fb--MochiDiffusion_v5.2.dmg
To retry an incomplete download, remove the file above.
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
