### PR TITLE
font-new-computer-modern: add font in new version

### DIFF
--- a/Casks/font/font-n/font-new-computer-modern.rb
+++ b/Casks/font/font-n/font-new-computer-modern.rb
@@ -45,6 +45,7 @@ cask "font-new-computer-modern" do
   font "newcm-#{version}/otf/NewCMSans10-BookOblique.otf"
   font "newcm-#{version}/otf/NewCMSans10-Oblique.otf"
   font "newcm-#{version}/otf/NewCMSans10-Regular.otf"
+  font "newcm-#{version}/otf/NewCMSansMath-Regular.otf"
   font "newcm-#{version}/otf/NewCMUncial08-Bold.otf"
   font "newcm-#{version}/otf/NewCMUncial08-Book.otf"
   font "newcm-#{version}/otf/NewCMUncial08-Regular.otf"


### PR DESCRIPTION
In version 7.0.0 they add a new sans math font: https://git.gnu.org.ua/newcm.git/commit/sfd?id=e9f2936ed67bb06bcce81a6b05365fbc7bcc657f

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
