### PR TITLE
various: address `livecheck` block style offenses

### DIFF
--- a/Casks/a/acronis-true-image-cleanup-tool.rb
+++ b/Casks/a/acronis-true-image-cleanup-tool.rb
@@ -9,7 +9,7 @@ cask "acronis-true-image-cleanup-tool" do
 
   livecheck do
     url :url
-    regex(/\x00cleanup_tool_mac_macarm64[._-]v?(\d+(?:\.\d+)*)\x00/)
+    regex(/\x00cleanup_tool_mac_macarm64[._-]v?(\d+(?:\.\d+)*)\x00/i)
   end
 
   depends_on macos: ">= :big_sur"

--- a/Casks/a/acronis-true-image.rb
+++ b/Casks/a/acronis-true-image.rb
@@ -9,7 +9,7 @@ cask "acronis-true-image" do
 
   livecheck do
     url "https://www.acronis.com/en-us/support/updates/changes.html?p=42798"
-    regex(/Build.*?>\s*v?(\d+(?:\.\d+)*)\s*</)
+    regex(/Build.*?>\s*v?(\d+(?:\.\d+)*)\s*</i)
   end
 
   auto_updates true

--- a/Casks/c/codespace.rb
+++ b/Casks/c/codespace.rb
@@ -8,7 +8,7 @@ cask "codespace" do
   homepage "https://codespace.app/"
 
   livecheck do
-    url "https://codespace.app/download/latest"
+    url :url
     strategy :header_match
   end
 

--- a/Casks/d/dcommander.rb
+++ b/Casks/d/dcommander.rb
@@ -5,16 +5,16 @@ cask "dcommander" do
   url "https://devstorm-apps.com/dc/download.php"
   name "DCommander"
   desc "Two-pane file manager"
-  homepage "https://devstorm-apps.com/dc/"
+  homepage "https://devstorm-apps.com/dcommander/"
 
   livecheck do
-    url "https://devstorm-apps.com/dc/download.php"
-    regex(/DCommander[._-]v?(\d+)\.dmg/i)
+    url :url
+    regex(/DCommander[._-]v?(\d+(?:\.\d+)*)\.dmg/i)
     strategy :header_match do |headers, regex|
       match = headers["content-disposition"]&.match(regex)
       next if match.blank?
 
-      match[1].split("", 4).join(".")
+      (version = match[1]).include?(".") ? version : version.chars.join(".")
     end
   end
 

--- a/Casks/d/deepl.rb
+++ b/Casks/d/deepl.rb
@@ -7,7 +7,7 @@ cask "deepl" do
 
     livecheck do
       url "https://appdownload.deepl.com/macos/"
-      regex(%r{^old/v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.(?:zip|tar\.gz)$}i)
+      regex(%r{^old/v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.(?:zip|t)}i)
       strategy :xml do |xml, regex|
         xml.get_elements("//Contents/Key").map do |item|
           match = item.text&.match(regex)
@@ -36,7 +36,7 @@ cask "deepl" do
 
     livecheck do
       url "https://appdownload.deepl.com/macos/"
-      regex(%r{^v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.tar\.gz$}i)
+      regex(%r{^v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.t}i)
       strategy :xml do |xml, regex|
         xml.get_elements("//ListBucketResult//Contents//Key").map do |item|
           match = item.text.match(regex)

--- a/Casks/o/opendnsupdater.rb
+++ b/Casks/o/opendnsupdater.rb
@@ -8,7 +8,7 @@ cask "opendnsupdater" do
   homepage "https://support.opendns.com/hc/en-us/articles/227987867"
 
   livecheck do
-    url "https://www.opendns.com/download/mac/"
+    url :url
     strategy :header_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This fixes various `livecheck` block style offenses:

```
Taps/homebrew/homebrew-cask/Casks/a/acronis-true-image-cleanup-tool.rb:12:11: C: [Correctable] Cask/Livecheck: Regexes should be case-insensitive unless sensitivity is explicitly required for proper matching.
    regex(/\x00cleanup_tool_mac_macarm64[._-]v?(\d+(?:\.\d+)*)\x00/)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Taps/homebrew/homebrew-cask/Casks/a/acronis-true-image.rb:12:11: C: [Correctable] Cask/Livecheck: Regexes should be case-insensitive unless sensitivity is explicitly required for proper matching.
    regex(/Build.*?>\s*v?(\d+(?:\.\d+)*)\s*</)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Taps/homebrew/homebrew-cask/Casks/c/codespace.rb:11:5: C: [Correctable] Cask/Livecheck: Use url :url
    url "https://codespace.app/download/latest"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Taps/homebrew/homebrew-cask/Casks/d/dcommander.rb:11:5: C: [Correctable] Cask/Livecheck: Use url :url
    url "https://devstorm-apps.com/dc/download.php"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Taps/homebrew/homebrew-cask/Casks/d/deepl.rb:39:16: C: [Correctable] Cask/Livecheck: Use \.t instead of \.tar\.gz
      regex(%r{^v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.tar\.gz$}i)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Taps/homebrew/homebrew-cask/Casks/o/opendnsupdater.rb:11:5: C: [Correctable] Cask/Livecheck: Use url :url
    url "https://www.opendns.com/download/mac/"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

`livecheck` block RuboCops don't apply to casks yet but I'm currently working on that. I had it working for simple casks but it now also handles more complex casks using on_arch/on_os blocks, which can contain a `livecheck` block, `url`, etc.

This PR includes fixes for some existing offenses that I had already identified and others that I've now found within on_arch/on_os blocks, as well new issues that have appeared in the interim time. These will be caught by `brew style` once I finish up that work (I'm working on handling similar nested blocks in formulae, writing tests, etc.) but this addresses these offenses for now.

Outside of style fixes, this also updates the `dcommander` homepage to resolve the redirection and reworks how the `strategy` block naively handles dotless versions (so it can work with more than four digits).