### PR TITLE
Add one more useful step to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,12 @@ Notice an application that's out-of-date in Homebrew Cask? In most cases, it's v
 brew bump --open-pr <outdated_cask>
 ```
 
+:warning: You will probably first need to run the command:
+
+```bash
+brew tap --force homebrew/cask
+```
+
 You can also follow the steps in the documentation on [adding a cask](https://docs.brew.sh/Adding-Software-to-Homebrew#casks) for more complicated changes.
 
 ## Getting Set Up To Contribute


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Just add one more useful command to contributing guide because I try to use command `brew bump --open-pr yandex-cloud-cli` but have error like this:
```
~$ brew bump yandex-cloud-cli
Error: These casks are not in any locally installed taps!

  yandex-cloud-cli

You may need to run `brew tap` to install additional taps.
```
I founded [here](https://github.com/orgs/Homebrew/discussions/3778#discussioncomment-3871446), that I need command `brew tap homebrew/cask`, but also have error (but with hint :)):
```
~$ brew tap homebrew/cask
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.
```
After use `brew tap --force homebrew/cask` I can do the main thing that I wanted - bump cask.
It would be nice to have this instruction in contributing guide.