### PR TITLE
opera@beta: add depends_on and update zap

### DIFF
--- a/Casks/o/opera@beta.rb
+++ b/Casks/o/opera@beta.rb
@@ -19,7 +19,11 @@ cask "opera@beta" do
 
   zap trash: [
     "~/Library/Application Support/com.operasoftware.OperaNext",
+    "~/Library/Caches/com.operasoftware.Installer.OperaNext",
     "~/Library/Caches/com.operasoftware.OperaNext",
+    "~/Library/Cookies/com.operasoftware.OperaNext.binarycookies",
+    "~/Library/HTTPStorages/com.operasoftware.Installer.OperaNext",
     "~/Library/Preferences/com.operasoftware.OperaNext.plist",
+    "~/Library/Saved Application State/com.operasoftware.OperaNext.savedState",
   ]
 end

--- a/Casks/o/opera@beta.rb
+++ b/Casks/o/opera@beta.rb
@@ -13,6 +13,7 @@ cask "opera@beta" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Opera Beta.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
This version of Opera is based on Chromium 130, as such it requires macOS 11 or later. This also makes the zap stanza equivalent to that in the other `opera` casks.