### PR TITLE
opera@developer: add depends_on and update zap

### DIFF
--- a/Casks/o/opera@developer.rb
+++ b/Casks/o/opera@developer.rb
@@ -19,8 +19,10 @@ cask "opera@developer" do
 
   zap trash: [
     "~/Library/Application Support/com.operasoftware.OperaDeveloper",
+    "~/Library/Caches/com.operasoftware.Installer.OperaDeveloper",
     "~/Library/Caches/com.operasoftware.OperaDeveloper",
     "~/Library/Cookies/com.operasoftware.OperaDeveloper.binarycookies",
+    "~/Library/HTTPStorages/com.operasoftware.Installer.OperaDeveloper",
     "~/Library/Preferences/com.operasoftware.OperaDeveloper.plist",
     "~/Library/Saved Application State/com.operasoftware.OperaDeveloper.savedState",
   ]

--- a/Casks/o/opera@developer.rb
+++ b/Casks/o/opera@developer.rb
@@ -13,6 +13,7 @@ cask "opera@developer" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Opera Developer.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
This version of Opera is based on Chromium 130, as such it requires macOS 11 or later. This also makes the zap stanza equivalent to that in the other `opera` casks.