### PR TITLE
opera-gx: add depends_on and update zap

### DIFF
--- a/Casks/o/opera-gx.rb
+++ b/Casks/o/opera-gx.rb
@@ -17,5 +17,13 @@ cask "opera-gx" do
 
   app "Opera GX.app"
 
-  zap trash: "~/Library/Application Support/com.operasoftware.OperaGX"
+  zap trash: [
+    "~/Library/Application Support/com.operasoftware.OperaGX",
+    "~/Library/Caches/com.operasoftware.Installer.OperaGX",
+    "~/Library/Caches/com.operasoftware.OperaGX",
+    "~/Library/Cookies/com.operasoftware.OperaGX.binarycookies",
+    "~/Library/HTTPStorages/com.operasoftware.Installer.OperaGX",
+    "~/Library/Preferences/com.operasoftware.OperaGX.plist",
+    "~/Library/Saved Application State/com.operasoftware.OperaGX.savedState",
+  ]
 end

--- a/Casks/o/opera-gx.rb
+++ b/Casks/o/opera-gx.rb
@@ -13,6 +13,7 @@ cask "opera-gx" do
   end
 
   auto_updates true
+  depends_on macos: ">= :catalina"
 
   app "Opera GX.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The current version of Opera is based on Chromium 128, as such it requires macOS 10.15 or later. This also makes the zap stanza equivalent to that in the other `opera` casks.