### PR TITLE
waterfox-classic: deprecate

### DIFF
--- a/Casks/w/waterfox-classic.rb
+++ b/Casks/w/waterfox-classic.rb
@@ -8,11 +8,7 @@ cask "waterfox-classic" do
   desc "Web browser"
   homepage "https://classic.waterfox.net/"
 
-  livecheck do
-    url :url
-    regex(/v?(\d+(?:\.\d+)+)-classic/i)
-    strategy :github_latest
-  end
+  deprecate! date: "2024-11-09", because: :unmaintained
 
   app "Waterfox Classic.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Waterfox Classic has not received any updates in over two years.