### PR TITLE
ripx: update livecheck

### DIFF
--- a/Casks/r/ripx.rb
+++ b/Casks/r/ripx.rb
@@ -10,7 +10,16 @@ cask "ripx" do
 
   livecheck do
     url "https://hitnmix.com/changes/"
-    regex(/v?(\d+(?:\.\d+)+)\s*changes/i)
+    regex(/^\s*v?(\d+(?:\.\d+)+)\s+changes(?:\s+\([^)]+?\))?(?:\s*(?:&[^;]+?;|.)?\s*mac(?:OS)?\s+Only)?\s*$/i)
+    strategy :page_match do |page, regex|
+      page.scan(%r{<h3[^>]*?>.+?</h3>}i).map do |match|
+        # Remove HTML tags from text to simplify matching
+        match = match.gsub(/<[^>]+?>/, "").match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `ripx` checks a page that lists changes for each version. livecheck is giving 7.1.1 as the latest version but this is listed as "Windows Only" (this appears to be the first release where this has happened).

This updates the regex to only match titles that don't include anything after text like "v7.1.0 changes (20th March 2024)". I've set up the regex to allow for something like "macOS Only" but that's the only exception. This addresses the issue for now but we could easily run into unexpected issues in the future if upstream does something different. Unfortunately, I don't see any other way around this, as this is the only version information that upstream seems to publish.