### PR TITLE
seafile-client: revert to 9.0.7

### DIFF
--- a/Casks/s/seafile-client.rb
+++ b/Casks/s/seafile-client.rb
@@ -1,6 +1,6 @@
 cask "seafile-client" do
-  version "9.0.9"
-  sha256 "bdcf2018a49181407a0e819394719e8eab8fbffd809b9436775a57eaaf6a27de"
+  version "9.0.7"
+  sha256 "c829cdec394534eaa1a8b6fd399c585f4b26779586c42a3cb37440dbd55aca91"
 
   url "https://download.seadrive.org/seafile-client-#{version}.dmg",
       verified: "seadrive.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

This reverts the Seafile client from 9.0.9 to 9.0.7.  Per one of the project leads at https://forum.seafile.com/t/was-seafile-macos-client-9-0-9-pulled-back/22624/3, version 9.0.9 was pulled (and, as can be seen from the download page at https://www.seafile.com/en/download/, is no longer publicly advertised).