### PR TITLE
Update vorta.rb

### DIFF
--- a/Casks/v/vorta.rb
+++ b/Casks/v/vorta.rb
@@ -1,14 +1,15 @@
 cask "vorta" do
-  version "0.10.0"
-  sha256 "3081d63e3e3b174ce5e9b0700a6ed26f406157601adfc4cd0a5028ad03bca020"
+  arch arm: "arm", intel: "intel"
 
-  url "https://github.com/borgbase/vorta/releases/download/v#{version}/Vorta-v#{version}.dmg"
+  version "0.10.0"
+  sha256 arm:   "3081d63e3e3b174ce5e9b0700a6ed26f406157601adfc4cd0a5028ad03bca020",
+         intel: "4df3d955d4b323910a935b6fb542fb35babb669948fa8e21be8d11731e10b27b"
+
+  url "https://github.com/borgbase/vorta/releases/download/v#{version}/Vorta-v#{version}-#{arch}.dmg"
   name "Vorta"
   desc "Desktop Backup Client for Borg"
   homepage "https://github.com/borgbase/vorta"
 
-  # Not every GitHub release provides a file for macOS, so we check multiple
-  # recent releases instead of only the "latest" release.
   livecheck do
     url :url
     regex(/^Vorta[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg|zip)$/i)


### PR DESCRIPTION
updated to use separate arm and intel binaries

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

