### PR TITLE
au-lab: add zap

### DIFF
--- a/Casks/a/au-lab.rb
+++ b/Casks/a/au-lab.rb
@@ -14,6 +14,8 @@ cask "au-lab" do
 
   app "AU Lab.app"
 
+  zap trash: "~/Library/Preferences/com.apple.aulab.plist"
+
   caveats do
     requires_rosetta
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Even though this product is from Apple directly, it hasn't been updated since 2015 and its signing certificate is invalid according to Apparency, having expired in 2021.  I was originally going to deprecate due to those reasons, since that falls in line with a lot of our deprecations.

For now, I've added a zap.  If anyone feels strongly this should be deprecated, I can add that back in.