### PR TITLE
mediainfo 24.11

### DIFF
--- a/Casks/m/mediainfo.rb
+++ b/Casks/m/mediainfo.rb
@@ -1,15 +1,17 @@
 cask "mediainfo" do
-  version "24.06"
-  sha256 "ece6a7c8bb28a706d9d784392b90766aa4ebe23955ae30cc0e72a4188fb21d1c"
+  version "24.11"
+  sha256 "65ae00f87a594215193b064123ef65c7ead1e4115336582465f74360f6b67d06"
 
   url "https://mediaarea.net/download/binary/mediainfo-gui/#{version}/MediaInfo_GUI_#{version}_Mac.dmg"
   name "MediaInfo"
   desc "Display technical and tag data for video and audio files"
   homepage "https://mediaarea.net/en/MediaInfo"
 
+  # We check the first-party download page, as the Sparkle feed has contained
+  # outdated versions or ones that are no longer available.
   livecheck do
-    url "https://mediaarea.net/rss/mediainfo_updates.xml"
-    strategy :sparkle
+    url "https://mediaarea.net/en/MediaInfo/Download/Mac_OS"
+    regex(/href=.*?MediaInfo[._-]GUI[._-]v?(\d+(?:\.\d+)+)(?:[._-]Mac)?\.dmg/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `mediainfo` to the latest version on the [first-party download page](https://mediaarea.net/en/MediaInfo/Download/Mac_OS), 24.11. The latest version in the Sparkle feed is 24.10 but the files for that version are no longer available (see the directory listing page: https://mediaarea.net/download/binary/mediainfo-gui/).

With that in mind, this updates the `livecheck` block to check the first-party download page instead of the Sparkle feed. We typically prefer to align with any in-app updater but not if it contains outdated versions and/or the latest version isn't available anymore.