### PR TITLE
brave-browser@beta 1.74.1.0

### DIFF
--- a/Casks/b/brave-browser@beta.rb
+++ b/Casks/b/brave-browser@beta.rb
@@ -2,9 +2,14 @@ cask "brave-browser@beta" do
   arch arm: "arm64", intel: "x64"
   folder = on_arch_conditional arm: "beta-arm64", intel: "beta"
 
-  version "1.72.96.0"
-  sha256 arm:   "9832ad6024fa7b8fc694de5063d591dcdea07716762941856b6e52a699df5e0f",
-         intel: "508920b1bc2439d4d441566929d39d5572420474789ffa041c90e46bd55d92f4"
+  on_arm do
+    version "1.74.1.0"
+    sha256 "cc2a3dc85caabb71ad53f663c7f908c530b481640f1534ac9ca8be05541d85ba"
+  end
+  on_intel do
+    version "1.72.96.0"
+    sha256 "508920b1bc2439d4d441566929d39d5572420474789ffa041c90e46bd55d92f4"
+  end
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Browser-Beta-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The 1.74.1.0 version of `brave-browser@beta` only applies to the ARM build, so this splits the versions based on architecture until the versions align again.