### PR TITLE
ransomwhere: add rosetta caveat, mark no zap required

### DIFF
--- a/Casks/r/ransomwhere.rb
+++ b/Casks/r/ransomwhere.rb
@@ -19,4 +19,10 @@ cask "ransomwhere" do
     args:       ["-uninstall"],
     sudo:       true,
   }
+
+  # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Adds a `requires_rosetta` caveat as the application that is launched by the install script is from 2018 and is Intel only.

Additionally, mark as no zap required.