### PR TITLE
various: update 5 zaps

### DIFF
--- a/Casks/h/heroic.rb
+++ b/Casks/h/heroic.rb
@@ -18,6 +18,7 @@ cask "heroic" do
     "~/Library/Application Support/heroic",
     "~/Library/Logs/heroic",
     "~/Library/Preferences/com.electron.heroic.plist",
+    "~/Library/Preferences/com.heroicgameslauncher.hgl.plist",
     "~/Library/Saved Application State/com.electron.heroic.savedState",
   ]
 end

--- a/Casks/k/kdenlive.rb
+++ b/Casks/k/kdenlive.rb
@@ -25,5 +25,6 @@ cask "kdenlive" do
     "~/Library/Caches/kdenlive",
     "~/Library/Preferences/kdenlive-layoutsrc",
     "~/Library/Preferences/kdenliverc",
+    "~/Library/Preferences/org.kde.Kdenlive.plist",
   ]
 end

--- a/Casks/k/keepassxc.rb
+++ b/Casks/k/keepassxc.rb
@@ -30,6 +30,7 @@ cask "keepassxc" do
     "~/Library/Application Support/keepassxc",
     "~/Library/Caches/org.keepassx.keepassxc",
     "~/Library/Logs/DiagnosticReports/KeePassXC_*.crash",
+    "~/Library/Preferences/keepassxc.keepassxc.plist",
     "~/Library/Preferences/org.keepassx.keepassxc.plist",
     "~/Library/Saved Application State/org.keepassx.keepassxc.savedState",
   ]

--- a/Casks/u/unity-hub.rb
+++ b/Casks/u/unity-hub.rb
@@ -19,6 +19,7 @@ cask "unity-hub" do
   uninstall quit: "com.unity3d.unityhub"
 
   zap trash: [
+        "~/Library/Application Support/UnityHub",
         "~/Library/Preferences/com.unity3d.unityhub.helper.plist",
         "~/Library/Preferences/com.unity3d.unityhub.plist",
       ],

--- a/Casks/u/unity.rb
+++ b/Casks/u/unity.rb
@@ -40,7 +40,10 @@ cask "unity" do
     "~/Library/Application Support/Unity*",
     "~/Library/Caches/com.unity3d.UnityEditor",
     "~/Library/Logs/Unity",
+    "~/Library/Preferences/com.unity.BugReporterV2.plist",
+    "~/Library/Preferences/com.unity3d.UnityEditor5.x.plist",
     "~/Library/Preferences/com.unity3d.unityhub.plist",
+    "~/Library/Preferences/unity.DefaultCompany.*",
     "~/Library/Saved Application State/com.unity3d.unityhub.savedState",
     "~/Library/Unity",
   ]


### PR DESCRIPTION
Updated zaps for performing a more full uninstallation of a cask when using a `--zap` flag.

List:
- heroic,
- kdenlive,
- keepassxc,
- unity-hub,
- unity.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
