### PR TITLE
tableau-*: use livecheck reference

### DIFF
--- a/Casks/t/tableau-prep.rb
+++ b/Casks/t/tableau-prep.rb
@@ -13,10 +13,7 @@ cask "tableau-prep" do
   homepage "https://www.tableau.com/support/releases/prep"
 
   livecheck do
-    url "https://downloads.tableau.com/TableauAutoUpdate.xml"
-    strategy :xml do |xml|
-      xml.get_elements("//version").map { |item| item.attributes["releaseNotesVersion"] }
-    end
+    cask "tableau"
   end
 
   depends_on macos: ">= :el_capitan"

--- a/Casks/t/tableau-public.rb
+++ b/Casks/t/tableau-public.rb
@@ -12,10 +12,7 @@ cask "tableau-public" do
   homepage "https://public.tableau.com/s/"
 
   livecheck do
-    url "https://downloads.tableau.com/TableauAutoUpdate.xml"
-    strategy :xml do |xml|
-      xml.get_elements("//version").map { |item| item.attributes["releaseNotesVersion"] }
-    end
+    cask "tableau"
   end
 
   pkg "TableauPublic-#{version.dots_to_hyphens}#{arch}.pkg"

--- a/Casks/t/tableau-reader.rb
+++ b/Casks/t/tableau-reader.rb
@@ -12,10 +12,7 @@ cask "tableau-reader" do
   homepage "https://www.tableau.com/products/reader"
 
   livecheck do
-    url "https://downloads.tableau.com/TableauAutoUpdate.xml"
-    strategy :xml do |xml|
-      xml.get_elements("//version").map { |item| item.attributes["releaseNotesVersion"] }
-    end
+    cask "tableau"
   end
 
   pkg "TableauReader-#{version.dots_to_hyphens}#{arch}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The various Tableau casks all contain an identical `livecheck` block that checks an upstream `TableauAutoUpdate.xml` file. The XML file only contains file information for Tableau Desktop, so that would suggest that these apps all use the same version if the in-app updater for each checks the same file.

Since the XML file lists information for Tableau Desktop, there's enough of a parent-child relationship between the `tableau` cask and the various `tableau-*` casks for us to simply use `cask "tableau"` in their `livecheck` blocks (instead of having to duplicate the same `livecheck` block in each). This will make it so that we only have to update the `tableau` `livecheck` block in the future (which may happen sooner or later, with regard to https://github.com/Homebrew/homebrew-cask/pull/191077#pullrequestreview-2435977087).