### PR TITLE
servo: remove livecheck

### DIFF
--- a/Casks/s/servo.rb
+++ b/Casks/s/servo.rb
@@ -1,16 +1,11 @@
 cask "servo" do
-  version "0.0.1"
+  version :latest
   sha256 :no_check
 
   url "https://download.servo.org/nightly/mac/servo-latest.dmg"
   name "Servo"
   desc "Parallel browser engine"
   homepage "https://servo.org/"
-
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
 
   app "Servo.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes the `livecheck` and changes the version to `:latest` since the binary is updated daily without incrementing the version number.

Related to #171006.
