### PR TITLE
splitshow: deprecate

### DIFF
--- a/Casks/s/splitshow.rb
+++ b/Casks/s/splitshow.rb
@@ -7,14 +7,14 @@ cask "splitshow" do
   desc "Dual-head presentation of PDF slides"
   homepage "https://github.com/mpflanzer/splitshow"
 
-  # This cask uses an unstable version and this `livecheck` block is only used
-  # to prevent livecheck from skipping pre-release versions by default. This
-  # should be removed/updated if the cask is updated to a stable version.
-  livecheck do
-    url :url
-  end
+  deprecate! date: "2024-11-16", because: :unmaintained
 
   app "SplitShow.app"
+
+  zap trash: [
+    "~/Library/Preferences/eu.mpflanzer.SplitShow.plist",
+    "~/Library/Saved Application State/eu.mpflanzer.SplitShow.savedState",
+  ]
 
   caveats do
     requires_rosetta


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The application has never had a stable release with the latest being in early 2020, which itself was a re-release of a version from 2018.