### PR TITLE
amazon-workdocs / amazon-workdocs-drive: disable

### DIFF
--- a/Casks/a/amazon-workdocs-drive.rb
+++ b/Casks/a/amazon-workdocs-drive.rb
@@ -16,7 +16,7 @@ cask "amazon-workdocs-drive" do
   desc "Fully managed, secure enterprise storage and sharing service"
   homepage "https://aws.amazon.com/workdocs/"
 
-  deprecate! date: "2024-07-24", because: :discontinued
+  disable! date: "2025-04-25", because: :discontinued
 
   depends_on macos: ">= :el_capitan"
 

--- a/Casks/a/amazon-workdocs.rb
+++ b/Casks/a/amazon-workdocs.rb
@@ -8,13 +8,7 @@ cask "amazon-workdocs" do
   desc "Fully managed, secure content creation, storage, and collaboration service"
   homepage "https://aws.amazon.com/workdocs/"
 
-  livecheck do
-    url "https://d28gdqadgmua23.cloudfront.net/mac/appcast/appcast-workdocs-prod.xml"
-    regex(%r{/(\d+(?:\.\d+)+)/(\d+)/Amazon WorkDocs\.app\.zip}i)
-    strategy :sparkle do |item, regex|
-      item.url.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
-    end
-  end
+  disable! date: "2025-04-25", because: :discontinued
 
   app "Amazon WorkDocs.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Places future disable dates of 2025-04-25 on `amazon-workdocs` and `amazon-workdocs-drive` as the Amazon Workdocs service is expected to shut down and be unavailable on and after this date.

Article: https://docs.aws.amazon.com/workdocs/latest/userguide/companion.html#:~:text=Important,web%20client%20in%20one%20step.