### PR TITLE
beyond-compare@4 4.4.7.28397 (new cask)

### DIFF
--- a/Casks/b/beyond-compare@4.rb
+++ b/Casks/b/beyond-compare@4.rb
@@ -1,0 +1,37 @@
+cask "beyond-compare@4" do
+  version "4.4.7.28397"
+  sha256 "a9ba4cea125bbfe00fa3e79de39937197ae5d479d94710f5b93da5bda377a0ce"
+
+  url "https://www.scootersoftware.com/BCompareOSX-#{version}.zip"
+  name "Beyond Compare"
+  desc "Compare files and folders"
+  homepage "https://www.scootersoftware.com/"
+
+  livecheck do
+    url "https://www.scootersoftware.com/download/v4"
+    regex(/BCompareOSX[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
+  auto_updates true
+  conflicts_with cask: [
+    "beyond-compare",
+    "beyond-compare@beta",
+  ]
+
+  app "Beyond Compare.app"
+  binary "#{appdir}/Beyond Compare.app/Contents/MacOS/bcomp"
+
+  zap trash: [
+    "~/Library/Application Support/Beyond Compare*",
+    "~/Library/Caches/com.apple.helpd/Generated/Beyond Compare Help*",
+    "~/Library/Caches/com.apple.helpd/Generated/com.ScooterSoftware.BeyondCompare.help*",
+    "~/Library/Caches/com.ScooterSoftware.BeyondCompare",
+    "~/Library/Containers/com.ScooterSoftware.BeyondCompare.BCFinder",
+    "~/Library/Preferences/com.ScooterSoftware.BeyondCompare.plist",
+    "~/Library/Saved Application State/com.ScooterSoftware.BeyondCompare.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

This file is a copy of last year's version of this cask 
https://github.com/Homebrew/homebrew-cask/blob/304ba4bce8d3c460fba93df2e45e7f59ef1c88ab/Casks/b/beyond-compare.rb

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
