### PR TITLE
electricbinary: add zap, update java version requirements

### DIFF
--- a/Casks/e/electricbinary.rb
+++ b/Casks/e/electricbinary.rb
@@ -16,7 +16,12 @@ cask "electricbinary" do
 
   artifact "electricBinary-#{version}.jar", target: "#{appdir}/electricBinary-#{version}.jar"
 
+  zap trash: [
+    "~/electric.log",
+    "~/Library/Preferences/com.sun.electric.plist",
+  ]
+
   caveats do
-    depends_on_java
+    depends_on_java "8"
   end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Marks that the application jar requires Java 8, as it would not run in my sandbox environment on 11 or newer.

Also, adds zap for files found.