### PR TITLE
morkro-papyrus: add zap, conflicts_with

### DIFF
--- a/Casks/m/morkro-papyrus.rb
+++ b/Casks/m/morkro-papyrus.rb
@@ -7,7 +7,15 @@ cask "morkro-papyrus" do
   desc "Unofficial Dropbox Paper desktop app"
   homepage "https://github.com/morkro/papyrus"
 
+  conflicts_with cask: "papyrus"
+
   app "Papyrus.app"
+
+  zap trash: [
+    "~/Library/Application Support/Papyrus",
+    "~/Library/Preferences/com.electron.papyrus.plist",
+    "~/Library/Saved Application State/com.electron.papyrus.savedState",
+  ]
 
   caveats do
     requires_rosetta

--- a/Casks/p/papyrus.rb
+++ b/Casks/p/papyrus.rb
@@ -15,6 +15,8 @@ cask "papyrus" do
     end
   end
 
+  conflicts_with cask: "morkro-papyrus"
+
   app "Papyrus.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Adds a zap stanza, but also discovered this conflicts with the `papyrus` Cask because both install `Papyrus.app`.