### PR TITLE
powershell, powershell@preview: drop needless dependency openssl

### DIFF
--- a/Casks/p/powershell.rb
+++ b/Casks/p/powershell.rb
@@ -15,7 +15,6 @@ cask "powershell" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on formula: "openssl"
   depends_on macos: ">= :mojave"
 
   pkg "powershell-#{version}-osx-#{arch}.pkg"

--- a/Casks/p/powershell@preview.rb
+++ b/Casks/p/powershell@preview.rb
@@ -15,7 +15,6 @@ cask "powershell@preview" do
     regex(/^v?(\d+(?:\.\d+)+[_-](?:preview|rc)(?:\.\d+)?)$/i)
   end
 
-  depends_on formula: "openssl"
   depends_on macos: ">= :mojave"
 
   pkg "powershell-#{version}-osx-#{arch}.pkg"


### PR DESCRIPTION
Dependency openssl was introduced at the initial commit of powershell@preview. https://github.com/Homebrew/homebrew-cask/commit/b3e4f51cf74b5ac871a8753f5f95e80ec0bee809 https://github.com/Homebrew/homebrew-cask-versions/commit/c42b970e5784473fb2c5f2a1cb51a4288b95f94d

But it's just a build dependency of powershell, only required when building from source. https://github.com/PowerShell/PowerShell/blob/master/docs/building/macos.md

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
 ```
audit for powershell@preview: failed
 - v7.5.0-rc.1 is not a GitHub pre-release but 'powershell@preview' is in the GitHub prerelease allowlist.
powershell@preview
  * line 8, col 2: v7.5.0-rc.1 is not a GitHub pre-release but 'powershell@preview' is in the GitHub prerelease allowlist.
Error: 1 problem in 1 cask detected.
```
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
