### PR TITLE
tsh@13: disable, tsh: deprecate

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1120,7 +1120,6 @@ trilium-notes
 truhu
 trunk-io
 tsh
-tsh@13
 tuist
 tunnelbear
 tunnelblick@beta

--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1119,7 +1119,6 @@ trezor-suite
 trilium-notes
 truhu
 trunk-io
-tsh
 tuist
 tunnelbear
 tunnelblick@beta

--- a/Casks/t/tsh.rb
+++ b/Casks/t/tsh.rb
@@ -8,12 +8,12 @@ cask "tsh" do
   desc "SSH server for teams managing distributed infrastructure"
   homepage "https://goteleport.com/"
 
-  livecheck do
-    url "https://goteleport.com/download/"
-    regex(/tsh[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
-  end
+  deprecate! date: "2024-11-18", because: :unmaintained, replacement: "teleport"
 
-  conflicts_with cask:    "tsh@13",
+  conflicts_with cask:    [
+                   "teleport",
+                   "tsh@13",
+                 ],
                  formula: "teleport"
 
   pkg "tsh-#{version}.pkg"

--- a/Casks/t/tsh@13.rb
+++ b/Casks/t/tsh@13.rb
@@ -8,12 +8,12 @@ cask "tsh@13" do
   desc "SSH server for teams managing distributed infrastructure"
   homepage "https://goteleport.com/"
 
-  livecheck do
-    url "https://goteleport.com/download/"
-    regex(/tsh[._-]v?(13(?:\.\d+)+)\.pkg/i)
-  end
+  disable! date: "2024-11-18", because: :discontinued
 
-  conflicts_with cask:    "tsh",
+  conflicts_with cask:    [
+                   "teleport",
+                   "tsh",
+                 ],
                  formula: "teleport"
 
   pkg "tsh-#{version}.pkg"


### PR DESCRIPTION
download page only shows the version from 14 now, and so let's skip the livecheck for v13.

BTW, `tsh` is merged into `teleport` package from v17 and so there is no separate app now.
So maybe we have to deprecate `tsh`. But we didn't register `teleport` cask and only formula is added.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
