### PR TITLE
battlescribe: deprecate

### DIFF
--- a/Casks/b/battlescribe.rb
+++ b/Casks/b/battlescribe.rb
@@ -7,10 +7,7 @@ cask "battlescribe" do
   desc "Army list creator for tabletop wargamers"
   homepage "https://battlescribe.net/"
 
-  livecheck do
-    url "https://battlescribe.net/?tab=downloads"
-    regex(/"desktop"\s*:\s*"(\d+(?:\.\d+)+)"/i)
-  end
+  deprecate! date: "2024-11-16", because: :unmaintained
 
   pkg "BattleScribe_#{version}_Installer.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

From [r/BattleScribe](https://www.reddit.com/r/BattleScribe/):

> This sub is no longer active as the Battlescribe application is abandonware. The datafiles Battlescribe uses are still under active development by the community.
