### PR TITLE
gimp: fix trashed paths

### DIFF
--- a/Casks/g/gimp.rb
+++ b/Casks/g/gimp.rb
@@ -39,7 +39,7 @@ cask "gimp" do
 
   zap trash: [
     "~/Library/Application Support/Gimp",
-    "~/Library/Preferences/org.gimp.gimp-#{version.major_minor}:.plist",
-    "~/Library/Saved Application State/org.gimp.gimp-#{version.major_minor}:.savedState",
+    "~/Library/Preferences/org.gimp.gimp-#{version.major_minor}.plist",
+    "~/Library/Saved Application State/org.gimp.gimp-#{version.major_minor}.savedState",
   ]
 end


### PR DESCRIPTION
The actual paths don't have embedded colons:
```
% /bin/ls -ld Library/Preferences/*gimp* Library/Saved\ Application\ State/*gimp*
-rw-------@ 1 aho  staff  126 Nov 17 22:46 Library/Preferences/org.gimp.gimp-2.10.plist
drwx------@ 4 aho  staff  128 Nov 17 22:46 Library/Saved Application State/org.gimp.gimp-2.10.savedState
```

Addresses https://github.com/orgs/Homebrew/discussions/5740#discussioncomment-11283702.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
