### PR TITLE
brave-browser@nightly 1.75.18.0

### DIFF
--- a/Casks/b/brave-browser@nightly.rb
+++ b/Casks/b/brave-browser@nightly.rb
@@ -2,9 +2,14 @@ cask "brave-browser@nightly" do
   arch arm: "arm64", intel: "x64"
   folder = on_arch_conditional arm: "nightly-arm64", intel: "nightly"
 
-  version "1.75.15.0"
-  sha256 arm:   "95b554c0015fa09fe9ca81e5c71c2ba8403b21e906b734a20ee875a7c0d775e0",
-         intel: "7efd455bb70a004eec91c3798d87c7c0ff13876ad3b610a60480e4157eef16c5"
+  on_arm do
+    version "1.75.18.0"
+    sha256 "13b208e012876a1d5da07a7e33251bc625f7cfb6125a71cd06ef2eb0481f0dd3"
+  end
+  on_intel do
+    version "1.75.15.0"
+    sha256 "7efd455bb70a004eec91c3798d87c7c0ff13876ad3b610a60480e4157eef16c5"
+  end
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Browser-Nightly-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

As was the case with `brave-browser@beta` previously, the most recent ARM release for `brave-browser@nightly` is 1.75.18.0 but the newest Intel release is still 1.75.15.0, so we have to split this by architecture for now.