### PR TITLE
font-maple-mono-nf 6.4 (new cask)

### DIFF
--- a/Casks/font/font-m/font-maple-mono-nf.rb
+++ b/Casks/font/font-m/font-maple-mono-nf.rb
@@ -1,0 +1,25 @@
+cask "font-maple-mono-nf" do
+  # Check on next version bump if the `container` stanza can be removed
+  version "6.4"
+  sha256 "7f2fa17546190d6e6790c562ae1926cacded22459eccf0eb9693719d1325e165"
+
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMono-NF.zip"
+  name "Maple Mono NF"
+  homepage "https://github.com/subframe7536/Maple-font"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  container type: :tar
+
+  font "MapleMono-NF-Bold.ttf"
+  font "MapleMono-NF-BoldItalic.ttf"
+  font "MapleMono-NF-Italic.ttf"
+  font "MapleMono-NF-Light.ttf"
+  font "MapleMono-NF-LightItalic.ttf"
+  font "MapleMono-NF-Regular.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This font is not part of the Nerd Fonts repository because it provides its own patched version (see https://github.com/ryanoasis/nerd-fonts/pull/1456).
