### PR TITLE
bluebubbles: add arm arch

### DIFF
--- a/Casks/b/bluebubbles.rb
+++ b/Casks/b/bluebubbles.rb
@@ -1,8 +1,11 @@
 cask "bluebubbles" do
-  version "1.9.8"
-  sha256 "0a014c5ca614b492eec09d1da9756632fdd4d6c8a90bdbda6442401f0d967122"
+  arch arm: "-arm64"
 
-  url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}.dmg",
+  version "1.9.8"
+  sha256 arm:   "b2f997d9f09e5a0502cc605af798ba3af38c744d2050d1c53f534f99d3060bde",
+         intel: "0a014c5ca614b492eec09d1da9756632fdd4d6c8a90bdbda6442401f0d967122"
+
+  url "https://github.com/BlueBubblesApp/bluebubbles-server/releases/download/v#{version}/BlueBubbles-#{version}#{arch}.dmg",
       verified: "github.com/BlueBubblesApp/bluebubbles-server/"
   name "BlueBubbles"
   desc "Server for forwarding iMessages"
@@ -36,8 +39,4 @@ cask "bluebubbles" do
     "~/Library/Preferences/com.BlueBubbles.BlueBubbles-Server.plist",
     "~/Library/Saved Application State/com.BlueBubbles.BlueBubbles-Server.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`bluebubbles` upstream now publishes a separate ARM64 dmg file as of the latest GitHub release (1.9.8), so this updates the cask accordingly. This is a quick follow-up to https://github.com/Homebrew/homebrew-cask/pull/192692, as I just missed pushing this to that PR before it was merged.