### PR TITLE
wezterm@nightly: add shell completions

### DIFF
--- a/Casks/w/wezterm@nightly.rb
+++ b/Casks/w/wezterm@nightly.rb
@@ -11,7 +11,6 @@ cask "wezterm@nightly" do
   conflicts_with cask: "wezterm"
 
   app "WezTerm.app"
-
   %w[
     wezterm
     wezterm-gui
@@ -20,6 +19,13 @@ cask "wezterm@nightly" do
   ].each do |tool|
     binary "#{appdir}/WezTerm.app/Contents/MacOS/#{tool}"
   end
+
+  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh",
+         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_wezterm"
+  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash",
+         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/wezterm"
+  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish",
+         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/wezterm.fish"
 
   preflight do
     # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/166026 Added the shell completions for wezterm but missed wezterm@nightly

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
