### PR TITLE
shortwave 2024.11.03 (new cask)

### DIFF
--- a/Casks/s/shortwave.rb
+++ b/Casks/s/shortwave.rb
@@ -1,0 +1,36 @@
+cask "shortwave" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2024.11.03"
+  sha256  arm:   "7e4ddd6d1afdbc8f70b186c566ad290ecad549764ca58809d38b26f58a0a15f1",
+          intel: "3ee4fb74425a426ba1f207a3f3ed776ad2aee4d31263417df4d9e4bfa0bd50ac"
+
+  url "https://storage.googleapis.com/shortwave-downloads/desktop_app/darwin/#{arch}/Shortwave-darwin-#{arch}-#{version}.zip",
+      verified: "storage.googleapis.com/shortwave-downloads/"
+  name "Shortwave"
+  desc "Email client"
+  homepage "https://www.shortwave.com/"
+
+  livecheck do
+    url "https://storage.googleapis.com/shortwave-downloads/desktop_app/darwin/#{arch}/RELEASES.json"
+    strategy :json do |json|
+      json["currentRelease"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Shortwave.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.shortwave.sfl*",
+    "~/Library/Application Support/Shortwave",
+    "~/Library/Caches/com.electron.shortwave",
+    "~/Library/Caches/com.electron.shortwave.ShipIt",
+    "~/Library/HTTPStorages/com.electron.shortwave",
+    "~/Library/Logs/Shortwave",
+    "~/Library/Preferences/com.electron.shortwave.plist",
+    "~/Library/Saved Application State/com.electron.shortwave.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

I was surprised that there was nothing to add to `zap trash`. Here is what I did to verify:
- Inspected all paths created within 30 minutes of installing and using the app
- Search `~/Library` for 'Shortwave' (case insensitive)
- Check the obvious paths manually: `~/Library/Application Support`, `~/Library/Preferences`.