### PR TITLE
expo-orbit 2.0.0

### DIFF
--- a/Casks/e/expo-orbit.rb
+++ b/Casks/e/expo-orbit.rb
@@ -1,8 +1,8 @@
 cask "expo-orbit" do
-  version "1.2.1"
-  sha256 "5b17cf8e6f4ac2de581ba531ac33f3a7ba3ecba7e7c5de9dbe75554ed71c65e0"
+  version "2.0.0"
+  sha256 "cb634ff97e107501c33d91e27a407f2a0f5262347919e6d12a30b257e7d414bd"
 
-  url "https://github.com/expo/orbit/releases/download/expo-orbit-v#{version}/expo-orbit.v#{version}.zip"
+  url "https://github.com/expo/orbit/releases/download/expo-orbit-v#{version}/expo-orbit.v#{version}-macos.zip"
   name "Expo Orbit"
   desc "Launch builds and start simulators from your menu bar"
   homepage "https://github.com/expo/orbit/"


### PR DESCRIPTION
Bump expo-orbit version to 2.0.0 and update `url`

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
