### PR TITLE
openframeworks: update livecheck

### DIFF
--- a/Casks/o/openframeworks.rb
+++ b/Casks/o/openframeworks.rb
@@ -8,9 +8,13 @@ cask "openframeworks" do
   desc "C++ toolkit for creative coding"
   homepage "https://openframeworks.cc/"
 
+  # Sometimes the "latest" release on GitHub is a `latest` tag that doesn't
+  # correspond to a version. This checks the first-party download page, which
+  # links to the newest versioned macOS file from GitHub, as this is lighter
+  # than using the `GithubReleases` strategy to check multiple recent releases.
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://openframeworks.cc/download/"
+    regex(/href=.*?of[._-]v?(\d+(?:\.\d+)+)[._-]osx[._-]release\.zip/i)
   end
 
   suite "of_v#{version}_osx_release"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The "latest" release on GitHub for `openframeworks` is a `latest` tag, which doesn't correspond to a version. We could check all recent releases using the `GithubReleases` strategy but this updates the `livecheck` block to check the first-party download page instead, as it links to the newest file for macOS on GitHub and requires less data transfer.