### PR TITLE
gama, gama-jdk: revert to 1.9.3

### DIFF
--- a/Casks/g/gama-jdk.rb
+++ b/Casks/g/gama-jdk.rb
@@ -1,9 +1,9 @@
 cask "gama-jdk" do
   arch arm: "_M1"
 
-  version "2024.10.0"
-  sha256 arm:   "71ebb0a59acbae57c49e8d450e439985e5174ffa3ce11bebd48f806831b84b41",
-         intel: "2b0f887dd78d353210fc121941b544a1d8859b89c5eaca7bc6e7dc1b1dc6b84d"
+  version "1.9.3"
+  sha256 arm:   "f26215c0069e9e633db327a6ca70d478316ef5ca564409fc262d94ce27380f13",
+         intel: "0c4daee9770693367a5d075e92c91dc036ead25029408c318361d55bf96bdf93"
 
   url "https://github.com/gama-platform/gama/releases/download/#{version}/GAMA_#{version}_MacOS#{arch}_with_JDK.dmg",
       verified: "github.com/gama-platform/gama/"

--- a/Casks/g/gama.rb
+++ b/Casks/g/gama.rb
@@ -1,9 +1,9 @@
 cask "gama" do
   arch arm: "_M1"
 
-  version "2024.10.0"
-  sha256 arm:   "c2b98db3f7807ae290dec3b18c55b30236f846743db8117556c45f9870212986",
-         intel: "84ec21450153a6296851e987a58a8f147e17729980eaf5ec32f5bca64e2c40de"
+  version "1.9.3"
+  sha256 arm:   "51051555e5eed50bf92bb5b6957ed1f39fec5a9080e0038b9109ed3d2fe68f08",
+         intel: "c29918550d6054374bdb657633db5c795ae07e047a1adab72bfe81f14c671d7f"
 
   url "https://github.com/gama-platform/gama/releases/download/#{version}/GAMA_#{version}_MacOS#{arch}.dmg",
       verified: "github.com/gama-platform/gama/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The "latest" release on GitHub for `gama`/`gama-jdk` is 1.9.3 and this is also the version on the [first-party download page](https://gama-platform.org/download). The 2024.10.0 release that the casks are currently using has been deleted and the only other release is 2024.11.0, which is described as an alpha version and is marked as "pre-release".

With that in mind, this downgrades the casks to 1.9.3. For what it's worth, the checksums have changed since the casks were previously updated to 1.9.3 on 2024-02-16 (127f43fd, 52e5051e).