### PR TITLE
mixed-in-key-live 11.0.1.550

### DIFF
--- a/Casks/m/mixed-in-key-live.rb
+++ b/Casks/m/mixed-in-key-live.rb
@@ -1,5 +1,5 @@
 cask "mixed-in-key-live" do
-  version "9676-494"
+  version "11.0.1.550"
   sha256 :no_check
 
   url "https://builds.mixedinkey.com/download/55/release/latest?key=public"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I'm not sure what happened with the one-off `9676-494` version for `mixed-in-key-live` but it looks like upstream is back to normal versions again.