### PR TITLE
vcam 2.0.250

### DIFF
--- a/Casks/v/vcam.rb
+++ b/Casks/v/vcam.rb
@@ -1,29 +1,29 @@
 cask "vcam" do
-  version "2.0.202"
-  sha256 "eede3b77ca5abce23cbd201313a03e7d1be40a58b7879ed7ab1f95611b63ba9a"
+  version "2.0.250"
+  sha256 "008a40957a243a4247f28adf2f5ce2c518c35908bb00f669a6598919ba13d7c8"
 
-  url "https://downloads.vcam.ai/mac/VCam.ai_#{version}.pkg"
-  name "VCam.ai"
+  url "https://installers.vcam.ai/VCam_#{version}.pkg"
+  name "VCam"
   desc "Webcam background tool"
   homepage "https://vcam.ai/"
 
   livecheck do
-    url "https://downloads.vcam.ai/mac/updates.txt"
-    regex(/v?(\d+(?:\.\d+)+)/i)
+    url "https://go.vcam.ai/download-mac"
+    strategy :header_match
   end
 
   depends_on macos: ">= :catalina"
 
-  pkg "VCam.ai_#{version}.pkg"
+  pkg "VCam_#{version}.pkg"
 
   postflight do
     # Description: Ensure console variant of postinstall is non-interactive.
-    # This is because `open /Applications/VCam.ai/VCam.app` is called from the
+    # This is because `open /Applications/VCam/VCam.app` is called from the
     # postinstall script of the package and we don't want any user intervention there.
     retries ||= 3
-    ohai "The VCam.ai package postinstall script launches the VCam app" if retries >= 3
+    ohai "The VCam package postinstall script launches the VCam app" if retries >= 3
     ohai "Attempting to close VCam.app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/VCam.ai/VCam.app"]
+    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/VCam/VCam.app"]
   rescue RuntimeError
     sleep 1
     retry unless (retries -= 1).zero?
@@ -36,7 +36,7 @@ cask "vcam" do
               "electron-app",
               "vcam.ai-uninstall",
             ],
-            delete:  "/Applications/VCam.ai"
+            delete:  "/Applications/VCam"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/ai.vcam.desktop.sfl*",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The domain/path in the `url` for `vcam` has changed between the existing version and now, so this brings it up to date for the latest version. Upstream now requires users to create an account to access the download URL but thankfully it was only necessary to do this once, as the generic download URL redirects to the newest [versioned] pkg file.

I've updated the `livecheck` block to check the download URL using the `HeaderMatch` strategy, as this redirects to the cask `url`. The `updates.txt` file references the newest version but it only contains `ProductVersion = 2.0.250`, so it's arguably less useful.