### PR TITLE
swiftcord: disable

### DIFF
--- a/Casks/s/swiftcord.rb
+++ b/Casks/s/swiftcord.rb
@@ -7,6 +7,9 @@ cask "swiftcord" do
   desc "Native Discord client built in Swift"
   homepage "https://github.com/SwiftcordApp/Swiftcord"
 
+  # https://github.com/SwiftcordApp/Swiftcord/discussions/189
+  disable! date: "2024-11-23", because: :unmaintained
+
   depends_on macos: ">= :monterey"
 
   app "Swiftcord.app"


### PR DESCRIPTION
This app has been unmaintained for several months now; the developer intends to release a newly-written replacement in the near future under a different name (see discussion in https://github.com/SwiftcordApp/Swiftcord/discussions/189).

As for this version, macOS Sequoia thinks it's malware:

<img width="260" alt="Screenshot 2024-11-23 at 11 09 33" src="https://github.com/user-attachments/assets/574544ae-b948-4a47-9c82-53f1f238216b">

***

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
