### PR TITLE
fujitsu-scansnap-home : set  auto_updates true

### DIFF
--- a/Casks/f/fujitsu-scansnap-home.rb
+++ b/Casks/f/fujitsu-scansnap-home.rb
@@ -15,7 +15,7 @@ cask "fujitsu-scansnap-home" do
       page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
-  
+
   auto_updates true
   depends_on macos: ">= :sierra"
   container nested: "Download/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"

--- a/Casks/f/fujitsu-scansnap-home.rb
+++ b/Casks/f/fujitsu-scansnap-home.rb
@@ -15,7 +15,8 @@ cask "fujitsu-scansnap-home" do
       page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
-
+  
+  auto_updates true
   depends_on macos: ">= :sierra"
   container nested: "Download/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"
 


### PR DESCRIPTION
Fujitsu ScanSnapp Home does handle auto updates. This PR adds the missing `auto_updates true` setting.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: Not applicable

