### PR TITLE
wezterm: remove preflight block

### DIFF
--- a/Casks/w/wezterm.rb
+++ b/Casks/w/wezterm.rb
@@ -18,7 +18,7 @@ cask "wezterm" do
 
   conflicts_with cask: "wezterm@nightly"
 
-  app "WezTerm.app"
+  app "WezTerm-macos-#{version.csv.first}-#{version.csv.second}/WezTerm.app"
   %w[
     wezterm
     wezterm-gui
@@ -28,21 +28,12 @@ cask "wezterm" do
     binary "#{appdir}/WezTerm.app/Contents/MacOS/#{tool}"
   end
 
-  binary "WezTerm.app/Contents/Resources/shell-completion/zsh",
+  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh",
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_wezterm"
-  binary "WezTerm.app/Contents/Resources/shell-completion/bash",
+  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash",
          target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/wezterm"
-  binary "WezTerm.app/Contents/Resources/shell-completion/fish",
+  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/wezterm.fish"
-
-  preflight do
-    # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder
-    staged_subfolder = staged_path.glob(["WezTerm-*", "wezterm-*"]).first
-    if staged_subfolder
-      FileUtils.mv(staged_subfolder/"WezTerm.app", staged_path)
-      FileUtils.rm_r(staged_subfolder)
-    end
-  end
 
   zap trash: "~/Library/Saved Application State/com.github.wez.wezterm.savedState"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes the need for the `preflight` block, as it is not run before the audit and therefore causes it to fail.
