### PR TITLE
font-cica-without-emoji 5.0.3 (new cask)

### DIFF
--- a/Casks/font/font-c/font-cica-without-emoji.rb
+++ b/Casks/font/font-c/font-cica-without-emoji.rb
@@ -1,0 +1,15 @@
+cask "font-cica-without-emoji" do
+  version "5.0.3"
+  sha256 "e14c95c8c3e98d3778632f577a2cafa69ee82cd8c2efdb1f38c821e37c487dbf"
+
+  url "https://github.com/miiton/Cica/releases/download/v#{version}/Cica_v#{version}_without_emoji.zip"
+  name "Cica without emoji"
+  homepage "https://github.com/miiton/Cica"
+
+  font "Cica-Bold.ttf"
+  font "Cica-BoldItalic.ttf"
+  font "Cica-Regular.ttf"
+  font "Cica-RegularItalic.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

[The font "Cica" is already available in homebrew-cask](https://github.com/Homebrew/homebrew-cask/blob/4df1fa05e48cc35f6b32de0088555be40a12a991/Casks/font/font-c/font-cica.rb), but there is no version without emojis.
Since I needed the Cica font without emojis, I created a Cask for it.

---

Please note that `brew audit --new-cask <cask>` fails with the following error:

```
audit for font-cica-without-emoji: failed
 - GitHub fork (not canonical repository)
font-cica-without-emoji
  * line 5, col 2: GitHub fork (not canonical repository)
Error: 1 problem in 1 cask detected.
```

The Cica font is a fork of the Ricty font; as stated in the README of the Cica repository, I see no problem.

---

Thank you.