### PR TITLE
yaak: update repo url and sha

### DIFF
--- a/Casks/y/yaak.rb
+++ b/Casks/y/yaak.rb
@@ -2,11 +2,11 @@ cask "yaak" do
   arch arm: "aarch64", intel: "x64"
 
   version "2024.12.1"
-  sha256 arm:   "0a7c7ea0a55734096f597d925a4b44ab233fe5b748e86eb18f5e4781603b44a6",
-         intel: "428b800825ddb74cd9a6fdebf7dafcf155df168fddf6bbe6cf209230cc8fa2ef"
+  sha256 arm:   "f268976584beee63fdf343a80ecd00d6beba56d1e3933fde067f6cf7640fceb5",
+         intel: "72f67494f1db8af4cd6f97858f10b77cea2f2ecca98666b458677d13580c7c0e"
 
-  url "https://github.com/yaakapp/app/releases/download/v#{version}/Yaak_#{version}_#{arch}.dmg",
-      verified: "github.com/yaakapp/app/"
+  url "https://github.com/mountain-loop/yaak/releases/download/v#{version}/Yaak_#{version}_#{arch}.dmg",
+      verified: "github.com/mountain-loop/yaak/"
   name "Yaak"
   desc "REST, GraphQL and gRPC client"
   homepage "https://yaak.app/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

I don't understand why, but `brew audit --cask --online yaak` returns `Error: Cask 'yaak' is unavailable: No Cask with this name exists.`
- [ ] `brew style --fix <cask>` reports no offenses.
---

Hey, 
I'm trying to install [Yaak](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/y/yaak.rb), and I have a sha issue.
```diff
- 0a7c7ea0a55734096f597d925a4b44ab233fe5b748e86eb18f5e4781603b44a6
+ f268976584beee63fdf343a80ecd00d6beba56d1e3933fde067f6cf7640fceb5
```

Alsp, the repo url in the formula is obsolete, as is the sha for the intel version. (I've directly downloaded the packages and did : 
```sh
$ shasum -a 256 Yaak_2024.12.1_x64.dmg                                                                                                                               
72f67494f1db8af4cd6f97858f10b77cea2f2ecca98666b458677d13580c7c0e  Yaak_2024.12.1_x64.dmg

$ shasum -a 256 Yaak_2024.12.1_aarch64.dmg
f268976584beee63fdf343a80ecd00d6beba56d1e3933fde067f6cf7640fceb5  Yaak_2024.12.1_aarch64.dmg
```
)

Thank you for your help,
Mathieu.
