### PR TITLE
devpod: Correct v0.6.2 SHA256

### DIFF
--- a/Casks/d/devpod.rb
+++ b/Casks/d/devpod.rb
@@ -2,8 +2,8 @@ cask "devpod" do
   arch arm: "aarch64", intel: "x64"
 
   version "0.6.2"
-  sha256 arm:   "8767805e89594e6e5ae55081dca485a7b1b24e144617faf06ecb714d647c31db",
-         intel: "25f99e8130f5f541d0cc105487869c4b69a046e41af90f7f258ad75f707752ac"
+  sha256 arm:   "dbcf3e5661a1e71679643fc85066f0cf50a8ddc255a666f03da5184ab73b508f",
+         intel: "87326e8f7bf91eed6e8ebcd8fb2ef87bfec8fc7b5ac17d58658bfaa256c0002a"
 
   url "https://github.com/loft-sh/devpod/releases/download/v#{version}/DevPod_macos_#{arch}.dmg",
       verified: "github.com/loft-sh/devpod/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The SHA256 checksum for the latest devpod version is incorrect.
```
❯ brew install --cask devpod
==> Downloading https://github.com/loft-sh/devpod/releases/download/v0.6.2/DevPod_macos_aarch64.dmg
Already downloaded: /Users/[redacted]/Library/Caches/Homebrew/downloads/0a10ca75d65a57add64315bd7c154f0dba346a56eeb7cb8b7bcac3b834733791--DevPod_macos_aarch64.dmg
Error: SHA256 mismatch
Expected: 8767805e89594e6e5ae55081dca485a7b1b24e144617faf06ecb714d647c31db
  Actual: dbcf3e5661a1e71679643fc85066f0cf50a8ddc255a666f03da5184ab73b508f
```

Validated new values via:
```
> curl -OL https://github.com/loft-sh/devpod/releases/download/v0.6.2/DevPod_macos_aarch64.dmg
> shasum -a 256 DevPod_macos_aarch64.dmg
dbcf3e5661a1e71679643fc85066f0cf50a8ddc255a666f03da5184ab73b508f  DevPod_macos_aarch64.dmg

> curl -OL https://github.com/loft-sh/devpod/releases/download/v0.6.2/DevPod_macos_x64.dmg
> shasum -a 256 DevPod_macos_x64.dmg
87326e8f7bf91eed6e8ebcd8fb2ef87bfec8fc7b5ac17d58658bfaa256c0002a  DevPod_macos_x64.dmg
```
