### PR TITLE
aerial@beta: update livecheck

### DIFF
--- a/Casks/a/aerial@beta.rb
+++ b/Casks/a/aerial@beta.rb
@@ -8,9 +8,21 @@ cask "aerial@beta" do
   desc "Apple TV Aerial screensaver"
   homepage "https://aerialscreensaver.github.io/"
 
+  # Beta releases are marked as pre-release, so we have to use the
+  # `GithubReleases` strategy to check all recent releases.
   livecheck do
-    url "https://github.com/JohnCoates/Aerial/releases?q=prerelease%3Atrue&expanded=true"
-    regex(/^v?(\d+(?:\.\d+)*beta\d+)$/i)
+    url :url
+    regex(/^v?(\d+(?:\.\d+)*(?:[._-]?beta\d+)?)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   conflicts_with cask: "aerial"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `aerial@beta` checks the releases page, searching for only pre-release releases and matching beta versions. This is an older `livecheck` block that hasn't been updated to use `GithubReleases`, so this updates it accordingly.

This also makes the beta suffix optional, so this will surface stable versions in addition to beta versions, like some other casks for unstable versions. Users can't have both the `aerial` and `aerial@beta` casks installed (since they conflict), so this ensures that users don't get stuck on an older unstable version when a newer stable version is available.