### PR TITLE
inso*: update livecheck

### DIFF
--- a/Casks/i/inso.rb
+++ b/Casks/i/inso.rb
@@ -8,12 +8,10 @@ cask "inso" do
   desc "CLI HTTP and GraphQL Client"
   homepage "https://insomnia.rest/products/inso"
 
-  # Upstream previously used a date-based version scheme (e.g., `2023.5.8`)
-  # before switching to a typical `8.1.0` format. The date-based versions are
-  # numerically higher, so we have to avoid matching them.
   livecheck do
     url :url
-    regex(/^core@v?(\d{1,3}(?:\.\d+)+)$/i)
+    regex(/^core@v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   conflicts_with cask: "inso@beta"

--- a/Casks/i/inso@beta.rb
+++ b/Casks/i/inso@beta.rb
@@ -9,9 +9,18 @@ cask "inso@beta" do
   homepage "https://insomnia.rest/products/inso"
 
   livecheck do
-    url "https://github.com/Kong/insomnia/releases?q=prerelease%3Atrue+Inso+CLI"
-    regex(%r{href=["']?[^"' >]*?/tag/core%40([^"' >]+?)["' >]}i)
-    strategy :page_match
+    url :url
+    regex(/^core@v?(\d+(?:\.\d+)+(?:[._-](?:beta|rc)[._-]?\d*)?)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   conflicts_with cask: "inso"

--- a/Casks/i/insomnia.rb
+++ b/Casks/i/insomnia.rb
@@ -8,12 +8,10 @@ cask "insomnia" do
   desc "HTTP and GraphQL Client"
   homepage "https://insomnia.rest/"
 
-  # Upstream previously used a date-based version scheme (e.g., `2023.5.8`)
-  # before switching to a typical `8.1.0` format. The date-based versions are
-  # numerically higher, so we have to avoid matching them.
   livecheck do
     url :url
-    regex(/^core@v?(\d{1,3}(?:\.\d+)+)$/i)
+    regex(/^core@v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   auto_updates true

--- a/Casks/i/insomnia@alpha.rb
+++ b/Casks/i/insomnia@alpha.rb
@@ -10,7 +10,7 @@ cask "insomnia@alpha" do
 
   livecheck do
     url :url
-    regex(/^core@v?(\d+(?:\.\d+)+[._-](?:alpha|beta|rc)[._-]?\d*)$/i)
+    regex(/^core@v?(\d+(?:\.\d+)+(?:[._-](?:alpha|beta|rc)[._-]?\d*)?)$/i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next if release["draft"]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the various `insomnia`/`inso` casks to normalize them on checking GitHub releases (as there appears to be a slight gap between when a version is tagged and the release is created) and to update the unstable variants to also use stable releases. Users can't have the stable and unstable casks installed at the same time (due to conflicts), so the latter ensures that users don't get stuck on an older unstable version if a newer stable version is available.

For what it's worth, the original goal here was to update `inso@beta` to use `GithubReleases` (instead of checking the releases page) and it grew from there.

I'm running this as syntax-only because there are version updates, so this will fail CI otherwise. These casks are in the autobump list, so they will be updated sometime after this is merged.