### PR TITLE
mongodb-compass@beta: update livecheck

### DIFF
--- a/Casks/m/mongodb-compass@beta.rb
+++ b/Casks/m/mongodb-compass@beta.rb
@@ -11,9 +11,16 @@ cask "mongodb-compass@beta" do
   homepage "https://www.mongodb.com/try/download/compass"
 
   livecheck do
-    url "https://github.com/mongodb-js/compass/releases?q=prerelease%3Atrue&expanded=true"
-    regex(%r{href=["']?[^"' >]*?/tag/\D*?(\d+(?:\.\d+)+-beta\.\d)[^"' >]*?["' >]}i)
-    strategy :page_match
+    url "https://info-mongodb-com.s3.amazonaws.com/com-download-center/compass.json"
+    regex(/^v?(\d+(?:\.\d+)+[._-]beta[._-]\d+)$/i)
+    strategy :json do |json, regex|
+      json["versions"]&.map do |item|
+        match = item["_id"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `mongdb-compass@beta` checks the GitHub releases page, searching for only pre-release releases and matching beta versions. This is an older `livecheck` block that hasn't been updated to use `GithubReleases` but checking GitHub releases doesn't align with the cask `url` source, which uses an asset from downloads.mongodb.com. This updates the `livecheck` block to check the `compass.json` file that's checked in the other `mongodb-compass` casks, bringing it in line with the others.

For what it's worth, I didn't update this to also use stable versions because `mongodb-compass` and `mongodb-compass@beta` don't conflict (the apps have unique names), so it's possible to have both installed at the same time.