### PR TITLE
tuist: deprecate

### DIFF
--- a/Casks/t/tuist.rb
+++ b/Casks/t/tuist.rb
@@ -8,6 +8,8 @@ cask "tuist" do
   desc "Create, maintain, and interact with Xcode projects at scale"
   homepage "https://tuist.io/"
 
+  deprecate! date: "2025-05-28", because: :discontinued
+
   binary "tuist"
 
   zap trash: "~/.tuist"

--- a/Casks/t/tuist.rb
+++ b/Casks/t/tuist.rb
@@ -1,16 +1,14 @@
-cask "tuist" do
-  version "4.36.0"
-  sha256 "6e6f177982396555c518214aa4506c03d6b3c3e01bf4962c8d688dc137b4a6f3"
+cask "tuist@0.8.1" do
+  version "0.8.1"
+  sha256 "4e121a0fa1803a9837cbfce740bedbd03531815df69ebd69dc92d555ab6b22f2"
 
-  url "https://github.com/tuist/tuist/releases/download/#{version}/tuist.zip",
-      verified: "github.com/tuist/tuist/"
+  url "https://github.com/tuist/tuist/releases/download/app@0.8.1/Tuist.dmg"
   name "Tuist"
-  desc "Create, maintain, and interact with Xcode projects at scale"
-  homepage "https://tuist.io/"
+  desc "Tuist macOS app"
+  homepage "https://github.com/tuist/tuist"
 
-  deprecate! date: "2025-05-28", because: :discontinued
+  auto_updates true
+  conflicts_with formula: "tuist"
 
-  binary "tuist"
-
-  zap trash: "~/.tuist"
+  app "Tuist.app"
 end


### PR DESCRIPTION
We've already tried to remove this cask in the past: https://github.com/Homebrew/homebrew-cask/pull/180746

It causes issues for us as maintainers of Tuist. The cask was _not_ added by a maintainer of Tuist and the maintainers have not approved of that: https://github.com/Homebrew/homebrew-cask/pull/145456. Additionally, as reasoned [here](https://github.com/Homebrew/homebrew-cask/pull/145456#issuecomment-1516949744), we don't think the cask should have been approved by the Homebrew team in the first place – even when not considering maintainers' (dis)approval

We much prefer to maintain our formulae and casks in our own repository: https://github.com/tuist/homebrew-tuist

Additionally, we added a cask for our new [macOS app](https://github.com/tuist/homebrew-tuist/tree/main/Casks) while this cask points to a CLI.

That means the only way for our users to download _our official_ macOS cask, they have to run `brew install --cask tuist/tuist/tuist` – that is use the fully qualified name, instead of just running `brew tap tuist/tuist && brew install --cask tuist`.

We'd very much like to go forward with a deprecation period followed up with the removal of this cask.

If this is not an option, we'd need to change this cask to instead download our app, not the CLI. That, however, feels like a breaking change as `brew install tuist` will suddenly download something completely different.

Our clear preference is for removal of this cask, but if there is no other way, would the Homebrew team accept this cask to be changed to download an app binary instead of a CLI?

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
