### PR TITLE
wiso-steuer-2025: update livecheck, use versioned url

### DIFF
--- a/Casks/w/wiso-steuer-2025.rb
+++ b/Casks/w/wiso-steuer-2025.rb
@@ -1,16 +1,23 @@
 cask "wiso-steuer-2025" do
   # NOTE: "2025" is not a version number, but an intrinsic part of the product name
-  version "32.01.1970"
-  sha256 :no_check
+  version "32.01.1970-RC2"
+  sha256 "01c32e3696e4b73480de94103852b6e31c74f59b0ffee6511154b2c02f05adad"
 
-  url "https://download.buhl.de/ESD/Steuer/2025/WISOSteuer2025.dmg"
+  url "https://update.buhl-data.com/Updates/Steuer/2025/Mac/Files/#{version}/SteuerMac2025-#{version.split("-").first}.dmg",
+      verified: "update.buhl-data.com/Updates/Steuer/"
   name "WISO Steuer 2025"
   desc "Tax declaration for the fiscal year 2024"
   homepage "https://www.buhl.de/download/wiso-steuer-2025/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://update.buhl-data.com/Updates/Steuer/2025/Mac/Aktuell/appcast-steuer.xml"
+    regex(%r{/v?(\d+(?:\.\d+)+[^/]*)/SteuerMac2025[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR aligns the `livecheck` and `url` stanzas with the other `wiso-steuer-*` casks, as the update feed is now available.

Follow-up to #193552.
