### PR TITLE
binary-ninja: rename to binary-ninja-free

### DIFF
--- a/Casks/b/binary-ninja-free.rb
+++ b/Casks/b/binary-ninja-free.rb
@@ -1,4 +1,4 @@
-cask "binary-ninja" do
+cask "binary-ninja-free" do
   version "4.2.6455"
   sha256 :no_check
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -5,6 +5,7 @@
   "ankiapp-anki": "ankiapp",
   "autodesk-fusion360": "autodesk-fusion",
   "betterdummy": "betterdisplay",
+  "binary-ninja": "binary-ninja-free",
   "clinq": "sipgate-clinq",
   "cloudapp": "zight",
   "codewhisperer": "amazon-q",


### PR DESCRIPTION
This is a free version that cannot be upgraded directly to the paid version. See https://github.com/orgs/Homebrew/discussions/5771.