### PR TITLE
eloston-chromium 131.0.6778.85-1.1 (ARM only)

### DIFF
--- a/Casks/e/eloston-chromium.rb
+++ b/Casks/e/eloston-chromium.rb
@@ -1,26 +1,54 @@
 cask "eloston-chromium" do
   arch arm: "arm64", intel: "x86-64"
 
-  version "130.0.6723.116-1.1"
-  sha256 arm:   "cfeffa806393c72184bd503631bfc4fb525ca19d0578a5c9ee8c1edcc448d04f",
+  sha256 arm:   "b84e27affc40ce2999c1990b231552e4f9c45f6f09f5255879127e99d3a4aebd",
          intel: "08a6d509a51c6056a5775e9ed9d4ba2233378d8fa532bcc917a6371dae017e5c"
+
+  on_arm do
+    version "131.0.6778.85-1.1"
+
+    livecheck do
+      url :url
+      regex(/^v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?$/i)
+      strategy :github_latest do |json, regex|
+        match = json["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+  on_intel do
+    version "130.0.6723.116-1.1"
+
+    # Upstream isn't able to provide Intel builds for the time being, so we
+    # have to use the `GithubReleases` strategy to check recent releases and
+    # identify the latest version with an Intel release asset.
+    # TODO: Switch back to one `GithubLatest` `livecheck` block when upstream
+    # reliably publishes Intel builds again.
+    livecheck do
+      url :url
+      regex(/ungoogled[._-]chromium[._-]v?(\d+(?:[.-]\d+)+)[._-]#{arch}[._-]macos\.dmg/i)
+      strategy :github_releases do |json, regex|
+        json.map do |release|
+          next if release["draft"] || release["prerelease"]
+
+          release["assets"]&.map do |asset|
+            match = asset["name"]&.match(regex)
+            next if match.blank?
+
+            match[1]
+          end
+        end.flatten
+      end
+    end
+  end
 
   url "https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/download/#{version}/ungoogled-chromium_#{version}_#{arch}-macos.dmg",
       verified: "github.com/ungoogled-software/ungoogled-chromium-macos/"
   name "Ungoogled Chromium"
   desc "Google Chromium, sans integration with Google"
   homepage "https://ungoogled-software.github.io/"
-
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:[.-]\d+)+)(?:[._-]#{arch})?(?:[._-]+?(\d+(?:\.\d+)*))?$/i)
-    strategy :github_latest do |json, regex|
-      match = json["tag_name"]&.match(regex)
-      next if match.blank?
-
-      match[1]
-    end
-  end
 
   conflicts_with cask: [
     "chromium",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/131.0.6778.85-1.1

```
As the Chromium project updated their macOS SDK used to macOS 15 SDK, and GitHub Action doesn't provide any up-to-date Intel macOS runner hosts, we are unable to provide Intel (x86_64) builds of Ungoogled-Chromium macOS for the time being.
We are looking for a solution to restore the Intel (x86_64) builds in the future, and we will provide updates on the progress to the community.
```