### PR TITLE
font-poppins-latin: add livecheck

### DIFF
--- a/Casks/font/font-p/font-poppins-latin.rb
+++ b/Casks/font/font-p/font-poppins-latin.rb
@@ -6,6 +6,12 @@ cask "font-poppins-latin" do
   name "PoppinsLatin"
   homepage "https://github.com/itfoundry/poppins"
 
+  livecheck do
+    url "https://github.com/itfoundry/Poppins/tree/master/products"
+    regex(/href=.*?PoppinsLatin[._-]v?(\d+(?:\.\d+)+)(?:[._-]Latin)?[._-]OTF\.zip/i)
+    strategy :page_match
+  end
+
   font "PoppinsLatin-Black.otf"
   font "PoppinsLatin-BlackItalic.otf"
   font "PoppinsLatin-Bold.otf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `font-poppins-latin` but it returns 4.003 instead of 5.001, as there is no 5.001 tag. The cask zip file is found in the `products` directory of the repository and the 5.001 version comes from the filename.

This adds a `livecheck` block that checks the `products` directory page and matches versions from the related zip file links.