### PR TITLE
konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver livecheck fix

### DIFF
--- a/Casks/k/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/k/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -18,7 +18,7 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
       strategy :json do |json|
         items = json.select do |i|
           i["TypeOfApplicationName_textS"]&.match?(/driver/i) &&
-            i["OperatingSystemsNames_textM"]&.grep(/macOS.*?#{Regexp.escape(MacOS.version.to_s)}/i)&.any?
+            i["OperatingSystemsNames_textM"]&.any? { |item| item =~ /macOS/i }
         end
 
         item = items.max_by { |i| i["ReleaseDate_textS"] }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I noticed that livecheck returns wrong (outdated) version, so I "borrowed" proper livecheck regex from konica-minolta-bizhub-c750i-driver
