### PR TITLE
caido: update livecheck

### DIFF
--- a/Casks/c/caido.rb
+++ b/Casks/c/caido.rb
@@ -12,7 +12,10 @@ cask "caido" do
   homepage "https://caido.io/"
 
   livecheck do
-    url "https://github.com/caido/caido/"
+    url "https://api.caido.io/releases/latest"
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `caido` only contains a URL for the GitHub repository, so it checks the repository's Git tags. However, the cask `url` is a first-party asset from caido.download, so the check doesn't closely align with the cask `url` source. [The GitHub release descriptions contain links to the caido.download files but this `livecheck` block simply checks the Git tags.]

The existing check technically works but we can update it to better align with the cask `url` source. The first-party download page has buttons to download the desktop app and this triggers an API request that returns JSON information about the latest release. This updates the `livecheck` block to check that URL and use the `version` field from the JSON response.