### PR TITLE
tableau 2024.3.1 and update livecheck strategy

### DIFF
--- a/Casks/t/tableau.rb
+++ b/Casks/t/tableau.rb
@@ -1,9 +1,9 @@
 cask "tableau" do
   arch arm: "-arm64"
 
-  version "2024.2.4"
-  sha256 arm:   "f2524f6db177bbc4ef639f519c98e4e59fcde8f7aa84aa2ff77e5062228121d0",
-         intel: "f496583c475601f9a9f0993b2fa7f53d6f9f502efa7ce6d5ba8498076cb606e3"
+  version "2024.3.1"
+  sha256 arm:   "cf6a00486ae06716f41cf1552425fea296ab227ed3cbd38febaa09b9c563b528",
+         intel: "f98a2631784242eccd68e4a41707d9b0d3aaee6ec9b40dea9847bb724f5d34d4"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauDesktop-#{version.dots_to_hyphens}#{arch}.dmg",
       user_agent: "curl/8.7.1"
@@ -12,9 +12,10 @@ cask "tableau" do
   homepage "https://www.tableau.com/products/desktop"
 
   livecheck do
-    url "https://downloads.tableau.com/TableauAutoUpdate.xml"
-    strategy :xml do |xml|
-      xml.get_elements("//version").map { |item| item.attributes["releaseNotesVersion"] }
+    url "https://www.tableau.com/app/discover/desktop"
+    strategy :page_match do |page|
+      match = page.match(/<section[^>]+data-version-before=["'](\d+\.\d+\.\d+)["']/i)
+      match[1] if match
     end
   end
 


### PR DESCRIPTION
change: 
- updated tableau 2024.3.1 released on November 21, 2024
- modified livecheck strategy url to https://www.tableau.com/app/discover/desktop

---
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online tableau` is error-free.
- [ ] `brew style --fix tableau` reports no offenses.
---