### PR TITLE
iText RUPS 7.2.5 (new cask)

### DIFF
--- a/Casks/i/itext-rups.rb
+++ b/Casks/i/itext-rups.rb
@@ -14,15 +14,13 @@ cask "itext-rups" do
 
   container type: :zip
 
-  # Create the wrapper script in the binary directory
-  wrapper_script = "#{staged_path}/itext-rups.wrapper.sh"
-  binary wrapper_script, target: "itext-rups"
+  # shim script (https://github.com/caskroom/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/itext-rups.wrapper.sh"
+  binary shimscript, target: "itext-rups"
 
   preflight do
     jar_path = "#{staged_path}/itext-rups-#{version}.jar"
-
-    # Write the wrapper script before the binary stanza executes
-    File.write(wrapper_script, <<~EOS)
+    File.write shimscript, <<~EOS
       #!/bin/bash
       exec java -jar "#{jar_path}" "$@"
     EOS

--- a/Casks/i/itext-rups.rb
+++ b/Casks/i/itext-rups.rb
@@ -1,0 +1,40 @@
+cask "itext-rups" do
+  version "7.2.5"
+  sha256 "509e81cbe629b331a80e9344a11fe573e6e4e065c4319c1532ac175da9af5dec"
+
+  url "https://github.com/itext/i7j-rups/releases/download/#{version}/iText7-RUPS-#{version}-only-jars.zip"
+  name "iText RUPS"
+  desc "GUI app for inspecting PDF internals"
+  homepage "https://github.com/itext/i7j-rups"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  container type: :zip
+
+  # Create the wrapper script in the binary directory
+  wrapper_script = "#{staged_path}/itext-rups.wrapper.sh"
+  binary wrapper_script, target: "itext-rups"
+
+  preflight do
+    jar_path = "#{staged_path}/itext-rups-#{version}.jar"
+
+    # Write the wrapper script before the binary stanza executes
+    File.write(wrapper_script, <<~EOS)
+      #!/bin/bash
+      exec java -jar "#{jar_path}" "$@"
+    EOS
+  end
+
+  zap trash: "~/Library/Preferences/com.itextpdf.rups.plist"
+
+  caveats do
+    depends_on_java "11+"
+  end
+  caveats <<~EOS
+    To launch iText RUPS, run:
+      itext-rups [<target>.pdf]
+  EOS
+end


### PR DESCRIPTION
iText RUPS -- A GUI for viewing structural contents of a PDF file.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This is a java GUI application to examine PDFs. Audit succeeds with command `brew audit --cask --new --no-signing itext-rups`, but with signing checked, I get a failure regarding the wrapper script I generate in the cask:

```
audit for itext-rups: failed
 - Signature verification failed:
/private/tmp/cask-audit20241201-98220-pro4ld/itext-rups.wrapper.sh: No such file or directory

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
itext-rups
  * line 5, col 2: Signature verification failed:
    /private/tmp/cask-audit20241201-98220-pro4ld/itext-rups.wrapper.sh: No such file or directory
    
    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 1 problem in 1 cask detected.
```

I could do with suggestions on how to fix this.