### PR TITLE
Stats v2.11.19 change SHA

### DIFF
--- a/Casks/s/stats.rb
+++ b/Casks/s/stats.rb
@@ -9,7 +9,7 @@ cask "stats" do
   end
   on_catalina :or_newer do
     version "2.11.19"
-    sha256 "9a8725e38bbe23e48e8b1b66608b902854b4b28b7b7271c49c74aeb507c614af"
+    sha256 "689f5bf3f99666660f6d2f44afab0ca0c0084bb1b40283d3ffb827131ed2b06c"
   end
 
   url "https://github.com/exelban/stats/releases/download/v#{version}/Stats.dmg"


### PR DESCRIPTION
The file download have a another SHA

==> Upgrading stats
==> Downloading https://github.com/exelban/stats/releases/download/v2.11.19/Stats.dmg ==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/189285554/ ==> Purging files for version 2.11.19 of Cask stats Error: stats: SHA256 mismatch
Expected: 9a8725e38bbe23e48e8b1b66608b902854b4b28b7b7271c49c74aeb507c614af
  Actual: 689f5bf3f99666660f6d2f44afab0ca0c0084bb1b40283d3ffb827131ed2b06c

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
