### PR TITLE
tableau-prep, tableau-reader 2024.3.1

### DIFF
--- a/Casks/t/tableau-prep.rb
+++ b/Casks/t/tableau-prep.rb
@@ -1,16 +1,16 @@
 cask "tableau-prep" do
   arch arm: "-arm64"
 
-  version "2024.2.4"
-  sha256 arm:   "772e04be0dd5de5a9751f8b43679c6b5d6eba00370e612809ed9135bed78c0e0",
-         intel: "3241d380df93f4baea889ceb44908f5862bd5bb3037a31d1a2d147f545934a5b"
+  version "2024.3.1"
+  sha256 arm:   "11ffbbddaeae8333eee2bf33895c5b1fc2e682cc9a6d4586a4b037cfa4f1d756",
+         intel: "edc225647b0f69bb627a8589ea93b3adba68bccecc2945ed56d624fc5efe2270"
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}#{arch}.dmg",
       user_agent: "curl/8.7.1"
   name "Tableau Prep"
   name "Tableau Prep Builder"
   desc "Combine, shape, and clean your data for analysis"
-  homepage "https://www.tableau.com/support/releases/prep"
+  homepage "https://www.tableau.com/products/prep"
 
   livecheck do
     cask "tableau"

--- a/Casks/t/tableau-reader.rb
+++ b/Casks/t/tableau-reader.rb
@@ -1,9 +1,9 @@
 cask "tableau-reader" do
   arch arm: "-arm64"
 
-  version "2024.2.3"
-  sha256 arm:   "3c205a94a82db6481be75395bd406d0a7109b1d16b853acbbb1958038a607d4f",
-         intel: "19bf1425bb3cfb048b97834affa501a59a0525e0fb78bd280e8ad747229e33c6"
+  version "2024.3.1"
+  sha256 arm:   "b6d64af76a9773851c0cfcb055c595de82308400862b7045dbd2d939f4b9bc67",
+         intel: "4f98d27f522177038a1601bb7d7a08ec76f41f9112b8010bb136298538bc506b"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauReader-#{version.dots_to_hyphens}#{arch}.pkg",
       user_agent: "curl/8.7.1"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the `tableau-prep` and `tableau-reader` casks to 2024.3.1, as is being done for `tableau` in https://github.com/Homebrew/homebrew-cask/pull/193816 and `tableau-public` in https://github.com/Homebrew/homebrew-cask/pull/191077.

I've applied the `ci-skip-livecheck` label, as this will fail CI otherwise. At the moment, it would fail because the `tableau` `livecheck` block is checking an XML file that only returns 2024.2.4 as the latest version (instead of 2024.3.1). If/when #193816 is merged, the updated `livecheck` block will return the correct latest version locally but will fail on CI, so we will have to continue skipping livecheck for the various Tableau casks unless/until upstream reliably updates the XML file and we can return to checking that (which doesn't fail on CI).

Like the aforementioned `livecheck` block changes, the homepage for `tableau-prep` uses a www.tableau.com/support/ page, so it will also encounter a 403 (Forbidden) response on CI. This updates the `homepage` to the product page, which shouldn't fail on CI and aligns with the `homepage` URLs for `tableau` and `tableau-reader`.