### PR TITLE
gqrx: variable baselines

### DIFF
--- a/Casks/g/gqrx.rb
+++ b/Casks/g/gqrx.rb
@@ -5,13 +5,18 @@ cask "gqrx" do
   sha256 arm:   "4f907f27d1eccdb9747ff6a349494eac90946900d87ee53f5bc9f6841f295f48",
          intel: "88c22615b1b75d159b8900dd0c0921bc019d78197ff9da11be36c75b460ab764"
 
+  on_arm do
+    depends_on macos: ">= :sonoma"
+  end
+  on_intel do
+    depends_on macos: ">= :ventura"
+  end
+
   url "https://github.com/gqrx-sdr/gqrx/releases/download/v#{version}/Gqrx-#{version}-#{arch}.dmg",
       verified: "github.com/gqrx-sdr/gqrx/"
   name "Gqrx"
   desc "Software-defined radio receiver powered by GNU Radio and Qt"
   homepage "https://www.gqrx.dk/"
-
-  depends_on macos: ">= :ventura"
 
   app "Gqrx.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
- originally updated in https://github.com/Homebrew/homebrew-cask/pull/193771
- however, there are two OS baselines by architecture: https://github.com/gqrx-sdr/gqrx/pull/1388
- ~added livecheck, tested with `brew livecheck --debug  --resources gqrx`~