### PR TITLE
steinberg-download-assistant 1.36.4,b373-64e7403f-c9c1-47cf-9540-521692d2a7a5 (new cask)

### DIFF
--- a/Casks/s/steinberg-download-assistant.rb
+++ b/Casks/s/steinberg-download-assistant.rb
@@ -1,0 +1,39 @@
+cask "steinberg-download-assistant" do
+  version "1.36.4,b373-64e7403f-c9c1-47cf-9540-521692d2a7a5"
+  sha256 "515e8151b0f9232d6c4efff1aba3b67d46fe0b19e2e744699cd639452fb8a7a3"
+
+  url "https://download.steinberg.net/automated_updates/sda-selfupdate/releases/absolute-downloader-#{version.csv.first}-#{version.csv.second}/mac/Steinberg_Download_Assistant_#{version.csv.first}_Installer_mac.dmg"
+  name "Steinberg Download Assistant"
+  desc "Tool to download files for Steinberg products"
+  homepage "https://o.steinberg.net/en/support/content_and_accessories/steinberg_download_assistant.html"
+
+  livecheck do
+    url "https://www.steinberg.net/sda-mac"
+    regex(%r{/absolute-downloader-v?(\d+(?:\.\d+)+)-([^/]+)/}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
+    end
+  end
+
+  depends_on macos: ">= :sierra"
+
+  installer manual: "Steinberg Download Assistant Setup.app"
+
+  uninstall launchctl: [
+              "application.net.steinberg.elicenser.SteinbergDownloadAssistant*",
+              "com.steinberg.SilentInstallHelper",
+            ],
+            quit:      "net.steinberg.elicenser.SteinbergDownloadAssistant",
+            pkgutil:   "com.steinberg.SteinbergInstallAssistant",
+            delete:    "/Application/Steinberg Download Assistant"
+
+  zap trash: [
+    "~/Library/Application Support/Steinberg/Download Assistant",
+    "~/Library/Logs/Steinberg/Download Assistant",
+    "~/Library/Saved Application State/net.steinberg.eLicenser.installer.SteinbergDownloadAssistant.savedState",
+    "~/Library/Saved Application State/net.steinberg.elicenser.SteinbergDownloadAssistant.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
