### PR TITLE
follow@nightly 0.2.5-nightly.20241203

### DIFF
--- a/Casks/f/follow@nightly.rb
+++ b/Casks/f/follow@nightly.rb
@@ -1,11 +1,11 @@
 cask "follow@nightly" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.2.4-nightly.20241124"
-  sha256 arm:   "33f337103f3734927374452c9a0bd45ad4f85be94aa4766a0e1c67b0be17f68e",
-         intel: "0731b4d51de3506b372b7f920ee2fbb5e07b677e633fc25dd49dfb1442448350"
+  version "0.2.5-nightly.20241203"
+  sha256 arm:   "09fe4f1c35e33d4225dfd1dd751688f75250ab8afa87315834b0a737050f5d8c",
+         intel: "d7316a15bdf3fe7b0927bf551529189650ba8e9a355598adefbe99906a5c87b4"
 
-  url "https://github.com/RSSNext/Follow/releases/download/nightly-#{version}/Follow-#{version}-macos-#{arch}.dmg",
+  url "https://github.com/RSSNext/Follow/releases/download/#{version}/Follow-#{version}-macos-#{arch}.dmg",
       verified: "github.com/RSSNext/Follow/"
   name "Follow Nightly"
   desc "Information browser"
@@ -13,7 +13,7 @@ cask "follow@nightly" do
 
   livecheck do
     url :url
-    regex(/^nightly[._-]v?(\d+(?:\.\d+)+(?:[._-]nightly[._-]?\d+)?)$/i)
+    regex(/^(?:nightly[._-])?v?(\d+(?:\.\d+)+(?:[._-]nightly[._-]?\d+)?)$/i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream has switched from a nightly tag format with a `nightly-` prefix (e.g., `nightly-0.2.2-nightly.20241120`) to a tag format without the prefix (e.g., 0.2.5-nightly.20241203). The existing `livecheck` block only matches tags with the `nightly-` prefix, so it's incorrectly reporting 0.2.2-nightly.20241120 as the newest version. Besides the version update, this updates the `livecheck` block regex to make the `nightly-` prefix optional, so it will match both the old and new nightly tag format.