### PR TITLE
netnewswire 6.1.6

### DIFF
--- a/Casks/n/netnewswire.rb
+++ b/Casks/n/netnewswire.rb
@@ -1,17 +1,27 @@
 cask "netnewswire" do
-  version "6.1.5"
-  sha256 "f7686c5521296baeb5aa179b792779971b7c32d209467ed86722a532cd2f95ed"
+  on_monterey :or_older do
+    version "6.1.4"
+    sha256 "74d75b9e25c6adef06dbf01cd060771872769357448879809535f77493840bbb"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_ventura :or_newer do
+    version "6.1.6"
+    sha256 "7e261dd4ca5262a792c308f258f34a89c87c5756f8484ddbd00c7c58c0b6d0da"
+
+    livecheck do
+      url :url
+      regex(/^mac[._-]v?(\d+(?:\.\d+)+)$/i)
+    end
+  end
 
   url "https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-#{version}/NetNewsWire#{version}.zip",
       verified: "github.com/Ranchero-Software/NetNewsWire/"
   name "NetNewsWire"
   desc "Free and open-source RSS reader"
   homepage "https://netnewswire.com/"
-
-  livecheck do
-    url :url
-    regex(/^mac[._-]v?(\d+(?:\.\d+)+)$/i)
-  end
 
   auto_updates true
   conflicts_with cask: "netnewswire@beta"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

- Update to version 6.1.6 for Ventura and newer
- Include version check for Monterey or older

The changelog does not mention that between the version bump from `6.1.4` to `6.1.5`[^1], the minimum requirement for `NetNewsWire` was bumped from Catalina to Ventura.

There is a closed issue[^2] with more information.

@brentsimmons 

[^1]: [Release NetNewsWire 6.1.5 for Mac · Ranchero-Software/NetNewsWire · GitHub](https://github.com/Ranchero-Software/NetNewsWire/releases/tag/mac-6.1.5)
[^2]: [Support MacOS 12, Monterey · Issue #4417 · Ranchero-Software/NetNewsWire · GitHub](https://github.com/Ranchero-Software/NetNewsWire/issues/4417)
