### PR TITLE
Mark `clickup` as `auto_update`-able

### DIFF
--- a/Casks/c/clickup.rb
+++ b/Casks/c/clickup.rb
@@ -26,6 +26,7 @@ cask "clickup" do
     end
   end
 
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "ClickUp.app"


### PR DESCRIPTION
![CleanShot 2024-12-06 at 08 20 34@2x](https://github.com/user-attachments/assets/b2170b19-9bac-459d-8fdb-74dccb28d6d7)

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

```
$ brew audit --cask --online clickup
Error: These casks are not in any locally installed taps!

  clickup

You may need to run `brew tap` to install additional taps.

$ brew info clickup
==> clickup: 3.5.64,2412032pphuew2k
https://clickup.com/
Installed    <-------------------------------
/opt/homebrew/Caskroom/clickup/3.5.61,2411271wsxc410e (359.7MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/c/clickup.rb
==> Name
ClickUp
==> Description
Productivity platform for tasks, docs, goals, and chat
==> Artifacts
ClickUp.app (App)
==> Analytics
install: 164 (30 days), 468 (90 days), 1,856 (365 days)
```

I'm not sure what's up with `brew audit`…

- [x] `brew style --fix <cask>` reports no offenses.

```
$ brew style --fix clickup

0 files inspected, no offenses detected
```

Technically, yes ✅, but "0 files inspected" does not inspire confidence…

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
