### PR TITLE
feat: add TypeSwitch.app v0.1.0

### DIFF
--- a/Casks/t/typeswitch.rb
+++ b/Casks/t/typeswitch.rb
@@ -1,0 +1,19 @@
+cask "typeswitch" do
+  version "0.1.0"
+  sha256 "5b138f7d30b095dbd389a9b24e79bba4d4be584898cc45c9ca140ff4fc30462f"
+
+  url "https://github.com/ygsgdbd/TypeSwitch/releases/download/v#{version}/TypeSwitch.dmg"
+  name "TypeSwitch"
+  desc "Automatic input method switcher for different applications"
+  homepage "https://github.com/ygsgdbd/TypeSwitch"
+
+  depends_on macos: ">= :ventura"
+
+  app "TypeSwitch.app"
+
+  zap trash: [
+    "~/Library/Application Support/TypeSwitch",
+    "~/Library/Caches/top.ygsgdbd.TypeSwitch",
+    "~/Library/Preferences/top.ygsgdbd.TypeSwitch.plist",
+  ]
+end


### PR DESCRIPTION
Add TypeSwitch.app v0.1.0

- [x] Checked all [cask audit rules](https://docs.brew.sh/Acceptable-Casks)
- [x] Tested installation (`brew install --cask typeswitch`)
- [x] Tested uninstallation (`brew uninstall --cask typeswitch`)
- [x] Tested launching app after installation

TypeSwitch is an automatic input method switcher that remembers and switches input methods based on the active application.

Features:
- Automatic input method switching based on active application
- Menu bar interface for easy access
- Supports all input methods available on the system