### PR TITLE
nvidia-nsight-compute 2025.1.0.14-35237751 (new cask)

### DIFF
--- a/Casks/n/nvidia-nsight-compute.rb
+++ b/Casks/n/nvidia-nsight-compute.rb
@@ -1,0 +1,35 @@
+cask "nvidia-nsight-compute" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "2025.1.0.14-35237751"
+  sha256 arm:   "0ac91ae97a9f4ffb96842280e3822fdc394cdcbf834b0acf16e7fab58abe2fd5",
+         intel: "6cfc100a8d03c6fffed25ce6b9c30ac162af7bf4a23a30169bb08d7958eb9c54"
+
+  url "https://developer.nvidia.com/downloads/assets/tools/secure/nsight-compute/#{version.major_minor_patch.dots_to_underscores}/nsight-compute-mac-#{arch}-#{version}.dmg"
+  name "NVIDIA Nsight Compute"
+  desc "Interactive profiler for CUDA and NVIDIA OptiX"
+  homepage "https://developer.nvidia.com/nsight-compute"
+
+  livecheck do
+    url "https://developer.nvidia.com/tools-downloads.json"
+    regex(/nsight[._-]compute[._-]mac[._-]#{arch}[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+    strategy :json do |json, regex|
+      json["downloads"]&.map do |download|
+        next unless download["development_platform"]&.include?("osx")
+
+        download["files"]&.map do |file|
+          match = file["url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end&.flatten
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "NVIDIA Nsight Compute.app"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Help needed: We need to skip the first match since NVIDIA requires login for the latest version. How do I skip the newest match, return the second match for livecheck? I've tried something like `end&.flatten.drop(1)`, but it did not go as I think. Any help will be appreciated.