### PR TITLE
screen-studio 2.26.0-3019

### DIFF
--- a/Casks/s/screen-studio.rb
+++ b/Casks/s/screen-studio.rb
@@ -1,11 +1,11 @@
 cask "screen-studio" do
   arch arm: "-arm64"
 
-  version "2.25.33"
-  sha256 arm:   "e5c5b73a7a7e3d3ca297a23e21f66820b3d234891ff40802715110ac1d45aae7",
-         intel: "41f3990c634f764d6fe37afba25b8da0e75152d04adb4746e49c29c90a4df28e"
+  version "2.26.0-3019"
+  sha256 arm:   "56a6d1601906a0b356d030f5207712b4b811931d16b09792bc433a2790ef4462",
+         intel: "de05524ad1c6cfa90f58b5fdcaacb4e8207b6a576f32992ebcbb72fac5249039"
 
-  url "https://screenstudioassets.com/Screen%20Studio-#{version}#{arch}-mac.zip",
+  url "https://screenstudioassets.com/releases/#{version}/Screen%20Studio-#{version}#{arch}-mac.zip",
       verified: "screenstudioassets.com/"
   name "Screen Studio"
   desc "Screen recorder and editor"
@@ -19,7 +19,7 @@ cask "screen-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :big_sur"
 
   app "Screen Studio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The cask `url` appears to have changed with this version (as seen in the response from the `livecheck` URL), so autobump failed this time around. This updates the `url`, so we can successfully update to the latest version, 2.26.0-3019.