### PR TITLE
workflows/ci: enable merge queue/group jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       casks:


### PR DESCRIPTION
This should allow us to make use of the GitHub merge queue to ensure that we're not merging outdated code (or breaking `master`) but avoiding the need to continually merge into/rebase PR branches.

This should be safe to merge as-is as is essentially a no-op without the merge queue enabled.