### PR TITLE
supremo 4.11.3.2751 (new cask)

### DIFF
--- a/Casks/s/supremo.rb
+++ b/Casks/s/supremo.rb
@@ -1,0 +1,29 @@
+cask "supremo" do
+  version "4.11.3.2751"
+  sha256 "c4f5b409cfa458714d96ea193ffa9ce95983157d8ad7c820e2c6eca4b6fd2162"
+
+  url "https://www.nanosystems.com/AutoUpdateS/macOS/stable/Supremo_#{version}.dmg",
+      verified: "nanosystems.com/"
+  name "Supremo"
+  desc "Remote desktop software"
+  homepage "https://www.supremocontrol.com/"
+
+  livecheck do
+    url "https://www.nanosystems.com/AutoUpdateS/macOS/stable/SupremoCast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sierra"
+
+  app "Supremo.app"
+
+  zap trash: [
+    "~/Library/Application Support/SupremoRemoteDesktop",
+    "~/Library/Preferences/Supremo.plist",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
    New cask for remote desktop control app Supremo

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
