### PR TITLE
moradownloader: update livecheck, zap and version

### DIFF
--- a/Casks/m/moradownloader.rb
+++ b/Casks/m/moradownloader.rb
@@ -1,5 +1,5 @@
 cask "moradownloader" do
-  version "2.0.0.6"
+  version "2.0.0.7"
   sha256 :no_check
 
   url "https://downloader.mora.jp/mac/MoraDownloader.pkg"

--- a/Casks/m/moradownloader.rb
+++ b/Casks/m/moradownloader.rb
@@ -8,15 +8,13 @@ cask "moradownloader" do
   homepage "https://mora.jp/"
 
   livecheck do
-    url "https://mora.jp/contents/data/system/noticeTouch.json"
-    regex(/Mac.*?v?\.?(\d+(?:\.\d+)+)/i)
+    url "https://downloader.mora.jp/mac/moradownloader.json"
+    regex(/(\d+(?:\.\d+)+)/i)
     strategy :json do |json, regex|
-      json["noticelist"]&.map do |notice|
-        match = notice["context"]&.match(regex)
-        next if match.blank?
+      match = json.dig("versionInfo", "latestVersionName")&.match(regex)
+      next if match.blank?
 
-        match[1]
-      end
+      match[1]
     end
   end
 
@@ -26,6 +24,8 @@ cask "moradownloader" do
 
   zap trash: [
     "~/Library/Application Support/moraDownloader",
+    "~/Library/Caches/jp.co.sonymusicsolutions.moradownloader",
+    "~/Library/HTTPStorages/jp.co.sonymusicsolutions.moradownloader",
     "~/Library/Preferences/jp.co.sonymusicsolutions.moradownloader.plist",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Current livecheck is not always accurate since it refers to an announcement page, so I have edited it to browse the internal endpoint that the app is requesting at startup. (BTW, I noticed later that you can obtain the version from the web page as well: https://mora.jp/pcdownloaderInstall)