### PR TITLE
kkbox 24.12.1

### DIFF
--- a/Casks/k/kkbox.rb
+++ b/Casks/k/kkbox.rb
@@ -1,8 +1,8 @@
 cask "kkbox" do
-  version "24.11.1"
-  sha256 "7ac243924ea7b2a81df0061ac8cda305673484f18c5618c062cf5f045ef548dd"
+  version "24.12.1"
+  sha256 "b14bc940f43a9255fabd3cfb243cc38e5c014c7b04f2aa3bfe1bc14f6cd6b030"
 
-  url "https://dl-universal-v2.kfs.io/KKBOX-#{version}.dmg",
+  url "https://dl-universal-v2.kfs.io/KKBOX-#{version}-universal.dmg",
       verified: "dl-universal-v2.kfs.io/"
   name "KKBOX"
   desc "Music streaming service"
@@ -13,7 +13,7 @@ cask "kkbox" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "KKBOX.app"
 
@@ -32,8 +32,4 @@ cask "kkbox" do
     "~/Library/Preferences/com.kkbox.KKBOX.plist",
     "~/Library/Saved Application State/com.kkbox.electron-app.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kkbox` is in the autobump list but the 24.12.1 version update has been failing because the filename now includes a `-universal` suffix. This updates the cask accordingly for this new version.