### PR TITLE
vsee 4.23.1

### DIFF
--- a/Casks/v/vsee.rb
+++ b/Casks/v/vsee.rb
@@ -1,6 +1,6 @@
 cask "vsee" do
-  version "4.23.0,51546"
-  sha256 "0ae552c45cdba0e317bca3fbe0fcf645098788d66be85ec7b4b64894dcf62218"
+  version "4.23.1,51571"
+  sha256 "343fdb149ec5e4acc5607d2059b9ba765a9c85ed55c8888cc8d494365f77d36b"
 
   url "https://d2q5hugz2rti4w.cloudfront.net/mac/#{version.csv.second}/vseemac.dmg",
       verified: "d2q5hugz2rti4w.cloudfront.net/mac/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vsee` is in the autobump list but livecheck encountered an error in the most recent autobump run, so this manually updates the cask to 4.23.1. If it continues to reliably fail on CI, we should remove `vsee` from the autobump list.