### PR TITLE
kdiff: fix sha256 hashes

### DIFF
--- a/Casks/k/kdiff3.rb
+++ b/Casks/k/kdiff3.rb
@@ -4,11 +4,11 @@ cask "kdiff3" do
 
   on_arm do
     version "1.12.0"
-    sha256 "e1abaf0fa973420e2261d5d368b04f1d2366376fc4d0292db39fa885ef8e66ef"
+    sha256 "88629976cd52ecded01afe35c2ad16375565033009df256097cb92cd76f94cb4"
   end
   on_intel do
     version "1.12.0"
-    sha256 "a813f787f205b7bb5fa8ebd8cc83f8a9d598d0da8812bc3eed77fd98c8da5edb"
+    sha256 "ef82fd651c4f23f29bad66682dc65f2a729bb8b12f41e160cdac9468c8e1f677"
   end
 
   url "https://download.kde.org/stable/kdiff3/kdiff3-#{version}-macos-#{arch}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The hashes in the kdiff3 seem to be wrong. I changed those to the ones from the KDE site:
https://download.kde.org/stable/kdiff3/kdiff3-1.12.0-macos-x86_64.dmg.mirrorlist
https://download.kde.org/stable/kdiff3/kdiff3-1.12.0-macos-arm64.dmg.mirrorlist