### PR TITLE
opal-composer 2.0.0

### DIFF
--- a/Casks/o/opal-composer.rb
+++ b/Casks/o/opal-composer.rb
@@ -1,6 +1,6 @@
 cask "opal-composer" do
-  version "1.4.4,22"
-  sha256 "9bfbcacfd68c853abdc1d8ebabc14402168f7f0412b8a71ad1ea8de2ca2cb880"
+  version "2.0.0,24"
+  sha256 "4eaa1225a203b057dbabaa7b17d7bbff91512cac32e942359b651dbef06928b3"
 
   url "https://updates.opal.camera/release/Opal_Composer_#{version.csv.first}_#{version.csv.second}.dmg",
       verified: "updates.opal.camera/release/"
@@ -8,9 +8,15 @@ cask "opal-composer" do
   desc "Professional webcam software for the Opal C1"
   homepage "https://opalcamera.com/opal-composer"
 
+  # The Sparkle `shortVersion` may not include the full version used in the
+  # filename (e.g. 2.0 instead of 2.0.0), so we match the version from the
+  # filename instead.
   livecheck do
     url "https://updates.opal.camera/release/appcast.xml"
-    strategy :sparkle
+    regex(/v?(\d+(?:[._]\d+)+)/i)
+    strategy :sparkle do |item, regex|
+      item.url[regex, 1]&.tr("_", ",")
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The newest version of `opal-composer` uses a 2.0 `shortVersion` in the Sparkle feed but the filename uses a 2.0.0 version. This adds a `strategy` block to the `livecheck` block that matches the version from the filename in the `url` field. This will likely only be an issue for major version releases but this accounts for the mismatch.

`opal-composer` is in the autobump list but the version update was failing because of the version mismatch, so this should get it back on track.