### PR TITLE
vscodium 1.96.0.24347

### DIFF
--- a/Casks/v/vscodium.rb
+++ b/Casks/v/vscodium.rb
@@ -1,38 +1,22 @@
 cask "vscodium" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.95.3.24321"
-  sha256 arm:   "9f595394c745339a8ed95b984f5728e78f6e543d2a244b821b250dad6fdd0d3b",
-         intel: "23cc8291acdadc6fcc84ad662ee28f31694e3198f08481e61604c3cdd3689612"
+  version "1.96.0.24347"
+  sha256 arm:   "a4b2038cb75c7cbcff3ab177fcb6ec695d166adca6376e953de8d5b04cffd7d7",
+         intel: "b6c0ad1c0c0bfd2d4655a91033c7e5a11c444bf8695ff763661b12b9306d7a77"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{arch}.#{version}.dmg"
   name "VSCodium"
   desc "Binary releases of VS Code without MS branding/telemetry/licensing"
   homepage "https://github.com/VSCodium/vscodium"
 
-  # Not every GitHub release provides a file for macOS, so we check multiple
-  # recent releases instead of only the "latest" release. NOTE: We should be
-  # able to use `strategy :github_latest` when subsequent releases provide
-  # files for macOS again.
   livecheck do
     url :url
-    regex(/^VScodium[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.(?:dmg|pkg)$/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        release["assets"]&.map do |asset|
-          match = asset["name"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end.flatten
-    end
+    strategy :github_latest
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "VSCodium.app"
   binary "#{appdir}/VSCodium.app/Contents/Resources/app/bin/codium"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `vscodium` cask is on the autobump list but there haven't been version bump PRs for newer versions because of a technical issue. This updates the cask to the latest version, 1.96.0.24347.

This also updates the `livecheck` block to use the `GithubLatest` strategy, as the upstream issue has been resolved and `GithubReleases` isn't necessary now. This may fix the issue with related autobump issue that we've been experiencing.