### PR TITLE
adobe-dng-converter 17.1

### DIFF
--- a/Casks/a/adobe-dng-converter.rb
+++ b/Casks/a/adobe-dng-converter.rb
@@ -1,6 +1,6 @@
 cask "adobe-dng-converter" do
-  version "17.0"
-  sha256 "2b4af4ed1e62385ff39abc8069f632a8c9aad8fde81bd1ddfae02713c4de3c4b"
+  version "17.1"
+  sha256 "8d6ca5b383831f5f0754066bc61b26ceebabd0ca3a09f361ee99c2744c47eb24"
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"
   name "Adobe DNG Converter"

--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -4,6 +4,10 @@
   "adobe-connect": "https://helpx.adobe.com/adobe-connect/connect-downloads-updates.html",
   "adobe-creative-cloud": "https://www.adobe.com/creativecloud.html",
   "adobe-creative-cloud-cleaner-tool": "https://helpx.adobe.com/creative-cloud/kb/cc-cleaner-tool-installation-problems.html",
+  "adobe-dng-converter": [
+    "https://helpx.adobe.com/camera-raw/using/adobe-dng-converter.html",
+    "https://helpx.adobe.com/photoshop/kb/uptodate.html"
+  ],
   "canon-ufrii-driver": "https://www.usa.canon.com/bin/canon/support/getsoftwarediver.ds.MACOS_14.39319.All.English.json",
   "elecom-mouse-util": "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/",
   "gotomeeting": "https://www.goto.com/meeting",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

strangely the urls are not reachable for brew, but in the browser I can reach those websites.

audit for adobe-dng-converter: failed
 - The homepage URL https://helpx.adobe.com/camera-raw/using/adobe-dng-converter.html is not reachable
 - The livecheck URL https://helpx.adobe.com/photoshop/kb/uptodate.html is not reachable
