### PR TITLE
rode-virtual-channels 1.0.0 (new cask)

### DIFF
--- a/Casks/r/rode-virtual-channels.rb
+++ b/Casks/r/rode-virtual-channels.rb
@@ -1,0 +1,28 @@
+cask "rode-virtual-channels" do
+  version "1.0.0"
+  sha256 "00c0b5a2f5f24eb80d4bb0d2e8b5ce2e409fc95ef37099ad7e3f629a4bfd72fe"
+
+  url "https://update.rode.com/virtual_dev_driver/RODECASTERDriver_MACOS_#{version}.zip"
+  name "RODE Virtual Channels"
+  desc "Virtual Device Driver for RODECASTER Pro II"
+  homepage "https://rode.com/en/user-guides/rodecaster-pro-ii/virtual-devices"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?RODECASTERDriver[._-]MACOS[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
+  depends_on macos: ">= :catalina"
+
+  pkg "RODE Virtual Channels-#{version}.pkg"
+
+  uninstall quit:    "com.rode.RODEVirtualChannels",
+            pkgutil: [
+              "com.rode.pkg.RODEVirtualChannels",
+              "com.rode.pkg.RODEVirtualChannelsApp",
+              "com.rode.pkg.RODEVirtualChannelsLaunchAgent",
+              "com.rode.RodeVirtualChannels.driver",
+            ]
+
+  zap trash: "~/Library/Saved Application State/com.rode.RODEVirtualChannels.savedState"
+end


### PR DESCRIPTION
Adding the driver for rodecaster virtual channels

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
