### PR TITLE
session 1.14.3: fix hash mismatch

### DIFF
--- a/Casks/s/session.rb
+++ b/Casks/s/session.rb
@@ -1,6 +1,6 @@
 cask "session" do
   version "1.14.3"
-  sha256 "ac4c19252d2a8d3b5b20c1c02b15e6e9ef826d8164358c697cc31a489f62c020"
+  sha256 "66b8d5c77efb04a381520d3c7f7ec24a70f5ae803ddc76031519ed6d2f3132f8"
 
   url "https://github.com/oxen-io/session-desktop/releases/download/v#{version}/session-desktop-mac-x64-#{version}.dmg",
       verified: "github.com/oxen-io/session-desktop/"


### PR DESCRIPTION
I only use Homebrew via [nix-homebrow](https://github.com/zhaofengli/nix-homebrew), so I do not know what to do about the second and third point below.

Anyway, this change fixed things (installing via `nix-homebrew`) for me.

---

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---