### PR TITLE
texstudio 4.8.5

### DIFF
--- a/Casks/t/texstudio.rb
+++ b/Casks/t/texstudio.rb
@@ -1,26 +1,24 @@
 cask "texstudio" do
-  arch arm: "-m1.zip", intel: ".dmg"
+  arch arm: "-m1", intel: ""
 
-  version "4.8.4"
-  sha256 arm:   "f66ede26faa71dbfbb12e3d02036a826e0a8f08f437078b25aa81b53336489d0",
-         intel: "43f70201a54d3622983093d99636529935a6d911a5cd99f70637c35f052ccd6e"
+  version "4.8.5"
+  sha256 arm:   "dd7b7b2d5918afe10c35ebdb06790b35b72364740faf9e35ef7b78b5dba456fc",
+         intel: "1f1925bda6d82003481c1952f8702597dfb71657d2ad774e452af1e9e45036d4"
 
   on_arm do
     depends_on macos: ">= :sonoma"
-
-    app "texstudio-#{version}-osx-m1.app"
   end
   on_intel do
     depends_on macos: ">= :big_sur"
-
-    app "texstudio.app"
   end
 
-  url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx#{arch}",
+  url "https://github.com/texstudio-org/texstudio/releases/download/#{version}/texstudio-#{version}-osx#{arch}.zip",
       verified: "github.com/texstudio-org/texstudio/"
   name "TeXstudio"
   desc "LaTeX editor"
   homepage "https://texstudio.org/"
+
+  app "texstudio-#{version}-osx#{arch}.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/texstudio.sfl*",


### PR DESCRIPTION
TeXstudio release asset for Intel Mac has changed from `texstudio-4.8.4-osx.dmg` (til [4.8.4](https://github.com/texstudio-org/texstudio/releases/tag/4.8.4)) to `texstudio-4.8.5-osx-m1.zip` (since [4.8.5](https://github.com/texstudio-org/texstudio/releases/tag/4.8.5)).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
