### PR TITLE
cloud-pbx: 44.11.0

### DIFF
--- a/Casks/c/cloud-pbx.rb
+++ b/Casks/c/cloud-pbx.rb
@@ -1,29 +1,36 @@
 cask "cloud-pbx" do
-  version "22.9.43.12"
-  sha256 "ce01e374cd476233b0078243961eaf85a4d8db62dfa5369197a02f8a461c3961"
+  arch arm: "arm", intel: "intel"
 
-  url "https://cpbx-hilfe.deutschland-lan.de/downloads/desktop-clients/cloud-pbx.osx-#{version}",
-      verified: "cpbx-hilfe.deutschland-lan.de/downloads/desktop-clients/"
+  on_arm do
+    version "44.11.0"
+    sha256 "ba3b20d7811e000f6cd7214a720aa157ba9b0422a8269cdd50eafa675518b369"
+  end
+  on_intel do
+    version "44.11"
+    sha256 "01de6c9e1ebb967939b43419dd4f1c6345a9563aa56f88e114a14e7046353342"
+  end
+
+  url "https://cpbx-hilfe.deutschland-lan.de/de/direkthilfe/hilfe-downloads/desktop-clients/cloud-pbx-2.0-#{arch}_v#{version}",
+      verified: "cpbx-hilfe.deutschland-lan.de/de/direkthilfe/hilfe-downloads/desktop-clients/"
   name "Cloud PBX"
   desc "Cloud-based telephone system"
   homepage "https://geschaeftskunden.telekom.de/internet-dsl/tarife/festnetz-internet-dsl/companyflex/cloud-pbx"
 
   livecheck do
     url "https://cpbx-hilfe.deutschland-lan.de/de/direkthilfe/hilfe-downloads/downloads"
-    regex(%r{href=.*?/cloud[._-]pbx\.osx[._-]v?(\d+(?:\.\d+)+)}i)
+    regex(%r{href=.*?/cloud[._-]pbx[._-]2\.0[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)}i)
   end
 
-  app "Cloud PBX.app"
+  app "Cloud PBX 2.0.app"
 
   zap trash: [
+    "~/Library/Application Support/Cisco Spark",
     "~/Library/Application Support/Telekom Deutschland GmbH",
     "~/Library/Caches/Telekom Deutschland GmbH",
+    "~/Library/Preferences/Cisco-Systems.Spark.plist",
     "~/Library/Preferences/com.broadsoft.communicator.plist",
     "~/Library/Preferences/de.deutschland-lan.Cloud PBX.plist",
+    "~/Library/Saved Application State/Cisco-Systems.Spark.savedState",
     "~/Library/Saved Application State/com.broadsoft.communicator.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
bump cloud-pbx to 2.0

livecheck gives `44.11` for intel but `44.11.0` for arm. I need help here 🥲

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
