### PR TITLE
purevpn: update version, livecheck

### DIFF
--- a/Casks/p/purevpn.rb
+++ b/Casks/p/purevpn.rb
@@ -1,5 +1,5 @@
 cask "purevpn" do
-  version "9.23.0"
+  version "9.25.0"
   sha256 :no_check
 
   url "https://dzglif4kkvz04.cloudfront.net/mac-2.0/packages/Production/PureVPN.pkg",
@@ -9,8 +9,10 @@ cask "purevpn" do
   homepage "https://www.purevpn.com/"
 
   livecheck do
-    url "https://support.purevpn.com/mac-release-notes"
-    regex(/>\s*Version\s*v?(\d+(?:\.\d+)+)\s*</i)
+    url :url
+    strategy :extract_plist do |items|
+      items["com.purevpn.app.mac"]&.short_version
+    end
   end
 
   pkg "PureVPN.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
This PR removes the `livecheck` block and changes the version to `:latest` because the page used for livechecking is often outdated for months with no end - the page was last updated over two months ago, and since that time, two newer versions have come out.

I left the block commented to remember the URL, just in case the page is properly updated in the future.