### PR TITLE
workflows/scheduled: fix template-injection zizmor warnings

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -51,6 +51,7 @@ jobs:
     needs: create_matrix
     name: "Online check (${{ matrix.os }}): ${{ matrix.cask }}"
     env:
+      CASK: ${{ matrix.cask }}
       HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
       GH_TOKEN: "${{ github.token }}"
       REPORTING_ISSUE: 172732
@@ -72,34 +73,34 @@ jobs:
 
       - name: Check cask source is not archived.
         id: archived
-        run: brew audit --cask --online --skip-style --only github_repository_archived,gitlab_repository_archived ${{ matrix.cask }}
+        run: brew audit --cask --online --skip-style --only github_repository_archived,gitlab_repository_archived "$CASK"
 
       - name: Report online issues
         if: ${{ failure() && steps.archived.conclusion == 'failure' }}
         run: |
           gh issue comment "$REPORTING_ISSUE" \
                            --repo homebrew/homebrew-cask \
-                           --body "${{ matrix.cask }} should be archived. Check ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                           --body "$CASK should be archived. Check $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       - name: Check cask for unavailable homepage.
         id: homepage
-        run: brew audit --cask --online --skip-style --only homepage ${{ matrix.cask }}
+        run: brew audit --cask --online --skip-style --only homepage "$CASK"
 
       - name: Report homepage issues
         if: ${{ failure() && steps.homepage.conclusion == 'failure' }}
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
                            --repo homebrew/homebrew-cask \
-                           --body "${{ matrix.cask }} has homepage issues. Check ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                           --body "$CASK has homepage issues. Check $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       - name: Check cask for missing sources.
         id: fetch
-        run: brew fetch --cask ${{ matrix.cask }}
+        run: brew fetch --cask "$CASK"
 
       - name: Report fetch issues
         if: ${{ failure() && steps.fetch.conclusion == 'failure' }}
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
                            --repo homebrew/homebrew-cask \
-                           --body "${{ matrix.cask }} source has problems. Check ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                           --body "$CASK source has problems. Check $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `workflows/scheduled.yml` to use environment variables to address `template-injection` warnings from `zizmor`. This borrows the general approach from similar fixes in the [Homebrew/actions](https://github.com/Homebrew/actions/pull/631) and [Homebrew/homebrew-test-bot](https://github.com/Homebrew/homebrew-test-bot/pull/1336) repositories.

I'm not very knowledgeable about GitHub Actions, so I've set this as a draft until more knowledgeable maintainers have had a chance to check my work and identify any issues.