### PR TITLE
workflows/ci: fix template-injection zizmor findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,24 +180,29 @@ jobs:
             File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
               f.puts "manual_installer=#{JSON.generate(manual_installer)}"
               f.puts "macos_requirement_satisfied=#{JSON.generate(macos_requirement_satisfied)}"
-              f.puts "cask_conflicts=#{JSON.generate(cask_conflicts)}"
-              f.puts "cask_dependencies=#{JSON.generate(cask_dependencies)}"
-              f.puts "formula_conflicts=#{JSON.generate(formula_conflicts)}"
               f.puts "formula_dependencies=#{JSON.generate(formula_dependencies)}"
+            end
+
+            File.open(ENV.fetch("GITHUB_ENV"), "a") do |f|
+              f.puts "CASK_CONFLICTS=\"#{cask_conflicts&.join(" ")}\"" if cask_conflicts.present?
+              f.puts "CASK_DEPENDENCIES=\"#{cask_dependencies&.join(" ")}\"" if cask_dependencies.present?
+              f.puts "FORMULA_CONFLICTS=\"#{formula_conflicts&.join(" ")}\"" if formula_conflicts.present?
             end
           EOF
         if: always() && steps.fetch.outcome == 'success' && matrix.cask
 
       - name: Uninstall conflicting formulae
         run: |
-          brew uninstall --formula ${{ join(fromJSON(steps.info.outputs.formula_conflicts), ' ') }}
-        if: always() && steps.info.outcome == 'success' && join(fromJSON(steps.info.outputs.formula_conflicts)) != ''
+          # shellcheck disable=SC2086
+          brew uninstall --formula $FORMULA_CONFLICTS
+        if: ${{ always() && steps.info.outcome == 'success' && env.FORMULA_CONFLICTS != '' }}
         timeout-minutes: 30
 
       - name: Uninstall conflicting casks
         run: |
-          brew uninstall --cask ${{ join(fromJSON(steps.info.outputs.cask_conflicts), ' ') }}
-        if: always() && steps.info.outcome == 'success' && join(fromJSON(steps.info.outputs.cask_conflicts)) != ''
+          # shellcheck disable=SC2086
+          brew uninstall --cask $CASK_CONFLICTS
+        if: ${{ always() && steps.info.outcome == 'success' && env.CASK_CONFLICTS != '' }}
         timeout-minutes: 30
 
       - name: Run brew uninstall --cask --force --zap ${{ matrix.cask.token }}
@@ -210,8 +215,10 @@ jobs:
         id: snapshot
         run: |
           brew ruby -r "$(brew --repository homebrew/cask)/cmd/lib/check.rb" <<'EOF'
-            File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
-              f.puts "before=#{JSON.generate(Check.all)}"
+            File.open(ENV.fetch("GITHUB_ENV"), "a") do |f|
+              # We have to use a `HOMEBREW_` prefix so it will survive the
+              # environment variable filtering in `brew`.
+              f.puts "HOMEBREW_SNAPSHOT_BEFORE=#{JSON.generate(Check.all)}"
             end
           EOF
         if: always() && steps.info.outcome == 'success'
@@ -232,8 +239,9 @@ jobs:
 
       - name: Uninstall cask dependencies
         run: |
-          brew uninstall --cask ${{ join(fromJSON(steps.info.outputs.cask_dependencies), ' ') }}
-        if: always() && steps.install.outcome == 'success' && join(fromJSON(steps.info.outputs.cask_dependencies)) != ''
+          # shellcheck disable=SC2086
+          brew uninstall --cask $CASK_DEPENDENCIES
+        if: ${{ always() && steps.install.outcome == 'success' && env.CASK_DEPENDENCIES != '' }}
         timeout-minutes: 30
 
       - name: Compare installed and running apps and services with snapshot
@@ -242,9 +250,8 @@ jobs:
             require "cask/cask_loader"
             require "utils/github/actions"
 
-            before = JSON.parse(<<~'EOS').transform_keys(&:to_sym)
-              ${{ steps.snapshot.outputs.before }}
-            EOS
+            before = JSON.parse(ENV.fetch("HOMEBREW_SNAPSHOT_BEFORE", "{}"))
+                         .transform_keys(&:to_sym)
             after = Check.all
 
             cask = Cask::CaskLoader.load('${{ matrix.cask.path }}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         id: generate-matrix
         env:
           INPUT_CASKS: ${{ github.event.inputs.casks }}
+          PULL_REQUEST_URL: ${{ github.event.pull_request.url }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]
           then
@@ -68,7 +69,7 @@ jobs:
           then
             brew generate-cask-ci-matrix --syntax-only
           else
-            brew generate-cask-ci-matrix --url "${{ github.event.pull_request.url }}"
+            brew generate-cask-ci-matrix --url "$PULL_REQUEST_URL"
           fi
 
   test:


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `workflows/ci.yml` to use environment variables to
address a `template-injection` error and similar info output from `zizmor`.

I've added `# shellcheck disable=SC2086` comments in a few places where `shellcheck` wanted quotes but the strings consist of space-separated packages:

```
ci.yml:194:9: shellcheck reported issue in this script: SC2086:info:1:26: Double quote to prevent globbing and word splitting [shellcheck]
    |
194 |         run: |
    |         ^~~~
ci.yml:202:9: shellcheck reported issue in this script: SC2086:info:1:23: Double quote to prevent globbing and word splitting [shellcheck]
    |
202 |         run: |
    |         ^~~~
ci.yml:240:9: shellcheck reported issue in this script: SC2086:info:1:23: Double quote to prevent globbing and word splitting [shellcheck]
    |
240 |         run: |
    |         ^~~~
```

Adding quotes in those instances would cause `brew` to interpret something like `"one two three"` as one package with that name instead of three packages. If there's a better way to handle this, let me know.

As with my other recent actions PRs, I'm not very knowledgeable about GitHub Actions, so I've created this as a draft until more knowledgeable maintainers have a chance to review this and catch any mistakes.