### PR TITLE
boring-notch 2.3 (new cask)

### DIFF
--- a/Casks/b/boring-notch.rb
+++ b/Casks/b/boring-notch.rb
@@ -1,0 +1,21 @@
+cask "boring-notch" do
+  version "2.3"
+  sha256 :no_check
+
+  url "https://github.com/TheBoredTeam/boring.notch/releases/download/glowing-panda/GlowingPanda.dmg"
+  name "boring-notch"
+  desc "Not so boring notch That Rocks"
+  homepage "https://github.com/TheBoredTeam/boring.notch"
+
+  livecheck do
+    url "https://TheBoredTeam.github.io/boring.notch/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "boringNotch.app"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---


I got the following when running `brew audit --cask --new boring-notch`.
```
macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
boring-notch
  * line 5, col 2: Signature verification failed:
    /private/tmp/cask-audit20241217-37828-wkotsf/boringNotch.app: rejected

    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
```