### PR TITLE
clamxav: use pkg installer and properly uninstall/zap

### DIFF
--- a/Casks/c/clamxav.rb
+++ b/Casks/c/clamxav.rb
@@ -1,8 +1,8 @@
 cask "clamxav" do
   version "3.8,10918"
-  sha256 "5149d3729b2f006b6cdc96cf5be16257476a6b635fdb5ab8888effc4d0030a32"
+  sha256 "49f81960914a300dcadd218cf232fdeeb37d76dbd11374d30f6260a8cc4a9ca0"
 
-  url "https://cdn.clamxav.com/ClamXAVdownloads/ClamXAV_#{version.csv.first}_#{version.csv.second}.zip"
+  url "https://cdn.clamxav.com/ClamXAVdownloads/ClamXAV_#{version.csv.first}_#{version.csv.second}_Installer.pkg"
   name "ClamXAV"
   desc "Anti-virus and malware scanner"
   homepage "https://www.clamxav.com/"
@@ -14,17 +14,49 @@ cask "clamxav" do
 
   auto_updates true
 
-  app "ClamXAV.app"
+  pkg "ClamXAV_#{version.csv.first}_#{version.csv.second}_Installer.pkg"
+
+  postflight do
+    # Partial uninstaller used because the full uninstaller removes user preferences
+    system_command "/usr/bin/curl",
+                   args: [
+                     "-L",
+                     "https://www.clamxav.com/downloads/StandaloneUninstaller-Partial.pkg",
+                     "-o",
+                     "#{staged_path}/StandaloneUninstaller-Partial.pkg",
+                   ]
+  end
+
+  uninstall script:  {
+              executable:   "/usr/sbin/installer",
+              args:         [
+                "-pkg", "#{staged_path}/StandaloneUninstaller-Partial.pkg",
+                "-target", "/"
+              ],
+              must_succeed: false,
+              sudo:         true,
+            },
+            pkgutil: [
+              "uk.co.canimaansoftware.clamxav*",
+              "uk.co.canimaansoftware.ClamXAV*",
+            ]
 
   zap trash: [
-    "~/Library/Caches/uk.co.markallan.clamxav",
+    "/Library/Application Support/ClamXAV",
+    "~/Library/Caches/uk.co.canimaansoftware.ClamXAV",
+    "~/Library/Caches/uk.co.canimaansoftware.ClamXAV-UI-Helper",
+    "~/Library/Caches/uk.co.canimaansoftware.ClamXAV.XAV",
+    "~/Library/HTTPStorages/uk.co.canimaansoftware.ClamXAV",
+    "~/Library/HTTPStorages/uk.co.canimaansoftware.ClamXAV-UI-Helper",
+    "~/Library/HTTPStorages/uk.co.canimaansoftware.ClamXAV.binarycookies",
+    "~/Library/HTTPStorages/uk.co.canimaansoftware.ClamXAV.XAV",
     "~/Library/Logs/ClamXAV-Console.log",
-    "~/Library/Logs/clamXav-scan.*",
     "~/Library/Logs/ClamXAV-UI-Helper-Console.log",
+    "~/Library/Preferences/uk.co.canimaansoftware.ClamXAV-UI-Helper.plist",
+    "~/Library/Preferences/uk.co.canimaansoftware.ClamXAV.plist",
   ]
 
   caveats do
-    # this happens sometime after installation, but still worth warning about
     files_in_usr_local
   end
 end

--- a/Casks/c/clamxav.rb
+++ b/Casks/c/clamxav.rb
@@ -16,29 +16,26 @@ cask "clamxav" do
 
   pkg "ClamXAV_#{version.csv.first}_#{version.csv.second}_Installer.pkg"
 
-  postflight do
-    # Partial uninstaller used because the full uninstaller removes user preferences
-    system_command "/usr/bin/curl",
-                   args: [
-                     "-L",
-                     "https://www.clamxav.com/downloads/StandaloneUninstaller-Partial.pkg",
-                     "-o",
-                     "#{staged_path}/StandaloneUninstaller-Partial.pkg",
-                   ]
-  end
-
-  uninstall script:  {
-              executable:   "/usr/sbin/installer",
-              args:         [
-                "-pkg", "#{staged_path}/StandaloneUninstaller-Partial.pkg",
-                "-target", "/"
-              ],
-              must_succeed: false,
-              sudo:         true,
-            },
-            pkgutil: [
+  uninstall launchctl: [
+              "uk.co.canimaansoftware.ClamXAV.Engine",
+              "uk.co.canimaansoftware.ClamXAV.HelperTool",
+              "uk.co.canimaansoftware.ClamXAV.HelperToolUpdater",
+              "uk.co.canimaansoftware.ClamXAV.Satellite",
+              "uk.co.canimaansoftware.ClamXAV.UI-Helper",
+              "uk.co.canimaansoftware.ClamXAV.UninstallWatcher",
+              "uk.co.canimaansoftware.ClamXavHelper",
+              "uk.co.canimaansoftware.ClamXavHelperUpdater",
+            ],
+            quit:      "uk.co.canimaansoftware.ClamXAV",
+            pkgutil:   [
               "uk.co.canimaansoftware.clamxav*",
               "uk.co.canimaansoftware.ClamXAV*",
+            ],
+            delete:    [
+              "/Applications/ClamXAV.app",
+              "/Library/PrivilegedHelperTools/uk.co.canimaansoftware.ClamX*",
+              "/usr/local/clamXav",
+              "/usr/local/ClamXAV3",
             ]
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

The pkg installer is preferred because it provides a 1-step install process and is the one referenced in the [documentation](https://www.clamxav.com/documentation/faq/installation-and-updates/). The uninstall process previously only removed the graphical interface and left everything else, including the engine itself, running and enabled on startup. Using only `pkgutil:` is likewise insufficient. Because the uninstaller is not included in the pkg installer or within the .app bundle, it is pulled from the official website. The zap stanza was updated for completeness and to reference new bundle IDs.