### PR TITLE
schism-tracker: update checksum

### DIFF
--- a/Casks/s/schism-tracker.rb
+++ b/Casks/s/schism-tracker.rb
@@ -1,6 +1,6 @@
 cask "schism-tracker" do
   version "20241021"
-  sha256 "61549e3d5088f1c32da2f08642810ee7653e6d96e057ca935d932bbdb0d18f0b"
+  sha256 "0ddf88b6196fc32337c9395ec07c839d84d68b75830eefd42029d763a3748837"
 
   url "https://github.com/schismtracker/schismtracker/releases/download/#{version}/schismtracker-#{version}-macos.zip"
   name "Schism Tracker"


### PR DESCRIPTION
The maintainer republished the archive after the fact to fix a path
issue.

> yes, I fixed an issue with the release where the path of utf8proc was incorrect on powerpc, but the actual contents of the binary have not changed, hence no new release. I'll put up a notice on the releases page if I end up doing this again in the future :)


See also https://github.com/schismtracker/schismtracker/discussions/544#discussioncomment-11501378

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
