### PR TITLE
google-drive: update uninstall and zap

### DIFF
--- a/Casks/g/google-drive.rb
+++ b/Casks/g/google-drive.rb
@@ -23,10 +23,11 @@ cask "google-drive" do
 
   # Some launchctl and pkgutil items are shared with other Google apps, they should only be removed in the zap stanza
   # See: https://github.com/Homebrew/homebrew-cask/pull/92704#issuecomment-727163169
-  # launchctl: com.google.keystone.daemon, com.google.keystone.system.agent, com.google.keystone.system.xpcservice
+  # launchctl: com.google.GoogleUpdater.wake.system, com.google.keystone.daemon,
+  #            com.google.keystone.system.agent, com.google.keystone.system.xpcservice
+
   # pkgutil: com.google.pkg.Keystone
-  uninstall launchctl:  "com.google.GoogleUpdater.wake.system",
-            quit:       [
+  uninstall quit:       [
               "com.google.drivefs",
               "com.google.drivefs.finderhelper.findersync",
             ],
@@ -40,6 +41,7 @@ cask "google-drive" do
             ]
 
   zap launchctl: [
+        "com.google.GoogleUpdater.wake.system",
         "com.google.keystone.agent",
         "com.google.keystone.daemon",
         "com.google.keystone.system.agent",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
The `com.google.GoogleUpdater.wake.system` service is part of GoogleUpdater, which is used by Chrome and other Google software. Removing it will break automatic updates for all Google software so it should only be present in the `zap` stanza.