### PR TITLE
duplicati: remove mono dependency

### DIFF
--- a/Casks/d/duplicati.rb
+++ b/Casks/d/duplicati.rb
@@ -21,8 +21,6 @@ cask "duplicati" do
     end
   end
 
-  depends_on formula: "mono"
-
   app "Duplicati.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

Removed mono as dependency. The newest version of Duplicati is built on .NET 8, so Mono is no longer necessary.