### PR TITLE
mouseless: update desc and depends_on macos

### DIFF
--- a/Casks/m/mouseless.rb
+++ b/Casks/m/mouseless.rb
@@ -4,7 +4,7 @@ cask "mouseless" do
 
   url "https://mouseless.click/mouseless-installer_v#{version}.dmg"
   name "mouseless"
-  desc "Full, fast mouse control with the keyboard"
+  desc "Mouse control with the keyboard"
   homepage "https://mouseless.click/"
 
   livecheck do

--- a/Casks/m/mouseless.rb
+++ b/Casks/m/mouseless.rb
@@ -4,7 +4,7 @@ cask "mouseless" do
 
   url "https://mouseless.click/mouseless-installer_v#{version}.dmg"
   name "mouseless"
-  desc "Mouse control with the keyboard"
+  desc "Full, fast mouse control with the keyboard"
   homepage "https://mouseless.click/"
 
   livecheck do
@@ -14,7 +14,7 @@ cask "mouseless" do
     end
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sonoma"
   depends_on arch: :arm64
 
   app "Mouseless.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Multiple users have reported the app not working on macOS 13 and below.  So I've updated the required macos version to `sonoma`.  Also tweaked the description a bit.