### PR TITLE
logitech-g-hub: requires_rosetta

### DIFF
--- a/Casks/l/logitech-g-hub.rb
+++ b/Casks/l/logitech-g-hub.rb
@@ -54,4 +54,8 @@ cask "logitech-g-hub" do
     "~/Library/Preferences/com.logi.ghub.plist",
     "~/Library/Saved Application State/com.logi.ghub.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Installing this failed because Rosetta wasn't installed on this machine. Mark it as `requires_rosetta`.
