### PR TITLE
whoozle-android-file-transfer@nightly: disable

### DIFF
--- a/Casks/w/whoozle-android-file-transfer@nightly.rb
+++ b/Casks/w/whoozle-android-file-transfer@nightly.rb
@@ -8,7 +8,7 @@ cask "whoozle-android-file-transfer@nightly" do
   desc "Android File Transfer for Linux"
   homepage "https://whoozle.github.io/android-file-transfer-linux/"
 
-  deprecate! date: "2025-05-01", because: :unsigned
+  disable! date: "2024-12-22", because: :unmaintained
 
   conflicts_with cask: "whoozle-android-file-transfer"
   depends_on macos: ">= :sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The nightly release no longer appears to have a download available.