### PR TITLE
sunvox: fix livecheck

### DIFF
--- a/Casks/s/sunvox.rb
+++ b/Casks/s/sunvox.rb
@@ -8,8 +8,8 @@ cask "sunvox" do
   homepage "https://www.warmplace.ru/soft/sunvox/"
 
   livecheck do
-    url "https://www.warmplace.ru/soft/sunvox/changelog.txt"
-    regex(/^v(\d+(?:\.\d+)*[a-z]?)\s*\(\d+/i)
+    url :homepage
+    regex(/href=.*?sunvox[._-]v?(\d+(?:\.\d+)+[a-z]?)\.zip/i)
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The current livecheck bugs because a new release has been made only for iOS. This livecheck fetches directly inside the download link in the site for macOS.