### PR TITLE
old-school-runescape: deprecate

### DIFF
--- a/Casks/o/old-school-runescape.rb
+++ b/Casks/o/old-school-runescape.rb
@@ -7,9 +7,7 @@ cask "old-school-runescape" do
   desc "Game client for Old School RuneScape"
   homepage "https://oldschool.runescape.com/"
 
-  livecheck do
-    skip "No version information available"
-  end
+  deprecate! date: "2024-12-25", because: :discontinued
 
   app "Old School RuneScape.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The legacy client has been deprecated (see [client update](https://secure.runescape.com/m=news/official-client-update---july-2024?oldschool=1#java)).
