### PR TITLE
ava: disable

### DIFF
--- a/Casks/a/ava.rb
+++ b/Casks/a/ava.rb
@@ -8,10 +8,7 @@ cask "ava" do
   desc "Run language models locally on your computer"
   homepage "https://avapls.com/"
 
-  livecheck do
-    url "https://avapls.com/docs/archive.html"
-    regex(/href=.*?Ava[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
-  end
+  disable! date: "2024-12-25", because: :no_longer_available
 
   app "Ava.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

All of the download artifacts posted on upstream no longer appear to be active resulting in this Cask unable to be used.  If `ava` becomes active again with release artifacts we can revert this PR.