### PR TITLE
dotnet*: update livecheck url

### DIFF
--- a/Casks/d/dotnet-sdk.rb
+++ b/Casks/d/dotnet-sdk.rb
@@ -19,7 +19,7 @@ cask "dotnet-sdk" do
   # cask version. New major/minor releases occur annually in November and the
   # check will automatically update its behavior when the cask is updated.
   livecheck do
-    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/#{version.major_minor}/releases.json"
+    url "https://builds.dotnet.microsoft.com/dotnet/release-metadata/#{version.major_minor}/releases.json"
     regex(%r{/download/pr/([^/]+)/([^/]+)/dotnet-sdk[._-]v?(\d+(?:\.\d+)+)[._-]osx[._-]#{arch}\.pkg}i)
     strategy :json do |json, regex|
       json["releases"]&.map do |release|

--- a/Casks/d/dotnet-sdk@preview.rb
+++ b/Casks/d/dotnet-sdk@preview.rb
@@ -16,7 +16,7 @@ cask "dotnet-sdk@preview" do
   homepage "https://dotnet.microsoft.com/en-us/"
 
   livecheck do
-    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/#{version.major_minor}/releases.json"
+    url "https://builds.dotnet.microsoft.com/dotnet/release-metadata/#{version.major_minor}/releases.json"
     regex(%r{/download/pr/([^/]+)/([^/]+)/dotnet-sdk[._-]v?(.+)[._-]osx[._-]#{arch}\.pkg}i)
     strategy :json do |json, regex|
       json["releases"]&.map do |release|

--- a/Casks/d/dotnet.rb
+++ b/Casks/d/dotnet.rb
@@ -19,7 +19,7 @@ cask "dotnet" do
   # cask version. New major/minor releases occur annually in November and the
   # check will automatically update its behavior when the cask is updated.
   livecheck do
-    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/#{version.major_minor}/releases.json"
+    url "https://builds.dotnet.microsoft.com/dotnet/release-metadata/#{version.major_minor}/releases.json"
     regex(%r{/download/pr/([^/]+)/([^/]+)/dotnet-runtime[._-]v?(\d+(?:\.\d+)+)[._-]osx[._-]#{arch}\.pkg}i)
     strategy :json do |json, regex|
       json["releases"]&.map do |release|

--- a/Casks/d/dotnet@preview.rb
+++ b/Casks/d/dotnet@preview.rb
@@ -16,7 +16,7 @@ cask "dotnet@preview" do
   homepage "https://dotnet.microsoft.com/en-us/"
 
   livecheck do
-    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/#{version.major_minor}/releases.json"
+    url "https://builds.dotnet.microsoft.com/dotnet/release-metadata/#{version.major_minor}/releases.json"
     regex(%r{/download/pr/([^/]+)/([^/]+)/dotnet-runtime[._-]v?(.+)[._-]osx[._-]#{arch}\.pkg}i)
     strategy :json do |json, regex|
       json["releases"]&.map do |release|


### PR DESCRIPTION
I was looking for a domain that will soon expire, per: https://github.com/dotnet/core/issues/9671. I found that these casks are using our storage account directly. It's best to use our new CDN. 

I am making this style of PR across GH. I didn't do any validation. The domain change is a drop-in replacement and uses a more official URL than before for the content.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
