### PR TITLE
tm-error-logger 8.0.2 (new cask)

### DIFF
--- a/Casks/t/tm-error-logger.rb
+++ b/Casks/t/tm-error-logger.rb
@@ -1,0 +1,24 @@
+cask "tm-error-logger" do
+  version "8.0.2"
+  sha256 :no_check
+
+  url "https://carnationsoftware.com/ftp/TM_Error_Logger_Installer.dmg"
+  name "TM Error Logger"
+  desc "Time Machine error reporting program"
+  homepage "https://carnationsoftware.com/TM_Error_Log_WebPage.html"
+
+  livecheck do
+    url "https://carnationsoftware.com/TM_Error_Logger_Versions.html"
+    regex(/<p>v?(\d+(?:\.\d+)+)[ "<]/i)
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "TM Error Logger.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.csw.TMErrorLogger.plist",
+    "~/Library/Preferences:Carnation Software Prefs",
+    "~/Library/Saved Application State/com.csw.TMErrorLogger.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

For the livecheck section, it could potentially be possible to scrape [this page](https://www.carnationsoftware.com/carnation/TMErrorLogger70.html) to get the latest version number, as the dmg has no version information and is replaced with the new version once the developer updates the program.

Additionally, I have not been able to find where the program stores its preferences (email sending settings). It seems to be using the Carbon API (which I didn't think was still possible), which may affect this though I'm not sure. I have checked in:

- `~/Library/Application Support`
- `~/Library/Preferences`
- `~/Library/Containers`
- `~/Library/Group Containers`
- `~/Library/GroupContainersAlias`
- `/Library/Application Support`
- `/Library/Preferences`

It does seem to create a folder at `~/Library/Preferences:Carnation Software Prefs`, but it never reads or writes to this folder after creation. The only persistent state I've been able to see is at `~/Library/Saved Application State/com.csw.TMErrorLogger.savedState/`