### PR TITLE
whatsapp 2.24.24.84

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,6 +1,6 @@
 cask "whatsapp" do
-  version "2.24.24.85"
-  sha256 "cf6f18c7b2fe373b7b14fb94ff050f960074d73ceedb3d185c22800315ed2793"
+  version "2.24.24.84"
+  sha256 "c7cac7bfd085286adc6e6949229a7ffa49fdc0945457d5792a387bc80917b855"
 
   url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&configuration=Release&branch=relbranch"
   name "WhatsApp"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, ~**if adding a new cask**~:
[...]

---

It appears that the 2.24.24.85 version of WhatsApp was yanked and is no longer downloadable. The current version is 2.24.24.84. This PR updates the cask accordingly.

To verify these claims:

* Try `brew install --cask whatsapp`, or simply open the current cask url in a browser, and observe the error
* Head to https://www.whatsapp.com/, click "Download", and observe that the obtained version is 2.24.24.84