### PR TITLE
gas-mask: change homepage and download link

### DIFF
--- a/Casks/g/gas-mask.rb
+++ b/Casks/g/gas-mask.rb
@@ -2,15 +2,10 @@ cask "gas-mask" do
   version "0.8.6"
   sha256 "9f75d0b11340d70832f87011c3d8ed97b9b18b3a56dec5f860d4040bb7404500"
 
-  url "http://gmask.clockwise.ee/files/gas_mask_#{version}.zip"
+  url "https://github.com/2ndalpha/gasmask/releases/download/#{version}/gas_mask_#{version}.zip"
   name "Gas Mask"
   desc "Hosts file editor/manager"
-  homepage "http://clockwise.ee/"
-
-  livecheck do
-    url "http://gmask.clockwise.ee/check_update/"
-    strategy :sparkle
-  end
+  homepage "https://github.com/2ndalpha/gasmask/"
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The website for the application is currently down, and as I do not know for how long it might be, I thought I might aswell find a better link to point to.

I've searched in the Internet Archive and found on [an old version of the website](https://web.archive.org/web/20150115100707/http://www.clockwise.ee/contact/) a link to [the Twitter profile of the creator of the app](https://x.com/clockwise_ee), which has linked back to [the GitHub repository](https://github.com/2ndalpha/gasmask) in previous releases. This fixes the homepage, livecheck and download link.

(I'm putting all of this to highlight the chain of trust of the GitHub repository)