### PR TITLE
miniforge: revert to 24.11.0-0

### DIFF
--- a/Casks/m/miniforge.rb
+++ b/Casks/m/miniforge.rb
@@ -1,9 +1,9 @@
 cask "miniforge" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "24.11.0-1"
-  sha256 arm:   "6c2ff0b7cf1b6300a3dc6125da8e78407d3ffd3a7359742957fcca0cd7cd7604",
-         intel: "5f42fb48c528b2f60a659d0cc19adb74a4098d8a1519ac7fe0724273eae050c5"
+  version "24.11.0-0"
+  sha256 arm:   "3c7c115de0ed6103b7d2e5c1fe969c2c9fd3aec4a454c1d5aa9b5721414413e0",
+         intel: "1f0527ec14784de0766d8405a674868e51afb869ea16c915fb2672256209ecfd"
 
   url "https://github.com/conda-forge/miniforge/releases/download/#{version}/Miniforge3-#{version}-MacOSX-#{arch}.sh"
   name "miniforge"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Version 24.11.0-1 has been marked as a pre-release due to a bug (see https://github.com/conda-forge/miniforge/issues/697).
