### PR TITLE
dymo-label: rename to dymo-connect

### DIFF
--- a/Casks/d/dymo-connect.rb
+++ b/Casks/d/dymo-connect.rb
@@ -1,9 +1,9 @@
-cask "dymo-label" do
+cask "dymo-connect" do
   version "1.4.7.49"
   sha256 "f8a6f2028467babfd6dc5480dd78735bee9d5cba5f5f6ee2b22123cb6d981072"
 
   url "https://download.dymo.com/dymo/Software/Mac/DCDMac#{version}.pkg"
-  name "Dymo Label"
+  name "Dymo Connect"
   desc "Software for DYMO LabelWriters"
   homepage "https://www.dymo.com/support?cfid=online-support"
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -11,6 +11,7 @@
   "codewhisperer": "amazon-q",
   "coqide": "coq-platform",
   "cron": "notion-calendar",
+  "dymo-label": "dymo-connect",
   "easy-move-plus-resize": "easy-move+resize",
   "emby-server": "embyserver",
   "epilogue-operator": "epilogue-playback",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR renames the cask as it actually installs Dymo Connect (see the [download center](https://www.dymo.com/support?cfid=dymo-compatibility-chart)). The original `dymo-label` cask was removed in #36884.
