### PR TITLE
ghostty: remove terminfo

### DIFF
--- a/Casks/g/ghostty.rb
+++ b/Casks/g/ghostty.rb
@@ -24,10 +24,6 @@ cask "ghostty" do
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/ghostty.fish"
   binary "#{appdir}/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty",
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/terminfo/67/ghostty",
-         target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/67/ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/terminfo/78/xterm-ghostty",
-         target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/78/xterm-ghostty"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
 

--- a/Casks/g/ghostty@tip.rb
+++ b/Casks/g/ghostty@tip.rb
@@ -30,10 +30,6 @@ cask "ghostty@tip" do
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/ghostty.fish"
   binary "#{appdir}/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty",
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/terminfo/67/ghostty",
-         target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/67/ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/terminfo/78/xterm-ghostty",
-         target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/78/xterm-ghostty"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
 


### PR DESCRIPTION
Ghostty always exports TERMINFO=/Applications/Ghostty.app/Contents/Resources/terminfo
This feature cannot be turned off in the Ghostty config.

Per macOS Sierra `man terminfo`:
> If the environment variable TERMINFO is set, it is interpreted as the pathname of a
  directory containing the compiled description you are working on.  Only that directory
  is searched.

IOW, linking from ~/.terminfo is redundant. These files can never be evaluated unless the user intentionally unsets $TERMINFO at runtime. Also, the iterm2 and kitty casks are doing fine without similar links.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

n/a
- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
