### PR TITLE
fixkey: downgrade to 2.0.5

### DIFF
--- a/Casks/f/fixkey.rb
+++ b/Casks/f/fixkey.rb
@@ -1,6 +1,6 @@
 cask "fixkey" do
-  version "2.0.6"
-  sha256 "d62beae9c7b87fbd5afc2967cd49bd396b1f12c674896d2a213aceef7999c992"
+  version "2.0.5"
+  sha256 "21a0e91cdd40aec5ffec95c7427f9f3b388f3b5ce98ff73ef97a6b6d6e4de1c3"
 
   url "https://fixkey.download/fixkey%20#{version}.dmg",
       verified: "fixkey.download/"


### PR DESCRIPTION
2.0.6 is gone away and cannot download, so downgrade to 2.0.5 and also change the livecheck to the header_match. This can be reverted after a new version released, maybe.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
