### PR TITLE
Update schism-tracker sha256 checksum

### DIFF
--- a/Casks/s/schism-tracker.rb
+++ b/Casks/s/schism-tracker.rb
@@ -1,6 +1,6 @@
 cask "schism-tracker" do
   version "20241226"
-  sha256 "a417558c55b6c32adb0fe1fc805494e4dcd1312d17a7ba173092c25f703094ad"
+  sha256 "7fabed1f3a3deda18f16440f3ebc539484bcf2ecbff4c7b60d9beca092e8c281"
 
   url "https://github.com/schismtracker/schismtracker/releases/download/#{version}/schismtracker-#{version}-macos.zip"
   name "Schism Tracker"


### PR DESCRIPTION
The maintainer republished the archive after the fact to fix a minor
issue.

See also https://github.com/schismtracker/schismtracker/issues/585
