### PR TITLE
opera: update depends_on

### DIFF
--- a/Casks/o/opera.rb
+++ b/Casks/o/opera.rb
@@ -13,7 +13,7 @@ cask "opera" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Opera.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
This version of Opera is based on Chromium 130, and as such it requires [macOS 11 or later](https://blogs.opera.com/desktop/2024/11/opera-115/).