### PR TITLE
mongotron: deprecate

### DIFF
--- a/Casks/m/mongotron.rb
+++ b/Casks/m/mongotron.rb
@@ -2,18 +2,12 @@ cask "mongotron" do
   version "1.0.0-alpha.5"
   sha256 "b20d014ae3a9355a112f84d98d2f81c27d3f99fd2dd7dc3455be465b27ab1e20"
 
-  url "https://github.com/officert/mongotron/releases/download/#{version}/Mongotron-darwin-x64.zip",
-      verified: "github.com/officert/mongotron/"
+  url "https://github.com/officert/mongotron/releases/download/#{version}/Mongotron-darwin-x64.zip"
   name "Mongotron"
   desc "Mongo DB management"
-  homepage "https://mongotron.io/"
+  homepage "https://github.com/officert/mongotron"
 
-  # This cask uses an unstable version and this `livecheck` block is only used
-  # to prevent livecheck from skipping pre-release versions by default. This
-  # should be removed/updated if the cask is updated to a stable version.
-  livecheck do
-    url :url
-  end
+  deprecate! date: "2024-12-30", because: :unmaintained
 
   app "Mongotron-darwin-x64/Mongotron.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The application has not been updated since 2016, and the homepage has been replaced with gambling ads.
