### PR TITLE
acorn 8.0

### DIFF
--- a/Casks/a/acorn.rb
+++ b/Casks/a/acorn.rb
@@ -1,6 +1,6 @@
 cask "acorn" do
-  version "7.4.6"
-  sha256 "4102c05f1b5fe8771b98e0070133768e665cfebf0eabf1573053e3833b96e8c0"
+  version "8.0"
+  sha256 "64065b7d6a3a801b701be40e082768fbf5aaa05aa41c8c421ed1bd8579ac1e62"
 
   url "https://flyingmeat.com/download/Acorn-#{version}.zip"
   name "Acorn"
@@ -13,7 +13,7 @@ cask "acorn" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :sonoma"
 
   app "Acorn.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

This is a new major version; the bump-cask-pr command notes that BrewTestBot automatically handles version updates for Acorn, but I believe it is looking at the Sparkle update file for the 7.x releases only. I confirmed that the Sparkle URL in the cask file will work for version 8 (resolving to https://www.flyingmeat.com/download/acorn8update.xml), and updated the minimum OS requirement to Sonoma per the requirement listed on the [Acorn product page](https://flyingmeat.com/acorn/). 

This is my first version bumping pull request so let me know if I missed anything. Thanks!