### PR TITLE
Green-Go Control 5.1.0 (new cask)

### DIFF
--- a/Casks/g/green-go-control.rb
+++ b/Casks/g/green-go-control.rb
@@ -1,0 +1,30 @@
+cask "green-go-control" do
+  version "5.1.0"
+  sha256 "5e654801997ae166c0218b4e1fd0cafe011b4361714904dc2fcb7b56698dd72e"
+
+  url "https://downloads.greengoconnect.com/#{version}/macos/green-go-control.dmg",
+      verified: "downloads.greengoconnect.com/"
+  name "Green-GO Control"
+  desc "Configure and manage Green-GO intercom systems"
+  homepage "https://www.greengodigital.com/"
+
+  livecheck do
+    url "https://manual.greengoconnect.com/en/release-notes/software/"
+    regex(%r{href=.*?/(\d+(?:\.\d+)+)/macos/green-go-control.dmg}i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Green-GO Control.app"
+
+  zap trash: [
+    "~/Library/Application Support/green-go-control",
+    "~/Library/Logs/green-go-control",
+    "~/Library/Preferences/com.green-go.control.plist",
+    "~/Library/Saved Application State/com.green-go.control.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
This commit adds a new cask for Green-Go Connect 5.1.0, a management package for the Green-Go digital IP-based intercom system.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
