### PR TITLE
macx-youtube-downloader: update livecheck

### DIFF
--- a/Casks/m/macx-youtube-downloader.rb
+++ b/Casks/m/macx-youtube-downloader.rb
@@ -1,5 +1,5 @@
 cask "macx-youtube-downloader" do
-  version "5.3.4,2024121301"
+  version "5.3.4"
   sha256 :no_check
 
   url "https://www.macxdvd.com/download/macx-youtube-downloader-free.dmg"
@@ -8,8 +8,14 @@ cask "macx-youtube-downloader" do
   homepage "https://www.macxdvd.com/free-youtube-video-downloader-mac/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "http://www.macxdvd.com/free-youtube-video-downloader-mac/upgrade/macx-youtube-downloader#{version.major}.plist"
+    strategy :xml do |xml|
+      puts xml
+      version = xml.elements["//key[text()='LastestVersion']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
+    end
   end
 
   app "MacX YouTube Downloader.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Updates the cask to use the built in update feed over `extract_plist`

Unfortunately, it uses http and not https.

I checked back through git history, and it does not seem as the second set of version numbers is used for updating.  On the website, this is just listed as the release date alongside the version so believe we can drop this without any issues.

And yes, I am aware the key in the livecheck is "LastestVersion" and not, presumably, LatestVersion.