### PR TITLE
jasp: update sha256

### DIFF
--- a/Casks/j/jasp.rb
+++ b/Casks/j/jasp.rb
@@ -3,7 +3,7 @@ cask "jasp" do
   livecheck_folder = on_arch_conditional arm: "-apple-silicon"
 
   version "0.19.2.0"
-  sha256 arm:   "4b6692c5b7d05d11f993ae5ee15eb7334e1ac80cf0f07483812740d60d17ce92",
+  sha256 arm:   "f5c463d4733b24b1d94ef77e4d3a63ff91a63b293e1a05518d96246cf17913cd",
          intel: "a0e2d44902baf3e8af0748c301b7aaa4cbac0d76ea4b18835c5ed756bcaac47a"
 
   url "https://github.com/jasp-stats/jasp-desktop/releases/download/v#{version.csv.first.major_minor_patch}/JASP-#{version.csv.first}-macOS-#{arch}.dmg",


### PR DESCRIPTION
Updated the MacOS-arm64 installer's checksum to match the new version

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
