### PR TITLE
find-any-file: fix checksum

### DIFF
--- a/Casks/f/find-any-file.rb
+++ b/Casks/f/find-any-file.rb
@@ -1,6 +1,6 @@
 cask "find-any-file" do
   version "2.5.5"
-  sha256 "9f7d95fec1124517877c6621fb68f392830ad75010784cb7070bdb31bd446ec7"
+  sha256 "57ef75b7ee92e9d27a570d4e878e4e1ccd2805456411f089bf0459224c555f2b"
 
   url "https://s3.amazonaws.com/files.tempel.org/FindAnyFile_#{version}.zip",
       verified: "s3.amazonaws.com/"


### PR DESCRIPTION
Checksum for `find-any-file` appears to be incorrect for v2.5.5; seems to be a regression from #197051.
This PR fixes the expected checksum.

[v2.5.4](https://s3.amazonaws.com/files.tempel.org/FindAnyFile_2.5.4.zip) checksum ✅:
- expected `ded32d0c8589562a721c3708f7a1425923d3f96dc19af7f2e5ef3e878aebea54`
- actual `ded32d0c8589562a721c3708f7a1425923d3f96dc19af7f2e5ef3e878aebea54`

[v2.5.5](https://s3.amazonaws.com/files.tempel.org/FindAnyFile_2.5.5.zip) checksum ❌:
- expected `9f7d95fec1124517877c6621fb68f392830ad75010784cb7070bdb31bd446ec7`
- actual `57ef75b7ee92e9d27a570d4e878e4e1ccd2805456411f089bf0459224c555f2b`

That said, I suspect PR #197051 was created automatically. Unsure what caused the checksum mismatch, and whether there is a deeper-rooted bug to be fixed(?).