### PR TITLE
infoflow: disable

### DIFF
--- a/Casks/i/infoflow.rb
+++ b/Casks/i/infoflow.rb
@@ -11,10 +11,7 @@ cask "infoflow" do
   desc "AI office platform"
   homepage "https://infoflow.baidu.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2025-01-04", because: :no_longer_meets_criteria
 
   app "如流.app"
 


### PR DESCRIPTION
In order to install `infoflow` from the homepage, it requires a captcha and then url will be returned with the tokens. Without token, we cannot download the package file and so here I disable this.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
