### PR TITLE
muyu: disable

### DIFF
--- a/Casks/m/muyu.rb
+++ b/Casks/m/muyu.rb
@@ -7,10 +7,7 @@ cask "muyu" do
   desc "Combination of work efficiency and health"
   homepage "https://breakit.thriller.fun/"
 
-  livecheck do
-    url "https://breakit.thriller.fun/packages/appcast/appcast.xml"
-    strategy :sparkle
-  end
+  disable! date: "2025-01-04", because: :no_longer_available
 
   auto_updates true
   depends_on macos: ">= :ventura"


### PR DESCRIPTION
Homepage is gone with 401 unauthorized, and so the artifact cannot be downloaded. I coudn't found any alternatives and so disable this.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
