### PR TITLE
makehuman: disable

### DIFF
--- a/Casks/m/makehuman.rb
+++ b/Casks/m/makehuman.rb
@@ -6,12 +6,9 @@ cask "makehuman" do
       verified: "tuxfamily.org/makehuman/"
   name "MakeHuman"
   desc "Open Source tool for making 3D characters"
-  homepage "http://www.makehumancommunity.org/"
+  homepage "https://static.makehumancommunity.org/"
 
-  livecheck do
-    url "https://download.tuxfamily.org/makehuman/releases/"
-    regex(/makehuman[._-]community[._-]v?(\d+(?:\.\d+)+)[._-]macos\.zip/i)
-  end
+  disable! date: "2025-01-04", because: :no_longer_available
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
New release upon 4 years doesn't support macos and also the homepage url is changed.
If I modify the livecheck correctly, then it cannot be bumped, so fix the homepage but also deprecate.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
