### PR TITLE
quiet-reader: disable

### DIFF
--- a/Casks/q/quiet-reader.rb
+++ b/Casks/q/quiet-reader.rb
@@ -7,10 +7,7 @@ cask "quiet-reader" do
   desc "Read articles or text highlights distraction free"
   homepage "https://quietreader.app/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2025-01-04", because: :no_longer_available
 
   app "Quiet Reader.app"
 


### PR DESCRIPTION
https://quietreader.app

homepage is gone, `dig` not return any server and I haven't found any alternatives.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
