### PR TITLE
New Cask - Flowkeeper

### DIFF
--- a/Casks/f/flowkeeper.rb
+++ b/Casks/f/flowkeeper.rb
@@ -5,10 +5,12 @@ cask "flowkeeper" do
 
   on_arm do
     sha256 "d499a6235ee79e78270924e2fc97dbdbe4cca4afec368e8e8473173e282bd097"
+
     url "https://github.com/flowkeeper-org/fk-desktop/releases/download/#{version}/Flowkeeper.dmg"
   end
   on_intel do
     sha256 "629c911ec98fa3c7eb6e67a85c9f9f5296d28d2f81b07271c13a48ea05bb2c1a"
+
     url "https://github.com/flowkeeper-org/fk-desktop/releases/download/#{version}/Flowkeeper-x86.dmg"
   end
 

--- a/Casks/f/flowkeeper.rb
+++ b/Casks/f/flowkeeper.rb
@@ -1,0 +1,27 @@
+cask "flowkeeper" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "v0.8.1"
+
+  on_arm do
+    sha256 "d499a6235ee79e78270924e2fc97dbdbe4cca4afec368e8e8473173e282bd097"
+    url "https://github.com/flowkeeper-org/fk-desktop/releases/download/#{version}/Flowkeeper.dmg"
+  end
+  on_intel do
+    sha256 "629c911ec98fa3c7eb6e67a85c9f9f5296d28d2f81b07271c13a48ea05bb2c1a"
+    url "https://github.com/flowkeeper-org/fk-desktop/releases/download/#{version}/Flowkeeper-x86.dmg"
+  end
+
+  name "Flowkeeper"
+  desc "Independent Pomodoro Technique desktop timer for power users"
+  homepage "https://flowkeeper.org/"
+
+  depends_on macos: ">= :ventura"
+
+  app "Flowkeeper.app"
+
+  zap trash: [
+    "~/flowkeeper-data.txt",
+    "~/flowkeeper.log",
+  ]
+end


### PR DESCRIPTION

Proposing this new Cask for the App Flowkeeper.

I just can't pass the audit validation due to latest version (that is in release candidate)

Error output : 
```
bash-5.2$ brew audit --cask --new flowkeeper
==> Downloading and extracting artifacts
==> Downloading https://github.com/flowkeeper-org/fk-desktop/releases/download/v0.8.1/Flowkeeper.dmg
Already downloaded: /Users/user/Library/Caches/Homebrew/downloads/11eaa2eb7116f284e7aa6f8f020b93a4b08d0f6636c03fbc8c87cd2b0716e4c0--Flowkeeper.dmg
==> Downloading https://github.com/flowkeeper-org/fk-desktop/releases/download/v0.8.1/Flowkeeper.dmg
Already downloaded: /Users/user/Library/Caches/Homebrew/downloads/11eaa2eb7116f284e7aa6f8f020b93a4b08d0f6636c03fbc8c87cd2b0716e4c0--Flowkeeper.dmg
audit for flowkeeper: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
 - Version 'v0.8.1' differs from '0.9.0' retrieved by livecheck.
 - Version 'v0.8.1' differs from '0.9.0' retrieved by livecheck.
 - The URL's domain github.com does not match the homepage domain flowkeeper.org, a 'verified' parameter has to be added to the 'url' stanza. See https://docs.brew.sh/Cask-Cookbook#when-url-and-homepage-domains-differ-add-verified
flowkeeper
  * line 9, col 4: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
  * Version 'v0.8.1' differs from '0.9.0' retrieved by livecheck.
  * The URL's domain github.com does not match the homepage domain flowkeeper.org, a 'verified' parameter has to be added to the 'url' stanza. See https://docs.brew.sh/Cask-Cookbook#when-url-and-homepage-domains-differ-add-verified
Error: 3 problems in 1 cask detected.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---
