### PR TITLE
aegisub 3.4.1

### DIFF
--- a/Casks/a/aegisub.rb
+++ b/Casks/a/aegisub.rb
@@ -1,14 +1,19 @@
 cask "aegisub" do
-  version "3.2.2"
-  sha256 "d71fa46f074a2d5a252f30779e0b8d913d5157258f5d9fc333411f8c9493f42b"
+  version "3.4.1"
+  sha256 "006f69f117552a071503f723ad9ac8685e8c051055dcb132e6409c9a2f4cde64"
 
-  url "https://github.com/Aegisub/Aegisub/releases/download/v#{version}/Aegisub-#{version}.dmg"
+  url "https://github.com/TypesettingTools/Aegisub/releases/download/v#{version}/Aegisub-#{version}.dmg"
   name "Aegisub"
   desc "Create and modify subtitles"
-  homepage "https://github.com/Aegisub/Aegisub"
+  homepage "https://github.com/TypesettingTools/Aegisub"
 
-  # https://github.com/Aegisub/Aegisub/issues/336
-  deprecate! date: "2024-09-06", because: :unmaintained
+  # The repo has a garbage "r6962" tag from 2012 that should be excluded
+  livecheck do
+    strategy :git do |tags|
+      # example: v3.4.1
+      tags.filter_map { |tag| tag[/^v?(\d+(?:\.\d+)*)$/i, 1] }
+    end
+  end
 
   app "Aegisub.app"
 

--- a/Casks/a/aegisub.rb
+++ b/Casks/a/aegisub.rb
@@ -7,12 +7,9 @@ cask "aegisub" do
   desc "Create and modify subtitles"
   homepage "https://github.com/TypesettingTools/Aegisub"
 
-  # The repo has a garbage "r6962" tag from 2012 that should be excluded
   livecheck do
-    strategy :git do |tags|
-      # example: v3.4.1
-      tags.filter_map { |tag| tag[/^v?(\d+(?:\.\d+)*)$/i, 1] }
-    end
+    url :url
+    strategy :github_latest
   end
 
   app "Aegisub.app"


### PR DESCRIPTION
Per https://github.com/Aegisub/Aegisub/releases/tag/v3.2.2-migrated the repo has moved to https://github.com/TypesettingTools/Aegisub/

Adds livecheck stanza to cope with a garbage tag that was being picked above recent ones.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [✅] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [✅] `brew audit --cask --online <cask>` is error-free.
- [✅] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
