### PR TITLE
various: undeprecate `:unsigned`

### DIFF
--- a/Casks/c/chromedriver@beta.rb
+++ b/Casks/c/chromedriver@beta.rb
@@ -18,8 +18,6 @@ cask "chromedriver@beta" do
     end
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   conflicts_with cask: "chromedriver"
 
   binary "chromedriver-mac-#{arch}/chromedriver"

--- a/Casks/g/geogebra@5.rb
+++ b/Casks/g/geogebra@5.rb
@@ -18,8 +18,6 @@ cask "geogebra@5" do
     end
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   app "Geogebra.app"
 
   uninstall quit:       "org.geogebra#{version.major}.mac",

--- a/Casks/k/keepassxc@snapshot.rb
+++ b/Casks/k/keepassxc@snapshot.rb
@@ -29,8 +29,6 @@ cask "keepassxc@snapshot" do
     end
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   app "KeePassXC.app"
   binary "#{appdir}/KeePassXC.app/Contents/MacOS/keepassxc-cli"
 

--- a/Casks/o/openscad@snapshot.rb
+++ b/Casks/o/openscad@snapshot.rb
@@ -12,8 +12,6 @@ cask "openscad@snapshot" do
     regex(/OpenSCAD[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   conflicts_with cask: "openscad"
 
   app "OpenSCAD.app"

--- a/Casks/q/qbittorrent@lt20.rb
+++ b/Casks/q/qbittorrent@lt20.rb
@@ -13,8 +13,6 @@ cask "qbittorrent@lt20" do
     regex(%r{url=.*?/qbittorrent[._-]v?(\d+(?:\.\d+)+)[._-]lt20\.dmg}i)
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   conflicts_with cask: "qbittorrent"
   depends_on macos: ">= :big_sur"
 

--- a/Casks/q/qgis@ltr.rb
+++ b/Casks/q/qgis@ltr.rb
@@ -15,8 +15,6 @@ cask "qgis@ltr" do
     end
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   depends_on macos: ">= :high_sierra"
 
   app "QGIS-LTR.app"

--- a/Casks/t/transmission@nightly.rb
+++ b/Casks/t/transmission@nightly.rb
@@ -15,8 +15,6 @@ cask "transmission@nightly" do
     end
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   conflicts_with cask: "transmission"
   depends_on macos: ">= :big_sur"
 

--- a/Casks/v/vlc@nightly.rb
+++ b/Casks/v/vlc@nightly.rb
@@ -39,8 +39,6 @@ cask "vlc@nightly" do
     end
   end
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   conflicts_with cask: "vlc"
 
   app "VLC.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This undeprecates a number of Casks that were marked to be disabled due to being unsigned.  A formal decision on existing unsigned Casks has not been made.

These particular Casks are still receiving regular updates so doesn't seem they should receive a different treatment.