### PR TITLE
startupizer: deprecate

### DIFF
--- a/Casks/s/startupizer.rb
+++ b/Casks/s/startupizer.rb
@@ -8,16 +8,7 @@ cask "startupizer" do
   desc "Login items handler"
   homepage "http://gentlebytes.com/startupizer/"
 
-  livecheck do
-    url "https://updates.devmate.com/com.gentlebytes.Startupizer#{version.major}.xml"
-    regex(%r{/(\d+)/Startupizer(\d+?)[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
-    strategy :sparkle do |item, regex|
-      match = item.url.match(regex)
-      next if match.blank?
-
-      "#{match[2]},#{match[3]},#{match[1]}"
-    end
-  end
+  deprecate! date: "2025-01-05", because: :discontinued
 
   app "Startupizer#{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app has not been updated since 2018.

> Important announcement: As of september 1st 2019, Startupizer is no longer available for sale and there are no further updates planned. I will continue to do my best in supporting it, as I did so far and it should work fine. But it may stop working if future macOS update introduces unforseen breaking changes.
