### PR TITLE
lectrote: use arch specific app

### DIFF
--- a/Casks/l/lectrote.rb
+++ b/Casks/l/lectrote.rb
@@ -1,11 +1,16 @@
 cask "lectrote" do
-  version "1.5.2"
-  sha256 "453ac8e37f3829b9fac98f288300d9bea6e3fb78d5c577f3df5d08098508074f"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://github.com/erkyrath/lectrote/releases/download/lectrote-#{version}/Lectrote-#{version}-macos-universal.dmg"
+  version "1.5.2"
+  sha256 arm:   "b727d4bc64d503eea6f2378782df786100851309bb970c7cc2ff475f5d2f70fb",
+         intel: "19351bb7f76a0a6b348e85b182cbcf6acbf3aadb903cb65e43cf4dd49cccb996"
+
+  url "https://github.com/erkyrath/lectrote/releases/download/lectrote-#{version}/Lectrote-#{version}-macos-#{arch}.dmg"
   name "lectrote"
   desc "Interactive Fiction interpreter in an Electron shell"
   homepage "https://github.com/erkyrath/lectrote"
+
+  depends_on macos: ">= :catalina"
 
   app "Lectrote.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Moves from a large (178mb) universal binary in favor of the smaller (~100mb) arch specific binaries.