### PR TITLE
bloop: deprecate due to archived repo

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -140,7 +140,6 @@ blockbench
 blockstream-green
 blocs
 blood-on-the-clocktower-online
-bloop
 bluewallet
 boinc
 boltai

--- a/Casks/b/bloop.rb
+++ b/Casks/b/bloop.rb
@@ -11,10 +11,7 @@ cask "bloop" do
   desc "Code search engine"
   homepage "https://bloop.ai/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2025-01-05", because: :discontinued
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---


https://github.com/BloopAI/bloop was archived on 2025-01-02.