### PR TITLE
Revise HyperConnect 1.2.0 SHA256

### DIFF
--- a/Casks/h/hyperconnect.rb
+++ b/Casks/h/hyperconnect.rb
@@ -1,6 +1,6 @@
 cask "hyperconnect" do
   version "1.2.0"
-  sha256 "62a3e74eccf1d92852b02a729f1b707fddfa37a55d1b3982def626dde62aa3b2"
+  sha256 "e164c24941a37ee117b00bb74de99ba83a19cad15f96780177bb3721f79d15eb"
 
   url "https://cdn.cnbj1.fds.api.mi-img.com/mijia-ios-adhoc/hyperconnect/HyperConnect-#{version}.dmg",
       verified: "mi-img.com/mijia-ios-adhoc/hyperconnect/"


### PR DESCRIPTION
When I was using the command `brew upgrade hyperconnect`, I noticed an inconsistency in the SHA256 value for HyperConnect version 1.2.0. The actual SHA256 value I obtained was `e164c24941a37ee117b00bb74de99ba83a19cad15f96780177bb3721f79d15eb`, whereas it is supposed to be `62a3e74eccf1d92852b02a729f1b707fddfa37a55d1b3982def626dde62aa3b2` according to the expected configuration. This might lead to potential issues with the integrity and correctness of the installation process. It would be great if the maintainers could look into this and clarify the discrepancy.

I'm not sure if this is a bug in the packaging, a misconfiguration in the brew formula, or some other underlying problem. But hopefully, this information helps in resolving the issue and ensuring a smooth upgrade experience for all users.

Thank you! 