### PR TITLE
thor: fix sha256

### DIFF
--- a/Casks/t/thor.rb
+++ b/Casks/t/thor.rb
@@ -1,6 +1,6 @@
 cask "thor" do
   version "1.5.16"
-  sha256 "a22d11d609fc87a7e67de1002077b47f6596d73cd82cdce4457bc88a6839b8d2"
+  sha256 "07bd68a6378ac66d00fe39e0f0f0589694b19a46d89120b5934173a8c3b41a5a"
 
   url "https://github.com/gbammc/Thor/releases/download/#{version}/Thor_#{version}.zip"
   name "Thor"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online thor` is error-free.
- [x] `brew style --fix thor` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [ ] `brew audit --cask --new thor` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask thor` worked successfully.
- [ ] `brew uninstall --cask thor` worked successfully.

---

After verifying the SHA256 mismatch, I've updated the checksum for Thor 1.5.16.

SHA256 verification steps:
```bash
curl -L -o Thor_1.5.16.zip https://github.com/gbammc/Thor/releases/download/1.5.16/Thor_1.5.16.zip
shasum -a 256 Thor_1.5.16.zip
New SHA256: 07bd68a6378ac66d00fe39e0f0f0589694b19a46d89120b5934173a8c3b41a5a
