### PR TITLE
smart-converter-pro: update checksum, remove rosetta caveat

### DIFF
--- a/Casks/s/smart-converter-pro.rb
+++ b/Casks/s/smart-converter-pro.rb
@@ -1,6 +1,6 @@
 cask "smart-converter-pro" do
   version "3.1.6"
-  sha256 "6690f2c2fa5c8147699ca5226b37f6177a01ff0df93c5f77c4254e86a81e0d18"
+  sha256 "2ab2d7e478eba3c54a46480589a10a94c6c00627b7375eae710877acdecc5050"
 
   url "https://download.shedworx.com/scp#{version.major}/SmartConverterPro-#{version}.dmg"
   name "Smart Converter Pro"
@@ -20,8 +20,4 @@ cask "smart-converter-pro" do
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.shedworx.smartconverter.sfl*",
     "~/Library/Containers/com.shedworx.smartconverter",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
```
smart-converter-pro
  * exception while auditing smart-converter-pro: SHA256 mismatch
    Expected: 6690f2c2fa5c8147699ca5226b37f6177a01ff0df93c5f77c4254e86a81e0d18
      Actual: 2ab2d7e478eba3c54a46480589a10a94c6c00627b7375eae710877acdecc5050
        File: ../downloads/3a6a2c0ee079479d81d8970155ca1cf565beaa51ae93a39ce7cdb14f89507bb4--SmartConverterPro-3.1.6.dmg
```