### PR TITLE
starnet2: make `uninstall_preflight` fail more gracefully

### DIFF
--- a/Casks/s/starnet2.rb
+++ b/Casks/s/starnet2.rb
@@ -54,8 +54,6 @@ cask "starnet2" do
   uninstaller = "#{bin_path}/uninstaller.sh"
   uninstall_preflight do
     script_dir = "#{caskroom_path}/#{version}/StarNet2T_MacOS/lib"
-
-    # skip if the script directory doesn't exist
     next unless Dir.exist?(script_dir)
 
     libs = Dir.children(script_dir).map { |lib| "/usr/local/lib/#{lib}" }

--- a/Casks/s/starnet2.rb
+++ b/Casks/s/starnet2.rb
@@ -53,7 +53,12 @@ cask "starnet2" do
 
   uninstaller = "#{bin_path}/uninstaller.sh"
   uninstall_preflight do
-    libs = Dir.children("#{caskroom_path}/#{version}/StarNet2T_MacOS/lib").map { |lib| "/usr/local/lib/#{lib}" }
+    script_dir = "#{caskroom_path}/#{version}/StarNet2T_MacOS/lib"
+
+    # skip if the script directory doesn't exist
+    next unless Dir.exist?(script_dir)
+
+    libs = Dir.children(script_dir).map { |lib| "/usr/local/lib/#{lib}" }
     File.write uninstaller, <<~EOS
       rm #{libs.join(" ")}
     EOS


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Discovered in https://github.com/Homebrew/homebrew-cask/pull/197409