### PR TITLE
neteasemusic 3.0.6.2300

### DIFF
--- a/Casks/n/neteasemusic.rb
+++ b/Casks/n/neteasemusic.rb
@@ -10,11 +10,17 @@ cask "neteasemusic" do
   desc "Music streaming platform"
   homepage "https://music.163.com/"
 
-  # NeteaseMusic(>3.0) uses POST method to fetch the latest download URL.
-  # POST method currently is not supported by Homebrew's `:url` strategy.
-  # See https://github.com/orgs/Homebrew/discussions/5756.
+  # The upstream download page (https://music.163.com/#/download) uses a POST
+  # request to fetch download link information but livecheck doesn't support
+  # POST requests yet. Additionally, the request parameters are encrypted in a
+  # particular way (see https://github.com/orgs/Homebrew/discussions/5756).
+  # That said, the API endpoint appears to work with a simple `GET` request.
   livecheck do
-    skip "No version information available without POST method."
+    url "https://music.163.com/api/appcustomconfig/get"
+    regex(/NeteaseMusic[._-]v?(\d+(?:[._]\d+)+)[._-]web/i)
+    strategy :json do |json, regex|
+      json.dig("data", "web-new-download", "osx", "downloadUrl")&.[](regex, 1)
+    end
   end
 
   auto_updates true

--- a/Casks/n/neteasemusic.rb
+++ b/Casks/n/neteasemusic.rb
@@ -1,6 +1,6 @@
 cask "neteasemusic" do
-  version "2.3.21_1077"
-  sha256 "ec75e32da23e59a3dde1fcc97a57da87c76bbbb72d4ca36396b554318d2d02eb"
+  version "3.0.6.2300"
+  sha256 "8f03e22cbcb03391f7639f3d680b7a2c56d499bc0cafc018a1b3ef04b50c75c0"
 
   url "https://d1.music.126.net/dmusic/NeteaseMusic_#{version}_web.dmg",
       verified:   "d1.music.126.net/",
@@ -10,17 +10,15 @@ cask "neteasemusic" do
   desc "Music streaming platform"
   homepage "https://music.163.com/"
 
-  # The Sparkle feed uses non-English pubDates, which are not parsed correctly
-  # by the `:sparkle` strategy. As a workaround, the version is just extracted
-  # from the XML using a regex pattern on the download URLs.
+  # NeteaseMusic(>3.0) uses POST method to fetch the latest download URL. 
+  # POST method currently is not supported by Homebrew's `:url` strategy.
+  # See https://github.com/orgs/Homebrew/discussions/5756.
   livecheck do
-    url "https://music.163.com/api/osx/download/latest"
-    regex(/NeteaseMusic[._-]v?(\d+(?:[._]\d+)+)_web/i)
-    strategy :header_match
+    skip "No version information available without POST method."
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :mojave"
 
   app "NeteaseMusic.app"
 
@@ -30,8 +28,10 @@ cask "neteasemusic" do
     "~/Library/Application Support/com.netease.163music",
     "~/Library/Caches/com.netease.163music",
     "~/Library/Containers/com.netease.163music",
+    "~/Library/HTTPStorages/com.netease.163music",
     "~/Library/Cookies/com.netease.163music.binarycookies",
     "~/Library/Preferences/com.netease.163music.plist",
+    "~/Library/WebKit/com.netease.163music",
     "~/Library/Saved Application State/com.netease.163music.savedState",
   ]
 end

--- a/Casks/n/neteasemusic.rb
+++ b/Casks/n/neteasemusic.rb
@@ -10,7 +10,7 @@ cask "neteasemusic" do
   desc "Music streaming platform"
   homepage "https://music.163.com/"
 
-  # NeteaseMusic(>3.0) uses POST method to fetch the latest download URL. 
+  # NeteaseMusic(>3.0) uses POST method to fetch the latest download URL.
   # POST method currently is not supported by Homebrew's `:url` strategy.
   # See https://github.com/orgs/Homebrew/discussions/5756.
   livecheck do
@@ -28,10 +28,10 @@ cask "neteasemusic" do
     "~/Library/Application Support/com.netease.163music",
     "~/Library/Caches/com.netease.163music",
     "~/Library/Containers/com.netease.163music",
-    "~/Library/HTTPStorages/com.netease.163music",
     "~/Library/Cookies/com.netease.163music.binarycookies",
+    "~/Library/HTTPStorages/com.netease.163music",
     "~/Library/Preferences/com.netease.163music.plist",
-    "~/Library/WebKit/com.netease.163music",
     "~/Library/Saved Application State/com.netease.163music.savedState",
+    "~/Library/WebKit/com.netease.163music",
   ]
 end


### PR DESCRIPTION
Netease music V3 has been flagged as the stable version on its homepage and AppStore page. But it changed to
use a POST method to fetch its download link. See https://github.com/orgs/Homebrew/discussions/5756.


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
