### PR TITLE
another-redis-desktop-manager: disable autoupdate

### DIFF
--- a/Casks/a/another-redis-desktop-manager.rb
+++ b/Casks/a/another-redis-desktop-manager.rb
@@ -15,8 +15,6 @@ cask "another-redis-desktop-manager" do
     strategy :github_latest
   end
 
-  auto_updates true
-
   app "Another Redis Desktop Manager.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

<!--
Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
-->
---
Autoupdate is disabled for macOS, according to the dialog message.
<img width="335" alt="スクリーンショット 2025-01-08 12 10 25" src="https://github.com/user-attachments/assets/92489ee4-61b0-4af5-84a3-b6ee14fb2365" />

