### PR TITLE
vamiga 3.1.1 & bump minimum macOS

### DIFF
--- a/Casks/v/vamiga.rb
+++ b/Casks/v/vamiga.rb
@@ -1,6 +1,6 @@
 cask "vamiga" do
-  version "3.1"
-  sha256 "001ce85d60864df4da66b0e1f50d64eee2697a52a64606fe14aba11810081e16"
+  version "3.1.1"
+  sha256 "215b4b917c1bb1662c956fcfd9456fb6f54cc7225c8bb5e21406f86a2e9002e1"
 
   url "https://github.com/dirkwhoffmann/vAmiga/releases/download/v#{version}/vAmiga.app.zip",
       verified: "github.com/dirkwhoffmann/vAmiga/"
@@ -13,7 +13,7 @@ cask "vamiga" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :ventura"
 
   app "vAmiga.app"
 


### PR DESCRIPTION
[Hotfix](https://github.com/dirkwhoffmann/vAmiga/releases/tag/v3.1.1) for crashing bug. Also bump minimum macOS to Ventura introduced in 3.1.