### PR TITLE
Fix appflowy.rb 0.8.0 SHA256

### DIFF
--- a/Casks/a/appflowy.rb
+++ b/Casks/a/appflowy.rb
@@ -1,6 +1,6 @@
 cask "appflowy" do
   version "0.8.0"
-  sha256 "d68a241c694dd604ffe7389a73fa5c6a24e6c8237e4b14e139efdebc814161fa"
+  sha256 "7b0fbcff7641c78adc8fe6eb96aac79e9861d2c2d8dc99dafb47a4fc7af85f64"
 
   url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-universal.zip",
       verified: "github.com/AppFlowy-IO/AppFlowy/"


### PR DESCRIPTION
# Issue:
Have appflowy 0.7.9 installed
```
==> Found outdated apps
     Cask      Current  Latest  A/U    Result
1/1  appflowy  0.7.9    0.8.0        [OUTDATED]
```
but upgrading fails due SHA mismatch:
```
==> Upgrading appflowy to 0.8.0
==> Downloading https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.8.0/Appflowy-0.8.0-macos-universal.zip
Already downloaded: /Users/giraffe/Library/Caches/Homebrew/downloads/8d0e5e0502ed56d3182f004a43f1af1d59eabd8776f39479907fff7442b4c53d--AppFlowy-0.8.0-macos-universal.zip
Error: SHA256 mismatch
Expected: d68a241c694dd604ffe7389a73fa5c6a24e6c8237e4b14e139efdebc814161fa
  Actual: 7b0fbcff7641c78adc8fe6eb96aac79e9861d2c2d8dc99dafb47a4fc7af85f64
    File: /Users/giraffe/Library/Caches/Homebrew/downloads/8d0e5e0502ed56d3182f004a43f1af1d59eabd8776f39479907fff7442b4c53d--AppFlowy-0.8.0-macos-universal.zip
To retry an incomplete download, remove the file above.
```

# Reason:
AppFlowy released new artefacts for 0.8.0 today (Jan 8, 2025, 5:37 AM UTC), making the previous 0.8.0 SHA265 invalid.
 
# Verification:
I downloaded the zip file and ran sha256sum.

```bash
❯ sha256sum AppFlowy-0.8.0-macos-universal.zip
7b0fbcff7641c78adc8fe6eb96aac79e9861d2c2d8dc99dafb47a4fc7af85f64  AppFlowy-0.8.0-macos-universal.zip
```


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---


```
❯ brew bump --open-pr appflowy
Error: These casks are not in any locally installed taps!

  appflowy

You may need to run `brew tap` to install additional taps.
```


```
brew audit --cask --online appflowy
Fetching gem metadata from https://rubygems.org/.......
Fetching ast 2.4.2
Fetching json 2.9.1
Fetching language_server-protocol 3.17.0.3
Fetching parallel 1.26.3
Installing ast 2.4.2
Fetching racc 1.8.1
Installing json 2.9.1 with native extensions
Installing language_server-protocol 3.17.0.3
Installing parallel 1.26.3
Fetching rainbow 3.1.1
Installing racc 1.8.1 with native extensions
Installing rainbow 3.1.1
Fetching regexp_parser 2.10.0
Installing regexp_parser 2.10.0
Fetching unicode-emoji 4.0.4
Installing unicode-emoji 4.0.4
Fetching unicode-display_width 3.1.3
Installing unicode-display_width 3.1.3
Fetching parser 3.3.6.0
Installing parser 3.3.6.0
Fetching rubocop-ast 1.37.0
Installing rubocop-ast 1.37.0
Fetching rubocop 1.69.2
Installing rubocop 1.69.2
Fetching rubocop-md 1.2.4
Fetching rubocop-performance 1.23.1
Fetching rubocop-rspec 3.3.0
Fetching rubocop-sorbet 0.8.7
Installing rubocop-md 1.2.4
Installing rubocop-performance 1.23.1
Installing rubocop-rspec 3.3.0
Installing rubocop-sorbet 0.8.7
Bundle complete! 41 Gemfile dependencies, 30 gems now installed.
Bundled gems are installed into `../../../opt/homebrew/Library/Homebrew/vendor/bundle`
Error: These casks are not in any locally installed taps!

  appflowy

You may need to run `brew tap` to install additional taps.
```


