### PR TITLE
offset-explorer: fixed the installation version

### DIFF
--- a/Casks/o/offset-explorer.rb
+++ b/Casks/o/offset-explorer.rb
@@ -2,7 +2,7 @@ cask "offset-explorer" do
   version "3.0.2"
   sha256 :no_check
 
-  url "https://www.kafkatool.com/download2/offsetexplorer.dmg"
+  url "https://www.kafkatool.com/download#{version.major}/offsetexplorer.dmg"
   name "Offset Explorer"
   name "Kafka Tool"
   desc "GUI for managing and using Apache Kafka clusters"
@@ -13,11 +13,7 @@ cask "offset-explorer" do
     regex(/Offset\s*Explorer\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  app "Offset Explorer 2.app"
+  app "Offset Explorer #{version.major}.app"
 
-  zap trash: "~/.kafkatool2"
-
-  caveats do
-    requires_rosetta
-  end
+  zap trash: "~/.kafkatool#{version.major}"
 end


### PR DESCRIPTION
- Corrected the installation URL and version, because the installation was version 2.3.5, not the latest actual 3.0.2. The actual images of the application moved from download2 to download3. The application version has been updated as well.

- Deleted the caveats because brew audit was returning an error - Artifacts does not require Rosetta 2 but the caveats say otherwise!