### PR TITLE
satdump 1.2.1 (new cask)

### DIFF
--- a/Casks/s/satdump.rb
+++ b/Casks/s/satdump.rb
@@ -1,0 +1,22 @@
+cask "satdump" do
+  arch arm: "Silicon", intel: "Intel"
+
+  version "1.2.2"
+  sha256 arm:   "a84cdf81b27a8b484b654ccafe6072cd5b3e7dc06fc3280dd2b801a2ffeef93c",
+         intel: "009e48d0b243a1090e07ffe71b2678a0aab314129802522c6aafef4c83b7dcd7"
+
+  url "https://github.com/SatDump/SatDump/releases/download/#{version}/SatDump-macOS-#{arch}.dmg",
+      verified: "github.com/SatDump/SatDump/"
+  name "SatDump"
+  desc "Generic satellite data processing software"
+  homepage "https://www.satdump.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "SatDump.app"
+
+  zap trash: "~/Library/Saved Application State/com.altillimity.satdump.savedState"
+end

--- a/Casks/s/satdump.rb
+++ b/Casks/s/satdump.rb
@@ -17,6 +17,7 @@ cask "satdump" do
   end
 
   app "SatDump.app"
+  binary "#{appdir}/SatDump.app/Contents/MacOS/satdump"
 
   zap trash: "~/Library/Saved Application State/com.altillimity.satdump.savedState"
 end


### PR DESCRIPTION
> [SatDump](https://www.satdump.org/)is a general purpose satellite data processing software. It is a one-stop-shop that provides all the necessary stages to get from the satellite transmission to actual products.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Note

```console
$ brew audit --cask --online satdump

==> Downloading and extracting artifacts
==> Downloading https://github.com/SatDump/SatDump/releases/download/1.2.2/SatDump-macOS-Silicon.dmg
Already downloaded: /Users/kosei/Library/Caches/Homebrew/downloads/ab2db0d5837b3a851bc10d2ce0b6945381afe22a6cc303eb5ccead94001f0123--SatDump-macOS-Silicon.dmg
==> Downloading https://github.com/SatDump/SatDump/releases/download/1.2.2/SatDump-macOS-Silicon.dmg
Already downloaded: /Users/kosei/Library/Caches/Homebrew/downloads/ab2db0d5837b3a851bc10d2ce0b6945381afe22a6cc303eb5ccead94001f0123--SatDump-macOS-Silicon.dmg
```
```console
$ brew style --fix satdump

1 file inspected, no offenses detected
```
```console
$ brew audit --cask --new satdump
==> Downloading and extracting artifacts
==> Downloading https://github.com/SatDump/SatDump/releases/download/1.2.2/SatDump-macOS-Silicon.dmg
Already downloaded: /Users/kosei/Library/Caches/Homebrew/downloads/ab2db0d5837b3a851bc10d2ce0b6945381afe22a6cc303eb5ccead94001f0123--SatDump-macOS-Silicon.dmg
==> Downloading https://github.com/SatDump/SatDump/releases/download/1.2.2/SatDump-macOS-Silicon.dmg
Already downloaded: /Users/kosei/Library/Caches/Homebrew/downloads/ab2db0d5837b3a851bc10d2ce0b6945381afe22a6cc303eb5ccead94001f0123--SatDump-macOS-Silicon.dmg
```
```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask satdump

==> Downloading https://github.com/SatDump/SatDump/releases/download/1.2.2/SatDump-macOS-Silicon.dmg
Already downloaded: /Users/kosei/Library/Caches/Homebrew/downloads/ab2db0d5837b3a851bc10d2ce0b6945381afe22a6cc303eb5ccead94001f0123--SatDump-macOS-Silicon.dmg
==> Installing Cask satdump
==> Moving App 'SatDump.app' to '/Applications/SatDump.app'
🍺  satdump was successfully installed!
```
```
$  brew uninstall --cask satdump

==> Uninstalling Cask satdump
==> Backing App 'SatDump.app' up to '/opt/homebrew/Caskroom/satdump/1.2.2/SatDump.app'
==> Removing App '/Applications/SatDump.app'
==> Purging files for version 1.2.2 of Cask satdump
```