### PR TITLE
amazon q: update download/index url

### DIFF
--- a/Casks/a/amazon-q.rb
+++ b/Casks/a/amazon-q.rb
@@ -2,14 +2,14 @@ cask "amazon-q" do
   version "1.6.0"
   sha256 "63d9da1896138e7370966d0c85543bd61aa8e0594f872b067e0b35104597ce3c"
 
-  url "https://desktop-release.codewhisperer.us-east-1.amazonaws.com/#{version}/Amazon%20Q.dmg",
-      verified: "desktop-release.codewhisperer.us-east-1.amazonaws.com/"
+  url "https://desktop-release.q.us-east-1.amazonaws.com/#{version}/Amazon%20Q.dmg",
+      verified: "desktop-release.q.us-east-1.amazonaws.com/"
   name "Amazon Q"
   desc "AI-powered productivity tool for the command-line"
   homepage "https://aws.amazon.com/q/developer/"
 
   livecheck do
-    url "https://desktop-release.codewhisperer.us-east-1.amazonaws.com/index.json"
+    url "https://desktop-release.q.us-east-1.amazonaws.com/index.json"
     strategy :json do |json|
       json["versions"]&.map { |item| item["version"] }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

A little more context on this PR, we changes the release URLs for the product when we rebranded to Amazon Q from codewhisperer but they were never updated here. The old URLs still work for now but are not guaranteed into the future so this PR addresses that.