### PR TITLE
Update netbeans.rb with required macOS version

### DIFF
--- a/Casks/n/netbeans.rb
+++ b/Casks/n/netbeans.rb
@@ -14,6 +14,8 @@ cask "netbeans" do
     regex(/>\s*Apache\s*NetBeans\s*v?(\d+(?:\.\d+)*)\s*</im)
   end
 
+  depends_on macos: ">= :big_sur"
+
   pkg "Apache-NetBeans-#{version}.pkg"
 
   uninstall pkgutil: [


### PR DESCRIPTION
This change will enforce the required macOS version and will prevent a user getting an error message:

**You can’t use this version of the application “Apache NetBeans” with this version of macOS.**

![image](https://github.com/user-attachments/assets/7c7719c3-d935-4b59-8a2c-dbf4403f74da)



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
