### PR TITLE
topaz-video-ai 6.0.1

### DIFF
--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -1,6 +1,6 @@
 cask "topaz-video-ai" do
-  version "6.0.0"
-  sha256 "fcd81c15d98ba589f3ea400e7234bf1d82541b17deb64c3aea6207dbf37e1cf1"
+  version "6.0.1"
+  sha256 "1e19389f49450503f328ccece6b62bc928a57c2c1047f902dbd3ad1e87ee6b2e"
 
   url "https://downloads.topazlabs.com/deploy/TopazVideoAI/#{version}/TopazVideoAI-#{version}.dmg"
   name "Topaz Video AI"


### PR DESCRIPTION
Their download url points to the wrong place, but anyway the app is updated.

- Pointed to : https://downloads.topazlabs.com/deploy/TopazVideoAI/6.0.0/TopazVideoAI-6.0.1.dmg
- Actual : https://downloads.topazlabs.com/deploy/TopazVideoAI/6.0.1/TopazVideoAI-6.0.1.dmg

Furthermore, the :header_match is not working and so changed it to the community board. It seems that the request is blocked, I am not sure.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
