### PR TITLE
grammarly-desktop: revert to 1.101.1.0

### DIFF
--- a/Casks/g/grammarly-desktop.rb
+++ b/Casks/g/grammarly-desktop.rb
@@ -1,6 +1,6 @@
 cask "grammarly-desktop" do
-  version "1.101.2.0"
-  sha256 "bb288d895e0d8cc38dbe5aa7f3f3bd4cc37cc9af1af78fdcc9d59492bb3c79dc"
+  version "1.101.1.0"
+  sha256 "dea38136321ff3d04d103cfe6e49bd119aadf18e5370a6551bc2e8de8db4b37f"
 
   url "https://download-mac.grammarly.com/versions/#{version}/Grammarly.dmg"
   name "Grammarly Desktop"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Version `1.101.1.0` is the latest release available on the homepage and through the in-app updater.
