### PR TITLE
Fix appflowy.rb 0.8.0 SHA256

### DIFF
--- a/Casks/a/appflowy.rb
+++ b/Casks/a/appflowy.rb
@@ -1,6 +1,6 @@
 cask "appflowy" do
   version "0.8.0"
-  sha256 "7b0fbcff7641c78adc8fe6eb96aac79e9861d2c2d8dc99dafb47a4fc7af85f64"
+  sha256 "b387024cad46080758db40bc01ac742b450e9eb09d35f60833ec057197f2f566"
 
   url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-universal.zip",
       verified: "github.com/AppFlowy-IO/AppFlowy/"


### PR DESCRIPTION
Artifacts rebuilt again upstream. Same issue that motivated #197658. I downloaded the updated artifact and cross-checked the `sha256sum`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
