### PR TITLE
Add ubpm.app

### DIFF
--- a/Casks/u/ubpm.rb
+++ b/Casks/u/ubpm.rb
@@ -1,0 +1,30 @@
+cask "ubpm" do
+  version "1.12.0"
+  sha256 "898622ba741a3021f45b314c140c22aba2f82e570476d50be6461d2b3fc5ad29"
+
+  url "https://codeberg.org/LazyT/ubpm/releases/download/#{version}/ubpm_qt6-#{version}-x86_64.dmg"
+  name "ubpm"
+  desc "Universal Blood Pressure Manager"
+  homepage "https://codeberg.org/LazyT/ubpm"
+
+  livecheck do
+    url "https://codeberg.org/LazyT/ubpm/releases/latest"
+    strategy :page_match
+    regex(/ubpm_qt6[._-]v?(\d+(?:\.\d+)+)[._-]x86_64\.dmg/i)
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "ubpm.app"
+
+  zap trash: [
+    "~/Library/Application Support/ubpm",
+    "~/Library/Caches/ubpm",
+    "~/Library/Preferences/ubpm",
+    "~/Library/Saved Application State/page.codeberg.lazyt.ubpm.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
The app isn't signed and needs to be opened by right click for the first time. The minimum requirements from the README is macOS 12, but the `.app` specifies macOS 11. Somehow `brew uninstall --cask ubpm` doesn't delete the zaps on my system.

Feel free to edit if it can be improved.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
