### PR TITLE
guitar-pro: install full package

### DIFF
--- a/Casks/g/guitar-pro.rb
+++ b/Casks/g/guitar-pro.rb
@@ -1,8 +1,8 @@
 cask "guitar-pro" do
   version "8.1.3-121"
-  sha256 "89c3cf2f3110ad39e034bbec879972d717199b56283b551bed7a3b62596caa87"
+  sha256 "3c7ed10d1945b7ccd83caeb7caa9aec6852ac24640ab35192bf11bd8a16d182a"
 
-  url "https://downloads.guitar-pro.com/gp#{version.major}/#{version}/macOS/guitar-pro.tar.gz"
+  url "https://downloads.guitar-pro.com/gp#{version.major}/#{version}/macOS/guitar-pro-soundbank-full.tar.gz"
   name "Guitar Pro"
   desc "Sheet music editor software for guitar, bass, keyboards, drums and more"
   homepage "https://www.guitar-pro.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

When `guitar-pro` was updated to use a versioned `url` (see https://github.com/Homebrew/homebrew-cask/pull/192833), a lighter version of the installer was used, which does not include all the features that were previously available. This PR updates the cask to use the full installer, and aligns with the download found in the appcast.

Closes https://github.com/Homebrew/homebrew-cask/issues/198102