### PR TITLE
iexplorer: fix livecheck

### DIFF
--- a/Casks/i/iexplorer.rb
+++ b/Casks/i/iexplorer.rb
@@ -7,14 +7,17 @@ cask "iexplorer" do
   desc "iOS device backup software and file manager"
   homepage "https://macroplant.com/iexplorer"
 
+  # The response format of this URL seems to randomly switch between a plain
+  # text changelog and a Sparkle appcast XML file. This matches the version
+  # from dmg URLs in the text, which should work in either format.
   livecheck do
-    url "https://macroplant.com/iexplorer/mac/v#{version.csv.first.major}/appcast"
+    url "https://macroplant.com/iexplorer/appcast"
     regex(%r{/(\d+)/iExplorer[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :sparkle do |item, regex|
-      match = item.url.match(regex)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
       next if match.blank?
 
-      "#{item.version},#{match[1]}"
+      "#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Page is not a classic sparkle update file and so the livecheck failed there.