### PR TITLE
mullvadvpn: fetch from github

### DIFF
--- a/Casks/m/mullvadvpn.rb
+++ b/Casks/m/mullvadvpn.rb
@@ -9,8 +9,8 @@ cask "mullvadvpn" do
   homepage "https://mullvad.net/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://mullvad.net/download/vpn/macos"
+    regex(/href=.*?MullvadVPN[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
   conflicts_with cask: "mullvadvpn@beta"

--- a/Casks/m/mullvadvpn.rb
+++ b/Casks/m/mullvadvpn.rb
@@ -2,14 +2,15 @@ cask "mullvadvpn" do
   version "2025.2"
   sha256 "f5fdbe009489ef6c3f2d5182ca5b460dae555fbcbe3c132a9b7ff9316e41be0f"
 
-  url "https://cdn.mullvad.net/app/desktop/releases/#{version}/MullvadVPN-#{version}.pkg"
+  url "https://github.com/mullvad/mullvadvpn-app/releases/download/#{version}/MullvadVPN-#{version}.pkg",
+      verified: "github.com/mullvad/mullvadvpn-app/"
   name "Mullvad VPN"
   desc "VPN client"
   homepage "https://mullvad.net/"
 
   livecheck do
-    url "https://mullvad.net/download/app/pkg/latest/"
-    strategy :header_match
+    url :url
+    strategy :github_latest
   end
 
   conflicts_with cask: "mullvadvpn@beta"


### PR DESCRIPTION
## Notes

I've noticed that the mullvadvpn's cdn is really slow (maybe it is slow in my region, not sure). Thought it would be better to use their artifact in github instead.

---

## Checkboxes

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
  - I have trouble running this because I use [nix-darwin](https://github.com/LnL7/nix-darwin)
  - I am checking the box because CI seemed to have ran that with no issues on both intel and arm
- [x] `brew style --fix <cask>` reports no offenses.
