### PR TITLE
bettertouchtool: update the sha256 checksum

### DIFF
--- a/Casks/b/bettertouchtool.rb
+++ b/Casks/b/bettertouchtool.rb
@@ -1,6 +1,6 @@
 cask "bettertouchtool" do
   version "5.068,2025011401"
-  sha256 "e3075e3196613cea350c2a17c15f28ae52df233f35926b61362f7dc36e6fb6f4"
+  sha256 "49c784c3637eb52735ee1005de9e8fa66dcf51cd1d93c262b088732bb35ddbb7"
 
   url "https://folivora.ai/releases/btt#{version.csv.first}-#{version.csv.second}.zip"
   name "BetterTouchTool"


### PR DESCRIPTION
The file btt5.068-2025011401.zip have other checksum:
<img width="486" alt="image" src="https://github.com/user-attachments/assets/847eaa65-303a-4749-8a86-959479cb6817" />
