### PR TITLE
termora 1.0.2 (new cask)

### DIFF
--- a/Casks/t/termora.rb
+++ b/Casks/t/termora.rb
@@ -1,0 +1,21 @@
+cask "termora" do
+    arch arm: "aarch64", intel: "x86-64"
+  
+    version "1.0.2"
+    sha256 arm:   "ca97a8dc8549db24b548f1ee8d8416dfb670cce16ee313fc434e806ed7468098",
+           intel: "025aadf7a900d213e3047cfa4f534147cfdec91ba4ad6bd8c70a3ca4c720dae2"
+  
+    url "https://github.com/TermoraDev/termora/releases/download/#{version}/termora-#{version}-osx-#{arch}.dmg"
+    name "Termora"
+    desc "A terminal emulator and SSH client"
+    homepage "https://github.com/TermoraDev/termora"
+  
+    auto_updates true
+    depends_on macos: ">= :high_sierra"
+  
+    app "Termora.app"
+  
+    zap trash: [
+      "~/.termora",
+    ]
+  end

--- a/Casks/t/termora.rb
+++ b/Casks/t/termora.rb
@@ -1,21 +1,19 @@
 cask "termora" do
-    arch arm: "aarch64", intel: "x86-64"
-  
-    version "1.0.2"
-    sha256 arm:   "ca97a8dc8549db24b548f1ee8d8416dfb670cce16ee313fc434e806ed7468098",
-           intel: "025aadf7a900d213e3047cfa4f534147cfdec91ba4ad6bd8c70a3ca4c720dae2"
-  
-    url "https://github.com/TermoraDev/termora/releases/download/#{version}/termora-#{version}-osx-#{arch}.dmg"
-    name "Termora"
-    desc "A terminal emulator and SSH client"
-    homepage "https://github.com/TermoraDev/termora"
-  
-    auto_updates true
-    depends_on macos: ">= :high_sierra"
-  
-    app "Termora.app"
-  
-    zap trash: [
-      "~/.termora",
-    ]
-  end
+  arch arm: "aarch64", intel: "x86-64"
+
+  version "1.0.2"
+  sha256 arm:   "ca97a8dc8549db24b548f1ee8d8416dfb670cce16ee313fc434e806ed7468098",
+         intel: "025aadf7a900d213e3047cfa4f534147cfdec91ba4ad6bd8c70a3ca4c720dae2"
+
+  url "https://github.com/TermoraDev/termora/releases/download/#{version}/termora-#{version}-osx-#{arch}.dmg"
+  name "Termora"
+  desc "Terminal emulator and SSH client"
+  homepage "https://github.com/TermoraDev/termora"
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Termora.app"
+
+  zap trash: "~/.termora"
+end


### PR DESCRIPTION

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions)
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
