### PR TITLE
cloudflare-warp: update URLs

### DIFF
--- a/Casks/c/cloudflare-warp.rb
+++ b/Casks/c/cloudflare-warp.rb
@@ -2,18 +2,15 @@ cask "cloudflare-warp" do
   version "2024.12.554.0"
   sha256 "1cc6d8a35452216165000266e13a03ac893dfc6b13302ea226fea6357c907a6d"
 
-  url "https://1111-releases.cloudflareclient.com/mac/Cloudflare_WARP_#{version}.pkg",
-      verified: "1111-releases.cloudflareclient.com/mac/"
+  url "https://downloads.cloudflareclient.com/v1/download/macos/version/#{version}",
+      verified: "downloads.cloudflareclient.com/v1/download/macos/"
   name "Cloudflare WARP"
   desc "Free app that makes your Internet safer"
   homepage "https://cloudflarewarp.com/"
 
   livecheck do
-    # :sparkle strategy using appcenter url cannot be used - see below link
-    # https://github.com/Homebrew/homebrew-cask/pull/109118#issuecomment-887184248
-    url "https://1111-releases.cloudflareclient.com/mac/latest"
-    regex(/Cloudflare[._-]WARP[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
-    strategy :header_match
+    url "https://downloads.cloudflareclient.com/v1/update/sparkle/macos/ga"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
Updated the download and `livecheck` URLs, given Cloudflare is now using a self-hosted Sparkle feed and new download endpoint.

The main change of this PR is to use `strategy :sparkle` for `livecheck`.

The provided URLs are official Cloudflare URLs. They are used in their [developer documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/download-warp/) and the currently used download URL redirects to the new one.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
