### PR TITLE
Un-quarantine ClickHouse after installation

### DIFF
--- a/Casks/c/clickhouse.rb
+++ b/Casks/c/clickhouse.rb
@@ -8,7 +8,7 @@ cask "clickhouse" do
   url "https://github.com/ClickHouse/ClickHouse/releases/download/v#{version}/clickhouse-macos#{arch}",
       verified: "github.com/ClickHouse/ClickHouse/"
   name "Clickhouse"
-  desc "Column-oriented database management system"
+  desc "Superfast database for analytics"
   homepage "https://clickhouse.com/"
 
   livecheck do
@@ -17,6 +17,10 @@ cask "clickhouse" do
   end
 
   binary "clickhouse-macos#{arch}", target: "clickhouse"
+
+  postflight do
+    system "xattr", "-d", "com.apple.quarantine", "#{staged_path}/clickhouse-macos#{arch}"
+  end
 
   # No zap stanza required
 end


### PR DESCRIPTION
There are frequent ~~complaints~~ [questions](https://clickhouse.com/docs/knowledgebase/fix-developer-verification-error-in-macos) why the ClickHouse binary is quarantined after installation with homebrew. This PR un-quarantines it automatically. I am not sure if this is best practice but I see [similar tricks applied](https://github.com/search?q=casks++%22com.apple.quarantine%22+language%3ARuby&type=code) in other casks as well.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
