### PR TITLE
Mark Waterfox as auto-updating

### DIFF
--- a/Casks/w/waterfox.rb
+++ b/Casks/w/waterfox.rb
@@ -12,6 +12,7 @@ cask "waterfox" do
     strategy :header_match
   end
 
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Waterfox.app"

--- a/Casks/w/waterfox.rb
+++ b/Casks/w/waterfox.rb
@@ -1,6 +1,6 @@
 cask "waterfox" do
   version "6.5.3"
-  sha256 "77a28d1465b023546a29fb3817ef06fb4a0ef130f5667075dbbec7424c7add66"
+  sha256 "0456b88335d9175a81893f3eadfe94bbd9b4480f26614830abede2f3a9010a0d"
 
   url "https://cdn1.waterfox.net/waterfox/releases/#{version}/Darwin_x86_64-aarch64/Waterfox%20#{version}.dmg"
   name "Waterfox"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

As title. `brew audit --cask --online` reports mismatching hash, don't think that matters for this fix, though.