### PR TITLE
coteditor: fix legacy pinning, add sparkle

### DIFF
--- a/Casks/c/coteditor.rb
+++ b/Casks/c/coteditor.rb
@@ -8,8 +8,8 @@ cask "coteditor" do
     end
   end
   on_sierra do
-    version "3.9.7"
-    sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
+    version "3.7.8"
+    sha256 "c67a0b5049da7096228074d7b71e7678fcaaf795a5ae45bc593019662f0c6f09"
 
     livecheck do
       skip "Legacy version"
@@ -55,13 +55,21 @@ cask "coteditor" do
       skip "Legacy version"
     end
   end
-  on_ventura :or_newer do
+  on_ventura do
+    version "4.8.7"
+    sha256 "9c439ace99d6b74cf94738d24368ccc39c579902c7062f8e107c596061a58dda"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_sonoma :or_newer do
     version "5.0.8"
     sha256 "1f0773115410510cc0074b01110260a03788e4a00c059eb7dd855b09226f3b17"
 
     livecheck do
-      url :url
-      strategy :github_latest
+      url "https://coteditor.com/appcast.xml"
+      strategy :sparkle, &:short_version
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

- Conform pinning of legacy versions to https://coteditor.com/archives
- Switch livecheck to sparkle strategy (from github_latest)