### PR TITLE
araxis-merge: Add caveat for the default git integration

### DIFF
--- a/Casks/a/araxis-merge.rb
+++ b/Casks/a/araxis-merge.rb
@@ -57,11 +57,12 @@ cask "araxis-merge" do
   ]
 
   caveats <<~EOS
-    For the default git integration, edit the config file:
+    For instructions to integrate Araxis Merge with Finder or other applications,
+    see https://www.araxis.com/merge/documentation-os-x/installing.en
+
+    Note that integrations that depend on the `compare` tool will require adjustment,
+    e.g. for git:
       [mergetool "araxis"]
 	    path = "#{HOMEBREW_PREFIX}/bin/araxiscompare"
-
-    For general instructions to integrate Araxis Merge with Finder or other applications,
-    see https://www.araxis.com/merge/documentation-os-x/installing.en
   EOS
 end

--- a/Casks/a/araxis-merge.rb
+++ b/Casks/a/araxis-merge.rb
@@ -60,7 +60,7 @@ cask "araxis-merge" do
     For the default git integration, edit the config file:
       [mergetool "araxis"]
 	    path = "#{HOMEBREW_PREFIX}/bin/araxiscompare"
-    
+
     For general instructions to integrate Araxis Merge with Finder or other applications,
     see https://www.araxis.com/merge/documentation-os-x/installing.en
   EOS

--- a/Casks/a/araxis-merge.rb
+++ b/Casks/a/araxis-merge.rb
@@ -57,7 +57,11 @@ cask "araxis-merge" do
   ]
 
   caveats <<~EOS
-    For instructions to integrate Araxis Merge with Finder or other applications,
+    For the default git integration, edit the config file:
+      [mergetool "araxis"]
+	    path = "#{HOMEBREW_PREFIX}/bin/araxiscompare"
+    
+    For general instructions to integrate Araxis Merge with Finder or other applications,
     see https://www.araxis.com/merge/documentation-os-x/installing.en
   EOS
 end


### PR DESCRIPTION
git [supports](https://github.com/git/git/blob/master/mergetools/araxis) the "araxis" mergetool out of the box, but it expects compare in PATH.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
