### PR TITLE
millie: update livecheck

### DIFF
--- a/Casks/m/millie.rb
+++ b/Casks/m/millie.rb
@@ -1,15 +1,21 @@
 cask "millie" do
-  version "2.1.2,100"
+  version "2.1.2"
   sha256 "1ec0830ae6daeafd0eefe335f8b005feacfb9b3af2b14ddddd6e33db13917123"
 
-  url "https://install.millie.co.kr/flutter/#{version.csv.first}/millie.dmg"
+  url "https://install.millie.co.kr/flutter/#{version}/millie.dmg"
   name "Millie"
   desc "Korean e-book store"
   homepage "https://www.millie.co.kr/"
 
   livecheck do
-    url "https://install.millie.co.kr/flutter/millie.dmg"
-    strategy :extract_plist
+    url "https://install.millie.co.kr/flutter/flutter_desktop_version.json"
+    strategy :json do |json|
+      json["versions"]&.map do |version, platforms|
+        next if platforms["macos"] != "prod"
+
+        version
+      end
+    end
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
In-app version check uses the json file not appcast, and so I added a livecheck with `:json` strategy. I am still not sure the appcast.xml is correct or not.

- https://install.millie.co.kr/flutter/appcast.xml

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
