### PR TITLE
pearcleaner: fix sha256

### DIFF
--- a/Casks/p/pearcleaner.rb
+++ b/Casks/p/pearcleaner.rb
@@ -1,6 +1,6 @@
 cask "pearcleaner" do
   version "4.0.6"
-  sha256 "624a6aa3419d04c46e446d93ee6e9ac3cb192f43202eeca42cc1f5bb5cd8b4d6"
+  sha256 "fa73dac39ba3a85ffc3aa80570ff42fc6d7ef93e2ab578810f7f570d4378e186"
 
   url "https://github.com/alienator88/Pearcleaner/releases/download/#{version}/Pearcleaner.zip",
       verified: "github.com/alienator88/Pearcleaner/"


### PR DESCRIPTION
fix pearcleaner sha256

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
