### PR TITLE
Provide the correct location of the fly tgz file

### DIFF
--- a/Casks/f/fly.rb
+++ b/Casks/f/fly.rb
@@ -2,7 +2,7 @@ cask "fly" do
   version "7.12.0"
   sha256 "24c2feb62b293196cda2e08950affa7f2850b42a985336035fd03a606b25b935"
 
-  url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
+  url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-darwin-amd64.tgz"
   name "fly"
   desc "Official CLI tool for Concourse CI"
   homepage "https://github.com/concourse/concourse"


### PR DESCRIPTION
This PR fixes the URL of the fly download. The cask is currently broken, and this should fix it.

My machine is not set up to develop homebrew so I was not able to audit the cask or validate the style. You can see that my changes are minimal.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
