### PR TITLE
lazarus: deprecate

### DIFF
--- a/Casks/l/lazarus.rb
+++ b/Casks/l/lazarus.rb
@@ -8,10 +8,7 @@ cask "lazarus" do
   desc "IDE for rapid application development"
   homepage "https://www.lazarus-ide.org/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?macOS%20x86-64/Lazarus%20v?(\d+(?:\.\d+)+)/}i)
-  end
+  deprecate! date: "2025-01-26", because: :no_longer_meets_criteria
 
   depends_on cask: "fpc-laz"
   depends_on cask: "fpc-src-laz"


### PR DESCRIPTION
From 3.8, it requests to user run `xattr` and does not support any `.pkg` or `.dmg` file.

https://sourceforge.net/projects/lazarus/files/Lazarus%20macOS%20x86-64/Lazarus%203.8/

>The fpc dmg contains the Free Pascal Compiler.
>The lazarus zip contains the Lazarus IDE and the fpc sources. Don't forget to unmark the zip before unzipping:
> ```
> xattr -cr lazarus-darwin-aarch64-4.0.zip
> ```
>Installation:
>Before installing the compiler, the XCode command line tools must be installed from the Mac App Store. See here for details: https://wiki.freepascal.org/Installing_Lazarus_on_macOS#Installation

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---
