### PR TITLE
mutesync: disable

### DIFF
--- a/Casks/m/mutesync.rb
+++ b/Casks/m/mutesync.rb
@@ -11,10 +11,7 @@ cask "mutesync" do
   desc "Companion app to the mütesync physical button"
   homepage "https://mutesync.com/"
 
-  livecheck do
-    url "https://mutesync.s3.amazonaws.com/latest-mac.yml"
-    strategy :electron_builder
-  end
+  disable! date: "2025-01-26", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
> NOTE: As of November 16, 2024 the physical mütesync mute button is supported via the MuteMe application. The mütesync app will no longer receive updates and will eventually be retired. We recommend downloading the MuteMe application to use your mütesync physical button. For more information, visit this page on the MuteMe [website](https://muteme.com/pages/welcome-mutesync-customers).

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
