### PR TITLE
squidman: update livecheck, zap

### DIFF
--- a/Casks/s/squidman.rb
+++ b/Casks/s/squidman.rb
@@ -8,13 +8,22 @@ cask "squidman" do
   homepage "https://squidman.net/squidman/"
 
   livecheck do
-    url "https://squidman.net/squidman/releasenotes/index.html"
-    regex(/Version\s*?(\d+(?:\.\d+)+).*?released/i)
+    url :homepage
+    regex(%r{href=.*?/resources/downloads/?[^>]+?>\s*version\s+v?(\d+(?:\.\d+)+)\s*<}im)
   end
 
   app "SquidMan.app"
 
-  zap trash: "/usr/local/squid"
+  zap trash: [
+    "/Library/LaunchDaemons/com.mac.adg.SquidMan.plist",
+    "/Library/PrivilegedHelperTools/com.mac.adg.SquidMan",
+    "/usr/local/squid",
+    "~/Library/Caches/squid",
+    "~/Library/Logs/squid",
+    "~/Library/Preferences/com.mac.adg.SquidMan.plist",
+    "~/Library/Preferences/squid.conf",
+    "~/Library/Saved Application State/com.mac.adg.SquidMan.savedState",
+  ]
 
   caveats do
     files_in_usr_local


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the `livecheck` block for `squidman` to check the homepage, which contains download links. This is a little closer to the cask `url` source than the release notes. We can technically check the /resources/downloads directory listing page but there may be something to be said for checking the homepage downloads, as a dmg file may be uploaded before it's considered released.

This also updates the `zap` to account for related app files, as well as `squid` files that newer versions of Squidman will remove using "Uninstall Squid" from the main menu (see https://squidman.net/squidman/faq/).