### PR TITLE
malimite 1.1 (new cask)

### DIFF
--- a/Casks/m/malimite.rb
+++ b/Casks/m/malimite.rb
@@ -1,0 +1,43 @@
+cask "malimite" do
+  version "1.1"
+  sha256 "a74fd75844aedec13b523da6f8faaf9ec0c2a37027c4e372f74294ea07069528"
+
+  url "https://github.com/LaurieWired/Malimite/releases/download/#{version}/Malimite-1-1.zip"
+  name "Malimite"
+  desc "Decompiler for Apple applications"
+  homepage "https://github.com/LaurieWired/Malimite"
+
+  depends_on formula: "java"
+
+  postflight do
+    libexec = "#{HOMEBREW_PREFIX}/libexec/malimite"
+    bin = "#{HOMEBREW_PREFIX}/bin/malimite"
+
+    FileUtils.mkdir_p libexec
+    FileUtils.mv Dir["#{staged_path}/*"], libexec
+
+    File.write(bin, <<~EOS)
+      #!/bin/bash
+      exec java -jar "#{libexec}/Malimite-1-1.jar" "$@"
+    EOS
+    FileUtils.chmod("+x", bin)
+  end
+
+  uninstall delete: [
+    "#{HOMEBREW_PREFIX}/bin/malimite",
+    "#{HOMEBREW_PREFIX}/libexec/malimite",
+  ]
+
+  zap trash: [
+    "~/Library/Application Support/Malimite",
+    "~/Library/Caches/Malimite",
+    "~/Library/Logs/Malimite",
+    "~/Library/Preferences/com.lauriewired.malimite.plist",
+    "~/Library/Saved Application State/com.lauriewired.malimite.savedState",
+  ]
+
+  caveats <<~EOS
+    Ghidra is a recommended dependency for Malimite. You can install it via:
+      brew install --cask ghidra
+  EOS
+end


### PR DESCRIPTION
Add new cask for Malimite decompiler for iOS and macOS applications.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online malimite` is error-free.
- [X] `brew style --fix malimite.rb` reports no offenses.
- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new malimite` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask malimite` worked successfully.
- [X] `brew uninstall --cask malimite` worked successfully.

---
