### PR TITLE
font-maple-mono font-maple-mono-nf 7.0-beta36

### DIFF
--- a/Casks/font/font-m/font-maple-mono-nf.rb
+++ b/Casks/font/font-m/font-maple-mono-nf.rb
@@ -1,25 +1,32 @@
 cask "font-maple-mono-nf" do
   # Check on next version bump if the `container` stanza can be removed
-  version "6.4"
-  sha256 "7f2fa17546190d6e6790c562ae1926cacded22459eccf0eb9693719d1325e165"
+  version "7.0-beta36"
+  sha256 "d4dc9980d35b1af1511f42a953ab14b16f5843d8dbe9a74564fa2d91a4796857"
 
-  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMono-NF.zip"
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMono-NF-unhinted.zip"
   name "Maple Mono NF"
   homepage "https://github.com/subframe7536/Maple-font"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    cask "font-maple-mono"
   end
-
-  container type: :tar
 
   font "MapleMono-NF-Bold.ttf"
   font "MapleMono-NF-BoldItalic.ttf"
+  font "MapleMono-NF-ExtraBold.ttf"
+  font "MapleMono-NF-ExtraBoldItalic.ttf"
+  font "MapleMono-NF-ExtraLight.ttf"
+  font "MapleMono-NF-ExtraLightItalic.ttf"
   font "MapleMono-NF-Italic.ttf"
   font "MapleMono-NF-Light.ttf"
   font "MapleMono-NF-LightItalic.ttf"
+  font "MapleMono-NF-Medium.ttf"
+  font "MapleMono-NF-MediumItalic.ttf"
   font "MapleMono-NF-Regular.ttf"
+  font "MapleMono-NF-SemiBold.ttf"
+  font "MapleMono-NF-SemiBoldItalic.ttf"
+  font "MapleMono-NF-Thin.ttf"
+  font "MapleMono-NF-ThinItalic.ttf"
 
   # No zap stanza required
 end

--- a/Casks/font/font-m/font-maple-mono.rb
+++ b/Casks/font/font-m/font-maple-mono.rb
@@ -1,25 +1,34 @@
 cask "font-maple-mono" do
   # Check on next version bump if the `container` stanza can be removed
-  version "6.4"
-  sha256 "7f07c594d6da5971428dc9e8ecd2b7759a80cec1cb87dadd1a44aadbac5cf6ac"
+  version "7.0-beta36"
+  sha256 "2774a3ac6ab66e46bfaaea98d3cd71bff696eabcb8c103eab7fc7bae461a534c"
 
-  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMono-otf.zip"
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMono-ttf.zip"
   name "Maple Mono"
   homepage "https://github.com/subframe7536/Maple-font"
 
   livecheck do
     url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:-beta\d+)?)$/i)
     strategy :github_latest
   end
 
-  container type: :tar
-
-  font "MapleMono-Bold.otf"
-  font "MapleMono-BoldItalic.otf"
-  font "MapleMono-Italic.otf"
-  font "MapleMono-Light.otf"
-  font "MapleMono-LightItalic.otf"
-  font "MapleMono-Regular.otf"
+  font "MapleMono-Bold.ttf"
+  font "MapleMono-BoldItalic.ttf"
+  font "MapleMono-ExtraBold.ttf"
+  font "MapleMono-ExtraBoldItalic.ttf"
+  font "MapleMono-ExtraLight.ttf"
+  font "MapleMono-ExtraLightItalic.ttf"
+  font "MapleMono-Italic.ttf"
+  font "MapleMono-Light.ttf"
+  font "MapleMono-LightItalic.ttf"
+  font "MapleMono-Medium.ttf"
+  font "MapleMono-MediumItalic.ttf"
+  font "MapleMono-Regular.ttf"
+  font "MapleMono-SemiBold.ttf"
+  font "MapleMono-SemiBoldItalic.ttf"
+  font "MapleMono-Thin.ttf"
+  font "MapleMono-ThinItalic.ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Despite the tag including "beta" - the release is considered stable by the vendor - https://github.com/subframe7536/maple-font/releases/tag/v7.0-beta36