### PR TITLE
dingtalk-lite: disable

### DIFF
--- a/Casks/d/dingtalk-lite.rb
+++ b/Casks/d/dingtalk-lite.rb
@@ -8,11 +8,7 @@ cask "dingtalk-lite" do
   desc "Teamwork app by Alibaba Group"
   homepage "https://www.dingtalk.com/"
 
-  livecheck do
-    url "https://www.dingtalk.com/mac/d/qd=20170420173511985"
-    regex(/DingTalkLite_v(\d+(?:\.\d+)+)\.dmg/i)
-    strategy :header_match
-  end
+  disable! date: "2024-01-27", because: :no_longer_available
 
   auto_updates true
 


### PR DESCRIPTION
download url is gone, cannot find lite version from the homepage.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
