### PR TITLE
synology-surveillance-station-client: revert to 2.2.0

### DIFF
--- a/Casks/s/synology-surveillance-station-client.rb
+++ b/Casks/s/synology-surveillance-station-client.rb
@@ -1,6 +1,6 @@
 cask "synology-surveillance-station-client" do
-  version "2.2.1,2564"
-  sha256 "ca5ed3645a1303230d66cbd0bc160c58af88db346e5266f06da0b2d3444d86e9"
+  version "2.2.0,2507"
+  sha256 "bf0b6f1a2a01ab685132fc92e1b86337515377bcabd74a2aba1782b076fedf18"
 
   url "https://global.download.synology.com/download/Utility/SurveillanceStationClient/#{version.tr(",", "-")}/Mac/Synology%20Surveillance%20Station%20Client-#{version.tr(",", "-")}.dmg"
   name "Synology Surveillance Station Client"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Version 2.2.1 of the SurveillanceStationClient has been recalled due to a reported issue. The version is no longer available for download.

This PR updates the Homebrew formula to roll back to the previous stable version.

For more details, refer to the [official Synology change log](https://www.synology.com/api/releaseNote/findChangeLog?identify=SurveillanceStationClient&lang=en-us).
