### PR TITLE
libreoffice: revert to 24.8.4

### DIFF
--- a/Casks/l/libreoffice.rb
+++ b/Casks/l/libreoffice.rb
@@ -2,9 +2,9 @@ cask "libreoffice" do
   arch arm: "aarch64", intel: "x86-64"
   folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
-  version "25.2.0"
-  sha256 arm:   "f0bdac9830d736afa716ba92049380851bf576b969ebd7f01d3397291dbe7359",
-         intel: "7c616e860ea62ef659c88eda716ba0a138d87825735c328c204be38944063627"
+  version "24.8.4"
+  sha256 arm:   "cef2ac5ae8dda894cdd86c97bcd6da72ede81e78b1afa7d99d8676ac135ae114",
+         intel: "4322f7bda190887605acbdd73cd568d55ac366ca1f2cda82b029ef3de9ae071a"
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"


### PR DESCRIPTION
This reverts commit 08d02cf51d8158f3d2ab095d0820ff1ade6658be.

Attempting to upgrade to this version shows the following error:

```console
$ brew upgrade
==> Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them.
==> Upgrading 1 outdated package:
libreoffice 24.8.4 -> 25.2.0
==> Upgrading libreoffice
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-cask/9792fddc0cd89d50674b764ec32767006c5b4f2a/Casks/l/libreoffice.rb
Already downloaded: /Users/ahedges/Library/Caches/Homebrew/downloads/402743c747d308fd036e27af8570c20a8e6c5a2cb3038423c6ade5c7fd334c85--libreoffice.rb
==> Downloading https://download.documentfoundation.org/libreoffice/stable/25.2.0/mac/aarch64/LibreOffice_25.2.0_MacOS_aarch64.dmg
curl: (56) The requested URL returned error: 403

==> Purging files for version 25.2.0 of Cask libreoffice
Error: libreoffice: Download failed on Cask 'libreoffice' with message: Download failed: https://download.documentfoundation.org/libreoffice/stable/25.2.0/mac/aarch64/LibreOffice_25.2.0_MacOS_aarch64.dmg
```

The download URL[^1] doesn't show this version being available, and the blog[^2] says, "LibreOffice 25.2 ... is due to arrive next week!", so I believe this commit was made in error.

[^1]: https://download.documentfoundation.org/libreoffice/stable/
[^2]: https://blog.documentfoundation.org/blog/2025/01/29/libreoffice-project-and-community-recap-january-2025/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
