### PR TITLE
mysql-shell: add user_agent

### DIFF
--- a/Casks/m/mysql-shell.rb
+++ b/Casks/m/mysql-shell.rb
@@ -68,7 +68,7 @@ cask "mysql-shell" do
     sha256 arm:   "bb887018744ba6865efedd8f89bebc4c665fb8ad74cfa8a85fe4690791008faa",
            intel: "5abc9c25fe04df8622365705e5181cc3054fe7d1824e00116a8c06f11a217aea"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
+    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg", user_agent: "curl/8.7.1"
 
     livecheck do
       url "https://dev.mysql.com/downloads/shell/?tpl=platform&os=33"

--- a/audit_exceptions/secure_connection_audit_skiplist.json
+++ b/audit_exceptions/secure_connection_audit_skiplist.json
@@ -12,6 +12,10 @@
   "elecom-mouse-util": "https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/",
   "gotomeeting": "https://www.goto.com/meeting",
   "logmein-client": "https://www.logmein.com/pro",
+  "mysql-shell": [
+    "https://dev.mysql.com/downloads/shell/",
+    "https://dev.mysql.com/downloads/shell/?tpl=platform&os=33"
+  ],
   "native-access": "https://www.native-instruments.com/en/specials/native-access-2/",
   "tableau": [
     "https://www.tableau.com/products/desktop",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The asset URL for `mysql-shell` is correct but the download appears to fail with the default user agent as well as `user_agent: :fake` (or `:browser`). It does appear to work with `user_agent: "curl/8.7.1"`, as used in a few other casks.

Fixes #200164.