### PR TITLE
libreoffice: update livecheck

### DIFF
--- a/Casks/l/libreoffice.rb
+++ b/Casks/l/libreoffice.rb
@@ -12,9 +12,12 @@ cask "libreoffice" do
   desc "Free cross-platform office suite, fresh version"
   homepage "https://www.libreoffice.org/"
 
+  # Upstream may upload a new version to the stable directory
+  # (https://download.documentfoundation.org/libreoffice/stable/) before it's
+  # released, so we check the versions in the release notes instead.
   livecheck do
-    url "https://download.documentfoundation.org/libreoffice/stable/"
-    regex(%r{href=["']v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://www.libreoffice.org/download/release-notes/"
+    regex(/LibreOffice\s*v?(\d+(?:\.\d+)+)\s*\([^)]+\)[^<]*?Latest\s+Release/im)
   end
 
   conflicts_with cask: "libreoffice-still"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `libreoffice` currently works but it recently returned 25.2.0 as newest before returning to 24.8.4. Assuming that version was not publicly released at the time, upstream may have been staging a version before changing their mind or they simply made a brief mistake. Either way, this has made it clear that we can't rely on the `stable` directory only containing released versions.

This updates the `livecheck` block to check the "Release Notes" page, which lists both the latest and previous ("still") version. This regex is naturally more fragile but it works for now.

I will `libreoffice-still*` in a follow-up PR.