### PR TITLE
gtkwave, obs-websocket: remove livecheck

### DIFF
--- a/Casks/g/gtkwave.rb
+++ b/Casks/g/gtkwave.rb
@@ -7,11 +7,6 @@ cask "gtkwave" do
   desc "GTK+ based wave viewer"
   homepage "https://gtkwave.sourceforge.net/"
 
-  livecheck do
-    url :url
-    regex(%r{url=.*?/gtkwave[._-]v?(\d+(?:\.\d+)+)[._-]osx[._-]app/}i)
-  end
-
   deprecate! date: "2024-10-29", because: :discontinued
 
   app "gtkwave.app"

--- a/Casks/o/obs-websocket.rb
+++ b/Casks/o/obs-websocket.rb
@@ -7,14 +7,6 @@ cask "obs-websocket" do
   desc "Remote-control OBS Studio through WebSockets"
   homepage "https://github.com/obsproject/obs-websocket"
 
-  # Upstream has published releases for two different major versions, so the
-  # "latest" release may be for an older major version. Unless/until this is
-  # resolved, we have to check more than just the "latest" release.
-  livecheck do
-    url :url
-    strategy :github_releases
-  end
-
   deprecate! date: "2024-10-27", because: :discontinued
 
   pkg "obs-websocket-#{version}-macOS.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes the casks' livechecks since they have been deprecated.
