### PR TITLE
cursor: update homepage link

### DIFF
--- a/Casks/c/cursor.rb
+++ b/Casks/c/cursor.rb
@@ -9,7 +9,7 @@ cask "cursor" do
       verified: "download.todesktop.com/230313mzl4w4u92/"
   name "Cursor"
   desc "Write, edit, and chat about your code with AI"
-  homepage "https://cursor.sh/"
+  homepage "https://www.cursor.com/"
 
   livecheck do
     url "https://download.todesktop.com/230313mzl4w4u92/latest-mac.yml"


### PR DESCRIPTION
The web site of cursor seems like relocated to `https://www.cursor.com/` from `https://cursor.sh/`.

```sh
$ curl -i https://cursor.sh/
HTTP/2 308
cache-control: public, max-age=0, must-revalidate
content-type: text/plain
date: Sat, 01 Feb 2025 17:03:13 GMT
location: https://www.cursor.com/
refresh: 0;url=https://www.cursor.com/
server: Vercel
strict-transport-security: max-age=63072000
x-vercel-id: kix1::7xmvp-1738429393320-983c594a8797

Redirecting...
```
---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.



---
