### PR TITLE
retcon: update url, zap

### DIFF
--- a/Casks/r/retcon.rb
+++ b/Casks/r/retcon.rb
@@ -2,8 +2,8 @@ cask "retcon" do
   version "1.1.5"
   sha256 "2d257aae8809807cd01cf2de8fe1a7e1407cf2067f631eb8c4c0ad50b51c3d43"
 
-  url "https://f000.backblazeb2.com/file/downloads-lemon-garden/retcon/retcon-#{version}.dmg",
-      verified: "f000.backblazeb2.com/file/downloads-lemon-garden/"
+  url "https://downloads.lemon.garden/retcon/retcon-#{version}.dmg",
+      verified: "downloads.lemon.garden/retcon/"
   name "Retcon"
   desc "Drag-and-drop Git history editor"
   homepage "https://retcon.app/"

--- a/Casks/r/retcon.rb
+++ b/Casks/r/retcon.rb
@@ -20,6 +20,7 @@ cask "retcon" do
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/garden.lemon.retcon.sfl*",
+    "~/Library/Application Support/Retcon",
     "~/Library/Caches/garden.lemon.Retcon",
     "~/Library/HTTPStorages/garden.lemon.Retcon",
     "~/Library/Preferences/garden.lemon.Retcon.plist",


### PR DESCRIPTION
This updates two parts of the Retcon formula:
- **Updates download URL pattern:** The new URL pattern is guaranteed to stay valid over time, and is the one specified by the app's appcast. The previous URL (on B2) currently still works, but might break in the future, and is less reliable than the new URL. (B2 is blocked by some ISPs and workplace firewalls)
- **Adds an Application Support location to trash when zapping the formula:** The current version of Retcon doesn't typically write files there, but the upcoming update will.

(PS: it was so cool to see Retcon being added to Homebrew, so quickly after its release. thank you @unitof!!)