### PR TITLE
open-eid 24.9.0.1949 (new cask)

### DIFF
--- a/Casks/o/open-eid.rb
+++ b/Casks/o/open-eid.rb
@@ -1,0 +1,27 @@
+cask "open-eid" do
+  version "24.9.0.1949"
+  sha256 "e9c83c37836d9d0b78d2867f978caae1bb781ffbf62e40559484f5fad400268e"
+
+  url "https://installer.id.ee/media/osx/Open-EID_#{version}.dmg"
+  name "Open-EID"
+  desc "Estonian ID-card drivers, authentication components & signing components"
+  homepage "https://www.id.ee/en/article/install-id-software/"
+
+  livecheck do
+    url "https://www.id.ee/en/article/install-id-software/"
+    regex(/href=.*?Open[._-]EID[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  pkg "Open-EID.pkg"
+
+  uninstall script: {
+    executable: "uninstall.sh",
+    input:      ["y\n"],
+    sudo:       true,
+  }
+
+  # No zap stanza required
+end


### PR DESCRIPTION
Estonian government gives all residents and e-residents personal ID-card which can be used to sign/encrypt/decrypt. This software package allows to use it in browsers and other utilities. I understand this is not needed by everybody but it's mandatory for everyone in Estonia and by having it here it would be easier to find for others and thus it would make their life easier when installing all of their software into new computers.

I understand it might get rejected and thus I added it also to my personal cask:
```
$ brew install --cask onnimonni/tap/open-eid
```

_In the following questions `<cask>` is the token of the cask you're submitting._

After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues).
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).
- [x] `brew audit --new-cask <cask>` worked successfully.
- [x] `brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.