### PR TITLE
Bump AnythingLLM CDN Endpoint

### DIFF
--- a/Casks/a/anythingllm.rb
+++ b/Casks/a/anythingllm.rb
@@ -5,14 +5,14 @@ cask "anythingllm" do
   sha256 arm:   "c642ee866d21ec5d6f867c6287de54a32cd4cbfb90aa80e4eee72b4c2d18eca1",
          intel: "c495348c176ba2ba7f8c790dd408be69e3375211294f63c95c8f37090449998a"
 
-  url "https://cdn.useanything.com/latest/AnythingLLMDesktop#{arch}.dmg",
-      verified: "cdn.useanything.com/"
+  url "https://cdn.anythingllm.com/latest/AnythingLLMDesktop#{arch}.dmg",
+      verified: "cdn.anythingllm.com/"
   name "AnythingLLM"
   desc "Private desktop AI chat application"
   homepage "https://anythingllm.com/"
 
   livecheck do
-    url "https://cdn.useanything.com/latest/version.txt"
+    url "https://cdn.anythingllm.com/latest/version.txt"
     regex(/(\d+(?:\.\d+)+)/i)
   end
 


### PR DESCRIPTION
[connect #197512](https://github.com/Homebrew/homebrew-cask/pull/197512)

**Context**

I am the creator and primary maintainer of [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) and need to update this cask so that new pulls use our updated CDN as we are migrating it and calls to the previous CDN will begin to fail soon as we take it offline during migration to the new host.

**Validations**:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
