### PR TITLE
ci: switch to SSH based signing

### DIFF
--- a/.github/workflows/google-fonts.yml
+++ b/.github/workflows/google-fonts.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
-          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+          ssh: true
+          signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Import Google Fonts
         run: ./developer/bin/import_google_fonts vendor/google-fonts ${{ matrix.mode }}
@@ -83,11 +84,10 @@ jobs:
         env:
           COMMIT_BODY: >
             This commit was created automatically by the
-            [\`google-fonts\`](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/google-fonts.yml) 
+            [\`google-fonts\`](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/google-fonts.yml)
             workflow.
           GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           MODE: ${{ matrix.mode }}
 
       - name: Push commits
@@ -98,7 +98,6 @@ jobs:
           branch: "auto-${{ matrix.mode }}-google-fonts"
           GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
 
       - name: Create pull request with updated files
@@ -106,8 +105,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           PR_BODY: >
-            This pull request was created automatically by the 
-            [`google-fonts`](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/google-fonts.yml) 
+            This pull request was created automatically by the
+            [`google-fonts`](https://github.com/Homebrew/homebrew-cask/blob/master/.github/workflows/google-fonts.yml)
             workflow.
         run: |
           gh pr create \

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
-          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+          ssh: true
+          signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Checkout removal branch
         run: git checkout -b "$REMOVAL_BRANCH" origin/master
@@ -54,7 +55,6 @@ jobs:
         id: remove_disabled
         uses: Homebrew/actions/remove-disabled-packages@master
         env:
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_EVAL_ALL: 1
           HOMEBREW_NO_INSTALL_FROM_API: 1
 
@@ -68,7 +68,6 @@ jobs:
         env:
           GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Create pull request
         id: pr-create


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This switches the workflows to our new SSH signing key. No functional changes otherwise 🙂 

Follows similar migrations on `brew` and `homebrew-core`.
