### PR TITLE
check: skip checking AppStore

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -4,7 +4,9 @@ require "forwardable"
 require "system_command"
 
 APPLE_LAUNCHJOBS_REGEX =
-  /\A(?:application\.)?com\.apple\.(installer|Preview|Safari|systemevents|systempreferences|Terminal)(?:\.|$)/
+  /\A(?:application\.)?com\.apple\.
+  (AppStore|installer|Preview|Safari|systemevents|systempreferences|Terminal)
+  (?:\.|$)/x
 
 module Check
   # TODO: replace with public API like Utils.safe_popen_read that's less likely to be volatile to changes


### PR DESCRIPTION
Co-authored-by: Bevan Kay <bevanjkay@gmail.com>**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

It is possible that some applications may launch the appstore on installation, but we shouldn't be forcibly closing it, so skip it in the check.

Unblocks https://github.com/Homebrew/homebrew-cask/pull/200611

