### PR TITLE
libreoffice 25.2.0

### DIFF
--- a/Casks/l/libreoffice.rb
+++ b/Casks/l/libreoffice.rb
@@ -2,9 +2,9 @@ cask "libreoffice" do
   arch arm: "aarch64", intel: "x86-64"
   folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
-  version "24.8.4"
-  sha256 arm:   "cef2ac5ae8dda894cdd86c97bcd6da72ede81e78b1afa7d99d8676ac135ae114",
-         intel: "4322f7bda190887605acbdd73cd568d55ac366ca1f2cda82b029ef3de9ae071a"
+  version "25.2.0"
+  sha256 arm:   "f0bdac9830d736afa716ba92049380851bf576b969ebd7f01d3397291dbe7359",
+         intel: "7c616e860ea62ef659c88eda716ba0a138d87825735c328c204be38944063627"
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"
@@ -12,12 +12,22 @@ cask "libreoffice" do
   desc "Free cross-platform office suite, fresh version"
   homepage "https://www.libreoffice.org/"
 
-  # Upstream may upload a new version to the stable directory
-  # (https://download.documentfoundation.org/libreoffice/stable/) before it's
-  # released, so we check the versions in the release notes instead.
+  # We check the wiki homepage for release versions because:
+  # * Upstream may upload a new version to the stable download directory
+  #   (https://download.documentfoundation.org/libreoffice/stable/) before it's
+  #   released.
+  # * The contents of the download page can change based on user agent(?),
+  #   sometimes in unpredictable ways that break the check, so it's not an
+  #   entirely dependable source for us to check.
+  # * The libreoffice.org Release Notes page may not be updated in a timely
+  #   manner after new releases are announced (whereas the wiki appears to be
+  #   updated relatively soon after).
+  #
+  # NOTE: This needs to check a page that provides the latest versons for both
+  # Fresh and Still, as this check is also used by the `libreoffice-still` cask.
   livecheck do
-    url "https://www.libreoffice.org/download/release-notes/"
-    regex(/LibreOffice\s*v?(\d+(?:\.\d+)+)\s*\([^)]+\)[^<]*?Latest\s+Release/im)
+    url "https://wiki.documentfoundation.org/Main_Page"
+    regex(/>\s*Download\s+LibreOffice\s+v?(\d+(?:\.\d+)+)\s*</im)
   end
 
   conflicts_with cask: "libreoffice-still"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

It looks like version 25.2.0 of LibreOffice has been officially released now, so this updates the cask (again).

The `livecheck` block is still returning 24.8.4 as the latest Fresh version because the /download/release-notes/ page hasn't been updated. This updates the `livecheck` block to check the inner text of the download links on the wiki homepage, as that has been updated to reflect the latest versions.

This check isn't ideal but, then again, nothing about the upstream situation is (you know there's a problem when I have to use bullet points in an explanatory comment). Let's see if we can make it a few months before this breaks in some way and we have to resort to using carrier pigeons to get version information.