### PR TITLE
libreoffice-still 24.8.4

### DIFF
--- a/Casks/l/libreoffice-still.rb
+++ b/Casks/l/libreoffice-still.rb
@@ -2,9 +2,9 @@ cask "libreoffice-still" do
   arch arm: "aarch64", intel: "x86-64"
   folder = on_arch_conditional arm: "aarch64", intel: "x86_64"
 
-  version "24.2.7"
-  sha256 arm:   "44e2229c4e26bdd7f9270a79e4da363a08f4de87b698a3806295e9e50cbb1b62",
-         intel: "57b0af3ca12043ec3da6782ba58c094b12123549806451557f5a0a6e307a575a"
+  version "24.8.4"
+  sha256 arm:   "cef2ac5ae8dda894cdd86c97bcd6da72ede81e78b1afa7d99d8676ac135ae114",
+         intel: "4322f7bda190887605acbdd73cd568d55ac366ca1f2cda82b029ef3de9ae071a"
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
       verified: "download.documentfoundation.org/libreoffice/stable/"
@@ -12,12 +12,18 @@ cask "libreoffice-still" do
   desc "Free cross-platform office suite, stable version recommended for enterprises"
   homepage "https://www.libreoffice.org/"
 
-  # Upstream may upload a new version to the stable directory
-  # (https://download.documentfoundation.org/libreoffice/stable/) before it's
-  # released, so we check the versions in the release notes instead.
+  # This checks the same source of version information as the `libreoffice`
+  # cask, so we need to make sure that the former always checks a page that
+  # provides the latest versions for both Fresh and Still.
   livecheck do
-    url "https://www.libreoffice.org/download/release-notes/"
-    regex(/LibreOffice\s*v?(\d+(?:\.\d+)+)\s*\([^)]+\)[^<]*?Previous\s+Release/im)
+    cask "libreoffice"
+    strategy :page_match do |page, regex|
+      versions = page.scan(regex).map(&:first)
+      uniq_major_minor = versions.map { |version| Version.new(version).major_minor }.uniq.sort.reverse
+      next if uniq_major_minor.length < 2
+
+      versions.select { |version| Version.new(version).major_minor == uniq_major_minor[1] }
+    end
   end
 
   conflicts_with cask: "libreoffice"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `libreoffice-still` to 24.8.4 (again), now that it has been officially released. As with `libreoffice`, the `livecheck` block is incorrectly returning 24.2.7 as the newest Still version because upstream hasn't updated the libreoffice.org Release Notes page yet.

This also updates the `livecheck` block to use the `libreoffice` check (inheriting the `url` and `regex`), along with the previous `strategy` block that uses the second-highest version. This means that we need to make sure that the `libreoffice` `livecheck` block always checks a page that lists both the latest Fresh and Still versions.

This depends on the related `libreoffice` PR (https://github.com/Homebrew/homebrew-cask/pull/200939), so I'm creating this as a draft until that's merged (and will rebase afterward).