### PR TITLE
profilecreator 0.3.7

### DIFF
--- a/Casks/p/profilecreator.rb
+++ b/Casks/p/profilecreator.rb
@@ -1,21 +1,19 @@
 cask "profilecreator" do
-  version "0.3.2,201907171032-beta"
-  sha256 "a4a1b45bfaa6bc83aac7ef532981aaa0c807cd17fbfb1f157980144e5d309aea"
+  version "0.3.7"
+  sha256 "8579e70603a932faa8498181056e09469fa55b3fc2d0397fba165ac21f3a84ba"
 
-  url "https://github.com/erikberglund/ProfileCreator/releases/download/v#{version.csv.first}/ProfileCreator_v#{version.csv.first}-#{version.csv.second}.dmg"
+  url "https://github.com/ProfileCreator/ProfileCreator/releases/download/#{version}/ProfileCreator-#{version}.dmg"
   name "ProfileCreator"
   desc "Create standard or customised configuration profiles"
-  homepage "https://github.com/erikberglund/ProfileCreator"
+  homepage "https://github.com/ProfileCreator/ProfileCreator"
 
-  disable! date: "2024-12-16", because: :discontinued
-
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :big_sur"
 
   app "ProfileCreator.app"
 
   zap trash: [
     "~/Library/Application Support/ProfileCreator",
     "~/Library/Application Support/ProfilePayloads",
-    "~/Library/Preferences/com.github.erikberglund.ProfileCreator.plist",
+    "~/Library/Preferences/com.github.ProfileCreator.plist",
   ]
 end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -39,7 +39,6 @@
   "plugdata": "all",
   "positron": "all",
   "powershell@preview": "all",
-  "profilecreator": "all",
   "qdesktop": "all",
   "seaglass": "all",
   "servpane": "all",


### PR DESCRIPTION
[profilecreator](https://github.com/ProfileCreator/ProfileCreator) has changed a lot in recent years:
- ownership is now under @profilecreator
- deprecated in #195366 narrowly before latest release
- latest stable release is 0.3.7
- stable release, no need to allow pre-releases

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
