### PR TITLE
consul: migrate formula to casks

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -3,7 +3,6 @@
   "basex": "homebrew/core",
   "borgbackup": "homebrew/core",
   "chronograf": "homebrew/core",
-  "consul": "homebrew/core",
   "consul-template": "homebrew/core",
   "cryptol": "homebrew/core",
   "cups-pdf": "homebrew/core",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
this formula was deprecated almost one year ago and yet it is still being used (see [analytics](https://formulae.brew.sh/formula/consul)) and some formulae use it as a dependency. i think it would be better to at least migrate this formula to casks rather than removing it from the official repo completely

p.s. for some reasons `brew audit --cask --new consul` prints `consul is listed in tap_migrations.json` despite being removed from the list