### PR TITLE
scribus: patch release (ARM-only)

### DIFF
--- a/Casks/s/scribus.rb
+++ b/Casks/s/scribus.rb
@@ -1,11 +1,16 @@
 cask "scribus" do
-  arch arm: "_1-arm64"
+  arch arm: "-arm64"
 
-  version "1.6.3"
-  sha256 arm:   "7b046918ad07cf11582436eb064d53b15ca41e5c0e003d4f73107e959d975586",
-         intel: "7fc542f8d36b8f8e4ffc345f32e1b34be510fba1cda5d34cddf8876f1b6d7489"
+  on_arm do
+    version "1.6.3,1.6.3_1"
+    sha256 "7b046918ad07cf11582436eb064d53b15ca41e5c0e003d4f73107e959d975586"
+  end
+  on_intel do
+    version "1.6.3"
+    sha256 "7fc542f8d36b8f8e4ffc345f32e1b34be510fba1cda5d34cddf8876f1b6d7489"
+  end
 
-  url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}#{arch}.dmg",
+  url "https://downloads.sourceforge.net/scribus/scribus/#{version.csv.first}/scribus-#{version.csv.second || version.csv.first}#{arch}.dmg",
       verified: "sourceforge.net/scribus/"
   name "Scribus"
   desc "Free and open-source page layout program"
@@ -13,7 +18,15 @@ cask "scribus" do
 
   livecheck do
     url "https://sourceforge.net/projects/scribus/rss?path=/scribus"
-    regex(%r{url=.*?/scribus[._-]v?(\d+(?:\.\d+)+)(?:#{arch})?\.(?:dmg|pkg)}i)
+    regex(%r{url=.*?/v?(\d+(?:\.\d+)+)/scribus[._-]v?(\d+(?:[._]\d+)+)(?:#{arch})?\.(?:dmg|pkg)}i)
+    strategy :sourceforge do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      next match[1] if match[1] == match[2]
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   app "Scribus.app"

--- a/Casks/s/scribus.rb
+++ b/Casks/s/scribus.rb
@@ -1,8 +1,8 @@
 cask "scribus" do
-  arch arm: "-arm64"
+  arch arm: "_1-arm64"
 
   version "1.6.3"
-  sha256 arm:   "68929bc13c65c4462e04ae6dd785ce9d9be38c459bac7fe0ef4b6b71bf48d981",
+  sha256 arm:   "7b046918ad07cf11582436eb064d53b15ca41e5c0e003d4f73107e959d975586",
          intel: "7fc542f8d36b8f8e4ffc345f32e1b34be510fba1cda5d34cddf8876f1b6d7489"
 
   url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}#{arch}.dmg",


### PR DESCRIPTION
This fixes a build error that marked the app bundle "Sequoia-only": https://bugs.scribus.net/view.php?id=17409

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
