### PR TITLE
kindle-comic-creator: deprecate cask

### DIFF
--- a/Casks/k/kindle-comic-creator.rb
+++ b/Casks/k/kindle-comic-creator.rb
@@ -8,10 +8,7 @@ cask "kindle-comic-creator" do
   desc "Turns comics, graphic novels and manga into Kindle books"
   homepage "https://www.amazon.com/b?node=23496309011"
 
-  livecheck do
-    url :homepage
-    regex(/v?(\d+(?:\.\d+)+)\s+for\s+Intel\s+Mac/i)
-  end
+  deprecate! date: "2025-02-09", because: :unmaintained
 
   pkg "Kindle Comic Creator.pkg"
 


### PR DESCRIPTION
There is no version info now, and also there is a note.
> NOTE: You can now use Kindle Create to create your Comic with Guided View panels. Guided View allows readers to view a book on a panel-by-panel basis in a way that mimics the natural motion of the user's eye through the comic. Kindle Create is available in English, Dutch, French, Italian, German, Spanish, Portuguese, and Japanese languages.

Maybe deprecate better.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
