### PR TITLE
thumbhost3mf 1.7.1 (new cask)

### DIFF
--- a/Casks/t/thumbhost3mf.rb
+++ b/Casks/t/thumbhost3mf.rb
@@ -3,14 +3,9 @@ cask "thumbhost3mf" do
   sha256 "76c6ad0cb2cefb2ef88efd96949afe0b8f03573871d0192146a6083df5d6e19e"
 
   url "https://github.com/DavidPhillipOster/ThumbHost3mf/releases/download/#{version}/ThumbHost3mf#{version}.zip"
-  name "thumbhost3mf"
-  desc "App makes the Finder displays thumbnails of some .gcode, .bgcode, and .3mf files"
+  name "ThumbHost3mf"
+  desc "Finder thumbnail provider for some .gcode, .bgcode and .3mf files"
   homepage "https://github.com/DavidPhillipOster/ThumbHost3mf/"
-
-  livecheck do
-    url "https://github.com/DavidPhillipOster/ThumbHost3mf/releases"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
 
   depends_on macos: ">= :catalina"
 

--- a/Casks/t/thumbhost3mf.rb
+++ b/Casks/t/thumbhost3mf.rb
@@ -1,0 +1,20 @@
+cask "thumbhost3mf" do
+  version "1.7.1"
+  sha256 "76c6ad0cb2cefb2ef88efd96949afe0b8f03573871d0192146a6083df5d6e19e"
+
+  url "https://github.com/DavidPhillipOster/ThumbHost3mf/releases/download/#{version}/ThumbHost3mf#{version}.zip"
+  name "thumbhost3mf"
+  desc "App makes the Finder displays thumbnails of some .gcode, .bgcode, and .3mf files"
+  homepage "https://github.com/DavidPhillipOster/ThumbHost3mf/"
+
+  livecheck do
+    url "https://github.com/DavidPhillipOster/ThumbHost3mf/releases"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "ThumbHost3mf.app"
+
+  zap trash: "~/Library/Containers/com.turbozen.-mfQuickLook/Data/Library/Preferences/com.turbozen.-mfQuickLook.plist"
+end


### PR DESCRIPTION
A macOS app that hosts a thumbnail provider that makes the Finder displays the thumbnails built in to some .gcode, .bgcode, and .3mf files.

See https://github.com/DavidPhillipOster/ThumbHost3mf/issues/11 for corresponding discussion.
https://github.com/Homebrew/homebrew-cask/pull/182172 was an earlier attempt.

This 1.7.1 version of ThumbHosr3mf is Signed, Notarized, and Validates.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask --online <cask>` is error-free.
- [x ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ x] `brew audit --cask --new <cask>` worked successfully.
- [ x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x ] `brew uninstall --cask <cask>` worked successfully.

---
