### PR TITLE
pycharm-edu: deprecate

### DIFF
--- a/Casks/p/pycharm-edu.rb
+++ b/Casks/p/pycharm-edu.rb
@@ -11,18 +11,7 @@ cask "pycharm-edu" do
   desc "Professional IDE for scientific and web Python development"
   homepage "https://www.jetbrains.com/pycharm-edu/"
 
-  livecheck do
-    url "https://data.services.jetbrains.com/products/releases?code=PCE&latest=true&type=release"
-    strategy :json do |json|
-      json["PCE"]&.map do |release|
-        version = release["version"]
-        build = release["build"]
-        next if version.blank? || build.blank?
-
-        "#{version},#{build}"
-      end
-    end
-  end
+  deprecate! date: "2025-02-10", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :el_capitan"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> Starting with EduTools 2022.11, we no longer release new versions of IntelliJ IDEA Edu and PyCharm Edu.
> https://blog.jetbrains.com/education/2022/12/01/sunsetting-educational-ides/