### PR TITLE
backblaze-downloader: fix installation

### DIFF
--- a/Casks/b/backblaze-downloader.rb
+++ b/Casks/b/backblaze-downloader.rb
@@ -1,5 +1,5 @@
 cask "backblaze-downloader" do
-  version "9.0.1.772"
+  version "9.1.0.832"
   sha256 :no_check
 
   url "https://secure.backblaze.com/mac_restore_downloader"
@@ -12,7 +12,7 @@ cask "backblaze-downloader" do
     regex(/Version\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  app "Backblaze Downloader.app"
+  app "BackblazeDownloader.app"
 
   uninstall quit: "com.backblaze.BackblazeDownloader"
 


### PR DESCRIPTION
Update the cask installation.
The version is required in the container path but when it is updated without release note, then it will be broken anyway.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
