### PR TITLE
transmit: downgrade to 5.10.6, update livecheck

### DIFF
--- a/Casks/t/transmit.rb
+++ b/Casks/t/transmit.rb
@@ -1,6 +1,6 @@
 cask "transmit" do
-  version "5.10.7"
-  sha256 "e2f6cfe089f9dbd1c404aa6d07a30a6942241dcc8751ea3be8f709d64e23281e"
+  version "5.10.6"
+  sha256 "0c686c9c636856a6739470ebf6abe4398f4985a37f6e4524edb0d8d4b79b4381"
 
   url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
   name "Transmit"
@@ -8,8 +8,8 @@ cask "transmit" do
   homepage "https://panic.com/transmit/"
 
   livecheck do
-    url "https://help.panic.com/transmit/transmit#{version.major}/release-integrity/"
-    regex(/href=.*?Transmit[\s._-]?v?(\d+(?:\.\d+)+)\.zip/i)
+    url "https://download.panic.com/transmit/Transmit-#{version.major}-Latest.zip"
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `transmit` is returning 5.10.7 as the latest version, as the Release Integrity page contains information for 5.10.7. However, the 5.10.7 link is currently giving a 404 response and the redirecting "latest" link on the main download page points to 5.10.6 instead. The cask was recently updated to 5.10.7 but upgrades are failing because the cask `url` isn't accessible.

This downgrades the cask to 5.10.6 until 5.10.7 is available and updates the `livecheck` block to check the "latest" link instead.