### PR TITLE
ibkr: Fix path to the uninstaller

### DIFF
--- a/Casks/i/ibkr.rb
+++ b/Casks/i/ibkr.rb
@@ -32,7 +32,7 @@ cask "ibkr" do
               ["TERM", "IBKR Desktop.app"],
             ],
             script: {
-              executable: "/Applications/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "~/Applications/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 

--- a/Casks/i/ibkr.rb
+++ b/Casks/i/ibkr.rb
@@ -23,7 +23,10 @@ cask "ibkr" do
 
   installer script: {
     executable: "#{staged_path}/IBKR Desktop Installer.app/Contents/MacOS/JavaApplicationStub",
-    args:       ["-q"],
+    args:       [
+      "-dir", "#{appdir}/IBKR Desktop",
+      "-q"
+    ],
   }
 
   uninstall signal: [
@@ -32,13 +35,12 @@ cask "ibkr" do
               ["TERM", "IBKR Desktop.app"],
             ],
             script: {
-              executable: "~/Applications/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
+              executable: "#{appdir}/IBKR Desktop/IBKR Desktop Uninstaller.app/Contents/MacOS/JavaApplicationStub",
               args:       ["-q"],
             }
 
   zap trash: [
-    "/Applications/IBKR Desktop",
-    "~/Applications/IBKR Desktop",
+    "#{appdir}/IBKR Desktop",
     "~/Desktop/IBKR Desktop",
     "~/Jts",
     "~/Library/Application Support/IBKR Desktop",


### PR DESCRIPTION
IBKR Desktop's installer uses  rather than  as its installation location.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---
