### PR TITLE
turbotax-2024: add livecheck and use versioned url

### DIFF
--- a/Casks/t/turbotax-2024.rb
+++ b/Casks/t/turbotax-2024.rb
@@ -1,11 +1,32 @@
 cask "turbotax-2024" do
-  version "2024.r15.018"
-  sha256 :no_check
+  version "2024.000.0134,EEC27609A06C50D941A28836AE5217A4"
+  sha256 "766ad9323834f063dbc133c9e0e4d0793332ea651f224b29b9926cf8768a31d8"
 
-  url "https://downloads.ecom.intuit.com/ttfed/24tax/Mac_TurboTax_Download.dmg"
+  url "https://downloadpatch.esd.intuit.com/ESD/Files/CTG/comp/#{version.csv.second}/v1/Content/Mac_TurboTax_Download2024.dmg"
   name "TurboTax 2024"
   desc "Tax declaration for the fiscal year 2024"
   homepage "https://turbotax.intuit.com/personal-taxes/cd-download/"
+
+  livecheck do
+    url "https://downloadpatch.esd.intuit.com/requestadapter/ctg/comp/2024/turbotaxpersonal/mcusi0000pp00/mac/deliverytarget_live.xml"
+    regex(%r{.*?/ESD/Files/CTG/comp/([^/]+)/.*}i)
+    strategy :xml do |xml, regex|
+      latest_version = xml.get_elements("//DeliveryPackages/CoreDeliveryPackageInfo/InternalName")
+                          .map { |item| item.text&.strip }.max
+      latest_package_info = xml.elements["//InternalName[text()='#{latest_version}']"]&.parent
+      latest_xml_url = latest_package_info.elements["BaseUri"]&.text
+      internal_version = latest_package_info.elements["InternalName"]&.text&.match(/(\d+(?:\.\d+)*)/i)
+      latest_content = Homebrew::Livecheck::Strategy.page_content(latest_xml_url)
+      next if latest_content.blank?
+
+      latest_xml = Homebrew::Livecheck::Strategy::Xml.parse_xml(latest_content[:content])
+      latest_url = latest_xml.elements["//DeliveryPackageData/FileContent/ContentNetworkBaseUri"]&.text&.strip
+      match = latest_url&.match(regex)
+      next if match.blank?
+
+      "#{internal_version},#{match[1]}"
+    end
+  end
 
   auto_updates true
   depends_on macos: ">= :ventura"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
