### PR TITLE
oso-cloud 0.26.1

### DIFF
--- a/Casks/o/oso-cloud.rb
+++ b/Casks/o/oso-cloud.rb
@@ -1,11 +1,10 @@
 cask "oso-cloud" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "0.26.0"
-  sha256 arm:   "8880d68f1a45615e9ce6e024630ab17e2bd9ef08a598eb7bbf6b73e6b85841d3",
-         intel: "c2879ef2ad0d41586bf6e896d4d9af10c4cc1fccbf5feb4d0dc07410be9c8f9a"
+  version "0.26.1"
+  sha256 :no_check
 
-  url "https://d3i4cc4dqewpo9.cloudfront.net/#{version}/oso_cli_mac_osx_#{arch}",
+  url "https://d3i4cc4dqewpo9.cloudfront.net/latest/oso_cli_mac_osx_#{arch}",
       verified: "d3i4cc4dqewpo9.cloudfront.net/"
   name "OSO Cloud CLI"
   desc "Tool for interacting with OSO Cloud"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The URL format changed, and we now have to seemingly use latest, as putting the latest version (0.26.1, confirmed by the docs) doesn't work. This behavior is replicated by the install script they provide.

Accordingly, I've removed the sha256 check, since if I remember correctly, it shouldn't be put with casks where the URL doesn't change between versions.