### PR TITLE
font-aporetic 1.1.0 (new cask), font-iosevka-comfy: deprecate

### DIFF
--- a/Casks/font/font-a/font-aporetic.rb
+++ b/Casks/font/font-a/font-aporetic.rb
@@ -1,0 +1,27 @@
+cask "font-aporetic" do
+  version "1.1.0"
+  sha256 "17e394ea286c2ecf6b7abbe25fc869f233796aa71678a9ef682df57164384f93"
+
+  url "https://github.com/protesilaos/aporetic/archive/refs/tags/#{version}.tar.gz"
+  name "Aporetic"
+  homepage "https://github.com/protesilaos/aporetic"
+
+  font "aporetic-#{version}/aporetic-sans/TTF/aporetic-sans-normalbolditalic.ttf"
+  font "aporetic-#{version}/aporetic-sans/TTF/aporetic-sans-normalboldupright.ttf"
+  font "aporetic-#{version}/aporetic-sans/TTF/aporetic-sans-normalregularitalic.ttf"
+  font "aporetic-#{version}/aporetic-sans/TTF/aporetic-sans-normalregularupright.ttf"
+  font "aporetic-#{version}/aporetic-sans-mono/TTF/aporetic-sans-mono-normalbolditalic.ttf"
+  font "aporetic-#{version}/aporetic-sans-mono/TTF/aporetic-sans-mono-normalboldupright.ttf"
+  font "aporetic-#{version}/aporetic-sans-mono/TTF/aporetic-sans-mono-normalregularitalic.ttf"
+  font "aporetic-#{version}/aporetic-sans-mono/TTF/aporetic-sans-mono-normalregularupright.ttf"
+  font "aporetic-#{version}/aporetic-serif/TTF/aporetic-serif-normalbolditalic.ttf"
+  font "aporetic-#{version}/aporetic-serif/TTF/aporetic-serif-normalboldupright.ttf"
+  font "aporetic-#{version}/aporetic-serif/TTF/aporetic-serif-normalregularitalic.ttf"
+  font "aporetic-#{version}/aporetic-serif/TTF/aporetic-serif-normalregularupright.ttf"
+  font "aporetic-#{version}/aporetic-serif-mono/TTF/aporetic-serif-mono-normalbolditalic.ttf"
+  font "aporetic-#{version}/aporetic-serif-mono/TTF/aporetic-serif-mono-normalboldupright.ttf"
+  font "aporetic-#{version}/aporetic-serif-mono/TTF/aporetic-serif-mono-normalregularitalic.ttf"
+  font "aporetic-#{version}/aporetic-serif-mono/TTF/aporetic-serif-mono-normalregularupright.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-i/font-iosevka-comfy.rb
+++ b/Casks/font/font-i/font-iosevka-comfy.rb
@@ -6,6 +6,8 @@ cask "font-iosevka-comfy" do
   name "Iosevka-Comfy"
   homepage "https://github.com/protesilaos/iosevka-comfy"
 
+  deprecate! date: "2024-02-19", because: :discontinued, replacement: "font-aporetic"
+
   font "iosevka-comfy-#{version}/iosevka-comfy-duo/TTF/iosevka-comfy-duo-normalbolditalic.ttf"
   font "iosevka-comfy-#{version}/iosevka-comfy-duo/TTF/iosevka-comfy-duo-normalboldupright.ttf"
   font "iosevka-comfy-#{version}/iosevka-comfy-duo/TTF/iosevka-comfy-duo-normalextrabolditalic.ttf"


### PR DESCRIPTION
Customised build of the Iosevka typeface, with a consistent rounded style and overrides for almost all individual glyphs in both upright (roman) and slanted (italic) variants. The successor to now-discontinued iosevka-comfy fonts.

- https://protesilaos.com/codelog/2025-02-12-aporetic-fonts-version-1-1-0/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
