### PR TITLE
dropbox-capture: disable and add uninstall and more zap entries

### DIFF
--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -26,6 +26,13 @@ cask "dropbox-capture" do
 
   app "Dropbox Capture.app"
 
+  uninstall quit:       [
+              "com.dropbox.capture.systemaudio",
+              "com.electron.dropbox-capture",
+              "com.electron.dropbox-capture.helper",
+            ],
+            login_item: "Dropbox Capture"
+
   zap trash: [
     "~/Library/Application Support/Dropbox-Capture",
     "~/Library/Caches/com.electron.dropbox-capture",

--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -1,5 +1,6 @@
 cask "dropbox-capture" do
   arch arm: "arm64", intel: "x86_64"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
 
   version "116.3.0"
   sha256 arm:   "3ef49cad0ade501f75bea5ff3fc260d55f59664c2db93d48974279779c35f0d3",
@@ -12,8 +13,10 @@ cask "dropbox-capture" do
   homepage "https://dropbox.com/capture/"
 
   livecheck do
-    url "https://dropbox.com/capture/download"
-    strategy :header_match
+    url "https://client.dropbox.com/squirrel/dropbox-capture/update_check/stable?localversion=0&arch=#{livecheck_arch}"
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   disable! date: "2025-03-24", because: :discontinued

--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -16,6 +16,8 @@ cask "dropbox-capture" do
     strategy :header_match
   end
 
+  disable! date: "2025-03-24", because: :discontinued
+
   auto_updates true
   depends_on macos: ">= :catalina"
 

--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -34,10 +34,13 @@ cask "dropbox-capture" do
             login_item: "Dropbox Capture"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.dropbox-capture.sfl*",
     "~/Library/Application Support/Dropbox-Capture",
     "~/Library/Caches/com.electron.dropbox-capture",
     "~/Library/Caches/com.electron.dropbox-capture.ShipIt",
     "~/Library/Caches/Dropbox-Capture",
+    "~/Library/HTTPStorages/com.electron.dropbox-capture",
+    "~/Library/HTTPStorages/com.electron.dropbox-capture.binarycookies",
     "~/Library/Logs/Dropbox-Capture",
     "~/Library/Preferences/com.electron.dropbox-capture.plist",
   ]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> On March 24, 2025, Dropbox Capture will be discontinued.
> https://help.dropbox.com/installs/dropbox-capture-end-of-support
