### PR TITLE
oso-cloud: versioned URLs and supported livecheck

### DIFF
--- a/Casks/o/oso-cloud.rb
+++ b/Casks/o/oso-cloud.rb
@@ -2,17 +2,18 @@ cask "oso-cloud" do
   arch arm: "arm64", intel: "x86_64"
 
   version "0.26.1"
-  sha256 :no_check
+  sha256 arm:   "b4f692a7d4f65e8f268eebaaf780022bb5db8817dbf29668bcaff55953f6d431",
+         intel: "7375deadf2ccd779b4c44a92fd6a3a1b421be57621e4f84ad6d222c74e8d55e3"
 
-  url "https://d3i4cc4dqewpo9.cloudfront.net/latest/oso_cli_mac_osx_#{arch}",
+  url "https://d3i4cc4dqewpo9.cloudfront.net/#{version}/oso_cli_mac_osx_#{arch}",
       verified: "d3i4cc4dqewpo9.cloudfront.net/"
   name "OSO Cloud CLI"
   desc "Tool for interacting with OSO Cloud"
   homepage "https://www.osohq.com/docs/app-integration/client-apis/cli"
 
   livecheck do
-    url "https://www.osohq.com/docs/changelog/oso-cloud-cli"
-    regex(/>\s*v?(\d+(?:\.\d+)+)\s*</i)
+    url "https://d3i4cc4dqewpo9.cloudfront.net/latest/version"
+    regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
   binary "oso_cli_mac_osx_#{arch}", target: "oso-cloud"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Undoing the change of unversioned URLs from #201861, and using a URL for livecheck mentioned in osohq/oso#1743 that should be more supported and shouldn't go out of sync with the actual download.