### PR TITLE
alex313031-thorium: update livecheck

### DIFF
--- a/Casks/a/alex313031-thorium.rb
+++ b/Casks/a/alex313031-thorium.rb
@@ -14,19 +14,7 @@ cask "alex313031-thorium" do
   livecheck do
     url :url
     regex(/^(M?\d+(?:\.\d+)+)$/i)
-    strategy :github_releases do |json, regex|
-      file_regex = /^Thorium[._-]macOS[._-]#{arch}\.dmg$/i
-
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-        next unless release["assets"]&.any? { |asset| asset["name"]&.match?(file_regex) }
-
-        match = release["tag_name"]&.match(regex)
-        next if match.blank?
-
-        match[1]
-      end
-    end
+    strategy :github_latest
   end
 
   conflicts_with cask: "thorium"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR reverts the `livecheck` changes made in #183159 since upstream fixed the issue preventing builds for Intel architectures (see https://github.com/Alex313031/Thorium-MacOS/releases/tag/M130.0.6723.174).
