### PR TITLE
whatsapp@legacy: disable

### DIFF
--- a/Casks/w/whatsapp@legacy.rb
+++ b/Casks/w/whatsapp@legacy.rb
@@ -7,12 +7,7 @@ cask "whatsapp@legacy" do
   desc "Legacy desktop client for WhatsApp"
   homepage "https://www.whatsapp.com/"
 
-  livecheck do
-    url "https://web.whatsapp.com/desktop/mac/releases"
-    strategy :json do |json|
-      json["name"]
-    end
-  end
+  disable! date: "2025-02-22", because: :no_longer_available
 
   auto_updates true
   conflicts_with cask: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The legacy version (Electron-based) version of WhatsApp is no longer available.
