### PR TITLE
deltawalker 2.7.0

### DIFF
--- a/Casks/d/deltawalker.rb
+++ b/Casks/d/deltawalker.rb
@@ -2,8 +2,8 @@ cask "deltawalker" do
   arch arm: "aarch64", intel: "x64"
 
   version "2.7.0"
-  sha256 arm:   "b1ec0b9bb355b934fce2f38ab471f3b885ed73018c11a39bea1d3736e1a55726",
-         intel: "21abf7076556c86baa13d47dc0934658126cda734ff08703c029d1fd193c24f9"
+  sha256 arm:   "804c509f0813e28c3b960a24ab57f200331ba2333ed9ef9dee479f29ac3bf554",
+         intel: "e1000806db159cd760fd4d812f475581851d5c02a6f4f7bc1040835bcc6668ad"
 
   url "https://deltawalker.s3.amazonaws.com/DeltaWalker-#{version}_#{arch}.dmg",
       verified: "deltawalker.s3.amazonaws.com/"


### PR DESCRIPTION
Looks like deltawalker sums aren't reliable.

```
❯ Downloads brew install --cask deltawalker                                                                           
==> Downloading https://deltawalker.s3.amazonaws.com/DeltaWalker-2.7.0_aarch64.dmg
Already downloaded: /Users/anatoli/Library/Caches/Homebrew/downloads/a694d627a95d2043bc7ee12c68be0996ddd1b1fd7b4e86277d82eae408ca7e71--DeltaWalker-2.7.0_aarch64.dmg
Error: SHA256 mismatch
Expected: b1ec0b9bb355b934fce2f38ab471f3b885ed73018c11a39bea1d3736e1a55726
  Actual: 804c509f0813e28c3b960a24ab57f200331ba2333ed9ef9dee479f29ac3bf554
    File: /Users/anatoli/Library/Caches/Homebrew/downloads/a694d627a95d2043bc7ee12c68be0996ddd1b1fd7b4e86277d82eae408ca7e71--DeltaWalker-2.7.0_aarch64.dmg
To retry an incomplete download, remove the file above.
```

Updated cask with latest ones.

```
❯ Downloads wget https://deltawalker.s3.us-east-1.amazonaws.com/DeltaWalker-2.7.0_x64.dmg -O DeltaWalker-2.7.0_x64.dmg
--2025-02-23 11:54:56--  https://deltawalker.s3.us-east-1.amazonaws.com/DeltaWalker-2.7.0_x64.dmg
Resolving deltawalker.s3.us-east-1.amazonaws.com (deltawalker.s3.us-east-1.amazonaws.com)... 54.231.231.18, 54.231.134.226, 54.231.236.138, ...
Connecting to deltawalker.s3.us-east-1.amazonaws.com (deltawalker.s3.us-east-1.amazonaws.com)|54.231.231.18|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 234148855 (223M) [application/x-apple-diskimage]
Saving to: ‘DeltaWalker-2.7.0_x64.dmg’

DeltaWalker-2.7.0_x64.dmg       100%[=======================================================>] 223,30M  5,65MB/s    in 36s     

2025-02-23 11:55:32 (6,20 MB/s) - ‘DeltaWalker-2.7.0_x64.dmg’ saved [234148855/234148855]

❯ Downloads sha256 DeltaWalker-2.7.0_x64.dmg                                                                          
SHA256 (DeltaWalker-2.7.0_x64.dmg) = e1000806db159cd760fd4d812f475581851d5c02a6f4f7bc1040835bcc6668ad
❯ Downloads wget https://deltawalker.s3.us-east-1.amazonaws.com/DeltaWalker-2.7.0_aarch64.dmg -O DeltaWalker-2.7.0_aarch64.dmg
--2025-02-23 11:55:58--  https://deltawalker.s3.us-east-1.amazonaws.com/DeltaWalker-2.7.0_aarch64.dmg
Resolving deltawalker.s3.us-east-1.amazonaws.com (deltawalker.s3.us-east-1.amazonaws.com)... 52.217.118.34, 52.217.72.232, 52.216.217.106, ...
Connecting to deltawalker.s3.us-east-1.amazonaws.com (deltawalker.s3.us-east-1.amazonaws.com)|52.217.118.34|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 233212724 (222M) [application/x-apple-diskimage]
Saving to: ‘DeltaWalker-2.7.0_aarch64.dmg’

DeltaWalker-2.7.0_aarch64.dmg   100%[=======================================================>] 222,41M  10,2MB/s    in 28s     

2025-02-23 11:56:26 (8,07 MB/s) - ‘DeltaWalker-2.7.0_aarch64.dmg’ saved [233212724/233212724]

❯ Downloads sha256 DeltaWalker-2.7.0_aarch64.dmg                                                                      
SHA256 (DeltaWalker-2.7.0_aarch64.dmg) = 804c509f0813e28c3b960a24ab57f200331ba2333ed9ef9dee479f29ac3bf554
```