### PR TITLE
banksiagui: fix livecheck

### DIFF
--- a/Casks/b/banksiagui.rb
+++ b/Casks/b/banksiagui.rb
@@ -11,8 +11,8 @@ cask "banksiagui" do
   homepage "https://banksiagui.com/"
 
   livecheck do
-    url "https://banksiagui.com/download/"
-    regex(/banksiagui[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.zip/i)
+    url "https://banksiagui.com/forums/viewforum.php?f=3"
+    regex(/Version v?(\d+(?:\.\d+)+)/i)
   end
 
   app "banksiagui-#{version}/banksiagui.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free - No, but the error is the main page being blocked for the same reasons as the old livecheck, which isn't fixable.
- [x] `brew style --fix <cask>` reports no offenses.

---
The old livecheck verifies the download page, which unfortunately has a anti-bot which triggers when using cURL, and returns 403. Instead, I've pointed it to the forums page, which is managed by a different software, and therefore doesn't have the anti-bot that blocks us.