### PR TITLE
kiwix 3.7.1

### DIFF
--- a/Casks/k/kiwix.rb
+++ b/Casks/k/kiwix.rb
@@ -1,13 +1,18 @@
 cask "kiwix" do
-  version "3.6.0"
-  sha256 "2b14b6b803f0d2046b5bb5534ec7d77ba35a82dc904648d83e8e089dc59765b0"
+  version "3.7.1"
+  sha256 "c64c45655020f6f5b769ee38dddcf0c027f475cf83ef29769b0fb87629f04afc"
 
   url "https://download.kiwix.org/release/kiwix-macos/kiwix-macos_#{version}.dmg"
   name "Kiwix"
   desc "App providing offline access to Wikipedia and many other web sites"
   homepage "https://www.kiwix.org/"
 
-  disable! date: "2024-12-02", because: :moved_to_mas
+  livecheck do
+    url "https://download.kiwix.org/release/kiwix-desktop-macos/kiwix-desktop-macos.dmg"
+    strategy :header_match
+  end
+
+  depends_on macos: ">= :ventura"
 
   app "Kiwix.app"
 


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The project README links to the different download URL, so it seems that the cask was prematurely disabled. I updated the cask to use the URL, then updated the version and set the new minimum required version of macOS.