### PR TITLE
Revert "Update OnionShare to version 2.6.3"

### DIFF
--- a/Casks/o/onionshare.rb
+++ b/Casks/o/onionshare.rb
@@ -1,6 +1,6 @@
 cask "onionshare" do
-  version "2.6.3"
-  sha256 "596c9d69650c77fbd5fe0f51624d8c350f718f1a76fd79ac27c50ee836ae0a50"
+  version "2.6.2"
+  sha256 "9588e045b794f15c23f57f584942fb6692d84ab07f2bbcdbb38a65b39befebd5"
 
   url "https://onionshare.org/dist/#{version}/OnionShare-#{version}.dmg"
   name "OnionShare"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#202837

Sorry @SMillerDev , we just identified a last minute problem with the OnionShare 2.6.3 release :( Could I please ask you to revert back to v2.6.2 while we look into it..

Thanks and sorry again.