### PR TITLE
jumpcloud-password-manager 3.0.149 (new cask)

### DIFF
--- a/Casks/j/jumpcloud-password-manager.rb
+++ b/Casks/j/jumpcloud-password-manager.rb
@@ -1,11 +1,16 @@
 cask "jumpcloud-password-manager" do
   version "3.0.149"
-  sha256 :no_check
+  sha256 "cff8776dc0396ebd32d2de53f0b364e028f2ffcd4a88645f6eb2d6701950cbcb"
 
-  url "https://cdn.pwm.jumpcloud.com/DA/release/JumpCloud-Password-Manager-latest.dmg"
-  name "jumpcloud-password-manager"
+  url "https://cdn.pwm.jumpcloud.com/DA/release/JumpCloud-Password-Manager-#{version}.dmg"
+  name "JumpCloud Password Manager"
   desc "Password management tool that provides authentication, sharing and credentials"
   homepage "https://cdn.pwm.jumpcloud.com/web/download.html#desktop"
+
+  livecheck do
+    url "https://cdn.pwm.jumpcloud.com/DA/release/latest-mac.yml"
+    strategy :electron_builder
+  end
 
   auto_updates true
   depends_on macos: ">= :catalina"

--- a/Casks/j/jumpcloud-password-manager.rb
+++ b/Casks/j/jumpcloud-password-manager.rb
@@ -1,0 +1,24 @@
+cask "jumpcloud-password-manager" do
+  version "3.0.149"
+  sha256 :no_check
+
+  url "https://cdn.pwm.jumpcloud.com/DA/release/JumpCloud-Password-Manager-latest.dmg"
+  name "jumpcloud-password-manager"
+  desc "Password management tool that provides authentication, sharing and credentials"
+  homepage "https://cdn.pwm.jumpcloud.com/web/download.html#desktop"
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "JumpCloud Password Manager.app"
+
+  zap trash: [
+    "~/Library/Application Support/JumpCloud Password Manager",
+    "~/Library/Preferences/com.jumpcloud.pwm.desktop.live.plist",
+    "~/Library/Saved Application State/com.jumpcloud.pwm.desktop.live.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
Password management tool that provides authentication, visibility, sharing and credentials.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask --zap <cask>` worked successfully.