### PR TITLE
Update bambu studio to v01.10.02.76

### DIFF
--- a/Casks/b/bambu-studio.rb
+++ b/Casks/b/bambu-studio.rb
@@ -1,6 +1,6 @@
 cask "bambu-studio" do
-  version "01.10.02.75,20250225101619"
-  sha256 "cfe6f45dcce60914f0ca63693b3118942ce05e1f5392d7eb3c0355c8b55d1b1f"
+  version "01.10.02.76,20250225202310"
+  sha256 "4bdcbe4844d8f874bf825625b59d75899946178a184c7cd1103a110e9ba0a09d"
 
   url "https://github.com/bambulab/BambuStudio/releases/download/v#{version.csv.third || version.csv.first}/Bambu_Studio_mac-v#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "github.com/bambulab/BambuStudio/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
---

Bambu Lab dropped the minor release .75 recently, now only .76 is hosted at github. Therefore the installation currently fails for that version:
```
==> Purging files for version 01.10.02.75,20250225101619 of Cask bambu-studio
Error: bambu-studio: Download failed on Cask 'bambu-studio' with message: Download failed: https://github.com/bambulab/BambuStudio/releases/download/v01.10.02.75/Bambu_Studio_mac-v01.10.02.75-20250225101619.dmg
```


Just changed the version stamps and the corresponding SHA256 to make it work again.