### PR TITLE
veracrypt-fuse-t 1.26.20

### DIFF
--- a/Casks/v/veracrypt-fuse-t.rb
+++ b/Casks/v/veracrypt-fuse-t.rb
@@ -1,0 +1,29 @@
+cask "veracrypt-fuse-t" do
+    version "1.26.20"
+    sha256 "25d94e9e145c48a16762d226e3a0117b66aa29adf16b5336658b8c02941a0e42"
+  
+    url "https://launchpad.net/veracrypt/trunk/#{version}/+download/VeraCrypt_FUSE-T_#{version}.dmg",
+        verified: "launchpad.net/veracrypt/trunk/"
+    name "VeraCrypt Fuse-T"
+    desc "Disk encryption software focusing on security based on TrueCrypt"
+    homepage "https://www.veracrypt.fr/"
+  
+    livecheck do
+      url "https://www.veracrypt.fr/en/Downloads.html"
+      regex(/href=.*?VeraCrypt_FUSE-T[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    end
+  
+    conflicts_with cask: "veracrypt"
+    depends_on cask: "macos-fuse-t/cask/fuse-t"
+  
+    pkg "VeraCrypt_Installer.pkg"
+  
+    uninstall pkgutil: "com.idrix.pkg.veracrypt"
+  
+    zap trash: [
+      "~/Library/Application Support/VeraCrypt",
+      "~/Library/Logs/DiagnosticRepots/VeraCrypt*.ips",
+      "~/Library/Preferences/org.idrix.VeraCrypt.plist",
+      "~/Library/Saved Application State/org.idrix.VeraCrypt.savedState",
+    ]
+  end


### PR DESCRIPTION
Add new cask veracrypt-fuse-t which uses a userland fuse library rather than a kext, recommended for Apple Silicon rather than the macfuse variant. veracrypt-fuse-t ensures mutual exclusion with veracrypt cask

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
