### PR TITLE
onionshare 2.6.3

### DIFF
--- a/Casks/o/onionshare.rb
+++ b/Casks/o/onionshare.rb
@@ -1,6 +1,6 @@
 cask "onionshare" do
-  version "2.6.2"
-  sha256 "9588e045b794f15c23f57f584942fb6692d84ab07f2bbcdbb38a65b39befebd5"
+  version "2.6.3"
+  sha256 "ba0d7c7a79cc4d9253f9591db9872f45ebdf2e9ca751f873af1a4ffcef9d1a05"
 
   url "https://onionshare.org/dist/#{version}/OnionShare-#{version}.dmg"
   name "OnionShare"


### PR DESCRIPTION
Hello! We fixed the issue with OnionShare (that was introduced in https://github.com/Homebrew/homebrew-cask/pull/202837 and then reverted in https://github.com/Homebrew/homebrew-cask/pull/202846)

We are ready for this version of OnionShare to be in Homebrew now. Thanks!

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
