### PR TITLE
Upgrade Headlamp version to 0.29.0

### DIFF
--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -1,9 +1,9 @@
 cask "headlamp" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.28.1"
-  sha256 arm:   "c394052f4f57905e44a57820b58a33d1cb03d2d60c916d090fa8faea456bd61b",
-         intel: "d79e44cefd55543a1d6587975c58e3fc9edeaf01c1380317b79281464b39831e"
+  version "0.29.0"
+  sha256 arm:   "e8b82d3d0d002239b9ef76b75101ceba5d54dfd618ad082f95c9fb65830af7e7",
+         intel: "a3f226f2acc714e670b52925f9af1fb3de222027366d683a28932d7293b3d778"
 
   url "https://github.com/headlamp-k8s/headlamp/releases/download/v#{version.sub(/-\d+/, "")}/Headlamp-#{version}-mac-#{arch}.dmg",
       verified: "github.com/headlamp-k8s/headlamp/"


### PR DESCRIPTION
Upgrade Headlamp version to 0.29.0
  cc: @joaquimrocha