### PR TITLE
clash-verge-rev: update sha256

### DIFF
--- a/Casks/c/clash-verge-rev.rb
+++ b/Casks/c/clash-verge-rev.rb
@@ -2,8 +2,8 @@ cask "clash-verge-rev" do
   arch arm: "aarch64", intel: "x64"
 
   version "2.1.1"
-  sha256 arm:   "ff6eafb5dc9911dfbd9b4661084c9612eb7c5a4fe1cdbd65249147e71cacfebf",
-         intel: "7bf7626bf7124bad5444b21b2811b37681f0a48f3404c7bf457eff063d258dfb"
+  sha256 arm:   "1b128e9116e040a3853aa4213a0c40991632e9d6bbecfb4836707fb946c8060d",
+         intel: "0a796f381a6a190478095c2ea3d93ed8a1d04dd464337066603edfa3c7c34a37"
 
   url "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v#{version}/Clash.Verge_#{version}_#{arch}.dmg",
       verified: "github.com/clash-verge-rev/clash-verge-rev/"


### PR DESCRIPTION
They redid the release:
https://github.com/clash-verge-rev/clash-verge-rev/actions/runs/13554598557
https://github.com/clash-verge-rev/clash-verge-rev/actions/runs/13555777368