### PR TITLE
swiftbar 2.0.1

### DIFF
--- a/Casks/s/swiftbar.rb
+++ b/Casks/s/swiftbar.rb
@@ -2,7 +2,7 @@ cask "swiftbar" do
   version "2.0.1"
   sha256 "ac70a9cbdde20d58dae27d360764aa42c3698f6e1bc4618c4b03297a2cee67fa"
 
-  url "https://github.com/swiftbar/SwiftBar/releases/download/v#{version}/SwiftBar.v#{version}.b536.zip",
+  url "https://github.com/swiftbar/SwiftBar/releases/download/v#{version}/SwiftBar.v#{version}.zip",
       verified: "github.com/swiftbar/SwiftBar/"
   name "SwiftBar"
   desc "Menu bar customization tool"

--- a/Casks/s/swiftbar.rb
+++ b/Casks/s/swiftbar.rb
@@ -1,8 +1,8 @@
 cask "swiftbar" do
-  version "2.0.0"
-  sha256 "626dacd22126dd3d9821892277ec7fdaf0390953344dc1d8ab5caa1abf6762b6"
+  version "2.0.1"
+  sha256 "ac70a9cbdde20d58dae27d360764aa42c3698f6e1bc4618c4b03297a2cee67fa"
 
-  url "https://github.com/swiftbar/SwiftBar/releases/download/v#{version}/SwiftBar.v#{version}.b520.zip",
+  url "https://github.com/swiftbar/SwiftBar/releases/download/v#{version}/SwiftBar.v#{version}.b536.zip",
       verified: "github.com/swiftbar/SwiftBar/"
   name "SwiftBar"
   desc "Menu bar customization tool"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`brew audit --cask --online swiftbar` output:

```
brew audit --cask --online swiftbar
==> Downloading and extracting artifacts
==> Downloading https://github.com/swiftbar/SwiftBar/releases/download/v2.0.0/SwiftBar.v2.0.0.b520.zip
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/307192103/4b8
######################################################################################################## 100.0%
==> Downloading https://github.com/swiftbar/SwiftBar/releases/download/v2.0.0/SwiftBar.v2.0.0.b520.zip
Already downloaded: /Users/fenhl/Library/Caches/Homebrew/downloads/92ea182f6a08828c57ecc823e140f62fd52bf973f7535219e26ee0f4b3893dda--SwiftBar.v2.0.0.b520.zip
audit for swiftbar: failed
 - Version '2.0.0' differs from '2.0.1' retrieved by livecheck.
 - Version '2.0.0' differs from '2.0.1' retrieved by livecheck.
swiftbar
  * Version '2.0.0' differs from '2.0.1' retrieved by livecheck.
Error: 1 problem in 1 cask detected.
```

Possibly related to the unpredictable version suffix?