### PR TITLE
gologin 3.3.81

### DIFF
--- a/Casks/g/gologin.rb
+++ b/Casks/g/gologin.rb
@@ -11,9 +11,16 @@ cask "gologin" do
   desc "Antidetect browser"
   homepage "https://gologin.com/"
 
+  # The `latest-mac.yml` file is served with a `Content-Encoding: aws-chunked`
+  # header, which will cause curl to error if the `--compressed` option is used.
+  # This checks the version on the first-party download page until we can
+  # account for this situation in livecheck.
   livecheck do
-    url "https://releases#{livecheck_arch}.gologin.com/latest-mac.yml"
-    strategy :electron_builder
+    url "https://gologin.com/download/"
+    regex(%r{href=.*?/release/gologin[._-]v?(\d+(?:[.-]\d+)+)}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("-", ".") }
+    end
   end
 
   auto_updates true

--- a/Casks/g/gologin.rb
+++ b/Casks/g/gologin.rb
@@ -2,9 +2,9 @@ cask "gologin" do
   arch arm: "-arm64"
   livecheck_arch = on_arch_conditional arm: "-arm"
 
-  version "3.3.80"
-  sha256 arm:   "96f6a5c6b1dcf5f6c4f5603c628f2188e2f2f288c1ff4c2b07d163a89bbfb4b4",
-         intel: "9f5461c37049015e296a060d0b2321c66b9eab0a64f43aeb8e94fae021745669"
+  version "3.3.81"
+  sha256 arm:   "e90e6ca99064e5f2bfc2235a0992acd4dd4b71dff68a29ffa3ebe686328cbae6",
+         intel: "61d065d38248e4b4f8bd28a5cd73138771c3b2c231fad9b0c22744a14e483059"
 
   url "https://releases#{livecheck_arch}.gologin.com/GoLogin-#{version}#{arch}.dmg"
   name "GoLogin"


### PR DESCRIPTION
Created using the GitHub CLI. If this creates a broken PR, please just close it. 

This should error out, as the livecheck page is half-broken, since curl doesn't seem to accept the content-encoding, since it is 'aws-chunked'. No idea on how to fix it. If you have any idea I'd be very thankful :)