### PR TITLE
candy-crisis 3.0.0 (new cask)

### DIFF
--- a/Casks/c/candy-crisis.rb
+++ b/Casks/c/candy-crisis.rb
@@ -1,0 +1,23 @@
+cask "candy-crisis" do
+  version "3.0.0"
+  sha256 "4c3359332d950e2836f9279c8ed1cb32e3c271e5dccb182134364976b4ef2095"
+
+  url "https://github.com/jorio/CandyCrisis/releases/download/v#{version}/CandyCrisis-#{version}-mac.dmg",
+      verified: "github.com/jorio/CandyCrisis/"
+  name "Candy Crisis"
+  desc "Tile matching puzzle/action game"
+  homepage "https://candycrisis.sourceforge.net/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Candy Crisis.app"
+
+  zap trash: [
+    "~/Library/Application Support/CandyCrisis",
+    "~/Library/Containers/com.cc.Candy-Crisis",
+    "~/Library/Saved Application State/io.jor.candycrisis.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
A from-source port of a classic Mac game for modern OS versions which, [like the author's other ports](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+jorio&type=code), is [well-known](https://macintoshgarden.org/games/candy-crisis) despite not meeting the notability threshold for GitHub projects.