### PR TITLE
td-agent: deprecate

### DIFF
--- a/Casks/t/td-agent.rb
+++ b/Casks/t/td-agent.rb
@@ -11,10 +11,7 @@ cask "td-agent" do
   desc "Fluentd distribution package"
   homepage "https://www.fluentd.org/"
 
-  livecheck do
-    url "https://td-agent-package-browser.herokuapp.com/#{version.major}/macosx"
-    regex(/href=.*?td-agent[._-]?v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
-  end
+  deprecate! date: "2025-03-01", because: :discontinued
 
   pkg "td-agent-#{version}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> Treasure Agent (td-agent) had already reached [End of Life (EOL)](https://www.fluentd.org/blog/schedule-for-td-agent-4-eol) in Dec, 2023.
> There is no support anymore - Thus No new release and No security update.
