### PR TITLE
scidvsmac: update SHA256

### DIFF
--- a/Casks/s/scidvsmac.rb
+++ b/Casks/s/scidvsmac.rb
@@ -1,6 +1,6 @@
 cask "scidvsmac" do
   version "4.26"
-  sha256 "8e39a3d96ae8d0b9e31b72eee9fedc15db696a7ffe0208c594d63bc18914fbae"
+  sha256 "f9f52ac36ecba8495e0fbd8cade2aec9bc5c1d991857469f53061ac828ec6965"
 
   url "https://downloads.sourceforge.net/scidvspc/ScidvsMac-#{version}.x64.dmg"
   name "Scid vs. Mac"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

This is merely a sha256 fix for an updated version of the `ScidvsMac` package