### PR TITLE
chipmunk: downgrade to 3.16.0

### DIFF
--- a/Casks/c/chipmunk.rb
+++ b/Casks/c/chipmunk.rb
@@ -1,9 +1,9 @@
 cask "chipmunk" do
   arch arm: "-arm64"
 
-  version "3.16.1"
-  sha256 arm:   "efa3c9ae7014e12a8d57826637a78191f766694a2b166644a9eb08bb8ae4a240",
-         intel: "79c08fff5be3af19b54b0fc6c5ba332ecc45541cf77dd45c7ec2c7562d658ec3"
+  version "3.16.0"
+  sha256 arm:   "c25f0e47b393afe9ff992096e2a98b6e011850bed999823818a92ce5675c8a76",
+         intel: "ecc69e77ee93c672ed7aff14ca86ff0776f3d0210f67784bb00fe671bd66d77d"
 
   url "https://github.com/esrlabs/chipmunk/releases/download/#{version}/chipmunk@#{version}-darwin#{arch}-portable.tgz"
   name "Chipmunk Log Analyzer & Viewer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `chipmunk` cask was autobumped to 3.16.1 a few days ago but the 3.16.1 and 3.16.2 releases are currently marked as pre-release on GitHub. This downgrades the cask to 3.16.0, which is currently the "latest" release on GitHub.

For what it's worth, the `livecheck` block has been using the `GithubLatest` strategy for quite some time, so upstream must have marked those versions as "pre-release" sometime after they were created.