### PR TITLE
leader-key 1.10.1

### DIFF
--- a/Casks/l/leader-key.rb
+++ b/Casks/l/leader-key.rb
@@ -1,22 +1,15 @@
 cask "leader-key" do
-  version "1.9.0,89"
-  sha256 "b1e75d7ba88933a82dc7829d1a073c81941903bdbe36c92cd572fe637ecae3b9"
+  version "1.10.1"
+  sha256 "f7b76965be9d41ad8d086ed26399e78e48aa31de769c04c66dcba1e554edcd95"
 
-  url "https://leader-key-updates.s3.amazonaws.com/Leader%20Key.b#{version.csv.second}.zip",
-      verified: "leader-key-updates.s3.amazonaws.com/"
+  url "https://github.com/mikker/LeaderKey.app/releases/download/v#{version}/Leader.Key.app.zip"
   name "Leader Key"
   desc "Application launcher"
   homepage "https://github.com/mikker/LeaderKey.app"
 
   livecheck do
-    url "https://leader-key-updates.s3.amazonaws.com/appcast.xml"
-    regex(%r{/Leader%20Key[._-]b(\d+(?:\.\d+)*)\.zip}i)
-    strategy :sparkle do |item, regex|
-      match = item.url.match(regex)
-      next if match.blank?
-
-      "#{item.short_version},#{match[1]}"
-    end
+    url "https://mikker.github.io/LeaderKey.app/appcast.xml"
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The appcast URL in the `livecheck` block for `leader-key` is currently giving a 404 (Not Found) response. Checking the source files, it appears that upstream is serving the appcast from github.io now, so this updates the `livecheck` block accordingly. The appcast links to the app.zip file found in the GitHub release assets, so this also switches the cask `url` to that source while updating to the newest version, 1.10.1.