### PR TITLE
macpilot: update livecheck

### DIFF
--- a/Casks/m/macpilot.rb
+++ b/Casks/m/macpilot.rb
@@ -24,8 +24,10 @@ cask "macpilot" do
     url "https://www.koingosw.com/products/macpilot/download/macpilot.dmg"
 
     livecheck do
-      url "https://www.koingosw.com/postback/versioncheck.php?appname=macpilot&type=sparkle"
-      strategy :sparkle
+      url "https://www.koingosw.com/postback/versioncheck.php?appname=macpilot"
+      strategy :xml do |xml|
+        xml.elements["//macpilot/version"]&.text&.strip
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `macpilot` is returning an `Unable to get versions` error because the XML response isn't a Sparkle feed anymore. The `type=sparkle` parameter doesn't appear to make a difference, so I've removed it here. The app's updater uses `type=normal` but the response format is the same if the `type` parameter is omitted.

The version is still provided in the `/root/macpilot/version` element, so this updates the `livecheck` block to simply use the `Xml` strategy.