### PR TITLE
mixed-in-key: update livecheck

### DIFF
--- a/Casks/m/mixed-in-key.rb
+++ b/Casks/m/mixed-in-key.rb
@@ -26,7 +26,7 @@ cask "mixed-in-key" do
       next if (download_page_content = download_page[:content]).blank?
 
       # Find the download ID for the Mac version
-      download_id = download_page_content[%r{href=.*?/download/(\d+)/release/.+?download(?:-|\s+for\s+)mac}im, 1]
+      download_id = download_page_content[%r{href=.*?/download/(\d+)/.+?download(?:-|\s+for\s+)mac}im, 1]
       next if download_id.blank?
 
       # Identify version from the filename in headers


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `mixed-in-key` is giving an `Unable to get versions` error, as the URLs on the download page now use a path like `/download/67/beta/latest?key=public`, so the related regex in the `strategy` block isn't matching. This updates the regex to remove the `release/` part of the URL path, as that's currently `beta/` instead. The rest of the `livecheck` block works as expected, so I've left it as-is for now.

For what it's worth, the `strategy` block still uses `release/` in the `page_headers` URL and this works fine for the current version but we may need to keep an eye on this in case it breaks with the next release.