### PR TITLE
postman@canary: update livecheck

### DIFF
--- a/Casks/p/postman@canary.rb
+++ b/Casks/p/postman@canary.rb
@@ -2,11 +2,10 @@ cask "postman@canary" do
   arch arm: "osx_arm64", intel: "osx64"
 
   version "11.2.14-canary240621-0734"
-  sha256 arm:   "a5630251d8463d567a3ea3da6b6d6bec5d47de47d594e9d64924aff0bca4bd4f",
-         intel: "907567df8bd91b3a9cce068779ff6746d089e578409169865cb89f341393019e"
+  sha256 :no_check
 
-  url "https://dl.pstmn.io/download/version/#{version}/#{arch}",
-      verified: "dl.pstmn.io/download/version/"
+  url "https://dl.pstmn.io/download/channel/canary/#{arch}",
+      verified: "dl.pstmn.io/download/channel/canary/"
   name "Postman Canary"
   desc "Collaboration platform for API development"
   homepage "https://www.postman.com/"

--- a/Casks/p/postman@canary.rb
+++ b/Casks/p/postman@canary.rb
@@ -11,15 +11,10 @@ cask "postman@canary" do
   desc "Collaboration platform for API development"
   homepage "https://www.postman.com/"
 
-  # This is a workaround to a slow-to-update livecheck. It uses the in-app
-  # update check link and queries the available versions for a generic major
-  # version. We cannot use #{version} as the URL does not exist if #{version}
-  # is the latest version available.
   livecheck do
-    url "https://dl.pstmn.io/update/status?currentVersion=#{version.major}.0.0&platform=#{arch}&channel=canary"
-    strategy :json do |json|
-      json["version"]
-    end
+    url "https://dl.pstmn.io/download/channel/canary/#{arch}"
+    regex(/PostmanCanary(?:%20|[._-])v?(\d+(?:\.\d+)+[._-]canary[._-]?(\d+(?:[.-]\d+)*))/i)
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Around 2025-02-18, the existing `livecheck` block for `postman@canary` stopped working, as the response body is empty. This remains the case, so this updates the `livecheck` block to check the redirecting links on the [Postman Canary download page](https://www.postman.com/downloads/canary/).

Edit: Hmm, it looks like the download link doesn't work either. The URL format hasn't changed for stable Postman, so I'm not sure what's going on with canary.