### PR TITLE
shearwater-cloud: update livecheck

### DIFF
--- a/Casks/s/shearwater-cloud.rb
+++ b/Casks/s/shearwater-cloud.rb
@@ -7,9 +7,18 @@ cask "shearwater-cloud" do
   desc "Review, edit and share dive log data"
   homepage "https://shearwater.com/"
 
+  # The macOS link on the download page points to a page that fetches a JSON
+  # file containing the file URLs and then uses JavaScript to redirect the
+  # browser to the file, so we match the version information from the JSON file.
   livecheck do
-    url "https://shearwater.com/pages/shearwater-cloud"
-    regex(/href=.*?ShearwaterCloudInstaller[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    url "https://downloads.shearwater.com/cloud_reference.json"
+    regex(/ShearwaterCloudInstaller[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :json do |json, regex|
+      match = json["swcloud_dmg"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `shearwater-cloud` is giving an `Unable to get versions` error, as the download page no longer links to files. Instead, upstream has updated the download buttons for macOS and Windows to point to an intermediary page that uses JavaScript to fetch a JSON file containing filenames and redirect to the relevant file. This updates the `livecheck` block to match the version information from the dmg filename in the JSON file.