### PR TITLE
docs: Clarify contributor initalization documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@
 * [Style Guide](#style-guide)
 * [Reporting Bugs](README.md#reporting-bugs)
 
+## Getting Set Up To Contribute
+
+Follow the guide in [How to Open a Homebrew Pull Request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#cask-related-pull-request).
+
 ## Updating a Cask
 
 Notice an application that's out-of-date in Homebrew Cask? In most cases, it's very simple to update it. We have a command that will take care of updating the cask file and submitting a pull request to us:
@@ -17,10 +21,6 @@ brew bump --open-pr <outdated_cask>
 ```
 
 You can also follow the steps in the documentation on [adding a cask](https://docs.brew.sh/Adding-Software-to-Homebrew#casks) for more complicated changes.
-
-## Getting Set Up To Contribute
-
-Follow the guide in [How to Open a Homebrew Pull Request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#cask-related-pull-request).
 
 ## Adding a Cask
 


### PR DESCRIPTION
While opening PR https://github.com/Homebrew/homebrew-cask/pull/203482 an enhancement was made.

A small documentation change is made to ensure the order of contributor instructions avoid opaque errors.  Else new contributors might engage in unnecessary debugging:

```shell
$ brew bump --cask $cask_name
Error: These casks are not in any locally installed taps!

  xld

You may need to run `brew tap` to install additional taps.
```

```shell
$ brew tap xld
Error: Invalid tap name: 'xld'
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/tap.rb:57:in `fetch'
/opt/homebrew/Library/Homebrew/cmd/tap.rb:62:in `run'
/opt/homebrew/Library/Homebrew/brew.rb:95:in `<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

**Reads remainder off CONTRIBUTING.md, realizing sequence is out of order**

```bash
$ brew tap homebrew/cask --force
$ brew bump xld --open-pr
# Success
```