### PR TITLE
wechat: revert minimum macos version

### DIFF
--- a/Casks/w/wechat.rb
+++ b/Casks/w/wechat.rb
@@ -16,7 +16,7 @@ cask "wechat" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sonoma"
+  depends_on macos: ">= :high_sierra"
 
   app "WeChat.app"
 


### PR DESCRIPTION
wechat require only macos>=10.13 

![QQ20250302-181454](https://github.com/user-attachments/assets/abc20523-6369-45f0-b0d1-3833a8e49233)
![QQ20250302-181525](https://github.com/user-attachments/assets/35ef2e18-6a4d-42ed-aa50-262e5baef7e2)

https://github.com/Homebrew/homebrew-cask/pull/197163

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
