### PR TITLE
pgadmin4: update livecheck

### DIFF
--- a/Casks/p/pgadmin4.rb
+++ b/Casks/p/pgadmin4.rb
@@ -12,8 +12,8 @@ cask "pgadmin4" do
   homepage "https://www.pgadmin.org/"
 
   livecheck do
-    url "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/"
-    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://www.pgadmin.org/download/pgadmin-4-macos/"
+    regex(%r{href=.*?/pgadmin4/v?(\d+(?:\.\d+)+)/macos/?["' >]}i)
   end
 
   app "pgAdmin 4.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `pgadmin4` checks the version directories on the directory listing page related to the cask `url` source. However, upstream has created a `v9.1` directory that doesn't contain any release assets yet, so this check is erroneously returning 9.1 instead of 9.0.

The first-party download page correctly links to 9.0 as the newest version, so this updates the `livecheck` block to check that instead.