### PR TITLE
inssider: deprecate

### DIFF
--- a/Casks/i/inssider.rb
+++ b/Casks/i/inssider.rb
@@ -8,10 +8,7 @@ cask "inssider" do
   desc "Defeat slow wifi"
   homepage "https://www.metageek.com/products/inssider/"
 
-  livecheck do
-    url "https://metageek.link/inssider-5-mac-update-xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-03-02", because: :unmaintained
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app has not been updated since 2020, and questions about the project's status remain unanswered (see [support forum](https://community.metageek.com/t/is-inssider-dead/3157)).
