### PR TITLE
trae-cn 1.0.8055 (new cask)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1397,6 +1397,7 @@ tower
 trader-workstation
 tradingview
 trae
+trae-cn
 trainerroad
 transmission@nightly
 transmit

--- a/Casks/t/trae-cn.rb
+++ b/Casks/t/trae-cn.rb
@@ -1,4 +1,4 @@
-cask "trae@cn" do
+cask "trae-cn" do
   arch arm: "arm64", intel: "x64"
 
   version "1.0.8055"

--- a/Casks/t/trae@cn.rb
+++ b/Casks/t/trae@cn.rb
@@ -1,0 +1,40 @@
+cask "trae@cn" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.0.8055"
+  sha256 arm:   "0ff40c8c3645c06e019b8942b34ac0f008e52e044a2316f5169444750ab6a7a8",
+         intel: "7d1e9977bfdeaebb0c9d76a0deb882cbd7022b082fbefe464e18c9392cc4b77e"
+
+  url "https://lf-cdn.trae.com.cn/obj/trae-com-cn/pkg/app/releases/stable/#{version}/darwin/Trae%20CN-darwin-#{arch}.dmg"
+  name "Trae CN"
+  desc "Adaptive AI IDE"
+  homepage "https://www.trae.com.cn/"
+
+  livecheck do
+    url "https://api.trae.ai/icube/api/v1/native/version/trae/cn/latest"
+    strategy :json do |json|
+      json.dig("data", "manifest", "darwin", "version")
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Trae CN.app"
+
+  uninstall launchctl: "cn.trae.ShipIt",
+            quit:      "cn.trae.app"
+
+  zap trash: [
+    "~/.trae-cn",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/cn.trae.app.sfl*",
+    "~/Library/Application Support/Trae CN",
+    "~/Library/Caches/cn.trae.app",
+    "~/Library/Caches/cn.trae.ShipIt",
+    "~/Library/HTTPStorages/cn.trae.app",
+    "~/Library/Preferences/ByHost/cn.trae.ShipIt.*.plist",
+    "~/Library/Preferences/cn.trae.app.helper.plist",
+    "~/Library/Preferences/cn.trae.app.plist",
+    "~/Library/Saved Application State/cn.trae.app.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Trae CN is a special edition of Trae:
1. It has a different homepage.
2. The model is different. Trae uses Claude, but Trae CN uses Doubao.
3. The account system may be different.
4. The package name, cache file name, config name, is "cn.something" rather than "com.something"

PS: It's Trae's official edition, not some wild custom edition.