### PR TITLE
publii: fix SHA256

### DIFF
--- a/Casks/p/publii.rb
+++ b/Casks/p/publii.rb
@@ -3,7 +3,7 @@ cask "publii" do
 
   version "0.46.4"
   sha256 arm:   "99dbb99716aaffec27c846f29f89260702e6a1c997e72dfe514be9b12698fb6d",
-         intel: "5ac351c5da08c325e1e3d490a44c40408b874e68cceb4d82a58db7f409c0732d"
+         intel: "4058915775162e0ef0cddf7989c9facc7f12ea9b561ec7e809b64304663501d9"
 
   url "https://getpublii.com/download/Publii-#{version}-#{arch}.dmg"
   name "Publii"

--- a/Casks/p/publii.rb
+++ b/Casks/p/publii.rb
@@ -2,7 +2,7 @@ cask "publii" do
   arch arm: "apple-silicon", intel: "intel"
 
   version "0.46.4"
-  sha256 arm:   "72892d7baca92acc045046f15641218da4c84f866d5709949a3bf18067c1c0d4",
+  sha256 arm:   "99dbb99716aaffec27c846f29f89260702e6a1c997e72dfe514be9b12698fb6d",
          intel: "5ac351c5da08c325e1e3d490a44c40408b874e68cceb4d82a58db7f409c0732d"
 
   url "https://getpublii.com/download/Publii-#{version}-#{arch}.dmg"


### PR DESCRIPTION
The SHA256 checksum specified for the latest version of the Publii cask seems to be incorrect. Manually downloading the latest version from [the downloads page](https://getpublii.com/download/) gives the following hashes:

- Intel: `4058915775162e0ef0cddf7989c9facc7f12ea9b561ec7e809b64304663501d9`
- Apple Silicon: `99dbb99716aaffec27c846f29f89260702e6a1c997e72dfe514be9b12698fb6d`

I'm not sure why the hashes seem to be different, but VirusTotal doesn't seem to show anything off with the new files: ([a](https://www.virustotal.com/gui/file/99dbb99716aaffec27c846f29f89260702e6a1c997e72dfe514be9b12698fb6d?nocache=1), [b](https://www.virustotal.com/gui/file/4058915775162e0ef0cddf7989c9facc7f12ea9b561ec7e809b64304663501d9?nocache=1)). In any case, this PR updates the hashes for the cask to the correct values.

---

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.*
- [ ] `brew style --fix <cask>` reports no offenses.*

\* I'm still figuring out how to to this on the new version (I probably have to tap `homebrew/cask` and stuff), I'll update this when I figure it out
