### PR TITLE
fxfactory 8.0.22,8145

### DIFF
--- a/Casks/f/fxfactory.rb
+++ b/Casks/f/fxfactory.rb
@@ -1,8 +1,8 @@
 cask "fxfactory" do
-  version "8.0.21,8056"
+  version "8.0.22,8145"
   sha256 :no_check # required as upstream package is often updated in place
 
-  url "https://store.fxfactory.com/products/noiseindustries/fxfactory/FxFactory-#{version.csv.first}-#{version.csv.second}.zip"
+  url "https://files.fxfactory.com/fxfactory/FxFactory-#{version.csv.first}-#{version.csv.second}.zip"
   name "FxFactory"
   desc "Browse, install and purchase effects and plugins from a huge catalogue"
   homepage "https://fxfactory.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `url` for `fxfactory` has changed, so the autobump workflow was failing to update this to the latest version. This updates the cask to use the current URL from the first-party download page as part of updating to 8.0.22-8145.