### PR TITLE
treesheets 3.3.0,13635709012

### DIFF
--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -1,8 +1,8 @@
 cask "treesheets" do
-  version "13440115216"
-  sha256 "d8607c8b5d17af36eaf3260369e3ecd404b02aba5488fa2d7f4803c3bbf6e0f8"
+  version "3.3.0,13635709012"
+  sha256 "c75f3cfa6e39f61e782c7f330cbacce1a9184deb6ca5b075f85b9f3d5580fd02"
 
-  url "https://github.com/aardappel/treesheets/releases/download/#{version}/mac_treesheets.zip",
+  url "https://github.com/aardappel/treesheets/releases/download/#{version.csv.second}/TreeSheets-#{version.csv.first}-Darwin.dmg",
       verified: "github.com/aardappel/treesheets/"
   name "TreeSheets"
   desc "Hierarchical spreadsheet and outline application"
@@ -10,8 +10,15 @@ cask "treesheets" do
 
   livecheck do
     url :url
-    regex(/^(\d+)$/i)
-    strategy :github_latest
+    regex(%r{/v?(\d+(?:\.\d+)*)/TreeSheets[._-]v?(\d+(?:\.\d+)+)(?:[._-]Darwin)?\.dmg$}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        "#{match[2]},#{match[1]}"
+      end
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

With the 13635709012 release, upstream now publishes a dmg release asset (e.g., `TreeSheets-3.3.0-Darwin.dmg`) instead of the previous `mac_treesheets.zip` file, so this updates the cask accordingly.