### PR TITLE
ba-connected: update livecheck

### DIFF
--- a/Casks/b/ba-connected.rb
+++ b/Casks/b/ba-connected.rb
@@ -9,8 +9,14 @@ cask "ba-connected" do
   homepage "https://www.brightsign.biz/resources/software-downloads/"
 
   livecheck do
-    url "https://downloads.bsn.cloud/latest-mac.yml"
-    strategy :electron_builder
+    url "https://brightsign-builds.s3.us-east-1.amazonaws.com/web/bs-download-versions.json"
+    regex(/BA(?:[+._-]|%20)connected[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :json do |json|
+      match = json.dig("general", "bacon", "mac-link")&.match(regex)
+      next unless match
+
+      match[1]
+    end
   end
 
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `ba-connected` checks the `latest-mac.yml` file that the app checks for new version information but it continues to present 1.49.1 as newest instead of 1.55.1 from the first-party download page. Even the latest version of the app checks the `latest-mac.yml` file, so we'll have to check a different source until upstream sorts this out.

This updates the `livecheck` block to check the JSON file that the download page uses to dynamically produce the download links client-side.