### PR TITLE
starcraft: disable

### DIFF
--- a/Casks/s/starcraft.rb
+++ b/Casks/s/starcraft.rb
@@ -5,12 +5,10 @@ cask "starcraft" do
   url "https://www.battle.net/download/getInstallerForGame?os=MAC&version=LIVE&gameProgram=STARCRAFT",
       verified: "battle.net/"
   name "Starcraft"
+  desc "RTS game"
   homepage "https://starcraft.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  disable! date: "2025-03-06", because: :no_longer_available
 
   depends_on macos: ">= :el_capitan"
 


### PR DESCRIPTION
No longer has its own launcher/updater. URL now downloads Battle.net installer instead.