### PR TITLE
appflowy: fix sha256

### DIFF
--- a/Casks/a/appflowy.rb
+++ b/Casks/a/appflowy.rb
@@ -1,6 +1,6 @@
 cask "appflowy" do
   version "0.8.5"
-  sha256 "7509df51f7fd6d390dd6bff6c893f9129aebab0dc3aa850c1cb3fe761af3d8ef"
+  sha256 "13c767d3178218177a1364786241b451b54cad661cd14df82cf4e0947658e87b"
 
   url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-universal.zip",
       verified: "github.com/AppFlowy-IO/AppFlowy/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

error here:
Upgrading appflowy
==> Upgrading 1 outdated package:
appflowy 0.8.4 -> 0.8.5
==> Upgrading appflowy
==> Downloading https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.8.5/Appflowy-0.8.5-macos-universal.zip
Already downloaded: /Volumes/home/thuvh/Library/Caches/Homebrew/downloads/92b2bd1d2f386f4ef9318f2190545c00dff12d7cf29d74989b7fcf34217222a4--AppFlowy-0.8.5-macos-universal.zip
Error: appflowy: SHA256 mismatch
Expected: 7509df51f7fd6d390dd6bff6c893f9129aebab0dc3aa850c1cb3fe761af3d8ef
  Actual: 13c767d3178218177a1364786241b451b54cad661cd14df82cf4e0947658e87b
    File: /Volumes/home/thuvh/Library/Caches/Homebrew/downloads/92b2bd1d2f386f4ef9318f2190545c00dff12d7cf29d74989b7fcf34217222a4--AppFlowy-0.8.5-macos-universal.zip
To retry an incomplete download, remove the file above.
==> Purging files for version 0.8.5 of Cask appflowy
