### PR TITLE
cloudflare-warp@beta 2025.1.634.1 (new cask)

### DIFF
--- a/Casks/c/cloudflare-warp@beta
+++ b/Casks/c/cloudflare-warp@beta
@@ -1,0 +1,49 @@
+cask "cloudflare-warp@beta" do
+  version "2025.1.634.1"
+  sha256 "62b6cbf50d8b8b6292c492f343b1a8f400cf6b87e7777181a9bc7e1ca1e88f86"
+
+  url "https://downloads.cloudflareclient.com/v1/download/macos/version/#{version}",
+      verified: "downloads.cloudflareclient.com/v1/download/macos/"
+  name "Cloudflare WARP"
+  desc "Free app that makes your Internet safer"
+  homepage "https://cloudflarewarp.com/"
+
+  livecheck do
+    url "https://downloads.cloudflareclient.com/v1/update/sparkle/macos/beta"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  pkg "Cloudflare_WARP_#{version}.pkg"
+
+  uninstall launchctl: [
+              "com.cloudflare.1dot1dot1dot1.macos.loginlauncherapp",
+              "com.cloudflare.1dot1dot1dot1.macos.warp.daemon",
+            ],
+            quit:      "com.cloudflare.1dot1dot1dot1.macos",
+            script:    {
+              executable: "/Applications/Cloudflare WARP.app/Contents/Resources/uninstall.sh",
+              sudo:       true,
+            },
+            pkgutil:   "com.cloudflare.1dot1dot1dot1.macos",
+            delete:    [
+              "/usr/local/bin/warp-cli",
+              "/usr/local/bin/warp-dex",
+              "/usr/local/bin/warp-diag",
+            ]
+
+  zap trash: [
+    "/Library/LaunchDaemons/com.cloudflare.1dot1dot1dot1.macos.warp.daemon.plist",
+    "~/Library/Application Scripts/com.cloudflare.1dot1dot1dot1.macos.loginlauncherapp",
+    "~/Library/Application Support/com.cloudflare.1dot1dot1dot1.macos",
+    "~/Library/Caches/com.cloudflare.1dot1dot1dot1.macos",
+    "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.cloudflare.1dot1dot1dot1.macos",
+    "~/Library/Containers/com.cloudflare.1dot1dot1dot1.macos.loginlauncherapp",
+    "~/Library/HTTPStorages/com.cloudflare.1dot1dot1dot1.macos",
+    "~/Library/HTTPStorages/com.cloudflare.1dot1dot1dot1.macos.binarycookies",
+    "~/Library/Preferences/com.cloudflare.1dot1dot1dot1.macos.plist",
+    "~/Library/WebKit/com.cloudflare.1dot1dot1dot1.macos",
+  ]
+end

--- a/Casks/c/cloudflare-warp@beta
+++ b/Casks/c/cloudflare-warp@beta
@@ -14,6 +14,7 @@ cask "cloudflare-warp@beta" do
   end
 
   auto_updates true
+  conflicts_with cask: "cloudflare-warp"
   depends_on macos: ">= :catalina"
 
   pkg "Cloudflare_WARP_#{version}.pkg"


### PR DESCRIPTION
Adding the official beta release of the Cloudflare WARP client https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/download-warp/beta-releases/

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
