### PR TITLE
creality-print: update sha256

### DIFF
--- a/Casks/c/creality-print.rb
+++ b/Casks/c/creality-print.rb
@@ -2,7 +2,7 @@ cask "creality-print" do
   arch arm: "arm64", intel: "x86_64"
 
   version "6.0.4.1793"
-  sha256 arm:   "61c3d5508db1548515ba57c0bb049dc7d2295aec377c473fb9ec7de593ee8e08",
+  sha256 arm:   "919e028270e3e41b01e9b26164d0941256f0f12023315e33fcbc39aae74f2ede",
          intel: "8ede800ba13104e9e68134f1a7f482f3bc7beed6fff8f9f3a37df5def214ed50"
 
   url "https://github.com/CrealityOfficial/CrealityPrint/releases/download/v#{version.major_minor_patch}/CrealityPrint-#{version}-macx-#{arch}-Release.dmg",

--- a/Casks/c/creality-print.rb
+++ b/Casks/c/creality-print.rb
@@ -3,7 +3,7 @@ cask "creality-print" do
 
   version "6.0.4.1793"
   sha256 arm:   "919e028270e3e41b01e9b26164d0941256f0f12023315e33fcbc39aae74f2ede",
-         intel: "8ede800ba13104e9e68134f1a7f482f3bc7beed6fff8f9f3a37df5def214ed50"
+         intel: "747e7a0e9fbbd16736a3b5c68fba3ae4d1f5f566ce137529df948ea84c012957"
 
   url "https://github.com/CrealityOfficial/CrealityPrint/releases/download/v#{version.major_minor_patch}/CrealityPrint-#{version}-macx-#{arch}-Release.dmg",
       verified: "github.com/CrealityOfficial/CrealityPrint/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I was trying to install _creality-print_, but got a SHA256 mismatch. After downloading the .dmg manually and running:

```sh
shasum -a 256 CrealityPrint-6.0.4.1793-macx-arm64-Release.dmg
```

I got the same hash as reported by brew: `919e028270e3e41b01e9b26164d0941256f0f12023315e33fcbc39aae74f2ede`.

This PR updates the SHA256 to the correct hash.

