### PR TITLE
visual-studio-code: add legacy version

### DIFF
--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -1,22 +1,33 @@
 cask "visual-studio-code" do
   arch arm: "darwin-arm64", intel: "darwin"
 
-  version "1.98.0"
-  sha256 arm:   "c794330a7e7b96a6f31d69c67b01c52f4d3a7574fc56d50d24e578b06495e72d",
-         intel: "0a5cebab8e2939592a631d162bec15589cfe573e2ebfb5cd466107ba1d0151d9"
+  on_catalina :or_older do
+    version "1.97.2"
+    sha256 arm:   "567ba4fae5545586a0bff02eea263d59873fcf488368a9a9ccf3d4c22dfa8ebc",
+           intel: "cfe48cf7bce34830cb7a20ee7b5e8fbe575fe95a47ef49f62dce8ccf3087dd89"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur :or_newer do
+    version "1.98.0"
+    sha256 arm:   "c794330a7e7b96a6f31d69c67b01c52f4d3a7574fc56d50d24e578b06495e72d",
+           intel: "0a5cebab8e2939592a631d162bec15589cfe573e2ebfb5cd466107ba1d0151d9"
+
+    livecheck do
+      url "https://update.code.visualstudio.com/api/update/#{arch}/stable/latest"
+      strategy :json do |json|
+        json["productVersion"]
+      end
+    end
+  end
 
   url "https://update.code.visualstudio.com/#{version}/#{arch}/stable"
   name "Microsoft Visual Studio Code"
   name "VS Code"
   desc "Open-source code editor"
   homepage "https://code.visualstudio.com/"
-
-  livecheck do
-    url "https://update.code.visualstudio.com/api/update/#{arch}/stable/latest"
-    strategy :json do |json|
-      json["productVersion"]
-    end
-  end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

### VS Code macOS 10.15 support has ended

> macOS 10.15 support has ended
> 
> VS Code 1.97 is the last release that supports macOS 10.15 (macOS Catalina). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.

https://code.visualstudio.com/updates/v1_98#_macos-1015-support-has-ended

### Related

https://github.com/Homebrew/homebrew-cask/issues/204140

https://github.com/microsoft/vscode/issues/242842
