### PR TITLE
multipass: update sha256

### DIFF
--- a/Casks/m/multipass.rb
+++ b/Casks/m/multipass.rb
@@ -1,6 +1,6 @@
 cask "multipass" do
   version "1.15.1"
-  sha256 "878dfb719a0f39e1481b32bdca43dabeac9b71904510a3601a9ac037e5514173"
+  sha256 "9d28152cef3d5dbb02f44355d01b45678a290be0bd66e9151fa7873594e1c94e"
 
   on_arm do
     postflight do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Updating the SHA256 hash for multipass, since upstream apparently uploaded a new `.pkg` for the same version (see how `multipass-1.15.1+mac-Darwin.pkg` is newer than the other fiiles [here](https://github.com/canonical/multipass/releases)).

Closes #204108
