### PR TITLE
roboform: revert to 9.6.5

### DIFF
--- a/Casks/r/roboform.rb
+++ b/Casks/r/roboform.rb
@@ -1,8 +1,8 @@
 cask "roboform" do
-  version "9.6.6"
-  sha256 :no_check
+  version "9.6.5"
+  sha256 "bb8a3e8d860a13334d86ddf4d91d9d3875ea0743d8e92a04f9336163a0294731"
 
-  url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg", cache: false
+  url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg"
   name "RoboForm"
   desc "Password manager and form filler application"
   homepage "https://www.roboform.com/"

--- a/Casks/r/roboform.rb
+++ b/Casks/r/roboform.rb
@@ -2,7 +2,7 @@ cask "roboform" do
   version "9.6.6"
   sha256 :no_check
 
-  url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg"
+  url "https://www.roboform.com/dist/roboform-mac-v#{version.major}.dmg", cache: false
   name "RoboForm"
   desc "Password manager and form filler application"
   homepage "https://www.roboform.com/"


### PR DESCRIPTION
Roboform does not publish versioned files, and currently their "Version News" page which I suspect you access with `livecheck` and have automated in some way, is advertising a future version which does not yet exist, ie 9.6.6. The actual latest is 9.6.5.

In the `homebrew-cask` formula, the `sha256` field is specified at `:no_check`. I am not sure why, and I have given it the actual has corresponding to 9.6.5.

Regarding the steps below, the `brew audit` step run locally does not work:
```
❰anthonyholland❙~/IdeaProjects/CYB/utils/homebrew-cask(master)❱✔≻ brew audit --cask --online ./Casks/r/roboform.rb
Error: Calling brew audit [path ...] is disabled! Use brew audit [name ...] instead.
Please report this issue:
  https://docs.brew.sh/Troubleshooting
❰anthonyholland❙~/IdeaProjects/CYB/utils/homebrew-cask(master)❱✘≻ 
```
And run as `brew audit --cask --online roboform` it is not checking anything about my change. I am not sure what to do here. I have created an issue as well, but am attempting to be a bit more helpful by submitting a PR.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
