### PR TITLE
kate 24.12.3 (new cask)

### DIFF
--- a/Casks/k/kate.rb
+++ b/Casks/k/kate.rb
@@ -1,0 +1,41 @@
+cask "kate" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "24.12,9168" # Format: "version,build"
+  sha256 "bbff57a3ad6bd028b2ae30b3e2861abd2008d05b853f6a8d0353e3e18818906a"
+
+  url "https://cdn.kde.org/ci-builds/utilities/kate/release-#{version.csv.first}/macos-#{arch}/kate-release_#{version.csv.first}-#{version.csv.second}-macos-clang-#{arch}.dmg", verified: "cdn.kde.org/ci-builds/utilities/kate/"
+  name "Kate"
+  desc "Multi-document editor by KDE"
+  homepage "https://kate-editor.org/"
+
+  livecheck do
+    url "https://cdn.kde.org/ci-builds/utilities/kate/"
+    regex(/release-(\d+\.\d+)/i)
+    strategy :page_match do |page, regex|
+      # First, find the latest version
+      version = page.scan(regex).flatten.map { |v| Gem::Version.new(v) }.max&.to_s
+      next if version.nil?
+
+      # Then, find the builds for that version
+      builds_url = "https://cdn.kde.org/ci-builds/utilities/kate/release-#{version}/macos-#{arch}/"
+      builds_page = Homebrew::Livecheck::Strategy.page_content(builds_url)
+      next if builds_page[:content].blank?
+
+      build_regex = /kate-release_#{version}-(\d+)-macos-clang-#{arch}\.dmg/i
+      build = builds_page[:content].scan(build_regex).flatten.map(&:to_i).max
+      next if build.nil?
+
+      "#{version},#{build}"
+    end
+  end
+
+  app "Kate.app"
+
+  zap trash: [
+    "~/Library/Application Support/kate",
+    "~/Library/Caches/kate",
+    "~/Library/Preferences/org.kde.kate.plist",
+    "~/Library/Saved Application State/org.kde.kate.savedState",
+  ]
+end


### PR DESCRIPTION
Little known secret is that KDE does mac stable arm64 and x86_64 builds of kate on top of the nightly builds they advertise. This should make auto updating far easier and more stable then using the nightly build. This is my first cask I just really like kate it is my favorite text editor so having it auto update on Mac would be wonderful. Currently I have to eye my Linux machine for updates and then manually swap out the .apps on MacOs.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X ] `brew audit --cask --online <cask>` is error-free.
- [ X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ X] `brew audit --cask --new <cask>` worked successfully.
- [X ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X ] `brew uninstall --cask <cask>` worked successfully.

---
