### PR TITLE
Bump command-x to 1.5.1

### DIFF
--- a/Casks/c/command-x.rb
+++ b/Casks/c/command-x.rb
@@ -1,9 +1,9 @@
 cask "command-x" do
-  version "1.4.0-1705659953,3zg73o7fs2rlpypaud9pj,x9gpppflpv4ve2t2qm1yg5ht9"
-  sha256 "8112631130d07332ce4fd403eeb248f060cbfa014641fa7dbc318fb3e56e198c"
+  version "1.5.1-1741281408,q29jqhoble8xbtvypmmkx,oo97q4f6g9mwjyqmhjakbr7to"
+  sha256 "1dfb20035ee833ef280d1267ad52aaacb372005415083348d5994b4b3fb57527"
 
-  url "https://www.dropbox.com/scl/fi/#{version.csv.second}/Command-X-#{version.major_minor_patch}.zip?rlkey=#{version.csv.third}&raw=1",
-      verified: "dropbox.com/scl/fi/"
+  url "https://dl.dropboxusercontent.com/s/#{version.csv.second}/Command-X-#{version.major_minor_patch}.zip?rlkey=#{version.csv.third}",
+      verified: "dl.dropboxusercontent.com/s/"
   name "Command X"
   desc "Cut and paste files in Finder"
   homepage "https://sindresorhus.com/command-x"


### PR DESCRIPTION
Use dl.dropboxusercontent.com to bypass redirect that `brew audit` flags as an issue.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
