### PR TITLE
seafile-client 9.0.12: fix `sha256`

### DIFF
--- a/Casks/s/seafile-client.rb
+++ b/Casks/s/seafile-client.rb
@@ -2,8 +2,8 @@ cask "seafile-client" do
   version "9.0.12"
   sha256 "80fd82cfa023917fe2f2606328b825c7b73f9234f3c27eaf6fb28e134081fc58"
 
-  url "https://download.seadrive.org/seafile-client-#{version}.dmg",
-      verified: "seadrive.org/"
+  url "https://s3.eu-central-1.amazonaws.com/download.seadrive.org/seafile-client-#{version}.dmg",
+      verified: "s3.eu-central-1.amazonaws.com/"
   name "Seafile Client"
   desc "File syncing client"
   homepage "https://www.seafile.com/"


### PR DESCRIPTION
Hi,

If you're currently trying to update from version `9.0.11` to `9.0.12` of the Seafile client using Homebrew Cask, you'll encounter an SHA256 mismatch error during the upgrade process.

```shell
 brew upgrade seafile-client
==> Upgrading 1 outdated package:
seafile-client 9.0.11 -> 9.0.12
==> Upgrading seafile-client
==> Downloading https://download.seadrive.org/seafile-client-9.0.12.dmg
################################################################################################# 100.0%
==> Purging files for version 9.0.12 of Cask seafile-client
Error: seafile-client: SHA256 mismatch
Expected: 80fd82cfa023917fe2f2606328b825c7b73f9234f3c27eaf6fb28e134081fc58
  Actual: 51dad61aaddf6dd4b0fccf7c41eff69241aa92ad243bc8970b7ac4feeae1aa06
    File: /Users/dennis/Library/Caches/Homebrew/downloads/4da546de69e7c794ec5f9ee4a9ec243d4c0a47de4ddf4371afac1bdd4e28bf6b--seafile-client-9.0.12.dmg
To retry an incomplete download, remove the file above.
```

The issue arises because the SHA256 checksum of the file downloaded from the URL specified in the cask (⁠https://download.seadrive.org/seafile-client-9.0.12.dmg) does not match the expected checksum listed in the cask.

```shell
curl --silent https://download.seadrive.org/seafile-client-9.0.12.dmg | sha256

51dad61aaddf6dd4b0fccf7c41eff69241aa92ad243bc8970b7ac4feeae1aa06
```

It appears that the download URL on the Seafile website (see https://www.seafile.com/en/download/) has been changed. The new link provides a version of the 9.0.12 client with the correct SHA256 checksum, and the checksum for the 9.0.11 version is also correct when using the updated link.

```shell
 curl --silent https://s3.eu-central-1.amazonaws.com/download.seadrive.org/seafile-client-9.0.12.dmg | sha256

80fd82cfa023917fe2f2606328b825c7b73f9234f3c27eaf6fb28e134081fc58
```

9.0.11 version:
```shell
curl --silent https://s3.eu-central-1.amazonaws.com/download.seadrive.org/seafile-client-9.0.11.dmg | sha256

f0a45015eee313a5245b5a8f29d3509df8b884168a38e90bf4248091fc0bd14a
```
-> see https://github.com/Homebrew/homebrew-cask/commit/3a0fd19a28401df30c86c91d39543ceff0f94d27#diff-09d9aab59cec8e0d3d0b058e202df7163466281c18d9cf4f198fa2fc02c2427bL3

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
