### PR TITLE
dbeaver*: update sha256

### DIFF
--- a/Casks/d/dbeaver-enterprise.rb
+++ b/Casks/d/dbeaver-enterprise.rb
@@ -2,8 +2,8 @@ cask "dbeaver-enterprise" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "25.0.0"
-  sha256 arm:   "92bf7f8c572bc8e09ed8dfeceda9a2c7049fc06166a161817f21286a7c14a39b",
-         intel: "0892a75cfc3804bbabcb78c502b988e54a7ead1e0aa69219a4c65a72f5ba22da"
+  sha256 arm:   "0c7f762ec81ca3ac792d2d8512c53e17e7f44168a1d8eff36d3385efb2f349ca",
+         intel: "ce59be18a76d559745cfd2d4d9de5e423a94be8e02bf4d11945e07e1634365b4"
 
   url "https://dbeaver.com/files/#{version}/dbeaver-ee-#{version}-macos-#{arch}.dmg"
   name "DBeaver Enterprise Edition"

--- a/Casks/d/dbeaverlite.rb
+++ b/Casks/d/dbeaverlite.rb
@@ -2,8 +2,8 @@ cask "dbeaverlite" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "25.0.0"
-  sha256 arm:   "68508050cd5b14b1aaaa19421caf40287ddda86d1a6916aa3d92fb4fb6c06c05",
-         intel: "0e98ae494ffea3e8a5bdcac751433784bacd284327b4590da01487f7343ad522"
+  sha256 arm:   "29c9cb36ef416b72dcd999ecf8916680446f035021eb9e1dbca9380be94ba49b",
+         intel: "8fb9b8d51aa2b174a959dae58923db5e3128524251923c45e6a329cc11b72a25"
 
   url "https://dbeaver.com/downloads-lite/#{version}/dbeaver-le-#{version}-macos-#{arch}.dmg"
   name "DBeaver Lite Edition"

--- a/Casks/d/dbeaverultimate.rb
+++ b/Casks/d/dbeaverultimate.rb
@@ -2,8 +2,8 @@ cask "dbeaverultimate" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "25.0.0"
-  sha256 arm:   "4d473cfbad2a214a909a0dc9edef8e77ec5dd98d257bf1d41ecb3ab0c0108969",
-         intel: "d50f62ce37a779a3eb081b0344f895afd803ab12f4b7b3cc7055175dd5d991b5"
+  sha256 arm:   "1d7b2d8130f2220b8152666944d0abd690497a06fb176f3bfac2d73baf56ef61",
+         intel: "a65e9fbbbc830d263b5e557d03d9e2b6be699402696f86922d9ad0474c3fe01a"
 
   url "https://dbeaver.com/downloads-ultimate/#{version}/dbeaver-ue-#{version}-macos-#{arch}.dmg"
   name "DBeaver Ultimate Edition"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `sha256` for a few DBeaver casks changed between when we merged the 25.0.0 update and now, so this updates the casks accordingly.