### PR TITLE
GHDL - add ghdl1-llvm

### DIFF
--- a/Casks/g/ghdl.rb
+++ b/Casks/g/ghdl.rb
@@ -24,8 +24,9 @@ cask "ghdl" do
   end
 
   url "https://github.com/ghdl/ghdl/releases/download/v#{version}/ghdl-llvm-#{version}-macos#{macos_version}-#{arch}.tar.gz"
+
   name "ghdl"
-  desc "VHDL 2008/93/87 simulator"
+  desc "VHDL 2019/2008/93/87 simulator"
   homepage "https://github.com/ghdl/ghdl/"
 
   livecheck do
@@ -35,10 +36,22 @@ cask "ghdl" do
 
   directory = "ghdl-llvm-#{version}-macos#{macos_version}-#{arch}"
 
-  binary "#{directory}/bin/ghdl"
-  binary "#{directory}/bin/ghwdump"
+  ghdlbins = ["ghdl", "ghwdump", "ghdl1-llvm"]
+  ghdlbins.each { |_bin|
+    binary "#{directory}/bin/#{_bin}"
+  }
+
   binary "#{directory}/include/ghdl", target: "#{HOMEBREW_PREFIX}/include/ghdl"
   binary "#{directory}/lib/ghdl", target: "#{HOMEBREW_PREFIX}/lib/ghdl"
+
+  postflight do
+    puts "Setting files as being from a nice developer"
+    ghdlbins.each { |_bin|
+      `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/bin/#{_bin}`
+    }
+    `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/include/ghdl`
+    `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/lib/ghdl`
+  end
 
   # No zap stanza required
 end

--- a/Casks/g/ghdl.rb
+++ b/Casks/g/ghdl.rb
@@ -26,7 +26,7 @@ cask "ghdl" do
   url "https://github.com/ghdl/ghdl/releases/download/v#{version}/ghdl-llvm-#{version}-macos#{macos_version}-#{arch}.tar.gz"
 
   name "ghdl"
-  desc "VHDL 2019/2008/93/87 simulator"
+  desc "VHDL 2008/93/87 simulator"
   homepage "https://github.com/ghdl/ghdl/"
 
   livecheck do

--- a/Casks/g/ghdl.rb
+++ b/Casks/g/ghdl.rb
@@ -24,9 +24,8 @@ cask "ghdl" do
   end
 
   url "https://github.com/ghdl/ghdl/releases/download/v#{version}/ghdl-llvm-#{version}-macos#{macos_version}-#{arch}.tar.gz"
-
   name "ghdl"
-  desc "VHDL 2008/93/87 simulator"
+  desc "VHDL 2019/2008/93/87 simulator"
   homepage "https://github.com/ghdl/ghdl/"
 
   livecheck do
@@ -37,18 +36,18 @@ cask "ghdl" do
   directory = "ghdl-llvm-#{version}-macos#{macos_version}-#{arch}"
 
   ghdlbins = ["ghdl", "ghwdump", "ghdl1-llvm"]
-  ghdlbins.each { |_bin|
-    binary "#{directory}/bin/#{_bin}"
-  }
+  ghdlbins.each do |bin|
+    binary "#{directory}/bin/#{bin}"
+  end
 
   binary "#{directory}/include/ghdl", target: "#{HOMEBREW_PREFIX}/include/ghdl"
   binary "#{directory}/lib/ghdl", target: "#{HOMEBREW_PREFIX}/lib/ghdl"
 
   postflight do
     puts "Setting files as being from a nice developer"
-    ghdlbins.each { |_bin|
-      `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/bin/#{_bin}`
-    }
+    ghdlbins.each do |bin|
+      `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/bin/#{bin}`
+    end
     `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/include/ghdl`
     `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/lib/ghdl`
   end

--- a/Casks/g/ghdl.rb
+++ b/Casks/g/ghdl.rb
@@ -43,14 +43,5 @@ cask "ghdl" do
   binary "#{directory}/include/ghdl", target: "#{HOMEBREW_PREFIX}/include/ghdl"
   binary "#{directory}/lib/ghdl", target: "#{HOMEBREW_PREFIX}/lib/ghdl"
 
-  postflight do
-    puts "Setting files as being from a nice developer"
-    ghdlbins.each do |bin|
-      `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/bin/#{bin}`
-    end
-    `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/include/ghdl`
-    `xattr -dr com.apple.quarantine #{HOMEBREW_PREFIX}/lib/ghdl`
-  end
-
   # No zap stanza required
 end

--- a/Casks/g/ghdl.rb
+++ b/Casks/g/ghdl.rb
@@ -25,7 +25,7 @@ cask "ghdl" do
 
   url "https://github.com/ghdl/ghdl/releases/download/v#{version}/ghdl-llvm-#{version}-macos#{macos_version}-#{arch}.tar.gz"
   name "ghdl"
-  desc "VHDL 2019/2008/93/87 simulator"
+  desc "VHDL 2008/93/87 simulator"
   homepage "https://github.com/ghdl/ghdl/"
 
   livecheck do


### PR DESCRIPTION
GHDL on macos is complaing about not having ghdl1-llvm.
This fixes this.
Also see:

[GHDL not properly compiling on MacOS 14.6 with command ghdl -a --ieee=synopsy command](https://github.com/ghdl/ghdl/issues/2711)
#2711

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x*] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

*I did not change the name
