### PR TITLE
Fix vscodium.rb for catalina

### DIFF
--- a/Casks/v/vscodium.rb
+++ b/Casks/v/vscodium.rb
@@ -1,19 +1,29 @@
 cask "vscodium" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.98.1.25070"
-  sha256 arm:   "6463f2beb0a834e59da6d386e797a09f6b33e0d089b93995df09257a1ef58377",
-         intel: "dcaa9e1a73cc5ae93c4cb82971e0b457b168f42f1e07c05df806bf7ce9252039"
+  on_catalina :or_older do
+    version "1.97.2.25045"
+    sha256 arm:   "48d01a0663b7a6396f41ddc11296eb812d58e9fe3b671b9d33e6b21621e40f21",
+           intel: "af8fe5721ef431ab59fe05a06a3a462c40884229f61cc2962ea01d3e66997243"
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur :or_newer do
+    version "1.98.1.25070"
+    sha256 arm:   "6463f2beb0a834e59da6d386e797a09f6b33e0d089b93995df09257a1ef58377",
+           intel: "dcaa9e1a73cc5ae93c4cb82971e0b457b168f42f1e07c05df806bf7ce9252039"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{arch}.#{version}.dmg"
   name "VSCodium"
   desc "Binary releases of VS Code without MS branding/telemetry/licensing"
   homepage "https://github.com/VSCodium/vscodium"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   auto_updates true
   depends_on macos: ">= :catalina"

--- a/Casks/v/vscodium.rb
+++ b/Casks/v/vscodium.rb
@@ -5,6 +5,7 @@ cask "vscodium" do
     version "1.97.2.25045"
     sha256 arm:   "48d01a0663b7a6396f41ddc11296eb812d58e9fe3b671b9d33e6b21621e40f21",
            intel: "af8fe5721ef431ab59fe05a06a3a462c40884229f61cc2962ea01d3e66997243"
+
     livecheck do
       skip "Legacy version"
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Since version +1.98, Catalina is no longer supported, applied a version check.

The `visual-studio-code.rb` already includes this fix.

Ref: https://code.visualstudio.com/updates/v1_98#_macos-1015-support-has-ended
