### PR TITLE
batfi: update livecheck

### DIFF
--- a/Casks/b/batfi.rb
+++ b/Casks/b/batfi.rb
@@ -9,7 +9,9 @@ cask "batfi" do
 
   livecheck do
     url "https://files.micropixels.software/batfi/appcast.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.short_version
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `batfi` checks the Sparkle appcast and it's currently returning 2.3.3 as newest but that version is on the beta channel and the file URL is `BatFi-beta.zip` instead of `BatFi-latest.zip` (which is 2.3.2). This updates the `livecheck` block to add a `strategy` block that finds the newest release on the main channel.

Related to https://github.com/Homebrew/homebrew-cask/pull/204857