### PR TITLE
expressscribe: correct version, update livecheck

### DIFF
--- a/Casks/e/expressscribe.rb
+++ b/Casks/e/expressscribe.rb
@@ -1,5 +1,5 @@
 cask "expressscribe" do
-  version "14.00"
+  version "13.11"
   sha256 :no_check
 
   url "https://www.nch.com.au/scribe/scribemaci.zip"
@@ -9,7 +9,7 @@ cask "expressscribe" do
 
   livecheck do
     url "https://www.nch.com.au/scribe/versions.html"
-    regex(/Version\s*v?(\d+(?:\.\d+)+)/i)
+    regex(/Version\s*v?(\d+(?:\.\d+)+)\s*<[^>]+>\s*macOS\s+Release/im)
   end
 
   app "ExpressScribe.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The current version of `expressscribe` is 13.11 and that's reflected in the app the cask is using. Subsequent versions like 14.00 have been Windows releases but the `livecheck` block regex incorrectly treats them all the same. This corrects the `version` and updates the `livecheck` block regex to only match macOS releases.

Related to https://github.com/Homebrew/homebrew-cask/pull/204879