### PR TITLE
charles@4 4.6.7 (new cask)

### DIFF
--- a/Casks/c/charles@4.rb
+++ b/Casks/c/charles@4.rb
@@ -1,0 +1,43 @@
+cask "charles@4" do
+  version "4.6.7"
+  sha256 "ba16148c7a6b3723488cc95968d96fba1de0807ad8e47467a2b5ac3ad13ff22b"
+
+  url "https://www.charlesproxy.com/assets/release/#{version}/charles-proxy-#{version}.dmg"
+  name "Charles"
+  desc "Web debugging Proxy application"
+  homepage "https://www.charlesproxy.com/"
+
+  livecheck do
+    url "https://www.charlesproxy.com/documentation/version-history/"
+    regex(/Version (4(?:\.\d+)+)/i)
+  end
+
+  app "Charles.app"
+
+  uninstall_postflight do
+    stdout, * = system_command "/usr/bin/security",
+                               args: ["find-certificate", "-a", "-c", "Charles", "-Z"],
+                               sudo: true
+    hashes = stdout.lines.grep(/^SHA-256 hash:/) { |l| l.split(":").second.strip }
+    hashes.each do |h|
+      system_command "/usr/bin/security",
+                     args: ["delete-certificate", "-Z", h],
+                     sudo: true
+    end
+  end
+
+  uninstall launchctl: "com.xk72.Charles.ProxyHelper",
+            quit:      "com.xk72.Charles",
+            delete:    "/Library/PrivilegedHelperTools/com.xk72.Charles.ProxyHelper"
+
+  zap trash: [
+    "~/Library/Application Support/Charles",
+    "~/Library/Preferences/com.xk72.charles.config",
+    "~/Library/Preferences/com.xk72.Charles.plist",
+    "~/Library/Saved Application State/com.xk72.Charles.savedState",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
Charles user licences are pinned to major versions, which was incremented recently, rendering software unusable after update.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [xgit status] `brew uninstall --cask <cask>` worked successfully.

---
