### PR TITLE
Deprecated/disabled casks: add `--cask` flag to the replacement

### DIFF
--- a/Casks/font/font-i/font-iosevka-comfy.rb
+++ b/Casks/font/font-i/font-iosevka-comfy.rb
@@ -6,7 +6,7 @@ cask "font-iosevka-comfy" do
   name "Iosevka-Comfy"
   homepage "https://github.com/protesilaos/iosevka-comfy"
 
-  deprecate! date: "2025-02-19", because: :discontinued, replacement: "font-aporetic"
+  deprecate! date: "2025-02-19", because: :discontinued, replacement: "--cask font-aporetic"
 
   font "iosevka-comfy-#{version}/iosevka-comfy-duo/TTF/iosevka-comfy-duo-normalbolditalic.ttf"
   font "iosevka-comfy-#{version}/iosevka-comfy-duo/TTF/iosevka-comfy-duo-normalboldupright.ttf"

--- a/Casks/l/logisim.rb
+++ b/Casks/l/logisim.rb
@@ -8,7 +8,7 @@ cask "logisim" do
   desc "Tool for designing and simulating digital logic circuits"
   homepage "http://www.cburch.com/logisim/"
 
-  disable! date: "2024-12-16", because: :discontinued
+  disable! date: "2024-12-16", because: :discontinued, replacement: "--cask logisim-evolution"
 
   app "Logisim.app"
 

--- a/Casks/m/mutesync.rb
+++ b/Casks/m/mutesync.rb
@@ -11,7 +11,7 @@ cask "mutesync" do
   desc "Companion app to the mütesync physical button"
   homepage "https://mutesync.com/"
 
-  disable! date: "2025-01-26", because: :discontinued, replacement: "muteme"
+  disable! date: "2025-01-26", because: :discontinued, replacement: "--cask muteme"
 
   auto_updates true
 

--- a/Casks/s/surge-synthesizer.rb
+++ b/Casks/s/surge-synthesizer.rb
@@ -8,7 +8,7 @@ cask "surge-synthesizer" do
   desc "Hybrid synthesiser"
   homepage "https://surge-synthesizer.github.io/"
 
-  deprecate! date: "2025-03-02", because: :discontinued, replacement: "surge-xt"
+  deprecate! date: "2025-03-02", because: :discontinued, replacement: "--cask surge-xt"
 
   pkg "Surge-#{version}-Setup.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---