### PR TITLE
librewolf 1.36.0.1,1

### DIFF
--- a/Casks/l/librewolf.rb
+++ b/Casks/l/librewolf.rb
@@ -1,9 +1,9 @@
 cask "librewolf" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "136.0-2"
-  sha256 arm:   "307d8e16123835f672cc1c6940300768e11cb9fb992454a75c3a290d505709b2",
-         intel: "b059803bd1d2146c7272225721ce705a45542bb7935f6367618fed0a7531b7b5"
+  version "136.0.1-1"
+  sha256 arm:   "1bca1beb412c9127b2ce6266ef9799b63986998bb594830b71d6f57d7d2ae614",
+         intel: "d0ffcb04a854b2a4d475465aea9fd3b8f74e283cd8290f7940da7606deb2cc09"
 
   url "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/#{version}/librewolf-#{version}-macos-#{arch}-package.dmg",
       verified: "gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/"

--- a/Casks/l/librewolf.rb
+++ b/Casks/l/librewolf.rb
@@ -16,7 +16,7 @@ cask "librewolf" do
     # Version is `<firefox_version>-<librewolf_release>`, e.g. `136.0.1-1`
     regex(/^(?<firefox_version>\d+(?:\.\d+)+)-(?<librewolf_release>\d+)/i)
     strategy :git do |tags, regex|
-      tags.map do |tag|
+      tags.filter_map do |tag|
         match = tag.match(regex)
         next unless match
 
@@ -24,11 +24,9 @@ cask "librewolf" do
         # This ensures the LibreWolf release number is always compared separately,
         # so that `136.0-2` is not newer than `136.0.1-1`.
         firefox_version_parts = match[:firefox_version].split(".")
-        while firefox_version_parts.size < 3
-          firefox_version_parts << "0"
-        end
-        "#{firefox_version_parts.join('.')}-#{match[:librewolf_release]}"
-      end.compact
+        firefox_version_parts << "0" while firefox_version_parts.size < 3
+        "#{firefox_version_parts.join(".")}-#{match[:librewolf_release]}"
+      end
     end
   end
 

--- a/Casks/l/librewolf.rb
+++ b/Casks/l/librewolf.rb
@@ -1,11 +1,11 @@
 cask "librewolf" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "136.0.1-1"
+  version "136.0.1,1"
   sha256 arm:   "1bca1beb412c9127b2ce6266ef9799b63986998bb594830b71d6f57d7d2ae614",
          intel: "d0ffcb04a854b2a4d475465aea9fd3b8f74e283cd8290f7940da7606deb2cc09"
 
-  url "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/#{version}/librewolf-#{version}-macos-#{arch}-package.dmg",
+  url "https://gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/#{version.tr(",", "-")}/librewolf-#{version.tr(",", "-")}-macos-#{arch}-package.dmg",
       verified: "gitlab.com/api/v4/projects/44042130/packages/generic/librewolf/"
   name "LibreWolf"
   desc "Web browser"
@@ -13,20 +13,9 @@ cask "librewolf" do
 
   livecheck do
     url "https://gitlab.com/librewolf-community/browser/bsys6.git"
-    # Version is `<firefox_version>-<librewolf_release>`, e.g. `136.0.1-1`
-    regex(/^(?<firefox_version>\d+(?:\.\d+)+)-(?<librewolf_release>\d+)/i)
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
     strategy :git do |tags, regex|
-      tags.filter_map do |tag|
-        match = tag.match(regex)
-        next unless match
-
-        # Normalize Firefox version to 3 parts, e.g. `136.0`, becomes `136.0.0`.
-        # This ensures the LibreWolf release number is always compared separately,
-        # so that `136.0-2` is not newer than `136.0.1-1`.
-        firefox_version_parts = match[:firefox_version].split(".")
-        firefox_version_parts << "0" while firefox_version_parts.size < 3
-        "#{firefox_version_parts.join(".")}-#{match[:librewolf_release]}"
-      end
+      tags.map { |tag| tag[regex, 1]&.tr("-", ",") }
     end
   end
 


### PR DESCRIPTION
Currently the `autobump` workflow is not finding the latest version of LibreWolf because of how the versioning scheme works.

- Current version: `136.0.1-1`
- Latest brew version: `136.0-2`

The `librewolf` cask version combines a Firefox version with a LibreWolf release number separated by `-`, e.g. `136.0.1-1`. However, when the Firefox version has only 2 places, the LibreWolf release is treated as the final part of the Firefox version.

So `[136, 0, 2]` is considered newer than `[136, 0, 1, 1]`.

This change to the `librewolf` formula updates the separator  from `-` to `,`, e.g. `136.0-2` becomes `136.0,2` to make sure the version comparison works correctly for detecting updates.

Output of `brew livecheck --cask --debug --autobump librewolf`:

**Before**
```
Cask:             librewolf
livecheck block?: Yes

URL:              https://gitlab.com/librewolf-community/browser/bsys6.git
Strategy:         Git

Matched Versions:
111.0-2, 111.0-2-2, 111.0-3, 111.0.1-1, 112.0-1, 112.0.1-2, 112.0.2-1, 113.0-3, 113.0.1-1, 113.0.2-1, 114.0-1, 114.0.1-2, 114.0.2-1, 115.0.1-1, 115.0.2-2, 116.0-1, 116.0.2-1, 116.0.3-1, 117.0-1, 117.0.1-1, 118.0.1-1, 118.0.2-1, 119.0-4, 119.0-5, 119.0-6, 119.0-7, 119.0.1-1, 120.0-1, 120.0-2, 120.0.1-1, 121.0-1, 122.0-1, 122.0-2, 122.0.1-2, 123.0-1, 123.0.1-1, 124.0.1-1, 125.0.2-1, 125.0.3-1, 126.0-1, 126.0.1-1, 127.0-1, 127.0.1-1, 127.0.2-2, 128.0-2, 128.0.3-1, 128.0.3-2, 129.0-1, 129.0.1-1, 129.0.2-1, 130.0-1, 130.0-2, 130.0-3, 130.0.1-1, 131.0-1, 131.0.2-1, 131.0.3-1, 132.0-1, 132.0.1-1, 132.0.2-1, 133.0-1, 133.0-3, 133.0.3-1, 134.0-1, 134.0.1-1, 134.0.2-1, 135.0-1, 135.0.1-1, 136.0-1, 136.0-2, 136.0.1-1

librewolf: 136.0-2 ==> 136.0-2
```

**After**
```
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromNameLoader): loading librewolf

Cask:             librewolf
livecheck block?: Yes

URL:              https://gitlab.com/librewolf-community/browser/bsys6.git
Strategy:         Git
Regex:            /^v?(\d+(?:[.-]\d+)+)$/i

Matched Versions:
111.0,2, 111.0,2,2, 111.0,3, 111.0.1,1, 112.0,1, 112.0.1,2, 112.0.2,1, 113.0,3, 113.0.1,1, 113.0.2,1, 114.0,1, 114.0.1,2, 114.0.2,1, 115.0.1,1, 115.0.2,2, 116.0,1, 116.0.2,1, 116.0.3,1, 117.0,1, 117.0.1,1, 118.0.1,1, 118.0.2,1, 119.0,4, 119.0,5, 119.0,6, 119.0,7, 119.0.1,1, 120.0,1, 120.0,2, 120.0.1,1, 121.0,1, 122.0,1, 122.0,2, 122.0.1,2, 123.0,1, 123.0.1,1, 124.0.1,1, 125.0.2,1, 125.0.3,1, 126.0,1, 126.0.1,1, 127.0,1, 127.0.1,1, 127.0.2,2, 128.0,2, 128.0.3,1, 128.0.3,2, 129.0,1, 129.0.1,1, 129.0.2,1, 130.0,1, 130.0,2, 130.0,3, 130.0.1,1, 131.0,1, 131.0.2,1, 131.0.3,1, 132.0,1, 132.0.1,1, 132.0.2,1, 133.0,1, 133.0,3, 133.0.3,1, 134.0,1, 134.0.1,1, 134.0.2,1, 135.0,1, 135.0.1,1, 136.0,1, 136.0,2, 136.0.1,1

librewolf: 136.0,2 ==> 136.0.1,1
```

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
