### PR TITLE
fantasy-grounds: deprecate

### DIFF
--- a/Casks/f/fantasy-grounds.rb
+++ b/Casks/f/fantasy-grounds.rb
@@ -6,9 +6,7 @@ cask "fantasy-grounds" do
   name "Fantasy Grounds"
   homepage "https://www.fantasygrounds.com/home/home.php"
 
-  livecheck do
-    skip "unversioned WineSkin application"
-  end
+  deprecate! date: "2025-03-15", because: :discontinued
 
   app "Fantasy Grounds.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> NOTE: Fantasy Grounds Classic has been discontinued and was retired with its end-of-life date being June 24th, 2021. Fantasy Grounds Classic will no longer receive any product updates or DLC releases after this date.