### PR TITLE
qobuz-downloader 2.0.0+1 (new cask)

### DIFF
--- a/Casks/q/qobuz-downloader.rb
+++ b/Casks/q/qobuz-downloader.rb
@@ -1,0 +1,26 @@
+cask "qobuz-downloader" do
+  version "2.0.0,1"
+  sha256 "914c782dd7d25e9a17865a48eeead7ffa43fba7acb638b062a1f8eefe40c0a01"
+
+  url "https://apps.qobuz.com/downloader/releases/macos/#{version.csv.first}+#{version.csv.second}/qobuz_downloader.dmg"
+  name "Qobuz Downloader"
+  desc "Tool to download entire purchases simultaneously"
+  homepage "https://www.qobuz.com/applications"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)\+(\d+)/qobuz[._-]downloader\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Qobuz Downloader.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.qobuz.downloader",
+    "~/Library/Caches/SentryCrash/Qobuz Downloader",
+  ]
+end


### PR DESCRIPTION
Add the official Qobuz Downloader tool to the cask library

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---
