### PR TITLE
deveco-studio: disable

### DIFF
--- a/Casks/d/deveco-studio.rb
+++ b/Casks/d/deveco-studio.rb
@@ -21,10 +21,7 @@ cask "deveco-studio" do
   desc "Development platform for HarmonyOS and OpenHarmony"
   homepage "https://developer.huawei.com/consumer/cn/"
 
-  livecheck do
-    url "https://developer.huawei.com/consumer/cn/deveco-studio/"
-    regex(/devecostudio[._-]mac#{arch}[._-](\d+(?:\.\d+)+)\.zip/i)
-  end
+  disable! date: "2025-03-17", because: :no_longer_available
 
   depends_on macos: ">= :catalina"
   container nested: "devecostudio-mac#{arch}-#{version}/deveco-studio-#{version}#{arch_suffix}.dmg"


### PR DESCRIPTION

<img width="492" alt="图片" src="https://github.com/user-attachments/assets/d9be95c9-9f20-4cf1-962a-5d16a23e8abc" />

Newest version is `DevEco Studio 5.0.2 Release` that released on 2025/02/17. This software is no longer available for public download. You can only log in to the developer account on the official site and authorize the download.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
