### PR TITLE
*: Group `arch` and `os` stanzas

### DIFF
--- a/Casks/1/1password-cli.rb
+++ b/Casks/1/1password-cli.rb
@@ -1,6 +1,5 @@
 cask "1password-cli" do
   arch arm: "arm64", intel: "amd64"
-
   os macos: "darwin", linux: "linux"
 
   version "2.30.3"

--- a/Casks/c/coterm.rb
+++ b/Casks/c/coterm.rb
@@ -1,6 +1,5 @@
 cask "coterm" do
   arch arm: "arm64", intel: "x64"
-
   os macos: "macos", linux: "linux"
 
   version "1.0.0"

--- a/Casks/w/wizcli.rb
+++ b/Casks/w/wizcli.rb
@@ -1,6 +1,5 @@
 cask "wizcli" do
   arch arm: "arm64", intel: "amd64"
-
   os macos: "darwin", linux: "linux"
 
   version "0.77.0"


### PR DESCRIPTION
- I ran `brew style --fix --only=Cask/StanzaGrouping homebrew/cask` as it was needed for https://github.com/Homebrew/brew/pull/19507.