### PR TITLE
nethlink 1.0.2 (new cask)

### DIFF
--- a/Casks/n/nethlink.rb
+++ b/Casks/n/nethlink.rb
@@ -1,0 +1,19 @@
+cask "nethlink" do
+  version "1.0.2"
+  sha256 "5109f6bdf6f9585dd22689cd469e836e1364cf376f3bb609fa58707bbbc49d17"
+
+  url "https://github.com/NethServer/nethlink/releases/download/v#{version}/nethlink-#{version}.dmg"
+  name "NethLink"
+  desc "Link NethServer systems and provide remote access tools"
+  homepage "https://github.com/NethServer/nethlink"
+
+  depends_on macos: ">= :catalina"
+
+  app "NethLink.app"
+
+  zap trash: "~/Library/Application Support/nethlink"
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

### Notes
The `brew audit --cask --new <cask>` fails because of:
```
audit for nethlink: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
nethlink
  * line 5, col 2: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 cask detected.
```
