### PR TITLE
font-maple-mono-normal* 7.0 (new cask) 

### DIFF
--- a/Casks/font/font-m/font-maple-mono-normal-cn.rb
+++ b/Casks/font/font-m/font-maple-mono-normal-cn.rb
@@ -1,0 +1,31 @@
+cask "font-maple-mono-normal-cn" do
+  version "7.0"
+  sha256 "130ffb2b028f5a5b85b584430ffd21836ead40254a6022144cda829589dd55f2"
+
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMonoNormal-CN-unhinted.zip"
+  name "Maple Mono Normal CN"
+  homepage "https://github.com/subframe7536/Maple-font"
+
+  livecheck do
+    cask "font-maple-mono"
+  end
+
+  font "MapleMonoNormal-CN-Bold.ttf"
+  font "MapleMonoNormal-CN-BoldItalic.ttf"
+  font "MapleMonoNormal-CN-ExtraBold.ttf"
+  font "MapleMonoNormal-CN-ExtraBoldItalic.ttf"
+  font "MapleMonoNormal-CN-ExtraLight.ttf"
+  font "MapleMonoNormal-CN-ExtraLightItalic.ttf"
+  font "MapleMonoNormal-CN-Italic.ttf"
+  font "MapleMonoNormal-CN-Light.ttf"
+  font "MapleMonoNormal-CN-LightItalic.ttf"
+  font "MapleMonoNormal-CN-Medium.ttf"
+  font "MapleMonoNormal-CN-MediumItalic.ttf"
+  font "MapleMonoNormal-CN-Regular.ttf"
+  font "MapleMonoNormal-CN-SemiBold.ttf"
+  font "MapleMonoNormal-CN-SemiBoldItalic.ttf"
+  font "MapleMonoNormal-CN-Thin.ttf"
+  font "MapleMonoNormal-CN-ThinItalic.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-m/font-maple-mono-normal-nf-cn.rb
+++ b/Casks/font/font-m/font-maple-mono-normal-nf-cn.rb
@@ -1,0 +1,31 @@
+cask "font-maple-mono-normal-nf-cn" do
+  version "7.0"
+  sha256 "bce945c1bd1af7bc9d24f47b61e109aa79938caf69284d8eeaccc61902474a14"
+
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMonoNormal-NF-CN-unhinted.zip"
+  name "Maple Mono Normal NF CN"
+  homepage "https://github.com/subframe7536/Maple-font"
+
+  livecheck do
+    cask "font-maple-mono"
+  end
+
+  font "MapleMonoNormal-NF-CN-Bold.ttf"
+  font "MapleMonoNormal-NF-CN-BoldItalic.ttf"
+  font "MapleMonoNormal-NF-CN-ExtraBold.ttf"
+  font "MapleMonoNormal-NF-CN-ExtraBoldItalic.ttf"
+  font "MapleMonoNormal-NF-CN-ExtraLight.ttf"
+  font "MapleMonoNormal-NF-CN-ExtraLightItalic.ttf"
+  font "MapleMonoNormal-NF-CN-Italic.ttf"
+  font "MapleMonoNormal-NF-CN-Light.ttf"
+  font "MapleMonoNormal-NF-CN-LightItalic.ttf"
+  font "MapleMonoNormal-NF-CN-Medium.ttf"
+  font "MapleMonoNormal-NF-CN-MediumItalic.ttf"
+  font "MapleMonoNormal-NF-CN-Regular.ttf"
+  font "MapleMonoNormal-NF-CN-SemiBold.ttf"
+  font "MapleMonoNormal-NF-CN-SemiBoldItalic.ttf"
+  font "MapleMonoNormal-NF-CN-Thin.ttf"
+  font "MapleMonoNormal-NF-CN-ThinItalic.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-m/font-maple-mono-normal-nf.rb
+++ b/Casks/font/font-m/font-maple-mono-normal-nf.rb
@@ -1,0 +1,31 @@
+cask "font-maple-mono-normal-nf" do
+  version "7.0"
+  sha256 "f4585b0e10671841705f6604d8611ecad788580e73ddbe152705114d6b167f79"
+
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMonoNormal-NF-unhinted.zip"
+  name "Maple Mono Normal NF"
+  homepage "https://github.com/subframe7536/Maple-font"
+
+  livecheck do
+    cask "font-maple-mono"
+  end
+
+  font "MapleMonoNormal-NF-Bold.ttf"
+  font "MapleMonoNormal-NF-BoldItalic.ttf"
+  font "MapleMonoNormal-NF-ExtraBold.ttf"
+  font "MapleMonoNormal-NF-ExtraBoldItalic.ttf"
+  font "MapleMonoNormal-NF-ExtraLight.ttf"
+  font "MapleMonoNormal-NF-ExtraLightItalic.ttf"
+  font "MapleMonoNormal-NF-Italic.ttf"
+  font "MapleMonoNormal-NF-Light.ttf"
+  font "MapleMonoNormal-NF-LightItalic.ttf"
+  font "MapleMonoNormal-NF-Medium.ttf"
+  font "MapleMonoNormal-NF-MediumItalic.ttf"
+  font "MapleMonoNormal-NF-Regular.ttf"
+  font "MapleMonoNormal-NF-SemiBold.ttf"
+  font "MapleMonoNormal-NF-SemiBoldItalic.ttf"
+  font "MapleMonoNormal-NF-Thin.ttf"
+  font "MapleMonoNormal-NF-ThinItalic.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-m/font-maple-mono-normal.rb
+++ b/Casks/font/font-m/font-maple-mono-normal.rb
@@ -1,0 +1,31 @@
+cask "font-maple-mono-normal" do
+  version "7.0"
+  sha256 "bcbe9f47010fd8648e441ace1af120480f9fc63ad9c989a96cd7ae20ca55bd83"
+
+  url "https://github.com/subframe7536/Maple-font/releases/download/v#{version}/MapleMonoNormal-TTF.zip"
+  name "Maple Mono Normal"
+  homepage "https://github.com/subframe7536/Maple-font"
+
+  livecheck do
+    cask "font-maple-mono"
+  end
+
+  font "MapleMonoNormal-Bold.ttf"
+  font "MapleMonoNormal-BoldItalic.ttf"
+  font "MapleMonoNormal-ExtraBold.ttf"
+  font "MapleMonoNormal-ExtraBoldItalic.ttf"
+  font "MapleMonoNormal-ExtraLight.ttf"
+  font "MapleMonoNormal-ExtraLightItalic.ttf"
+  font "MapleMonoNormal-Italic.ttf"
+  font "MapleMonoNormal-Light.ttf"
+  font "MapleMonoNormal-LightItalic.ttf"
+  font "MapleMonoNormal-Medium.ttf"
+  font "MapleMonoNormal-MediumItalic.ttf"
+  font "MapleMonoNormal-Regular.ttf"
+  font "MapleMonoNormal-SemiBold.ttf"
+  font "MapleMonoNormal-SemiBoldItalic.ttf"
+  font "MapleMonoNormal-Thin.ttf"
+  font "MapleMonoNormal-ThinItalic.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
Homebrew-cask currently includes the standard Maple Mono variants (font-maple-mono, font-maple-mono-cn, font-maple-mono-nf, font-maple-mono-nf-cn), but lacks the "Normal" versions which are also officially provided by the Maple Mono project.

The standard Maple Mono fonts use stylized glyphs for certain symbols (such as @, #, $, %), which can be difficult to recognize in coding contexts.
The "Normal" variants provide conventional, easily recognizable shapes for these special characters, making them more suitable for everyday programming use while maintaining the overall aesthetic of Maple Mono.

**These additions would give users more options to choose the variant that best suits their readability preferences.**