### PR TITLE
discord: add legacy version

### DIFF
--- a/Casks/d/discord.rb
+++ b/Casks/d/discord.rb
@@ -1,17 +1,27 @@
 cask "discord" do
-  version "0.0.341"
-  sha256 "157c85eee5b09cd5cf7b9427d966415c2af7f764661d94774366904e88d0dbda"
+  on_catalina :or_older do
+    version "0.0.336"
+    sha256 "470fc7ad490d7ad42f01632af16dee69fbec6e3db7e3f79af4f2ee246e382398"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_big_sur :or_newer do
+    version "0.0.341"
+    sha256 "157c85eee5b09cd5cf7b9427d966415c2af7f764661d94774366904e88d0dbda"
+
+    livecheck do
+      url "https://discord.com/api/download/stable?platform=osx"
+      strategy :header_match
+    end
+  end
 
   url "https://dl.discordapp.net/apps/osx/#{version}/Discord.dmg",
       verified: "dl.discordapp.net/"
   name "Discord"
   desc "Voice and text chat software"
   homepage "https://discord.com/"
-
-  livecheck do
-    url "https://discord.com/api/download/stable?platform=osx"
-    strategy :header_match
-  end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
![Screenshot 2025-03-18 at 15 40 01](https://github.com/user-attachments/assets/e314182a-0d00-45cb-b23d-85392696b5ba)

NOTE: If you're on macOS 10.15 or lower and Discord no longer launches, it is recommended to install [this](https://dl.discordapp.net/apps/osx/0.0.336/Discord.dmg) version of the Discord app. This version will continue to work without updating, but installing any newer version will prevent Discord from launching.

Source: https://support.discord.com/hc/en-us/articles/20900540446231--Known-Issue-Support-for-macOS-10-15

Related: https://github.com/Homebrew/homebrew-cask/issues/205697

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
