### PR TITLE
font-pretendard-gov 1.3.9 (new cask)

### DIFF
--- a/Casks/font/font-p/font-pretendard-gov.rb
+++ b/Casks/font/font-p/font-pretendard-gov.rb
@@ -1,0 +1,20 @@
+cask "font-pretendard-gov" do
+  version "1.3.9"
+  sha256 "080266d2faa8911b0e239b367405fdbcb2b4e17b22067e40aeb34a6c3fca0ac4"
+
+  url "https://github.com/orioncactus/pretendard/releases/download/v#{version}/PretendardGOV-#{version}.zip"
+  name "Pretendard GOV"
+  homepage "https://github.com/orioncactus/pretendard"
+
+  font "public/static/PretendardGOV-Black.otf"
+  font "public/static/PretendardGOV-Bold.otf"
+  font "public/static/PretendardGOV-ExtraBold.otf"
+  font "public/static/PretendardGOV-ExtraLight.otf"
+  font "public/static/PretendardGOV-Light.otf"
+  font "public/static/PretendardGOV-Medium.otf"
+  font "public/static/PretendardGOV-Regular.otf"
+  font "public/static/PretendardGOV-SemiBold.otf"
+  font "public/static/PretendardGOV-Thin.otf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Additional Information

This font, "Pretendard GOV", is a new family in the Pretendard series, optimized for public services in South Korea. It's developed by [orioncactus/pretendard](https://github.com/orioncactus/pretendard). Homebrew already includes variants of Pretendard fonts, such as [font-pretendard](https://formulae.brew.sh/cask/font-pretendard), [font-pretendard-jp](https://formulae.brew.sh/cask/font-pretendard-jp), and [font-pretendard-std](https://formulae.brew.sh/cask/font-pretendard-std). This new font variant was added since version 1.3.7 and is also distributed under the SIL Open Font License.

Please note that I am not affiliated with the font developer. I noticed that only the "PretendardGOV" variant is not present in Homebrew while other variants exist, so I wanted to complete the series.
