### PR TITLE
stellarium: fix macOS versions and update 25.1

### DIFF
--- a/Casks/s/stellarium.rb
+++ b/Casks/s/stellarium.rb
@@ -1,5 +1,5 @@
 cask "stellarium" do
-  on_high_sierra :or_older do
+  on_sierra :or_older do
     version "0.22.2"
     sha256 "5e8c2ee315f8c00a393e7bd22461f9b48355538cec39e1bb771e92a5795bcfb4"
 
@@ -10,9 +10,21 @@ cask "stellarium" do
       skip "Legacy version"
     end
   end
+  on_high_sierra do
+    version "25.1"
+    sha256 "09d5cf56397a5e334ead321b93ca63e23e67d152f9d52d96fcb373ac212817c8"
+
+    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
+        verified: "github.com/Stellarium/stellarium/"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
   on_mojave do
-    version "24.4"
-    sha256 "2474235caf179cdc0d1fe0b70b6da39a13c16aaf24faf9740ced2ea3c3543ad7"
+    version "25.1"
+    sha256 "09d5cf56397a5e334ead321b93ca63e23e67d152f9d52d96fcb373ac212817c8"
 
     url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
         verified: "github.com/Stellarium/stellarium/"
@@ -23,8 +35,8 @@ cask "stellarium" do
     end
   end
   on_catalina do
-    version "24.4"
-    sha256 "2474235caf179cdc0d1fe0b70b6da39a13c16aaf24faf9740ced2ea3c3543ad7"
+    version "25.1"
+    sha256 "09d5cf56397a5e334ead321b93ca63e23e67d152f9d52d96fcb373ac212817c8"
 
     url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
         verified: "github.com/Stellarium/stellarium/"
@@ -35,8 +47,8 @@ cask "stellarium" do
     end
   end
   on_big_sur :or_newer do
-    version "24.4"
-    sha256 "e3a8c9ac2c7e52b4eb971b84941e801affaa69f156b844f806c42dbd9f08f63c"
+    version "25.1"
+    sha256 "8e7a811dbc2f94315390606d64e58aa443f67286cd2e67d644c730b8d580642e"
 
     url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt6-macOS.zip",
         verified: "github.com/Stellarium/stellarium/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
~~This is a draft because 25.1 isn't fully released yet (the binaries for macOS aren't all uploaded) but I also noticed macOS 10.13 was supported by the Qt5 version of the app, but wasn't included in the Cask file.~~ Outdated comment.