### PR TITLE
hy-rpe2 1.2.9 (new cask)

### DIFF
--- a/Casks/h/hy-rpe2.rb
+++ b/Casks/h/hy-rpe2.rb
@@ -1,0 +1,40 @@
+cask "hy-rpe2" do
+  version "1.2.9,2020"
+  sha256 :no_check
+
+  url "https://hy-plugins.com/wp-content/uploads#{"/#{version.csv[1..].join("/")}" if version.csv.length > 1}/HY-RPE2.pkg.zip"
+  name "HY-RPE2"
+  desc "8 track midi sequencer plugin"
+  homepage "https://hy-plugins.com/product/hy-rpewin-mac/"
+
+  livecheck do
+    url :homepage
+    regex(/v?(\d+(?:\.\d+)+)\s*\(/i)
+    strategy :page_match do |page, regex|
+      # Find the highest version from the release notes
+      version = page.scan(regex)
+                    .map { |match| match[0] }
+                    .max_by { |v| Version.new(v) }
+      next unless version
+
+      # Match the date from the file path (if any)
+      path_date = page[%r{(?:/(\d+(?:/\d+)*))?/HY-RPE2\.pkg\.zip}i, 1]
+
+      path_date ? "#{version},#{path_date.tr("/", ",")}" : version
+    end
+  end
+
+  depends_on macos: ">= :sierra"
+
+  pkg "HY-RPE2.pkg"
+
+  uninstall pkgutil: [
+    "com.hyplugins.pkg.HY-RPE2-au",
+    "com.hyplugins.pkg.HY-RPE2-presets",
+    "com.hyplugins.pkg.HY-RPE2-vst2",
+    "com.hyplugins.pkg.HY-RPE2-vst3",
+  ]
+
+  zap trash: "~/Library/Application Support/HY-Plugins/HY-RPE2.ini",
+      rmdir: "~/Library/Application Support/HY-Plugins"
+end


### PR DESCRIPTION
Add HY-RPE2 MIDI sequencer plugin to cask library.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---
