### PR TITLE
google-cloud-sdk: use trash for uninstall

### DIFF
--- a/Casks/g/google-cloud-sdk.rb
+++ b/Casks/g/google-cloud-sdk.rb
@@ -54,7 +54,7 @@ cask "google-cloud-sdk" do
     end
   end
 
-  uninstall delete: staged_path.dirname/"latest"
+  uninstall trash: staged_path.dirname/"latest"
 
   zap trash: [
     "#{google_cloud_sdk_root}.staging",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Use `trash` in favor of `delete` for `uninstall` directive, since this cask installs the CLI tools into the "standard" brew directories, the `sudo` based delete is unnecessary.

Fixes: https://github.com/Homebrew/homebrew-cask/issues/205734
