### PR TITLE
clash-verge-rev: downgrade to 2.1.2

### DIFF
--- a/Casks/c/clash-verge-rev.rb
+++ b/Casks/c/clash-verge-rev.rb
@@ -1,9 +1,9 @@
 cask "clash-verge-rev" do
   arch arm: "aarch64", intel: "x64"
 
-  version "2.2.1"
-  sha256 arm:   "6bff260c5bb0ecb7398d940e74a93d24aa4b23674f114bfcc99ff040ac9724c5",
-         intel: "73182533c7d477be9913f37a59db68223aea9ab385856a2a0f91edc6ee61b49c"
+  version "2.1.2"
+  sha256 arm:   "9315c7c6fddf1cb2a3f2e1c13915b727578da410df625a8593675cb18e5beb04",
+         intel: "2f08c76c00b3a172967fb69557e9bb5955f755a60ff044114f26e57bb167c33a"
 
   url "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v#{version}/Clash.Verge_#{version}_#{arch}.dmg",
       verified: "github.com/clash-verge-rev/clash-verge-rev/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `clash-verge-rev` cask was updated to 2.2.1 but there is no longer a `v2.2.1` tag or release. Despite this, the [autoupdate information for stable versions](https://github.com/clash-verge-rev/clash-verge-rev/releases/download/updater/update.json) contains links to release assets for the now-removed `v2.2.1` release. 2.2.1 is currently found in a [release using the `alpha` tag](https://github.com/clash-verge-rev/clash-verge-rev/releases/tag/alpha), which is marked as pre-release.

This downgrades the cask to 2.1.2, which is the "latest" release on GitHub and the highest stable release at the moment (contrary to the upstream autoupdate information).