### PR TITLE
insta360-studio 5.5.3,RC_build24

### DIFF
--- a/Casks/i/insta360-studio.rb
+++ b/Casks/i/insta360-studio.rb
@@ -1,8 +1,8 @@
 cask "insta360-studio" do
-  version "5.5.3,7115bd1ce37d273124011a801a75c81a,insta360,RC_build19,_20250313_215505_signed_1741874194174"
-  sha256 "1b2e782cc1e43686ffc48b5246a183f132e92ba768864ba70a71ac612142a57f"
+  version "5.5.3,insta360,RC_build24,_20250320_173718_signed_1742463527994,7ef51b9930c6cfb7a1afffa727045413"
+  sha256 "3ccedbf9b75c53dff31249fcd23a5847de3a4522f4aa344a8596f0e2a0ce848b"
 
-  url "https://file.insta360.com/static/#{version.csv.second}/Insta360Studio_#{version.csv.first}_#{version.csv.third}(#{version.csv.fourth})#{version.csv.fifth}.pkg"
+  url "https://file.insta360.com/static/#{version.csv.fifth}/Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.pkg"
   name "Insta360 Studio"
   desc "Video and photo editor"
   homepage "https://www.insta360.com/"
@@ -36,11 +36,11 @@ cask "insta360-studio" do
       match = channel["download_url"]&.match(regex)
       next if version.blank? || match.blank?
 
-      "#{version},#{match[1]},#{match[2].tr("()", ",")}"
+      "#{version},#{match[2].tr("()", ",")},#{match[1]}"
     end
   end
 
-  pkg "Insta360Studio_#{version.csv.first}_#{version.csv.third}(#{version.csv.fourth})#{version.csv.fifth}.pkg"
+  pkg "Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.pkg"
 
   uninstall quit:    "com.insta360.studio",
             pkgutil: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `version` format for `insta360-studio` causes version comparison issues because the hash part of the path is included as the second part of the version. If the hash is seen as lower than the existing version hash, then the cask version will be seen as newer than upstream even if the upstream version is actually higher.

This updates the cask to the newest version and moves the hash part of the version to the end, so we compare the meaningful parts of the `version` first. The second part can vary but text like `beta2_insta360` is seen as lower than `insta360`, so we can leave that as it is until it causes problems (at which point we will have to move it after the third `RC_build24` part).