### PR TITLE
backblaze: downgrade to 9.1.0.832

### DIFF
--- a/Casks/b/backblaze.rb
+++ b/Casks/b/backblaze.rb
@@ -1,6 +1,6 @@
 cask "backblaze" do
-  version "9.2.0.836"
-  sha256 "9ffc7126d33cdd72936d93fc7b1960f5d8f404090b0d34f5bbeeda7f46efbc82"
+  version "9.1.0.832"
+  sha256 "d23f326b2eccc847e4bfad98a827760419c1a31f78f39aa5b270bcbdcde49981"
 
   url "https://secure.backblaze.com/api/install_backblaze?file=bzinstall-mac-#{version}.dmg"
   name "Backblaze"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream is referencing 9.1.0.832 as the newest `backblaze` version (in the `clientversion.yml` file as well as on the [update page](https://www.backblaze.com/status/update)), so they must have yanked 9.2.0.836. This situation hasn't changed for at least a few days, so this downgrades the cask.