### PR TITLE
k6-studio: remove `binary` link

### DIFF
--- a/Casks/k/k6-studio.rb
+++ b/Casks/k/k6-studio.rb
@@ -1,6 +1,5 @@
 cask "k6-studio" do
   arch arm: "arm64", intel: "x64"
-  folder = on_arch_conditional arm: "arm64", intel: "x86_64"
 
   version "1.0.2"
   sha256  arm:   "bc86a6fff6547aca5c8123eb83e830f15279dd3e0efc33610b9113d9dc4c19fd",
@@ -16,7 +15,6 @@ cask "k6-studio" do
   depends_on macos: ">= :catalina"
 
   app "k6 Studio.app"
-  binary "#{appdir}/k6 Studio.app/Contents/Resources/#{folder}/k6"
 
   zap trash: [
         "~/Library/Application Support/k6 Studio",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Per [upstream](https://github.com/grafana/k6-studio/issues/514#issuecomment-2736742142), the `k6` binary shouldn't be linked as it's supposed to be an internal dependency for `k6-studio`.  Users can bring their own `k6` cli binary.