### PR TITLE
nvidia-geforce-now: don’t rename app

### DIFF
--- a/Casks/n/nvidia-geforce-now.rb
+++ b/Casks/n/nvidia-geforce-now.rb
@@ -16,8 +16,7 @@ cask "nvidia-geforce-now" do
 
   depends_on macos: ">= :el_capitan"
 
-  # Renamed for consistency: app name is different in the Finder and in a shell.
-  app "GeForceNOW.app", target: "NVIDIA GeForce NOW.app"
+  app "GeForceNOW.app"
 
   zap trash: [
     "~/Library/Application Support/NVIDIA/GeForceNOW",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This change is to fix the following problem:

When GeForce NOW is installed via Homebrew, the app displays an error message modal not long after it's opened. It reads 'Problem Detected. GeForce NOW encountered a problem. Relaunching the app, rebooting the system, or reinstalling the app may fix the problem.', together with a 'Quit' button. The modal prevents further use of the app, as it cannot be dismissed without quitting.

The app's display name as set in the app bundle is NVIDIA GeForce Now, but the filename is GeForceNOW.app. Until now, this Cask has renamed GeForceNOW.app to 'NVIDIA GeForce NOW.app' upon installation. This is described in the comment as being for reasons of consistency.

This pull request removes the `target:` key from the `app` stanza, preserving the original filename, which fixes the problem.

I believe this is occurring because NVIDIA has recently introduced a (rather strict) consistency check within the app, presumably to detect tampering with the app. I think this consistency check also takes into account the app's filename, so changing it causes the check to fail. 
