### PR TITLE
Restore 3dconnexion from homebrew-cask-drivers; update to 10.8.7

### DIFF
--- a/Casks/3/3dconnexion.rb
+++ b/Casks/3/3dconnexion.rb
@@ -7,7 +7,6 @@ cask "3dconnexion" do
       skip "Legacy version"
     end
   end
-
   on_catalina :or_newer do
     version "10-8-7,r3836,81855983"
     sha256 "167b6b68adc64b21ae5579bc84b5aa990a6fb61e20857bae323674cbf0e85515"
@@ -30,19 +29,19 @@ cask "3dconnexion" do
 
   pkg "Install 3Dconnexion software.pkg"
 
-  uninstall pkgutil:   "com.3dconnexion.*",
-            launchctl: [
+  uninstall launchctl: [
               "com.3dconnexion.helper",
               "com.3dconnexion.nlserverIPalias",
             ],
             quit:      [
-              "com.3Dconnexion.3DxUpdater",
               "com.3dconnexion.*",
+              "com.3Dconnexion.3DxUpdater",
             ],
             script:    [
               { executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
                 sudo:       true },
             ],
+            pkgutil:   "com.3dconnexion.*",
             delete:    [
               "/Applications/3Dconnexion",
               "/Library/Application Support/3Dconnexion",

--- a/Casks/3/3dconnexion.rb
+++ b/Casks/3/3dconnexion.rb
@@ -1,0 +1,65 @@
+cask "3dconnexion" do
+  on_mojave :or_older do
+    version "10-6-7,r3287,36E24890-6B5F-443a-8A9F-1851F9ADB985"
+    sha256 "4752bd4297733743fb512121116b536ffe260152f97134398d028b9936bc26f9"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+
+  on_catalina :or_newer do
+    version "10-8-0,r3554,84D61C7D-29AE-4BE1-B02E-461ED14BDE2E"
+    sha256 "6edacc2ba5ff3bb095393b97192fe00b9b026f3d38b2f0c5130a481806b869af"
+
+    livecheck do
+      url "https://3dconnexion.com/us/drivers/"
+      regex(%r{href=.*?_([\dA-F]+(?:-[\dA-F]+)*)/3DxWareMac_v(\d+(?:-\d+)*)_(r\d+)\.dmg}i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| "#{match[1]},#{match[2]},#{match[0]}" }
+      end
+    end
+  end
+
+  url "https://download.3dconnexion.com/drivers/mac/#{version.csv.first}_#{version.csv.third}/3DxWareMac_v#{version.csv.first}_#{version.csv.second}.dmg"
+  name "3Dconnexion"
+  desc "3DxWare Driver"
+  homepage "https://3dconnexion.com/"
+
+  depends_on macos: ">= :el_capitan"
+
+  pkg "Install 3Dconnexion software.pkg"
+
+  uninstall pkgutil:   "com.3dconnexion.*",
+            launchctl: [
+              "com.3dconnexion.helper",
+              "com.3dconnexion.nlserverIPalias",
+            ],
+            quit:      [
+              "com.3Dconnexion.3DxUpdater",
+              "com.3dconnexion.*",
+            ],
+            script:    [
+              { executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
+                sudo:       true },
+            ],
+            delete:    [
+              "/Applications/3Dconnexion",
+              "/Library/Application Support/3Dconnexion",
+              "/Library/Extensions/3Dconnexion.kext",
+              "/Library/Frameworks/3DconnexionClient.framework",
+              "/Library/LaunchDaemons/com.3dconnexion.nlserverIPalias.plist",
+              "/Library/PreferencePanes/3Dconnexion.prefPane",
+            ]
+
+  zap trash: [
+    "~/Library/Logs/3Dconnexion",
+    "~/Library/Preferences/3Dconnexion",
+    "~/Library/Preferences/com.3dconnexion.*.plist",
+    "~/Library/Saved Application State/com.3dconnexion.*.savedState",
+  ]
+
+  caveats do
+    reboot
+  end
+end

--- a/Casks/3/3dconnexion.rb
+++ b/Casks/3/3dconnexion.rb
@@ -9,8 +9,8 @@ cask "3dconnexion" do
   end
 
   on_catalina :or_newer do
-    version "10-8-0,r3554,84D61C7D-29AE-4BE1-B02E-461ED14BDE2E"
-    sha256 "6edacc2ba5ff3bb095393b97192fe00b9b026f3d38b2f0c5130a481806b869af"
+    version "10-8-7,r3836,81855983"
+    sha256 "167b6b68adc64b21ae5579bc84b5aa990a6fb61e20857bae323674cbf0e85515"
 
     livecheck do
       url "https://3dconnexion.com/us/drivers/"

--- a/Casks/3/3dconnexion.rb
+++ b/Casks/3/3dconnexion.rb
@@ -38,12 +38,14 @@ cask "3dconnexion" do
               "com.3Dconnexion.3DxUpdater",
             ],
             script:    [
-              { executable: "#{appdir}/3Dconnexion/Uninstall 3Dconnexion Driver.app/Contents/Resources/rm3dcx",
+              { executable: "#{appdir}/3DconnexionUninstaller.app/Contents/Resources/rm3dcx",
                 sudo:       true },
             ],
             pkgutil:   "com.3dconnexion.*",
             delete:    [
               "/Applications/3Dconnexion",
+              "/Applications/3DconnexionHelper.app",
+              "/Applications/3DconnexionUninstaller.app",
               "/Library/Application Support/3Dconnexion",
               "/Library/Extensions/3Dconnexion.kext",
               "/Library/Frameworks/3DconnexionClient.framework",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I'm opening this as a draft for now, because I need a little help: after being installed, this doesn't work out-of-the-box, because it includes a macOS "Driver Extension." I couldn't find anything in the Homebrew docs about this, is there a particular programmatic way to handle this?

At the moment, the workaround is to manually launch the `3DconnexionHelper.app` that's included when this installs, which will then cause the system-prompt to enable the driver extension. After this, it will show up in System Preferences.

The 3Dconnexion applications handle this, for the most part, prompting you to go into system prefs and enable it; but it doesn't _appear_ in system prefs until you've launched the helper-app at least once:

<img width="490" alt="image" src="https://github.com/user-attachments/assets/ca7aedf3-14d4-42f5-8bc4-539c95b564fc" />

Any feedback? Is there a best-practices for driver extensions?