### PR TITLE
canon-eos-utility: Uninstall EOS Network Setting Tool

### DIFF
--- a/Casks/c/canon-eos-utility.rb
+++ b/Casks/c/canon-eos-utility.rb
@@ -35,6 +35,7 @@ cask "canon-eos-utility" do
   uninstall delete: [
               "/Applications/Canon Utilities/CameraSurveyProgram",
               "/Applications/Canon Utilities/EOS Lens Registration Tool",
+              "/Applications/Canon Utilities/EOS Network Setting Tool",
               "/Applications/Canon Utilities/EOS Utility",
               "/Applications/Canon Utilities/EOS Web Service Registration Tool",
               "/Library/Application Support/Canon_Inc_IC/ImageBrowser EX Shared/Camera/{A2E97706-9B71-482d-92F1-70B1D010B943}.plist",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I noticed that `/Applications/Canon Utilities/EOS Network Setting Tool/EOS Network Setting Tool.app` was left behind after uninstall, so add that to the `uninstall` stanza.