### PR TITLE
slidepad 1.5.7 (new cask)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1328,6 +1328,7 @@ slack-cli
 slack@beta
 sleek
 slicer
+slidepad
 slippi-dolphin
 smartgit
 smartsvn

--- a/Casks/s/slidepad.rb
+++ b/Casks/s/slidepad.rb
@@ -1,0 +1,32 @@
+cask "slidepad" do
+  version "1.5.7"
+  sha256 "01c803234d436b87ff64e2234df54d43f7bc191eca111195b11eb97907f134e4"
+
+  url "https://f002.backblazeb2.com/file/Slidepad/Slidepad_#{version.dots_to_underscores}.zip",
+      verified: "f002.backblazeb2.com/file/Slidepad/"
+  name "Slidepad"
+  desc "Slide over browser"
+  homepage "https://slidepad.app/"
+
+  livecheck do
+    url "https://slidepad.app/release/0.0.1.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Slidepad.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.slidepad.slidepad",
+    "~/Library/Application Support/Slidepad",
+    "~/Library/Caches/com.slidepad.slidepad",
+    "~/Library/Caches/com.slidepad.slidepad.ShipIt",
+    "~/Library/HTTPStorages/com.slidepad.slidepad",
+    "~/Library/Preferences/com.slidepad.slidepad.plist",
+    "~/Library/WebKit/com.slidepad.slidepad",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

The original download URL from the official website is https://storage.googleapis.com/slidepad/releases/Slidepad.dmg, however it does not give version info.

During analyzing the update behavior of the app, I found it will send a GET request to  https://slidepad.app/release/1.5.7.json where 1.5.7 is the current version. If there are no updates, it will return 304 Not Modified.
![current version request](https://github.com/user-attachments/assets/53f254a4-0912-4187-8911-6579ae670ac7)
If there is a new update (i.e., pretend the current version is 0.0.1), it will give the latest version and the corresponding download link.
![old version request](https://github.com/user-attachments/assets/9b358a57-9559-4745-af47-ebb3d6397de7)

Thus, my questions are:
1)  for `url`, should we use the one found on the website or the one I get from the API end point?
2) for `livecheck`, is there a better way to check the version? I could not find other end points. (tried `latest.json`, `releases.json` but non of them seem to exist)

Thanks :)