### PR TITLE
osxfuse: deprecate

### DIFF
--- a/Casks/o/osxfuse.rb
+++ b/Casks/o/osxfuse.rb
@@ -8,10 +8,7 @@ cask "osxfuse" do
   desc "File system integration"
   homepage "https://osxfuse.github.io/"
 
-  livecheck do
-    url :url
-    regex(/^osxfuse[._-]v?(\d+(?:\.\d+)+)$/i)
-  end
+  deprecate! date: "2025-03-28", because: :discontinued, replacement: "macfuse"
 
   pkg "Extras/FUSE for macOS #{version}.pkg"
 
@@ -30,12 +27,5 @@ cask "osxfuse" do
 
   caveats do
     reboot
-    <<~EOS
-      `#{token}` has been succeeded by `macfuse` as of version 4.0.0.
-
-      To update to a newer version, do:
-        brew uninstall #{token}
-        brew install macfuse
-    EOS
   end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
