### PR TITLE
azahar 2120.2 (new cask)

### DIFF
--- a/Casks/a/azahar.rb
+++ b/Casks/a/azahar.rb
@@ -1,0 +1,27 @@
+cask "azahar" do
+  version "2120.2"
+  sha256 "74a0cad400ffc9fcb590a82d0660474ac0898e02eac5c3a9b8c08096d3af0b07"
+
+  url "https://github.com/azahar-emu/azahar/releases/download/#{version}/azahar-#{version}-macos-universal.zip",
+      verified: "github.com/azahar-emu/azahar/"
+  name "Azahar"
+  desc "Nintendo 3DS emulator"
+  homepage "https://azahar-emu.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "azahar-#{version}-macos-universal/Azahar.app"
+
+  uninstall delete: "/Applications/Azahar"
+
+  zap trash: [
+    "~/Library/Application Support/Azahar",
+    "~/Library/Preferences/com.azahar-emu.azahar.plist",
+    "~/Library/Saved Application State/com.azahar-emu.azahar.savedState",
+  ]
+end


### PR DESCRIPTION
Adding Azahar, a new stable Nintendo 3DS emulator that replaces Citra which has shut down.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
