### PR TITLE
workflows/triage: add linux cask label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -84,3 +84,7 @@ jobs:
             - label: autobump
               path: \.github/autobump\.txt
               allow_any_match: true
+
+            - label: linux cask
+              path: Casks/.+
+              content: (x86_64|arm64)_linux


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---

Giving this a try... I don't mess with the Actions config much. 🤷 

Adds a Linux Cask label.  We don't currently have CI for Linux in Casks, so these can be missed when the macOS version is autobumped.  This reminds us that we should check the Linux version is updated also.