### PR TITLE
tor-browser: update livecheck

### DIFF
--- a/Casks/t/tor-browser.rb
+++ b/Casks/t/tor-browser.rb
@@ -7,11 +7,13 @@ cask "tor-browser" do
   desc "Web browser focusing on security"
   homepage "https://www.torproject.org/"
 
+  # Upstream may publish a new version for platforms other than macOS. The JSON
+  # download information only provides information for the highest version,
+  # which is a problem if the newest version for macOS is lower. This checks
+  # the download page instead, which links to the newest file for macOS.
   livecheck do
-    url "https://aus1.torproject.org/torbrowser/update_3/release/downloads.json"
-    strategy :json do |json|
-      json["version"]
-    end
+    url "https://www.torproject.org/download/"
+    regex(/href=.*?tor-browser(?:-macos)?[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `tor-browser` checks a JSON file that provides information for the newest version. However, the newest version, 14.0.8, only applies to Windows and the newest version for macOS (and Linux) is 14.0.7. This is predictably causing autobump to error for `tor-browser`, as there isn't a dmg file for 14.0.8.

The JSON also contains file URLs but it only covers platforms and architectures that apply to the newest version. For 14.0.8, the JSON only contains information for `win32` and `win64`, so we can't use this source to reliably identify the newest version for macOS.

This updates the `livecheck` block to check the first-party download page, which links to the newest macOS dmg file.