### PR TITLE
bluesense: deprecate

### DIFF
--- a/Casks/b/bluesense.rb
+++ b/Casks/b/bluesense.rb
@@ -7,10 +7,7 @@ cask "bluesense" do
   desc "Detect the presence of your Bluetooth device"
   homepage "https://apps.inspira.io/bluesense/"
 
-  livecheck do
-    url "https://apps.inspira.io/updates/bluesense-appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-03-30", because: :unmaintained
 
   app "BlueSense.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app has not been updated since 2018.
