### PR TITLE
chatmate-for-whatsapp: deprecate

### DIFF
--- a/Casks/c/chatmate-for-whatsapp.rb
+++ b/Casks/c/chatmate-for-whatsapp.rb
@@ -8,16 +8,7 @@ cask "chatmate-for-whatsapp" do
   desc "Extension app WhatsApp"
   homepage "https://chatmate.io/"
 
-  livecheck do
-    url "https://updates.devmate.com/net.coldx.mac.WhatsApp.xml"
-    regex(%r{/(\d+)/ChatMateforWhatsApp\d*?[_-]v?(\d+(?:\.\d+)*)\.(?:dmg|zip)}i)
-    strategy :sparkle do |item, regex|
-      match = item.url.match(regex)
-      next if match.blank?
-
-      "#{item.short_version},#{match[2]},#{match[1]}"
-    end
-  end
+  deprecate! date: "2025-03-30", because: :unmaintained
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app has not been updated since 2018.
