### PR TITLE
notion-mail 0.0.32 (new cask)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1009,6 +1009,7 @@ notebooks
 notesnook
 notion
 notion-calendar
+notion-mail
 nova
 novabench
 nozbe

--- a/Casks/n/notion-mail.rb
+++ b/Casks/n/notion-mail.rb
@@ -1,0 +1,32 @@
+cask "notion-mail" do
+  arch arm: "arm64", intel: "universal"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "latest"
+
+  version "0.0.32"
+  sha256 arm:   "26ba79fe30964c7627e347da0281b855b7fa38f77a12e68c148ae7a24b16e839",
+         intel: "038f144d3c087563c7b92e3feae602ddc75297b0026dfc9048ceb615239f8f34"
+
+  url "https://s3.us-west-2.amazonaws.com/mail-desktop-release.notion-static.com/Notion%20Mail-#{version}-#{arch}.zip",
+      verified: "s3.us-west-2.amazonaws.com/mail-desktop-release.notion-static.com/"
+  name "Notion Mail"
+  desc "Email client integrated with Notion workspace"
+  homepage "https://www.notion.com/product/mail"
+
+  livecheck do
+    url "https://s3-us-west-2.amazonaws.com/mail-desktop-release.notion-static.com/notion-mail-#{livecheck_arch}-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "Notion Mail.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/notion.mail.id.sfl*",
+    "~/Library/Application Support/Notion Mail",
+    "~/Library/Logs/Notion Mail",
+    "~/Library/Preferences/notion.mail.id.*",
+    "~/Library/Saved Application State/notion.mail.id.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
Got this S3 url from the `get info` on the dmg download. This download was is only viewable after one gets an invite from Notion for their mail closed invite application. I will include pictures below for how I got the file and the corresponding `get info` url info, so this is less sketchy-esk.

| Web app | Get info from download |
|--------|--------|
| ![Screenshot 2025-03-31 at 12 18 58 PM](https://github.com/user-attachments/assets/0461eaa3-291b-47c1-8b77-0a783b57cd94)| ![Screenshot 2025-03-31 at 12 20 07 PM](https://github.com/user-attachments/assets/3de942ce-48e2-4d90-a744-02a5a3f8d963) | 


  

