### PR TITLE
Add bergen 0.1.17

### DIFF
--- a/Casks/b/bergen.rb
+++ b/Casks/b/bergen.rb
@@ -1,0 +1,20 @@
+cask "bergen" do
+  version "0.1.17"
+  sha256 "13647bc16971ce8decc9181b5d05e97660ef9f9f43bff7688202aa701b93ef97"
+
+  url "https://github.com/kkarimi/bergen/releases/download/v#{version}/bergen-macos-v0.1.17.zip"
+  name "Bergen"
+  desc "Lightweight markdown reader"
+  homepage "https://github.com/kkarimi/bergen"
+  
+  depends_on macos: ">= :big_sur"
+  
+  app "bergen.app"
+
+  zap trash: [
+    "~/Library/Application Support/bergen",
+    "~/Library/Caches/bergen",
+    "~/Library/Preferences/com.zendo.bergen.plist",
+    "~/Library/Saved Application State/com.zendo.bergen.savedState",
+  ]
+end


### PR DESCRIPTION
This PR adds a cask for bergen version 0.1.17. 
    
bergen is a lightweight markdown reader.

**App homepage:** https://github.com/kkarimi/bergen