### PR TITLE
vesktop 1.5.5 (new cask)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1555,6 +1555,7 @@ vbrokers
 vcam
 vcv-rack
 vellum
+vesktop
 vial
 videofusion
 vienna

--- a/Casks/v/vesktop.rb
+++ b/Casks/v/vesktop.rb
@@ -4,7 +4,7 @@ cask "vesktop" do
 
   url "https://github.com/Vencord/Vesktop/releases/download/v#{version}/Vesktop-#{version}-universal.dmg"
   name "Vesktop"
-  desc "Custom Discord App aiming to give better performance and improve linux support"
+  desc "Custom Discord App aiming to give better performance"
   homepage "https://github.com/Vencord/Vesktop"
 
   livecheck do

--- a/Casks/v/vesktop.rb
+++ b/Casks/v/vesktop.rb
@@ -4,7 +4,7 @@ cask "vesktop" do
 
   url "https://github.com/Vencord/Vesktop/releases/download/v#{version}/Vesktop-#{version}-universal.dmg"
   name "Vesktop"
-  desc "Custom Discord App aiming to give better performance"
+  desc "Custom Discord App"
   homepage "https://github.com/Vencord/Vesktop"
 
   livecheck do
@@ -12,6 +12,7 @@ cask "vesktop" do
     strategy :electron_builder
   end
 
+  auto_updates true
   depends_on macos: ">= :big_sur"
 
   app "Vesktop.app"

--- a/Casks/v/vesktop.rb
+++ b/Casks/v/vesktop.rb
@@ -1,0 +1,27 @@
+cask "vesktop" do
+  version "1.5.5"
+  sha256 "9644e6e5d59b28ff34c3a25b9c5c24d3510cdf0de0bbe1ef2c0bff0e07ca64d2"
+
+  url "https://github.com/Vencord/Vesktop/releases/download/v#{version}/Vesktop-#{version}-universal.dmg"
+  name "Vesktop"
+  desc "Custom Discord App aiming to give better performance and improve linux support"
+  homepage "https://github.com/Vencord/Vesktop"
+
+  livecheck do
+    url "https://github.com/Vencord/Vesktop/releases/latest/download/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Vesktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/vesktop",
+    "~/Library/Caches/dev.vencord.vesktop",
+    "~/Library/Caches/dev.vencord.vesktop.Shipit",
+    "~/Library/HTTPStorages/dev.vencord.vesktop",
+    "~/Library/Preferences/dev.vencord.vesktop.plist",
+    "~/Library/Saved Application State/dev.vencord.vesktop.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

The cask was rejected before because of [not having a signature](https://github.com/Homebrew/homebrew-cask/pull/173504), this is especially problematic for arm64 Macs. However its been recently updated to be signed and notorized, which should now meet the criteria for being on brew casks.

Link: https://github.com/Vencord/Vesktop
