### PR TITLE
espanso: update livecheck

### DIFF
--- a/Casks/e/espanso.rb
+++ b/Casks/e/espanso.rb
@@ -11,9 +11,15 @@ cask "espanso" do
   desc "Cross-platform Text Expander written in Rust"
   homepage "https://espanso.org/"
 
+  # Upstream may not mark unstable releases like `1.2.3-beta` as pre-release
+  # on GitHub, so they can end up as the "latest" release. They also tag
+  # versions that may not end up with a release and some releases use a stable
+  # version format but are marked as pre-release, so we can't rely on Git tags.
+  # This checks the first-party website's Installation page, which links to
+  # release files on GitHub.
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://espanso.org/install/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/Espanso-Mac-#{arch}\.zip}i)
   end
 
   app "Espanso.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `espanso` uses the `GithubLatest` strategy but this is currently returning 2.2.3 as the newest version from the `2.2.3-beta` release. This version isn't marked as pre-release on GitHub, so it's currently the "latest" release.

This updates the `livecheck` block to check the first-party Installation page, which links to release files on GitHub. This correctly returns 2.2.1 as the newest version for now and hopefully we won't run into similar problems with this approach.

For context, we can't check Git tags because upstream sometimes tags a version but doesn't create a release. They have also created releases with a stable version format that are marked as pre-release on GitHub.