### PR TITLE
sipgate 2.8.4

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1321,7 +1321,7 @@ simplex
 singlebox
 singlecrystal
 sip
-sipgate-clinq
+sipgate
 sitesucker-pro
 siyuan
 sketch

--- a/Casks/s/sipgate.rb
+++ b/Casks/s/sipgate.rb
@@ -1,10 +1,10 @@
-cask "sipgate-clinq" do
-  version "2.7.1"
-  sha256 "3ee129ad11dc84548931d2b6c5d862daad3898400a6474de60e5438db8effd10"
+cask "sipgate" do
+  version "2.8.4"
+  sha256 "e17bdf2270b36b3a9bad19bf0404a69f57fa79c7e96d7f04303d0de3bb70dd5d"
 
-  url "https://s3-eu-central-1.amazonaws.com/desktop.download.sipgate.com/sipgate%20CLINQ-#{version}.zip",
+  url "https://s3-eu-central-1.amazonaws.com/desktop.download.sipgate.com/sipgate-#{version}.zip",
       verified: "s3-eu-central-1.amazonaws.com/desktop.download.sipgate.com/"
-  name "Sipgate CLINQ"
+  name "sipgate"
   desc "Softphone for making telephone calls over the internet"
   homepage "https://www.sipgate.de/app"
 
@@ -16,10 +16,14 @@ cask "sipgate-clinq" do
   auto_updates true
   depends_on macos: ">= :catalina"
 
-  app "sipgate CLINQ.app"
+  app "sipgate.app"
 
   zap trash: [
     "~/Library/Application Support/sipgate-desktop",
+    "~/Library/Caches/com.sipgate.desktop",
+    "~/Library/Caches/com.sipgate.desktop.ShipIt",
+    "~/Library/Caches/sipgate-desktop-updater",
+    "~/Library/HTTPStorages/com.sipgate.desktop",
     "~/Library/Logs/sipgate-desktop",
     "~/Library/Preferences/com.sipgate.desktop.plist",
     "~/Library/Saved Application State/com.sipgate.desktop.savedState",

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -58,6 +58,7 @@
   "score": "ossia-score",
   "senabluetoothdevicemanager": "senadevicemanager",
   "simplistic": "jlutil",
+  "sipgate-clinq": "sipgate",
   "starnet-plus-plus": "starnet++",
   "streamlabs-obs": "streamlabs",
   "suitcase-fusion": "connect-fonts",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`sipgate-clinq` is in the autobump list but the update for 2.8.4 is failing because sipgate CLINQ is now simply named "sipgate". This updates the cask to the latest version and renames it to `sipgate`.