### PR TITLE
reminders-menubar 1.24.1

### DIFF
--- a/Casks/r/reminders-menubar.rb
+++ b/Casks/r/reminders-menubar.rb
@@ -1,6 +1,6 @@
 cask "reminders-menubar" do
-  version "1.24.0"
-  sha256 "79fc0099410414fec3c07818f9631b6c1f8651c74b6c42cb2c4393972608a5ce"
+  version "1.24.1"
+  sha256 "ee2319d036fa1ebf0d904c9ffac3567a757f20f57d1ee4b156a196cc94aa1f63"
 
   url "https://github.com/DamascenoRafael/reminders-menubar/releases/download/v#{version}/reminders-menubar.zip"
   name "Reminders MenuBar"
@@ -15,8 +15,10 @@ cask "reminders-menubar" do
 
   zap trash: [
     "~/Library/Application Scripts/br.com.damascenorafael.reminders-menubar",
+    "~/Library/Application Scripts/br.com.damascenorafael.reminders-menubar-launcher",
     "~/Library/Application Scripts/br.com.damascenorafael.RemindersLauncher",
     "~/Library/Containers/br.com.damascenorafael.reminders-menubar",
+    "~/Library/Containers/br.com.damascenorafael.reminders-menubar-launcher",
     "~/Library/Containers/br.com.damascenorafael.RemindersLauncher",
   ]
 end


### PR DESCRIPTION
This is a simple version bump from 1.24.0 to 1.24.1. Additionally, I'm adding to `zap trash` paths corresponding to the new bundleId related to the launcher target (used only for the launch at login option) which has been renamed.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
