### PR TITLE
lunasea: deprecate

### DIFF
--- a/Casks/l/lunasea.rb
+++ b/Casks/l/lunasea.rb
@@ -2,14 +2,10 @@ cask "lunasea" do
   on_mojave :or_older do
     version "10.2.2"
     sha256 "61ef622b70c31550ec6f700eba1e938c23fb97717344e8876d56e2d856a51be4"
-
-    livecheck do
-      skip "Legacy version"
-    end
   end
   on_catalina :or_newer do
-    version "10.2.6"
-    sha256 "6debb79ca5657161c63b93266455e5b4a48c97856dd65e93517231dd839cf079"
+    version "11.0.0"
+    sha256 "fa4ecb5bdf57d6f1326e356e248232040f1b2d0d409ea93ac96dc560eded980c"
   end
 
   url "https://github.com/JagandeepBrar/LunaSea/releases/download/v#{version}/lunasea-macos-amd64.zip",
@@ -17,6 +13,8 @@ cask "lunasea" do
   name "LunaSea"
   desc "Self-hosted controller built using the Flutter framework"
   homepage "https://www.lunasea.app/"
+
+  deprecate! date: "2025-04-02", because: :discontinued
 
   app "LunaSea.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> This is the final release of LunaSea.
> This release's intention is for a final clean-up before archival and does not add any new functionality.
