### PR TITLE
btp: add support for linux

### DIFF
--- a/Casks/b/btp.rb
+++ b/Casks/b/btp.rb
@@ -1,11 +1,14 @@
 cask "btp" do
   arch arm: "arm64", intel: "amd64"
+  os macos: "darwin", linux: "linux"
 
   version "2.83.0"
-  sha256 arm:   "4bdd685a85b0aad8d52f7e9f9a6685dea688730b2b8ac0b546cc0434513ad37f",
-         intel: "2277b0d9753faf35e6c4911dc53cd4eb225fdf16d7edff0a51a3c0740afa0468"
+  sha256 arm:          "4bdd685a85b0aad8d52f7e9f9a6685dea688730b2b8ac0b546cc0434513ad37f",
+         intel:        "2277b0d9753faf35e6c4911dc53cd4eb225fdf16d7edff0a51a3c0740afa0468",
+         arm64_linux:  "2c8431a6432082e1f46b11ce1b317c5ee09382bab3f1e970debcf58ab1f62faf",
+         x86_64_linux: "bdf3d3256061c0230cd60e6c0d62d7020b9d503090cc19d2007fadb1cb4ee45f"
 
-  url "https://tools.hana.ondemand.com/additional/btp-cli-darwin-#{arch}-#{version}.tar.gz",
+  url "https://tools.hana.ondemand.com/additional/btp-cli-#{os}-#{arch}-#{version}.tar.gz",
       cookies: {
         "eula_3_2_agreed" => "tools.hana.ondemand.com/developer-license-3_2.txt",
       }
@@ -18,7 +21,7 @@ cask "btp" do
     regex(/btp[._-]cli[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  binary "darwin-#{arch}/btp", target: "btp"
+  binary "#{os}-#{arch}/btp", target: "btp"
 
   # No zap stanza required
 

--- a/Casks/b/btp.rb
+++ b/Casks/b/btp.rb
@@ -18,7 +18,7 @@ cask "btp" do
 
   livecheck do
     url :homepage
-    regex(/btp[._-]cli[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/btp[._-]cli[._-]#{os}[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   binary "#{os}-#{arch}/btp", target: "btp"


### PR DESCRIPTION
Adds Linux support for the `btp` cask. 

The livecheck is left unchanged as referencing the `os` stanza within the `livecheck` stanza seems to be unsupported. That is, if I rewrite the livecheck as follows...

```rb
livecheck do
  url :homepage
  regex(/btp[._-]cli[._-]#{os}[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.t/i)
end
```

... I get the following error message:

```
Error: Cask 'btp' is unreadable: undefined local variable or method `os' for an instance of Livecheck
```

Any guidance as to how to address this issue is appreciated. Generally, new versions of the SAP BTP CLI seem to be simultaneously released on all platforms.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
