### PR TITLE
marvin: update checksums

### DIFF
--- a/Casks/m/marvin.rb
+++ b/Casks/m/marvin.rb
@@ -3,8 +3,8 @@ cask "marvin" do
   hostname_arch = on_arch_conditional arm: "amarm", intel: "amazingmarvin"
 
   version "1.66.2"
-  sha256 arm:   "745c93689aaea6e49a0572d222c475abb3bb0cf55bb0360fc298bac343a5c54f",
-         intel: "11697f25d2dfb8c5b039b563bde33cc1b518b05332dd8288d506685b17a0a55d"
+  sha256 arm:   "f0bdf3eb1c7741cbdae40a096c131fe0739c9273696dc915ed87c8169d9d15b6",
+         intel: "2b0f33b383a111fe1c4ef1e761cda0f78ca65d964fbfdc49793c2032f829db0e"
 
   url "https://#{hostname_arch}.s3.amazonaws.com/Marvin-#{version}#{arch}-mac.zip",
       verified: "#{hostname_arch}.s3.amazonaws.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The install of marvin fails
![CleanShot 2025-04-03 at 8  25 38@2x](https://github.com/user-attachments/assets/49da9152-901f-40d9-a938-b3d90587cff8)


The checksums are not correct and I cannot even install the cask locally so I cannot perform audit using `brew audit --cask --online marvin`.

I've downloaded both versions (arm64 and intel) and calculated checksums using `sha256sum`

Downloading packages
- `curl -o Marvin-1.66.2-arm64-mac.zip https://amarm.s3.amazonaws.com/Marvin-1.66.2-arm64-mac.zip`
- `curl -o Marvin-1.66.2-mac.zip https://amazingmarvin.s3.amazonaws.com/Marvin-1.66.2-mac.zip`