### PR TITLE
Revert "divvy: deprecate"

### DIFF
--- a/Casks/d/divvy.rb
+++ b/Casks/d/divvy.rb
@@ -7,7 +7,10 @@ cask "divvy" do
   desc "Application window manager focusing on simplicity"
   homepage "https://mizage.com/divvy/"
 
-  deprecate! date: "2025-03-30", because: :unmaintained
+  livecheck do
+    url "https://mizage.com/updates/profiles/divvy.php"
+    strategy :sparkle, &:short_version
+  end
 
   app "Divvy.app"
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#206974

---

The application may not have been updated for some time, but it is reported to still be fully functional and vaailable for sale by the vendor.
https://github.com/Homebrew/homebrew-cask/pull/206974#issuecomment-2777213916

---

@paulanunda Before we merge this, can you please confirm the application works as expected on the latest version of MacOS?