### PR TITLE
add lix cask

### DIFF
--- a/Casks/l/lix.rb
+++ b/Casks/l/lix.rb
@@ -1,0 +1,34 @@
+cask "lix" do
+  version :latest
+  sha256 :no_check
+
+  url "https://install.lix.systems/lix"
+  name "lix"
+  desc "Is an implementation of the Nix functional package management language"
+  homepage "https://lix.systems/"
+
+  depends_on macos: ">= :sequoia"
+
+  installer script: {
+    executable: "lix",
+    args:       ["install", "--no-confirm"],
+    sudo:       true,
+  }
+
+  uninstall launchctl: "org.nixos.nix-daemon",
+            script:    {
+              executable: "/nix/nix-installer",
+              args:       ["uninstall", "--no-confirm"],
+              sudo:       true,
+            }
+
+  zap trash: [
+    "~/.cache/nix",
+    "~/.local/state/nix",
+    "~/.nix-channels",
+    "~/.nix-defexpr",
+    "~/.nix-profile",
+  ]
+
+  caveats "See https://lix.systems/install/ for update instructions"
+end


### PR DESCRIPTION
I have added a new cask for https://lix.systems/ - this is an implementation of the [nix language](https://nix.dev/manual/nix/2.24/language/index.html) which powers the [nix package manager](https://search.nixos.org/packages) and the declarative [NixOS](https://nixos.org) and [nix-darwin](https://github.com/nix-darwin/nix-darwin) system description frameworks.

I have communication with the upstream team about the package via matrix, [and have tried to document the outcomes here](https://git.lix.systems/lix-project/lix-installer/issues/43).

Currently the cask points to their initial upgrade script that can install lix for `{x86_64,aarch64}(linux,darwin}` - though I have not found yet how to add this metadata to the cask. Guidance very much appreciated.

Upstream does not have versioned download urls for the different platforms, which is why I have linked to the entry point script that auto chooses the right binary for now.

That script could be pinned with a sha265, as it shouldn't change often, i.e. far less often than new versions are released. However the brew style checker advised me to remove that check. So here I would also appreciate some guidance.

As soon as upstream provides versioned urls of the package, I would be happy to upgrade the package description to point to them, if that is something you desire.

Is there anything else I can provide to make this as smooth a merge as possible for you?

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
