### PR TITLE
prezi-classic: disable

### DIFF
--- a/Casks/p/prezi-classic.rb
+++ b/Casks/p/prezi-classic.rb
@@ -7,12 +7,7 @@ cask "prezi-classic" do
   desc "Desktop client for the Prezi presentation SaaS"
   homepage "https://prezi.com/desktop"
 
-  livecheck do
-    url "https://prezidesktop.s3.amazonaws.com/assets/mac/pd6/updates/prezi-classic.xml"
-    strategy :sparkle do |items|
-      items.map(&:nice_version)
-    end
-  end
+  disable! date: "2025-04-05", because: :discontinued
 
   app "Prezi Classic.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Normally would deprecate, but this software appears to be non-functional for a while now so seems fine to disable straight away.

Per [upstream](https://support.prezi.com/hc/en-us/articles/6190328412695-Discontinuing-the-Prezi-Classic-desktop-application)
```
As of June 30 2022, we decided to discontinue the Prezi Classic desktop application as well. 

After this date, you won't be able to view and edit presentations in the Classic desktop app as access to it will be blocked completely, which also means that you won't be able to open local presentations and PEZ files. 
```