### PR TITLE
prezi-next: deprecate

### DIFF
--- a/Casks/p/prezi-next.rb
+++ b/Casks/p/prezi-next.rb
@@ -7,10 +7,7 @@ cask "prezi-next" do
   desc "Presentation software"
   homepage "https://prezi.com/"
 
-  livecheck do
-    url "https://prezidesktop.s3.amazonaws.com/assets/mac/pitch/updates/prezi-business.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-04-05", because: :discontinued
 
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Prezi Next has been discontinued and effectively now rolls into Prezi Present (or just "Prezi").

I have the download links for Prezi because Prezi Next automatically downloads the latest version and was able to grab them using Proxyman.  It rebrands itself to Prezi, but unfortuantely the desktop app links appear to be walled behind a sign-in requirement.  

Per our usual guidelines I am deprecating due to the sign-in wall, but open to reworking it to support the latest Prezi release if there's a desire.  This doesn't have a high download count per analytics.