### PR TITLE
repo-prompt 1.0.27 (new cask)

### DIFF
--- a/Casks/r/repo-prompt.rb
+++ b/Casks/r/repo-prompt.rb
@@ -1,0 +1,29 @@
+cask "repo-prompt" do
+  version "1.0.27"
+  sha256 "0bd5d03c88cbfa09e567fb68fa6832b31453242c485cea1b8f886ea5a6c79467"
+
+  url "https://repoprompt.s3.us-east-2.amazonaws.com/RepoPrompt-#{version}.dmg",
+      verified: "repoprompt.s3.us-east-2.amazonaws.com/"
+  name "Repo Prompt"
+  desc "Prompt generation tool"
+  homepage "https://repoprompt.com/"
+
+  livecheck do
+    url "https://repoprompt.s3.us-east-2.amazonaws.com/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Repo Prompt.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.pvncher.repoprompt",
+    "~/Library/Application Support/RepoPrompt",
+    "~/Library/Caches/com.pvncher.repoprompt",
+    "~/Library/HTTPStorages/com.pvncher.repoprompt",
+    "~/Library/HTTPStorages/com.pvncher.repoprompt.binarycookies",
+    "~/Library/Preferences/com.pvncher.repoprompt.plist",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for a stable version.
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.