### PR TITLE
duplicate-file-finder: updates

### DIFF
--- a/Casks/d/duplicate-file-finder.rb
+++ b/Casks/d/duplicate-file-finder.rb
@@ -1,26 +1,29 @@
 cask "duplicate-file-finder" do
-  version "6.17.3,588"
-  sha256 "27a1aa5c6d4ebe8ef54b8baabb79041550ad460a366f89282f68bf5c3001d9a8"
+  version "8.4.1,918"
+  sha256 "da5b1168e279ee28d768756e5702eb77082b2791f5da736bb0ff57484a203926"
 
-  url "https://download.nektony.com/pro-support/duplicates-finder-site/update/dffs_v#{version.csv.first}b#{version.csv.second}.zip"
+  url "https://download.nektony.com/download/duplicate-file-finder/duplicate-file-finder.dmg?build=#{version.csv.second}"
   name "Duplicate File Finder"
   desc "Find and remove unwanted duplicate files and folders"
   homepage "https://nektony.com/duplicate-finder-free"
 
   livecheck do
-    url "https://download.nektony.com/pro-support/duplicates-finder-site/update/update.xml"
+    url "https://download.nektony.com/pro-support/v3/duplicates-finder-site/update/update.xml"
     strategy :sparkle
   end
 
-  depends_on macos: ">= :sierra"
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Duplicate File Finder #{version.major}.app"
 
   zap trash: [
-    "~/Library/Application Scripts/com.nektony.Duplicate-File-Finder-SII",
-    "~/Library/Application Support/com.nektony.Duplicate-File-Finder-SII",
-    "~/Library/Caches/com.nektony.Duplicate-File-Finder-SII",
+    "~/Library/Application Scripts/com.nektony.Duplicate-File-Finder-SII*",
+    "~/Library/Application Support/com.nektony.Duplicate-File-Finder-SII*",
+    "~/Library/Caches/com.nektony.Duplicate-File-Finder-SII*",
     "~/Library/Cookies/com.nektony.Duplicate-File-Finder-SII.binarycookies",
-    "~/Library/Preferences/com.nektony.Duplicate-File-Finder-SII.plist",
+    "~/Library/HTTPStorages/com.nektony.Duplicate-File-Finder-SII*",
+    "~/Library/Preferences/com.nektony.Duplicate-File-Finder-SII*.plist",
+    "~/Library/Saved Application State/com.nektony.Duplicate-File-Finder-SII*.savedState",
   ]
 end


### PR DESCRIPTION
* Bump to version 8.4.1

* Update livecheck and url for latest version

* Adds `auto_updates true`

* Update minimum macOS requirement

* Update zap stanza

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This cask has unfortunately gotten a bit out of date, so this brings it up to the latest release.  The `livecheck` url for the newer releases changed, but the legacy link still worked so we weren't able to pick up on the updates.

This introduces a rework to the cask to bring it up to date.

Zap stanzas are wildcarded because the latest update slightly changes the files, and we want to capture them - see below for an example file.

```
(v6) => ~/Library/Preferences/com.nektony.Duplicate-File-Finder-SII.plist
(v8) => ~/Library/Preferences/com.nektony.Duplicate-File-Finder-SIII.plist
```