### PR TITLE
xiami: disable

### DIFF
--- a/Casks/x/xiami.rb
+++ b/Casks/x/xiami.rb
@@ -8,15 +8,7 @@ cask "xiami" do
   desc "Music content management and distribution"
   homepage "https://www.xiami.com/"
 
-  livecheck do
-    url "https://g.alicdn.com/music/desktop-app/XiamiMac.xml"
-    regex(%r{/([^/]+)/([^/]+)\.zip}i)
-    strategy :sparkle do |item, regex|
-      item.url.scan(regex).map do |match|
-        "#{item.short_version},#{item.version},#{match[0]},#{match[1]}"
-      end
-    end
-  end
+  disable! date: "2025-04-05", because: :discontinued
 
   app "虾米音乐.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The Xiami Music app was discontinued in February 2021.
