### PR TITLE
repo-prompt 1.1.0

### DIFF
--- a/Casks/r/repo-prompt.rb
+++ b/Casks/r/repo-prompt.rb
@@ -1,6 +1,6 @@
 cask "repo-prompt" do
-  version "1.0.27"
-  sha256 "0bd5d03c88cbfa09e567fb68fa6832b31453242c485cea1b8f886ea5a6c79467"
+  version "1.1.0"
+  sha256 "d57f98c2f3650edd9c8f5eb4aaf0413cd1fb4d63f8dc28917842d5357049a34b"
 
   url "https://repoprompt.s3.us-east-2.amazonaws.com/RepoPrompt-#{version}.dmg",
       verified: "repoprompt.s3.us-east-2.amazonaws.com/"


### PR DESCRIPTION
- [x] The submission is for a stable version.
- [x] `brew audit --cask --online repo-prompt` is error-free.
- [x] `brew style --fix repo-prompt` reports no offenses.