### PR TITLE
whatsapp: change minimum macos version from "big_sur" to "monterey"

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -20,7 +20,7 @@ cask "whatsapp" do
     "whatsapp@beta",
     "whatsapp@legacy",
   ]
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "WhatsApp.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

----

#### Additional Information:

Meta recently changed the minimum required macOS version for WhatsApp Desktop from 11 (Big Sur) to 12.1 (Monterey):

> Requires macOS 12.1 or newer.
https://www.whatsapp.com/download 

Thus, installing the most recent version of WhatsApp Desktop (2.25.8.76) on a Big Sur system will yield in a non-functional application being deployed, an issue which this fix addresses.