### PR TITLE
whatsapp@beta: change minimum macos version from "big_sur" to "monterey"

### DIFF
--- a/Casks/w/whatsapp@beta.rb
+++ b/Casks/w/whatsapp@beta.rb
@@ -20,7 +20,7 @@ cask "whatsapp@beta" do
     "whatsapp",
     "whatsapp@legacy",
   ]
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "WhatsApp.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

----

#### Additional Information:

Adhering to changed macOS system requirements for WhatsApp Desktop.

Addressed in WhatApp Desktop stable at: https://github.com/Homebrew/homebrew-cask/pull/207854