### PR TITLE
Fix 1Password CLI beta version

### DIFF
--- a/Casks/1/1password-cli@beta.rb
+++ b/Casks/1/1password-cli@beta.rb
@@ -1,6 +1,6 @@
 cask "1password-cli@beta" do
-  version "2.30.3"
-  sha256 "4559e0ee1b997d1451f7d4cb2b09a6ba7eb0a1288884ce589da11f5a074f26be"
+  version "2.30.0-beta.03"
+  sha256 "d0eca14110185dab4e43674d60a20f530fd43b640d9fe18520b69b5e7b058010"
 
   url "https://cache.agilebits.com/dist/1P/op2/pkg/v#{version}/op_apple_universal_v#{version}.pkg",
       verified: "cache.agilebits.com/dist/1P/op2/pkg/"
@@ -9,10 +9,8 @@ cask "1password-cli@beta" do
   homepage "https://developer.1password.com/docs/cli"
 
   livecheck do
-    url "https://app-updates.agilebits.com/check/1/0/CLI2/en/0/Y"
-    strategy :json do |json|
-      json["version"]
-    end
+    url "https://app-updates.agilebits.com/product_history/CLI2"
+    regex(%r{href=.*?/op_apple_universal[._-]v?(\d+(?:\.\d+)+-beta\.\d+)\.pkg}i)
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
The updated livecheck doesn't properly get the latest beta version of the 1Password CLI. Therefore, it's reverted to how it used to be done.

This is done to fix the changes brought to the 1Password CLI @beta as part of https://github.com/Homebrew/homebrew-cask/pull/206871.

Specifically, the URL `https://app-updates.agilebits.com/check/1/0/CLI2/en/0/Y` returns the latest release of the CLI. If it is a beta, then get that one. If it is a stable one, then get that one.
This URL `https://app-updates.agilebits.com/check/1/0/CLI2/en/0/N` return the latest **stable** release of the CLI, even when the latest release done is a beta version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
