### PR TITLE
microsoft-edge: switch to dmg

### DIFF
--- a/Casks/m/microsoft-edge.rb
+++ b/Casks/m/microsoft-edge.rb
@@ -1,23 +1,15 @@
 cask "microsoft-edge" do
-  linkid = on_arch_conditional arm: "2093504", intel: "2069148"
+  version "135.0.3179.54,07494f63-fb3c-45d8-9302-bedbe6515189"
+  sha256 "08605055b97df5ed14de25494e99c4223eb7eb57d1dbe58d49138aa1230adb79"
 
-  on_arm do
-    version "135.0.3179.54,d3d754a3-4afc-4dc2-b1b9-5226894fdf12"
-    sha256 "7bb07e3722866a4b5e44f0efe42c204a72105cbcfd3abe96811d6f00d08e8a61"
-  end
-  on_intel do
-    version "135.0.3179.54,49dee093-4997-47ab-b57f-0e7858fbe7ae"
-    sha256 "0d5997c8a5d0121e40f98bcb45a97192fb636f5ee2b633857441c5c830030857"
-  end
-
-  url "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/#{version.csv.second}/MicrosoftEdge-#{version.csv.first}.pkg"
+  url "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/#{version.csv.second}/MicrosoftEdge-#{version.csv.first}.dmg"
   name "Microsoft Edge"
   desc "Multi-platform web browser"
   homepage "https://www.microsoft.com/en-us/edge?form="
 
   livecheck do
-    url "https://go.microsoft.com/fwlink/?linkid=#{linkid}"
-    regex(%r{/([^/]+)/MicrosoftEdge[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+    url "https://go.microsoft.com/fwlink/?linkid=2192091"
+    regex(%r{/([^/]+)/MicrosoftEdge[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)
       next if match.blank?
@@ -29,37 +21,26 @@ cask "microsoft-edge" do
   auto_updates true
   depends_on macos: ">= :big_sur"
 
-  pkg "MicrosoftEdge-#{version.csv.first}.pkg",
-      choices: [
-        {
-          "choiceIdentifier" => "com.microsoft.package.Microsoft_AutoUpdate.app", # Office16_all_autoupdate.pkg
-          "choiceAttribute"  => "selected",
-          "attributeSetting" => 0,
-        },
-      ]
+  app "Microsoft Edge.app"
 
-  uninstall launchctl: [
-              "com.microsoft.EdgeUpdater.update-internal.109.0.1518.89.system",
-              "com.microsoft.EdgeUpdater.update.system",
-              "com.microsoft.EdgeUpdater.wake.system",
-            ],
-            pkgutil:   "com.microsoft.edgemac"
+  uninstall launchctl: "com.microsoft.EdgeUpdater.wake"
 
-  zap delete: "/Library/Application Support/Microsoft/EdgeUpdater",
-      trash:  [
+  zap trash: [
         "~/Library/Application Scripts/com.microsoft.edgemac.wdgExtension",
         "~/Library/Application Support/Microsoft Edge",
         "~/Library/Caches/com.microsoft.edgemac",
+        "~/Library/Caches/com.microsoft.EdgeUpdater",
         "~/Library/Caches/Microsoft Edge",
         "~/Library/Containers/com.microsoft.edgemac.wdgExtension",
         "~/Library/HTTPStorages/com.microsoft.edgemac",
+        "~/Library/HTTPStorages/com.microsoft.EdgeUpdater",
         "~/Library/LaunchAgents/com.microsoft.EdgeUpdater.*.plist",
         "~/Library/Microsoft/MicrosoftSoftwareUpdate/Actives/com.microsoft.edgemac",
         "~/Library/Preferences/com.microsoft.edgemac.plist",
         "~/Library/Saved Application State/com.microsoft.edgemac.savedState",
         "~/Library/WebKit/com.microsoft.edgemac",
       ],
-      rmdir:  [
+      rmdir: [
         "/Library/Application Support/Microsoft",
         "~/Library/Microsoft",
       ]


### PR DESCRIPTION
microsoft-edge is now distributed as a .dmg instead of a .pkg.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
