### PR TITLE
Use `appdir` in `uninstall delete` paths

### DIFF
--- a/Casks/a/adobe-connect.rb
+++ b/Casks/a/adobe-connect.rb
@@ -23,7 +23,7 @@ cask "adobe-connect" do
 
   installer manual: "AdobeConnectInstaller.app"
 
-  uninstall delete: "/Applications/Adobe Connect"
+  uninstall delete: "#{appdir}/Adobe Connect"
 
   zap trash: [
     "~/adobeconnectapp.log",

--- a/Casks/b/battle-net.rb
+++ b/Casks/b/battle-net.rb
@@ -24,7 +24,7 @@ cask "battle-net" do
     set_permissions "#{staged_path}/Battle.net-Setup.app", "a+x"
   end
 
-  uninstall delete: "/Applications/Battle.net.app"
+  uninstall delete: "#{appdir}/Battle.net.app"
 
   zap trash: [
         "/Users/Shared/Battle.net",

--- a/Casks/c/citra.rb
+++ b/Casks/c/citra.rb
@@ -12,7 +12,7 @@ cask "citra" do
 
   installer manual: "citra-setup-mac.app"
 
-  uninstall delete: "/Applications/Citra"
+  uninstall delete: "#{appdir}/Citra"
 
   zap trash: [
     "~/Library/Preferences/com.citra-emu.citra.plist",

--- a/Casks/i/irpf2023.rb
+++ b/Casks/i/irpf2023.rb
@@ -18,7 +18,7 @@ cask "irpf2023" do
 
   installer manual: "IRPF2023.app"
 
-  uninstall delete: "/Applications/IRPF2023"
+  uninstall delete: "#{appdir}/IRPF2023"
 
   # No zap stanza required
 

--- a/Casks/i/irpf2024.rb
+++ b/Casks/i/irpf2024.rb
@@ -18,7 +18,7 @@ cask "irpf2024" do
 
   installer manual: "IRPF2024.app"
 
-  uninstall delete: "/Applications/IRPF2024"
+  uninstall delete: "#{appdir}/IRPF2024"
 
   # No zap stanza required
 end

--- a/Casks/i/irpf2025.rb
+++ b/Casks/i/irpf2025.rb
@@ -18,7 +18,7 @@ cask "irpf2025" do
 
   installer manual: "IRPF2025.app"
 
-  uninstall delete: "/Applications/IRPF2025"
+  uninstall delete: "#{appdir}/IRPF2025"
 
   # No zap stanza required
 end

--- a/Casks/i/izotope-product-portal.rb
+++ b/Casks/i/izotope-product-portal.rb
@@ -25,7 +25,7 @@ cask "izotope-product-portal" do
     sudo:       true,
   }
 
-  uninstall delete: "/Applications/iZotope Product Portal.app"
+  uninstall delete: "#{appdir}/iZotope Product Portal.app"
 
   zap trash: [
     "~/Library/Application Support/iZotope",

--- a/Casks/l/league-of-legends.rb
+++ b/Casks/l/league-of-legends.rb
@@ -15,7 +15,7 @@ cask "league-of-legends" do
 
   installer manual: "Install League of Legends na.app"
 
-  uninstall delete: "/Applications/League of Legends.app"
+  uninstall delete: "#{appdir}/League of Legends.app"
 
   zap trash: [
         "/Users/Shared/Riot Games/Metadata/league_of_legends.live",

--- a/Casks/m/mqttfx.rb
+++ b/Casks/m/mqttfx.rb
@@ -22,7 +22,7 @@ cask "mqttfx" do
     sudo:       true,
   }
 
-  uninstall delete: "/Applications/MQTT.fx.app"
+  uninstall delete: "#{appdir}/MQTT.fx.app"
 
   zap trash: [
     "~/Library/Application Support/MQTT-FX",

--- a/Casks/p/prosys-opc-ua-browser.rb
+++ b/Casks/p/prosys-opc-ua-browser.rb
@@ -26,7 +26,7 @@ cask "prosys-opc-ua-browser" do
     args:       ["-q"],
   }
 
-  uninstall delete: "/Applications/Prosys OPC UA Browser.app"
+  uninstall delete: "#{appdir}/Prosys OPC UA Browser.app"
 
   zap trash: [
     "~/.prosysopc",

--- a/Casks/r/ripme.rb
+++ b/Casks/r/ripme.rb
@@ -19,7 +19,7 @@ cask "ripme" do
 
   artifact "ripme-#{version}.jar", target: "#{appdir}/ripme.jar"
 
-  uninstall delete: "/Applications/rips"
+  uninstall delete: "#{appdir}/rips"
 
   zap trash: "~/Library/Application Support/ripme"
 

--- a/Casks/s/starcraft.rb
+++ b/Casks/s/starcraft.rb
@@ -14,7 +14,7 @@ cask "starcraft" do
 
   installer manual: "StarCraft-Setup.app"
 
-  uninstall delete: "/Applications/StarCraft"
+  uninstall delete: "#{appdir}/StarCraft"
 
   zap trash: [
     "/Users/Shared/Battle.net",


### PR DESCRIPTION
- Because `appdir` is more compatible than `/Applications/`.
- And it fixes an item on the someday projects list: https://github.com/orgs/Homebrew/projects/5/views/1?pane=issue&itemId=100592363.