### PR TITLE
ontime 3.14.4

### DIFF
--- a/Casks/o/ontime.rb
+++ b/Casks/o/ontime.rb
@@ -1,11 +1,11 @@
 cask "ontime" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.14.3"
-  sha256 arm:   "751b2869292dbad7848e989d137efb970c730e325a267c6a0039023247a01f20",
-         intel: "b2c6c2443be059c34aafb0c876e1a08fa660b9cce7d9f39d1d4d1e3e756e7747"
+  version "3.14.4"
+  sha256 arm:   "6f5e47bdf90a666dacf696758c959e46022126024a34b858434037144e861661",
+         intel: "1fe1d81cc75f10dce22f193914f4f38064fc4b07ae965b567164a2209c1fdf08"
 
-  url "https://github.com/cpvalente/ontime/releases/download/v.#{version}/ontime-macOS-#{arch}.dmg",
+  url "https://github.com/cpvalente/ontime/releases/download/v#{version}/ontime-macOS-#{arch}.dmg",
       verified: "github.com/cpvalente/ontime/"
   name "Ontime"
   desc "Time keeping for live events"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `ontime` to the newest version, 3.14.4, and removes the rogue dot from the tag in the URL, since upstream is using the expected `v1.2.3` tag format again (after the one-off typo in `v.3.14.3`). `ontime` is in the autobump list but it's failing to update because we have to manually update the URL, so this should get it back on track.