### PR TITLE
moom: update livecheck

### DIFF
--- a/Casks/m/moom.rb
+++ b/Casks/m/moom.rb
@@ -14,7 +14,7 @@ cask "moom" do
     url "https://manytricks.com/moom/appcast/"
     regex(/moom[._-]?v?(\d+(?:\.\d+)*)\.dmg/i)
     strategy :sparkle do |item, regex|
-      dotless_short_version = DSL::Version.new(item.short_version).no_dots
+      dotless_short_version = item.short_version.tr(".", "")
       next if dotless_short_version.blank?
 
       file_version = item.url[regex, 1]&.tr(".", "")


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` `strategy` block for `moom` uses `Cask::DSL::Version#no_dots` to produce a version string with no dots but we can simply use `.tr(".", "")` instead (as seen in the `file_version` definition). This updates the `livecheck` block accordingly, so we can remove this private API usage.