### PR TITLE
kate: add shimscript

### DIFF
--- a/Casks/k/kate.rb
+++ b/Casks/k/kate.rb
@@ -31,6 +31,15 @@ cask "kate" do
   end
 
   app "Kate.app"
+  shimscript = "#{staged_path}/kate.wrapper.sh"
+  binary shimscript, target: "kate"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/bash
+      exec '#{appdir}/Kate.app/Contents/MacOS/kate' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/Library/Application Support/kate",


### PR DESCRIPTION
Kate has a CLI which exposes some useful functionality (most notably the `-b` and `-i` flags). Having a shimscript present in `$(brew --prefix)/bin/kate` makes this CLI easy to acceess.

This is implemented as a shimscript rather than a symlink because, when a symlink is used, the CLI is unable to attach to an existing Kate session started directly from the Application bundle.

On platforms without D-Bus, Kate uses SingleApplication, a wrapper around QLocalServer. The QLocalServer key is the SHA-256 hash of various pieces of app data, including the executable path (returned from `QCoreApplication::applicationFilePath()`).

When launched from a symlink, the executable path will be different to the raw path of the binary within the Application bundle. Thus, a different QLocalServer key will be calculated and the two Kate instances are unable to communicate.

This only poses issues with the CLI attaching to sessions started through other means. The CLI can successfully talk to sessions also started from the same symlink because the executable path matches. For example, `kate file1.txt` and then `kate file2.txt` in a second Terminal will open file2.txt in the same window as file1.txt, and then exit the second instance.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
