### PR TITLE
genesys-cloud 2.41.631

### DIFF
--- a/Casks/g/genesys-cloud.rb
+++ b/Casks/g/genesys-cloud.rb
@@ -1,6 +1,6 @@
 cask "genesys-cloud" do
-  version "2.40.607,106"
-  sha256 "b678ef8c0e1e388e5ee1e07871eea171ebf07b0bab6cb58fac1fdafe0f921133"
+  version "2.41.631,125"
+  sha256 "2cacc92d72bccab20c33238e8d55bd5f7f26fad1444815af8695a60df74bf309"
 
   url "https://app.mypurecloud.com/directory-mac/build-assets/#{version.csv.first}-#{version.csv.second}/genesys-cloud-mac-#{version.csv.first}.dmg"
   name "Genesys Cloud for macOS"
@@ -9,7 +9,7 @@ cask "genesys-cloud" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/build-assets/(\d+(?:\.\d+)+)[._-](\d+).*?\.dmg}i)
+    regex(%r{/v?(\d+(?:\.\d+)+)-(\d+)/[^"' >]*?\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         "#{match[0]},#{match[1]}"
@@ -18,6 +18,7 @@ cask "genesys-cloud" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Genesys Cloud.app"
 
@@ -27,8 +28,4 @@ cask "genesys-cloud" do
     "~/Library/Preferences/com.inin.purecloud.directory.plist",
     "~/Library/Saved Application State/com.inin.purecloud.directory.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `genesys-cloud` is returning an `Unable to get version` error, as the URL/filename format has changed. This updates the regex to match the current setup.

This also updates `genesys-cloud` to the newest version, 2.41.631, adding a couple of `brew audit` fixes in the process.