### PR TITLE
docker: add compose-bridge symlink

### DIFF
--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -39,6 +39,8 @@ cask "docker" do
          target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker-compose"
   binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
          target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
+  binary "#{appdir}/Docker.app/Contents/Resources/bin/compose-bridge",
+         target: "/usr/local/bin/compose-bridge"
   binary "#{appdir}/Docker.app/Contents/Resources/bin/docker",
          target: "/usr/local/bin/docker"
   binary "#{appdir}/Docker.app/Contents/Resources/bin/docker-credential-desktop",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

Docker Desktop showed me a popup saying that an external tool had modified the Docker installation. When I clicked on it, it said a symlink was missing for `compose-bridge`. When I hit "Repair", the symlink it created was:

```
/usr/local/bin/compose-bridge -> /Applications/Docker.app/Contents/Resources/bin/compose-bridge
```

This PR adds that symlink to the cask file.