### PR TITLE
opencloud 1.0.0-rc.1 (new cask)

### DIFF
--- a/Casks/o/opencloud.rb
+++ b/Casks/o/opencloud.rb
@@ -10,10 +10,21 @@ cask "opencloud" do
   desc "Desktop syncing client for OpenCloud"
   homepage "https://github.com/opencloud-eu/desktop"
 
+  # TODO: Update this to use the `GithubLatest` strategy (without a regex or
+  # `strategy` block) when a stable version becomes available.
   livecheck do
-    url "https://github.com/opencloud-eu/desktop/releases"
-    strategy :github_releases
-    regex(/^v?(\d+(?:\.\d+)+)$/i) # Only matches stable versions without suffixes
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+.+)$/i)
+    strategy :github_releases do |json, regex|
+      json.filter_map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   auto_updates true

--- a/Casks/o/opencloud.rb
+++ b/Casks/o/opencloud.rb
@@ -23,6 +23,7 @@ cask "opencloud" do
 
   uninstall pkgutil: [
     "eu.opencloud.client",
+    "eu.opencloud.desktop",
     "eu.opencloud.finderPlugin",
   ]
 

--- a/Casks/o/opencloud.rb
+++ b/Casks/o/opencloud.rb
@@ -1,0 +1,38 @@
+cask "opencloud" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "1.0.0-rc.1"
+  sha256 arm:   "9b97142b7fa207cbb68e5a1926d9dafbd1375e06a5f2336b197f3fdb774a2626",
+         intel: "95443b0ea69d40d5916965aa7e3155bd10d048598a942fd9e78c519c1e1cdb7d"
+
+  url "https://github.com/opencloud-eu/desktop/releases/download/v#{version}/OpenCloud_Desktop-v#{version}-macos-clang-#{arch}.pkg"
+  name "OpenCloud Desktop"
+  desc "Desktop syncing client for OpenCloud"
+  homepage "https://github.com/opencloud-eu/desktop"
+
+  livecheck do
+    url "https://github.com/opencloud-eu/desktop/releases"
+    strategy :github_releases
+    regex(/^v?(\d+(?:\.\d+)+)$/i) # Only matches stable versions without suffixes
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  pkg "OpenCloud_Desktop-v#{version}-macos-clang-#{arch}.pkg"
+
+  uninstall pkgutil: [
+    "eu.opencloud.client",
+    "eu.opencloud.finderPlugin",
+  ]
+
+  zap trash: [
+    "~/Library/Application Scripts/eu.opencloud.desktopclient.FinderSyncExt",
+    "~/Library/Application Support/OpenCloud",
+    "~/Library/Caches/eu.opencloud.desktopclient",
+    "~/Library/Containers/eu.opencloud.desktopclient.FinderSyncExt",
+    "~/Library/Group Containers/9B5WD74GWJ.eu.opencloud.desktopclient",
+    "~/Library/Preferences/eu.opencloud.desktopclient.plist",
+    "~/Library/Preferences/OpenCloud",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online opencloud` is error-free.
- [x] `brew style --fix opencloud` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new opencloud` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask michaelstingl/opencloud/opencloud` worked successfully.
- [x] `brew uninstall --cask opencloud` worked successfully.

This is a new cask for OpenCloud Desktop, a desktop syncing client for OpenCloud. 

Note: The cask has been successfully tested through my personal tap (michaelstingl/opencloud). The style check passes with no offenses. The audit commands fail with a "Not Found" error since the cask is not yet in the main repository.