### PR TITLE
sejda-pdf: add support for arm64 builds

### DIFF
--- a/Casks/s/sejda-pdf.rb
+++ b/Casks/s/sejda-pdf.rb
@@ -1,8 +1,11 @@
 cask "sejda-pdf" do
-  version "7.8.6"
-  sha256 "f22fc3fa2cd56a28bdf25e9066359b4284c36ffd26ec312f978128505c2580fc"
+  arch arm: "_arm64"
 
-  url "https://downloads.sejda-cdn.com/sejda-desktop_#{version}.dmg",
+  version "7.8.6"
+  sha256 arm:   "3cedd0aa2dd65f124222038b5779eb446f8a7346408ad20e914f3b17926606a1",
+         intel: "f22fc3fa2cd56a28bdf25e9066359b4284c36ffd26ec312f978128505c2580fc"
+
+  url "https://downloads.sejda-cdn.com/sejda-desktop_#{version}#{arch}.dmg",
       verified: "downloads.sejda-cdn.com/"
   name "Sejda PDF Desktop"
   desc "PDF editor"
@@ -24,8 +27,4 @@ cask "sejda-pdf" do
     "~/Library/Preferences/com.sejda.sejda-desktop.plist",
     "~/Library/Saved Application State/com.sejda.sejda-desktop.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Sejda PDF Desktop started offering ARM64 builds recently. I added the appropriate download filename and SHA256 sum to the cask. I also removed the Rosetta warning, as it should not be required anymore with an ARM64 build. Hope this is correct.

This is my first PR, so I'm not sure I did everything correctly, even though I tried following the documentation for pull requests closely. 

Thanks for considering!
Andreas