### PR TITLE
onyx: specify `on_sequoia` without any modifier

### DIFF
--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -28,7 +28,7 @@ cask "onyx" do
   on_sonoma do
     version "4.6.2"
   end
-  on_sequoia :or_newer do
+  on_sequoia do
     version "4.7.7"
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Fix an issue where the wrong version is being installed on macOS Sequoia. The issue was caused by the `:or_newer` modifier, which was installing the Sonoma version instead of the intended one.
