### PR TITLE
deeper, maintenance, onyx: update url setup

### DIFF
--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -1,44 +1,65 @@
 cask "deeper" do
   sha256 :no_check
 
+  # NOTE: We use separate `url` values in each of the macOS on_system blocks
+  # so that the API data correctly includes URL variants for each.
   on_el_capitan :or_older do
     version "2.1.4"
+
+    url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
   end
   on_sierra do
     version "2.2.3"
+
+    url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
   end
   on_high_sierra do
     version "2.3.3"
+
+    url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
   end
   on_mojave do
     version "2.4.8"
+
+    url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
   end
   on_catalina do
     version "2.6.0"
+
+    url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
   end
   on_big_sur do
     version "2.7.1"
+
+    url "https://www.titanium-software.fr/download/11/Deeper.dmg"
   end
   on_monterey do
     version "2.8.0"
+
+    url "https://www.titanium-software.fr/download/12/Deeper.dmg"
   end
   on_ventura do
     version "2.9.2"
+
+    url "https://www.titanium-software.fr/download/13/Deeper.dmg"
   end
   on_sonoma do
     version "3.0.9"
+
+    url "https://www.titanium-software.fr/download/14/Deeper.dmg"
   end
   on_sequoia :or_newer do
     version "3.1.3"
+
+    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Deeper.dmg"
   end
 
-  url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Deeper.dmg"
   name "Deeper"
   desc "Tool to enable and disable hidden functions of Finder and other apps"
   homepage "https://www.titanium-software.fr/en/deeper.html"
 
   livecheck do
-    url "https://www.titanium-software.fr/download/#{MacOS.version}/Deeper.plist"
+    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Deeper.plist"
     strategy :xml do |xml|
       version = xml.elements["//key[text()='Version']"]&.next_element&.text
       next if version.blank?

--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -49,7 +49,7 @@ cask "deeper" do
     url "https://www.titanium-software.fr/download/14/Deeper.dmg"
   end
   on_sequoia :or_newer do
-    version "3.1.3"
+    version "3.1.4"
 
     url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Deeper.dmg"
   end

--- a/Casks/m/maintenance.rb
+++ b/Casks/m/maintenance.rb
@@ -1,44 +1,65 @@
 cask "maintenance" do
   sha256 :no_check
 
+  # NOTE: We use separate `url` values in each of the macOS on_system blocks
+  # so that the API data correctly includes URL variants for each.
   on_el_capitan :or_older do
     version "2.1.8"
+
+    url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
   end
   on_sierra do
     version "2.3.0"
+
+    url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
   end
   on_high_sierra do
     version "2.4.2"
+
+    url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
   end
   on_mojave do
     version "2.5.6"
+
+    url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
   end
   on_catalina do
     version "2.7.1"
+
+    url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
   end
   on_big_sur do
     version "2.8.2"
+
+    url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
   end
   on_monterey do
     version "2.9.2"
+
+    url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
   end
   on_ventura do
     version "3.0.2"
+
+    url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
   end
   on_sonoma do
     version "3.2.0"
+
+    url "https://www.titanium-software.fr/download/14/Maintenance.dmg"
   end
   on_sequoia :or_newer do
     version "3.2.9"
+
+    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Maintenance.dmg"
   end
 
-  url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Maintenance.dmg"
   name "Maintenance"
   desc "Operating system maintenance and cleaning utility"
   homepage "https://www.titanium-software.fr/en/maintenance.html"
 
   livecheck do
-    url "https://www.titanium-software.fr/download/#{MacOS.version}/Maintenance.plist"
+    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Maintenance.plist"
     strategy :xml do |xml|
       version = xml.elements["//key[text()='Version']"]&.next_element&.text
       next if version.blank?

--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -1,44 +1,65 @@
 cask "onyx" do
   sha256 :no_check
 
+  # NOTE: We use separate `url` values in each of the macOS on_system blocks
+  # so that the API data correctly includes URL variants for each.
   on_el_capitan :or_older do
     version "3.1.9"
+
+    url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
   end
   on_sierra do
     version "3.3.1"
+
+    url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
   end
   on_high_sierra do
     version "3.4.9"
+
+    url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
   end
   on_mojave do
     version "3.6.8"
+
+    url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
   end
   on_catalina do
     version "3.8.7"
+
+    url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
   end
   on_big_sur do
     version "4.0.2"
+
+    url "https://www.titanium-software.fr/download/11/OnyX.dmg"
   end
   on_monterey do
     version "4.2.7"
+
+    url "https://www.titanium-software.fr/download/12/OnyX.dmg"
   end
   on_ventura do
     version "4.4.7"
+
+    url "https://www.titanium-software.fr/download/13/OnyX.dmg"
   end
   on_sonoma do
     version "4.6.2"
+
+    url "https://www.titanium-software.fr/download/14/OnyX.dmg"
   end
   on_sequoia :or_newer do
     version "4.7.7"
+
+    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/OnyX.dmg"
   end
 
-  url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/OnyX.dmg"
   name "OnyX"
   desc "Verify system files structure, run miscellaneous maintenance and more"
   homepage "https://www.titanium-software.fr/en/onyx.html"
 
   livecheck do
-    url "https://www.titanium-software.fr/download/#{MacOS.version}/OnyX.plist"
+    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/OnyX.plist"
     strategy :xml do |xml|
       version = xml.elements["//key[text()='Version']"]&.next_element&.text
       next if version.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

As detailed in #209423, the `deeper`, `maintenance`, and `onyx` casks are incorrectly installing the Sonoma version of the software on macOS versions other than Sonoma. These casks only include one `url` that interpolates the macOS version, which is tidy but doesn't produce correct API data. When this cask is parsed to produce the API data, the `url` is simply a string and there's no indication that it varies based on macOS version after interpolation. As a result, the JSON data only contains one `url` that's appropriate for the execution environment where the API data is produced (currently Sonoma). This addresses the issue by including a `url` value in each macOS on_system block, so the variants will be correctly detected and included in the API data. This won't be fixed immediately after merging but it should be addressed the next time the API data is automatically generated.

This also updates the `livecheck` block URL to also use `MacOS.version.to_s.delete(".")`, as `MacOS.version` will produce an invalid URL for older macOS versions like 10.15.

Besides that, I checked the plist files for each version and updated `deeper` to the newest version (3.1.4). The El Capitan version of `maintenance` is listed as 2.1.7 in the related plist file but is 2.1.8 on the download page, so I've left that as is.

Closes #209423.