### PR TITLE
ace-link: remove VLC dependency

### DIFF
--- a/Casks/a/ace-link.rb
+++ b/Casks/a/ace-link.rb
@@ -4,7 +4,7 @@ cask "ace-link" do
 
   url "https://github.com/blaise-io/acelink/releases/download/#{version}/Ace.Link.#{version}.dmg"
   name "Ace Link"
-  desc "Menu bar app that allows playing Ace Stream video streams in the VLC player"
+  desc "Menu bar app for playing Ace Stream video streams in an external media player"
   homepage "https://github.com/blaise-io/acelink"
 
   livecheck do
@@ -13,10 +13,7 @@ cask "ace-link" do
   end
 
   depends_on macos: ">= :high_sierra"
-  depends_on cask: [
-    "vlc",
-    "docker",
-  ]
+  depends_on cask: "docker"
 
   app "Ace Link.app"
 


### PR DESCRIPTION
Ace Link hasn't required specifically VLC since 2.0

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---