### PR TITLE
autumn: deprecate

### DIFF
--- a/Casks/a/autumn.rb
+++ b/Casks/a/autumn.rb
@@ -8,6 +8,8 @@ cask "autumn" do
   desc "Window manager for JavaScript development"
   homepage "https://apandhi.github.io/Autumn/"
 
+  deprecate! date: "2025-04-21", because: :unmaintained
+
   depends_on macos: ">= :high_sierra"
 
   app "Autumn.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The app has not been updated since 2019. From the upstream repository:

> It was originally developed by Sephware and opened sourced in hopes that the community would keep the project alive.
