### PR TITLE
highlight 1.1.29 (new cask)

### DIFF
--- a/Casks/h/highlight.rb
+++ b/Casks/h/highlight.rb
@@ -1,0 +1,29 @@
+cask "highlight" do
+  arch arm: "arm64", intel: "x64"
+  arch_suffix = on_arch_conditional arm: "-arm64"
+
+  version "1.1.29"
+  sha256 arm:   "c11ff166aa81ed1a11c0b1433d3848e82551a18245942c0de7b8c2c16b1eb208",
+         intel: "a7f5cca252959232d54d77da16210b87e1df04921d9ccece6f4258348e2e02e3"
+
+  url "https://cdn.highlightai.com/releases/darwin/#{arch}/Highlight-#{version}#{arch_suffix}.dmg"
+  name "Highlight"
+  desc "Context-aware AI assistant"
+  homepage "https://highlightai.com/"
+
+  livecheck do
+    url "https://cdn.highlightai.com/releases/darwin/#{arch}/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Highlight.app"
+
+  zap trash: [
+    "~/Library/Application Support/Highlight",
+    "~/Library/Preferences/tv.medal.highlight.plist",
+    "~/Library/Saved Application State/tv.medal.highlight.savedState",
+  ]
+end


### PR DESCRIPTION
https://highlightai.com/

⚠️ is it okay to have a cask called `highlight` when there is a [core brew called `highlight`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/h/highlight.rb)? Could potentially change this cask to `highlight-ai` I will ask the developers what they think.

![image](https://github.com/user-attachments/assets/fa05db75-8b73-4dc0-8213-2a68c40c0d76)

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
