### PR TITLE
calhash 1.4.4

### DIFF
--- a/Casks/c/calhash.rb
+++ b/Casks/c/calhash.rb
@@ -5,41 +5,63 @@ cask "calhash" do
     version "1.0.5"
 
     url "https://www.titanium-software.fr/download/1015/CalHash.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_big_sur do
     version "1.1.1"
 
     url "https://www.titanium-software.fr/download/11/CalHash.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_monterey do
     version "1.1.9"
 
     url "https://www.titanium-software.fr/download/12/CalHash.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_ventura do
     version "1.2.1"
 
     url "https://www.titanium-software.fr/download/13/CalHash.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sonoma do
     version "1.3.4"
 
     url "https://www.titanium-software.fr/download/14/CalHash.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sequoia :or_newer do
-    version "1.4.3"
+    version "1.4.4"
 
     url "https://www.titanium-software.fr/download/15/CalHash.dmg"
+
+    # We check the version on the homepage, as the version in the related plist
+    # file can be out of date.
+    livecheck do
+      url :homepage
+      regex(/>\s*CalHash\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s]*15\s*</i)
+    end
   end
 
   name "CalHash"
   desc "Calculate and compare file checksums"
   homepage "https://www.titanium-software.fr/en/calhash.html"
-
-  livecheck do
-    url :homepage
-    regex(/>\s*CalHash\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s.-]*\s+#{MacOS.version}\s*</i)
-  end
 
   depends_on macos: [
     :catalina,


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `calhash` to the latest version for Sequoia, 1.4.4, and updates the `livecheck` block setup. The homepage states, "Titanium Software has discontinued developing the old versions and will no longer update them", so I've added `skip` `livecheck` blocks to the older versions and moved the existing `livecheck` block into the newest on_system block. In the process, I tweaked the regex and replaced the interpolated `MacOS.version` with a hardcoded version, so this will work predictably regardless of the execution environment.

For what it's worth, this `livecheck` block will eventually stop returning the newest version but it will continue working, so we won't know that the cask needs to be updated. We could update the `livecheck` block to return all versions on the page regardless of the macOS version but we would have to remove these casks from the autobump list, as we have to update the macOS on_system block setup when a version for a newer macOS version is released (and the current version becomes an old/unmaintained version). I'm not fond of `livecheck` blocks that quietly return an incorrect value (the only way to identify the issue is by manually checking the page outside of livecheck), so what do we think about the tradeoffs here?

I'm working on PRs to similarly update the other Titanium Software casks and will have those up shortly.