### PR TITLE
maintenance 3.3.1

### DIFF
--- a/Casks/m/maintenance.rb
+++ b/Casks/m/maintenance.rb
@@ -7,66 +7,99 @@ cask "maintenance" do
     version "2.1.8"
 
     url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sierra do
     version "2.3.0"
 
     url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_high_sierra do
     version "2.4.2"
 
     url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_mojave do
     version "2.5.6"
 
     url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_catalina do
     version "2.7.1"
 
     url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_big_sur do
     version "2.8.2"
 
     url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_monterey do
     version "2.9.2"
 
     url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_ventura do
     version "3.0.2"
 
     url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sonoma do
     version "3.2.0"
 
     url "https://www.titanium-software.fr/download/14/Maintenance.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sequoia :or_newer do
-    version "3.2.9"
+    version "3.3.1"
 
     url "https://www.titanium-software.fr/download/15/Maintenance.dmg"
+
+    # We check the version on the homepage, as the version in the related plist
+    # file can be out of date.
+    livecheck do
+      url :homepage
+      regex(/>\s*Maintenance\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s]*15\s*</i)
+    end
   end
 
   name "Maintenance"
   desc "Operating system maintenance and cleaning utility"
   homepage "https://www.titanium-software.fr/en/maintenance.html"
-
-  livecheck do
-    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Maintenance.plist"
-    strategy :xml do |xml|
-      version = xml.elements["//key[text()='Version']"]&.next_element&.text
-      next if version.blank?
-
-      version.strip
-    end
-  end
 
   depends_on macos: [
     :el_capitan,


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/209545.

This updates `maintenance` to the latest version for Sequoia, 3.3.1, and updates the `livecheck` block setup. The homepage states, "Titanium Software has discontinued developing the old versions and will no longer update them", so I've added `skip` `livecheck` blocks to the older versions and moved the existing `livecheck` block into the newest on_system block.

I updated the `livecheck` block to use the approach from the `calhash` cask, which checks the versions on the homepage. The Sequoia plist file for `maintenance` lists 3.2.9 as the newest version but the homepage says it's 3.3.1, so we can't rely on the plist file being kept up to date.

Besides that, I tweaked the regex and replaced the interpolated `MacOS.version` with a hardcoded version, so this will work predictably regardless of the execution environment.