### PR TITLE
deeper, onyx: update livecheck

### DIFF
--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -7,66 +7,99 @@ cask "deeper" do
     version "2.1.4"
 
     url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sierra do
     version "2.2.3"
 
     url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_high_sierra do
     version "2.3.3"
 
     url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_mojave do
     version "2.4.8"
 
     url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_catalina do
     version "2.6.0"
 
     url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_big_sur do
     version "2.7.1"
 
     url "https://www.titanium-software.fr/download/11/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_monterey do
     version "2.8.0"
 
     url "https://www.titanium-software.fr/download/12/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_ventura do
     version "2.9.2"
 
     url "https://www.titanium-software.fr/download/13/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sonoma do
     version "3.0.9"
 
     url "https://www.titanium-software.fr/download/14/Deeper.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sequoia :or_newer do
     version "3.1.4"
 
     url "https://www.titanium-software.fr/download/15/Deeper.dmg"
+
+    # We check the version on the homepage, as the version in the related plist
+    # file can be out of date.
+    livecheck do
+      url :homepage
+      regex(/>\s*Deeper\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s]*15\s*</i)
+    end
   end
 
   name "Deeper"
   desc "Tool to enable and disable hidden functions of Finder and other apps"
   homepage "https://www.titanium-software.fr/en/deeper.html"
-
-  livecheck do
-    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/Deeper.plist"
-    strategy :xml do |xml|
-      version = xml.elements["//key[text()='Version']"]&.next_element&.text
-      next if version.blank?
-
-      version.strip
-    end
-  end
 
   depends_on macos: [
     :el_capitan,

--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -7,66 +7,99 @@ cask "onyx" do
     version "3.1.9"
 
     url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sierra do
     version "3.3.1"
 
     url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_high_sierra do
     version "3.4.9"
 
     url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_mojave do
     version "3.6.8"
 
     url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_catalina do
     version "3.8.7"
 
     url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_big_sur do
     version "4.0.2"
 
     url "https://www.titanium-software.fr/download/11/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_monterey do
     version "4.2.7"
 
     url "https://www.titanium-software.fr/download/12/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_ventura do
     version "4.4.7"
 
     url "https://www.titanium-software.fr/download/13/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sonoma do
     version "4.6.2"
 
     url "https://www.titanium-software.fr/download/14/OnyX.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
   on_sequoia :or_newer do
     version "4.7.7"
 
     url "https://www.titanium-software.fr/download/15/OnyX.dmg"
+
+    # We check the version on the homepage, as the version in the related plist
+    # file can be out of date.
+    livecheck do
+      url :homepage
+      regex(/>\s*OnyX\s+v?(\d+(?:\.\d+)+)\s+for\s+[\w\s]*15\s*</i)
+    end
   end
 
   name "OnyX"
   desc "Verify system files structure, run miscellaneous maintenance and more"
   homepage "https://www.titanium-software.fr/en/onyx.html"
-
-  livecheck do
-    url "https://www.titanium-software.fr/download/#{MacOS.version.to_s.delete(".")}/OnyX.plist"
-    strategy :xml do |xml|
-      version = xml.elements["//key[text()='Version']"]&.next_element&.text
-      next if version.blank?
-
-      version.strip
-    end
-  end
 
   depends_on macos: [
     :el_capitan,


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/209545.

This updates the `livecheck` block setup for `deeper` and `onyx`. The homepage states, "Titanium Software has discontinued developing the old versions and will no longer update them", so I've added `skip` `livecheck` blocks to the older versions and moved the existing `livecheck` block into the newest on_system block.

I updated the `livecheck` block to use the approach from the `calhash` cask, which checks the versions on the homepage. The related plist files sometimes contain an outdated version with respect to what's listed on the homepage, so this seems like the more reliable source of version information.

Besides that, I tweaked the regex and replaced the interpolated `MacOS.version` with a hardcoded version, so this will work predictably regardless of the execution environment.