### PR TITLE
warp@preview 0.2025.04.16.08.11.preview_02 (new cask)

### DIFF
--- a/Casks/w/warp-preview.rb
+++ b/Casks/w/warp-preview.rb
@@ -1,0 +1,27 @@
+cask "warp-preview" do
+  version "0.2025.04.16.08.11.preview_02"
+  sha256 "ec84cf869824ab6e5156a2841e2c77a7b92f1a2be0635d26def8472e9e71d0fc"
+
+  url "https://releases.warp.dev/preview/v#{version}/WarpPreview.dmg"
+  name "Warp Preview"
+  desc "Rust-based terminal"
+  homepage "https://www.warp.dev/"
+
+  livecheck do
+    url "https://releases.warp.dev/channel_versions.json"
+    strategy :json do |json|
+      json.dig("preview", "version")&.delete_prefix("v")
+    end
+  end
+
+  auto_updates true
+
+  app "WarpPreview.app"
+
+  zap trash: [
+    "~/Library/Application Support/dev.warp.Warp-Preview",
+    "~/Library/Logs/warp_preview.log",
+    "~/Library/Preferences/dev.warp.Warp-Preview.plist",
+    "~/Library/Saved Application State/dev.warp.Warp-Preview.savedState",
+  ]
+end

--- a/Casks/w/warp@preview.rb
+++ b/Casks/w/warp@preview.rb
@@ -1,4 +1,4 @@
-cask "warp-preview" do
+cask "warp@preview" do
   version "0.2025.04.16.08.11.preview_02"
   sha256 "ec84cf869824ab6e5156a2841e2c77a7b92f1a2be0635d26def8472e9e71d0fc"
 


### PR DESCRIPTION
Add Warp Preview Cask from https://www.warp.dev/download-preview

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

