### PR TITLE
Update Rogue Amoeba `livecheck` blocks

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -6,12 +6,24 @@ cask "airfoil" do
 
     url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil-ACE.zip"
 
+    # The ACE release supports macOS 11 to 14.3.1, so we use the highest
+    # supported macOS version in the URL.
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.12.4"
 
     url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
+
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :sonoma"
 
@@ -22,11 +34,6 @@ cask "airfoil" do
   name "Airfoil"
   desc "Sends audio from computer to outputs"
   homepage "https://rogueamoeba.com/airfoil/mac/"
-
-  livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
-  end
 
   auto_updates true
 

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -6,12 +6,24 @@ cask "audio-hijack" do
 
     url "https://cdn.rogueamoeba.com/audiohijack/download/AudioHijack-ACE.zip"
 
+    # The ACE release supports macOS 11 to 14.3.1, so we use the highest
+    # supported macOS version in the URL.
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "4.5.0"
 
     url "https://cdn.rogueamoeba.com/audiohijack/download/AudioHijack.zip"
+
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :sonoma"
 
@@ -22,11 +34,6 @@ cask "audio-hijack" do
   name "Audio Hijack"
   desc "Records audio from any application"
   homepage "https://rogueamoeba.com/audiohijack/"
-
-  livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
-  end
 
   auto_updates true
 

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -6,12 +6,24 @@ cask "loopback" do
 
     url "https://cdn.rogueamoeba.com/loopback/download/Loopback-ACE.zip"
 
+    # The ACE release supports macOS 11 to 14.4.1, so we use the highest
+    # supported macOS version in the URL.
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "2.4.5"
 
     url "https://cdn.rogueamoeba.com/loopback/download/Loopback.zip"
+
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :sonoma"
 
@@ -22,11 +34,6 @@ cask "loopback" do
   name "Loopback"
   desc "Cable-free audio router"
   homepage "https://rogueamoeba.com/loopback/"
-
-  livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
-  end
 
   auto_updates true
 

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -6,12 +6,24 @@ cask "piezo" do
 
     url "https://cdn.rogueamoeba.com/piezo/download/Piezo-ACE.zip"
 
+    # The ACE release supports macOS 11 to 14.3.1, so we use the highest
+    # supported macOS version in the URL.
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "1.9.5"
 
     url "https://cdn.rogueamoeba.com/piezo/download/Piezo.zip"
+
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :sonoma"
 
@@ -22,11 +34,6 @@ cask "piezo" do
   name "Piezo"
   desc "Audio recording application"
   homepage "https://rogueamoeba.com/piezo/"
-
-  livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
-  end
 
   auto_updates true
 

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -6,12 +6,24 @@ cask "soundsource" do
 
     url "https://cdn.rogueamoeba.com/soundsource/download/SoundSource-ACE.zip"
 
+    # The ACE release supports macOS 11 to 14.4.1, so we use the highest
+    # supported macOS version in the URL.
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
+
     depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.8.2"
 
     url "https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip"
+
+    livecheck do
+      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
+      strategy :sparkle
+    end
 
     depends_on macos: ">= :sonoma"
 
@@ -22,11 +34,6 @@ cask "soundsource" do
   name "SoundSource"
   desc "Sound and audio controller"
   homepage "https://rogueamoeba.com/soundsource/"
-
-  livecheck do
-    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=#{MacOS.full_version.to_s.delete(".")}&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
-    strategy :sparkle
-  end
 
   auto_updates true
   conflicts_with cask: "soundsource@test"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` blocks for the Rogue Amoeba casks with ACE/ARK versions use `MacOS.full_version` in the `url`, so we don't have to maintain a `livecheck` block in each on_system block. However, `MacOS` isn't something that `SimulateSystem` handles, so it will always be the macOS version from the execution environment and that can cause unexpected behavior. `MacOS` also doesn't exist on Linux, so this causes an error when the `livecheck` block isn't guarded behind a macOS on_system block.

This moves the existing `livecheck` block into each on_system block and replaces `MacOS.full_version` with a hardcoded macOS version. I've used the highest supported macOS version for the ACE release and 999 as an arbitrarily high version for the ARK release, as we're already doing in the `farrago` and `fission` casks. I checked that the latter returns the same version as when using `system=1541`, at least for now.