### PR TITLE
cocktail: update livecheck

### DIFF
--- a/Casks/c/cocktail.rb
+++ b/Casks/c/cocktail.rb
@@ -55,7 +55,7 @@ cask "cocktail" do
       url "https://www.maintain.se/downloads/Cocktail#{version.major}VE.dmg"
     end
     on_sonoma do
-      version "17.10"
+      version "17.10.1"
       sha256 :no_check
 
       url "https://www.maintain.se/downloads/Cocktail#{version.major}SE.dmg"

--- a/Casks/c/cocktail.rb
+++ b/Casks/c/cocktail.rb
@@ -47,29 +47,37 @@ cask "cocktail" do
       skip "Legacy version"
     end
   end
-  on_ventura :or_newer do
-    on_ventura do
-      version "16.7"
-      sha256 :no_check
+  on_ventura do
+    version "16.7"
+    sha256 :no_check
 
-      url "https://www.maintain.se/downloads/Cocktail#{version.major}VE.dmg"
-    end
-    on_sonoma do
-      version "17.10.1"
-      sha256 :no_check
-
-      url "https://www.maintain.se/downloads/Cocktail#{version.major}SE.dmg"
-    end
-    on_sequoia :or_newer do
-      version "18.4.1"
-      sha256 :no_check
-
-      url "https://www.maintain.se/downloads/Cocktail#{version.major}SE.dmg"
-    end
+    url "https://www.maintain.se/downloads/Cocktail#{version.major}VE.dmg"
 
     livecheck do
       url :homepage
-      regex(/macOS\s+#{MacOS.version}.*?v?(\d+(?:\.\d+)+)/i)
+      regex(/macOS\s+13.*?v?(\d+(?:\.\d+)+)/i)
+    end
+  end
+  on_sonoma do
+    version "17.10.1"
+    sha256 :no_check
+
+    url "https://www.maintain.se/downloads/Cocktail#{version.major}SE.dmg"
+
+    livecheck do
+      url :homepage
+      regex(/macOS\s+14.*?v?(\d+(?:\.\d+)+)/i)
+    end
+  end
+  on_sequoia :or_newer do
+    version "18.4.1"
+    sha256 :no_check
+
+    url "https://www.maintain.se/downloads/Cocktail#{version.major}SE.dmg"
+
+    livecheck do
+      url :homepage
+      regex(/macOS\s+15.*?v?(\d+(?:\.\d+)+)/i)
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the `livecheck` setup for `cocktail` to move the `livecheck` block into the Ventura, Sonoma, and Sequoia on_system blocks and to use a hardcoded macOS version. `SimulateSystem` doesn't modify `MacOS`, so `MacOS.version` will always be the macOS version of the execution environment and this may produce unexpected behavior. Using a hardcoded value ensures that these checks will work as expected regardless of the execution environment.

Besides that, this updates the Sonoma version of `cocktail` to the latest version
on the homepage, 17.10.1.