### PR TITLE
realvnc-connect 8.0.0 (new cask)

### DIFF
--- a/Casks/r/realvnc-connect.rb
+++ b/Casks/r/realvnc-connect.rb
@@ -1,0 +1,30 @@
+cask "realvnc-connect" do
+  version "8.0.0"
+  sha256 "7bdab2dd010d240d394ee018b705d83b39cde4524628b58efee231ed0c5e00b4"
+
+  url "https://downloads.realvnc.com/download/file/realvnc-connect/RealVNC-Connect-#{version}-MacOSX-universal.pkg"
+  name "RealVNC Connect"
+  desc "Remote desktop client and server application"
+  homepage "https://www.realvnc.com/"
+
+  livecheck do
+    url "https://www.realvnc.com/en/connect/download"
+    regex(/RealVNC[._-]Connect[._-]v?(\d+(?:\.\d+)+)[._-]MacOSX[._-]universal\.pkg/i)
+  end
+
+  depends_on macos: ">= :sequoia"
+
+  pkg "RealVNC-Connect-#{version}-MacOSX-universal.pkg"
+
+  uninstall launchctl: [
+              "com.realvnc.rvncserver",
+              "com.realvnc.rvncserver.peruser",
+            ],
+            pkgutil:   "com.realvnc.rvncconnect.pkg"
+
+  zap trash: [
+    "~/Library/Application Support/com.realvnc.rvncconnect",
+    "~/Library/Logs/vnc",
+    "~/Library/Preferences/com.realvnc.rvncconnect.plist",
+  ]
+end


### PR DESCRIPTION
RealVNC has a new "RealVNC Connect" v8 app that combines the functionality of the now-legacy RealVNC "VNC Viewer" and "VNC Server" v7 apps.

More info can be found on their [website](https://www.realvnc.com/en/connect/download/).

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
