### PR TITLE
tunnelblick, tunnelblick@beta: revert to 6.*

### DIFF
--- a/Casks/t/tunnelblick.rb
+++ b/Casks/t/tunnelblick.rb
@@ -1,6 +1,6 @@
 cask "tunnelblick" do
-  version "7.0,6210"
-  sha256 "ab79a65ec56a7c02af93a798041c32acb29e2d7ccd81aa7c9ce6447a5df5b652"
+  version "6.0.1,6161"
+  sha256 "728f929d890b1a577d2db8de7d38fdaf9e648ca831e0c9d913cf98ec73520608"
 
   url "https://tunnelblick.net/iprelease/Tunnelblick_#{version.csv.first}_build_#{version.csv.second}.dmg"
   name "Tunnelblick"

--- a/Casks/t/tunnelblick@beta.rb
+++ b/Casks/t/tunnelblick@beta.rb
@@ -1,6 +1,6 @@
 cask "tunnelblick@beta" do
-  version "7.1beta01,6220"
-  sha256 "76b0c31dd7846e6d0e53da07f64a4fa0a2f4e867a9863e225ca80a3b71ddd38f"
+  version "6.1beta2,6180"
+  sha256 "4619513160824205409a3c6fb0049e6daf50a0f21f1e0aab47731ecdc16295b1"
 
   url "https://tunnelblick.net/iprelease/Tunnelblick_#{version.csv.first}_build_#{version.csv.second}.dmg"
   name "Tunnelblick"


### PR DESCRIPTION
The two releases were withdrawn because of installation issues: https://github.com/Tunnelblick/Tunnelblick/issues/848#issuecomment-2820441198

This pull request reverts the two version bumps.