### PR TITLE
autobump: remove calhash, deeper, maintenance

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -198,7 +198,6 @@ cables
 cacher
 cahier
 caido
-calhash
 calibre
 calmly-writer
 camerabag-photo
@@ -340,7 +339,6 @@ deadbolt
 decentr
 deckset
 deepchat
-deeper
 deepl
 deezer
 default-folder-x
@@ -845,7 +843,6 @@ macwhisper
 maestral
 mailbird
 mailbutler
-maintenance
 maltego
 malwarebytes
 manico


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR removes all Titanium Software casks from the autobump list so that they can be bumped manually. Since their livechecks are only active within `on_sequoia :or_newer` blocks, they are currently skipped in the autobump workflow running on macOS 14.
