### PR TITLE
standard-notes: revert to 3.195.13

### DIFF
--- a/Casks/s/standard-notes.rb
+++ b/Casks/s/standard-notes.rb
@@ -1,9 +1,9 @@
 cask "standard-notes" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.195.29"
-  sha256 arm:   "6de4391fe4d8dbafc48ddf8c34107e02f6b917b98f5eae71635d02d57d29f929",
-         intel: "7ebe1faf3434084cfaa5052d3846d909923fb93cc392882a514b6d539209bd03"
+  version "3.195.13"
+  sha256 arm:   "c38c64428e7ab367f5899bc1242a1619c797d75630255116dfe42146c7cdf090",
+         intel: "b29f8c16b597ff63b3ce9e6ecdf413d7dff77562dc77cf4aecdb48db271f4271"
 
   url "https://github.com/standardnotes/app/releases/download/%40standardnotes%2Fdesktop%40#{version}/standard-notes-#{version}-mac-#{arch}.zip",
       verified: "github.com/standardnotes/app/"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#209559

3.195.29 was pulled due to a bug, 3.195.13 is still the latest version.