### PR TITLE
wsjt-x 2.7.0 (new cask)

### DIFF
--- a/Casks/w/wsjt-x.rb
+++ b/Casks/w/wsjt-x.rb
@@ -1,0 +1,53 @@
+cask "wsjt-x" do
+  version "2.7.0"
+  sha256 "f3ef11f3612f1db7bcdea55e5a4ce409b0c1db43ae6bc1a5e048fc99833e031e"
+
+  url "https://downloads.sourceforge.net/wsjt/wsjtx-#{version}/wsjtx-#{version}-Darwin.dmg",
+      verified: "downloads.sourceforge.net/wsjt/"
+  name "WSJT-X"
+  desc "Weak Signal Communication, by K1JT"
+  homepage "https://wsjt.sourceforge.io/wsjtx.html"
+
+  livecheck do
+    url "https://sourceforge.net/projects/wsjt/rss?path=/"
+    regex(%r{url=.*?/wsjtx-?(\d+(?:\.\d+)+)/wsjtx-?(\d+(?:\.\d+)+[a-z]?)-Darwin.dmg}i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      (match[1] == match[2]) ? match[2] : "#{match[2]},#{match[1]}"
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "wsjtx.app"
+  installer script: {
+    executable: "cp",
+    args:       ["#{staged_path}/com.wsjtx.sysctl.plist", "/Library/LaunchDaemons/com.wsjtx.sysctl.plist"],
+    sudo:       true,
+  }
+  installer script: {
+    executable: "chown",
+    args:       ["root:wheel", "/Library/LaunchDaemons/com.wsjtx.sysctl.plist"],
+    sudo:       true,
+  }
+
+  uninstall delete: "/Library/LaunchDaemons/com.wsjtx.sysctl.plist"
+
+  caveats do
+    reboot
+    requires_rosetta
+    <<~EOS
+      Visit Applications > Utilities > Audio MIDI Setup and select your sound card and then set Format to be '48000Hz 2ch-16bit' for input and output. On rare occasions problems with audio output to your rig can be corrected if you select 44100Hz.
+
+      If your Mac is using Sonoma 14.6 or later then in addition to these two commands you must visit: System Settings > General > Login Items > sysctl and select ON for sysctl or if using Sequioa then visit  System Settings > Privacy & Security then ON for sysctl.
+    EOS
+  end
+
+  zap trash: [
+    "~/Library/Application Support/WSJT-X",
+    "~/Library/Preferences/WSJT-X.ini",
+  ]
+
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Currently the app is unsigned and fails the audit:
```
audit for wsjt-x: failed
 - Signature verification failed:
/private/tmp/cask-audit20250424-87117-7cuztu/wsjtx.app: rejected

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
wsjt-x
  * line 5, col 2: Signature verification failed:
    /private/tmp/cask-audit20250424-87117-7cuztu/wsjtx.app: rejected

    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 1 problem in 1 cask detected.
```

I've emailed the developers list to ask about plans to notarize & sign the app. 
