### PR TITLE
opencloud: update livecheck to use github_latest strategy

### DIFF
--- a/Casks/o/opencloud.rb
+++ b/Casks/o/opencloud.rb
@@ -10,21 +10,9 @@ cask "opencloud" do
   desc "Desktop syncing client for OpenCloud"
   homepage "https://github.com/opencloud-eu/desktop"
 
-  # TODO: Update this to use the `GithubLatest` strategy (without a regex or
-  # `strategy` block) when a stable version becomes available.
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+.+)$/i)
-    strategy :github_releases do |json, regex|
-      json.filter_map do |release|
-        next if release["draft"]
-
-        match = release["tag_name"]&.match(regex)
-        next if match.blank?
-
-        match[1]
-      end
-    end
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online opencloud` is error-free.
- [x] `brew style --fix opencloud` reports no offenses.

This PR simplifies the livecheck configuration for the OpenCloud cask, as mentioned in the TODO comment.

Since a stable version (v1.0.0) is now available, we can replace the complex livecheck strategy with the simpler `github_latest` strategy as suggested by @samford in the original PR: https://github.com/Homebrew/homebrew-cask/pull/208683#issuecomment-2803620608