### PR TITLE
vmware-fusion: re-disable

### DIFF
--- a/Casks/v/vmware-fusion.rb
+++ b/Casks/v/vmware-fusion.rb
@@ -8,18 +8,7 @@ cask "vmware-fusion" do
   desc "Create, manage, and run virtual machines"
   homepage "https://www.vmware.com/products/desktop-hypervisor/workstation-and-fusion"
 
-  livecheck do
-    url "https://softwareupdate-dev.broadcom.com/cds/vmw-desktop/fusion-universal.xml"
-    regex(%r{fusion/(\d+(?:\.\d+)+/\d+)}i)
-    strategy :xml do |xml, regex|
-      xml.get_elements("//url").map do |item|
-        match = item.text&.strip&.match(regex)
-        next if match.blank?
-
-        match[1].tr("/", ",")
-      end
-    end
-  end
+  disable! date: "2025-04-25", because: "download requires a Broadcom Profile"
 
   auto_updates true
   conflicts_with cask: "vmware-fusion@preview"


### PR DESCRIPTION
Re-disable now that all known public URLs noted in #206132 have been [intentionally removed](https://community.broadcom.com/vmware-cloud-foundation/question/certificate-error-is-occured-during-connecting-update-server).

Fixes #210104.