### PR TITLE
elemental 7.0.0 (new cask)

### DIFF
--- a/Casks/e/elemental.rb
+++ b/Casks/e/elemental.rb
@@ -1,0 +1,18 @@
+cask "elemental" do
+  version "7.0.0"
+  sha256 "fea71251b2b9859923a1ba4f9509c0f0b104b4265e8ba7fcb33828b110b399cf"
+
+  url "https://github.com/evolvedbinary/elemental/releases/download/elemental-#{version}/elemental-#{version}.dmg",
+      verified: "github.com/evolvedbinary/elemental/"
+  name "elemental"
+  desc "Native XML Database with XQuery and XSLT"
+  homepage "https://www.elemental.xyz/"
+
+  app "Elemental.app"
+
+  zap trash: "~/Library/Application Support/xyz.elemental"
+
+  caveats do
+    depends_on_java "8"
+  end
+end


### PR DESCRIPTION
I would like to submit Elemental to Homebrew. Elemental is a fork of eXist-db (which is already in Homebrew: https://formulae.brew.sh/cask/exist-db). I (`adamretter`) have been the main developer of eXist-db for the last 8 years, contributing over 80% of all changes, see: https://github.com/eXist-db/exist/graphs/contributors

I have created the last 22 releases of eXist-db, see: https://github.com/eXist-db/exist/releases
The eXist-db project has a notable GitHub project, but Elemental does not as it is a new repo, and so Elemental is failing the Homebrew `GitHub repository not notable enough` check.

However as Elemental starts at version 6.4.0, and eXist-db stopped at version 6.3.0. It would seem sensible to view this more as a "name change" than a new project and that many users would likely want to migrate from eXist-db to Elemental. Would you consider accepting Elemental into Homebrew please?

---
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---
