### PR TITLE
reaper 7.37

### DIFF
--- a/Casks/r/reaper.rb
+++ b/Casks/r/reaper.rb
@@ -1,8 +1,8 @@
 cask "reaper" do
-  version "7.36"
+  version "7.37"
 
   on_mojave :or_older do
-    sha256 "987e46b3911ec6168af0477ba6d925ba1ec6a29bd0742a9d9084096e2971c4f1"
+    sha256 "5a0225986dd66cba3768c3f2ecdfbd6613e9d5be5996e51d80b137a5e341dc22"
 
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
 
@@ -11,7 +11,7 @@ cask "reaper" do
     end
   end
   on_catalina :or_newer do
-    sha256 "fbe2d60273943557b710e9013251e2cda0524390760c93e13544fcc36993ba22"
+    sha256 "38bf60704171d2b9d5aefdd40ac4b43880993a5b6a882804ff7914bbe7e6adb2"
 
     url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_universal.dmg"
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

[failed in last autobump](https://github.com/Homebrew/homebrew-cask/actions/runs/14711698145/job/41285448142#step:6:5527), as far as I remember it also failed in previous autobump at the 7.36 version upgrade, should it be deleted from autobump list or is it fixable?

