### PR TITLE
retroarch, retroarch-metal 1.21.0

### DIFF
--- a/Casks/r/retroarch-metal.rb
+++ b/Casks/r/retroarch-metal.rb
@@ -1,5 +1,5 @@
 cask "retroarch-metal" do
-  version "1.20.0"
+  version "1.21.0"
   sha256 :no_check # required as upstream package is often updated in place
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/universal/RetroArch_Metal.dmg",

--- a/Casks/r/retroarch.rb
+++ b/Casks/r/retroarch.rb
@@ -1,5 +1,5 @@
 cask "retroarch" do
-  version "1.20.0"
+  version "1.21.0"
   sha256 :no_check # required as upstream package is often updated in place
 
   url "https://buildbot.libretro.com/stable/#{version}/apple/osx/x86_64/RetroArch.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Running `brew audit --cask --online retroarch` results in `Error: Cask 'retroarch' is unavailable: No Cask with this name exists.`. Same error for `retroarch-metal` as well but they are available online according to these pages:
- `retroarch`: https://formulae.brew.sh/cask/retroarch
- `retroarch-metal`:  https://formulae.brew.sh/cask/retroarch-metal#default

<img width="553" alt="homebre-cask-retroarch-audit-command-error" src="https://github.com/user-attachments/assets/02d0a133-3f4a-4bcb-b9e3-d7261d65a6d5" />
