### PR TITLE
Add cask: joltnotes-lite

### DIFF
--- a/Casks/joltnotes-lite.rb
+++ b/Casks/joltnotes-lite.rb
@@ -1,0 +1,16 @@
+cask "joltnotes-lite" do
+  version "1.0.0"
+  sha256 "9dba50767ef4fc2137ed118db33526ef93ad6ea5de1e866e172d8bef251ada2d"
+
+  url "https://github.com/Mineman130Dev/Notes-App-JoltNotes/releases/download/v1.0/JoltNotesLite.zip"
+  name "JoltNotes Lite"
+  desc "Simple and lightweight note-taking application"
+  homepage "https://github.com/Mineman130Dev/Notes-App-JoltNotes"
+
+  app "JoltNotesLite.app"
+
+  zap trash: [
+    "~/Library/Application Support/JoltNotesLite",
+    "~/Library/Preferences/com.mineman130.joltnoteslite.plist", # Ensure this is correct
+  ]
+end


### PR DESCRIPTION
Add cask: joltnotes-lite

- [x] The submission is for a stable version.
- [ ] `brew audit --cask --online joltnotes-lite` is error-free.
- [x] `brew style --fix Casks/joltnotes-lite.rb` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the token reference.
- [ ] Checked the cask was not already refused (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new joltnotes-lite` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask joltnotes-lite` worked successfully.
- [x] `brew uninstall --cask joltnotes-lite` worked successfully.

---
Adds a Cask for JoltNotes Lite.

JoltNotes Lite is a simple and lightweight note-taking application for macOS. It offers a clean and distraction-free interface for users who need a basic solution for creating and managing notes.

This Cask downloads the application from its GitHub releases page. I have tested this Cask locally, and it installs and uninstalls JoltNotes Lite correctly.

Homepage: https://github.com/Mineman130Dev/Notes-App-JoltNotes
