### PR TITLE
Update SHA256 ARM hash for 1password

### DIFF
--- a/Casks/1/1password.rb
+++ b/Casks/1/1password.rb
@@ -2,7 +2,7 @@ cask "1password" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "8.10.74"
-  sha256 arm:   "8b547c094b6e0506a05e92b80170205123e59a98b93995a9e06d5475bc3c5e1c",
+  sha256 arm:   "96323a92e9162e1f3aec197479802c9bfe9fec9e4c34d8a6c2e7f6f1a6f9f6d2",
          intel: "62238cb4b62137530b987450eca659dea90eb05f30655ee826674d3c6e5a636b"
 
   url "https://downloads.1password.com/mac/1Password-#{version}-#{arch}.zip"

--- a/Casks/1/1password.rb
+++ b/Casks/1/1password.rb
@@ -3,7 +3,7 @@ cask "1password" do
 
   version "8.10.74"
   sha256 arm:   "96323a92e9162e1f3aec197479802c9bfe9fec9e4c34d8a6c2e7f6f1a6f9f6d2",
-         intel: "62238cb4b62137530b987450eca659dea90eb05f30655ee826674d3c6e5a636b"
+         intel: "863913199234f877ffd2ec4310b97d7e0689a7204e84bfcea6f2073f5572a619"
 
   url "https://downloads.1password.com/mac/1Password-#{version}-#{arch}.zip"
   name "1Password"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

SHA256 hash for 1password 8.10.74 ARM is wrong for some reason -- possibly a new package was uploaded with the same version number. I have updated it with the correct value (which I also double-checked against the  package)