### PR TITLE
theiaide: add ARM support

### DIFF
--- a/Casks/t/theiaide.rb
+++ b/Casks/t/theiaide.rb
@@ -1,16 +1,19 @@
 cask "theiaide" do
-  version "1.60.200"
-  sha256 "c83ad723f7d3adb751c06d924cac6317eba8147533a5191e3b07626105ace53b"
+  arch arm: "-arm"
 
-  url "https://download.eclipse.org/theia/ide/#{version}/macos/TheiaIDE.dmg",
+  version "1.60.200"
+  sha256 arm:   "694e51126c637ce74b3ff707f081bf790ed8509dcd36bb5c5099e09931791972",
+         intel: "c83ad723f7d3adb751c06d924cac6317eba8147533a5191e3b07626105ace53b"
+
+  url "https://download.eclipse.org/theia/ide/#{version}/macos#{arch}/TheiaIDE.dmg",
       verified: "download.eclipse.org/theia/ide/"
   name "TheiaIDE"
   desc "IDE framework"
   homepage "https://theia-ide.org/"
 
   livecheck do
-    url "https://download.eclipse.org/theia/ide/latest/macos/"
-    regex(/href=.*?TheiaIDE[._-]v?(\d+(?:\.\d+)+)(?:-mac)?\.zip/i)
+    url "https://download.eclipse.org/theia/ide/latest/macos#{arch}/latest-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true
@@ -26,8 +29,4 @@ cask "theiaide" do
     "~/Library/Preferences/eclipse.theia.plist",
     "~/Library/Saved Application State/eclipse.theia.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ a stable version] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Eclipse Theia added support for ARM so you no longer need Rosetta 2 to run it if you are on ARM