### PR TITLE
floorp 11.26.0

### DIFF
--- a/Casks/f/floorp.rb
+++ b/Casks/f/floorp.rb
@@ -1,17 +1,12 @@
 cask "floorp" do
-  version "11.25.0"
-  sha256 "76225e9b2e13e72f7ad82b420eb6a7d0e0553b2341d32a68c89e4fadf7f273ab"
+  version "11.26.0"
+  sha256 "b2a9de1277e24bd71c41fba7f86cfbe3876ab7675edc697f1639d99d310cd161"
 
   url "https://github.com/Floorp-Projects/Floorp/releases/download/v#{version}/floorp-macOS-universal.dmg",
       verified: "github.com/Floorp-Projects/Floorp/"
   name "Floorp browser"
   desc "Privacy-focused Firefox-based browser"
   homepage "https://floorp.app/"
-
-  livecheck do
-    url "https://floorp.app/en/download"
-    regex(%r{/v?(\d+(?:\.\d+)+)/floorp[._-]macOS[._-]universal\.dmg}i)
-  end
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
Switching to git tags since the download page uses Javascript now. Closes #210836.