### PR TITLE
cernbox: downgrade to 5.2.1.13464

### DIFF
--- a/Casks/c/cernbox.rb
+++ b/Casks/c/cernbox.rb
@@ -1,18 +1,24 @@
 cask "cernbox" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "5.3.2.15486"
-  sha256 arm:   "d421a2e07f546bac998c64f2f93db8ed8ee0c17125c538a77a9440d46f080195",
-         intel: "12c8ba2c90bdf08a63c7540b7dcc7c048db610745b1e834167237b3068e8c739"
+  version "5.2.1.13464"
+  sha256 arm:   "9d41958720d3c796ce265a71820975aa208de006f7115c9d67d040b0a2349517",
+         intel: "aa1d3e29201167f519a7c121ff8882430f7982ca44a9c18909624badea9259f0"
 
   url "https://cernbox.cern.ch/cernbox/doc/MacOSX/cernbox-#{version}-#{arch}.pkg"
   name "CERNBox Client"
   desc "Cloud storage for CERN users"
   homepage "https://cernbox.web.cern.ch/cernbox/"
 
+  # The download page contains links for both stable and unstable versions.
+  # This only uses the first match on the page, which should be the stable
+  # version.
   livecheck do
-    url "https://cernbox.cern.ch/cernbox/doc/MacOSX/"
+    url "https://cernbox.web.cern.ch/cernbox/downloads/"
     regex(/href=.*?cernbox[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.pkg/i)
+    strategy :page_match do |page, regex|
+      page[regex, 1]
+    end
   end
 
   pkg "cernbox-#{version}-#{arch}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This downgrades `cernbox` to the latest stable version, 5.2.1.13464. 5.3.2.15486 is a beta version, so we shouldn't have updated the cask to 5.3.x versions yet. The filename format is the same for both stable and unstable versions, so livecheck is returning a beta version as the newest version because it's highest.

With that in mind, this updates the `livecheck` block to check the first-party download page (instead of the directory listing page), as it distinguishes between stable and unstable versions. At the moment, the stable version appears first on the page and the beta version is second, so I've added a `strategy` block that only uses the first match. This should be fine for now but it could break if upstream changes the structure of the page.