### PR TITLE
dolphin@dev 2503a-444

### DIFF
--- a/Casks/d/dolphin@dev.rb
+++ b/Casks/d/dolphin@dev.rb
@@ -1,6 +1,6 @@
 cask "dolphin@dev" do
-  version "2503-253,97,82"
-  sha256 "f33668269938ccfc8d90eb73ff83b65d78f41ba1f93f731473d5320f73e59e68"
+  version "2503a-444,9f,5c"
+  sha256 "2b695402740d749e8fcfa636d9e762cff7be3c5961e5ab178b6f904944d087cf"
 
   url "https://dl.dolphin-emu.org/builds/#{version.csv.second}/#{version.csv.third}/dolphin-master-#{version.csv.first}-universal.dmg"
   name "Dolphin Dev"
@@ -9,7 +9,7 @@ cask "dolphin@dev" do
 
   livecheck do
     url "https://dolphin-emu.org/download/"
-    regex(%r{href=.*?/builds/([^/]+?)/([^/]+?)/dolphin[._-]master[._-]v?(\d+(?:[.-]\d+)+)-universal\.dmg}i)
+    regex(%r{href=.*?/builds/([^/]+?)/([^/]+?)/dolphin[._-]master[._-]v?(\d+[a-z]?-\d+)-universal\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[2]},#{match[0]},#{match[1]}" }
     end
@@ -19,7 +19,7 @@ cask "dolphin@dev" do
     "dolphin",
     "dolphin@beta",
   ]
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Dolphin.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `dolphin@dev` to the latest development version, 2503a-444. The cask had been stuck on an older version because the regex wasn't able to match versions due to the letter at the end of the first part (2503a). This updates the regex to be able to match this format.

Besides that, this updates the macOS dependency to resolve the related audit failure ("Upstream defined :big_sur as the minimum OS version but the cask declared :catalina").