### PR TITLE
jottacloud 25.04.28.135128

### DIFF
--- a/Casks/j/jottacloud.rb
+++ b/Casks/j/jottacloud.rb
@@ -1,8 +1,8 @@
 cask "jottacloud" do
-  version "25.03.25.132613,762a71b29db6fbcf9a669580e4dd63b83289f74af89a44c03b5c767c630736c2"
-  sha256 "762a71b29db6fbcf9a669580e4dd63b83289f74af89a44c03b5c767c630736c2"
+  version "25.04.28.135128,9a2964b65e21c157fe767e0cd4cb342a94b6c9c679531f330d9ff4fc21c04b96"
+  sha256 "9a2964b65e21c157fe767e0cd4cb342a94b6c9c679531f330d9ff4fc21c04b96"
 
-  url "https://sw.jotta.cloud/desktop/download/data/#{version.csv.second}/Jottacloud%20Installer.dmg",
+  url "https://sw.jotta.cloud/desktop/download/data/#{version.csv.second}/Jottacloud.dmg",
       verified: "sw.jotta.cloud/"
   name "Jottacloud"
   desc "Client for the Jottacloud cloud storage service"
@@ -10,7 +10,7 @@ cask "jottacloud" do
 
   livecheck do
     url "https://sw.jotta.cloud/desktop/appcast/CUST/release"
-    regex(%r{/([^/]+)/Jottacloud\sInstaller\.dmg})
+    regex(%r{/([^/]+)/Jottacloud(?:\s*Installer)?\.dmg})
     strategy :sparkle do |item, regex|
       id = item.url[regex, 1]
       next if id.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `jottacloud` to the latest version, 25.04.28.135128.

The existing `livecheck` block is returning an "Unable to get versions" error, as the filename is now `Jottacloud.dmg`. This updates the regex to make the previous " Installer" part optional, so it will match both the previous and current filename formats.