### PR TITLE
skype*: deprecate

### DIFF
--- a/Casks/s/skype-for-business.rb
+++ b/Casks/s/skype-for-business.rb
@@ -7,10 +7,7 @@ cask "skype-for-business" do
   desc "Microsofts instant messaging enterprise software"
   homepage "https://www.microsoft.com/en-us/download/details.aspx?id=54108"
 
-  livecheck do
-    url :homepage
-    regex(/SkypeForBusinessInstaller[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
-  end
+  deprecate! date: "2025-05-05", because: :discontinued
 
   auto_updates true
   depends_on cask: "microsoft-auto-update"

--- a/Casks/s/skype.rb
+++ b/Casks/s/skype.rb
@@ -7,10 +7,7 @@ cask "skype" do
   desc "Video chat, voice call and instant messaging application"
   homepage "https://www.skype.com/"
 
-  livecheck do
-    url "https://get.skype.com/go/getskype-skypeformac"
-    strategy :header_match
-  end
+  deprecate! date: "2025-05-05", because: :discontinued
 
   auto_updates true
   conflicts_with cask: "skype@preview"

--- a/Casks/s/skype@preview.rb
+++ b/Casks/s/skype@preview.rb
@@ -5,12 +5,9 @@ cask "skype@preview" do
   url "https://download.skype.com/s4l/download/mac/Skype-#{version}.dmg"
   name "Skype Preview"
   desc "Video chat, voice call and instant messaging application"
-  homepage "https://www.skype.com/en/insider/"
+  homepage "https://www.skype.com"
 
-  livecheck do
-    url "https://get.skype.com/go/getskype-skypeformacinsider"
-    strategy :header_match
-  end
+  deprecate! date: "2025-05-05", because: :discontinued
 
   auto_updates true
   conflicts_with cask: "skype"

--- a/Casks/s/skype@preview.rb
+++ b/Casks/s/skype@preview.rb
@@ -5,7 +5,7 @@ cask "skype@preview" do
   url "https://download.skype.com/s4l/download/mac/Skype-#{version}.dmg"
   name "Skype Preview"
   desc "Video chat, voice call and instant messaging application"
-  homepage "https://www.skype.com"
+  homepage "https://www.skype.com/"
 
   deprecate! date: "2025-05-05", because: :discontinued
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Skype is officially retired.  https://support.microsoft.com/en-us/skype/skype-is-retiring-in-may-2025-what-you-need-to-know-2a7d2501-427f-485e-8be0-2068a9f90472

Updated the `skype@preview` homepage to the standard Skype homepage as the insider page is gone.