### PR TITLE
aqua-voice 0.3.10 (new cask)

### DIFF
--- a/Casks/a/aqua-voice.rb
+++ b/Casks/a/aqua-voice.rb
@@ -12,10 +12,13 @@ cask "aqua-voice" do
   homepage "https://withaqua.com/"
 
   livecheck do
-    url "https://withaqua.com/download/"
-    regex(/href=.*?Aqua\+Voice-(\d+(?:\.\d+)+)-#{arch}\.dmg/i)
+    url "https://aqua-desktop-builds.s3.amazonaws.com/aqua-voice-updates/darwin/#{arch}/RELEASES.json"
+    strategy :json do |json|
+      json["currentRelease"]
+    end
   end
 
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Aqua Voice.app"

--- a/Casks/a/aqua-voice.rb
+++ b/Casks/a/aqua-voice.rb
@@ -1,0 +1,28 @@
+cask "aqua-voice" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.3.10"
+  sha256 arm:   "44e77a8a51342edbec168807bad1c1543d87beee98c68ae91668b9e14cad3634",
+         intel: "ac23a0b7577614c26e25a4f5b56ac1c8410ba4ce6dae6724854ca477e3c2d3c0"
+
+  url "https://d1a1dx1sgvjqrz.cloudfront.net/aqua-voice-updates/darwin/#{arch}/Aqua+Voice-#{version}-#{arch}.dmg",
+      verified: "d1a1dx1sgvjqrz.cloudfront.net/"
+  name "Aqua Voice"
+  desc "Speech-to-text system"
+  homepage "https://withaqua.com/"
+
+  livecheck do
+    url "https://withaqua.com/download/"
+    regex(/href=.*?Aqua\+Voice-(\d+(?:\.\d+)+)-#{arch}\.dmg/i)
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Aqua Voice.app"
+
+  zap trash: [
+    "~/Library/Application Support/Aqua Voice",
+    "~/Library/Caches/com.electron.aqua-voice",
+    "~/Library/Logs/Aqua Voice",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online aqua-voice` is error-free.
- [x] `brew style --fix aqua-voice` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new aqua-voice` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aqua-voice` worked successfully.
- [x] `brew uninstall --cask aqua-voice` worked successfully.

---
