### PR TITLE
Add two new fonts (from FounderType)

### DIFF
--- a/Casks/font/font-f/font-fzhei-b01.rb
+++ b/Casks/font/font-f/font-fzhei-b01.rb
@@ -1,0 +1,12 @@
+cask "font-fzhei-b01" do
+  version :latest
+  sha256 :no_check
+
+  url "https://cdn1.foundertype.com/Public/Uploads/ttf/FZHTK.TTF"
+  name "Fangzheng Heiti GBK"
+  homepage "https://www.foundertype.com/index.php/FontInfo/index/id/131"
+
+  font "FZHTK.ttf"
+
+  # No zap stanza required
+end

--- a/Casks/font/font-f/font-fzxiheii-z08.rb
+++ b/Casks/font/font-f/font-fzxiheii-z08.rb
@@ -1,0 +1,12 @@
+cask "font-fzxiheii-z08" do
+  version :latest
+  sha256 :no_check
+
+  url "https://cdn1.foundertype.com/Public/Uploads/ttf/FZXH1K.TTF"
+  name "Fangzheng XiheiI GBK"
+  homepage "https://www.foundertype.com/index.php/FontInfo/index/id/161"
+
+  font "FZXH1K.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

## Add two new FounderType fonts

This PR adds two new fonts from FounderType (方正字库):

1. `font-fzhei-b01` - Founder Fangzheng Heiti GBK (方正黑体GBK)
2. `font-fzxiheii-z08` - Founder Fangzheng XiheiI GBK (方正细黑一GBK)

## Additional Info

- Homebrew Cask already includes 4 FounderType fonts: `font-fzkai-z03`, `font-fzxiaobiaosong-b05`, `font-fzfangsong-z02`, and `font-fzshusong-z01`
- These 6 fonts together form the complete set required by the `ctex` LaTeX package when using the `fontset=founder` option
- With this addition, users can now properly configure the Founder fontset for Chinese typesetting in LaTeX
