### PR TITLE
gns3: update livecheck

### DIFF
--- a/Casks/g/gns3.rb
+++ b/Casks/g/gns3.rb
@@ -10,9 +10,13 @@ cask "gns3" do
   desc "GUI for the Dynamips Cisco router emulator"
   homepage "https://www.gns3.com/"
 
+  # Upstream creates releases for multiple major versions and the "latest"
+  # release isn't guaranteed to be the highest version, so we have to use the
+  # `GithubReleases` strategy. Unfortunately, the download page on www.gns3.com
+  # simply uses the "latest" GitHub release version, so it's also affected.
   livecheck do
     url :url
-    strategy :github_latest
+    strategy :github_releases
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `gns3` uses the `GithubLatest` strategy but upstream creates releases for multiple major versions (e.g., 3.0.4, 2.2.54) and the "latest" release isn't guaranteed to be the highest version. Unfortunately, the download page on www.gns3.com simply uses the "latest" GitHub release version, so it's also affected.

At the moment, 2.2.54 is the "latest" release but the highest version is 3.0.4 (the previous release). This addresses the issue by updating the `livecheck` block to use the `GithubReleases` strategy.