### PR TITLE
workflow/autobump: stop relying on `autobump.txt` file

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -36,15 +36,21 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
-      - name: Get list of autobump casks
-        id: autobump
-        run: echo "autobump_list=$(xargs < "$(brew --repo homebrew/cask)"/.github/autobump.txt)" >> "$GITHUB_OUTPUT"
-
-      - name: Bump casks
+      - name: Bump input casks
         uses: Homebrew/actions/bump-packages@master
         continue-on-error: true
+        if: ${{ github.event.inputs.casks }}
         with:
           token: ${{ secrets.HOMEBREW_CASK_REPO_WORKFLOW_TOKEN }}
-          casks: ${{ github.event.inputs.casks || steps.autobump.outputs.autobump_list }}
+          casks: ${{ github.event.inputs.casks }}
         env:
           HOMEBREW_TEST_BOT_AUTOBUMP: 1
+
+      - name: Bump casks
+        if: ${{ ! github.event.inputs.casks }}
+        with:
+          HOMEBREW_TEST_BOT_AUTOBUMP: 1
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CASK_REPO_WORKFLOW_TOKEN }}
+          HOMEBREW_GIT_COMMITTER_NAME: BrewTestBot
+          HOMEBREW_GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
+        run: brew bump --no-fork --open-pr --cask --auto --tap=Homebrew/cask


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
