### PR TITLE
exist-db 6.4.0

### DIFF
--- a/Casks/e/exist-db.rb
+++ b/Casks/e/exist-db.rb
@@ -1,6 +1,6 @@
 cask "exist-db" do
-  version "6.3.0"
-  sha256 "4cb5858e2f1f0e5b8e74217c9cea7d85c31292120883e672d87e636374b46412"
+  version "6.4.0"
+  sha256 "96eb36111abc43786536a26de6437b2e675bf7ae4780633d37d832b0fe6c28c2"
 
   url "https://github.com/eXist-db/exist/releases/download/eXist-#{version}/eXist-db-#{version}.dmg",
       verified: "github.com/eXist-db/exist/"
@@ -14,6 +14,5 @@ cask "exist-db" do
 
   caveats do
     depends_on_java "8"
-    requires_rosetta
   end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

A few notes about this PR:
 
- With this version (6.4.0), the `exist-db` cask longer requires Rosetta, so I removed the Rosetta caveat.
- I had tried `bump-cask-pr` first and got a notice that BrewTestBot would automatically perform bump-cask-pr 3 hours after the release, but >4 hours have passed with no PR.
- A PR with the Rosetta caveat change was needed anyway, so I bundled both the version bump and caveat change into this PR.