### PR TITLE
session 1.16.0

### DIFF
--- a/Casks/s/session.rb
+++ b/Casks/s/session.rb
@@ -1,8 +1,12 @@
 cask "session" do
-  version "1.15.2"
-  sha256 "1472c3a5be3b559eed16c1db18ec0139babcbac3621ac40bc88b64f97384a994"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://github.com/session-foundation/session-desktop/releases/download/v#{version}/session-desktop-mac-x64-#{version}.dmg",
+  version "1.16.0"
+  sha256 arm:
+                "29f767b92aeaca116e0680b1cbb8950f68bd8a6b0682d807435a5859085c06ea",
+         intel: "12fad84567dff4b4ae799508d0aa9606777cc969d8c864105c2cd83c3bd49e93"
+
+  url "https://github.com/session-foundation/session-desktop/releases/download/v#{version}/session-desktop-mac-#{arch}-#{version}.dmg",
       verified: "github.com/session-foundation/session-desktop/"
   name "Session"
   desc "Onion routing based messenger"
@@ -13,6 +17,7 @@ cask "session" do
     strategy :github_latest
   end
 
+  auto_updates true
   depends_on macos: ">= :ventura"
 
   app "Session.app"
@@ -23,8 +28,4 @@ cask "session" do
     "~/Library/Preferences/com.loki-project.messenger-desktop.plist",
     "~/Library/Saved Application State/com.loki-project.messenger-desktop.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - Error `Upstream defined :big_sur as the minimum OS version but the cask declared :ventura`
  - Required version is now Ventura see Release Notes https://github.com/session-foundation/session-desktop/releases/tag/v1.16.0#user-content-supported-platforms
- [x] `brew style --fix <cask>` reports no offenses.
---

Hello I'm on the Session Desktop dev team, with the release of 1.16.0 we have added arm64 support to Session 💪

I have commented on https://github.com/Homebrew/homebrew-cask/pull/211409 and hope this PR can replace that one.

See confirmation of arm64 support on https://getsession.org/download

Thanks 🙏