### PR TITLE
Update logitune lifecheck URL

### DIFF
--- a/Casks/l/logitune.rb
+++ b/Casks/l/logitune.rb
@@ -1,5 +1,5 @@
 cask "logitune" do
-  version "3.7.187"
+  version "3.9.168"
   sha256 :no_check
 
   url "https://software.vc.logitech.com/downloads/tune/LogiTuneInstaller.dmg"
@@ -8,7 +8,7 @@ cask "logitune" do
   homepage "https://www.logitech.com/en-us/video-collaboration/software/logi-tune-software.html"
 
   livecheck do
-    url "https://prosupport.logi.com/api/v2/help_center/de/articles.json?label_names=webcontent=productdownload,webproduct=bad331b5-1feb-11ea-ae1b-a561623ae541"
+    url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,websoftware=ef17cf4f-8e0b-11e9-9708-775e53090089"
     regex(/Software[\s-]Version:.*?v?(\d+(?:\.\d+)+)/i)
     strategy :json do |json, regex|
       json["articles"]&.map do |item|


### PR DESCRIPTION
Update the livecheck URL for logitune to support the installation of new versions (3.9.168).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
