### PR TITLE
middleclick 3.0.1

### DIFF
--- a/Casks/m/middleclick.rb
+++ b/Casks/m/middleclick.rb
@@ -1,6 +1,6 @@
 cask "middleclick" do
-  version "3.0.0"
-  sha256 "e80bc000bc8370349c83648307f5443dfa3e7cac3f67faaad589bceebec9fc33"
+  version "3.0.1"
+  sha256 "5b512d9d76f83a019c630c240292906682cea1c085fd834030a798e091640589"
 
   url "https://github.com/artginzburg/MiddleClick/releases/download/#{version}/MiddleClick.zip"
   name "MiddleClick"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online middleclick` is error-free.
- [x] `brew style --fix middleclick` reports no offenses.

---

Bumping this manually because it's been 5 hours since the release, and BrewTestBot did not create a PR yet.