### PR TITLE
stolendata-mpv tarball format change and 0.40.0

### DIFF
--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -2,8 +2,8 @@ cask "stolendata-mpv" do
   arch arm: "-arm64"
 
   on_arm do
-    version "0.39.0"
-    sha256 "9c81c5cf2e756cf9c2fef97a00627140ea7c6b46079469ce3b1a13b4cd4f5b2b"
+    version "0.40.0"
+    sha256 "3170fb709defebaba33e9755297d70dc3562220541de54fc3d494a8309ef1260"
 
     livecheck do
       url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
@@ -40,9 +40,15 @@ cask "stolendata-mpv" do
 
   conflicts_with formula: "mpv"
 
-  app "mpv.app"
+  xtar_root = if version >= "0.40.0"
+    "mpv#{arch}-#{version}/"
+  else
+    ""
+  end
+
+  app "#{xtar_root}mpv.app"
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"
-  manpage "documentation/man/mpv.1"
+  manpage "#{xtar_root}documentation/man/mpv.1"
 
   zap trash: [
     "~/.config/mpv",

--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -11,6 +11,9 @@ cask "stolendata-mpv" do
     end
 
     depends_on macos: ">= :sonoma"
+
+    app "mpv#{arch}-#{version}/mpv.app"
+    manpage "mpv#{arch}-#{version}/documentation/man/mpv.1"
   end
   on_intel do
     on_catalina :or_older do
@@ -30,6 +33,9 @@ cask "stolendata-mpv" do
         regex(/mpv-(\d+(?:\.\d+)+)\.t/i)
       end
     end
+
+    app "mpv.app"
+    manpage "documentation/man/mpv.1"
   end
 
   url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv#{arch}-#{version}.tar.gz",
@@ -40,15 +46,7 @@ cask "stolendata-mpv" do
 
   conflicts_with formula: "mpv"
 
-  xtar_root = if version >= "0.40.0"
-    "mpv#{arch}-#{version}/"
-  else
-    ""
-  end
-
-  app "#{xtar_root}mpv.app"
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"
-  manpage "#{xtar_root}documentation/man/mpv.1"
 
   zap trash: [
     "~/.config/mpv",


### PR DESCRIPTION
The tarball format for `stolendata-mpv-0.40.0` changed to now extract into a new directory and not the current working directory. This PR both updates the arm64 release to `0.40.0` and adds an extracted root dir as needed.. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
