### PR TITLE
lunarbar 1.4.3

### DIFF
--- a/Casks/l/lunarbar.rb
+++ b/Casks/l/lunarbar.rb
@@ -1,6 +1,6 @@
 cask "lunarbar" do
-  version "1.4.2"
-  sha256 "4323fac011a3b878ec949a50a7d51e7a101dcba2657bd49201b448e92bd884b3"
+  version "1.4.3"
+  sha256 "7f2ab19b68fac51c842d468f43ddaaadaebcd9ff37d6f66568afdbf69e8b1210"
 
   url "https://github.com/LunarBar-app/LunarBar/releases/download/v#{version}/LunarBar-#{version}.dmg"
   name "LunarBar"


### PR DESCRIPTION
I've veried:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Note this PR was not created using `bump-cask-pr` because I hit this:

```
Error: Whoops, the lunarbar cask has its version update
pull requests automatically opened by BrewTestBot every ~3 hours!
We'd still love your contributions, though, so try another one
that is excluded from autobump list (i.e. it has 'no_autobump!'
method or 'livecheck' block with 'skip'.)
```

Is this an error? I don't see `lunarbar` in [autobump.txt](https://github.com/Homebrew/homebrew-cask/blob/master/.github/autobump.txt).