### PR TITLE
Revert "logseq 0.10.10"

### DIFF
--- a/Casks/l/logseq.rb
+++ b/Casks/l/logseq.rb
@@ -1,9 +1,9 @@
 cask "logseq" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.10.10"
-  sha256 arm:   "7a9e40d8617dbf1d70bf6cf018ee8a737e35ca81bb896142bef271409419d96f",
-         intel: "40d62d82a797a3c269bea4cde43f015473cb311d2a629ff4d64bd0e6c7d5b97d"
+  version "0.10.9"
+  sha256 arm:   "64ec0b6b818ab2a449bfd0aae4494578ac2d251a0575e5ce24e78999451df4cd",
+         intel: "a4560dfbff7f1b6142d6a1ed82db3f7fdd7626fb64e2d5c230c045245a1cfedf"
 
   url "https://github.com/logseq/logseq/releases/download/#{version}/logseq-darwin-#{arch}-#{version}.dmg"
   name "Logseq"


### PR DESCRIPTION
This reverts commit 8ba736f14efa1e6e7dc95b5aaf2e1b21ab12721e / #211470

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Fixes #211766 