### PR TITLE
fmail2 2.8.4

### DIFF
--- a/Casks/f/fmail2.rb
+++ b/Casks/f/fmail2.rb
@@ -1,16 +1,16 @@
 cask "fmail2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  version "2.8.3"
-  sha256 "92c33507afd1be0f679095131401369200e94a3851c1f9c20537043e61c49a4d"
+  version "2.8.4"
+  sha256 "d96fbbeabc1a8a0d9eb098b2dab9a305081a947c532791d3ba70b68f248c0e39"
 
-  url "https://arievanboxel.fr/fmail2/sparkle/FMail2_#{version.no_dots}.zip",
-      verified: "arievanboxel.fr/fmail2/sparkle/"
+  url "https://fmail.appmac.fr/update/sparkle/FMail2_#{version.no_dots}.zip",
+      verified: "fmail.appmac.fr/update/sparkle/"
   name "FMail2"
   desc "Unofficial native application for Fastmail"
-  homepage "https://fmail-app.fr/"
+  homepage "https://fmail.arievanboxel.fr/"
 
   livecheck do
-    url "https://arievanboxel.fr/fmail2/sparkle/appcast.xml"
+    url "https://fmail.appmac.fr/update/sparkle/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`fmail2` is in the autobump list but the 2.8.4 update is failing because the URLs have changed with the 2.8.4 update, so this modifies the following URLs while updating the cask version:

* `url`: Use the zip URL from the appcast
* `homepage`: Update to resolve redirection
* `livecheck`: Update to align with the cask `url` source