### PR TITLE
pcoipclient 25.03.2

### DIFF
--- a/Casks/p/pcoipclient.rb
+++ b/Casks/p/pcoipclient.rb
@@ -1,14 +1,14 @@
 cask "pcoipclient" do
-  version "25.03.1"
-  sha256 "dd86ae92028983baadbf1c02112e479f834f6b2015657fec63b935df3f52e47e"
+  version "25.03.2"
+  sha256 "d3b123e57fa5b8168f83d311faea86882e09dd93e1e3a830e5496002180325eb"
 
-  url "https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/#{version}/pcoip-client_#{version}.dmg"
+  url "https://dl.anyware.hp.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/#{version}/pcoip-client_#{version}.dmg"
   name "Teradici PCoIP Software Client for macOS"
   desc "Client for VM agents and remote workstation cards"
-  homepage "https://docs.teradici.com/find/product/software-and-mobile-clients/"
+  homepage "https://anyware.hp.com/find/product/hp-anyware"
 
   livecheck do
-    url "https://dl.teradici.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg"
+    url "https://dl.anyware.hp.com/DeAdBCiUYInHcSTy/pcoip-client/raw/names/pcoip-client-dmg/versions/latest/pcoip-client_latest.dmg"
     strategy :header_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`pcoipclient` is in the autobump list but the latest update, 25.03.2, is failing because some of the cask URLs are unreachable (whether temporarily or permanently). While looking into this, I saw that the `livecheck` block URL redirects to dl.anyware.hp.com, so this updates the cask `url` and `livecheck` block URL accordingly.

This also updates the `homepage` URL to reference an upstream HP anywhere page but there may be a better option.