### PR TITLE
repo-prompt 1.2.3

### DIFF
--- a/Casks/r/repo-prompt.rb
+++ b/Casks/r/repo-prompt.rb
@@ -1,8 +1,8 @@
 cask "repo-prompt" do
-  version "1.2.1"
-  sha256 "9c649f06a8dcd76c6084c950472e352e9dbc6018b931c069f07ae19bd0fb3707"
+  version "1.2.3"
+  sha256 "9bbc637544af26a972bac4eff4d57ec72ab7a021c1b76df00e54c978a80b0ccc"
 
-  url "https://repoprompt.s3.us-east-2.amazonaws.com/RepoPrompt-#{version}.dmg",
+  url "https://repoprompt.s3.us-east-2.amazonaws.com/RepoPrompt_#{version}.dmg",
       verified: "repoprompt.s3.us-east-2.amazonaws.com/"
   name "Repo Prompt"
   desc "Prompt generation tool"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`repo-prompt` is in the autobump list but the 1.2.3 update is failing because the delimiter in the filename changed from a hyphen to an underscore (i.e., `-` to `_`). This updates the `url` while updating the version.