### PR TITLE
deprecate: barrier add: input-leap as replacement

### DIFF
--- a/Casks/b/barrier.rb
+++ b/Casks/b/barrier.rb
@@ -7,6 +7,8 @@ cask "barrier" do
   desc "Open-source KVM software"
   homepage "https://github.com/debauchee/barrier/"
 
+  deprecate! date: "2025-05-12", because: :unmaintained
+
   depends_on macos: ">= :sierra"
 
   app "Barrier.app"

--- a/Casks/i/input-leap.rb
+++ b/Casks/i/input-leap.rb
@@ -1,0 +1,18 @@
+cask "input-leap" do
+  version "3.0.2"
+  sha256 "e7a27f187e4e97f724e7b0ae9f9490be27d3e81a6cac0e3cf85654b37f28b1a3"
+
+  url "https://github.com/input-leap/input-leap/releases/download/v#{version}/InputLeap_#{version}_macos_AppleSilicon.dmg"
+  name "Input Leap"
+  desc "Open-source KVM software"
+  homepage "https://github.com/input-leap/input-leap"
+
+  depends_on macos: ">= :catalina"
+
+  app "InputLeap.app"
+
+  zap trash: [
+    "~/Library/Application Support/InputLeap",
+    "~/Library/Saved Application State/InputLeap.savedState",
+  ]
+end


### PR DESCRIPTION
[Barrier](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/b/barrier.rb) has been depercated in favour of [InputLeap](https://github.com/input-leap/input-leap), see [last release of Barrier](https://github.com/debauchee/barrier/releases), https://github.com/input-leap/input-leap/issues/1414 and [InputLeap FAQ](https://github.com/input-leap/input-leap#faq---frequently-asked-questions).



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
    <details>
    <summary>audit for input-leap: failed</summary>

	* Barrier was also not notarized
	* Catalina is listed as the minimum supported version on https://github.com/input-leap/input-leap/releases/tag/v3.0.2

	```bash
	 - Upstream defined :sierra as the minimum OS version but the cask declared :catalina
	 - Signature verification failed:
	/private/tmp/cask-audit20250512-68109-jwujn2/InputLeap.app: code has no resources but signature indicates they must be present
	
	macOS on ARM requires software to be signed.
	Please contact the upstream developer to let them know they should sign and notarize their software.
	input-leap
	  * Upstream defined :sierra as the minimum OS version but the cask declared :catalina
	  * line 5, col 2: Signature verification failed:
	    /private/tmp/cask-audit20250512-68109-jwujn2/InputLeap.app: code has no resources but signature indicates they must be present
	    
	    macOS on ARM requires software to be signed.
	    Please contact the upstream developer to let them know they should sign and notarize their software.
	Error: 2 problems in 1 cask detected.
	```
    </details>
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
