### PR TITLE
flying-carpet 9.0.4

### DIFF
--- a/Casks/f/flying-carpet.rb
+++ b/Casks/f/flying-carpet.rb
@@ -1,6 +1,6 @@
 cask "flying-carpet" do
-  version "9.0.0"
-  sha256 "aa05edc1553b88c9662997e0d76d1d8e46f9a97b55ef02cb2491dfb3268f4a46"
+  version "9.0.4"
+  sha256 "686dfec58bbd3cbfd495c74dd5c8c7c7d5fd18b5b0b108e6e44b69d6433ac80a"
 
   url "https://github.com/spieglt/FlyingCarpet/releases/download/v#{version}/macOS_FlyingCarpet_#{version}.zip"
   name "Flying Carpet"

--- a/Casks/f/flying-carpet.rb
+++ b/Casks/f/flying-carpet.rb
@@ -1,5 +1,5 @@
 cask "flying-carpet" do
-  version "9.0.4"
+  version "9.0.4,9.0.0"
   sha256 "686dfec58bbd3cbfd495c74dd5c8c7c7d5fd18b5b0b108e6e44b69d6433ac80a"
 
   url "https://github.com/spieglt/FlyingCarpet/releases/download/v#{version}/macOS_FlyingCarpet_#{version}.zip"
@@ -7,9 +7,27 @@ cask "flying-carpet" do
   desc "File transfer over ad-hoc wifi"
   homepage "https://github.com/spieglt/flyingcarpet"
 
+  # Upstream regularly adds patch versions to existing releases
+  # (e.g., adding 9.0.1 files to the 9.0.0 release), so we append
+  # the tag version if it differs from the file version.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/macOS[._-]FlyingCarpet[._-]v?(\d+(?:\.\d+)+)(?:[._-]|.*\.zip)/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        tag_version = release["tag_name"]&.[](/^v?(\d+(?:\.\d+)+)$/i, 1)
+        next if tag_version.blank?
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          (match[1] == tag_version) ? tag_version : "#{match[1]},#{tag_version}"
+        end
+      end.flatten
+    end
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/f/flying-carpet.rb
+++ b/Casks/f/flying-carpet.rb
@@ -30,7 +30,7 @@ cask "flying-carpet" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :ventura"
 
   app "FlyingCarpet.app"
 

--- a/Casks/f/flying-carpet.rb
+++ b/Casks/f/flying-carpet.rb
@@ -2,7 +2,7 @@ cask "flying-carpet" do
   version "9.0.4,9.0.0"
   sha256 "686dfec58bbd3cbfd495c74dd5c8c7c7d5fd18b5b0b108e6e44b69d6433ac80a"
 
-  url "https://github.com/spieglt/FlyingCarpet/releases/download/v#{version}/macOS_FlyingCarpet_#{version}.zip"
+  url "https://github.com/spieglt/FlyingCarpet/releases/download/v#{version.csv.second || version.csv.first}/macOS_FlyingCarpet_#{version.csv.first}.zip"
   name "Flying Carpet"
   desc "File transfer over ad-hoc wifi"
   homepage "https://github.com/spieglt/flyingcarpet"


### PR DESCRIPTION
This PR performs two tasks:
- Fixes the `flying-carpet` cask: Its `9.0.0` zip file has been updated since https://github.com/Homebrew/homebrew-cask/pull/206687 merged and therefore errors out due to a mismatched SHA256 hash during installation. This appears to be because the `9.0.0` release was replaced-in-place with a macOS-specific `9.0.4` bugfix release.
- Updates it to `9.0.4`: Instead of just fixing the hash, I went ahead and bumped it to properly align the versioning in the Tap and upstream GitHub releases.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I was not able to run `brew audit` and `brew style --fix` on my systems(s) for reasons I haven't been able to debug yet. I can confirm the modified cask installs and uninstalls without error though and my modifications are trivial.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
