### PR TITLE
olive: update livecheck

### DIFF
--- a/Casks/o/olive.rb
+++ b/Casks/o/olive.rb
@@ -1,15 +1,33 @@
 cask "olive" do
-  version "1e3cf53"
+  arch arm: "arm64", intel: "x86_64"
+
+  version "0.1.0,1e3cf53"
   sha256 "9ab6afc7ee9d7fb5083d1a49adea7dc5934bdbf6d635454cae4f8667fbd7c368"
 
-  url "https://olivevideoeditor.org/dl/Olive-#{version}-macOS-x86_64.zip"
+  url "https://github.com/olive-editor/olive/releases/download/#{version.csv.first}/Olive-#{version.csv.second}-macOS.zip",
+      verified: "github.com/olive-editor/olive/"
   name "Olive"
   desc "Non-linear video editor"
   homepage "https://www.olivevideoeditor.org/"
 
+  # The upstream download page (https://www.olivevideoeditor.org/download) says
+  # "Olive will return. Old downloads can be found on GitHub". This has to use
+  # `GithubReleases` for now, as all releases are marked as pre-release.
   livecheck do
-    url "https://www.olivevideoeditor.org/download"
-    regex(/golegacy\?hash=(.*)&type=/i)
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/Olive[._-](\h+)-macOS(?:[._-]#{arch})?\.(?:dmg|zip)}i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          "#{match[1]},#{match[2]}"
+        end
+      end.flatten
+    end
   end
 
   depends_on macos: ">= :sierra"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -39,6 +39,7 @@
   "my-budget": "all",
   "netnewswire@beta": "any",
   "nuclear": "all",
+  "olive": "any",
   "opencloud": "any",
   "openra-playtest": "all",
   "openshot-video-editor@daily": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The first-party website for `olive` now only contains a message saying, "Olive will return. Old downloads can be found on GitHub", so the existing `livecheck` block is returning an `Unable to get versions` error. The URL for the zip file still resolves but there's no way to identify new versions from the first-party website for now.

This updates the cask to use the zip file from GitHub and to update the `livecheck` block to check GitHub releases. There are subsequent releases on GitHub (e.g., 0.1.1, 0.1.2) but they don't have release assets and 1e3cf53 was the last non-development version linked on the [previous download page before it was removed](https://web.archive.org/web/20250331012545/https://www.olivevideoeditor.org/download). The 0.2.0-nightly release has ARM and Intel dmg files but that's a development version, so I figured I would leave the version as-is.

This `livecheck` block will hopefully catch a new version if it uses a stable tag format (e.g., `1.2.3`) and the filename format doesn't change. This situation isn't great but this is maybe better than nothing. [It would be nice to migrate this away from `GithubReleases` whenever possible but that won't happen until releases aren't marked as pre-release or the upstream website provides version information again.] I've also added a numeric version in the process, so that's at least an improvement over using a hash as a version (which causes `Version` comparison issues).