### PR TITLE
deprecate: barrier

### DIFF
--- a/Casks/b/barrier.rb
+++ b/Casks/b/barrier.rb
@@ -7,6 +7,8 @@ cask "barrier" do
   desc "Open-source KVM software"
   homepage "https://github.com/debauchee/barrier/"
 
+  deprecate! date: "2025-05-13", because: :unmaintained
+
   depends_on macos: ">= :sierra"
 
   app "Barrier.app"


### PR DESCRIPTION
[Barrier](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/b/barrier.rb) has been [marked as unmaintained on their GitHub page](https://github.com/debauchee/barrier/releases)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
