### PR TITLE
Add TDengine Cask

### DIFF
--- a/Casks/tdengine.rb
+++ b/Casks/tdengine.rb
@@ -1,0 +1,44 @@
+cask "tdengine" do
+  version "3.3.6.3"
+  sha256 intel: "58a52b25cb5436c330f0f26509b155109cc77b3a77c511ce45ca5b8e381474cf",  # Intel
+         arm:   "8f8496708cc24aa680a12b188162fea7a11e992c3d13a698f0bb0f6fd1673812"  # ARM
+
+  url "https://www.taosdata.com/assets-download/3.0/TDengine-server-#{version}-macOS-#{Hardware::CPU.intel? ? "x64" : "arm64"}.pkg"
+  name "TDengine"
+  desc "Time-Series Database"
+  homepage "https://www.taosdata.com/"
+
+  pkg "TDengine-server-#{version}-macOS-#{Hardware::CPU.intel? ? "x64" : "arm64"}.pkg"
+
+  livecheck do
+    url "https://github.com/taosdata/TDengine/releases/latest"
+    strategy :header_match
+    regex(/(\d+\.\d+\.\d+\.\d+)/)
+  end
+
+  uninstall pkgutil: "com.taosdata.tdengine",
+  script:  {
+    executable: "/usr/local/bin/rmtaos",
+    args:       ["-e", "no"],  # 强制删除
+    sudo:       true,            # 需要sudo权限
+  }
+
+  postflight do
+    puts <<~EOS
+
+      TDengine is installed successfully. Please open an Mac terminal and execute the commands below:
+
+      To configure TDengine, sudo vi /etc/taos/taos.cfg
+      To configure taosadapter, sudo vi /etc/taos/taoadapter.toml
+      To configure taos-explorer, sudo vi /etc/taos/explorer.toml
+      To start service, sudo launchctl start com.tdengine.taosd
+      To start Taos Adapter, sudo launchctl start com.tdengine.taosadapter
+      To start Taos Explorer, sudo launchctl start com.tdengine.taos-explorer
+
+      To start all the components, sudo start-all.sh
+      To access TDengine Commnd Line Interface, taos -h YourServerName
+      To access TDengine Graphic User Interface, http://YourServerName:6060
+      To read the user manual, http://YourServerName:6060/docs-en
+    EOS
+  end
+end


### PR DESCRIPTION
## Description
This PR adds/updates the TDengine Cask for macOS, allowing users to install the latest version via `brew install --cask tdengine`.

## Changes
- **New Cask**: Adds TDengine v3.3.6.3 (or updates from a previous version).
- **Platform Support**: Supports both Intel (`x64`) and Apple Silicon (`arm64`).
- **Installation**: Uses the official `.pkg` installer from [taosdata.com](https://www.taosdata.com/).
- **Uninstall**: Clean removal via `pkgutil`.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
