### PR TITLE
kindle-comic-converter minimum macos-12

### DIFF
--- a/Casks/k/kindle-comic-converter.rb
+++ b/Casks/k/kindle-comic-converter.rb
@@ -16,7 +16,7 @@ cask "kindle-comic-converter" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :monterey"
 
   app "Kindle Comic Converter.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

- https://github.com/ciromattia/kcc/issues/891
- https://github.com/ciromattia/kcc/issues/737
- https://github.com/ciromattia/kcc/blob/master/.github/workflows/package-macos.yml#L28

App is built on macos-13 and macos-14, and seems to run on macos-12 fine, but not on macos-11. I remember seeing somewhere that apps built on macos-13 tend to run fine on macos-12 anyways. If you have the source for this I'd appreciate the link.