### PR TITLE
expresslrs-configurator 1.7.7 (new cask)

### DIFF
--- a/Casks/e/expresslrs-configurator.rb
+++ b/Casks/e/expresslrs-configurator.rb
@@ -1,0 +1,24 @@
+cask "expresslrs-configurator" do
+  version "1.7.7"
+  sha256 "0b42dab2aa3a7c72dfc79ac74ac55e8fa9fdf993be666d2377a0d8429b6092aa"
+
+  url "https://github.com/ExpressLRS/ExpressLRS-Configurator/releases/download/v#{version}/ExpressLRS-Configurator-#{version}.dmg",
+      verified: "github.com/ExpressLRS/ExpressLRS-Configurator/"
+  name "ExpressLRS Configurator"
+  desc "Cross platform configuration & build tool for the ExpressLRS radio link"
+  homepage "https://www.expresslrs.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "ExpressLRS Configurator.app"
+
+  uninstall quit: "org.expresslrs.configurator"
+
+  zap trash: [
+    "~/Library/Application Support/ExpressLRS Configurator",
+    "~/Library/Preferences/org.expresslrs.configurator.plist",
+  ]
+end


### PR DESCRIPTION
New cask for ExpressLRS Configurator used by all FPV drone pilots.

I've tested install/uninstall only for Macos. I couldn't test `audit` commands due to brew installed within Nix configuration on protected storage.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online expresslrs-configurator` is error-free.
- [ ] `brew style --fix expresslrs-configurator` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new expresslrs-configurator` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask expresslrs-configurator` worked successfully.
- [x] `brew uninstall --cask expresslrs-configurator` worked successfully.

---
