### PR TITLE
jetdrive-toolbox 4.5 (new cask)

### DIFF
--- a/Casks/j/jetdrive-toolbox.rb
+++ b/Casks/j/jetdrive-toolbox.rb
@@ -1,0 +1,32 @@
+cask "jetdrive-toolbox" do
+  version "4.5"
+  sha256 "2a52a2d24d22a120c737e5d9a13eceadd7be59751185a0821ef84fdf6f5605f8"
+
+  url "https://cdn.transcend-info.com/files/special/JetDriveToolbox_v#{version}.zip",
+      user_agent: :fake
+  name "JetDrive Toolbox"
+  desc "Helper for Transcend SSDs and expansion cards"
+  homepage "https://www.transcend-info.com/Support/Software-181/"
+
+  livecheck do
+    url "https://www.transcend-info.com/Software/1151/"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :catalina"
+
+  pkg "JetDriveToolbox_v#{version}.pkg"
+
+  uninstall launchctl: "com.transcend.JetDriveToolbox-v2",
+            quit:      "com.transcend.JetDriveToolbox-v2",
+            pkgutil:   "com.transcend.pkg.JetDriveM1",
+            delete:    "/Applications/JetDriveToolbox.app"
+
+  zap trash: [
+    "~/Library/Caches/com.transcend.JetDriveToolbox-v2",
+    "~/Library/HTTPStorages/com.transcend.JetDriveToolbox-v2",
+    "~/Library/Preferences/com.transcend.JetDriveToolbox-v2.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

It's a quite cheap way to expand macbook storage with 1TB SD card from Transcend. Yes it's slow but it works.

The only problem is that MacOS automatically ejects the SD-card when power saving gets toggled and then contents can be corrupted and the SD-card doesn't get automatically mounted when the machine is used next time.

The included cask fixes these power saving issues.
