### PR TITLE
swiftformat-for-xcode 0.56.1

### DIFF
--- a/Casks/s/swiftformat-for-xcode.rb
+++ b/Casks/s/swiftformat-for-xcode.rb
@@ -1,8 +1,8 @@
 cask "swiftformat-for-xcode" do
-  version "0.56.0"
-  sha256 "26d076a64f910aa584954e0633ac5cd0c8a8a6df0c0b08730b6a702cc4a4aa42"
+  version "0.56.1"
+  sha256 "0f7d431e930e16a1aac61a98d4f507f2a295acd4245ff76c8c5adf36fe035e42"
 
-  url "https://github.com/nicklockwood/SwiftFormat/releases/download/#{version}/SwiftFormat.for.Xcode.zip"
+  url "https://github.com/nicklockwood/SwiftFormat/releases/download/#{version}/SwiftFormat.for.Xcode.app.zip"
   name "SwiftFormat for Xcode"
   desc "Xcode Extension for reformatting Swift code"
   homepage "https://github.com/nicklockwood/SwiftFormat"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`swiftformat-for-xcode` is in the autobump list but the 0.56.1 update is failing because the filename unpredictably alternates between `SwiftFormat.for.Xcode.zip` and `SwiftFormat.for.Xcode.app.zip`, so updating breaks with each switch. In this case, the 0.56.0 release did not include `.app` in the filename and 0.56.1 does. This temporarily resolves the issue by manually updating the formula.