### PR TITLE
psychopy: update version and url

### DIFF
--- a/Casks/p/psychopy.rb
+++ b/Casks/p/psychopy.rb
@@ -1,8 +1,8 @@
 cask "psychopy" do
-  version "2025.1.1,2025-05-09_11-38"
+  version "2025.1.1"
   sha256 "9e791fb5323b2ae56f470a37f2a47738282bf2e853b653f44ff793094f3402fc"
 
-  url "https://github.com/psychopy/psychopy/releases/download/#{version.csv.first.major_minor_patch}/StandalonePsychoPy-#{version.csv.first}-macOS#{"_#{version.csv.second}" if version.csv.second}_3.10.dmg",
+  url "https://github.com/psychopy/psychopy/releases/download/#{version.csv.first.major_minor_patch}/StandalonePsychoPy-#{version.csv.first}-macOS#{"_#{version.csv.second}" if version.csv.second}-py3.10.dmg",
       verified: "github.com/psychopy/psychopy/"
   name "PsychoPy"
   desc "Create experiments in behavioral science"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The 2025.1.1 `psychopy` release on GitHub no longer provides the file that the cask currently references, so the download will predictably fail. The current dmg file uses a similar filename as some previous releases (albeit, upstream is inconsistent about the filename format from one release to the next), where there is no second part of the cask `version` and it uses a `-py3.10` suffix instead of `_3.10`. This updates the `version` and `url` accordingly.