### PR TITLE
void 1.99.30033 (new cask)

### DIFF
--- a/Casks/v/void.rb
+++ b/Casks/v/void.rb
@@ -1,0 +1,30 @@
+cask "void" do
+  arch arm: "arm64", intel: "x64"
+
+  version "1.99.30033"
+  sha256 arm:   "cdf28a11fca4542fb9031c4d4874ac7de7b42d9ad2e2a2739b63742cff3b8521",
+         intel: "6f5328a42ee5833af6496001e58f5c49d2bcd2facf3fdee775b2e5734eadacbf"
+
+  url "https://github.com/voideditor/binaries/releases/download/#{version}/Void.#{arch}.#{version}.dmg",
+      verified: "github.com/voideditor/"
+  name "Void"
+  desc "AI code editor"
+  homepage "https://voideditor.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Void.app"
+
+  zap trash: [
+    "~/Library/Application Support/Void",
+    "~/Library/Caches/com.voideditor.Void",
+    "~/Library/Preferences/com.voideditor.Void.plist",
+    "~/Library/Saved Application State/com.voideditor.Void.savedState",
+  ]
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online void is error-free.
- [x] `brew style --fix void` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new void` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask void` worked successfully.
- [x] `brew uninstall --cask void` worked successfully.

---

Note:

```plaintext
brew audit --cask --new void
==> Downloading and extracting artifacts
==> Downloading https://github.com/voideditor/binaries/releases/download/1.99.30033/Void.arm64.1.99.30
Already downloaded: /Users/kayvan/Library/Caches/Homebrew/downloads/daa4dc394f7c6514b9d20897cbbc85eb319f70210c2c8dabd0a63c811cda805d--Void.arm64.1.99.30033.dmg
==> Downloading https://github.com/voideditor/binaries/releases/download/1.99.30033/Void.arm64.1.99.30
Already downloaded: /Users/kayvan/Library/Caches/Homebrew/downloads/daa4dc394f7c6514b9d20897cbbc85eb319f70210c2c8dabd0a63c811cda805d--Void.arm64.1.99.30033.dmg
audit for void: failed
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
void
  * line 8, col 2: GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 cask detected.
```

This is because they use this repo for their binaries: <https://github.com/voideditor/binaries>

The actual repo for Void is this one: <https://github.com/voideditor/void> which has over 1.1k forks and 19.2k stars.