### PR TITLE
mullvadvpn: update livecheck

### DIFF
--- a/Casks/m/mullvadvpn.rb
+++ b/Casks/m/mullvadvpn.rb
@@ -9,8 +9,9 @@ cask "mullvadvpn" do
   homepage "https://mullvad.net/"
 
   livecheck do
-    url "https://mullvad.net/download/vpn/macos"
-    regex(/href=.*?MullvadVPN[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    url "https://mullvad.net/en/download/app/pkg/latest"
+    regex(/MullvadVPN[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    strategy :header_match
   end
 
   conflicts_with cask: "mullvadvpn@beta"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The upstream download page for `mullvadvpn` now only contains generic, redirecting links (instead of links to specific files) and this is causing livecheck to return an `Unable to get versions` error. This updates the `livecheck` block to check the redirecting URL for the latest pkg file using the `HeaderMatch` strategy, matching the version from the filename in the response's `location` header URL.