### PR TITLE
fix hash mismatch for aldante

### DIFF
--- a/Casks/a/aldente.rb
+++ b/Casks/a/aldente.rb
@@ -1,6 +1,6 @@
 cask "aldente" do
   version "1.33"
-  sha256 "b94925c694045555e9d9e64b601a6602c568e73895d33bc74490382518890099"
+  sha256 "d0d50a79ba0907db1bf62e739a750b854b8c4435a0e450cd27376c1e67902086"
 
   url "https://apphousekitchen.com/aldente/AlDente#{version}.dmg"
   name "AlDente"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

```
≻ brew install --cask aldente
==> Upgrading 1 outdated package:
aldente 1.32 -> 1.33
==> Upgrading aldente
==> Downloading https://apphousekitchen.com/aldente/AlDente1.33.dmg
Already downloaded: /Users/shreyansh/Library/Caches/Homebrew/downloads/f1ebcf0ce99ac8edb0831fc648da3c1ae77e9db2bb808fff03dbd8c735f69519--AlDente1.33.dmg
==> Purging files for version 1.33 of Cask aldente
Error: aldente: SHA256 mismatch
Expected: b94925c694045555e9d9e64b601a6602c568e73895d33bc74490382518890099
  Actual: d0d50a79ba0907db1bf62e739a750b854b8c4435a0e450cd27376c1e67902086
    File: /Users/shreyansh/Library/Caches/Homebrew/downloads/f1ebcf0ce99ac8edb0831fc648da3c1ae77e9db2bb808fff03dbd8c735f69519--AlDente1.33.dmg
To retry an incomplete download, remove the file above.
```