### PR TITLE
sketch: update livecheck

### DIFF
--- a/Casks/s/sketch.rb
+++ b/Casks/s/sketch.rb
@@ -19,9 +19,13 @@ cask "sketch" do
     version "101.9,182113"
     sha256 "e6de9d00399f4511711f895c74b909496f690d4f0f4ba66340b158106262e873"
 
+    # Older versions may have a more recent `pubDate` than newer versions, so
+    # we have to check all of the items in the appcast.
     livecheck do
       url "https://download.sketch.com/sketch-versions.xml"
-      strategy :sparkle
+      strategy :sparkle do |items|
+        items.map(&:nice_version)
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `sketch` checks an appcast file but the `Sparkle` strategy is incorrectly returning 100.4,180172 as newest. The 100.4 item has a `pubDate` of 13 May 2025 but the newest item, 101.9, only has a `pubDate` of 12 May 2025. This resolves the issue by adding a `strategy` block that simply collects all item `nice_version` values, ignoring the default strategy sorting.