### PR TITLE
nextcloud-talk 1.1.9 (new cask)

### DIFF
--- a/Casks/n/nextcloud-talk.rb
+++ b/Casks/n/nextcloud-talk.rb
@@ -1,0 +1,24 @@
+cask "nextcloud-talk" do
+  version "1.1.9"
+  sha256 "72dd275f600939d31e5556e59e7118b89c55884f7590d471005ebb68baa97b93"
+
+  url "https://github.com/nextcloud-releases/talk-desktop/releases/download/v#{version}/Nextcloud.Talk-macos-universal.dmg",
+      verified: "github.com/nextcloud-releases/talk-desktop/releases/download/"
+  name "Nextcloud Talk Desktop"
+  desc "Official Nextcloud Talk Desktop client"
+  homepage "https://nextcloud.com/talk/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Nextcloud Talk.app"
+
+  zap trash: [
+    "~/Library/Application Support/Nextcloud Talk",
+    "~/Library/Preferences/com.nextcloud.talk.mac.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

`brew audit --cask --new nextcloud-talk` reported an error:

```
 - GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

However, this is a binary repo only. The source repository (https://github.com/nextcloud/talk-desktop) has 32 forks, 329 stars and 16 wathers. Is it still a relevant warning in this case?

