### PR TITLE
burp-suite@early-adopter 2025.5 (new cask)

### DIFF
--- a/Casks/b/burp-suite@early-adopter.rb
+++ b/Casks/b/burp-suite@early-adopter.rb
@@ -1,0 +1,37 @@
+cask "burp-suite@early-adopter" do
+  arch arm: "MacOsArm64", intel: "MacOsx"
+
+  version "2025.5"
+  sha256 arm:   "3ac138a464a5f796e811f6138ae2b2f46b7eeb7192a3668f4396381922cb82b8",
+         intel: "6dfe1b9f076a54b4d5f9067cb590456ba0a656c0527b462dfc748f31548730f6"
+
+  url "https://portswigger-cdn.net/burp/releases/download?product=community&version=#{version}&type=#{arch}",
+      verified: "portswigger-cdn.net/burp/releases/"
+  name "Burp Suite Community Edition"
+  desc "Web security testing toolkit"
+  homepage "https://portswigger.net/burp/"
+
+  livecheck do
+    url "https://portswigger.net/burp/releases/data"
+    strategy :json do |json|
+      all_versions = json.dig("ResultSet", "Results")
+      next if all_versions.blank?
+
+      all_versions.filter_map do |item|
+        item["version"] if
+              item["releaseChannels"]&.include?("Early Adopter") &&
+              item["categories"]&.include?("Community") &&
+              item["builds"]&.any? do |build|
+                build["ProductPlatform"] == arch.to_s
+              end
+      end
+    end
+  end
+
+  conflicts_with cask: "burp-suite"
+  depends_on macos: ">= :catalina"
+
+  app "Burp Suite Community Edition.app"
+
+  zap trash: "~/.BurpSuite"
+end


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online burp-suite@early-adopter` is error-free.
- [x] `brew style --fix burp-suite@early-adopter` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new burp-suite@early-adopter` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask burp-suite@early-adopter` worked successfully.
- [x] `brew uninstall --cask burp-suite@early-adopter` worked successfully.

---
