### PR TITLE
gitkraken 11.1.1

### DIFF
--- a/Casks/g/gitkraken.rb
+++ b/Casks/g/gitkraken.rb
@@ -1,18 +1,19 @@
 cask "gitkraken" do
-  arch arm: "darwin-arm64", intel: "darwin"
+  arch arm: "arm64", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "-arm64"
 
-  version "11.1.0"
-  sha256 arm:   "756ae6731cfaae17034399b03b3f731fed27f7b2d4f4a66588cf7f498d596527",
-         intel: "39ebac8f165a976a04f3469c7e46d352b3f02b44c1d7c92e2a1bb21c9f11e05d"
+  version "11.1.1"
+  sha256 arm:   "054177a6d6ca8366d369d26ef2c6bff28403d3adc21c81eebf47b8d872dbc68b",
+         intel: "6358a16fda6ead501ac0f279c2ce6cef555bf3027a8a4feb6fe9b5277fba396f"
 
-  url "https://release.axocdn.com/#{arch}/GitKraken-v#{version}.zip",
-      verified: "release.axocdn.com/"
+  url "https://api.gitkraken.dev/releases/production/darwin/#{arch}/#{version}/GitKraken-v#{version}.zip",
+      verified: "api.gitkraken.dev/releases/production/"
   name "GitKraken"
   desc "Git client focusing on productivity"
   homepage "https://www.gitkraken.com/"
 
   livecheck do
-    url "https://release.axocdn.com/#{arch}/RELEASES?v=0.0.0&darwin=999"
+    url "https://release.gitkraken.com/darwin#{livecheck_arch}/RELEASES?v=0.0.0&darwin=999"
     strategy :json do |json|
       json["name"]
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gitkraken` is in the autobump list but the 11.1.1 update is failing because upstream now serves files from api.gitkraken.dev. The file can be fetched from release.gitkraken.com but the upstream download page links to api.gitkraken.dev, so this updates the URL accordingly.

Similarly, the `livecheck` block works but it returns 11.1.0 as the newest version instead of 11.1.1. GitKraken 11.1.1 checks release.gitkraken.com and that URL returns 11.1.1, as expected, so this updates the `livecheck` block URL as well.

I will update `gitkraken-on-premise-serverless` shortly in a follow-up PR (https://github.com/Homebrew/homebrew-cask/pull/212749).