### PR TITLE
gitkraken-on-premise-serverless 11.1.1

### DIFF
--- a/Casks/g/gitkraken-on-premise-serverless.rb
+++ b/Casks/g/gitkraken-on-premise-serverless.rb
@@ -1,12 +1,12 @@
 cask "gitkraken-on-premise-serverless" do
-  arch arm: "darwin-arm64", intel: "darwin"
+  arch arm: "arm64", intel: "x64"
 
-  version "11.1.0"
-  sha256 arm:   "895852189553d89bc2bbd402fbccac19164ba07b931e1ef240fd95737f124a89",
-         intel: "c6bba9370758da8b1e6ad923c3cc3779ddf04ffb0445d7dc602f8317f9e6e0d6"
+  version "11.1.1"
+  sha256 arm:   "e56f196fca86c101d9238ad4661376c2d27c7b7f484ff060f2f91012df0e58e8",
+         intel: "da56a573d8085ddafc2182f19ba6db9225fab337a7d38249ef4bed9bb462d0c1"
 
-  url "https://release.axocdn.com/#{arch}-standalone/GitKraken-v#{version}.zip",
-      verified: "release.axocdn.com/"
+  url "https://api.gitkraken.dev/releases/standalone/production/darwin/#{arch}/#{version}/GitKraken-v#{version}.zip",
+      verified: "api.gitkraken.dev/releases/standalone/production/"
   name "GitKraken Serverless"
   desc "Git client focusing on productivity"
   homepage "https://www.gitkraken.com/git-client/on-premise"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Like the [`gitkraken` 11.1.1 update](https://github.com/Homebrew/homebrew-cask/pull/212744), the existing cask URL doesn't work for version 11.1.1 of `gitkraken-on-premise-serverless`. The upstream download pages now redirect to api.gitkraken.dev URLs, so this updates the cask URL accordingly (aligning it with `gitkraken`).