### PR TITLE
superduper 3.10.0

### DIFF
--- a/Casks/s/superduper.rb
+++ b/Casks/s/superduper.rb
@@ -1,5 +1,5 @@
 cask "superduper" do
-  version "3.9.1,134"
+  version "3.10.0,135"
   sha256 :no_check
 
   url "https://shirtpocket.s3.amazonaws.com/SuperDuper/SuperDuper!.dmg",
@@ -10,7 +10,7 @@ cask "superduper" do
 
   livecheck do
     url "https://shirtpocket.s3.amazonaws.com/SuperDuper/superduperinfo.rtf"
-    regex(/SuperDuper!\s*v?(\d+(?:\.\d+)+)\s*\(v(\d+)\)/i)
+    regex(/v?(\d+(?:\.\d+)+)\s*\(v?(\d+)\)/i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `superduper` to the latest version mentioned in the `superduperinfo.rtf` file, 3.10.0.

The existing `livecheck` block for `superduper` is returning an `Unable to get versions` error, as the current `superduperinfo.rtf` file doesn't contain version text in the expected format. Namely, the current "Version 3.10.0 (v135)" text doesn't start with "SuperDuper!", so the regex fails to match it.

This addresses the issue by loosening the regex to be able to match text like "3.10.0 (v135)" without any concern for what comes before it. This text uses a specific-enough format that hopefully it shouldn't lead to any unexpected matches but we can always revisit it in the future if it does.