### PR TITLE
teleport@16 (new cask)

### DIFF
--- a/Casks/t/teleport@16.rb
+++ b/Casks/t/teleport@16.rb
@@ -1,0 +1,42 @@
+cask "teleport@16" do
+  version "16.5.9"
+  sha256 "3db8672e2c1b1b4b3b6fc2a4ce31bdaa0164ad944b35cc2d1384df42d1fe6732"
+
+  url "https://cdn.teleport.dev/teleport-#{version}.pkg",
+      verified: "cdn.teleport.dev/"
+  name "Teleport"
+  desc "Modern SSH server for teams managing distributed infrastructure"
+  homepage "https://goteleport.com/"
+
+  livecheck do
+    url "https://goteleport.com/download/"
+    regex(/teleport[._-]v?(16(?:\.\d+)+)\.pkg/i)
+  end
+
+  conflicts_with cask:    [
+                   "teleport",
+                   "tsh",
+                   "tsh@13",
+                 ],
+                 formula: [
+                   "etsh",
+                   "teleport",
+                 ]
+
+  pkg "teleport-#{version}.pkg"
+
+  uninstall pkgutil: [
+              "(.*).com.gravitational.teleport.tctl",
+              "(.*).com.gravitational.teleport.tsh",
+              "com.gravitational.teleport",
+            ],
+            delete:  [
+              "/usr/local/bin/fdpass-teleport",
+              "/usr/local/bin/tbot",
+              "/usr/local/bin/tctl",
+              "/usr/local/bin/teleport",
+              "/usr/local/bin/tsh",
+            ]
+
+  zap trash: "~/.tsh"
+end

--- a/Casks/t/teleport@16.rb
+++ b/Casks/t/teleport@16.rb
@@ -13,6 +13,8 @@ cask "teleport@16" do
     regex(/teleport[._-]v?(16(?:\.\d+)+)\.pkg/i)
   end
 
+  disable! date: "2025-10-01", because: :discontinued
+
   conflicts_with cask:    [
                    "teleport",
                    "tsh",


### PR DESCRIPTION
This PR introduces a versioned cask of Teleport from https://goteleport.com/ . Homebrew already has the newest version of this application as a cask. However, teleport operates with both a server and a client. A server with an old version (e.g. 16, this cask) won't accept a connection from a client with a newer version (e.g. 17, the most recent). So it would be useful to be able to install an older version of the client.

---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
