### PR TITLE
simplex: Fix SHA-256 hashes

### DIFF
--- a/Casks/s/simplex.rb
+++ b/Casks/s/simplex.rb
@@ -2,8 +2,8 @@ cask "simplex" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "6.3.4"
-  sha256 arm:   "3d688d3c9fc16d9258bbc448e1d9e8c6bb6f8219a5e672ee116033bf94cbcf67",
-         intel: "82dc688a5926a250e30aff22e253487476cd36a01ee20e95f06fc3ca56c4ac7b"
+  sha256 arm:   "e2c11dd46d75fc05af37b3ece1320fbefbd58e6aa244c99636cef6165cf2ab43",
+         intel: "01eafa1774bb7658f63b436f782e34d089ed57a0cb9cb000b9b08cca9de9b33d"
 
   url "https://github.com/simplex-chat/simplex-chat/releases/download/v#{version}/simplex-desktop-macos-#{arch}.dmg",
       verified: "github.com/simplex-chat/simplex-chat/"


### PR DESCRIPTION
Updated hashes per release notes at https://github.com/simplex-chat/simplex-chat/releases/tag/v6.3.4

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The only things changed were the SHA-256 hashes to bring in line with the released hashes.