### PR TITLE
transcribe: simplify legacy blocks

### DIFF
--- a/Casks/t/transcribe.rb
+++ b/Casks/t/transcribe.rb
@@ -1,60 +1,24 @@
 cask "transcribe" do
   arch arm: "arm", intel: "intel"
+  url_arch = on_arch_conditional arm: "_arm"
 
-  on_catalina :or_older do
-    version "8.75.2"
-    sha256 "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
+  on_monterey :or_older do
+    on_catalina :or_older do
+      version "8.75.2"
+      sha256 "f01781100cd3b9987c8f8892145a2eaa358df07b92e10e26f30b6a877f5b352c"
 
-    url "https://www.seventhstring.com/xscribe/downmo/transcribe#{version.no_dots}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.seventhstring.com/xscribe/downmo/transcribe#{version.no_dots}.dmg"
     end
+    on_big_sur :or_newer do
+      version "9.21"
+      sha256 :no_check
 
-    zap trash: [
-      "~/Library/Preferences/com.seventhstring.transcribe.plist",
-      "~/Library/Preferences/Transcribe!#{version.major} Preferences",
-    ]
-  end
-  on_big_sur do
-    version "9.21"
-    sha256 :no_check
-
-    on_arm do
-      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe_arm.dmg"
-    end
-    on_intel do
-      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe.dmg"
+      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe#{url_arch}.dmg"
     end
 
     livecheck do
       skip "Legacy version"
     end
-
-    zap trash: [
-      "~/Library/Preferences/com.seventhstring.transcribe.plist",
-      "~/Library/Preferences/Transcribe!#{version.major} Preferences",
-    ]
-  end
-  on_monterey do
-    version "9.21"
-    sha256 :no_check
-
-    on_arm do
-      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe_arm.dmg"
-    end
-    on_intel do
-      url "https://www.seventhstring.com/xscribe/downmo/11_12/transcribe.dmg"
-    end
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    zap trash: [
-      "~/Library/Preferences/com.seventhstring.transcribe.plist",
-      "~/Library/Preferences/Transcribe!#{version.major} Preferences",
-    ]
   end
   on_ventura :or_newer do
     version "9.41.2"
@@ -67,11 +31,6 @@ cask "transcribe" do
       url "https://www.seventhstring.com/xscribe/download_mac.html"
       regex(/transcribe[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
     end
-
-    zap trash: [
-      "~/Library/Preferences/com.seventhstring.transcribe.plist",
-      "~/Library/Preferences/Transcribe!#{version.major} Preferences",
-    ]
   end
 
   name "Transcribe!"
@@ -81,4 +40,9 @@ cask "transcribe" do
   app "Transcribe!.app"
 
   uninstall quit: "com.seventhstring.transcribe"
+
+  zap trash: [
+    "~/Library/Preferences/com.seventhstring.transcribe.plist",
+    "~/Library/Preferences/Transcribe!#{version.major} Preferences",
+  ]
 end


### PR DESCRIPTION
Simplify `transcribe`'s legacy blocks by relocating `zap`, eliminating `on_arch` blocks and nesting them so that `skip "Legacy version"` only appears once. Output of `brew info --cask --json=v2 --variations transcribe` is unchanged.