### PR TITLE
various: consolidate legacy blocks

### DIFF
--- a/Casks/a/apparency.rb
+++ b/Casks/a/apparency.rb
@@ -1,29 +1,23 @@
 cask "apparency" do
-  on_mojave do
-    version "1.3"
-    sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
+  on_big_sur :or_older do
+    on_mojave do
+      version "1.3"
+      sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
 
-    url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
     end
-  end
-  on_catalina do
-    version "1.4.1"
-    sha256 "850d19c6d6a86380211d9acdb3d8b0ee3b2a4c8af833126c28141f105823c59a"
+    on_catalina do
+      version "1.4.1"
+      sha256 "850d19c6d6a86380211d9acdb3d8b0ee3b2a4c8af833126c28141f105823c59a"
 
-    url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
     end
-  end
-  on_big_sur do
-    version "1.6.1"
-    sha256 "cadd8894ec15b664fd60a141f82136cbe139af0b13000851497d880235abe8b2"
+    on_big_sur do
+      version "1.6.1"
+      sha256 "cadd8894ec15b664fd60a141f82136cbe139af0b13000851497d880235abe8b2"
 
-    url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
+      url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/a/araxis-merge.rb
+++ b/Casks/a/araxis-merge.rb
@@ -1,23 +1,17 @@
 cask "araxis-merge" do
-  on_mojave :or_older do
-    version "2021.5602"
-    sha256 "06c56e6d08057090f3718b6db560e2a79551f953d4c83c0fad8b60f415c59347"
-
-    livecheck do
-      skip "Legacy version"
+  on_big_sur :or_older do
+    on_mojave :or_older do
+      version "2021.5602"
+      sha256 "06c56e6d08057090f3718b6db560e2a79551f953d4c83c0fad8b60f415c59347"
     end
-  end
-  on_catalina do
-    version "2022.5786"
-    sha256 "a8a65089d7965a3ecdf3b65dbeaed54f4f31d0bc7b85c9d970aa999ab5cfa4df"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "2022.5786"
+      sha256 "a8a65089d7965a3ecdf3b65dbeaed54f4f31d0bc7b85c9d970aa999ab5cfa4df"
     end
-  end
-  on_big_sur do
-    version "2023.5915"
-    sha256 "8e9372f56a3597bdea49caadab1f11e998d8686c5e2d19472ec9470db643032e"
+    on_big_sur do
+      version "2023.5915"
+      sha256 "8e9372f56a3597bdea49caadab1f11e998d8686c5e2d19472ec9470db643032e"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/c/calhash.rb
+++ b/Casks/c/calhash.rb
@@ -1,46 +1,32 @@
 cask "calhash" do
   sha256 :no_check
 
-  on_catalina do
-    version "1.0.5"
+  on_sonoma :or_older do
+    on_catalina do
+      version "1.0.5"
 
-    url "https://www.titanium-software.fr/download/1015/CalHash.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1015/CalHash.dmg"
     end
-  end
-  on_big_sur do
-    version "1.1.1"
+    on_big_sur do
+      version "1.1.1"
 
-    url "https://www.titanium-software.fr/download/11/CalHash.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/11/CalHash.dmg"
     end
-  end
-  on_monterey do
-    version "1.1.9"
+    on_monterey do
+      version "1.1.9"
 
-    url "https://www.titanium-software.fr/download/12/CalHash.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/12/CalHash.dmg"
     end
-  end
-  on_ventura do
-    version "1.2.1"
+    on_ventura do
+      version "1.2.1"
 
-    url "https://www.titanium-software.fr/download/13/CalHash.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/13/CalHash.dmg"
     end
-  end
-  on_sonoma do
-    version "1.3.4"
+    on_sonoma do
+      version "1.3.4"
 
-    url "https://www.titanium-software.fr/download/14/CalHash.dmg"
+      url "https://www.titanium-software.fr/download/14/CalHash.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -1,47 +1,29 @@
 cask "calibre" do
-  on_high_sierra :or_older do
-    version "3.48.0"
-    sha256 "68829cd902b8e0b2b7d5cf7be132df37bcc274a1e5720b4605d2dd95f3a29168"
-
-    livecheck do
-      skip "Legacy version"
+  on_ventura :or_older do
+    on_high_sierra :or_older do
+      version "3.48.0"
+      sha256 "68829cd902b8e0b2b7d5cf7be132df37bcc274a1e5720b4605d2dd95f3a29168"
     end
-  end
-  on_mojave do
-    version "5.44.0"
-    sha256 "89d7772ba1b95d219b34e285353340a174a013e06b4d8ad370433b3b98c94ad4"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "5.44.0"
+      sha256 "89d7772ba1b95d219b34e285353340a174a013e06b4d8ad370433b3b98c94ad4"
     end
-  end
-  on_catalina do
-    version "6.11.0"
-    sha256 "d7c40f3f35ba9043c13303632526f135b2c4086471a5c09ceb8b397c55c076fa"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "6.11.0"
+      sha256 "d7c40f3f35ba9043c13303632526f135b2c4086471a5c09ceb8b397c55c076fa"
     end
-  end
-  on_big_sur do
-    version "6.29.0"
-    sha256 "2f76428ae19617875c5725cd892751a80eb2acdda76e06cd19c2f21a63966998"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "6.29.0"
+      sha256 "2f76428ae19617875c5725cd892751a80eb2acdda76e06cd19c2f21a63966998"
     end
-  end
-  on_monterey do
-    version "6.29.0"
-    sha256 "2f76428ae19617875c5725cd892751a80eb2acdda76e06cd19c2f21a63966998"
-
-    livecheck do
-      skip "Legacy version"
+    on_monterey do
+      version "6.29.0"
+      sha256 "2f76428ae19617875c5725cd892751a80eb2acdda76e06cd19c2f21a63966998"
     end
-  end
-  on_ventura do
-    version "7.26.0"
-    sha256 "6c329e20bc575fb2445b2279f1c9df73efecfd371a3864a35f1b575b87332ee4"
+    on_ventura do
+      version "7.26.0"
+      sha256 "6c329e20bc575fb2445b2279f1c9df73efecfd371a3864a35f1b575b87332ee4"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/c/choosy.rb
+++ b/Casks/c/choosy.rb
@@ -1,83 +1,57 @@
 cask "choosy" do
-  on_el_capitan :or_older do
-    version "1.1"
-    sha256 "c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c"
+  on_ventura :or_older do
+    on_el_capitan :or_older do
+      version "1.1"
+      sha256 "c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c"
+
+      prefpane "Choosy.prefPane"
+    end
+    on_sierra do
+      version "1.3"
+      sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
+
+      prefpane "Choosy.prefPane"
+    end
+    on_high_sierra do
+      version "1.3"
+      sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
+
+      prefpane "Choosy.prefPane"
+    end
+    on_mojave do
+      version "2.1"
+      sha256 "758da621d3a92358885333b767d64b024197a8147a339b1a0d14e938673452f9"
+
+      pkg "Choosy.pkg"
+    end
+    on_catalina do
+      version "2.2.1"
+      sha256 "71fe3c3c592d449063189a575a39b1f00735ee20cf1de94552896f5f8e93bf47"
+
+      pkg "Choosy.pkg"
+    end
+    on_big_sur do
+      version "2.3.1"
+      sha256 "8d6a44b78ed256d6f502872fd1f62cf1f7fea877906bedddc5bbf26f93b6ea57"
+
+      pkg "Choosy.pkg"
+    end
+    on_monterey do
+      version "2.3.1"
+      sha256 "8d6a44b78ed256d6f502872fd1f62cf1f7fea877906bedddc5bbf26f93b6ea57"
+
+      pkg "Choosy.pkg"
+    end
+    on_ventura do
+      version "2.3.1"
+      sha256 "8d6a44b78ed256d6f502872fd1f62cf1f7fea877906bedddc5bbf26f93b6ea57"
+
+      pkg "Choosy.pkg"
+    end
 
     livecheck do
       skip "Legacy version"
     end
-
-    prefpane "Choosy.prefPane"
-  end
-  on_sierra do
-    version "1.3"
-    sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    prefpane "Choosy.prefPane"
-  end
-  on_high_sierra do
-    version "1.3"
-    sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    prefpane "Choosy.prefPane"
-  end
-  on_mojave do
-    version "2.1"
-    sha256 "758da621d3a92358885333b767d64b024197a8147a339b1a0d14e938673452f9"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Choosy.pkg"
-  end
-  on_catalina do
-    version "2.2.1"
-    sha256 "71fe3c3c592d449063189a575a39b1f00735ee20cf1de94552896f5f8e93bf47"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Choosy.pkg"
-  end
-  on_big_sur do
-    version "2.3.1"
-    sha256 "8d6a44b78ed256d6f502872fd1f62cf1f7fea877906bedddc5bbf26f93b6ea57"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Choosy.pkg"
-  end
-  on_monterey do
-    version "2.3.1"
-    sha256 "8d6a44b78ed256d6f502872fd1f62cf1f7fea877906bedddc5bbf26f93b6ea57"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Choosy.pkg"
-  end
-  on_ventura do
-    version "2.3.1"
-    sha256 "8d6a44b78ed256d6f502872fd1f62cf1f7fea877906bedddc5bbf26f93b6ea57"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Choosy.pkg"
   end
   on_sonoma :or_newer do
     version "2.4.2"

--- a/Casks/c/coteditor.rb
+++ b/Casks/c/coteditor.rb
@@ -1,63 +1,37 @@
 cask "coteditor" do
-  on_el_capitan :or_older do
-    version "3.5.4"
-    sha256 "0b2cbf38cc531268e3691f307445e05ae5da64b48ceaf86c4d16b993c9be3e9f"
-
-    livecheck do
-      skip "Legacy version"
+  on_ventura :or_older do
+    on_el_capitan :or_older do
+      version "3.5.4"
+      sha256 "0b2cbf38cc531268e3691f307445e05ae5da64b48ceaf86c4d16b993c9be3e9f"
     end
-  end
-  on_sierra do
-    version "3.7.8"
-    sha256 "c67a0b5049da7096228074d7b71e7678fcaaf795a5ae45bc593019662f0c6f09"
-
-    livecheck do
-      skip "Legacy version"
+    on_sierra do
+      version "3.7.8"
+      sha256 "c67a0b5049da7096228074d7b71e7678fcaaf795a5ae45bc593019662f0c6f09"
     end
-  end
-  on_high_sierra do
-    version "3.9.7"
-    sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "3.9.7"
+      sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
     end
-  end
-  on_mojave do
-    version "3.9.7"
-    sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "3.9.7"
+      sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
     end
-  end
-  on_catalina do
-    version "4.0.9"
-    sha256 "969e891f4a36146c317150806fee01559d177f956734595c73537affc8897e79"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "4.0.9"
+      sha256 "969e891f4a36146c317150806fee01559d177f956734595c73537affc8897e79"
     end
-  end
-  on_big_sur do
-    version "4.3.6"
-    sha256 "8c1ecf6fd66a9885d428a6303d9d1c5ecb811c1c35c97bdbccdad72359d96ad9"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "4.3.6"
+      sha256 "8c1ecf6fd66a9885d428a6303d9d1c5ecb811c1c35c97bdbccdad72359d96ad9"
     end
-  end
-  on_monterey do
-    version "4.5.9"
-    sha256 "fa3e4a1fdf7edfc109c5588292906d864d430d2e8bd3d84161b1f0a7892163f6"
-
-    livecheck do
-      skip "Legacy version"
+    on_monterey do
+      version "4.5.9"
+      sha256 "fa3e4a1fdf7edfc109c5588292906d864d430d2e8bd3d84161b1f0a7892163f6"
     end
-  end
-  on_ventura do
-    version "4.8.7"
-    sha256 "9c439ace99d6b74cf94738d24368ccc39c579902c7062f8e107c596061a58dda"
+    on_ventura do
+      version "4.8.7"
+      sha256 "9c439ace99d6b74cf94738d24368ccc39c579902c7062f8e107c596061a58dda"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -3,82 +3,52 @@ cask "deeper" do
 
   # NOTE: We use separate `url` values in each of the macOS on_system blocks
   # so that the API data correctly includes URL variants for each.
-  on_el_capitan :or_older do
-    version "2.1.4"
+  on_sonoma :or_older do
+    on_el_capitan :or_older do
+      version "2.1.4"
 
-    url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
     end
-  end
-  on_sierra do
-    version "2.2.3"
+    on_sierra do
+      version "2.2.3"
 
-    url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
     end
-  end
-  on_high_sierra do
-    version "2.3.3"
+    on_high_sierra do
+      version "2.3.3"
 
-    url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
     end
-  end
-  on_mojave do
-    version "2.4.8"
+    on_mojave do
+      version "2.4.8"
 
-    url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
     end
-  end
-  on_catalina do
-    version "2.6.0"
+    on_catalina do
+      version "2.6.0"
 
-    url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
     end
-  end
-  on_big_sur do
-    version "2.7.1"
+    on_big_sur do
+      version "2.7.1"
 
-    url "https://www.titanium-software.fr/download/11/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/11/Deeper.dmg"
     end
-  end
-  on_monterey do
-    version "2.8.0"
+    on_monterey do
+      version "2.8.0"
 
-    url "https://www.titanium-software.fr/download/12/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/12/Deeper.dmg"
     end
-  end
-  on_ventura do
-    version "2.9.2"
+    on_ventura do
+      version "2.9.2"
 
-    url "https://www.titanium-software.fr/download/13/Deeper.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/13/Deeper.dmg"
     end
-  end
-  on_sonoma do
-    version "3.0.9"
+    on_sonoma do
+      version "3.0.9"
 
-    url "https://www.titanium-software.fr/download/14/Deeper.dmg"
+      url "https://www.titanium-software.fr/download/14/Deeper.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/d/displaylink.rb
+++ b/Casks/d/displaylink.rb
@@ -1,63 +1,49 @@
 cask "displaylink" do
-  on_sierra :or_older do
-    version "4.3.1,2021-02"
-    sha256 "d5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97"
+  on_big_sur :or_older do
+    on_sierra :or_older do
+      version "4.3.1,2021-02"
+      sha256 "d5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97"
 
-    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20Mac%20OS%20X%20and%20macOS#{version.csv.first}-EXE.dmg"
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20Mac%20OS%20X%20and%20macOS#{version.csv.first}-EXE.dmg"
+
+      pkg "DisplayLink Software Installer.pkg"
+    end
+    on_high_sierra do
+      version "5.1.1,2021-02"
+      sha256 "1ac9093f8113af8c35d6f3ff5b1ae3f119a5aff0d5309d75c7a1742f159184b5"
+
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
+
+      pkg "DisplayLink Software Installer.pkg"
+    end
+    on_mojave do
+      version "5.2.6,2021-05"
+      sha256 "9f1854cd5720105d6d45c91172419c503358543e4a23d7113387aedf16a39cbb"
+
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
+
+      pkg "DisplayLink Software Installer.pkg"
+    end
+    on_catalina do
+      version "1.5,2021-09"
+      sha256 "d703cc8e9093e4d163c5e612326c0907a02c6d4eec6aaca8d0727503859ef95d"
+
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
+
+      pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
+    end
+    on_big_sur do
+      version "1.9,2023-07"
+      sha256 "cd7f7c7c313b0699bfa187f7112a45e5c5441264447b381569839318676208aa"
+
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
+
+      pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
+    end
 
     livecheck do
       skip "Legacy version"
     end
-
-    pkg "DisplayLink Software Installer.pkg"
-  end
-  on_high_sierra do
-    version "5.1.1,2021-02"
-    sha256 "1ac9093f8113af8c35d6f3ff5b1ae3f119a5aff0d5309d75c7a1742f159184b5"
-
-    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "DisplayLink Software Installer.pkg"
-  end
-  on_mojave do
-    version "5.2.6,2021-05"
-    sha256 "9f1854cd5720105d6d45c91172419c503358543e4a23d7113387aedf16a39cbb"
-
-    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "DisplayLink Software Installer.pkg"
-  end
-  on_catalina do
-    version "1.5,2021-09"
-    sha256 "d703cc8e9093e4d163c5e612326c0907a02c6d4eec6aaca8d0727503859ef95d"
-
-    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
-  end
-  on_big_sur do
-    version "1.9,2023-07"
-    sha256 "cd7f7c7c313b0699bfa187f7112a45e5c5441264447b381569839318676208aa"
-
-    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
   end
   on_monterey :or_newer do
     version "1.12.2,2025-05"

--- a/Casks/e/evernote.rb
+++ b/Casks/e/evernote.rb
@@ -1,29 +1,23 @@
 cask "evernote" do
-  on_el_capitan :or_older do
-    version "7.2.3_456885"
-    sha256 "eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97"
+  on_high_sierra :or_older do
+    on_el_capitan :or_older do
+      version "7.2.3_456885"
+      sha256 "eb9a92d57ceb54570c009e37fa7657a0fa3ab927a445eef382487a3fdde6bb97"
 
-    url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
     end
-  end
-  on_sierra do
-    version "7.14_458244"
-    sha256 "1049a40b8497c0e37d7fed8828552dba89fa52c826134e05b0d56e431e5033ad"
+    on_sierra do
+      version "7.14_458244"
+      sha256 "1049a40b8497c0e37d7fed8828552dba89fa52c826134e05b0d56e431e5033ad"
 
-    url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
     end
-  end
-  on_high_sierra do
-    version "7.14_458244"
-    sha256 "1049a40b8497c0e37d7fed8828552dba89fa52c826134e05b0d56e431e5033ad"
+    on_high_sierra do
+      version "7.14_458244"
+      sha256 "1049a40b8497c0e37d7fed8828552dba89fa52c826134e05b0d56e431e5033ad"
 
-    url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
+      url "https://cdn1.evernote.com/mac-smd/public/Evernote_RELEASE_#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/g/grandperspective.rb
+++ b/Casks/g/grandperspective.rb
@@ -1,23 +1,17 @@
 cask "grandperspective" do
-  on_high_sierra :or_older do
-    version "3.0.1"
-    sha256 "64faab94df5ac39abbeb9e869a6c429d3441c3796ef67f79dab232ba7f0cb222"
-
-    livecheck do
-      skip "Legacy version"
+  on_catalina :or_older do
+    on_high_sierra :or_older do
+      version "3.0.1"
+      sha256 "64faab94df5ac39abbeb9e869a6c429d3441c3796ef67f79dab232ba7f0cb222"
     end
-  end
-  on_mojave do
-    version "3.3"
-    sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "3.3"
+      sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
     end
-  end
-  on_catalina do
-    version "3.3"
-    sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
+    on_catalina do
+      version "3.3"
+      sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/i/itsycal.rb
+++ b/Casks/i/itsycal.rb
@@ -1,38 +1,26 @@
 cask "itsycal" do
-  on_el_capitan :or_older do
-    version "0.10.16"
-    sha256 "dbf1b104c7a3a2ca3ead9879145cb0557955c29d53f35a92b42f48e68122957c"
+  on_catalina :or_older do
+    on_el_capitan :or_older do
+      version "0.10.16"
+      sha256 "dbf1b104c7a3a2ca3ead9879145cb0557955c29d53f35a92b42f48e68122957c"
+    end
+    on_sierra do
+      version "0.11.17"
+      sha256 "fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11"
+    end
+    on_high_sierra do
+      version "0.11.17"
+      sha256 "fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11"
+    end
+    on_mojave do
+      version "0.14.1"
+      sha256 "3cbd422fb43409bb2bdf5341c61d69882302dfb216a7bc50b3c08e4318e3a395"
+    end
+    on_catalina do
+      version "0.14.1"
+      sha256 "3cbd422fb43409bb2bdf5341c61d69882302dfb216a7bc50b3c08e4318e3a395"
+    end
 
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_sierra do
-    version "0.11.17"
-    sha256 "fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_high_sierra do
-    version "0.11.17"
-    sha256 "fda1ba5611deaf4d5b834118b3af37ea9c5d08d1f8c813d04e7dd0552a270e11"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave do
-    version "0.14.1"
-    sha256 "3cbd422fb43409bb2bdf5341c61d69882302dfb216a7bc50b3c08e4318e3a395"
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina do
-    version "0.14.1"
-    sha256 "3cbd422fb43409bb2bdf5341c61d69882302dfb216a7bc50b3c08e4318e3a395"
     livecheck do
       skip "Legacy version"
     end

--- a/Casks/k/klayout.rb
+++ b/Casks/k/klayout.rb
@@ -1,32 +1,26 @@
 cask "klayout" do
-  on_catalina :or_older do
-    version "0.28.12"
-    sha256 "b2bca1ad625f84be8d6eeba7cc4864c83dd09d01d4e413059c8cff130c825b3e"
+  on_monterey :or_older do
+    on_catalina :or_older do
+      version "0.28.12"
+      sha256 "b2bca1ad625f84be8d6eeba7cc4864c83dd09d01d4e413059c8cff130c825b3e"
 
-    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Catalina-1-qt5Brew-RsysPhb39.dmg",
-        verified: "klayout.org/downloads/MacOS/"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Catalina-1-qt5Brew-RsysPhb39.dmg",
+          verified: "klayout.org/downloads/MacOS/"
     end
-  end
-  on_big_sur do
-    version "0.28.12"
-    sha256 "1c7b6e12ac722d718dfc1711dd4d05cfa0a7b97d60ad02f98cd15cbae22d7fb0"
+    on_big_sur do
+      version "0.28.12"
+      sha256 "1c7b6e12ac722d718dfc1711dd4d05cfa0a7b97d60ad02f98cd15cbae22d7fb0"
 
-    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-BigSur-1-qt5Brew-RsysPhb39.dmg",
-        verified: "klayout.org/downloads/MacOS/"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-BigSur-1-qt5Brew-RsysPhb39.dmg",
+          verified: "klayout.org/downloads/MacOS/"
     end
-  end
-  on_monterey do
-    version "0.29.6"
-    sha256 "2c324dc95d77a0167d6c56608d2beca5f78b5190259480d97ef1500b19bc7389"
+    on_monterey do
+      version "0.29.6"
+      sha256 "2c324dc95d77a0167d6c56608d2beca5f78b5190259480d97ef1500b19bc7389"
 
-    url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Monterey-1-qt5MP-RsysPhb311.dmg",
-        verified: "klayout.org/downloads/MacOS/"
+      url "https://www.klayout.org/downloads/MacOS/HW-klayout-#{version}-macOS-Monterey-1-qt5MP-RsysPhb311.dmg",
+          verified: "klayout.org/downloads/MacOS/"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/maintenance.rb
+++ b/Casks/m/maintenance.rb
@@ -3,82 +3,52 @@ cask "maintenance" do
 
   # NOTE: We use separate `url` values in each of the macOS on_system blocks
   # so that the API data correctly includes URL variants for each.
-  on_el_capitan :or_older do
-    version "2.1.8"
+  on_sonoma :or_older do
+    on_el_capitan :or_older do
+      version "2.1.8"
 
-    url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1011/Maintenance.dmg"
     end
-  end
-  on_sierra do
-    version "2.3.0"
+    on_sierra do
+      version "2.3.0"
 
-    url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1012/Maintenance.dmg"
     end
-  end
-  on_high_sierra do
-    version "2.4.2"
+    on_high_sierra do
+      version "2.4.2"
 
-    url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1013/Maintenance.dmg"
     end
-  end
-  on_mojave do
-    version "2.5.6"
+    on_mojave do
+      version "2.5.6"
 
-    url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1014/Maintenance.dmg"
     end
-  end
-  on_catalina do
-    version "2.7.1"
+    on_catalina do
+      version "2.7.1"
 
-    url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1015/Maintenance.dmg"
     end
-  end
-  on_big_sur do
-    version "2.8.2"
+    on_big_sur do
+      version "2.8.2"
 
-    url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/11/Maintenance.dmg"
     end
-  end
-  on_monterey do
-    version "2.9.2"
+    on_monterey do
+      version "2.9.2"
 
-    url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/12/Maintenance.dmg"
     end
-  end
-  on_ventura do
-    version "3.0.2"
+    on_ventura do
+      version "3.0.2"
 
-    url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/13/Maintenance.dmg"
     end
-  end
-  on_sonoma do
-    version "3.2.0"
+    on_sonoma do
+      version "3.2.0"
 
-    url "https://www.titanium-software.fr/download/14/Maintenance.dmg"
+      url "https://www.titanium-software.fr/download/14/Maintenance.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/microsoft-excel.rb
+++ b/Casks/m/microsoft-excel.rb
@@ -1,55 +1,33 @@
 cask "microsoft-excel" do
-  on_el_capitan :or_older do
-    version "16.16.20101200"
-    sha256 "bdd23b696d54e5ffeb40f30a9bd7f968d2936380ab78a6eaf29d05f5fc8eb78e"
-
-    livecheck do
-      skip "Legacy version"
+  on_monterey :or_older do
+    on_el_capitan :or_older do
+      version "16.16.20101200"
+      sha256 "bdd23b696d54e5ffeb40f30a9bd7f968d2936380ab78a6eaf29d05f5fc8eb78e"
     end
-  end
-  on_sierra do
-    version "16.30.19101301"
-    sha256 "9886b661067f4a99de544d140980fb0f8ef2f4871baa519024781fb814a02fe5"
-
-    livecheck do
-      skip "Legacy version"
+    on_sierra do
+      version "16.30.19101301"
+      sha256 "9886b661067f4a99de544d140980fb0f8ef2f4871baa519024781fb814a02fe5"
     end
-  end
-  on_high_sierra do
-    version "16.43.20110804"
-    sha256 "2711a1b8864f7474458086b4b0a56673fee0097d2049f276788c50e004c47d72"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "16.43.20110804"
+      sha256 "2711a1b8864f7474458086b4b0a56673fee0097d2049f276788c50e004c47d72"
     end
-  end
-  on_mojave do
-    version "16.54.21101001"
-    sha256 "e09fe9f49a36b37af3745673a385be4de9ae8ec774965fd1753f8479a775fc54"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "16.54.21101001"
+      sha256 "e09fe9f49a36b37af3745673a385be4de9ae8ec774965fd1753f8479a775fc54"
     end
-  end
-  on_catalina do
-    version "16.66.22101101"
-    sha256 "94148628c6f143f07555b3d2a70cea61cef817d963539d281b092834496f8f16"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "16.66.22101101"
+      sha256 "94148628c6f143f07555b3d2a70cea61cef817d963539d281b092834496f8f16"
     end
-  end
-  on_big_sur do
-    version "16.77.23091703"
-    sha256 "582fca32104e828e01c0928e674122f2d8044d84fd2dc1d7964e0a807e2f4695"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "16.77.23091703"
+      sha256 "582fca32104e828e01c0928e674122f2d8044d84fd2dc1d7964e0a807e2f4695"
     end
-  end
-  on_monterey do
-    version "16.89.24091630"
-    sha256 "81e02698c209b0681999737d9be8f685e12e43c8ceaf7ee2c7a08ad61adc99f7"
+    on_monterey do
+      version "16.89.24091630"
+      sha256 "81e02698c209b0681999737d9be8f685e12e43c8ceaf7ee2c7a08ad61adc99f7"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/microsoft-outlook.rb
+++ b/Casks/m/microsoft-outlook.rb
@@ -1,55 +1,33 @@
 cask "microsoft-outlook" do
-  on_el_capitan :or_older do
-    version "16.16.20101200"
-    sha256 "aafedfe466b7bf10f96fdfbf6b0f9bcf84e94a5097e5fccb3740d3d0cc666f26"
-
-    livecheck do
-      skip "Legacy version"
+  on_monterey :or_older do
+    on_el_capitan :or_older do
+      version "16.16.20101200"
+      sha256 "aafedfe466b7bf10f96fdfbf6b0f9bcf84e94a5097e5fccb3740d3d0cc666f26"
     end
-  end
-  on_sierra do
-    version "16.30.19101301"
-    sha256 "a131eb9ea7d0f498376f678198b27eab3139ec264a3a4d873be522ec8fe48845"
-
-    livecheck do
-      skip "Legacy version"
+    on_sierra do
+      version "16.30.19101301"
+      sha256 "a131eb9ea7d0f498376f678198b27eab3139ec264a3a4d873be522ec8fe48845"
     end
-  end
-  on_high_sierra do
-    version "16.43.20110804"
-    sha256 "0e53acefafc25d1eebbf257f343de0d0a5258099c154f7ba5d99aa709fb50d08"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "16.43.20110804"
+      sha256 "0e53acefafc25d1eebbf257f343de0d0a5258099c154f7ba5d99aa709fb50d08"
     end
-  end
-  on_mojave do
-    version "16.54.21101001"
-    sha256 "c7b3ced52462b611a9762941088fa05e42d79b26349ca62b705a9bcbce00b41e"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "16.54.21101001"
+      sha256 "c7b3ced52462b611a9762941088fa05e42d79b26349ca62b705a9bcbce00b41e"
     end
-  end
-  on_catalina do
-    version "16.66.22102801"
-    sha256 "bddede85956713be21fdb5ab72be07ecefd05552752e8e60c649e6a15fd0a2c2"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "16.66.22102801"
+      sha256 "bddede85956713be21fdb5ab72be07ecefd05552752e8e60c649e6a15fd0a2c2"
     end
-  end
-  on_big_sur do
-    version "16.77.23091703"
-    sha256 "becfe797d1c799a4366385f449e42f7377bd3d6de5d4db20e37bd36ba2f24ef5"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "16.77.23091703"
+      sha256 "becfe797d1c799a4366385f449e42f7377bd3d6de5d4db20e37bd36ba2f24ef5"
     end
-  end
-  on_monterey do
-    version "16.89.24091630"
-    sha256 "24731ffca0b78c02f2544b145b4a103bd11b724fef0dc938bf5899e156495a72"
+    on_monterey do
+      version "16.89.24091630"
+      sha256 "24731ffca0b78c02f2544b145b4a103bd11b724fef0dc938bf5899e156495a72"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/microsoft-powerpoint.rb
+++ b/Casks/m/microsoft-powerpoint.rb
@@ -1,55 +1,33 @@
 cask "microsoft-powerpoint" do
-  on_el_capitan :or_older do
-    version "16.16.20101200"
-    sha256 "0c898068408082124f7fe45717e3fb4b4f5647b609b54dc5fa6c90e295f499c3"
-
-    livecheck do
-      skip "Legacy version"
+  on_monterey :or_older do
+    on_el_capitan :or_older do
+      version "16.16.20101200"
+      sha256 "0c898068408082124f7fe45717e3fb4b4f5647b609b54dc5fa6c90e295f499c3"
     end
-  end
-  on_sierra do
-    version "16.30.19101301"
-    sha256 "d0b16f96bb390a225c52808952a66f0e02bf3f355234cbe733b250d37bb44c72"
-
-    livecheck do
-      skip "Legacy version"
+    on_sierra do
+      version "16.30.19101301"
+      sha256 "d0b16f96bb390a225c52808952a66f0e02bf3f355234cbe733b250d37bb44c72"
     end
-  end
-  on_high_sierra do
-    version "16.43.20110804"
-    sha256 "a89e0aed18e5b1e56293b1f9eaccc3e3f5089eb37a9eec64bb6f3a3fa90587eb"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "16.43.20110804"
+      sha256 "a89e0aed18e5b1e56293b1f9eaccc3e3f5089eb37a9eec64bb6f3a3fa90587eb"
     end
-  end
-  on_mojave do
-    version "16.54.21101001"
-    sha256 "75a57c82b46d0e2558c454f19610576b7a48baf1ccc5cd1fa61b69cca5bf0bd1"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "16.54.21101001"
+      sha256 "75a57c82b46d0e2558c454f19610576b7a48baf1ccc5cd1fa61b69cca5bf0bd1"
     end
-  end
-  on_catalina do
-    version "16.66.22101101"
-    sha256 "bea8c4790445f726debd0f64d24fbdac59e3a9b51e95c092fb31da3913164540"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "16.66.22101101"
+      sha256 "bea8c4790445f726debd0f64d24fbdac59e3a9b51e95c092fb31da3913164540"
     end
-  end
-  on_big_sur do
-    version "16.77.23091703"
-    sha256 "9ece350fa314584aafacfcdf559bb67b8707bc2c2e7a961f7881d1ea280aac4d"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "16.77.23091703"
+      sha256 "9ece350fa314584aafacfcdf559bb67b8707bc2c2e7a961f7881d1ea280aac4d"
     end
-  end
-  on_monterey do
-    version "16.89.24091630"
-    sha256 "44801ae2e12318f6f8982da6fabb1c7c1d79fb38cc464fecfd60189aa36e9555"
+    on_monterey do
+      version "16.89.24091630"
+      sha256 "44801ae2e12318f6f8982da6fabb1c7c1d79fb38cc464fecfd60189aa36e9555"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -1,55 +1,33 @@
 cask "microsoft-word" do
-  on_el_capitan :or_older do
-    version "16.16.20101200"
-    sha256 "0c61b7db7a6a13653270795c085a909aa54668e8de2f2ca749257ce6aa5957d1"
-
-    livecheck do
-      skip "Legacy version"
+  on_monterey :or_older do
+    on_el_capitan :or_older do
+      version "16.16.20101200"
+      sha256 "0c61b7db7a6a13653270795c085a909aa54668e8de2f2ca749257ce6aa5957d1"
     end
-  end
-  on_sierra do
-    version "16.30.19101301"
-    sha256 "6abd7939b0d935023ebb8fabeb206c4cbbe8eb8f9a3ff7d318448d2ba5f332e4"
-
-    livecheck do
-      skip "Legacy version"
+    on_sierra do
+      version "16.30.19101301"
+      sha256 "6abd7939b0d935023ebb8fabeb206c4cbbe8eb8f9a3ff7d318448d2ba5f332e4"
     end
-  end
-  on_high_sierra do
-    version "16.43.20110804"
-    sha256 "3d957d534fb2142f6e95a688552890a31f0d942796f0128ca837a3e98405d413"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "16.43.20110804"
+      sha256 "3d957d534fb2142f6e95a688552890a31f0d942796f0128ca837a3e98405d413"
     end
-  end
-  on_mojave do
-    version "16.54.21101001"
-    sha256 "7f3ed397b517aac3637d8b8f8b4233f9e7132941f0657eaca8ec423ac068616e"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "16.54.21101001"
+      sha256 "7f3ed397b517aac3637d8b8f8b4233f9e7132941f0657eaca8ec423ac068616e"
     end
-  end
-  on_catalina do
-    version "16.66.22101101"
-    sha256 "5a6a75d9a5b46cceeff5a1b7925c0eab6e4976cba529149b7b291a0355e7a7c9"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "16.66.22101101"
+      sha256 "5a6a75d9a5b46cceeff5a1b7925c0eab6e4976cba529149b7b291a0355e7a7c9"
     end
-  end
-  on_big_sur do
-    version "16.77.23091703"
-    sha256 "10c8db978206275a557faf3650763a656b1f7170c9b2a65fa6fdce220bd23066"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "16.77.23091703"
+      sha256 "10c8db978206275a557faf3650763a656b1f7170c9b2a65fa6fdce220bd23066"
     end
-  end
-  on_monterey do
-    version "16.89.24091630"
-    sha256 "e064013cf26dc3742f07436fae1bb1a37fdd21fc4fb09640c0de0fc977f4ffd3"
+    on_monterey do
+      version "16.89.24091630"
+      sha256 "e064013cf26dc3742f07436fae1bb1a37fdd21fc4fb09640c0de0fc977f4ffd3"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/mysql-shell.rb
+++ b/Casks/m/mysql-shell.rb
@@ -1,63 +1,45 @@
 cask "mysql-shell" do
   arch arm: "arm64", intel: "x86-64bit"
 
-  on_sierra :or_older do
-    version "8.0.12,10.13-x86-64bit"
-    sha256 "7e4f01f4f5c9f4567b2eafa6ffefe502096be89e4cdfb9952e6d379be8fffe7f"
+  on_monterey :or_older do
+    on_sierra :or_older do
+      version "8.0.12,10.13-x86-64bit"
+      sha256 "7e4f01f4f5c9f4567b2eafa6ffefe502096be89e4cdfb9952e6d379be8fffe7f"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
     end
-  end
-  on_high_sierra do
-    version "8.0.18,10.14-x86-64bit"
-    sha256 "23676e36670ae4753583344e012066782d09c7df3ed11d2611d604c85d91693d"
+    on_high_sierra do
+      version "8.0.18,10.14-x86-64bit"
+      sha256 "23676e36670ae4753583344e012066782d09c7df3ed11d2611d604c85d91693d"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
     end
-  end
-  on_mojave do
-    version "8.0.23,10.15-x86-64bit"
-    sha256 "75ee22c5cf7fd4dda05c87ea5bfcbd46e76a589c2132de4f875cd8605514315b"
+    on_mojave do
+      version "8.0.23,10.15-x86-64bit"
+      sha256 "75ee22c5cf7fd4dda05c87ea5bfcbd46e76a589c2132de4f875cd8605514315b"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
     end
-  end
-  on_catalina do
-    version "8.0.27,11-x86-64bit"
-    sha256 "3214e9d35b4950cd326b0bef3b9c582cf01957fbf64cebce4b7bb85b7e38add9"
+    on_catalina do
+      version "8.0.27,11-x86-64bit"
+      sha256 "3214e9d35b4950cd326b0bef3b9c582cf01957fbf64cebce4b7bb85b7e38add9"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
     end
-  end
-  on_big_sur do
-    version "8.0.29,12"
-    sha256 arm:   "7095eaa8c67a8952101e0e6173645ac4377b1c06df5e8f87ceddea418d79b5a6",
-           intel: "971e88d93f477437b7b6507408c0c31183f36af7922b7c2f6570ec314779ad20"
+    on_big_sur do
+      version "8.0.29,12"
+      sha256 arm:   "7095eaa8c67a8952101e0e6173645ac4377b1c06df5e8f87ceddea418d79b5a6",
+             intel: "971e88d93f477437b7b6507408c0c31183f36af7922b7c2f6570ec314779ad20"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
     end
-  end
-  on_monterey do
-    version "8.0.34,13"
-    sha256 arm:   "c67890eff6829afbc234260b3f54d34cb65b699e53ae59520b94feee8e337d71",
-           intel: "6fd9e3855e70028b88a05ba6be76e9101a601f1416fd6c0eb2078169dbe8937d"
+    on_monterey do
+      version "8.0.34,13"
+      sha256 arm:   "c67890eff6829afbc234260b3f54d34cb65b699e53ae59520b94feee8e337d71",
+             intel: "6fd9e3855e70028b88a05ba6be76e9101a601f1416fd6c0eb2078169dbe8937d"
 
-    url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/m/mysqlworkbench.rb
+++ b/Casks/m/mysqlworkbench.rb
@@ -1,52 +1,38 @@
 cask "mysqlworkbench" do
   arch arm: "arm64", intel: "x86_64"
 
-  on_high_sierra :or_older do
-    version "8.0.18"
-    sha256 "965f85163d1723be26c1f0c74c5b1cd908fac79e02c00fa371c217c9a3bf09ae"
+  on_monterey :or_older do
+    on_high_sierra :or_older do
+      version "8.0.18"
+      sha256 "965f85163d1723be26c1f0c74c5b1cd908fac79e02c00fa371c217c9a3bf09ae"
 
-    url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
     end
-  end
-  on_mojave do
-    version "8.0.21"
-    sha256 "7d812551cc1cc38e1d5f588e6c91b07f1778c78a04bfe94dafac3a23ea425e88"
+    on_mojave do
+      version "8.0.21"
+      sha256 "7d812551cc1cc38e1d5f588e6c91b07f1778c78a04bfe94dafac3a23ea425e88"
 
-    url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
     end
-  end
-  on_catalina do
-    version "8.0.23"
-    sha256 "4c8664f5686a449a9760bda9b85d7e8c6beb1367d35f668048ffe534652da7b3"
+    on_catalina do
+      version "8.0.23"
+      sha256 "4c8664f5686a449a9760bda9b85d7e8c6beb1367d35f668048ffe534652da7b3"
 
-    url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
     end
-  end
-  on_big_sur do
-    version "8.0.31"
-    sha256 "6807ac1138c424c57d7e912c08301a838a90935dd0fc7a5658d3ded23f98a865"
+    on_big_sur do
+      version "8.0.31"
+      sha256 "6807ac1138c424c57d7e912c08301a838a90935dd0fc7a5658d3ded23f98a865"
 
-    url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
     end
-  end
-  on_monterey do
-    version "8.0.34"
-    sha256 arm:   "aea67c39354d76c38f2e9aca4390dbe4f75ecc3f12110ff598bf2fc46f48bf8c",
-           intel: "9fba65a06db4c67e353014b49c41d7cd0e915dd6584df43d6cb099f38cf841e2"
+    on_monterey do
+      version "8.0.34"
+      sha256 arm:   "aea67c39354d76c38f2e9aca4390dbe4f75ecc3f12110ff598bf2fc46f48bf8c",
+             intel: "9fba65a06db4c67e353014b49c41d7cd0e915dd6584df43d6cb099f38cf841e2"
 
-    url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-#{arch}.dmg"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-#{arch}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/o/omnidisksweeper.rb
+++ b/Casks/o/omnidisksweeper.rb
@@ -1,39 +1,29 @@
 cask "omnidisksweeper" do
-  on_sierra do
-    version "1.10"
-    sha256 "0d8f5b7ff075fca4503a41e1ea898a145001f3f602f6b53ffb310e0a465af080"
+  on_catalina :or_older do
+    on_sierra do
+      version "1.10"
+      sha256 "0d8f5b7ff075fca4503a41e1ea898a145001f3f602f6b53ffb310e0a465af080"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniDiskSweeper-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniDiskSweeper-#{version}.dmg"
     end
-  end
-  on_high_sierra do
-    version "1.11"
-    sha256 "f06b150239e5c5ee27615b1e8bd6ec2c87c61c4cda575547f124ff84986b6f37"
+    on_high_sierra do
+      version "1.11"
+      sha256 "f06b150239e5c5ee27615b1e8bd6ec2c87c61c4cda575547f124ff84986b6f37"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniDiskSweeper-#{version}(n).dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniDiskSweeper-#{version}(n).dmg"
     end
-  end
-  on_mojave do
-    version "1.13"
-    sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
+    on_mojave do
+      version "1.13"
+      sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
     end
-  end
-  on_catalina do
-    version "1.13"
-    sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
+    on_catalina do
+      version "1.13"
+      sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/o/omnifocus.rb
+++ b/Casks/o/omnifocus.rb
@@ -1,99 +1,57 @@
 cask "omnifocus" do
-  on_el_capitan :or_older do
-    version "2.10"
-    sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
+  on_ventura :or_older do
+    on_el_capitan :or_older do
+      version "2.10"
+      sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
+    end
+    on_sierra do
+      version "2.12.4"
+      sha256 "8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0"
+
+      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
+    end
+    on_high_sierra do
+      version "3.4.6"
+      sha256 "b770b046c2c59f6e55f54d0ad822d5aa755a18aa201d333341de14ebbbcc6a85"
+
+      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniFocus-#{version}.dmg"
+    end
+    on_mojave do
+      version "3.11.7"
+      sha256 "21c0a63b6bd8c8ff3e5067f4ccd0ab16c9fd65815a7305e184ed27723bd0aa15"
+
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniFocus-#{version}.dmg"
+    end
+    on_catalina do
+      version "3.11.7"
+      sha256 "21c0a63b6bd8c8ff3e5067f4ccd0ab16c9fd65815a7305e184ed27723bd0aa15"
+
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniFocus-#{version}.dmg"
+    end
+    on_big_sur do
+      version "3.15.8"
+      sha256 "f0fe7bf0fafc35d50a23fe0d614b9403b58de9439704a2e3d93fbdc602aab661"
+
+      url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
+    end
+    on_monterey do
+      version "3.15.8"
+      sha256 "f0fe7bf0fafc35d50a23fe0d614b9403b58de9439704a2e3d93fbdc602aab661"
+
+      url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
+    end
+    on_ventura do
+      version "4.3.3"
+      sha256 "3baf339d5ea9e421d0467c41d64c9ee0de820b1881ceb28acbc6597c4c93a53a"
+
+      url "https://downloads.omnigroup.com/software/macOS/13/OmniFocus-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"
     end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_sierra do
-    version "2.12.4"
-    sha256 "8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_high_sierra do
-    version "3.4.6"
-    sha256 "b770b046c2c59f6e55f54d0ad822d5aa755a18aa201d333341de14ebbbcc6a85"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_mojave do
-    version "3.11.7"
-    sha256 "21c0a63b6bd8c8ff3e5067f4ccd0ab16c9fd65815a7305e184ed27723bd0aa15"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_catalina do
-    version "3.11.7"
-    sha256 "21c0a63b6bd8c8ff3e5067f4ccd0ab16c9fd65815a7305e184ed27723bd0aa15"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_big_sur do
-    version "3.15.8"
-    sha256 "f0fe7bf0fafc35d50a23fe0d614b9403b58de9439704a2e3d93fbdc602aab661"
-
-    url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_monterey do
-    version "3.15.8"
-    sha256 "f0fe7bf0fafc35d50a23fe0d614b9403b58de9439704a2e3d93fbdc602aab661"
-
-    url "https://downloads.omnigroup.com/software/macOS/11/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
-  end
-  on_ventura do
-    version "4.3.3"
-    sha256 "3baf339d5ea9e421d0467c41d64c9ee0de820b1881ceb28acbc6597c4c93a53a"
-
-    url "https://downloads.omnigroup.com/software/macOS/13/OmniFocus-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
   end
   on_sonoma :or_newer do
     version "4.5.3"
@@ -105,8 +63,6 @@ cask "omnifocus" do
       url "https://www.omnigroup.com/download/latest/omnifocus/"
       strategy :header_match
     end
-
-    uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
   end
 
   name "OmniFocus"
@@ -116,6 +72,8 @@ cask "omnifocus" do
   auto_updates true
 
   app "OmniFocus.app"
+
+  uninstall quit: "com.omnigroup.OmniFocus#{version.major}"
 
   zap trash: [
     "~/Library/Application Scripts/34YW5XSRB7.com.omnigroup.OmniFocus*",

--- a/Casks/o/omnigraffle.rb
+++ b/Casks/o/omnigraffle.rb
@@ -1,59 +1,41 @@
 cask "omnigraffle" do
-  on_el_capitan :or_older do
-    version "7.5"
-    sha256 "d8d8963a85ee34270d7d0148aaaa7aee75bc7d3fffc1bb89e64626546c943d34"
+  on_big_sur :or_older do
+    on_el_capitan :or_older do
+      version "7.5"
+      sha256 "d8d8963a85ee34270d7d0148aaaa7aee75bc7d3fffc1bb89e64626546c943d34"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniGraffle-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniGraffle-#{version}.dmg"
     end
-  end
-  on_sierra do
-    version "7.8.2"
-    sha256 "ab463ea6c12d49c4104d3814ac3280d0359072702d4751f5074f644fc79de0c6"
+    on_sierra do
+      version "7.8.2"
+      sha256 "ab463ea6c12d49c4104d3814ac3280d0359072702d4751f5074f644fc79de0c6"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniGraffle-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniGraffle-#{version}.dmg"
     end
-  end
-  on_high_sierra do
-    version "7.11.5"
-    sha256 "83ef24af2dbd7977b9922e992f17f23e102562f0589d28bc37d5579b4a4d4938"
+    on_high_sierra do
+      version "7.11.5"
+      sha256 "83ef24af2dbd7977b9922e992f17f23e102562f0589d28bc37d5579b4a4d4938"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
     end
-  end
-  on_mojave do
-    version "7.18.6"
-    sha256 "5dfc4f56f5a243f39abf0baf3d9dc2b1921f981bc6edb876f4eec710379e1fa6"
+    on_mojave do
+      version "7.18.6"
+      sha256 "5dfc4f56f5a243f39abf0baf3d9dc2b1921f981bc6edb876f4eec710379e1fa6"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
     end
-  end
-  on_catalina do
-    version "7.18.6"
-    sha256 "5dfc4f56f5a243f39abf0baf3d9dc2b1921f981bc6edb876f4eec710379e1fa6"
+    on_catalina do
+      version "7.18.6"
+      sha256 "5dfc4f56f5a243f39abf0baf3d9dc2b1921f981bc6edb876f4eec710379e1fa6"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
     end
-  end
-  on_big_sur do
-    version "7.22.6"
-    sha256 "1159e731ab282b2f2b3881cbc75cc7bb40263cb3b56826f4ef6334295b47a883"
+    on_big_sur do
+      version "7.22.6"
+      sha256 "1159e731ab282b2f2b3881cbc75cc7bb40263cb3b56826f4ef6334295b47a883"
 
-    url "https://downloads.omnigroup.com/software/macOS/11/OmniGraffle-#{version}.dmg"
+      url "https://downloads.omnigroup.com/software/macOS/11/OmniGraffle-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/o/omnioutliner.rb
+++ b/Casks/o/omnioutliner.rb
@@ -1,59 +1,41 @@
 cask "omnioutliner" do
-  on_el_capitan :or_older do
-    version "5.1.4"
-    sha256 "91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0"
+  on_big_sur :or_older do
+    on_el_capitan :or_older do
+      version "5.1.4"
+      sha256 "91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
     end
-  end
-  on_sierra do
-    version "5.3.4"
-    sha256 "dd329a070980ae6fe1aa9c55d398a2ab5b6192082455e7eb3526a9fccb3eaf42"
+    on_sierra do
+      version "5.3.4"
+      sha256 "dd329a070980ae6fe1aa9c55d398a2ab5b6192082455e7eb3526a9fccb3eaf42"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
     end
-  end
-  on_high_sierra do
-    version "5.4.2"
-    sha256 "a9364dcf2ee97a871a881530785fa54d269f5e95298e2e4d2e979c70b6365395"
+    on_high_sierra do
+      version "5.4.2"
+      sha256 "a9364dcf2ee97a871a881530785fa54d269f5e95298e2e4d2e979c70b6365395"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniOutliner-#{version}(n).dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniOutliner-#{version}(n).dmg"
     end
-  end
-  on_mojave do
-    version "5.8.5"
-    sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
+    on_mojave do
+      version "5.8.5"
+      sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
     end
-  end
-  on_catalina do
-    version "5.8.5"
-    sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
+    on_catalina do
+      version "5.8.5"
+      sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
     end
-  end
-  on_big_sur do
-    version "5.12"
-    sha256 "1f417470258c3505cc2226689a814f5a4b1fde78f268ba4a151aae923cbe694c"
+    on_big_sur do
+      version "5.12"
+      sha256 "1f417470258c3505cc2226689a814f5a4b1fde78f268ba4a151aae923cbe694c"
 
-    url "https://downloads.omnigroup.com/software/macOS/11/OmniOutliner-#{version}.dmg"
+      url "https://downloads.omnigroup.com/software/macOS/11/OmniOutliner-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/o/omniplan.rb
+++ b/Casks/o/omniplan.rb
@@ -1,59 +1,41 @@
 cask "omniplan" do
-  on_el_capitan :or_older do
-    version "3.7.3"
-    sha256 "1a3ab3a1ea22bdbdf9c1afda8cafc9a2fdf60cb4414f142b621c8758f81720bd"
+  on_big_sur :or_older do
+    on_el_capitan :or_older do
+      version "3.7.3"
+      sha256 "1a3ab3a1ea22bdbdf9c1afda8cafc9a2fdf60cb4414f142b621c8758f81720bd"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPlan-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPlan-#{version}.dmg"
     end
-  end
-  on_sierra do
-    version "3.10.4"
-    sha256 "a30728e72ae970dbf37b2ef9942a6b54267aa3456288dcc1815f20b44667e9e5"
+    on_sierra do
+      version "3.10.4"
+      sha256 "a30728e72ae970dbf37b2ef9942a6b54267aa3456288dcc1815f20b44667e9e5"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
     end
-  end
-  on_high_sierra do
-    version "3.13"
-    sha256 "82e0d7db2626d751f93f97d80dc032e4bc01bba1e05ea52c553e4771c8cfeec5"
+    on_high_sierra do
+      version "3.13"
+      sha256 "82e0d7db2626d751f93f97d80dc032e4bc01bba1e05ea52c553e4771c8cfeec5"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
     end
-  end
-  on_mojave do
-    version "4.2.7"
-    sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
+    on_mojave do
+      version "4.2.7"
+      sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
     end
-  end
-  on_catalina do
-    version "4.2.7"
-    sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
+    on_catalina do
+      version "4.2.7"
+      sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
 
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
     end
-  end
-  on_big_sur do
-    version "4.6"
-    sha256 "2d674c80ee5c60e3697a38b4933084958ea2b1f990a28827722b803257e7722d"
+    on_big_sur do
+      version "4.6"
+      sha256 "2d674c80ee5c60e3697a38b4933084958ea2b1f990a28827722b803257e7722d"
 
-    url "https://downloads.omnigroup.com/software/macOS/11/OmniPlan-#{version}.dmg"
+      url "https://downloads.omnigroup.com/software/macOS/11/OmniPlan-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -3,82 +3,52 @@ cask "onyx" do
 
   # NOTE: We use separate `url` values in each of the macOS on_system blocks
   # so that the API data correctly includes URL variants for each.
-  on_el_capitan :or_older do
-    version "3.1.9"
+  on_sonoma :or_older do
+    on_el_capitan :or_older do
+      version "3.1.9"
 
-    url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
     end
-  end
-  on_sierra do
-    version "3.3.1"
+    on_sierra do
+      version "3.3.1"
 
-    url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
     end
-  end
-  on_high_sierra do
-    version "3.4.9"
+    on_high_sierra do
+      version "3.4.9"
 
-    url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
     end
-  end
-  on_mojave do
-    version "3.6.8"
+    on_mojave do
+      version "3.6.8"
 
-    url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
     end
-  end
-  on_catalina do
-    version "3.8.7"
+    on_catalina do
+      version "3.8.7"
 
-    url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
     end
-  end
-  on_big_sur do
-    version "4.0.2"
+    on_big_sur do
+      version "4.0.2"
 
-    url "https://www.titanium-software.fr/download/11/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/11/OnyX.dmg"
     end
-  end
-  on_monterey do
-    version "4.2.7"
+    on_monterey do
+      version "4.2.7"
 
-    url "https://www.titanium-software.fr/download/12/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/12/OnyX.dmg"
     end
-  end
-  on_ventura do
-    version "4.4.7"
+    on_ventura do
+      version "4.4.7"
 
-    url "https://www.titanium-software.fr/download/13/OnyX.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.titanium-software.fr/download/13/OnyX.dmg"
     end
-  end
-  on_sonoma do
-    version "4.6.2"
+    on_sonoma do
+      version "4.6.2"
 
-    url "https://www.titanium-software.fr/download/14/OnyX.dmg"
+      url "https://www.titanium-software.fr/download/14/OnyX.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/p/powerphotos.rb
+++ b/Casks/p/powerphotos.rb
@@ -1,59 +1,41 @@
 cask "powerphotos" do
-  on_el_capitan :or_older do
-    version "1.2.3"
-    sha256 "b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb"
+  on_big_sur :or_older do
+    on_el_capitan :or_older do
+      version "1.2.3"
+      sha256 "b07eb9f8801fb397d55e3dd7e0569dbef5d3265debaf3ee68247062901d93fcb"
 
-    url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
     end
-  end
-  on_sierra do
-    version "1.4.2"
-    sha256 "ed9be64f4cb5a3d3848ad5177947bd8cd33e36846ea36266ef9d4d7b46813538"
+    on_sierra do
+      version "1.4.2"
+      sha256 "ed9be64f4cb5a3d3848ad5177947bd8cd33e36846ea36266ef9d4d7b46813538"
 
-    url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
     end
-  end
-  on_high_sierra do
-    version "1.6.4"
-    sha256 "e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a"
+    on_high_sierra do
+      version "1.6.4"
+      sha256 "e7c7d5970b734827a5f112029491d2d97f9a6bb318f457893905718bea6b595a"
 
-    url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
     end
-  end
-  on_mojave do
-    version "1.8.5"
-    sha256 "365b6c8c9f5e356daa56ae2666498b826746cc1301ee3acdbe66379e7d3e67d0"
+    on_mojave do
+      version "1.8.5"
+      sha256 "365b6c8c9f5e356daa56ae2666498b826746cc1301ee3acdbe66379e7d3e67d0"
 
-    url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
     end
-  end
-  on_catalina do
-    version "1.9.12"
-    sha256 "cbb7cb47b20d947bc8bb30dc29e6eba88ba1e39d073bc304962e3f4759c8f0be"
+    on_catalina do
+      version "1.9.12"
+      sha256 "cbb7cb47b20d947bc8bb30dc29e6eba88ba1e39d073bc304962e3f4759c8f0be"
 
-    url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
     end
-  end
-  on_big_sur do
-    version "2.1.8"
-    sha256 "b9fbf7b188e157b20b779611d5fd4f922574d8818517f4341a538c06bbfcd88d"
+    on_big_sur do
+      version "2.1.8"
+      sha256 "b9fbf7b188e157b20b779611d5fd4f922574d8818517f4341a538c06bbfcd88d"
 
-    url "https://www.fatcatsoftware.com/powerphotos/downloads/PowerPhotos_#{version.no_dots}.zip"
+      url "https://www.fatcatsoftware.com/powerphotos/downloads/PowerPhotos_#{version.no_dots}.zip"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/q/qbittorrent.rb
+++ b/Casks/q/qbittorrent.rb
@@ -1,23 +1,17 @@
 cask "qbittorrent" do
-  on_high_sierra :or_older do
-    version "4.3.2"
-    sha256 "dd38e80710978430694c430276a6b7749ef3533cbd0271075bc9eada484ea36b"
-
-    livecheck do
-      skip "Legacy version"
+  on_catalina :or_older do
+    on_high_sierra :or_older do
+      version "4.3.2"
+      sha256 "dd38e80710978430694c430276a6b7749ef3533cbd0271075bc9eada484ea36b"
     end
-  end
-  on_mojave do
-    version "4.3.9"
-    sha256 "c43323a625a937383da68e50a99d823d56e6843580dc8550dd4942683467c3ed"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "4.3.9"
+      sha256 "c43323a625a937383da68e50a99d823d56e6843580dc8550dd4942683467c3ed"
     end
-  end
-  on_catalina do
-    version "4.6.7"
-    sha256 "0b1051af73562fc3f7c0c71abd27c3433ad238fbca0c4612f554db35be3eba6e"
+    on_catalina do
+      version "4.6.7"
+      sha256 "0b1051af73562fc3f7c0c71abd27c3433ad238fbca0c4612f554db35be3eba6e"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/sip.rb
+++ b/Casks/s/sip.rb
@@ -1,47 +1,29 @@
 cask "sip" do
-  on_sierra :or_older do
-    version "1.2"
-    sha256 "eb4507ce67c6d19c4e649d3e033542265be8d2aaccabc7f8ee00080842a886c0"
-
-    livecheck do
-      skip "Legacy version"
+  on_monterey :or_older do
+    on_sierra :or_older do
+      version "1.2"
+      sha256 "eb4507ce67c6d19c4e649d3e033542265be8d2aaccabc7f8ee00080842a886c0"
     end
-  end
-  on_high_sierra do
-    version "2.4.1"
-    sha256 "9e8e69b8874891fab4fcc44edfb9b6ff2e510a1f41c87e9faea6060fc3f33073"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "2.4.1"
+      sha256 "9e8e69b8874891fab4fcc44edfb9b6ff2e510a1f41c87e9faea6060fc3f33073"
     end
-  end
-  on_mojave do
-    version "2.5.5"
-    sha256 "a67550abe2f43981b7b41827ee9ccc0f826383cc1d146e748bde399f3c352d62"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "2.5.5"
+      sha256 "a67550abe2f43981b7b41827ee9ccc0f826383cc1d146e748bde399f3c352d62"
     end
-  end
-  on_catalina do
-    version "2.8"
-    sha256 "95e2bd14ce3de9743304efee4fb9964f00fc9505401f1e036de8175616ca58dd"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "2.8"
+      sha256 "95e2bd14ce3de9743304efee4fb9964f00fc9505401f1e036de8175616ca58dd"
     end
-  end
-  on_big_sur do
-    version "2.8"
-    sha256 "95e2bd14ce3de9743304efee4fb9964f00fc9505401f1e036de8175616ca58dd"
-
-    livecheck do
-      skip "Legacy version"
+    on_big_sur do
+      version "2.8"
+      sha256 "95e2bd14ce3de9743304efee4fb9964f00fc9505401f1e036de8175616ca58dd"
     end
-  end
-  on_monterey do
-    version "3.5.1"
-    sha256 "8dd74db34c925c9712c5b383bae43dc9cb2339ed3af2ad0a8677e0a22815f35f"
+    on_monterey do
+      version "3.5.1"
+      sha256 "8dd74db34c925c9712c5b383bae43dc9cb2339ed3af2ad0a8677e0a22815f35f"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -1,41 +1,31 @@
 cask "sonic-pi" do
   arch arm: "Mac-arm64", intel: "Intel-Mac-x64"
 
-  on_mojave :or_older do
-    version "3.3.1"
-    sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
+  on_monterey :or_older do
+    on_mojave :or_older do
+      version "3.3.1"
+      sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
     end
-  end
-  on_catalina do
-    version "4.3.0"
-    sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
+    on_catalina do
+      version "4.3.0"
+      sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
     end
-  end
-  on_big_sur do
-    version "4.5.1"
-    sha256 "15d589a27636edc4a4b9e9685950d857c7dd076d310497d650f90a387645456a"
+    on_big_sur do
+      version "4.5.1"
+      sha256 "15d589a27636edc4a4b9e9685950d857c7dd076d310497d650f90a387645456a"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
     end
-  end
-  on_monterey do
-    version "4.5.1"
-    sha256 "15d589a27636edc4a4b9e9685950d857c7dd076d310497d650f90a387645456a"
+    on_monterey do
+      version "4.5.1"
+      sha256 "15d589a27636edc4a4b9e9685950d857c7dd076d310497d650f90a387645456a"
 
-    url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+      url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Intel-Mac-x64-v#{version.dots_to_hyphens}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/sourcetree.rb
+++ b/Casks/s/sourcetree.rb
@@ -1,32 +1,26 @@
 cask "sourcetree" do
-  on_sierra :or_older do
-    version "2.7.6a"
-    sha256 "d60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e"
+  on_mojave :or_older do
+    on_sierra :or_older do
+      version "2.7.6a"
+      sha256 "d60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e"
 
-    url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip",
-        verified: "downloads.atlassian.com/software/sourcetree/"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip",
+          verified: "downloads.atlassian.com/software/sourcetree/"
     end
-  end
-  on_high_sierra do
-    version "3.2.1,225"
-    sha256 "4bd82affa3402814c3d07ff613fbc8f45da8b0cda294d498ffbb0667bf729c9f"
+    on_high_sierra do
+      version "3.2.1,225"
+      sha256 "4bd82affa3402814c3d07ff613fbc8f45da8b0cda294d498ffbb0667bf729c9f"
 
-    url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
-        verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
-
-    livecheck do
-      skip "Legacy version"
+      url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
+          verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
     end
-  end
-  on_mojave do
-    version "4.2.1,248"
-    sha256 "3dac6ab514c7debe960339e2aee99f018342a41baf743dbb59524728b373561f"
+    on_mojave do
+      version "4.2.1,248"
+      sha256 "3dac6ab514c7debe960339e2aee99f018342a41baf743dbb59524728b373561f"
 
-    url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
-        verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
+      url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
+          verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
+    end
 
     livecheck do
       skip "Legacy version"

--- a/Casks/s/suspicious-package.rb
+++ b/Casks/s/suspicious-package.rb
@@ -1,47 +1,25 @@
 cask "suspicious-package" do
-  on_sierra :or_older do
-    version "3.4.1"
-    sha256 "e4673a0c590e7dcb711789d98fcadd2283c2152d262b7809dfd8c8a1b3e9094b"
-
-    url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+  on_big_sur :or_older do
+    on_sierra :or_older do
+      version "3.4.1"
+      sha256 "e4673a0c590e7dcb711789d98fcadd2283c2152d262b7809dfd8c8a1b3e9094b"
     end
-  end
-  on_high_sierra do
-    version "3.5.3"
-    sha256 "fad69db99a60058f8136954653fa2de81667f12cb731957a6d921d36ceaf195d"
-
-    url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+    on_high_sierra do
+      version "3.5.3"
+      sha256 "fad69db99a60058f8136954653fa2de81667f12cb731957a6d921d36ceaf195d"
     end
-  end
-  on_mojave do
-    version "4.0"
-    sha256 "844708fb75f8aa102f3ede8ddef3c20180f469b7bc8ec65bbc0370ce9f7db33c"
-
-    url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+    on_mojave do
+      version "4.0"
+      sha256 "844708fb75f8aa102f3ede8ddef3c20180f469b7bc8ec65bbc0370ce9f7db33c"
     end
-  end
-  on_catalina do
-    version "4.2.1"
-    sha256 "5c05df9bf3d56758a3eefa972597e3138afdea4c3774f91fe2849482b7112823"
-
-    url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
+    on_catalina do
+      version "4.2.1"
+      sha256 "5c05df9bf3d56758a3eefa972597e3138afdea4c3774f91fe2849482b7112823"
     end
-  end
-  on_big_sur do
-    version "4.3.3"
-    sha256 "a262c317ad2d6949e0d0f2bec9524a4a85e0e69d6aec0373cf185892acac1f69"
+    on_big_sur do
+      version "4.3.3"
+      sha256 "a262c317ad2d6949e0d0f2bec9524a4a85e0e69d6aec0373cf185892acac1f69"
+    end
 
     url "https://www.mothersruin.com/software/downloads/SuspiciousPackage-#{version}.dmg"
 


### PR DESCRIPTION
Similar to #213233 and #213246, this nests groups of 3 or more legacy on_os blocks so that `skip "Legacy version"` only has to be mentioned once. The output is unchanged and the files are more readable. (See `birdfont`, `cocktail` and `macpilot` for current examples.)