### PR TITLE
ocenaudio: fix legacy downloads

### DIFF
--- a/Casks/o/ocenaudio.rb
+++ b/Casks/o/ocenaudio.rb
@@ -2,19 +2,16 @@ cask "ocenaudio" do
   version "3.15.0"
   sha256 :no_check
 
-  on_arm do
-    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg"
-  end
-  on_intel do
+  on_big_sur :or_older do
     on_high_sierra :or_older do
       url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg"
     end
-    on_mojave do
-      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_mojave.dmg"
+    on_mojave :or_newer do
+      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal_legacy.dmg"
     end
-    on_catalina :or_newer do
-      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg"
-    end
+  end
+  on_monterey :or_newer do
+    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg"
   end
 
   name "ocenaudio"


### PR DESCRIPTION
Latest version still being released for 10.12+, but the download names and OS ranges have changed slightly. 