### PR TITLE
Add Cask for Tencent IMA (腾讯元器)

### DIFF
--- a/Casks/t/tencent-ima.rb
+++ b/Casks/t/tencent-ima.rb
@@ -1,0 +1,36 @@
+cask "tencent-ima" do
+  version "1.3.1_1919"
+  sha256 "dd859b18ad187681f68ba0295157dbc400e7c520b643018964c955ee497c4016"
+
+  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_#{version}.dmg"
+  name "Tencent IMA"
+  desc "Knowledge base application by Tencent."
+  homepage "https://ima.qq.com/"
+
+  livecheck do
+    url :homepage
+    regex(/ima\.copilot_universal_(\d+(?:\.\d+)*_\d+)\.dmg/i)
+    strategy :page_match
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sierra"
+
+  app "ima.copilot.app"
+
+  uninstall quit: "com.tencent.ima.copilot" # Likely, but unverified
+
+  zap trash: [
+    "~/Library/Application Scripts/com.tencent.ima.copilot",
+    "~/Library/Application Support/ima.copilot",
+    "~/Library/Application Support/Tencent/ima.copilot",
+    "~/Library/Caches/com.tencent.ima.copilot",
+    "~/Library/Caches/ima.copilot",
+    "~/Library/Containers/com.tencent.ima.copilot",
+    "~/Library/HTTPStorages/com.tencent.ima.copilot",
+    "~/Library/Preferences/com.tencent.ima.copilot.plist",
+    "~/Library/Saved Application State/com.tencent.ima.copilot.savedState",
+    "~/Library/WebKit/com.tencent.ima.copilot",
+    "~/Library/Logs/ima.copilot",
+  ]
+end

--- a/Casks/t/tencent-ima.rb
+++ b/Casks/t/tencent-ima.rb
@@ -2,19 +2,20 @@ cask "tencent-ima" do
   version "1.3.1_1919"
   sha256 "dd859b18ad187681f68ba0295157dbc400e7c520b643018964c955ee497c4016"
 
-  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_#{version}.dmg"
+  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_#{version}.dmg",
+      verified: "ima-app.image.myqcloud.com"
   name "Tencent IMA"
-  desc "Knowledge base application by Tencent."
+  desc "Knowledge base application by Tencent"
   homepage "https://ima.qq.com/"
 
   livecheck do
-    url :homepage
-    regex(/ima\.copilot_universal_(\d+(?:\.\d+)*_\d+)\.dmg/i)
+    url "https://qbtool.static.qq.com/ima/assets/official-website/assets/index-BKuCC9QK.js"
+    regex(/ima\.copilot_universal_(\d+(?:[._]\d+)+)\.dmg/i)
     strategy :page_match
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
+  depends_on macos: ">= :big_sur"
 
   app "ima.copilot.app"
 
@@ -22,15 +23,15 @@ cask "tencent-ima" do
 
   zap trash: [
     "~/Library/Application Scripts/com.tencent.ima.copilot",
-    "~/Library/Application Support/ima.copilot",
     "~/Library/Application Support/Tencent/ima.copilot",
+    "~/Library/Application Support/ima.copilot",
     "~/Library/Caches/com.tencent.ima.copilot",
     "~/Library/Caches/ima.copilot",
     "~/Library/Containers/com.tencent.ima.copilot",
     "~/Library/HTTPStorages/com.tencent.ima.copilot",
+    "~/Library/Logs/ima.copilot",
     "~/Library/Preferences/com.tencent.ima.copilot.plist",
     "~/Library/Saved Application State/com.tencent.ima.copilot.savedState",
     "~/Library/WebKit/com.tencent.ima.copilot",
-    "~/Library/Logs/ima.copilot",
   ]
 end

--- a/Casks/t/tencent-ima.rb
+++ b/Casks/t/tencent-ima.rb
@@ -1,17 +1,15 @@
 cask "tencent-ima" do
-  version "1.3.1_1919"
-  sha256 "dd859b18ad187681f68ba0295157dbc400e7c520b643018964c955ee497c4016"
+  version "1.7.2_2662"
+  sha256 "5a4507fb60fcd43df4d821f2752e2fb32938602b711745e88d08b5674b31b511"
 
-  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_#{version}.dmg",
+  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_1018_1.7.2_2662.dmg",
       verified: "ima-app.image.myqcloud.com"
   name "Tencent IMA"
   desc "Knowledge base application by Tencent"
   homepage "https://ima.qq.com/"
 
   livecheck do
-    url "https://qbtool.static.qq.com/ima/assets/official-website/assets/index-BKuCC9QK.js"
-    regex(/ima\.copilot_universal_(\d+(?:[._]\d+)+)\.dmg/i)
-    strategy :page_match
+    skip "No reliable automated version detection available"
   end
 
   auto_updates true

--- a/Casks/t/tencent-ima.rb
+++ b/Casks/t/tencent-ima.rb
@@ -1,8 +1,8 @@
 cask "tencent-ima" do
-  version "1.7.2_2662"
+  version "1018_1.7.2_2662"
   sha256 "5a4507fb60fcd43df4d821f2752e2fb32938602b711745e88d08b5674b31b511"
 
-  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_1018_1.7.2_2662.dmg",
+  url "https://ima-app.image.myqcloud.com/app/ima.copilot_universal_#{version}.dmg",
       verified: "ima-app.image.myqcloud.com"
   name "Tencent IMA"
   desc "Knowledge base application by Tencent"

--- a/Casks/t/tencent-ima.rb
+++ b/Casks/t/tencent-ima.rb
@@ -23,8 +23,8 @@ cask "tencent-ima" do
 
   zap trash: [
     "~/Library/Application Scripts/com.tencent.ima.copilot",
-    "~/Library/Application Support/Tencent/ima.copilot",
     "~/Library/Application Support/ima.copilot",
+    "~/Library/Application Support/Tencent/ima.copilot",
     "~/Library/Caches/com.tencent.ima.copilot",
     "~/Library/Caches/ima.copilot",
     "~/Library/Containers/com.tencent.ima.copilot",


### PR DESCRIPTION
This commit adds a new Cask for Tencent IMA (腾讯元器), a knowledge base application by Tencent.

Cask name: tencent-ima
Version: 1.3.1_1919
Homepage: https://ima.qq.com/
Download URL: https://ima-app.image.myqcloud.com/app/ima.copilot_universal_1.3.1_1919.dmg
SHA256: dd859b18ad187681f68ba0295157dbc400e7c520b643018964c955ee497c4016

The application bundle name has been verified as `ima.copilot.app`. The `livecheck` stanza has been implemented.
The `uninstall quit` and `zap trash` stanzas are based on conventions for Tencent applications and the verified app name. The bundle ID `com.tencent.ima.copilot` for `uninstall quit` is an educated guess and may require verification during the PR review process, as direct installation testing was not possible in the development environment.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
