### PR TITLE
various: move `depends_on macos:` to outside OS blocks

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -12,8 +12,6 @@ cask "airfoil" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.12.4"
@@ -25,8 +23,6 @@ cask "airfoil" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :sonoma"
-
     # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Airfoil+for+Mac
     caveats "Airfoil #{version} requires macOS 14.4 or higher."
   end
@@ -36,6 +32,7 @@ cask "airfoil" do
   homepage "https://rogueamoeba.com/airfoil/mac/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Airfoil/Airfoil Satellite.app"
   app "Airfoil/Airfoil.app"

--- a/Casks/a/audio-hijack.rb
+++ b/Casks/a/audio-hijack.rb
@@ -12,8 +12,6 @@ cask "audio-hijack" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.audiohijack&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "4.5.1"
@@ -25,8 +23,6 @@ cask "audio-hijack" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :sonoma"
-
     # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Audio+Hijack
     caveats "Audio Hijack #{version} requires macOS 14.5 or higher."
   end
@@ -36,6 +32,7 @@ cask "audio-hijack" do
   homepage "https://rogueamoeba.com/audiohijack/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Audio Hijack.app"
 

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -12,8 +12,6 @@ cask "loopback" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "2.4.6"
@@ -25,8 +23,6 @@ cask "loopback" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :sonoma"
-
     # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Loopback
     caveats "Loopback #{version} requires macOS 14.5 or newer."
   end
@@ -36,6 +32,7 @@ cask "loopback" do
   homepage "https://rogueamoeba.com/loopback/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Loopback.app"
 

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -12,8 +12,6 @@ cask "piezo" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "1.9.5"
@@ -25,8 +23,6 @@ cask "piezo" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :sonoma"
-
     # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Piezo
     caveats "Piezo #{version} requires macOS 14.4 or higher."
   end
@@ -36,6 +32,7 @@ cask "piezo" do
   homepage "https://rogueamoeba.com/piezo/"
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Piezo.app"
 

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -12,8 +12,6 @@ cask "soundsource" do
       url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
       strategy :sparkle
     end
-
-    depends_on macos: ">= :big_sur"
   end
   on_sonoma :or_newer do
     version "5.8.2"
@@ -25,8 +23,6 @@ cask "soundsource" do
       strategy :sparkle
     end
 
-    depends_on macos: ">= :sonoma"
-
     # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=SoundSource
     caveats "SoundSource #{version} requires macOS 14.5 or higher."
   end
@@ -37,6 +33,7 @@ cask "soundsource" do
 
   auto_updates true
   conflicts_with cask: "soundsource@test"
+  depends_on macos: ">= :big_sur"
 
   app "SoundSource.app"
 


### PR DESCRIPTION
A cask should have a single `depends_on macos:` stanza outside any on_os blocks that [encompass all releases listed in the cask](https://docs.brew.sh/Cask-Cookbook#handling-different-system-configurations). Otherwise, the cask's generated API lists macOS versions that aren't supported (example: [`airfoil`](https://formulae.brew.sh/cask/airfoil)). (This should be an audit at some point.) 

xref #179849 