### PR TITLE
widelands: fix macOS requirements

### DIFF
--- a/Casks/w/widelands.rb
+++ b/Casks/w/widelands.rb
@@ -1,15 +1,20 @@
 cask "widelands" do
-  arch arm: "14-arm64", intel: "12-x86"
-
   version "1.2.1"
-  sha256 arm:   "7067e26809ba92395644b58ced3d99b2ecd5f83844c913c1cae7290351cc6f38",
-         intel: "de55c686a82c904c4e585cf93802af3b475ed330e5420b3ef9b4a23d649e6b9e"
 
-  on_arm do
-    depends_on macos: ">= :sonoma"
+  on_ventura :or_older do
+    arch arm: "12-x86", intel: "12-x86"
+
+    sha256 "de55c686a82c904c4e585cf93802af3b475ed330e5420b3ef9b4a23d649e6b9e"
+
+    caveats do
+      requires_rosetta
+    end
   end
-  on_intel do
-    depends_on macos: ">= :monterey"
+  on_sonoma :or_newer do
+    arch arm: "14-arm64", intel: "12-x86"
+
+    sha256 arm:   "7067e26809ba92395644b58ced3d99b2ecd5f83844c913c1cae7290351cc6f38",
+           intel: "de55c686a82c904c4e585cf93802af3b475ed330e5420b3ef9b4a23d649e6b9e"
   end
 
   url "https://github.com/widelands/widelands/releases/download/v#{version}/Widelands-#{version}-MacOS#{arch}.dmg",
@@ -22,6 +27,8 @@ cask "widelands" do
     url "https://www.widelands.org/wiki/Download/"
     regex(/href=.*?Widelands[._-]v?(\d+(?:\.\d+)+)[._-]MacOS#{arch}\.dmg/i)
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Widelands.app"
 


### PR DESCRIPTION
As mentioned in #213329, having `depends_on macos:` nested in an on_system block causes the generated API to be inaccurate (see https://formulae.brew.sh/cask/widelands). So, instead of having different macOS dependencies depending on architecture, this has a single minimum OS requirement for the entire cask, and gives different downloads depending on if we're running Sonoma vs. something earlier. 

The way to handle this kind of bifurcated OS/arch requirements isn't obvious (in this case, where macOS ARM versions of a certain age only have the option of running the Intel version), but it's been done before in [`jellyfin-media-player`](https://github.com/Homebrew/homebrew-cask/blob/c40ffdeb73ba81618af19b5f0f14c1437020af80/Casks/j/jellyfin-media-player.rb).