### PR TITLE
pieces-cli (deprecate)

### DIFF
--- a/Casks/p/pieces-cli.rb
+++ b/Casks/p/pieces-cli.rb
@@ -18,6 +18,9 @@ cask "pieces-cli" do
     end
   end
 
+  # Warning: pieces-cli has been deprecated because it is now maintained as a formula
+  deprecate! date: "2025-05-22", because: :discontinued, replacement_formula: "pieces-cli"
+
   binary "pieces"
 
   zap trash: "~/Library/Application Support/cli-agent"


### PR DESCRIPTION
We now build pieces-cli as a formula and no longer wish to maintain the cask. The cask is much slower than the formula and there is no reason to use it.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
