### PR TITLE
tap_migrations: add `pieces-cli`

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -34,6 +34,7 @@
   "pandoc": "homebrew/core",
   "pgloader": "homebrew/core",
   "pgweb": "homebrew/core",
+  "pieces-cli": "homebrew/core",
   "podman": "homebrew/core",
   "purescript": "homebrew/core",
   "python": "homebrew/core",


### PR DESCRIPTION
Deprecated in https://github.com/Homebrew/homebrew-cask/pull/213431.