### PR TITLE
orbstack: add Group Containers directory to zap stanza

### DIFF
--- a/Casks/o/orbstack.rb
+++ b/Casks/o/orbstack.rb
@@ -37,6 +37,7 @@ cask "orbstack" do
   zap trash: [
         "~/.orbstack",
         "~/Library/Caches/dev.kdrag0n.MacVirt",
+        "~/Library/Group Containers/*.dev.orbstack",
         "~/Library/HTTPStorages/dev.kdrag0n.MacVirt",
         "~/Library/HTTPStorages/dev.kdrag0n.MacVirt.binarycookies",
         "~/Library/Preferences/dev.kdrag0n.MacVirt.plist",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
The current OrbStack zap stanza doesn't include "~/Library/Group Containers/HUAQ24HBR6.dev.orbstack" as indicated in https://docs.orbstack.dev/install#uninstalling. "*" was added for Team ID instead of "HUAQ24HBR6" in case the Team ID changes, but this can be reverted if requested.
