### PR TITLE
calmly-writer: simplify URLs

### DIFF
--- a/Casks/c/calmly-writer.rb
+++ b/Casks/c/calmly-writer.rb
@@ -1,30 +1,23 @@
 cask "calmly-writer" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "-arm64"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
 
   version "2.0.59"
+  sha256 arm:   "f96af9da430bc222b7e389e05e3af65b5064902e20d9608a11f55398d81c6867",
+         intel: "7801e93a01320dd230b4862dda8dfc4bc905649219c8882f83eaae0e410b5df2"
 
-  on_arm do
-    sha256 "f96af9da430bc222b7e389e05e3af65b5064902e20d9608a11f55398d81c6867"
-
-    url "https://www.calmlywriter.com/releases/Calmly%20Writer-#{version}-#{arch}.dmg"
-  end
-  on_intel do
-    sha256 "7801e93a01320dd230b4862dda8dfc4bc905649219c8882f83eaae0e410b5df2"
-
-    url "https://www.calmlywriter.com/releases/Calmly%20Writer-#{version}.dmg"
-  end
-
+  url "https://www.calmlywriter.com/releases/Calmly%20Writer-#{version}#{arch}.dmg"
   name "Calmly Writer"
   desc "Word processor with markdown formatting and select themes"
   homepage "https://calmlywriter.com/"
 
   livecheck do
-    url "https://calmlywriter.com/releases/#{arch}/download.php"
+    url "https://calmlywriter.com/releases/#{livecheck_arch}/download.php"
     regex(/Calmly(?:\s+|%20|[._-])?Writer[._-]v?(\d+(?:\.\d+)+)/i)
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :big_sur"
 
   app "Calmly Writer.app"
 


### PR DESCRIPTION
Specifying the URL once obviates the need for on_arch blocks. Output of `brew info --cask --json=v2 --variations calmly-writer` is unchanged.