### PR TITLE
gpgfrontend: consolidate URLs, fix legacy version

### DIFF
--- a/Casks/g/gpgfrontend.rb
+++ b/Casks/g/gpgfrontend.rb
@@ -1,10 +1,11 @@
 cask "gpgfrontend" do
+  macos_version = nil
+
   on_monterey :or_older do
+    macos_version = 12
+
     version "2.1.5"
     sha256 "731acf48fea4fed6fc4a0065b8e50655e8cff911c62e31f1fc5f4b8c2b478db2"
-
-    url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-12.dmg",
-        verified: "github.com/saturneric/GpgFrontend/"
 
     livecheck do
       skip "Legacy version"
@@ -15,37 +16,44 @@ cask "gpgfrontend" do
     end
   end
   on_ventura do
-    version "2.1.8"
-    sha256 "6a115d7201f59d00a550428fd3f1ebbb2917f59eab85a60aa19e9d3bd371b9e0"
+    macos_version = 13
 
-    url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-13.dmg",
-        verified: "github.com/saturneric/GpgFrontend/"
+    version "2.1.7"
+    sha256 "e7492fcaf2522992f1a4a2f62656f22b64403f56325f11a975c5d875c54c3558"
+
+    livecheck do
+      skip "Legacy version"
+    end
 
     caveats do
       requires_rosetta
     end
   end
   on_sonoma do
+    macos_version = 14
+
     version "2.1.8"
     sha256 "5d1c2f1e9b2a4157d13be4ab6afb3e95a0d8eae20ce8c3942090d4acc622bb10"
 
-    url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-14.dmg",
-        verified: "github.com/saturneric/GpgFrontend/"
+    depends_on arch: :arm64
   end
   on_sequoia :or_newer do
+    macos_version = 15
+
     version "2.1.8"
     sha256 "691e220a0bf6a5af95dc476ef41c81dc73b59430d7b9940d42b7750af0943f66"
 
-    url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-15.dmg",
-        verified: "github.com/saturneric/GpgFrontend/"
+    depends_on arch: :arm64
   end
 
+  url "https://github.com/saturneric/GpgFrontend/releases/download/v#{version}/GpgFrontend-#{version}-macos-#{macos_version}.dmg",
+      verified: "github.com/saturneric/GpgFrontend/"
   name "GpgFrontend"
   desc "OpenPGP/GnuPG crypto, sign and key management tool"
   homepage "https://gpgfrontend.bktus.com/"
 
-  depends_on macos: ">= :monterey"
   depends_on formula: "gnupg"
+  depends_on macos: ">= :monterey"
 
   app "GpgFrontend.app"
 


### PR DESCRIPTION
Borrowed the URL simplification strategy from `ghdl`. Also, the `2.1.8-macos-13` build actually requires macOS 14.2 or later to run, so scaled it back to 2.1.7 for Ventura.