### PR TITLE
cherry-studio: fix sha256

### DIFF
--- a/Casks/c/cherry-studio.rb
+++ b/Casks/c/cherry-studio.rb
@@ -2,7 +2,7 @@ cask "cherry-studio" do
   arch arm: "arm64", intel: "x64"
 
   version "1.3.11"
-  sha256 arm:   "3156d8a86c5566a6a658c2280d1a0b04534f56d61d337ab5bc02f82adcc0e106",
+  sha256 arm:   "dd33f119d9401ae19456b279affb6b30fd42e830f2e0a95bcb37c0fa8d38935a",
          intel: "65423e37c814485fc4f212f190f3b9e9f2e31a7febc35bef6995ec4d8f3a30d4"
 
   url "https://github.com/CherryHQ/cherry-studio/releases/download/v#{version}/Cherry-Studio-#{version}-#{arch}.zip",

--- a/Casks/c/cherry-studio.rb
+++ b/Casks/c/cherry-studio.rb
@@ -3,7 +3,7 @@ cask "cherry-studio" do
 
   version "1.3.11"
   sha256 arm:   "dd33f119d9401ae19456b279affb6b30fd42e830f2e0a95bcb37c0fa8d38935a",
-         intel: "65423e37c814485fc4f212f190f3b9e9f2e31a7febc35bef6995ec4d8f3a30d4"
+         intel: "850e647302ac122818bf6429fccac939a1b1b912527ab7a66d9470763366d7ab"
 
   url "https://github.com/CherryHQ/cherry-studio/releases/download/v#{version}/Cherry-Studio-#{version}-#{arch}.zip",
       verified: "github.com/CherryHQ/cherry-studio/"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

> Only the `sha256` value was updated. Unable to run `brew audit` or `brew style` locally due to cask not being tapped.

**Summary:**
Update `sha256` for `cherry-studio` 1.3.11 (arm64) to match the official release:
SHA256: `dd33f119d9401ae19456b279affb6b30fd42e830f2e0a95bcb37c0fa8d38935a`
Reference: https://github.com/CherryHQ/cherry-studio/releases/download/v1.3.11/Cherry-Studio-1.3.11-arm64.zip