### PR TITLE
fastrawviewer: update SHA256 hash

### DIFF
--- a/Casks/f/fastrawviewer.rb
+++ b/Casks/f/fastrawviewer.rb
@@ -1,6 +1,6 @@
 cask "fastrawviewer" do
   version "2.0.10.2058"
-  sha256 "0379081f2d490853758edfbefea8db3175d18a39fa8cb5a2661b9ea5c8aa4e67"
+  sha256 "5784f817a4ef56084871674b86b8a1a506606fdace3bd31dbb9d554b85c0f1fb"
 
   url "https://updates.fastrawviewer.com/data/FastRawViewer-#{version}.dmg"
   name "FastRawViewer"


### PR DESCRIPTION
The hash seems to have changed despite no version number bump, so this updates the hash to match. See my comment here: https://github.com/Homebrew/homebrew-cask/pull/212857#issuecomment-2894799222

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
```
$ brew audit --cask --online fastrawviewer
==> Downloading and extracting artifacts
==> Downloading https://updates.fastrawviewer.com/data/FastRawViewer-2.0.10.2058.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/c9460869140895e9726bb672964aa3246afa8f9f68de257f076cd53a72180dae--FastRawViewer-2.0.10.2058.dmg
==> Downloading https://updates.fastrawviewer.com/data/FastRawViewer-2.0.10.2058.dmg
Already downloaded: ~/Library/Caches/Homebrew/downloads/c9460869140895e9726bb672964aa3246afa8f9f68de257f076cd53a72180dae--FastRawViewer-2.0.10.2058.dmg
$ echo $status
0
```

- [x] `brew style --fix <cask>` reports no offenses.

```
$ brew style --fix fastrawviewer

1 file inspected, no offenses detected
```

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
