### PR TITLE
coinomi-wallet: deprecate

### DIFF
--- a/Casks/c/coinomi-wallet.rb
+++ b/Casks/c/coinomi-wallet.rb
@@ -8,10 +8,7 @@ cask "coinomi-wallet" do
   desc "Securely store, manage and exchange many blockchain assets"
   homepage "https://www.coinomi.com/en/"
 
-  livecheck do
-    url "https://www.coinomi.com/downloads/"
-    regex(/href=.*?coinomi[._-]wallet[._-]v?(\d+(?:\.\d+)+)[._-]macos\.dmg/i)
-  end
+  deprecate! date: "2025-05-25", because: :moved_to_mas
 
   depends_on macos: ">= :sierra"
 


### PR DESCRIPTION
Application is now distributed via the Mac App Store

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Application is now distributed via MAS.

![coinomi-wallet](https://github.com/user-attachments/assets/011ac3a3-dd1e-4132-bad6-2df4d3a4dc66)