### PR TITLE
mmhmm-studio: deprecate

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -994,7 +994,6 @@ mixxx@snapshot
 mkvtoolnix
 mmex
 mmhmm
-mmhmm-studio
 mochi
 mochi-diffusion
 mockoon

--- a/Casks/m/mmhmm-studio.rb
+++ b/Casks/m/mmhmm-studio.rb
@@ -2,30 +2,18 @@ cask "mmhmm-studio" do
   on_monterey :or_older do
     version "2.5.2,1687464000"
     sha256 "49ddb6c2b02050386f7786a619a5d2e87eea130f5b68fcd03ebb2ac4dfb8986f"
-
-    livecheck do
-      skip "Legacy version"
-    end
   end
   on_ventura :or_newer do
     version "2.6.4,1726550000"
     sha256 "960737943bfbde565926f8b336b78843ce52a07f948805ad48701eb8e1e68bab"
-
-    # This appcast sometimes uses a newer pubDate for an older version, so we
-    # have to ignore the default `Sparkle` strategy sorting (which involves the
-    # pubDate) and simply work with the version numbers.
-    livecheck do
-      url "https://updates.mmhmm.app/mac/production/sparkle.xml"
-      strategy :sparkle do |items|
-        items.map(&:nice_version)
-      end
-    end
   end
 
   url "https://updates.mmhmm.app/mac/production/mmhmmStudio_#{version.csv.first}.zip"
   name "mmhmm Studio"
   desc "Virtual video presentation software"
   homepage "https://www.mmhmm.app/product"
+
+  deprecate! date: "2025-05-26", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Follow-on to #213757.  The app has been replaced by Airtime (see [announcement](https://www.airtimetools.com/blog/mmhmm-becomes-airtime)), which seems to require a login to download.