### PR TITLE
vagrant: install shell completions

### DIFF
--- a/Casks/v/vagrant.rb
+++ b/Casks/v/vagrant.rb
@@ -17,6 +17,8 @@ cask "vagrant" do
   end
 
   pkg "vagrant.pkg"
+  bash_completion "/opt/vagrant/embedded/gems/gems/vagrant-#{version}/contrib/bash/completion.sh", target: "vagrant"
+  zsh_completion "/opt/vagrant/embedded/gems/gems/vagrant-#{version}/contrib/zsh/_vagrant"
 
   uninstall script:  {
               executable: "uninstall.tool",


### PR DESCRIPTION
Skips need to manually run `vagrant autocomplete install`, which appends lines to your bash and zsh dotfiles.