### PR TITLE
license-control-center: deprecate

### DIFF
--- a/Casks/l/license-control-center.rb
+++ b/Casks/l/license-control-center.rb
@@ -13,6 +13,8 @@ cask "license-control-center" do
     strategy :header_match
   end
 
+  deprecate! date: "2025-05-27", because: :discontinued
+
   installer manual: "eLicenserControlSetup.app"
 
   uninstall delete: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

> After years of managing your Steinberg software licenses, the eLicenser-based licensing service closed down on May 20, 2025.
> https://www.steinberg.net/licensing/elicenser-end-of-service/

However, I did not disable the cask, as some of the functions still seemed to work:

> Since the [eLicenser service was shut down on May 20, 2025](https://helpcenter.steinberg.de/hc/en-us/articles/26707291820562), the eLicenser Control Center has only one function: to provide licenses contained in a USB-eLicenser (dongle, license plug) or a Soft-eLicenser (virtual license container on the hard drive).
> https://helpcenter.steinberg.de/hc/en-us/articles/360008841379