### PR TITLE
packet-peeper: update homepage

### DIFF
--- a/Casks/p/packet-peeper.rb
+++ b/Casks/p/packet-peeper.rb
@@ -2,11 +2,10 @@ cask "packet-peeper" do
   version "2022-08-31"
   sha256 "d930f595ccd391df292c09ae82e3404bf00ed59d8b8f66b462671ee9e1c7c4a2"
 
-  url "https://github.com/choll/packetpeeper/releases/download/#{version}/PacketPeeper_#{version}.dmg",
-      verified: "github.com/choll/packetpeeper/"
+  url "https://github.com/choll/packetpeeper/releases/download/#{version}/PacketPeeper_#{version}.dmg"
   name "Packet Peeper"
   desc "Network protocol analyzer"
-  homepage "https://packetpeeper.org/"
+  homepage "https://github.com/choll/packetpeeper"
 
   app "Packet Peeper.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Upstreams homepage appears to be gone.  This Cask has been updated in the last couple years, so lets set the homepage to the GitHub repository.