### PR TITLE
font-noto-sans-symbols 2.003

### DIFF
--- a/Casks/font/font-n/font-noto-sans-symbols.rb
+++ b/Casks/font/font-n/font-noto-sans-symbols.rb
@@ -2,20 +2,14 @@ cask "font-noto-sans-symbols" do
   version :latest
   sha256 :no_check
 
-  url "https://noto-website-2.storage.googleapis.com/pkgs/NotoSansSymbols-unhinted.zip",
-      verified: "noto-website-2.storage.googleapis.com/"
+  url "https://github.com/google/fonts.git",
+      verified:  "github.com/google/fonts",
+      branch:    "main",
+      only_path: "ofl/notosanssymbols"
   name "Noto Sans Symbols"
-  homepage "https://www.google.com/get/noto/#sans-zsym"
+  homepage "https://fonts.google.com/noto/specimen/Noto+Sans+Symbols"
 
-  font "NotoSansSymbols-Black.ttf"
-  font "NotoSansSymbols-Bold.ttf"
-  font "NotoSansSymbols-ExtraBold.ttf"
-  font "NotoSansSymbols-ExtraLight.ttf"
-  font "NotoSansSymbols-Light.ttf"
-  font "NotoSansSymbols-Medium.ttf"
-  font "NotoSansSymbols-Regular.ttf"
-  font "NotoSansSymbols-SemiBold.ttf"
-  font "NotoSansSymbols-Thin.ttf"
+  font "NotoSansSymbols[wght].ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
This brings `font-noto-sans-symbols` into sync with `font-noto-sans-symbols-2` by downloading the typeface from GitHub and including all weights in a single file. This is also a version bump, the previous file was version 2.000.

---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
