### PR TITLE
tofu: update livecheck

### DIFF
--- a/Casks/t/tofu.rb
+++ b/Casks/t/tofu.rb
@@ -7,9 +7,10 @@ cask "tofu" do
   desc "E-reader software"
   homepage "https://amarsagoo.info/tofu/"
 
+  # The homepage lists the current version but the website is gated behind a
+  # CAPTCHA, so we can't check it programmatically.
   livecheck do
-    url :homepage
-    regex(/Version\s+(\d+(?:\.\d+)+)/i)
+    skip "Upstream website uses a CAPTCHA"
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `tofu` is returning an `Unable to get versions` error because the upstream website is now gated behind an automated CAPTCHA that doesn't work outside of a browser. This updates the `livecheck` block to skip the cask.