### PR TITLE
mullvad-vpn: renamed from mullvadvpn

### DIFF
--- a/Casks/m/mullvad-vpn.rb
+++ b/Casks/m/mullvad-vpn.rb
@@ -1,4 +1,4 @@
-cask "mullvadvpn" do
+cask "mullvad-vpn" do
   version "2025.6"
   sha256 "c2f5899b53f8385d86e0fe6facd3cf3572db71635120e216d3e8ddaf0999b991"
 

--- a/Casks/m/mullvad-vpn@beta.rb
+++ b/Casks/m/mullvad-vpn@beta.rb
@@ -1,4 +1,4 @@
-cask "mullvadvpn@beta" do
+cask "mullvad-vpn@beta" do
   version "2025.6"
   sha256 "c2f5899b53f8385d86e0fe6facd3cf3572db71635120e216d3e8ddaf0999b991"
 

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -36,7 +36,7 @@
   "magicavoxel": "all",
   "messenger-native": "all",
   "mongotron": "all",
-  "mullvadvpn@beta": "any",
+  "mullvad-vpn@beta": "any",
   "my-budget": "all",
   "netnewswire@beta": "any",
   "nuclear": "all",

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -43,6 +43,7 @@
   "minecraftpe": "minecraft-education",
   "mouse-fix": "mac-mouse-fix",
   "mpv": "stolendata-mpv",
+  "mullvadvpn": "mullvad-vpn",
   "mysteriumvpn": "mysteriumdark",
   "obs-ndi": "distroav",
   "obsbot-webcam": "obsbot-center",

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -44,6 +44,7 @@
   "mouse-fix": "mac-mouse-fix",
   "mpv": "stolendata-mpv",
   "mullvadvpn": "mullvad-vpn",
+  "mullvadvpn@beta": "mullvad-vpn@beta",
   "mysteriumvpn": "mysteriumdark",
   "obs-ndi": "distroav",
   "obsbot-webcam": "obsbot-center",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

It seems to me the token reference suggests mullvadvpn should be named mullvad-vpn. Also, this would seem more consistent with mullvad-browser.