### PR TITLE
Standardize regex letter/number character classes

### DIFF
--- a/Casks/l/liclipse.rb
+++ b/Casks/l/liclipse.rb
@@ -18,7 +18,7 @@ cask "liclipse" do
 
   livecheck do
     url "https://www.liclipse.com/download.html"
-    regex(%r{href=.*?/([0-9a-z]+)/liclipse[._-]v?(\d+(?:\.\d+)+)_macosx\.cocoa\.#{arch.downcase}\.t}i)
+    regex(%r{href=.*?/([a-z0-9]+)/liclipse[._-]v?(\d+(?:\.\d+)+)_macosx\.cocoa\.#{arch.downcase}\.t}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end

--- a/Casks/t/tap-forms.rb
+++ b/Casks/t/tap-forms.rb
@@ -10,7 +10,7 @@ cask "tap-forms" do
 
   livecheck do
     url "https://vendors.paddle.com/download/product/503174"
-    regex(/([A-z0-9]+)[._-]Tap%20Forms%20Install%20v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(/([a-z0-9]+)[._-]Tap%20Forms%20Install%20v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)
       next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

When creating a character class consisting of only letters and numbers, we typically use `[a-z0-9]` for case-insensitive regexes (unless working with hex values, where we simply use `\h`). This updates a couple of instances where the order was different (`liclipse`) or the capitalization was different (`tap-forms`). [The `tap-forms` character class ends up matching more characters than intended (i.e., [, \\, ], ^, _, `), so it's more than just a style issue.]