### PR TITLE
mozilla-vpn 2.28.0 (new cask)

### DIFF
--- a/Casks/m/mozilla-vpn.rb
+++ b/Casks/m/mozilla-vpn.rb
@@ -1,0 +1,31 @@
+cask "mozilla-vpn" do
+  version "2.28.0"
+  sha256 "26e8daba2845d1aa655feb206f0db7e3fb24162f9ea8a1d5344fc3c0c6182a31"
+
+  url "https://archive.mozilla.org/pub/vpn/releases/#{version}/mac/MozillaVPN.pkg"
+  name "Mozilla VPN"
+  desc "VPN client"
+  homepage "https://vpn.mozilla.org/"
+
+  livecheck do
+    url "https://vpn.mozilla.org/r/vpn/download/mac"
+    strategy :header_match
+  end
+
+  depends_on macos: ">= :mojave"
+
+  pkg "MozillaVPN.pkg"
+
+  uninstall quit:    "org.mozilla.macos.FirefoxVPN",
+            pkgutil: "org.mozilla.macos.FirefoxVPN"
+
+  zap trash: [
+    "/Library/Application Support/Crash Reporter/Mozilla VPN_*",
+    "/Library/Logs/DiagnosticReports/Mozilla VPN_*",
+    "~/Library/Application Support/CrashReporter/Mozilla VPN_*",
+    "~/Library/Application Support/Mozilla/Mozilla VPN",
+    "~/Library/Application Support/mozillavpn.txt",
+    "~/Library/Caches/Mozilla VPN",
+    "~/Library/Saved Application State/org.mozilla.macos.FirefoxVPN.savedState",
+  ]
+end


### PR DESCRIPTION
Coming from https://github.com/Homebrew/homebrew-cask/pull/98206 I can confirm that Mozilla VPN is actually available and working in Germany now, which it didn't use to. I'm assuming that the aforementioned regional availability concern is therefore resolved.

Let me know if you have further questions. 🙃 

cross-ref @msanders 

---

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
