### PR TITLE
font-jetbrains-mono: Add missing TTF files

### DIFF
--- a/Casks/font/font-j/font-jetbrains-mono.rb
+++ b/Casks/font/font-j/font-jetbrains-mono.rb
@@ -12,6 +12,22 @@ cask "font-jetbrains-mono" do
     strategy :gitHub_latest
   end
 
+  font "fonts/ttf/JetBrainsMono-Bold.ttf"
+  font "fonts/ttf/JetBrainsMono-BoldItalic.ttf"
+  font "fonts/ttf/JetBrainsMono-ExtraBold.ttf"
+  font "fonts/ttf/JetBrainsMono-ExtraBoldItalic.ttf"
+  font "fonts/ttf/JetBrainsMono-ExtraLight.ttf"
+  font "fonts/ttf/JetBrainsMono-ExtraLightItalic.ttf"
+  font "fonts/ttf/JetBrainsMono-Italic.ttf"
+  font "fonts/ttf/JetBrainsMono-Light.ttf"
+  font "fonts/ttf/JetBrainsMono-LightItalic.ttf"
+  font "fonts/ttf/JetBrainsMono-Medium.ttf"
+  font "fonts/ttf/JetBrainsMono-MediumItalic.ttf"
+  font "fonts/ttf/JetBrainsMono-Regular.ttf"
+  font "fonts/ttf/JetBrainsMono-SemiBold.ttf"
+  font "fonts/ttf/JetBrainsMono-SemiBoldItalic.ttf"
+  font "fonts/ttf/JetBrainsMono-Thin.ttf"
+  font "fonts/ttf/JetBrainsMono-ThinItalic.ttf"
   font "fonts/ttf/JetBrainsMonoNL-Bold.ttf"
   font "fonts/ttf/JetBrainsMonoNL-BoldItalic.ttf"
   font "fonts/ttf/JetBrainsMonoNL-ExtraBold.ttf"


### PR DESCRIPTION
The current version of this cask copies over the non-ligature variant of the font in several fixed TTF files, and then copies over the main ligature variant in two variable weight TTF files (suffixed with [wght]).

Variable fonts unfortunately lack support in many applications—for example, I'd like to use a heavier weight of the ligature variant of this font in Sublime Text, but ST doesn't support variable font options. I updated this cask to install both variable and fixed variants for maximum compatibility.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
