### PR TITLE
Add Agentkube 1.0.4 (new cask)

### DIFF
--- a/Casks/a/agentkube.rb
+++ b/Casks/a/agentkube.rb
@@ -1,0 +1,26 @@
+cask "agentkube" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "1.0.4"
+  sha256 arm:   "8afb8b9aa6fa9d13cc7e8018c0ff836600f5b08e57fc50305a592ffc63098373",
+         intel: "8bd840ccfaaf884517bdf6c40b49bfd9263f5025d40787a3e78975607e2a2fd5"
+
+  url "https://github.com/agentkube/agentkube/releases/download/v#{version}/agentkube_#{version}_#{arch}-apple-darwin.tar.gz",
+      verified: "github.com/agentkube/agentkube/"
+  name "Agentkube"
+  desc "AI-powered Kubernetes IDE"
+  homepage "https://agentkube.com/"
+
+  auto_updates true
+  depends_on macos: ">= :high_sierra"
+
+  app "Agentkube.app"
+
+  zap trash: [
+    "~/.agentkube",
+    "~/Library/Application Support/agentkube",
+    "~/Library/Logs/agentkube.log",
+    "~/Library/Preferences/agentkube.plist",
+    "~/Library/Saved Application State/com.agentkube.app.savedState",
+  ]
+end


### PR DESCRIPTION
Agentkube is an AI-Powered Kubernetes IDE for cluster management and monitoring.

- **Homepage**: https://agentkube.com/
- **Repository**: https://github.com/agentkube/agentkube
- **Platform**: Macos only

---

**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

*In the following questions `<cask>` is the token of the cask you're submitting.*

After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+agentkube&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

