### PR TITLE
font-poppins-latin: update livecheck

### DIFF
--- a/Casks/font/font-p/font-poppins-latin.rb
+++ b/Casks/font/font-p/font-poppins-latin.rb
@@ -8,7 +8,7 @@ cask "font-poppins-latin" do
 
   livecheck do
     url "https://github.com/itfoundry/Poppins/tree/master/products"
-    regex(/href=.*?PoppinsLatin[._-]v?(\d+(?:\.\d+)+)(?:[._-]Latin)?[._-]OTF\.zip/i)
+    regex(/PoppinsLatin[._-]v?(\d+(?:\.\d+)+)(?:[._-]Latin)?[._-]OTF\.zip/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `font-poppins-latin` uses a regex that matches a zip link in the page HTML but this now returns an `Unable to get versions` error because the URL is only found in a JavaScript object. This addresses the issue by removing the leading `href=.*?` from the regex, allowing it to match the filename anywhere in the page HTML.