### PR TITLE
agent-tars 1.0.0-alpha.9

### DIFF
--- a/Casks/a/agent-tars.rb
+++ b/Casks/a/agent-tars.rb
@@ -1,6 +1,6 @@
 cask "agent-tars" do
-  version "1.0.0-alpha.8"
-  sha256 "4e2c8c30740c32196955874b3357a06994863abc33330898e214690a61529132"
+  version "1.0.0-alpha.9"
+  sha256 "3e104fcf21a52025c024aa674b5d2931454f884d710bcfb3d393fddd7a7c815c"
 
   url "https://github.com/bytedance/UI-TARS-desktop/releases/download/Agent-TARS-v#{version}/Agent.TARS-#{version}-universal.dmg"
   name "Agent TARS"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,5 +1,6 @@
 {
   "aerial@beta": "any",
+  "agent-tars": "all",
   "altdeploy": "all",
   "amethyst": "any",
   "bitbar": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`agent-tars` is in the autobump list but it isn't able to be updated because the cask is using pre-release versions until a stable version appears but the cask is not in the prerelease allowlist. This updates the cask to the newest version and adds it to the prerelease allowlist for now.

My intention with the prerelease allowlist change is to allow unstable versions until a stable version appears but I can never remember whether it's `all` or `any` that uses that behavior, so do correct me if I'm using the wrong value.