### PR TITLE
feat: add `tng-digital-mini-program-studio` cask

### DIFF
--- a/Casks/t/tng-digital-mini-program-studio.rb
+++ b/Casks/t/tng-digital-mini-program-studio.rb
@@ -1,0 +1,32 @@
+cask "tng-digital-mini-program-studio" do
+  arch arm: "arm64", intel: "x64"
+
+  on_arm do
+    version "3.7.1031"
+    sha256 "890d30a02ce90a002e86878dc869084031135528082f056c35ed51e90b3a34ba"
+  end
+  on_intel do
+    version "3.7.1032"
+    sha256 "64d3d927f548f92d31c222d89470c7fb48593f7f29ef845a5d0f36e24e796ea6"
+  end
+
+  url "https://ide-release.marmot-cloud.com/storage/miniprogram-studio/common/#{version.major_minor}/MiniProgramStudio-#{version}-#{arch}.dmg",
+      verified: "ide-release.marmot-cloud.com/storage/miniprogram-studio/common/"
+  name "TnG Digital Mini Program Studio"
+  desc "IDE for building mini programs"
+  homepage "https://miniprogram.tngdigital.com.my/index"
+
+  livecheck do
+    skip "No reliable automated version detection available"
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "MiniProgramStudio.app"
+
+  zap trash: [
+    "~/Library/Application Support/MiniProgramStudio",
+    "~/Library/Preferences/com.ant.miniprogram.intl.poc.plist",
+    "~/Library/Saved Application State/com.ant.miniprogram.intl.poc.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This PR introduces a new cask for the [TnG Digital Mini Program Studio](https://miniprogram.tngdigital.com.my/downloadList). While this appears very similar to [Alipay Mini Program Studio](https://miniprogram.alipay.com/downloadList) and the existing cask [mini-program-studio](https://formulae.brew.sh/cask/mini-program-studio), they seems to be different applications based on context. I've named it with the "TnG Digital" prefix to avoid conflicts with other mini program studio applications.

Regarding version checking, I've found that versions are hardcoded in their React bundle, which has a unique hash on each deploy. Due to these limitations and the absence of a public API, I've implemented a `livecheck skip` as there's no reliable way to automate version detection based on my observations.
