### PR TITLE
slideshower 3.0 (new cask)

### DIFF
--- a/Casks/s/slideshower.rb
+++ b/Casks/s/slideshower.rb
@@ -4,12 +4,12 @@ cask "slideshower" do
 
   url "https://slideshower.com/slideshower_#{version.dots_to_underscores}.dmg"
   name "Slideshower for macOS"
-  desc "Simplest app to run photo slideshows"
+  desc "Slideshow application"
   homepage "https://slideshower.com/"
 
   livecheck do
-    url :homepage
-    regex(/Release Notes[\s\S]*?v(\d+(?:\.\d+)+)/i)
+    url "https://slideshower.com/appcast.xml"
+    strategy :sparkle, &:short_version
   end
 
   depends_on macos: ">= :monterey"

--- a/Casks/s/slideshower.rb
+++ b/Casks/s/slideshower.rb
@@ -1,0 +1,23 @@
+cask "slideshower" do
+  version "3.0"
+  sha256 "72b2b7f82104b6d49ee8621127c2da741d5eeaca736f6b98272d09da8d09c4ec"
+
+  url "https://slideshower.com/slideshower_#{version.dots_to_underscores}.dmg"
+  name "Slideshower for macOS"
+  desc "Simplest app to run photo slideshows"
+  homepage "https://slideshower.com/"
+
+  livecheck do
+    url :homepage
+    regex(/Release Notes[\s\S]*?v(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "Slideshower for macOS.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/trybulski.slideshower",
+    "~/Library/Containers/trybulski.slideshower",
+  ]
+end


### PR DESCRIPTION
Add Slideshower for macOS, a simple photo slideshow application.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
