### PR TITLE
grads: add macOS requirement, update caveats

### DIFF
--- a/Casks/g/grads.rb
+++ b/Casks/g/grads.rb
@@ -13,6 +13,8 @@ cask "grads" do
     regex(/href=.*?grads[._-]?v?(\d+(?:\.\d+)+)-bin-darwin.*?\.t/i)
   end
 
+  depends_on macos: ">= :high_sierra"
+
   binary "grads-#{version}/bin/bufrscan"
   binary "grads-#{version}/bin/grads"
   binary "grads-#{version}/bin/grib2scan"
@@ -25,13 +27,10 @@ cask "grads" do
   caveats do
     requires_rosetta
     <<~EOS
-      In order to use the GrADS tools, you will need
-      the GrADS fonts and maps data sets, and may need
-      to set some environmental variables.
+      In order to use the GrADS tools, you will need the GrADS fonts and maps data sets
+      and may need to set some environment variables. For more information, see:
 
-      See the documentation at:
-
-      #{staged_path}/grads-#{version}/bin/INSTALL
+        http://cola.gmu.edu/grads/downloads.php
     EOS
   end
 end


### PR DESCRIPTION
`INSTALL` is no longer provided with the binary package.