### PR TITLE
various: fix deprecate/disable reason wording

### DIFF
--- a/Casks/l/lando.rb
+++ b/Casks/l/lando.rb
@@ -11,7 +11,7 @@ cask "lando" do
   desc "Local development environment and DevOps tool built on Docker"
   homepage "https://lando.dev/"
 
-  deprecate! date: "2024-09-07", because: "no longer distributing an install package"
+  deprecate! date: "2024-09-07", because: "no longer distributes an install package"
 
   conflicts_with cask: "lando@edge"
   depends_on cask: "docker"

--- a/Casks/l/lando@edge.rb
+++ b/Casks/l/lando@edge.rb
@@ -11,7 +11,7 @@ cask "lando@edge" do
   desc "Local development environment and DevOps tool built on Docker"
   homepage "https://docs.lando.dev/"
 
-  deprecate! date: "2024-09-07", because: "no longer distributing an install package"
+  deprecate! date: "2024-09-07", because: "no longer distributes an install package"
 
   conflicts_with cask: "lando"
   depends_on cask: "docker"

--- a/Casks/m/mblock.rb
+++ b/Casks/m/mblock.rb
@@ -8,7 +8,7 @@ cask "mblock" do
   desc "Coding tool designed for teaching STEAM"
   homepage "https://www.mblock.cc/"
 
-  disable! date: "2024-06-12", because: "download artifact behind signed url"
+  disable! date: "2024-06-12", because: "now has the download artifact behind a signed URL"
 
   depends_on macos: ">= :sierra"
 

--- a/Casks/o/obsbot-center.rb
+++ b/Casks/o/obsbot-center.rb
@@ -8,7 +8,7 @@ cask "obsbot-center" do
   desc "Configuration and firmware update utility for OBSBOT Tiny and Meet series"
   homepage "https://www.obsbot.com/download"
 
-  disable! date: "2025-04-07", because: "download artifact behind signed url"
+  disable! date: "2025-04-07", because: "now has the download artifact behind a signed URL"
 
   depends_on macos: ">= :big_sur"
 

--- a/Casks/s/shadow-bot.rb
+++ b/Casks/s/shadow-bot.rb
@@ -11,7 +11,7 @@ cask "shadow-bot" do
   desc "Application for robotic process automation"
   homepage "https://www.yingdao.com/"
 
-  disable! date: "2024-12-30", because: "download artifact behind signed url"
+  disable! date: "2024-12-30", because: "now has the download artifact behind a signed URL"
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/t/todesk.rb
+++ b/Casks/t/todesk.rb
@@ -9,7 +9,7 @@ cask "todesk" do
   desc "Remote control software"
   homepage "https://www.todesk.com/"
 
-  disable! date: "2024-08-01", because: "download artifact behind CAPTCHA-verified url"
+  disable! date: "2024-08-01", because: "now has the download artifact behind a CAPTCHA-verified URL"
 
   auto_updates true
 


### PR DESCRIPTION
`because: "no longer distributes an install package"` becomes `Deprecated because it no longer distributes an install package!` from `brew info`. There's an audit that prevents reasons from starting with "it" since that word is auto-inserted, but that doesn't prevent some awkward wordings from occurring.