### PR TITLE
bricklink-studio: update URL & livecheck, remove caveat

### DIFF
--- a/Casks/b/bricklink-studio.rb
+++ b/Casks/b/bricklink-studio.rb
@@ -2,15 +2,15 @@ cask "bricklink-studio" do
   version "2.25.5_1"
   sha256 "a1f1e49786afae5e8a6df62029dbb6416922b80368399088729cfb130ccbd1c9"
 
-  url "https://blstudio.s3.amazonaws.com/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg",
-      verified: "blstudio.s3.amazonaws.com/"
+  url "https://studio.download.bricklink.info/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg",
+      verified: "studio.download.bricklink.info/"
   name "Studio"
   desc "Build, render, and create LEGO instructions"
   homepage "https://www.bricklink.com/v3/studio/download.page"
 
   livecheck do
-    url "https://store.bricklink.com/v2/studio/download.page"
-    regex(/"version"\s*:\s*"(\d+(?:[._-]\d+)*)"/i)
+    url :homepage
+    regex(/"strVersion"\s*:\s*"([^"]+)"/i)
   end
 
   auto_updates true
@@ -27,8 +27,4 @@ cask "bricklink-studio" do
     "~/Library/Saved Application State/unity.BrickLink.Patcher.savedState",
     "~/Library/Saved Application State/unity.BrickLink.Studio.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
To match `bricklink-partdesigner` as of #215316. App is now ARM-native as well.