### PR TITLE
multiapp: disable

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1045,7 +1045,6 @@ mudlet
 mullvad-browser
 mullvad-vpn
 mullvad-vpn@beta
-multiapp
 multitouch
 multiviewer-for-f1
 mumuplayer

--- a/Casks/m/multiapp.rb
+++ b/Casks/m/multiapp.rb
@@ -7,10 +7,7 @@ cask "multiapp" do
   desc "Multiplayer Collaboration"
   homepage "https://www.multi.app/"
 
-  livecheck do
-    url "https://updates.multi.app/installers/appcast.xml"
-    strategy :sparkle, &:short_version
-  end
+  disable! date: "2025-06-06", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream discontinued Multi on 2024-07-24 after being acquired but the URLs for the files and appcast continued to work, so we didn't notice the deprecation. This has become apparent now that the URLs no longer work, so this disables `multiapp` and removes it from the autobump list.