### PR TITLE
pokemon-showdown: deprecate (discontinued)

### DIFF
--- a/Casks/p/pokemon-showdown.rb
+++ b/Casks/p/pokemon-showdown.rb
@@ -6,10 +6,7 @@ cask "pokemon-showdown" do
   name "Pokémon Showdown"
   homepage "https://pokemonshowdown.com/"
 
-  livecheck do
-    url :url
-    strategy :extract_plist
-  end
+  deprecate! date: "2025-06-07", because: :discontinued
 
   app "Pokemon Showdown.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
App has stopped being listed on the website in April, and after [confirming with a team member](https://imgur.com/a/7a7VGpS), the app has been discontinued. It still installs and works correctly, so this is why I am not disabling it outright.