### PR TITLE
sherlock: version url, update zap

### DIFF
--- a/Casks/s/sherlock.rb
+++ b/Casks/s/sherlock.rb
@@ -1,9 +1,9 @@
 cask "sherlock" do
   version "2.12.0"
-  sha256 :no_check
+  sha256 "97ca67d876eb3524c1bfdb74248a686097957f598c233d1458d19588a732348d"
 
-  url "https://dl.devmate.com/io.inspiredcode.Sherlock/Sherlock.dmg",
-      verified: "dl.devmate.com/io.inspiredcode.Sherlock/"
+  url "https://sherlock-macos-releases.s3.amazonaws.com/Sherlock+#{version}.dmg",
+      verified: "sherlock-macos-releases.s3.amazonaws.com/"
   name "Sherlock"
   desc "iOS simulator visual debugger"
   homepage "https://sherlock.inspiredcode.io/"
@@ -19,8 +19,12 @@ cask "sherlock" do
 
   zap trash: [
     "/Users/Shared/Sherlock",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/io.inspiredcode.sherlock.sfl*",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/io.inspiredcode.sherlocklauncher.sfl*",
     "~/Library/Application Support/io.inspiredcode.Sherlock",
     "~/Library/Application Support/Sherlock",
+    "~/Library/Caches/io.inspiredcode.Sherlock",
+    "~/Library/Caches/io.inspiredcode.Sherlock",
     "~/Library/Preferences/io.inspiredcode.Sherlock.plist",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Adds a versioned URL from the Sparkle feed, and adds some new zap entries.

Though this uses Sparkle, it doesn't seem to have auto-update.  There is a check for updates button, but no toggle to activate automatic checking and does not appear to check on startup.