### PR TITLE
various: install completions using `*_completion`

### DIFF
--- a/Casks/a/alacritty.rb
+++ b/Casks/a/alacritty.rb
@@ -13,21 +13,18 @@ cask "alacritty" do
   end
 
   app "Alacritty.app"
-  binary "Alacritty.app/Contents/MacOS/alacritty"
-  binary "Alacritty.app/Contents/Resources/completions/_alacritty",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_alacritty"
-  binary "Alacritty.app/Contents/Resources/completions/alacritty.bash",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/alacritty"
-  binary "Alacritty.app/Contents/Resources/completions/alacritty.fish",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/alacritty.fish"
-  binary "Alacritty.app/Contents/Resources/61/alacritty",
+  binary "#{appdir}/Alacritty.app/Contents/MacOS/alacritty"
+  binary "#{appdir}/Alacritty.app/Contents/Resources/61/alacritty",
          target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/61/alacritty"
-  binary "Alacritty.app/Contents/Resources/61/alacritty-direct",
+  binary "#{appdir}/Alacritty.app/Contents/Resources/61/alacritty-direct",
          target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/61/alacritty-direct"
-  manpage "Alacritty.app/Contents/Resources/alacritty.1.gz"
-  manpage "Alacritty.app/Contents/Resources/alacritty.5.gz"
-  manpage "Alacritty.app/Contents/Resources/alacritty-msg.1.gz"
-  manpage "Alacritty.app/Contents/Resources/alacritty-bindings.5.gz"
+  manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty.1.gz"
+  manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty.5.gz"
+  manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty-msg.1.gz"
+  manpage "#{appdir}/Alacritty.app/Contents/Resources/alacritty-bindings.5.gz"
+  bash_completion "#{appdir}/Alacritty.app/Contents/Resources/completions/alacritty.bash"
+  fish_completion "#{appdir}/Alacritty.app/Contents/Resources/completions/alacritty.fish"
+  zsh_completion "#{appdir}/Alacritty.app/Contents/Resources/completions/_alacritty"
 
   zap trash: [
     "~/Library/Preferences/org.alacritty.plist",

--- a/Casks/c/contour.rb
+++ b/Casks/c/contour.rb
@@ -6,16 +6,20 @@ cask "contour" do
          intel: "fd560a5e58f55ac20cd0d440b136365428126ba6fac8edde69b4d36d98467c7e"
 
   url "https://github.com/contour-terminal/contour/releases/download/v#{version}/contour-#{version}-macOS-#{arch}.dmg"
-  name "contour"
+  name "Contour"
   desc "Terminal emulator"
   homepage "https://github.com/contour-terminal/contour/"
 
   app "contour.app"
-  binary "contour.app/Contents/MacOS/contour"
-  binary "contour.app/Contents/Resources/shell-integration/shell-integration.zsh",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_contour"
-  binary "contour.app/Contents/Resources/terminfo/63/contour",
+  binary "#{appdir}/contour.app/Contents/MacOS/contour"
+  binary "#{appdir}/contour.app/Contents/Resources/terminfo/63/contour",
          target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/63/contour"
+  bash_completion "#{appdir}/contour.app/Contents/Resources/shell-integration/shell-integration.bash",
+                  target: "contour"
+  fish_completion "#{appdir}/contour.app/Contents/Resources/shell-integration/shell-integration.fish",
+                  target: "contour.fish"
+  zsh_completion "#{appdir}/contour.app/Contents/Resources/shell-integration/shell-integration.zsh",
+                 target: "_contour"
 
   zap trash: "~/.config/contour"
 end

--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -6,7 +6,7 @@ cask "docker" do
          intel: "7d6077cd24aa11127b5d01a857f08f0af4378d9983212b73d8c6f29cd04cfb66"
 
   on_intel do
-    binary "Docker.app/Contents/Resources/bin/com.docker.hyperkit",
+    binary "#{appdir}/Docker.app/Contents/Resources/bin/com.docker.hyperkit",
            target: "/usr/local/bin/hyperkit"
   end
 
@@ -33,12 +33,6 @@ cask "docker" do
   depends_on macos: ">= :ventura"
 
   app "Docker.app"
-  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker-compose"
-  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.zsh-completion",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker-compose"
-  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker-compose.fish"
   binary "#{appdir}/Docker.app/Contents/Resources/bin/compose-bridge",
          target: "/usr/local/bin/compose-bridge"
   binary "#{appdir}/Docker.app/Contents/Resources/bin/docker",
@@ -55,12 +49,12 @@ cask "docker" do
          target: "/usr/local/bin/kubectl.docker"
   binary "#{appdir}/Docker.app/Contents/Resources/cli-plugins/docker-compose",
          target: "/usr/local/cli-plugins/docker-compose"
-  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/docker"
-  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.zsh-completion",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_docker"
-  binary "#{appdir}/Docker.app/Contents/Resources/etc/docker.fish-completion",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/docker.fish"
+  bash_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion"
+  bash_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.bash-completion"
+  fish_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.fish-completion"
+  fish_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.fish-completion"
+  zsh_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.zsh-completion"
+  zsh_completion "#{appdir}/Docker.app/Contents/Resources/etc/docker.zsh-completion"
 
   postflight do
     kubectl_target = Pathname("/usr/local/bin/kubectl")

--- a/Casks/f/filebot.rb
+++ b/Casks/f/filebot.rb
@@ -19,8 +19,7 @@ cask "filebot" do
 
   app "FileBot.app"
   binary "#{appdir}/FileBot.app/Contents/MacOS/filebot.sh", target: "filebot"
-  binary "#{appdir}/FileBot.app/Contents/Resources/bash_completion.d/filebot_completion",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/filebot"
+  bash_completion "#{appdir}/FileBot.app/Contents/Resources/bash_completion.d/filebot_completion", target: "filebot"
 
   zap trash: [
     "~/Library/Application Scripts/net.filebot.FileBot",

--- a/Casks/g/ghostty.rb
+++ b/Casks/g/ghostty.rb
@@ -18,14 +18,11 @@ cask "ghostty" do
 
   app "Ghostty.app"
   binary "#{appdir}/Ghostty.app/Contents/MacOS/ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/bash-completion/completions/ghostty.bash",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/ghostty.fish"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_ghostty"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
+  bash_completion "#{appdir}/Ghostty.app/Contents/Resources/bash-completion/completions/ghostty.bash"
+  fish_completion "#{appdir}/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish"
+  zsh_completion "#{appdir}/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty"
 
   zap trash: [
     "~/.config/ghostty/",

--- a/Casks/g/ghostty@tip.rb
+++ b/Casks/g/ghostty@tip.rb
@@ -24,14 +24,11 @@ cask "ghostty@tip" do
 
   app "Ghostty.app"
   binary "#{appdir}/Ghostty.app/Contents/MacOS/ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/bash-completion/completions/ghostty.bash",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/ghostty"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/ghostty.fish"
-  binary "#{appdir}/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_ghostty"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man1/ghostty.1"
   manpage "#{appdir}/Ghostty.app/Contents/Resources/man/man5/ghostty.5"
+  bash_completion "#{appdir}/Ghostty.app/Contents/Resources/bash-completion/completions/ghostty.bash"
+  fish_completion "#{appdir}/Ghostty.app/Contents/Resources/fish/vendor_completions.d/ghostty.fish"
+  zsh_completion "#{appdir}/Ghostty.app/Contents/Resources/zsh/site-functions/_ghostty"
 
   zap trash: [
     "~/.config/ghostty/",

--- a/Casks/g/google-cloud-sdk.rb
+++ b/Casks/g/google-cloud-sdk.rb
@@ -36,10 +36,8 @@ cask "google-cloud-sdk" do
   binary "google-cloud-sdk/bin/gcloud"
   binary "google-cloud-sdk/bin/git-credential-gcloud.sh", target: "git-credential-gcloud"
   binary "google-cloud-sdk/bin/gsutil"
-  binary "google-cloud-sdk/completion.bash.inc",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/google-cloud-sdk"
-  binary "google-cloud-sdk/completion.zsh.inc",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_google_cloud_sdk"
+  bash_completion "google-cloud-sdk/completion.bash.inc", target: "google-cloud-sdk"
+  zsh_completion "google-cloud-sdk/completion.zsh.inc", target: "_google_cloud_sdk"
 
   preflight do
     FileUtils.cp_r staged_path/"google-cloud-sdk/.", google_cloud_sdk_root, remove_destination: true

--- a/Casks/s/sauce-connect.rb
+++ b/Casks/s/sauce-connect.rb
@@ -13,9 +13,9 @@ cask "sauce-connect" do
   end
 
   binary "sc"
-  binary "completions/sc.bash", target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/sc"
-  binary "completions/sc.fish", target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/sc.fish"
-  binary "completions/sc.zsh", target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_sc"
+  bash_completion "completions/sc.bash"
+  fish_completion "completions/sc.fish"
+  zsh_completion "completions/sc.zsh"
 
   # No zap stanza required
 end

--- a/Casks/w/wezterm.rb
+++ b/Casks/w/wezterm.rb
@@ -28,12 +28,9 @@ cask "wezterm" do
     binary "#{appdir}/WezTerm.app/Contents/MacOS/#{tool}"
   end
 
-  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_wezterm"
-  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/wezterm"
-  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/wezterm.fish"
+  bash_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash", target: "wezterm"
+  fish_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish", target: "wezterm.fish"
+  zsh_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh", target: "_wezterm"
 
   zap trash: [
     "~/.local/share/wezterm",

--- a/Casks/w/wezterm@nightly.rb
+++ b/Casks/w/wezterm@nightly.rb
@@ -9,6 +9,7 @@ cask "wezterm@nightly" do
   homepage "https://wezterm.org/"
 
   conflicts_with cask: "wezterm"
+  depends_on macos: ">= :sierra"
 
   app "WezTerm.app"
   %w[
@@ -20,12 +21,9 @@ cask "wezterm@nightly" do
     binary "#{appdir}/WezTerm.app/Contents/MacOS/#{tool}"
   end
 
-  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh",
-         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_wezterm"
-  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash",
-         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/wezterm"
-  binary "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish",
-         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/wezterm.fish"
+  bash_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/bash", target: "wezterm"
+  fish_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/fish", target: "wezterm.fish"
+  zsh_completion "#{appdir}/WezTerm.app/Contents/Resources/shell-completion/zsh", target: "_wezterm"
 
   preflight do
     # Move "WezTerm-macos-#{version}/WezTerm.app" out of the subfolder


### PR DESCRIPTION
For casks that install shell completions, switch to using the new `bash_completion` / `fish_completion` / `zsh_completion` stanzas. In most cases `target:` is not needed, since the installer removes or changes the file extension (bash, fish, zsh)  and prepends an underscore (zsh) as needed.