### PR TITLE
[Docker] Bump minimum macOS version to Ventura

### DIFF
--- a/Casks/d/docker.rb
+++ b/Casks/d/docker.rb
@@ -30,7 +30,7 @@ cask "docker" do
                    docker-compose
                    docker-credential-helper-ecr
                  ]
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :ventura"
 
   app "Docker.app"
   binary "#{appdir}/Docker.app/Contents/Resources/etc/docker-compose.bash-completion",


### PR DESCRIPTION
For docker 4.42:
According to https://docs.docker.com/desktop/release-notes
"Minimum version to install or update Docker Desktop on is now macOS Ventura 13.3."