### PR TITLE
virtualbuddy: link `vctool`

### DIFF
--- a/Casks/v/virtualbuddy.rb
+++ b/Casks/v/virtualbuddy.rb
@@ -19,6 +19,7 @@ cask "virtualbuddy" do
   depends_on macos: ">= :ventura"
 
   app "VirtualBuddy.app"
+  binary "#{appdir}/VirtualBuddy.app/Contents/MacOS/vctool", target: "vctool"
 
   zap trash: [
     "~/Library/Application Support/VirtualBuddy",

--- a/Casks/v/virtualbuddy@beta.rb
+++ b/Casks/v/virtualbuddy@beta.rb
@@ -18,6 +18,7 @@ cask "virtualbuddy@beta" do
   depends_on macos: ">= :ventura"
 
   app "VirtualBuddy.app"
+  binary "#{appdir}/VirtualBuddy.app/Contents/MacOS/vctool", target: "vctool"
 
   zap trash: [
     "~/Library/Application Support/VirtualBuddy",


### PR DESCRIPTION
VirtualBuddy has a new tool for managing its software catalog. Let's link that binary for ease of use.

CC @insidegui.