### PR TITLE
stolendata-mpv: support newer Intel macOS

### DIFF
--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -1,43 +1,41 @@
 cask "stolendata-mpv" do
-  arch arm: "-arm64"
+  label = nil
 
-  on_arm do
-    version "0.40.0"
-    sha256 "3170fb709defebaba33e9755297d70dc3562220541de54fc3d494a8309ef1260"
+  on_catalina :or_older do
+    version "0.35.0"
+    sha256 "376415c787aef391a3927cdecd5bb0dac9f21ef9d7742516b8cd8d8ce502e7b6"
 
     livecheck do
-      url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
-      regex(/mpv-arm64-(\d+(?:\.\d+)+)\.t/i)
+      skip "Legacy version"
     end
-
-    depends_on macos: ">= :sonoma"
-
-    app "mpv#{arch}-#{version}/mpv.app"
-    manpage "mpv#{arch}-#{version}/documentation/man/mpv.1"
   end
-  on_intel do
-    on_catalina :or_older do
-      version "0.35.0"
-      sha256 "376415c787aef391a3927cdecd5bb0dac9f21ef9d7742516b8cd8d8ce502e7b6"
-
-      livecheck do
-        skip "Legacy version"
-      end
-    end
-    on_big_sur :or_newer do
+  on_big_sur :or_newer do
+    on_ventura :or_older do
       version "0.39.0"
       sha256 "35ec81ad86a97b24956a8d0f4fa1ba2690b44ae7741c920e923620bcd7bd402a"
 
-      livecheck do
-        url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
-        regex(/mpv-(\d+(?:\.\d+)+)\.t/i)
+      caveats do
+        requires_rosetta
+      end
+    end
+    on_sonoma :or_newer do
+      arch arm: "-arm64"
+      label = on_arch_conditional arm: "mpv#{arch}-VERSION/"
+
+      on_arm do
+        version "0.40.0"
+        sha256 "3170fb709defebaba33e9755297d70dc3562220541de54fc3d494a8309ef1260"
+      end
+      on_intel do
+        version "0.39.0"
+        sha256 "35ec81ad86a97b24956a8d0f4fa1ba2690b44ae7741c920e923620bcd7bd402a"
       end
     end
 
-    depends_on macos: ">= :mojave"
-
-    app "mpv.app"
-    manpage "documentation/man/mpv.1"
+    livecheck do
+      url "https://laboratory.stolendata.net/~djinn/mpv_osx/"
+      regex(/mpv#{arch}-(\d+(?:\.\d+)+)\.t/i)
+    end
   end
 
   url "https://laboratory.stolendata.net/~djinn/mpv_osx/mpv#{arch}-#{version}.tar.gz",
@@ -47,8 +45,13 @@ cask "stolendata-mpv" do
   homepage "https://mpv.io/"
 
   conflicts_with formula: "mpv"
+  depends_on macos: ">= :mojave"
 
+  folder = label&.sub("VERSION", version)
+
+  app "#{folder}mpv.app"
   binary "#{appdir}/mpv.app/Contents/MacOS/mpv"
+  manpage "#{folder}documentation/man/mpv.1"
 
   zap trash: [
     "~/.config/mpv",


### PR DESCRIPTION
This is the first in a series of somewhat cursed PRs to include support for newer Intel macOS versions in casks whose packages abruptly switch from being Intel-only or universal to ARM-only. In this case the older Intel version needs to be specified twice, since it has to serve as an alternative for older macOS ARM releases and newer macOS Intel releases.
|           | **Intel** | **ARM** |
| --------- | --------- | ------- |
| **10.14** | 0.35.0    |         |
| **10.15** | 0.35.0    |         |
| **11.x**  | 0.39.0    | <       |
| **12.x**  | 0.39.0    | <       |
| **13.x**  | 0.39.0    | <       |
| **14.x**  | ^         | 0.40.0  |
| **15.x**  | ^         | 0.40.0  |
 