### PR TITLE
x-moto: support newer Intel macOS

### DIFF
--- a/Casks/x/x-moto.rb
+++ b/Casks/x/x-moto.rb
@@ -1,14 +1,23 @@
 cask "x-moto" do
-  arch arm: "-arm64"
-
-  sha256 arm:   "e40aae18c90a0f41c9cc48e63c3da278f44ba1e3328804d80d4ba0819ccc9baa",
-         intel: "40818cff5020b8b962f680ef7f99f6cce26b3ff1da6775bba39313461df62d44"
-
-  on_arm do
-    version "0.6.3"
-  end
-  on_intel do
+  on_sonoma :or_older do
     version "0.6.2"
+    sha256 "40818cff5020b8b962f680ef7f99f6cce26b3ff1da6775bba39313461df62d44"
+
+    caveats do
+      requires_rosetta
+    end
+  end
+  on_sequoia :or_newer do
+    arch arm: "-arm64"
+
+    on_arm do
+      version "0.6.3"
+      sha256 "e40aae18c90a0f41c9cc48e63c3da278f44ba1e3328804d80d4ba0819ccc9baa"
+    end
+    on_intel do
+      version "0.6.2"
+      sha256 "40818cff5020b8b962f680ef7f99f6cce26b3ff1da6775bba39313461df62d44"
+    end
   end
 
   url "https://github.com/xmoto/xmoto/releases/download/v#{version}/xmoto-#{version}#{arch}-macos.dmg",
@@ -35,6 +44,8 @@ cask "x-moto" do
       end.flatten
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "X-Moto.app"
 


### PR DESCRIPTION
Similar to #215694, this package switched from Intel-only to ARM-only requiring 15.x or later, so provide the older Intel version to >= macOS 15.x for Intel.