### PR TITLE
oclint: support older ARM macOS

### DIFF
--- a/Casks/o/oclint.rb
+++ b/Casks/o/oclint.rb
@@ -1,29 +1,35 @@
 cask "oclint" do
   arch arm: "arm64", intel: "x86_64"
 
-  sha256 arm:   "85062776d437bfa496df542077e6a87f88dfd7435cdbe651a01b17ed8f9df972",
-         intel: "6f102a568af3a4344f9658b5f4bdf3d599a851456287bf7a1fae447891f7368c"
-
-  on_arm do
-    version "24.11"
-
-    url "https://github.com/oclint/oclint/releases/download/v#{version}/oclint-#{version}-llvm-16.0.5-#{arch}-darwin-macos-15.1.1-xcode-16.1.tar.gz"
-  end
-  on_intel do
+  on_sonoma :or_older do
     version "22.02"
+    sha256 arm:   "b18196a459f1b30bb4b6849b5952327458671ff9f65b30c9766e8a430de23c35",
+           intel: "6f102a568af3a4344f9658b5f4bdf3d599a851456287bf7a1fae447891f7368c"
+
+    on_intel do
+      binary "oclint-#{version}/include/c++/v1", target: "#{HOMEBREW_PREFIX}/include/c++/v1"
+    end
 
     url "https://github.com/oclint/oclint/releases/download/v#{version}/oclint-#{version}-llvm-13.0.1-#{arch}-darwin-macos-12.2-xcode-13.2.tar.gz"
 
     livecheck do
       skip "Legacy version"
     end
+  end
+  on_sequoia :or_newer do
+    version "24.11"
+    sha256 "85062776d437bfa496df542077e6a87f88dfd7435cdbe651a01b17ed8f9df972"
 
-    binary "oclint-#{version}/include/c++/v1", target: "#{HOMEBREW_PREFIX}/include/c++/v1"
+    url "https://github.com/oclint/oclint/releases/download/v#{version}/oclint-#{version}-llvm-16.0.5-#{arch}-darwin-macos-15.1.1-xcode-16.1.tar.gz"
+
+    depends_on arch: :arm64
   end
 
   name "OCLint"
   desc "Static source code analysis tool"
   homepage "https://github.com/oclint/oclint/"
+
+  depends_on macos: ">= :monterey"
 
   binary "oclint-#{version}/bin/oclint-json-compilation-database"
   binary "oclint-#{version}/bin/oclint-xcodebuild"


### PR DESCRIPTION
The previous version had builds for both architectures, so supply each for macOS <= 14.x. The current version is ARM-only, and while it'd be possible to supply the last Intel version for newer macOS for Intel releases (e.g. #215694) I've held off doing so, opting instead to mark it as ARM-only for >= 15.x. With macOS on Intel now [officially winding down](https://www.macrumors.com/2025/06/09/intel-macs-no-more-updates/), we should expect to see its support being summarily dropped from many more casks in the near future.