### PR TITLE
libreoffice-language-pack, libreoffice-still-language-pack: use arch params for sha256 stanzas

### DIFF
--- a/Casks/l/libreoffice-language-pack.rb
+++ b/Casks/l/libreoffice-language-pack.rb
@@ -4,793 +4,495 @@ cask "libreoffice-language-pack" do
 
   version "25.2.4"
 
-  on_arm do
-    language "af" do
-      sha256 "a5cf056d4987c8cc0d82a3276c8a79e4066b0720e52ac043f5053e1034030c4a"
-      "af"
-    end
-    language "am" do
-      sha256 "5c949d659256a96546be7b1daf941037646c058d8ff2f8f62fc412d11c1f782a"
-      "am"
-    end
-    language "ar" do
-      sha256 "8c72a2faa0e4378845e861a6687bcaa728004e5226078fb4b96b2995e291796a"
-      "ar"
-    end
-    language "as" do
-      sha256 "c701d38a9e43cf910d440b7d4b0f9d87d0c6d2ce9780de023e957529088a3384"
-      "as"
-    end
-    language "be" do
-      sha256 "b0f627f8dd05a07682b002b6af12dd2833cb1869d537bec6627487600765764f"
-      "be"
-    end
-    language "bg" do
-      sha256 "6c810bfa48e3581b5d79a2f5c0824777d0ca82c7f9be233fab34fc4a0a6a887d"
-      "bg"
-    end
-    language "bn-IN" do
-      sha256 "8a93486dcc23ec2a7b78ab55f4bb7ba917fce1608e559fe977bf9695371d0c90"
-      "bn-IN"
-    end
-    language "bn" do
-      sha256 "756b16412f65026afa7608d2d4e43b15a5fca4973610a516e95c474c08facbd9"
-      "bn"
-    end
-    language "bo" do
-      sha256 "e42564960f04c4d21ad6dbc898eb91d5257ce8a8bb35a1fde4e4760485e34429"
-      "bo"
-    end
-    language "br" do
-      sha256 "76215ef4fb3f11d80b96ed63f2efee4a7df5e04438e538eea0e38d75cbfd0278"
-      "br"
-    end
-    language "bs" do
-      sha256 "7ec98624f5582da67b4012e6217d8a96e10f279c1d70ab12ed28e0a60775994c"
-      "bs"
-    end
-    language "ca" do
-      sha256 "e49bef7132732cd56e1ea38bb7e65b2da8273b88c6992f1ec452b87f1b17e999"
-      "ca"
-    end
-    language "cs" do
-      sha256 "d0a18099fa0424084b337fea6efee557661df3ed55f67193efed167644274df0"
-      "cs"
-    end
-    language "cy" do
-      sha256 "afad51f7cc126570c9d943ab31f75cf5f28e65c89fec5abd4fd1508f2dded83a"
-      "cy"
-    end
-    language "da" do
-      sha256 "4bff8d771a69645bb96c6fde25d8157c5a630a63ebae9b6a2f86cd2abcd21301"
-      "da"
-    end
-    language "de" do
-      sha256 "0eee936fac497409a68d26b48ac4f70ba1a121de414224464c7519f34e70af21"
-      "de"
-    end
-    language "dz" do
-      sha256 "b3e8611f49edfccbb86abc1da85428bef719081164c86f15cfddd7521a7f0d68"
-      "dz"
-    end
-    language "el" do
-      sha256 "7a0c24ec6bcb638581629145776667979114ff786e892e129d9c76d89cc5ca4f"
-      "el"
-    end
-    language "en-GB", default: true do
-      sha256 "84206de7848ffd2069864845940a9ceba6db578a5f46c1d36ff259c627f39d38"
-      "en-GB"
-    end
-    language "en-ZA" do
-      sha256 "d4604336b9b114ecda2158c8c6b2e6dbc86a7605da0de70bde0494d9a02088a6"
-      "en-ZA"
-    end
-    language "eo" do
-      sha256 "b345a72edacb9f5412f8fa45428bbe96daa5b4952869e7e3e7fd5a0fa3c605b0"
-      "eo"
-    end
-    language "es" do
-      sha256 "54b305fced36b21ecbfc11f650415a9f0500f63e7363b17e8d6dd48232cd86c7"
-      "es"
-    end
-    language "et" do
-      sha256 "d2590f7b14b53da74c093948ef6cad094ea8a0186229df550ea53ac7b45c9b60"
-      "et"
-    end
-    language "eu" do
-      sha256 "b6d3674843d928ff554535c37629a7eaf5684253a787375eafcd218f3afc1d55"
-      "eu"
-    end
-    language "fa" do
-      sha256 "2dd4b3ef646c0b2850a01d0ba8a9a28f26ca6a5ba5cbdd4d29bb9c0586de41cc"
-      "fa"
-    end
-    language "fi" do
-      sha256 "c1638551cd997831da3c53598662195b7848985ecb054f28f0e897023a680f3b"
-      "fi"
-    end
-    language "fr" do
-      sha256 "64ceb17e8fd4cd2182b94a30f31f80c319c193709a6b71835605ee3ed63f040b"
-      "fr"
-    end
-    language "fy" do
-      sha256 "77ff6a03d69a1bb6e2737e0ec2071bf0bc88e626f932b884da60e2fa689a8f99"
-      "fy"
-    end
-    language "ga" do
-      sha256 "1ce4797daa24f4f082381a77d5401a9dd0dcd91e958247b255006e71c8a0f807"
-      "ga"
-    end
-    language "gd" do
-      sha256 "44e34211cc01681cf6026b1f7e100f1af4824053e335acbe56eed436210f3546"
-      "gd"
-    end
-    language "gl" do
-      sha256 "e2776d79f2aa7e06dd66979dac456e0a81c211869008e6e35071b472e73bf535"
-      "gl"
-    end
-    language "gu" do
-      sha256 "e7d60208775bcd8a57434f3e314328f8e3264823a236ba82dec924d28851f6b8"
-      "gu"
-    end
-    language "he" do
-      sha256 "6c104dee533ac77d139309201b91efbabb4d681e80fcbc3f11adba5f55020112"
-      "he"
-    end
-    language "hi" do
-      sha256 "f391881972a7ff6d013a6f25256b3630d637ec41f967f06b1c3e7644e333e685"
-      "hi"
-    end
-    language "hr" do
-      sha256 "3302d2d586471db155fa2181354fe2c67828ab2283eb6467bc54085006d5e997"
-      "hr"
-    end
-    language "hu" do
-      sha256 "057d6ae10ee02bd441ef92bdc0b33fe27735bbf9b365293f6cbcf97db1acb9a0"
-      "hu"
-    end
-    language "id" do
-      sha256 "68eabb7919522f58e91e1338afd6581bb948e1ea68277525500ee96b840f28ec"
-      "id"
-    end
-    language "is" do
-      sha256 "749e26a98be03585888926594ce8d601f3835cc30b87d4f79d0b70150945ec0b"
-      "is"
-    end
-    language "it" do
-      sha256 "1dd52ae3f202aa49e6db135c83db8dd6a835235284df7427ebb1514306011708"
-      "it"
-    end
-    language "ja" do
-      sha256 "79c78f14a87b899e8446b885cd2125f1b324ccc4150913e948ae8a26b7031205"
-      "ja"
-    end
-    language "ka" do
-      sha256 "5559b2bc090afa9a692664fef20e203b0b08df40c6e0b68f4b53124b9354338f"
-      "ka"
-    end
-    language "kk" do
-      sha256 "460bb90c8dd3155af4ac563a0ad181ef50b36b0b42f7b46d5aef3792ad933cfb"
-      "kk"
-    end
-    language "km" do
-      sha256 "dac02a6aa04b62f1f533106a6a99bbb041d06af4e306dcba5098c0dc33561a93"
-      "km"
-    end
-    language "kn" do
-      sha256 "7a41343b5d65e1ea8bb33bbb448571766bd21318c551df2d9f8c31243b8ce13a"
-      "kn"
-    end
-    language "ko" do
-      sha256 "66a46761c4fb69b60a7804afc8ba0c118a26c8eeac8caad3e216e5489cc3f762"
-      "ko"
-    end
-    language "ks" do
-      sha256 "7b5c0ff0fdf9cccc1f22ced9567524455714e7bec2e3f7c698a74800e49487b0"
-      "ks"
-    end
-    language "lb" do
-      sha256 "8c792cdcb6e9d3cf1c3b3ba60ae2ab7282239ea38d6ba4028d5ab6f62da5ae40"
-      "lb"
-    end
-    language "lo" do
-      sha256 "33dbe370f1a5f302d977904d3bc73c05ef4cdfa6e497bc5eb9ee0a8eb534e666"
-      "lo"
-    end
-    language "lt" do
-      sha256 "aa8a87c5b49633798bdef2609989ee2d06fee529fb1bf66d467527a903637d96"
-      "lt"
-    end
-    language "lv" do
-      sha256 "5bcaaf6aab8302c9f9e7e255ae73daeb556e0fb8bc0dffc39d818e80a7a10450"
-      "lv"
-    end
-    language "mk" do
-      sha256 "b23c52797a5a196cb87cfbb93c29dbf9dd6ad437de1b3a819f4eda0756a60518"
-      "mk"
-    end
-    language "ml" do
-      sha256 "78e3e9205b735469b98bcb33113a9b60b4ba59d9630940cfae955a7f8b4d62e3"
-      "ml"
-    end
-    language "mn" do
-      sha256 "3c9defca40ab2c7adab84fdeac7363a6b07fc9ebc5ea688b762127c0d0724dde"
-      "mn"
-    end
-    language "mr" do
-      sha256 "4caed057b39425537ea3fad126b0da03e69d9e09c3fd5be74d792616f1c93672"
-      "mr"
-    end
-    language "my" do
-      sha256 "5f6269620687ee166a24245a844fae5df6f8c4f48627eef1ba6de4f76d81ee39"
-      "my"
-    end
-    language "nb" do
-      sha256 "32149334fffd3d96c8acb1a455be19b735eff49bd37ea8509aaa919c681c7278"
-      "nb"
-    end
-    language "ne" do
-      sha256 "8a3cf0a05b889a5358317504a4926bcadf401fc2809c102343bf0202aa9efcfb"
-      "ne"
-    end
-    language "nl" do
-      sha256 "10c313b15b8caccb89f6232b74b36f2baf935db08cef0f680fea5f5d73912064"
-      "nl"
-    end
-    language "nn" do
-      sha256 "3c44afe7b9b2c8fec5a41d9ea77929f37da65d04ae47648f0ae359dd30e0ab0c"
-      "nn"
-    end
-    language "nr" do
-      sha256 "8ded2269bec526555495095f4b052bd49068b312bed74a8ce76cda2a04a4ccf8"
-      "nr"
-    end
-    language "oc" do
-      sha256 "0a1f9057a75927bb3ed7b701e1df3a22fd3e5b586517d5466026a7f78e504ab0"
-      "oc"
-    end
-    language "om" do
-      sha256 "d98623e85785644c385d96c9673bb22f081fffadddd6af3e6d487b423c846d29"
-      "om"
-    end
-    language "or" do
-      sha256 "81add8262de89d55131dddf3f4b61f6a63a4e75557f6b4af7a110e7f6c23d86b"
-      "or"
-    end
-    language "pa-IN" do
-      sha256 "cf46d4acb710b3efe527faf107ab2e82632f49539fc1a7f76228b8afd5992f71"
-      "pa-IN"
-    end
-    language "pl" do
-      sha256 "c90663127838b9101f191971203e8c470b77c0433eda05e7fcaceda1ca8e63e3"
-      "pl"
-    end
-    language "pt-BR" do
-      sha256 "c944f00439fc15b500c1107ae7d91db6b1371874cd7259a960e6a3f9f842f61f"
-      "pt-BR"
-    end
-    language "pt" do
-      sha256 "7adf258b8ffa05865cc1773dc0390aa364120c480b83efd4d2ff84f582d4eedb"
-      "pt"
-    end
-    language "ro" do
-      sha256 "f4b046927e0af5ae549196a17c3761e2c4b9d3cbedb5d648cd3d646ebe2a9500"
-      "ro"
-    end
-    language "ru" do
-      sha256 "3ac1cc4fc30a87a9fe3f39fe82987ac945c5187948749d152c340368523501b1"
-      "ru"
-    end
-    language "rw" do
-      sha256 "a49a86f64a47e0d4cdb175755dd2b4f6be902f0836a8d7a6f2616a30b346935e"
-      "rw"
-    end
-    language "sa-IN" do
-      sha256 "9aebb6339d4dda320e367ac770d6c88607921aa02baa0785e8f7e131ed326d38"
-      "sa-IN"
-    end
-    language "sd" do
-      sha256 "d745839885ebc52064402190955445bf2103906cfe280d88a903be1e3f87f4ed"
-      "sd"
-    end
-    language "si" do
-      sha256 "6cf3fe1f45e77aec82b2da5613c45b603696945243aa52cdf8231215d316bedf"
-      "si"
-    end
-    language "sk" do
-      sha256 "b49f89decdf06cfcb0923cd30b500774da2b9c69560a46f9448037f6aef32192"
-      "sk"
-    end
-    language "sl" do
-      sha256 "0220a2b0d6c4d8d219918a694b4648db67793475c5a7ca0f170a81b7a1c4c184"
-      "sl"
-    end
-    language "sq" do
-      sha256 "675bee1ac2d7a56307b5b3fedc0f6b63a8815e122d999b99098b0592dd47e802"
-      "sq"
-    end
-    language "sr" do
-      sha256 "0ee48ca9404548f11ef86ace48aff4b71f6064b35737d0a48f261eff4e9872b4"
-      "sr"
-    end
-    language "ss" do
-      sha256 "4656efe4258e57c054d07ebb8056abc177dec9fddc1a6d7345dfac8f9615c5d7"
-      "ss"
-    end
-    language "st" do
-      sha256 "42b945850673e5ffab97d1c6c89cbbedcd78d4f0b569b3a68da303623b779532"
-      "st"
-    end
-    language "sv" do
-      sha256 "a5a3469862cd7f469fda5662a0d222fcc521595654560185a91c249b9d1ef50f"
-      "sv"
-    end
-    language "sw-TZ" do
-      sha256 "0e977a57e94bb0aaa678c1ca4407f6fde0d30fe05b0099d69dae135dfdf75d9a"
-      "sw-TZ"
-    end
-    language "ta" do
-      sha256 "dddb54491b56569f6c8c2c6e19b0e768e998fb43eb0856aa861bc6c09542fb5b"
-      "ta"
-    end
-    language "te" do
-      sha256 "afcd6c791c30b7d9dfcb682845670d47d85b1423a56422e55e11a99b0d67eec6"
-      "te"
-    end
-    language "tg" do
-      sha256 "028e5c7678ef5712302dc23f16348483c23ad1e0328be4197ce977887c619b0d"
-      "tg"
-    end
-    language "th" do
-      sha256 "16bc58792c0ec74dce6f59fa9e5c1e2bdc5d6bd503d4ecd554723332d115a8b7"
-      "th"
-    end
-    language "tn" do
-      sha256 "0557e976901949c092f3d35000725bc6c7cb709ce43382d00d6775b657c64c25"
-      "tn"
-    end
-    language "tr" do
-      sha256 "07b242977abee6f16c66add8b0e8eadc5e53dcbdf46cace00b7010a03cac3c35"
-      "tr"
-    end
-    language "ts" do
-      sha256 "221538dde30b706b4bb9cdeff5f39fc130200f7829ce0ebdcee60ea9dc4575d1"
-      "ts"
-    end
-    language "tt" do
-      sha256 "ad6098dd96b72261c0460868ed7fdd9a5d2c611858b394f9984b84faf1849628"
-      "tt"
-    end
-    language "ug" do
-      sha256 "6ecf4d14bcb3c995e828b278d4150681ed8aea08f3f81f52b892466009399d1a"
-      "ug"
-    end
-    language "uk" do
-      sha256 "a9ff7c43eadcb5dd9d217358d50027b0c3ded83b1cc689ba36f8ac5c9e73641d"
-      "uk"
-    end
-    language "uz" do
-      sha256 "aba6d100c73cbbcc8051ebfe9d0803f321fb055c72eb88b50ab68699e0c6b581"
-      "uz"
-    end
-    language "ve" do
-      sha256 "d7ed8eaed9e4dee6b5ca997a89e5f87432c7a09b74a1559df6f2ade7b84ee01a"
-      "ve"
-    end
-    language "vi" do
-      sha256 "f5e638a921921ad4d45eb9cb676b6dba4db309fe77a967f47fe44bed05156073"
-      "vi"
-    end
-    language "xh" do
-      sha256 "1a96a3bc9259915e6ec86cff11375e7ff34474a5cfcd640e5e66be149eefc149"
-      "xh"
-    end
-    language "zh-CN" do
-      sha256 "a5518cc7023ac35b0dff7a4e7932e9a3fad508cd5dbc7ede3421f63b6fab1a4e"
-      "zh-CN"
-    end
-    language "zh-TW" do
-      sha256 "c9dbd235cc9fc0d88d0aec08b8bad8e5933eed1d986164b3d1022968e19ac974"
-      "zh-TW"
-    end
-    language "zu" do
-      sha256 "19d2189ec1b562b7815d865bb602076114d287eaa7048b92a5f0f5dd173faaa7"
-      "zu"
-    end
+  language "af" do
+    sha256 arm:   "a5cf056d4987c8cc0d82a3276c8a79e4066b0720e52ac043f5053e1034030c4a",
+           intel: "505c297614893c0904ee9c624e319f0e8b2cdb916ccfabb2e2b8a5bf13e9b128"
+    "af"
   end
-  on_intel do
-    language "af" do
-      sha256 "505c297614893c0904ee9c624e319f0e8b2cdb916ccfabb2e2b8a5bf13e9b128"
-      "af"
-    end
-    language "am" do
-      sha256 "bd8ad6a426d65f397b52e8f359a12462b71a83b4ba2ad86999a4823ea9d0cf34"
-      "am"
-    end
-    language "ar" do
-      sha256 "f0781902b1bd65a54f54a2848e749b930954aa912c1ca5bef3aa4a69ed5499a5"
-      "ar"
-    end
-    language "as" do
-      sha256 "a87fb355b5e832823906da7ba5ff047ed3414d3e427dcf1de501cd3e7b71c527"
-      "as"
-    end
-    language "be" do
-      sha256 "ce58bc8452fa8cb8b8aa740cee584b1a2da02f283e23b724121c6a392805c069"
-      "be"
-    end
-    language "bg" do
-      sha256 "ad656c42f57da6ab9a53e55a5cd57554b456712bbfd7f42ae7588b9df522957e"
-      "bg"
-    end
-    language "bn-IN" do
-      sha256 "7e6687314f64e593b42a45720ab1118a755fa37262350724d2ff6f09c8a50ed9"
-      "bn-IN"
-    end
-    language "bn" do
-      sha256 "f2302c69f37ec542e6fb0b67a2509f8e9584c7b7a76cfd130165780307f43160"
-      "bn"
-    end
-    language "bo" do
-      sha256 "359e80f716389637f4cfae57a08825db0f83ac22befb9c39a177b31b3c8a9334"
-      "bo"
-    end
-    language "br" do
-      sha256 "25ac908d26986102b2173d17ca52522558a90daafdd33df542eff1c2690a2849"
-      "br"
-    end
-    language "bs" do
-      sha256 "16d2dd01db4941771b85fda53f801e0af918f12d37d2013b10217d0e6a0aaa21"
-      "bs"
-    end
-    language "ca" do
-      sha256 "df8b2b7680af28fdc0600dcb2c6d12efa768dfdaec395e16538f6242607cdf1c"
-      "ca"
-    end
-    language "cs" do
-      sha256 "ea4099d54fba8c0e507b4b42f96d036cff012f9b1f2b16aa6b16e88a65edb065"
-      "cs"
-    end
-    language "cy" do
-      sha256 "18e2524d3fdfd00e8ae70f5f32b2f4cd7c420a3ea2c9729f5676ceb1d395d42b"
-      "cy"
-    end
-    language "da" do
-      sha256 "8a1d5bc4e62822dca62c6e8c973235cb3f7ad18575c6125a412ebca6eb190ec7"
-      "da"
-    end
-    language "de" do
-      sha256 "d0466658f0fd15def2e2daaf4d3d4fd88638af71c4df739f974dd93f8ac309a1"
-      "de"
-    end
-    language "dz" do
-      sha256 "fbf1f89e2fb330e4c1fd74241eac036987773227cc7f2de7feed4166a85189f5"
-      "dz"
-    end
-    language "el" do
-      sha256 "556bad67c8f43c4d1ff9cfebee7f8ffead006389ff6770e4636473a0339b152c"
-      "el"
-    end
-    language "en-GB", default: true do
-      sha256 "ab2025334b9807d301724c90efc3656e043d72d252f0fe7ef9d0cd8f733f00c5"
-      "en-GB"
-    end
-    language "en-ZA" do
-      sha256 "7d40973d89692063b3d25dc78dfe2cb921d922e04e8dd30fea180aa4351d9546"
-      "en-ZA"
-    end
-    language "eo" do
-      sha256 "c4cb3b4f658eca22a7a1f26959288445f65b480fc03227a1f6e3ba14e7b03f88"
-      "eo"
-    end
-    language "es" do
-      sha256 "06d35ba09a13b0391e1e67d8dfb3e3dd7f2acf42e48cc0df709a8851e6d8cd9f"
-      "es"
-    end
-    language "et" do
-      sha256 "43a70beb1b7c290310c5cdde7498db3fe5db0b5140882296e3f1282e739c910b"
-      "et"
-    end
-    language "eu" do
-      sha256 "9cbec42b36425db6874899e68ff16783f919473b45c7e692083e9833a177ed9a"
-      "eu"
-    end
-    language "fa" do
-      sha256 "12282ac45bd52a6e31af5dfaf8bf092f48c00fddd0ec9f33bceecb9ee2c48955"
-      "fa"
-    end
-    language "fi" do
-      sha256 "6bdcc6ed02dc4fd56f938e3bc8e7d37153f2202560d93a19a91034c72b68a622"
-      "fi"
-    end
-    language "fr" do
-      sha256 "16fff7d81ff1912df26a4ea81575ae058823f4ca73dfb7be7ab8b14445496d17"
-      "fr"
-    end
-    language "fy" do
-      sha256 "5ff8fcb47351d4a9e3cd3398fc1eb77a52fd622d5238fc7a91a0e8fb839e8e02"
-      "fy"
-    end
-    language "ga" do
-      sha256 "8f7944bda30a0b2bf027bee7dc3544d70cfe9be8a463118c5f63c4dc96fdc883"
-      "ga"
-    end
-    language "gd" do
-      sha256 "53307b2a55bd267cc832be6461b5a8bbca6ed9060992c5b013a4291e35507ec8"
-      "gd"
-    end
-    language "gl" do
-      sha256 "1964e9846988ff595ac8fc43c8f199430c4297396c2aeaadd031bc5fb6959af6"
-      "gl"
-    end
-    language "gu" do
-      sha256 "27187436bf712d3e302c3158c9d692a0c6ee1b21906a8a1e353aa3883cd4939b"
-      "gu"
-    end
-    language "he" do
-      sha256 "df20fba764206b3f1d0c28f7f2794e21aca6c1364be2234bd8c4cac513f85fbe"
-      "he"
-    end
-    language "hi" do
-      sha256 "43cdcef6947c3592511dad6acd90bf7f192ec365d7164cb85ef8621b81578f25"
-      "hi"
-    end
-    language "hr" do
-      sha256 "34d65c408272c6d7819349186796e8cb96539c1a4e70193ee685e1fb321987cf"
-      "hr"
-    end
-    language "hu" do
-      sha256 "4f0fcaf89bc538b20cda031a8bec3966be59f886bf87d2a314d119b3e79f3fd8"
-      "hu"
-    end
-    language "id" do
-      sha256 "b29dfbb16e7faf9d8f65b4fd7df31bf64144c2622dea3a8ddebed9e4f99730ee"
-      "id"
-    end
-    language "is" do
-      sha256 "f04010e6e97ffe0da09b1f771c6b2496a5e48064a17d980d5ba6c39d8f955d2f"
-      "is"
-    end
-    language "it" do
-      sha256 "3ea589ea09f5b1ea8d7cbd95bbc2e241d4a07ae7b0c3a8ebfd7e6d56f4d0e23e"
-      "it"
-    end
-    language "ja" do
-      sha256 "bde96c57a26f50cdec87a7a16544b88935ddf5a15d5c287568a59a926309ad07"
-      "ja"
-    end
-    language "ka" do
-      sha256 "0af563463eb3f951a169b5993e3a77a7417520fc96f01f72ec3a0987a65039be"
-      "ka"
-    end
-    language "kk" do
-      sha256 "e65ccb4ca509b2bfc9f8649f81a6585a2f12ed8d931c6a7b47de67963bd502ac"
-      "kk"
-    end
-    language "km" do
-      sha256 "744bb229ca889f057a59573f6f93a5d3f96d910004cde779a8e4ada5d67427a2"
-      "km"
-    end
-    language "kn" do
-      sha256 "2c8348cb860fa33cfb9020098f6d23d0951c910b67f95c1db335fbd45b4a49ee"
-      "kn"
-    end
-    language "ko" do
-      sha256 "a02619923caf312ce10fddea00296c7ad377e9e420b174ecc021e796de9fbf46"
-      "ko"
-    end
-    language "ks" do
-      sha256 "14f41901951701dffc114d14e8915ce727e0f816c5aa0cb20faf84330586308d"
-      "ks"
-    end
-    language "lb" do
-      sha256 "29679dd93705b9f8387a41ef43ca1ce102054afe48b4bbab7e2685e484b278eb"
-      "lb"
-    end
-    language "lo" do
-      sha256 "6896ae02a9f219a10d0279213cdfb945efacf1890ff89c4eccd061b38cfec9a4"
-      "lo"
-    end
-    language "lt" do
-      sha256 "12d74554c25511368fcb422fbfd271b4fb1b0475918a663879384cb251f34ce6"
-      "lt"
-    end
-    language "lv" do
-      sha256 "292edb1e7fe7a1524cba7068e375612d062c6e37fbe3bbacaa74342a59d20a43"
-      "lv"
-    end
-    language "mk" do
-      sha256 "3af5d55169b63fee84026fffd7241d5f028cb09279ed56f1616d49515add299a"
-      "mk"
-    end
-    language "ml" do
-      sha256 "85a4812ca2cf1acf003ca1a7274fdfa7640beef49915e23b97679b53b4b045f9"
-      "ml"
-    end
-    language "mn" do
-      sha256 "82badda64e5ca5e21f3fb780cbd0fd2af74ca10710e8873c8285639afc453a02"
-      "mn"
-    end
-    language "mr" do
-      sha256 "56ed4dcbaf74dc9d1e1556bd099789969fc1a683a409c0777320845f202eedae"
-      "mr"
-    end
-    language "my" do
-      sha256 "b20c0ae119768a8c662459460ae5e679c538fa499b0200216e72708f892e4e64"
-      "my"
-    end
-    language "nb" do
-      sha256 "2a3ec4fd36739ccf078afd3abd74d2f77f71b15d26299786908cb7cfad5bb822"
-      "nb"
-    end
-    language "ne" do
-      sha256 "21ff03c1a140a2336dd9f5c3dc00d02ac1383fcc10434dea6aa0dfc345529587"
-      "ne"
-    end
-    language "nl" do
-      sha256 "7c692da9189c402474adc1674de33281b4c4cb3cd3a39cbc484a791b90c95946"
-      "nl"
-    end
-    language "nn" do
-      sha256 "b40cb2bf6f5ed6013bf00857ec1dc76afee76e155888ce67d4965650fad270a5"
-      "nn"
-    end
-    language "nr" do
-      sha256 "36676d67b0053c5849fd20ed8252948686e34eb720258be535a4d612a250a043"
-      "nr"
-    end
-    language "oc" do
-      sha256 "060a5a80beac786d1c5e3975c98a5d37590de48bf4b07874253e57e843c62362"
-      "oc"
-    end
-    language "om" do
-      sha256 "3a9d3922132b7ce82982001474950f4d7cdaf933de5476216f018e74269959a1"
-      "om"
-    end
-    language "or" do
-      sha256 "6e0d804fe69be9ee62cb9eef3692145da2bb7f26eff66befac206492ac94a360"
-      "or"
-    end
-    language "pa-IN" do
-      sha256 "de47e5109bd97d986dae12b8f09623d55db04a53ae91da084dae28ffadcedf24"
-      "pa-IN"
-    end
-    language "pl" do
-      sha256 "ba6974d809594202c1fb35dd3d41247b8b316854593d5756c83c53a2bcc02139"
-      "pl"
-    end
-    language "pt-BR" do
-      sha256 "1e23ea4afcf2988f6f155d8db664bfad81bf4d50dc7bc9ecdf228742c2a38d17"
-      "pt-BR"
-    end
-    language "pt" do
-      sha256 "4ffd95004430056c745f7a5a39bea12b1e48132a61bae0d6304177132c68768c"
-      "pt"
-    end
-    language "ro" do
-      sha256 "5aed7e7e6e3742883a728ae60da13d9ff910ee3e66fb7f21ab79e6934e8a561a"
-      "ro"
-    end
-    language "ru" do
-      sha256 "789538a07b2a2654f87d412b0ccd20702817ec002dab4a3958431ada4a2b9c2f"
-      "ru"
-    end
-    language "rw" do
-      sha256 "1bbe49dd6d1bb5b957bbc6db45216ab58c0ced785ab041d46a12577b0543cd3a"
-      "rw"
-    end
-    language "sa-IN" do
-      sha256 "8184094257b6caad2e1cfe7d49c81fa4adc55be43f41f30f31c0fc9034271cd1"
-      "sa-IN"
-    end
-    language "sd" do
-      sha256 "22a53985351fdb2febc7af84e5d8ebe4f74c1b8c878a25b7b2bf45034c6fd296"
-      "sd"
-    end
-    language "si" do
-      sha256 "8a24967a00ae7040c57f855ad297757cb356cbf2265e4f8c2b59f42513405810"
-      "si"
-    end
-    language "sk" do
-      sha256 "6d51acf8b516c28640a3c333e68309113b381821b415294c5d6f5940e3aa9643"
-      "sk"
-    end
-    language "sl" do
-      sha256 "3687044c3cbd9409c87af0ff316dcbdcfae36ad09a8c04e4c7844ac8fc4b566a"
-      "sl"
-    end
-    language "sq" do
-      sha256 "cc69c5e973c98b40592a9e9c35396251146f013899fda6c18e5c71d3c3ba3bfc"
-      "sq"
-    end
-    language "sr" do
-      sha256 "7781b166e26b41714607f68e246838de2c2a51a137a886b2f8707b80871f238c"
-      "sr"
-    end
-    language "ss" do
-      sha256 "fa30a2c5b1bf12715b5b818ad9be3745e67fa8e18a21b1d0c8a33d0244800a96"
-      "ss"
-    end
-    language "st" do
-      sha256 "908becb34611329913effa38d9c7c62390a7147be3fc9f5d42639879e532d857"
-      "st"
-    end
-    language "sv" do
-      sha256 "683093c047c8d0cb2199da5536268ea979e78db2e3881a65934fda45c5e08947"
-      "sv"
-    end
-    language "sw-TZ" do
-      sha256 "8d867ef9030208f3dafc1bb702fd361b47f3ea707595d4823879052681249c6f"
-      "sw-TZ"
-    end
-    language "ta" do
-      sha256 "e29f2540eec23aa281de2b56a23326839fe6e893e426e878321c3517ddc9580d"
-      "ta"
-    end
-    language "te" do
-      sha256 "32c43f4acc3b51855d6e38067509e58159589c4281ffd5d020f3d502edc95a6e"
-      "te"
-    end
-    language "tg" do
-      sha256 "ea09f65c2502fa11e64942f832d7fd27b5007639afebee404eeac678c9765bff"
-      "tg"
-    end
-    language "th" do
-      sha256 "b8e8b5b4d49e1b97b9e6bda39d5ba5a289dd845b64c4a7e336956550dfab764b"
-      "th"
-    end
-    language "tn" do
-      sha256 "928eb7cdf381bd8a98f024470de16780bf4e62c17e7eed50a6fb99d6759b763f"
-      "tn"
-    end
-    language "tr" do
-      sha256 "37f98667db5fa9c906ce341b3f0c4b8b7537403acbd040f5092fc4313ebca00d"
-      "tr"
-    end
-    language "ts" do
-      sha256 "3759dfb102ac9a44f7f251e826b11ddec2f7b72400dbff3f807a8565104cdee5"
-      "ts"
-    end
-    language "tt" do
-      sha256 "a5b98a930b835af823897a06741b8aa137957c7a27d18858b2192d81c0366d68"
-      "tt"
-    end
-    language "ug" do
-      sha256 "075d3da261e17a942c6cf1b9dc88c6a6972dcec2f8dc5db04f7c13e08e3e390f"
-      "ug"
-    end
-    language "uk" do
-      sha256 "b210805caf240c2231339fe2ffde84661236263d47b3fb226c72902fb806135b"
-      "uk"
-    end
-    language "uz" do
-      sha256 "134e478e4c8958fea9b8ef8d888738e333cf494db8f1047bfa065dd8cffd401e"
-      "uz"
-    end
-    language "ve" do
-      sha256 "d88b74f2bd695216c9a218a28ea8163fa400573f28c6ceef0b878cc4589fa88e"
-      "ve"
-    end
-    language "vi" do
-      sha256 "3bb037de76a0ebe28163afc5b77c1c57bd13d01f5c2a6ac3c87ac7d7805f825e"
-      "vi"
-    end
-    language "xh" do
-      sha256 "2a3d1ee690285b1cddbb06c7bb1c46c9f182b0f09d7f45128f30e5b3790df2c6"
-      "xh"
-    end
-    language "zh-CN" do
-      sha256 "02585992b193eb662f52f8200d0383f54ebe8c6dea13f87a7b354854937cbd0a"
-      "zh-CN"
-    end
-    language "zh-TW" do
-      sha256 "e535928782358417081dd334beb0e8d3a1e36dfa753ef04a8af6b7728f7ff16e"
-      "zh-TW"
-    end
-    language "zu" do
-      sha256 "c8c23844b1be09dbeefd3dab964a94b822bd482e7e6fc2cedd05e772adeae6b6"
-      "zu"
-    end
+  language "am" do
+    sha256 arm:   "5c949d659256a96546be7b1daf941037646c058d8ff2f8f62fc412d11c1f782a",
+           intel: "bd8ad6a426d65f397b52e8f359a12462b71a83b4ba2ad86999a4823ea9d0cf34"
+    "am"
+  end
+  language "ar" do
+    sha256 arm:   "8c72a2faa0e4378845e861a6687bcaa728004e5226078fb4b96b2995e291796a",
+           intel: "f0781902b1bd65a54f54a2848e749b930954aa912c1ca5bef3aa4a69ed5499a5"
+    "ar"
+  end
+  language "as" do
+    sha256 arm:   "c701d38a9e43cf910d440b7d4b0f9d87d0c6d2ce9780de023e957529088a3384",
+           intel: "a87fb355b5e832823906da7ba5ff047ed3414d3e427dcf1de501cd3e7b71c527"
+    "as"
+  end
+  language "be" do
+    sha256 arm:   "b0f627f8dd05a07682b002b6af12dd2833cb1869d537bec6627487600765764f",
+           intel: "ce58bc8452fa8cb8b8aa740cee584b1a2da02f283e23b724121c6a392805c069"
+    "be"
+  end
+  language "bg" do
+    sha256 arm:   "6c810bfa48e3581b5d79a2f5c0824777d0ca82c7f9be233fab34fc4a0a6a887d",
+           intel: "ad656c42f57da6ab9a53e55a5cd57554b456712bbfd7f42ae7588b9df522957e"
+    "bg"
+  end
+  language "bn-IN" do
+    sha256 arm:   "8a93486dcc23ec2a7b78ab55f4bb7ba917fce1608e559fe977bf9695371d0c90",
+           intel: "7e6687314f64e593b42a45720ab1118a755fa37262350724d2ff6f09c8a50ed9"
+    "bn-IN"
+  end
+  language "bn" do
+    sha256 arm:   "756b16412f65026afa7608d2d4e43b15a5fca4973610a516e95c474c08facbd9",
+           intel: "f2302c69f37ec542e6fb0b67a2509f8e9584c7b7a76cfd130165780307f43160"
+    "bn"
+  end
+  language "bo" do
+    sha256 arm:   "e42564960f04c4d21ad6dbc898eb91d5257ce8a8bb35a1fde4e4760485e34429",
+           intel: "359e80f716389637f4cfae57a08825db0f83ac22befb9c39a177b31b3c8a9334"
+    "bo"
+  end
+  language "br" do
+    sha256 arm:   "76215ef4fb3f11d80b96ed63f2efee4a7df5e04438e538eea0e38d75cbfd0278",
+           intel: "25ac908d26986102b2173d17ca52522558a90daafdd33df542eff1c2690a2849"
+    "br"
+  end
+  language "bs" do
+    sha256 arm:   "7ec98624f5582da67b4012e6217d8a96e10f279c1d70ab12ed28e0a60775994c",
+           intel: "16d2dd01db4941771b85fda53f801e0af918f12d37d2013b10217d0e6a0aaa21"
+    "bs"
+  end
+  language "ca" do
+    sha256 arm:   "e49bef7132732cd56e1ea38bb7e65b2da8273b88c6992f1ec452b87f1b17e999",
+           intel: "df8b2b7680af28fdc0600dcb2c6d12efa768dfdaec395e16538f6242607cdf1c"
+    "ca"
+  end
+  language "cs" do
+    sha256 arm:   "d0a18099fa0424084b337fea6efee557661df3ed55f67193efed167644274df0",
+           intel: "ea4099d54fba8c0e507b4b42f96d036cff012f9b1f2b16aa6b16e88a65edb065"
+    "cs"
+  end
+  language "cy" do
+    sha256 arm:   "afad51f7cc126570c9d943ab31f75cf5f28e65c89fec5abd4fd1508f2dded83a",
+           intel: "18e2524d3fdfd00e8ae70f5f32b2f4cd7c420a3ea2c9729f5676ceb1d395d42b"
+    "cy"
+  end
+  language "da" do
+    sha256 arm:   "4bff8d771a69645bb96c6fde25d8157c5a630a63ebae9b6a2f86cd2abcd21301",
+           intel: "8a1d5bc4e62822dca62c6e8c973235cb3f7ad18575c6125a412ebca6eb190ec7"
+    "da"
+  end
+  language "de" do
+    sha256 arm:   "0eee936fac497409a68d26b48ac4f70ba1a121de414224464c7519f34e70af21",
+           intel: "d0466658f0fd15def2e2daaf4d3d4fd88638af71c4df739f974dd93f8ac309a1"
+    "de"
+  end
+  language "dz" do
+    sha256 arm:   "b3e8611f49edfccbb86abc1da85428bef719081164c86f15cfddd7521a7f0d68",
+           intel: "fbf1f89e2fb330e4c1fd74241eac036987773227cc7f2de7feed4166a85189f5"
+    "dz"
+  end
+  language "el" do
+    sha256 arm:   "7a0c24ec6bcb638581629145776667979114ff786e892e129d9c76d89cc5ca4f",
+           intel: "556bad67c8f43c4d1ff9cfebee7f8ffead006389ff6770e4636473a0339b152c"
+    "el"
+  end
+  language "en-GB", default: true do
+    sha256 arm:   "84206de7848ffd2069864845940a9ceba6db578a5f46c1d36ff259c627f39d38",
+           intel: "ab2025334b9807d301724c90efc3656e043d72d252f0fe7ef9d0cd8f733f00c5"
+    "en-GB"
+  end
+  language "en-ZA" do
+    sha256 arm:   "d4604336b9b114ecda2158c8c6b2e6dbc86a7605da0de70bde0494d9a02088a6",
+           intel: "7d40973d89692063b3d25dc78dfe2cb921d922e04e8dd30fea180aa4351d9546"
+    "en-ZA"
+  end
+  language "eo" do
+    sha256 arm:   "b345a72edacb9f5412f8fa45428bbe96daa5b4952869e7e3e7fd5a0fa3c605b0",
+           intel: "c4cb3b4f658eca22a7a1f26959288445f65b480fc03227a1f6e3ba14e7b03f88"
+    "eo"
+  end
+  language "es" do
+    sha256 arm:   "54b305fced36b21ecbfc11f650415a9f0500f63e7363b17e8d6dd48232cd86c7",
+           intel: "06d35ba09a13b0391e1e67d8dfb3e3dd7f2acf42e48cc0df709a8851e6d8cd9f"
+    "es"
+  end
+  language "et" do
+    sha256 arm:   "d2590f7b14b53da74c093948ef6cad094ea8a0186229df550ea53ac7b45c9b60",
+           intel: "43a70beb1b7c290310c5cdde7498db3fe5db0b5140882296e3f1282e739c910b"
+    "et"
+  end
+  language "eu" do
+    sha256 arm:   "b6d3674843d928ff554535c37629a7eaf5684253a787375eafcd218f3afc1d55",
+           intel: "9cbec42b36425db6874899e68ff16783f919473b45c7e692083e9833a177ed9a"
+    "eu"
+  end
+  language "fa" do
+    sha256 arm:   "2dd4b3ef646c0b2850a01d0ba8a9a28f26ca6a5ba5cbdd4d29bb9c0586de41cc",
+           intel: "12282ac45bd52a6e31af5dfaf8bf092f48c00fddd0ec9f33bceecb9ee2c48955"
+    "fa"
+  end
+  language "fi" do
+    sha256 arm:   "c1638551cd997831da3c53598662195b7848985ecb054f28f0e897023a680f3b",
+           intel: "6bdcc6ed02dc4fd56f938e3bc8e7d37153f2202560d93a19a91034c72b68a622"
+    "fi"
+  end
+  language "fr" do
+    sha256 arm:   "64ceb17e8fd4cd2182b94a30f31f80c319c193709a6b71835605ee3ed63f040b",
+           intel: "16fff7d81ff1912df26a4ea81575ae058823f4ca73dfb7be7ab8b14445496d17"
+    "fr"
+  end
+  language "fy" do
+    sha256 arm:   "77ff6a03d69a1bb6e2737e0ec2071bf0bc88e626f932b884da60e2fa689a8f99",
+           intel: "5ff8fcb47351d4a9e3cd3398fc1eb77a52fd622d5238fc7a91a0e8fb839e8e02"
+    "fy"
+  end
+  language "ga" do
+    sha256 arm:   "1ce4797daa24f4f082381a77d5401a9dd0dcd91e958247b255006e71c8a0f807",
+           intel: "8f7944bda30a0b2bf027bee7dc3544d70cfe9be8a463118c5f63c4dc96fdc883"
+    "ga"
+  end
+  language "gd" do
+    sha256 arm:   "44e34211cc01681cf6026b1f7e100f1af4824053e335acbe56eed436210f3546",
+           intel: "53307b2a55bd267cc832be6461b5a8bbca6ed9060992c5b013a4291e35507ec8"
+    "gd"
+  end
+  language "gl" do
+    sha256 arm:   "e2776d79f2aa7e06dd66979dac456e0a81c211869008e6e35071b472e73bf535",
+           intel: "1964e9846988ff595ac8fc43c8f199430c4297396c2aeaadd031bc5fb6959af6"
+    "gl"
+  end
+  language "gu" do
+    sha256 arm:   "e7d60208775bcd8a57434f3e314328f8e3264823a236ba82dec924d28851f6b8",
+           intel: "27187436bf712d3e302c3158c9d692a0c6ee1b21906a8a1e353aa3883cd4939b"
+    "gu"
+  end
+  language "he" do
+    sha256 arm:   "6c104dee533ac77d139309201b91efbabb4d681e80fcbc3f11adba5f55020112",
+           intel: "df20fba764206b3f1d0c28f7f2794e21aca6c1364be2234bd8c4cac513f85fbe"
+    "he"
+  end
+  language "hi" do
+    sha256 arm:   "f391881972a7ff6d013a6f25256b3630d637ec41f967f06b1c3e7644e333e685",
+           intel: "43cdcef6947c3592511dad6acd90bf7f192ec365d7164cb85ef8621b81578f25"
+    "hi"
+  end
+  language "hr" do
+    sha256 arm:   "3302d2d586471db155fa2181354fe2c67828ab2283eb6467bc54085006d5e997",
+           intel: "34d65c408272c6d7819349186796e8cb96539c1a4e70193ee685e1fb321987cf"
+    "hr"
+  end
+  language "hu" do
+    sha256 arm:   "057d6ae10ee02bd441ef92bdc0b33fe27735bbf9b365293f6cbcf97db1acb9a0",
+           intel: "4f0fcaf89bc538b20cda031a8bec3966be59f886bf87d2a314d119b3e79f3fd8"
+    "hu"
+  end
+  language "id" do
+    sha256 arm:   "68eabb7919522f58e91e1338afd6581bb948e1ea68277525500ee96b840f28ec",
+           intel: "b29dfbb16e7faf9d8f65b4fd7df31bf64144c2622dea3a8ddebed9e4f99730ee"
+    "id"
+  end
+  language "is" do
+    sha256 arm:   "749e26a98be03585888926594ce8d601f3835cc30b87d4f79d0b70150945ec0b",
+           intel: "f04010e6e97ffe0da09b1f771c6b2496a5e48064a17d980d5ba6c39d8f955d2f"
+    "is"
+  end
+  language "it" do
+    sha256 arm:   "1dd52ae3f202aa49e6db135c83db8dd6a835235284df7427ebb1514306011708",
+           intel: "3ea589ea09f5b1ea8d7cbd95bbc2e241d4a07ae7b0c3a8ebfd7e6d56f4d0e23e"
+    "it"
+  end
+  language "ja" do
+    sha256 arm:   "79c78f14a87b899e8446b885cd2125f1b324ccc4150913e948ae8a26b7031205",
+           intel: "bde96c57a26f50cdec87a7a16544b88935ddf5a15d5c287568a59a926309ad07"
+    "ja"
+  end
+  language "ka" do
+    sha256 arm:   "5559b2bc090afa9a692664fef20e203b0b08df40c6e0b68f4b53124b9354338f",
+           intel: "0af563463eb3f951a169b5993e3a77a7417520fc96f01f72ec3a0987a65039be"
+    "ka"
+  end
+  language "kk" do
+    sha256 arm:   "460bb90c8dd3155af4ac563a0ad181ef50b36b0b42f7b46d5aef3792ad933cfb",
+           intel: "e65ccb4ca509b2bfc9f8649f81a6585a2f12ed8d931c6a7b47de67963bd502ac"
+    "kk"
+  end
+  language "km" do
+    sha256 arm:   "dac02a6aa04b62f1f533106a6a99bbb041d06af4e306dcba5098c0dc33561a93",
+           intel: "744bb229ca889f057a59573f6f93a5d3f96d910004cde779a8e4ada5d67427a2"
+    "km"
+  end
+  language "kn" do
+    sha256 arm:   "7a41343b5d65e1ea8bb33bbb448571766bd21318c551df2d9f8c31243b8ce13a",
+           intel: "2c8348cb860fa33cfb9020098f6d23d0951c910b67f95c1db335fbd45b4a49ee"
+    "kn"
+  end
+  language "ko" do
+    sha256 arm:   "66a46761c4fb69b60a7804afc8ba0c118a26c8eeac8caad3e216e5489cc3f762",
+           intel: "a02619923caf312ce10fddea00296c7ad377e9e420b174ecc021e796de9fbf46"
+    "ko"
+  end
+  language "ks" do
+    sha256 arm:   "7b5c0ff0fdf9cccc1f22ced9567524455714e7bec2e3f7c698a74800e49487b0",
+           intel: "14f41901951701dffc114d14e8915ce727e0f816c5aa0cb20faf84330586308d"
+    "ks"
+  end
+  language "lb" do
+    sha256 arm:   "8c792cdcb6e9d3cf1c3b3ba60ae2ab7282239ea38d6ba4028d5ab6f62da5ae40",
+           intel: "29679dd93705b9f8387a41ef43ca1ce102054afe48b4bbab7e2685e484b278eb"
+    "lb"
+  end
+  language "lo" do
+    sha256 arm:   "33dbe370f1a5f302d977904d3bc73c05ef4cdfa6e497bc5eb9ee0a8eb534e666",
+           intel: "6896ae02a9f219a10d0279213cdfb945efacf1890ff89c4eccd061b38cfec9a4"
+    "lo"
+  end
+  language "lt" do
+    sha256 arm:   "aa8a87c5b49633798bdef2609989ee2d06fee529fb1bf66d467527a903637d96",
+           intel: "12d74554c25511368fcb422fbfd271b4fb1b0475918a663879384cb251f34ce6"
+    "lt"
+  end
+  language "lv" do
+    sha256 arm:   "5bcaaf6aab8302c9f9e7e255ae73daeb556e0fb8bc0dffc39d818e80a7a10450",
+           intel: "292edb1e7fe7a1524cba7068e375612d062c6e37fbe3bbacaa74342a59d20a43"
+    "lv"
+  end
+  language "mk" do
+    sha256 arm:   "b23c52797a5a196cb87cfbb93c29dbf9dd6ad437de1b3a819f4eda0756a60518",
+           intel: "3af5d55169b63fee84026fffd7241d5f028cb09279ed56f1616d49515add299a"
+    "mk"
+  end
+  language "ml" do
+    sha256 arm:   "78e3e9205b735469b98bcb33113a9b60b4ba59d9630940cfae955a7f8b4d62e3",
+           intel: "85a4812ca2cf1acf003ca1a7274fdfa7640beef49915e23b97679b53b4b045f9"
+    "ml"
+  end
+  language "mn" do
+    sha256 arm:   "3c9defca40ab2c7adab84fdeac7363a6b07fc9ebc5ea688b762127c0d0724dde",
+           intel: "82badda64e5ca5e21f3fb780cbd0fd2af74ca10710e8873c8285639afc453a02"
+    "mn"
+  end
+  language "mr" do
+    sha256 arm:   "4caed057b39425537ea3fad126b0da03e69d9e09c3fd5be74d792616f1c93672",
+           intel: "56ed4dcbaf74dc9d1e1556bd099789969fc1a683a409c0777320845f202eedae"
+    "mr"
+  end
+  language "my" do
+    sha256 arm:   "5f6269620687ee166a24245a844fae5df6f8c4f48627eef1ba6de4f76d81ee39",
+           intel: "b20c0ae119768a8c662459460ae5e679c538fa499b0200216e72708f892e4e64"
+    "my"
+  end
+  language "nb" do
+    sha256 arm:   "32149334fffd3d96c8acb1a455be19b735eff49bd37ea8509aaa919c681c7278",
+           intel: "2a3ec4fd36739ccf078afd3abd74d2f77f71b15d26299786908cb7cfad5bb822"
+    "nb"
+  end
+  language "ne" do
+    sha256 arm:   "8a3cf0a05b889a5358317504a4926bcadf401fc2809c102343bf0202aa9efcfb",
+           intel: "21ff03c1a140a2336dd9f5c3dc00d02ac1383fcc10434dea6aa0dfc345529587"
+    "ne"
+  end
+  language "nl" do
+    sha256 arm:   "10c313b15b8caccb89f6232b74b36f2baf935db08cef0f680fea5f5d73912064",
+           intel: "7c692da9189c402474adc1674de33281b4c4cb3cd3a39cbc484a791b90c95946"
+    "nl"
+  end
+  language "nn" do
+    sha256 arm:   "3c44afe7b9b2c8fec5a41d9ea77929f37da65d04ae47648f0ae359dd30e0ab0c",
+           intel: "b40cb2bf6f5ed6013bf00857ec1dc76afee76e155888ce67d4965650fad270a5"
+    "nn"
+  end
+  language "nr" do
+    sha256 arm:   "8ded2269bec526555495095f4b052bd49068b312bed74a8ce76cda2a04a4ccf8",
+           intel: "36676d67b0053c5849fd20ed8252948686e34eb720258be535a4d612a250a043"
+    "nr"
+  end
+  language "oc" do
+    sha256 arm:   "0a1f9057a75927bb3ed7b701e1df3a22fd3e5b586517d5466026a7f78e504ab0",
+           intel: "060a5a80beac786d1c5e3975c98a5d37590de48bf4b07874253e57e843c62362"
+    "oc"
+  end
+  language "om" do
+    sha256 arm:   "d98623e85785644c385d96c9673bb22f081fffadddd6af3e6d487b423c846d29",
+           intel: "3a9d3922132b7ce82982001474950f4d7cdaf933de5476216f018e74269959a1"
+    "om"
+  end
+  language "or" do
+    sha256 arm:   "81add8262de89d55131dddf3f4b61f6a63a4e75557f6b4af7a110e7f6c23d86b",
+           intel: "6e0d804fe69be9ee62cb9eef3692145da2bb7f26eff66befac206492ac94a360"
+    "or"
+  end
+  language "pa-IN" do
+    sha256 arm:   "cf46d4acb710b3efe527faf107ab2e82632f49539fc1a7f76228b8afd5992f71",
+           intel: "de47e5109bd97d986dae12b8f09623d55db04a53ae91da084dae28ffadcedf24"
+    "pa-IN"
+  end
+  language "pl" do
+    sha256 arm:   "c90663127838b9101f191971203e8c470b77c0433eda05e7fcaceda1ca8e63e3",
+           intel: "ba6974d809594202c1fb35dd3d41247b8b316854593d5756c83c53a2bcc02139"
+    "pl"
+  end
+  language "pt-BR" do
+    sha256 arm:   "c944f00439fc15b500c1107ae7d91db6b1371874cd7259a960e6a3f9f842f61f",
+           intel: "1e23ea4afcf2988f6f155d8db664bfad81bf4d50dc7bc9ecdf228742c2a38d17"
+    "pt-BR"
+  end
+  language "pt" do
+    sha256 arm:   "7adf258b8ffa05865cc1773dc0390aa364120c480b83efd4d2ff84f582d4eedb",
+           intel: "4ffd95004430056c745f7a5a39bea12b1e48132a61bae0d6304177132c68768c"
+    "pt"
+  end
+  language "ro" do
+    sha256 arm:   "f4b046927e0af5ae549196a17c3761e2c4b9d3cbedb5d648cd3d646ebe2a9500",
+           intel: "5aed7e7e6e3742883a728ae60da13d9ff910ee3e66fb7f21ab79e6934e8a561a"
+    "ro"
+  end
+  language "ru" do
+    sha256 arm:   "3ac1cc4fc30a87a9fe3f39fe82987ac945c5187948749d152c340368523501b1",
+           intel: "789538a07b2a2654f87d412b0ccd20702817ec002dab4a3958431ada4a2b9c2f"
+    "ru"
+  end
+  language "rw" do
+    sha256 arm:   "a49a86f64a47e0d4cdb175755dd2b4f6be902f0836a8d7a6f2616a30b346935e",
+           intel: "1bbe49dd6d1bb5b957bbc6db45216ab58c0ced785ab041d46a12577b0543cd3a"
+    "rw"
+  end
+  language "sa-IN" do
+    sha256 arm:   "9aebb6339d4dda320e367ac770d6c88607921aa02baa0785e8f7e131ed326d38",
+           intel: "8184094257b6caad2e1cfe7d49c81fa4adc55be43f41f30f31c0fc9034271cd1"
+    "sa-IN"
+  end
+  language "sd" do
+    sha256 arm:   "d745839885ebc52064402190955445bf2103906cfe280d88a903be1e3f87f4ed",
+           intel: "22a53985351fdb2febc7af84e5d8ebe4f74c1b8c878a25b7b2bf45034c6fd296"
+    "sd"
+  end
+  language "si" do
+    sha256 arm:   "6cf3fe1f45e77aec82b2da5613c45b603696945243aa52cdf8231215d316bedf",
+           intel: "8a24967a00ae7040c57f855ad297757cb356cbf2265e4f8c2b59f42513405810"
+    "si"
+  end
+  language "sk" do
+    sha256 arm:   "b49f89decdf06cfcb0923cd30b500774da2b9c69560a46f9448037f6aef32192",
+           intel: "6d51acf8b516c28640a3c333e68309113b381821b415294c5d6f5940e3aa9643"
+    "sk"
+  end
+  language "sl" do
+    sha256 arm:   "0220a2b0d6c4d8d219918a694b4648db67793475c5a7ca0f170a81b7a1c4c184",
+           intel: "3687044c3cbd9409c87af0ff316dcbdcfae36ad09a8c04e4c7844ac8fc4b566a"
+    "sl"
+  end
+  language "sq" do
+    sha256 arm:   "675bee1ac2d7a56307b5b3fedc0f6b63a8815e122d999b99098b0592dd47e802",
+           intel: "cc69c5e973c98b40592a9e9c35396251146f013899fda6c18e5c71d3c3ba3bfc"
+    "sq"
+  end
+  language "sr" do
+    sha256 arm:   "0ee48ca9404548f11ef86ace48aff4b71f6064b35737d0a48f261eff4e9872b4",
+           intel: "7781b166e26b41714607f68e246838de2c2a51a137a886b2f8707b80871f238c"
+    "sr"
+  end
+  language "ss" do
+    sha256 arm:   "4656efe4258e57c054d07ebb8056abc177dec9fddc1a6d7345dfac8f9615c5d7",
+           intel: "fa30a2c5b1bf12715b5b818ad9be3745e67fa8e18a21b1d0c8a33d0244800a96"
+    "ss"
+  end
+  language "st" do
+    sha256 arm:   "42b945850673e5ffab97d1c6c89cbbedcd78d4f0b569b3a68da303623b779532",
+           intel: "908becb34611329913effa38d9c7c62390a7147be3fc9f5d42639879e532d857"
+    "st"
+  end
+  language "sv" do
+    sha256 arm:   "a5a3469862cd7f469fda5662a0d222fcc521595654560185a91c249b9d1ef50f",
+           intel: "683093c047c8d0cb2199da5536268ea979e78db2e3881a65934fda45c5e08947"
+    "sv"
+  end
+  language "sw-TZ" do
+    sha256 arm:   "0e977a57e94bb0aaa678c1ca4407f6fde0d30fe05b0099d69dae135dfdf75d9a",
+           intel: "8d867ef9030208f3dafc1bb702fd361b47f3ea707595d4823879052681249c6f"
+    "sw-TZ"
+  end
+  language "ta" do
+    sha256 arm:   "dddb54491b56569f6c8c2c6e19b0e768e998fb43eb0856aa861bc6c09542fb5b",
+           intel: "e29f2540eec23aa281de2b56a23326839fe6e893e426e878321c3517ddc9580d"
+    "ta"
+  end
+  language "te" do
+    sha256 arm:   "afcd6c791c30b7d9dfcb682845670d47d85b1423a56422e55e11a99b0d67eec6",
+           intel: "32c43f4acc3b51855d6e38067509e58159589c4281ffd5d020f3d502edc95a6e"
+    "te"
+  end
+  language "tg" do
+    sha256 arm:   "028e5c7678ef5712302dc23f16348483c23ad1e0328be4197ce977887c619b0d",
+           intel: "ea09f65c2502fa11e64942f832d7fd27b5007639afebee404eeac678c9765bff"
+    "tg"
+  end
+  language "th" do
+    sha256 arm:   "16bc58792c0ec74dce6f59fa9e5c1e2bdc5d6bd503d4ecd554723332d115a8b7",
+           intel: "b8e8b5b4d49e1b97b9e6bda39d5ba5a289dd845b64c4a7e336956550dfab764b"
+    "th"
+  end
+  language "tn" do
+    sha256 arm:   "0557e976901949c092f3d35000725bc6c7cb709ce43382d00d6775b657c64c25",
+           intel: "928eb7cdf381bd8a98f024470de16780bf4e62c17e7eed50a6fb99d6759b763f"
+    "tn"
+  end
+  language "tr" do
+    sha256 arm:   "07b242977abee6f16c66add8b0e8eadc5e53dcbdf46cace00b7010a03cac3c35",
+           intel: "37f98667db5fa9c906ce341b3f0c4b8b7537403acbd040f5092fc4313ebca00d"
+    "tr"
+  end
+  language "ts" do
+    sha256 arm:   "221538dde30b706b4bb9cdeff5f39fc130200f7829ce0ebdcee60ea9dc4575d1",
+           intel: "3759dfb102ac9a44f7f251e826b11ddec2f7b72400dbff3f807a8565104cdee5"
+    "ts"
+  end
+  language "tt" do
+    sha256 arm:   "ad6098dd96b72261c0460868ed7fdd9a5d2c611858b394f9984b84faf1849628",
+           intel: "a5b98a930b835af823897a06741b8aa137957c7a27d18858b2192d81c0366d68"
+    "tt"
+  end
+  language "ug" do
+    sha256 arm:   "6ecf4d14bcb3c995e828b278d4150681ed8aea08f3f81f52b892466009399d1a",
+           intel: "075d3da261e17a942c6cf1b9dc88c6a6972dcec2f8dc5db04f7c13e08e3e390f"
+    "ug"
+  end
+  language "uk" do
+    sha256 arm:   "a9ff7c43eadcb5dd9d217358d50027b0c3ded83b1cc689ba36f8ac5c9e73641d",
+           intel: "b210805caf240c2231339fe2ffde84661236263d47b3fb226c72902fb806135b"
+    "uk"
+  end
+  language "uz" do
+    sha256 arm:   "aba6d100c73cbbcc8051ebfe9d0803f321fb055c72eb88b50ab68699e0c6b581",
+           intel: "134e478e4c8958fea9b8ef8d888738e333cf494db8f1047bfa065dd8cffd401e"
+    "uz"
+  end
+  language "ve" do
+    sha256 arm:   "d7ed8eaed9e4dee6b5ca997a89e5f87432c7a09b74a1559df6f2ade7b84ee01a",
+           intel: "d88b74f2bd695216c9a218a28ea8163fa400573f28c6ceef0b878cc4589fa88e"
+    "ve"
+  end
+  language "vi" do
+    sha256 arm:   "f5e638a921921ad4d45eb9cb676b6dba4db309fe77a967f47fe44bed05156073",
+           intel: "3bb037de76a0ebe28163afc5b77c1c57bd13d01f5c2a6ac3c87ac7d7805f825e"
+    "vi"
+  end
+  language "xh" do
+    sha256 arm:   "1a96a3bc9259915e6ec86cff11375e7ff34474a5cfcd640e5e66be149eefc149",
+           intel: "2a3d1ee690285b1cddbb06c7bb1c46c9f182b0f09d7f45128f30e5b3790df2c6"
+    "xh"
+  end
+  language "zh-CN" do
+    sha256 arm:   "a5518cc7023ac35b0dff7a4e7932e9a3fad508cd5dbc7ede3421f63b6fab1a4e",
+           intel: "02585992b193eb662f52f8200d0383f54ebe8c6dea13f87a7b354854937cbd0a"
+    "zh-CN"
+  end
+  language "zh-TW" do
+    sha256 arm:   "c9dbd235cc9fc0d88d0aec08b8bad8e5933eed1d986164b3d1022968e19ac974",
+           intel: "e535928782358417081dd334beb0e8d3a1e36dfa753ef04a8af6b7728f7ff16e"
+    "zh-TW"
+  end
+  language "zu" do
+    sha256 arm:   "19d2189ec1b562b7815d865bb602076114d287eaa7048b92a5f0f5dd173faaa7",
+           intel: "c8c23844b1be09dbeefd3dab964a94b822bd482e7e6fc2cedd05e772adeae6b6"
+    "zu"
   end
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}_langpack_#{language}.dmg",
@@ -848,6 +550,8 @@ cask "libreoffice-language-pack" do
   # No zap stanza required
 
   caveats <<~EOS
-    #{token} cannot be upgraded, use brew reinstall --cask #{token} instead
+    #{token} cannot be upgraded, instead use:
+
+      brew reinstall --cask #{token}
   EOS
 end

--- a/Casks/l/libreoffice-still-language-pack.rb
+++ b/Casks/l/libreoffice-still-language-pack.rb
@@ -4,793 +4,495 @@ cask "libreoffice-still-language-pack" do
 
   version "24.8.7"
 
-  on_arm do
-    language "af" do
-      sha256 "0ba8ceaf36d7a09988cce9babdd0e6c67edfe243ca057728d030871890373f74"
-      "af"
-    end
-    language "am" do
-      sha256 "2dfefe819409e51ff151aedc9b2099adfe2dc100fb3804b84f586e43af19254d"
-      "am"
-    end
-    language "ar" do
-      sha256 "e384365bcbd5efd6af3aedc0cdc79572e81ac1a79b789e69fe9e29caaba569db"
-      "ar"
-    end
-    language "as" do
-      sha256 "24aa8665b3e9e344df11bcb87b37230e396862fa6b674393710f5af4d1cc66a8"
-      "as"
-    end
-    language "be" do
-      sha256 "73f5e9e6241261817f45582d09e446847df0a12d8127d8758053e3287ef8040b"
-      "be"
-    end
-    language "bg" do
-      sha256 "bd3962e692aa32e9de32e9af8de56f76bdc8c34898ffebb213676ab8c8b9e5ad"
-      "bg"
-    end
-    language "bn-IN" do
-      sha256 "ec7298c17c32d410e86e0466ec35ba7b4a43412dd276d5427c480f9df8d3c1ee"
-      "bn-IN"
-    end
-    language "bn" do
-      sha256 "274c9ed69da7beb65763b0f83ba8a56a0e02ae44514842db811bee4a41e110e2"
-      "bn"
-    end
-    language "bo" do
-      sha256 "fc2cbc9e01ccb6f4ae5cc931fe5fdef4f1b9595f7b0d157739bf37a9bed8d04e"
-      "bo"
-    end
-    language "br" do
-      sha256 "5b2e534218bccca748da2a33bf7b6c0f719ab1ed97e9af25d0adc03cb5294574"
-      "br"
-    end
-    language "bs" do
-      sha256 "a4deb45d11b164bbd5861c7309cc59d3557a230e9ac2d5f578d63ac589b8a6eb"
-      "bs"
-    end
-    language "ca" do
-      sha256 "84781e7d789639c23832e477dd37e3638d91883ff66da88065602ec1fad90ec8"
-      "ca"
-    end
-    language "cs" do
-      sha256 "1019c2d7c79f318d15f2aedb50d634d83736752ed337c40e9c23205024fe3fe4"
-      "cs"
-    end
-    language "cy" do
-      sha256 "216f05d79a87e95768d52e8fbcf5717c5a1f96a7565c8d63f6a826e070aff517"
-      "cy"
-    end
-    language "da" do
-      sha256 "026c59a4723124dfda40f7585df1dc0dcf656c1cef6c08bfb651268760568ba8"
-      "da"
-    end
-    language "de" do
-      sha256 "ff18723298254c5601354d776b07c5e1eb4a81e8b9df983fb932fbd6770739ac"
-      "de"
-    end
-    language "dz" do
-      sha256 "aca930d257ec34a6d60c2772ddda557a9c91a92d2c937f1dbe42940a8abc6e44"
-      "dz"
-    end
-    language "el" do
-      sha256 "fa0c4dbe79e380b16081bed3b021db7932ae8b7c4e7bd41fcdbbeced037bd17c"
-      "el"
-    end
-    language "en-GB", default: true do
-      sha256 "d5cdfa8863e8adcd97c8b9230c752a563daf40abc619745d7cd22c7d70cd712c"
-      "en-GB"
-    end
-    language "en-ZA" do
-      sha256 "35157cdca934b24d121f4c1f78c7f7e109c61ba08d77a1baa3631b4034fbf6e2"
-      "en-ZA"
-    end
-    language "eo" do
-      sha256 "065fdcf954d9f3e307bcc708fb6308656d1e4b2088f986166974facb9375459a"
-      "eo"
-    end
-    language "es" do
-      sha256 "a9297c4a5f17a4f69269087e678fb9a202b51e14ee00e8cb0e637672c78cec78"
-      "es"
-    end
-    language "et" do
-      sha256 "87685f03d04c3c9902239413fed4b6acb0e716c98886bce4865c79df8584a620"
-      "et"
-    end
-    language "eu" do
-      sha256 "e069a968c5bc2878a2bd8576c369043d7d6f3d711643d9fca056cb4e9febed58"
-      "eu"
-    end
-    language "fa" do
-      sha256 "e7586e2fa61e1a79487344dda1c4c96a117756c8035040c352ce9edf7d87d9a5"
-      "fa"
-    end
-    language "fi" do
-      sha256 "c6633659c6495f9060f776b9e1fb023b6bb0dd971488f4ce74ffc8ed7b484aa9"
-      "fi"
-    end
-    language "fr" do
-      sha256 "1d3da9bc4e4c2943d4a71edcd54033287c1e7a84f490357d2ed4b54b09d81ff6"
-      "fr"
-    end
-    language "fy" do
-      sha256 "316d6c89b5202c0557460d4e86672354933401dcbcf8087e7ea2a0aa81453594"
-      "fy"
-    end
-    language "ga" do
-      sha256 "93594065894f1169b5ceef837842af5209c2a336728bf541a220cd2e3003ce14"
-      "ga"
-    end
-    language "gd" do
-      sha256 "1c1c641a6907de5cfa31d49b48229eba385c7c5a655787fd702cf954e6eb95a2"
-      "gd"
-    end
-    language "gl" do
-      sha256 "52e1638c9b6629da5ac943c451cc2909aba2d11608cada6ae4a386f23672c306"
-      "gl"
-    end
-    language "gu" do
-      sha256 "0bd043868321376ae1f142e1eef0748d9302ea2da83fb66fa4b1ae314c2e3b93"
-      "gu"
-    end
-    language "he" do
-      sha256 "fa2697451a3f5a49a504ccb827978fefa69a9c6734f4bd5ba25a398766ec111e"
-      "he"
-    end
-    language "hi" do
-      sha256 "0730e104aaefaa0cdddb96f7675f9a2398e607c6ce6ae657ee0cf4a6da4c119b"
-      "hi"
-    end
-    language "hr" do
-      sha256 "d4a72a49dc3e9ffb45fd863b49860c958dc0bf19519c18a538e91c1728a15e65"
-      "hr"
-    end
-    language "hu" do
-      sha256 "3a1d1188868c6a434ef446d6f6580b918d18c236031687f16967eabb95a8414b"
-      "hu"
-    end
-    language "id" do
-      sha256 "0c1c7063fb4bf836e3ffb2352bb28fa7c840acd7f872adc26ecaf8ec985f5557"
-      "id"
-    end
-    language "is" do
-      sha256 "9f95434cf68c2e84be5e24f4f21318456761255aa2402a42f64b4d86171a2384"
-      "is"
-    end
-    language "it" do
-      sha256 "1244c5957c937355b5f3fc760904162696eeefbf0aa58e808c1ac3a2946d6903"
-      "it"
-    end
-    language "ja" do
-      sha256 "f57afbeaefefeedbebbfaa12a8b6df101e9825d1ae60da134772f9def5cb6752"
-      "ja"
-    end
-    language "ka" do
-      sha256 "8f08bb346359ee6d6e554bf38f35afe23535dc1769ade335c87f286c6aeae989"
-      "ka"
-    end
-    language "kk" do
-      sha256 "0ade1a08ae4e33884a7a256be1002f5b9fa6c08c8d3335f25b6dcf0e07f2325c"
-      "kk"
-    end
-    language "km" do
-      sha256 "495e4dee15dda07d268cff222b60f574c010575a4d8fd7d5dd6e2e79699c004d"
-      "km"
-    end
-    language "kn" do
-      sha256 "66a077d7a4483d603a4d41f6cab7cf91ce24b94b25285efcfc3b56c17bea1544"
-      "kn"
-    end
-    language "ko" do
-      sha256 "49f936e1bb63711a234c39dd8cb73334b7af71ce23bbe4889718bd6db6ffcb36"
-      "ko"
-    end
-    language "ks" do
-      sha256 "148237c4ce5060cd5077b3c412632bf68297d183445f7dc254f51ae8aec8eabc"
-      "ks"
-    end
-    language "lb" do
-      sha256 "1a6917efe06dc0fb33c8db66b4ae18a2ed30fad2aa9252a8975d7739e582d685"
-      "lb"
-    end
-    language "lo" do
-      sha256 "a771364383a12d51a3f9a26c0c676a4b9ec86eb5d116fbf8dad3bd084a146450"
-      "lo"
-    end
-    language "lt" do
-      sha256 "2d3b1c232d865654a76defbc5ba3a20f8cd4d57374488ffc64a4b0f64be003d2"
-      "lt"
-    end
-    language "lv" do
-      sha256 "7a7549407f20fd590e5afc590af0febea720217782e6796b79d148b0f8e7366f"
-      "lv"
-    end
-    language "mk" do
-      sha256 "c423cde387cde9e5528c9e25f507fcaafd5b7e15d8dff2bc3a139397d007f669"
-      "mk"
-    end
-    language "ml" do
-      sha256 "d6cf1468f06ce71a9386137b71e489266a8316f50ef49e9cbf4d111d9ca6d61a"
-      "ml"
-    end
-    language "mn" do
-      sha256 "1681829407e1dc47060fb228668c0c25d1db2b1f35899195c2cc8bc69cdc1810"
-      "mn"
-    end
-    language "mr" do
-      sha256 "0484b9252022d933d4c8442e54102c6800c8e9793bd0b09e092ca7aeb4cb8df0"
-      "mr"
-    end
-    language "my" do
-      sha256 "3e53b9524b93868fca64d4226bbfc55c6facda025893b1c652afd82775fba5f4"
-      "my"
-    end
-    language "nb" do
-      sha256 "07250c6d192ed3d638c0641f34131fdc73eefb9f6d38a59b38109d1638a45885"
-      "nb"
-    end
-    language "ne" do
-      sha256 "ff0da73906a44d60e0a293d65a48bce69733b0cbab841e711933497b6a3e7ab5"
-      "ne"
-    end
-    language "nl" do
-      sha256 "24e85dbde23bd3d2f14db503e42a3109df5d2b62599abcb809cdfed5840327b9"
-      "nl"
-    end
-    language "nn" do
-      sha256 "219dbee3e2f1eda45a3d5c39119bbd7792fca49991f076d4b04cba275ebf8710"
-      "nn"
-    end
-    language "nr" do
-      sha256 "66ed8755fee2ee094b4575343e0d760b98a73bc7edb1950f2239049240e92743"
-      "nr"
-    end
-    language "oc" do
-      sha256 "a256f34b000f8923916d78bfb6feb65a289ef35c6e3d7bd2a8b8819ce362dea9"
-      "oc"
-    end
-    language "om" do
-      sha256 "bf76b9ec673341cb987046eaca0c615b11264cddeb4f67502f52b26d15d889d0"
-      "om"
-    end
-    language "or" do
-      sha256 "2eb36549009a4f3af43f16c18397a0341b41e0b59957a549fc57c6ed53ea62ad"
-      "or"
-    end
-    language "pa-IN" do
-      sha256 "45096867242f5d90c6e6cef78eb233e7f92c6b88da15a7a6aaf1b61e1955f377"
-      "pa-IN"
-    end
-    language "pl" do
-      sha256 "c759fdec01a85fe245868847d3e27cc5adcf1da23f5ce4d6e82accaac274fa84"
-      "pl"
-    end
-    language "pt-BR" do
-      sha256 "ff06d99f1cd9cf292d04229d504abb585712848c56c9d838270beb9077dab83a"
-      "pt-BR"
-    end
-    language "pt" do
-      sha256 "87bd6621ff16f7b4c76be1457ac23d11f7add2e2bf22a2d71dace2fe94631601"
-      "pt"
-    end
-    language "ro" do
-      sha256 "bea6e2ac21c3281ad7a037fa7cd2612c6e9c4bba6e251be4e6773be0ed186634"
-      "ro"
-    end
-    language "ru" do
-      sha256 "89595c1a3acf18bfb32bf189626a24239e7dde515b38708db3a6893386f56979"
-      "ru"
-    end
-    language "rw" do
-      sha256 "49daf077f13e67d2acc7ea31bdb2841e198e9e0fd43c8151f05b45b38306394e"
-      "rw"
-    end
-    language "sa-IN" do
-      sha256 "36795b4b1d1b1d28b617b5c1af86cb92f527d35c0eceeb24538acd40df41e798"
-      "sa-IN"
-    end
-    language "sd" do
-      sha256 "ca478380d78aa0df28f7bf5991a1cfd2af35fd5992517a94c11f03356da55561"
-      "sd"
-    end
-    language "si" do
-      sha256 "d5c6e96cba1ba54fd666cdba3dbd9dfd88f697d84fc87c6f73923c372489f5f4"
-      "si"
-    end
-    language "sk" do
-      sha256 "d216a825d3aa2df5c292ccb761843d274593f88d5df1d419d2b420159086b4d5"
-      "sk"
-    end
-    language "sl" do
-      sha256 "0ac484b600f78f45ca27a5fa3d7715c392615a24f96eb8ab84713e1a9af2a17d"
-      "sl"
-    end
-    language "sq" do
-      sha256 "e90d12d9ba314fb280923f30ec0fcf59e9a2b750e4778512b657c9536e0e5788"
-      "sq"
-    end
-    language "sr" do
-      sha256 "12bb6feb8845249659faecd270f4a1ff7350919bbe986c00d79e469f665b50b5"
-      "sr"
-    end
-    language "ss" do
-      sha256 "dd0ce40ccd2451c5cdfda67448ecd9223f4d5468a2315418abd0baf164aea844"
-      "ss"
-    end
-    language "st" do
-      sha256 "ff95bb36fbbe0608dcd823ada62a2e86dbba2ee0646d7f9c3ec594a3c700ca9e"
-      "st"
-    end
-    language "sv" do
-      sha256 "df4d5026474fda8ec3ca13308af5aa0368dda15b493fe58780754badb418a7f3"
-      "sv"
-    end
-    language "sw-TZ" do
-      sha256 "569112ea5b12477cc4277f3006c77a612a693979da4bc951233f9917828bee8b"
-      "sw-TZ"
-    end
-    language "ta" do
-      sha256 "e9dac0a9910ff0546e150c4bcfb1463bfe83e11fd27435fc0db691ae39bc5761"
-      "ta"
-    end
-    language "te" do
-      sha256 "5143196b59f9afe32c58f76ec00a7a634335096f055b35b3cd7042b6e67ac1a8"
-      "te"
-    end
-    language "tg" do
-      sha256 "0611f3727d1249bf6a287c795d1a7979afaf72652d70d00839d23ef84f901589"
-      "tg"
-    end
-    language "th" do
-      sha256 "e23f4bf636e1a99c8ae64274c3b3823eb14c0e8411339e06eb3d75576c61eb4a"
-      "th"
-    end
-    language "tn" do
-      sha256 "29cf9c84768fc769d8ef286a8df13a9f2ed2fc04ea55407c5133f8dc11dd56de"
-      "tn"
-    end
-    language "tr" do
-      sha256 "f38e4e2ffe5d7ffd473a569e4e7aa84ab16a3d7fa492bf00070e24f8895d5ac4"
-      "tr"
-    end
-    language "ts" do
-      sha256 "3072cd9268906936527de42a4c4bfae3722b50ef173e6a5bcd24b2a46b6c3eb3"
-      "ts"
-    end
-    language "tt" do
-      sha256 "850595c0b3f376d538675eba9d569a53226b78f756d705a72d08a2e745af688e"
-      "tt"
-    end
-    language "ug" do
-      sha256 "f2c17ce04432c5fa1f1ae2804456356545e4bd8ab883a7f211edb93b2f4990be"
-      "ug"
-    end
-    language "uk" do
-      sha256 "cfe49669c56f921f23ec3b254f99e904cdbca4e22b5e554d9ba54c398c5c0fc9"
-      "uk"
-    end
-    language "uz" do
-      sha256 "5a51c8f1b0fa878c27fa076283c1f1523332a0bbd615614cb82c5dca99619b7c"
-      "uz"
-    end
-    language "ve" do
-      sha256 "b3d323ab29dacf86001ca58d60099ddd1c1c72e75154128bdadabd8bb4ca3f04"
-      "ve"
-    end
-    language "vi" do
-      sha256 "3be538deb65381dc3fe4cd812a4168df22479ad87ff376f6a4247f84c8306736"
-      "vi"
-    end
-    language "xh" do
-      sha256 "a5132f0dd649744c2e74a74905a15f294e419d51c4412bada8fc1f2566f282bd"
-      "xh"
-    end
-    language "zh-CN" do
-      sha256 "674436e941212c10bb31df42c2a2570e9ce7ddaf1ec379f7b561b438e6529527"
-      "zh-CN"
-    end
-    language "zh-TW" do
-      sha256 "fc649f04371a801c77d12859dc3f47bc1336948dfab29970114f32f3501a8134"
-      "zh-TW"
-    end
-    language "zu" do
-      sha256 "46a4d3116915d56b4b454a0c819328b69779d1d4020a1af0c186ae9bb1fd631e"
-      "zu"
-    end
+  language "af" do
+    sha256 arm:   "0ba8ceaf36d7a09988cce9babdd0e6c67edfe243ca057728d030871890373f74",
+           intel: "b9c2a1e3534ff47e4aa67bebad09a5760cbb53ac585d369dc7b70957baf82235"
+    "af"
   end
-  on_intel do
-    language "af" do
-      sha256 "b9c2a1e3534ff47e4aa67bebad09a5760cbb53ac585d369dc7b70957baf82235"
-      "af"
-    end
-    language "am" do
-      sha256 "9ce4c94cebeab557b26f0971c95c8247acea2b6aca49b90c4b99048cdb5c9b5c"
-      "am"
-    end
-    language "ar" do
-      sha256 "597e717d42cd0716109c14d4eae5b3ee731858c212c8e62ddaa2b8b4c1b18df7"
-      "ar"
-    end
-    language "as" do
-      sha256 "42fc0d9f84d8964bd48a7a98f5e3c8b5c25d03d34a50c1ab9d92a6c51bb54879"
-      "as"
-    end
-    language "be" do
-      sha256 "0ac6849b2ada431d7f10f0fc0db504d8a9daa01377931b8ad3c906431d1b5f43"
-      "be"
-    end
-    language "bg" do
-      sha256 "c4974b13a358082c4c2c098ee9cf5511b4f5abe752f63a8b49550e0699722ce2"
-      "bg"
-    end
-    language "bn-IN" do
-      sha256 "70bee8cd1951435a23a40d951b018137e2eadd20aba3dd7cfa5f6d4f0831c023"
-      "bn-IN"
-    end
-    language "bn" do
-      sha256 "718b51b6c4e54fb70054f005f6b6250a576abb5cd707c7b356c5f535c5c14fcc"
-      "bn"
-    end
-    language "bo" do
-      sha256 "0010e15d75eaabae023f6bf8ba15d21d88ef818f5b5b61d76411e9b433dc26c3"
-      "bo"
-    end
-    language "br" do
-      sha256 "144976bfded80a20bd0bdfdeaa6e6d5b9ab79e0f68d45a74199d9879290466c0"
-      "br"
-    end
-    language "bs" do
-      sha256 "d9e81eef95d3cf1653c1061244b28120a7c122ce14c17d78766081116201639c"
-      "bs"
-    end
-    language "ca" do
-      sha256 "a59145453e72d010a8150931c687837cebc2505a4444aa71cd87a504ab163fec"
-      "ca"
-    end
-    language "cs" do
-      sha256 "6d96b1c9b297704ae81e39b2eaf3eaf004ed9b4fdf709f93ab0e8e4e4141423a"
-      "cs"
-    end
-    language "cy" do
-      sha256 "f7b3a07a9d3085e28965cb7d56030e59110674e7cb6a45dacfad7090a82499eb"
-      "cy"
-    end
-    language "da" do
-      sha256 "02d7419da1eef27d85c7eab1777ee86d0742674c24d3364ac99ee0858f0005f9"
-      "da"
-    end
-    language "de" do
-      sha256 "81d62ae17d5341bec55156f74939cc2696e62a34301c1bfa296d2da58f979fad"
-      "de"
-    end
-    language "dz" do
-      sha256 "1da86a8c40443ba55f032287ec7fddb00f40378715064360ccfec19efdc6aeaa"
-      "dz"
-    end
-    language "el" do
-      sha256 "2cd1d29dca2acdd97c26a7936730f3c775cf9a84d9400b11717cd56c55123a4e"
-      "el"
-    end
-    language "en-GB", default: true do
-      sha256 "03c460c81ec80e97875acf71dbe13da4c6d7a5de8cd9078145a8cf8bb2532769"
-      "en-GB"
-    end
-    language "en-ZA" do
-      sha256 "61de7b45ed8c913340bfd818ed20d856cdaee8fff9e526b11bdcbace3da4a785"
-      "en-ZA"
-    end
-    language "eo" do
-      sha256 "5c16f456af6a2d532341a7dde6f43cae2f9e413d13d1328f5061bb614cdca700"
-      "eo"
-    end
-    language "es" do
-      sha256 "5ba842c8d15c2d8c3f1a45105d8a7d080fe1e6eb424e8ef837f0eee7bcecbdc2"
-      "es"
-    end
-    language "et" do
-      sha256 "13cada3e93d5393bd589e930cbd4ac36cc878df77d298b37910457e5f540ff88"
-      "et"
-    end
-    language "eu" do
-      sha256 "947fdc3a50b72511e2e5747dd8a61f188ae793458a3f3b60ac27c043d53d0d7f"
-      "eu"
-    end
-    language "fa" do
-      sha256 "5e27d86cb7da64ce9903ad82f96fa573efacfd3b73cf248be4647802f91db7f5"
-      "fa"
-    end
-    language "fi" do
-      sha256 "a7e52c99c8ec572fdc23c128832044c65c8f4d0f3a8571c82f623acd10000a8d"
-      "fi"
-    end
-    language "fr" do
-      sha256 "2ff80a74cab68858b2af9c826c32e404394e3934bfd8ac5f8538273eeb88d913"
-      "fr"
-    end
-    language "fy" do
-      sha256 "85dd8eff9d927773ff38b708d97dfed8d1bbb43386f7fe0b1e8a324d72781ee4"
-      "fy"
-    end
-    language "ga" do
-      sha256 "c793d1d3f485e4ed9cc507c7b6ae56f5872fd1178be2fea3516b3159b25c2cbf"
-      "ga"
-    end
-    language "gd" do
-      sha256 "752df5affb7e927c9b1f1386c5abdf85635e1453fc9bda28ab64311fa79990fe"
-      "gd"
-    end
-    language "gl" do
-      sha256 "ac163b5031c34439604168332db2d8fedac5a0206dd619ea98099f383355a290"
-      "gl"
-    end
-    language "gu" do
-      sha256 "97e18825fd8cc48366d60424f86d5e238fa6ab699055cc9597cd200fa27a8004"
-      "gu"
-    end
-    language "he" do
-      sha256 "deb34f34d59ca348f0121832736c85160157b8508a5d5522c3464dfb8a2d34f3"
-      "he"
-    end
-    language "hi" do
-      sha256 "188e4d13ae3cbdebcd5467a4618dbe80f58e58a5268edd90f485b2436296ca99"
-      "hi"
-    end
-    language "hr" do
-      sha256 "a4dcec9e1c3f2a72a9a2eec24498ed94567aa458d32cf32e9756716ec963d53e"
-      "hr"
-    end
-    language "hu" do
-      sha256 "0fe973de606e5f7f585db1981dea38a801e3a8f516b943be7352956f79b23760"
-      "hu"
-    end
-    language "id" do
-      sha256 "c07611921abacb90e82d997d92b67517ce949200884da48ecb2d0113e92f6d82"
-      "id"
-    end
-    language "is" do
-      sha256 "07852d30c2c722439586a0ae96b27f179ebf2775e695f1c60b4b15d5f4ae8b80"
-      "is"
-    end
-    language "it" do
-      sha256 "b5e2442fd09715397e3c5e77c4a43c4ad7d8c735de9ba657cc3b686cc5e16e5e"
-      "it"
-    end
-    language "ja" do
-      sha256 "f7945fe8e6decd93af88ebb4277a3a24800a56f2bfdfa7ae06d1de5e7e4ee4aa"
-      "ja"
-    end
-    language "ka" do
-      sha256 "a5d5df053e2dced8f0db33474eac09dbbdfa5cfe2ec18f91351571f389a02793"
-      "ka"
-    end
-    language "kk" do
-      sha256 "11393c448b48ce54f150f36c0c464d6a2b61fe48fba5666068abd6664bddb837"
-      "kk"
-    end
-    language "km" do
-      sha256 "4bfb621e907d5a2d9dff10f8c9d9236b0aae0a4ec1f13e084a8ed709b9825fd0"
-      "km"
-    end
-    language "kn" do
-      sha256 "6fdbcb5ccf74243de38124da53311772be73bdb3e4d9fdb5d713e7679f6101f4"
-      "kn"
-    end
-    language "ko" do
-      sha256 "a84772712fd85f3542cad9ca30d3fce30c20d6346c607294eafc27e0f601bcb0"
-      "ko"
-    end
-    language "ks" do
-      sha256 "58bcb22460329d7691bf6213a20d48b502007f53398a8c4bc70e65b25da3bc41"
-      "ks"
-    end
-    language "lb" do
-      sha256 "af201cf202fd1d15d1d6cec8d3df78df319e8178f896695dcf3695386a62b2a9"
-      "lb"
-    end
-    language "lo" do
-      sha256 "606ac7598c41631d7c3b1495e2f27903ae48d1960963c2c32108fbeece843ba4"
-      "lo"
-    end
-    language "lt" do
-      sha256 "ec72530c9120c4cc3a557b3bd0059f99ba9b431a14aee7e4ecaf814658d60690"
-      "lt"
-    end
-    language "lv" do
-      sha256 "1d66deb707fc94acbee3ebf56c64763f6600637b7382f7a29d186904cdaf41d8"
-      "lv"
-    end
-    language "mk" do
-      sha256 "9ddf2d72d3801850abce49a0c9f75e3252be4595bd95557d04146be6d34445d1"
-      "mk"
-    end
-    language "ml" do
-      sha256 "9f22da5ad07450932911be1ca3ee8144f8f732bc5cd865061d9a589c26a2a4a0"
-      "ml"
-    end
-    language "mn" do
-      sha256 "2b9853986757f469bf0529378edb4f468cb80f0d1105f447d387a2814ef027e6"
-      "mn"
-    end
-    language "mr" do
-      sha256 "348c9a9c16ff01fada1f4001a6a807d507bf36c8d1fd17f7815d5683417d9d72"
-      "mr"
-    end
-    language "my" do
-      sha256 "aaeab9692d43ad70eaa0f7aec3c38a1923ebc5c6a215c32c5a5559ba9e751874"
-      "my"
-    end
-    language "nb" do
-      sha256 "8a24eb103b017000fca35dd694ae05b3424cbeaf052455cfafdebdfe80da13ba"
-      "nb"
-    end
-    language "ne" do
-      sha256 "3e30df919bd06b14b7bf1259f800a525091c229278a3c3e40fde16cdade2083a"
-      "ne"
-    end
-    language "nl" do
-      sha256 "d407922b481e8668bf31ee63d896f1b9a1178aa7a7bd2cdc08d2651f6e2db97e"
-      "nl"
-    end
-    language "nn" do
-      sha256 "062365598437ea0af8542858cd40a573d52e0cafe3b8a4e2eebcabe47ddb4c3a"
-      "nn"
-    end
-    language "nr" do
-      sha256 "0b2ccf544dcfcd9789ddccf4f8c77d4a368b5a8a2cfff17c6745a0347151fef5"
-      "nr"
-    end
-    language "oc" do
-      sha256 "2d9a4c91bc9dd5a9c9f104b79b401447769b8471d31d6af53407dc400949e3e0"
-      "oc"
-    end
-    language "om" do
-      sha256 "134ef17e6a22f9259948f689de5201f5396e9966f4cd1dd74c970246df9d7257"
-      "om"
-    end
-    language "or" do
-      sha256 "9df13ed6fd3371c80e33c7960ba313aac018902268c20f5e1ce323c1aa56e031"
-      "or"
-    end
-    language "pa-IN" do
-      sha256 "839b845a2dacfc33b0be0866e0e6a5686313164a625536042601eab88fb441e7"
-      "pa-IN"
-    end
-    language "pl" do
-      sha256 "5b9082a9c3b75bd66cbc24689c95121cb8a81aa36da2bde1452ca07e9b25f209"
-      "pl"
-    end
-    language "pt-BR" do
-      sha256 "c753b8069b33e3f9d7327ae042e95d22006fe95dc4c57d05a3dcdd3642f2ef2f"
-      "pt-BR"
-    end
-    language "pt" do
-      sha256 "d70936e02db7242e1d582e31cd7bbef683f5ca8dcfd8b508e8e7fa747dd81ce8"
-      "pt"
-    end
-    language "ro" do
-      sha256 "c1d11c1bf78d078d23498370ebe6cc1701be524984dea320e3d9ec4ece4a6f02"
-      "ro"
-    end
-    language "ru" do
-      sha256 "0dd882cc4b073721fba43ad60d75ef91f662eb8fc444767691faf40c7dcf80f8"
-      "ru"
-    end
-    language "rw" do
-      sha256 "37c5741fa9925c9fae38ff73246067b830123218199a2ccf87e81d36435b1c11"
-      "rw"
-    end
-    language "sa-IN" do
-      sha256 "3ac5a7053ae9f82636e24fdb68ab20a3276190a0c48a55a7a3802450905addb8"
-      "sa-IN"
-    end
-    language "sd" do
-      sha256 "f8512283e2280dc314b54a5adabca61777a75ad635c6eda8552ab3daeb529a8e"
-      "sd"
-    end
-    language "si" do
-      sha256 "0eba5fd563522ddca0fa3fcbb2fe10393c06689e6caa77991068d612993790e8"
-      "si"
-    end
-    language "sk" do
-      sha256 "11b9ad0a4b5e85055b52902ffc9562868637b7d39474b0a4e31a2f026d67af3f"
-      "sk"
-    end
-    language "sl" do
-      sha256 "6f05d8aeed57fad613e85d128343adb7283558e5c34cee1e60d52e2c29300f4b"
-      "sl"
-    end
-    language "sq" do
-      sha256 "7053cd43304d4d1c6173d41a4ef884c977d1b12cf4c5faa097b39bcd0487848c"
-      "sq"
-    end
-    language "sr" do
-      sha256 "c4e9686f876ad56c491048101941523fe5388e0a380a2b29a9292062ba3e62f8"
-      "sr"
-    end
-    language "ss" do
-      sha256 "04733806686973c5ec3d32902447a0ea8ce0bb0ea45528835b933878fccb92b0"
-      "ss"
-    end
-    language "st" do
-      sha256 "fdf52712ee169600819e84bda336a6a55e01302cbe1aaa44229755a395dff3e4"
-      "st"
-    end
-    language "sv" do
-      sha256 "c9f2a0033d4794439415b09544537f5acb5bda0fcdce84535d1adec3fbaca9d1"
-      "sv"
-    end
-    language "sw-TZ" do
-      sha256 "cc7ccaddf1db447ad3be249c052589d54a593a57ec37023fa8f486465c1c21c0"
-      "sw-TZ"
-    end
-    language "ta" do
-      sha256 "b11295b2d0ada7461ff4cdc8635ecfbd3e983e8784c4b4e957347b9adcf3e86c"
-      "ta"
-    end
-    language "te" do
-      sha256 "0f88a9da6927aff4a2f9d3caa79cbf6341cc7ca695bad510acd7d5e60e9b9485"
-      "te"
-    end
-    language "tg" do
-      sha256 "c65754bf431f932011de4ec2eb5773ab8f995311faec155dd9ea1b030bfe95e4"
-      "tg"
-    end
-    language "th" do
-      sha256 "0bd577551150527cf3990858f683176d687f131430c1757abf4dbdc7f1baee96"
-      "th"
-    end
-    language "tn" do
-      sha256 "a567e6969c57abd5efc1ea88d500e43c9a8c531003fceb91603d77e12cbf6500"
-      "tn"
-    end
-    language "tr" do
-      sha256 "0d956d5ac9b7ac3cdc70de4645ee9d9df7c633b749467f9b412a435491f04c85"
-      "tr"
-    end
-    language "ts" do
-      sha256 "8c835462c9dbbff0245444698230d2c2bcb8f72f93020ae3f68e89077bffab40"
-      "ts"
-    end
-    language "tt" do
-      sha256 "331beffe8927f88f0eccdba906e514c6ed8b60953a82164a8a69371348dfc795"
-      "tt"
-    end
-    language "ug" do
-      sha256 "4996578f044cd55f9666a6bab364648b03e04f967e263f64c3aad776a4afec1d"
-      "ug"
-    end
-    language "uk" do
-      sha256 "0ad8bb885d4d05db184917f52b1be885187bbc3081a51b3ba785d945be24bfbc"
-      "uk"
-    end
-    language "uz" do
-      sha256 "09b6fdd7e2d83ee8b46006c18f294278e5df7422339787fc2515c07cfd0f82b6"
-      "uz"
-    end
-    language "ve" do
-      sha256 "f03b3f2f926aa422100dcca21b2b4a673e2c1a5360d973e0f7cc5a94d981fe2b"
-      "ve"
-    end
-    language "vi" do
-      sha256 "b58d2b1c0c4560516bcc4b849150c9658336822cede449704e4d89d018f7fffc"
-      "vi"
-    end
-    language "xh" do
-      sha256 "8e45e65119247a0c31c71c9b139fcdcf614fcbb65a3a8c2bad8f4bd6e42fa5f0"
-      "xh"
-    end
-    language "zh-CN" do
-      sha256 "cf5de5b6b877828d749f3ced138168a611ab38fe1d46f736f2f6848a9cb15123"
-      "zh-CN"
-    end
-    language "zh-TW" do
-      sha256 "25ee96811cc9dc04ecde91fca02e5230f672d5f6cacb0ec87c3b445aacdc65cb"
-      "zh-TW"
-    end
-    language "zu" do
-      sha256 "b4f7dcf94cb5606548efbbcd543adc2274013a49b8e19439b2587eba2fa4c45f"
-      "zu"
-    end
+  language "am" do
+    sha256 arm:   "2dfefe819409e51ff151aedc9b2099adfe2dc100fb3804b84f586e43af19254d",
+           intel: "9ce4c94cebeab557b26f0971c95c8247acea2b6aca49b90c4b99048cdb5c9b5c"
+    "am"
+  end
+  language "ar" do
+    sha256 arm:   "e384365bcbd5efd6af3aedc0cdc79572e81ac1a79b789e69fe9e29caaba569db",
+           intel: "597e717d42cd0716109c14d4eae5b3ee731858c212c8e62ddaa2b8b4c1b18df7"
+    "ar"
+  end
+  language "as" do
+    sha256 arm:   "24aa8665b3e9e344df11bcb87b37230e396862fa6b674393710f5af4d1cc66a8",
+           intel: "42fc0d9f84d8964bd48a7a98f5e3c8b5c25d03d34a50c1ab9d92a6c51bb54879"
+    "as"
+  end
+  language "be" do
+    sha256 arm:   "73f5e9e6241261817f45582d09e446847df0a12d8127d8758053e3287ef8040b",
+           intel: "0ac6849b2ada431d7f10f0fc0db504d8a9daa01377931b8ad3c906431d1b5f43"
+    "be"
+  end
+  language "bg" do
+    sha256 arm:   "bd3962e692aa32e9de32e9af8de56f76bdc8c34898ffebb213676ab8c8b9e5ad",
+           intel: "c4974b13a358082c4c2c098ee9cf5511b4f5abe752f63a8b49550e0699722ce2"
+    "bg"
+  end
+  language "bn-IN" do
+    sha256 arm:   "ec7298c17c32d410e86e0466ec35ba7b4a43412dd276d5427c480f9df8d3c1ee",
+           intel: "70bee8cd1951435a23a40d951b018137e2eadd20aba3dd7cfa5f6d4f0831c023"
+    "bn-IN"
+  end
+  language "bn" do
+    sha256 arm:   "274c9ed69da7beb65763b0f83ba8a56a0e02ae44514842db811bee4a41e110e2",
+           intel: "718b51b6c4e54fb70054f005f6b6250a576abb5cd707c7b356c5f535c5c14fcc"
+    "bn"
+  end
+  language "bo" do
+    sha256 arm:   "fc2cbc9e01ccb6f4ae5cc931fe5fdef4f1b9595f7b0d157739bf37a9bed8d04e",
+           intel: "0010e15d75eaabae023f6bf8ba15d21d88ef818f5b5b61d76411e9b433dc26c3"
+    "bo"
+  end
+  language "br" do
+    sha256 arm:   "5b2e534218bccca748da2a33bf7b6c0f719ab1ed97e9af25d0adc03cb5294574",
+           intel: "144976bfded80a20bd0bdfdeaa6e6d5b9ab79e0f68d45a74199d9879290466c0"
+    "br"
+  end
+  language "bs" do
+    sha256 arm:   "a4deb45d11b164bbd5861c7309cc59d3557a230e9ac2d5f578d63ac589b8a6eb",
+           intel: "d9e81eef95d3cf1653c1061244b28120a7c122ce14c17d78766081116201639c"
+    "bs"
+  end
+  language "ca" do
+    sha256 arm:   "84781e7d789639c23832e477dd37e3638d91883ff66da88065602ec1fad90ec8",
+           intel: "a59145453e72d010a8150931c687837cebc2505a4444aa71cd87a504ab163fec"
+    "ca"
+  end
+  language "cs" do
+    sha256 arm:   "1019c2d7c79f318d15f2aedb50d634d83736752ed337c40e9c23205024fe3fe4",
+           intel: "6d96b1c9b297704ae81e39b2eaf3eaf004ed9b4fdf709f93ab0e8e4e4141423a"
+    "cs"
+  end
+  language "cy" do
+    sha256 arm:   "216f05d79a87e95768d52e8fbcf5717c5a1f96a7565c8d63f6a826e070aff517",
+           intel: "f7b3a07a9d3085e28965cb7d56030e59110674e7cb6a45dacfad7090a82499eb"
+    "cy"
+  end
+  language "da" do
+    sha256 arm:   "026c59a4723124dfda40f7585df1dc0dcf656c1cef6c08bfb651268760568ba8",
+           intel: "02d7419da1eef27d85c7eab1777ee86d0742674c24d3364ac99ee0858f0005f9"
+    "da"
+  end
+  language "de" do
+    sha256 arm:   "ff18723298254c5601354d776b07c5e1eb4a81e8b9df983fb932fbd6770739ac",
+           intel: "81d62ae17d5341bec55156f74939cc2696e62a34301c1bfa296d2da58f979fad"
+    "de"
+  end
+  language "dz" do
+    sha256 arm:   "aca930d257ec34a6d60c2772ddda557a9c91a92d2c937f1dbe42940a8abc6e44",
+           intel: "1da86a8c40443ba55f032287ec7fddb00f40378715064360ccfec19efdc6aeaa"
+    "dz"
+  end
+  language "el" do
+    sha256 arm:   "fa0c4dbe79e380b16081bed3b021db7932ae8b7c4e7bd41fcdbbeced037bd17c",
+           intel: "2cd1d29dca2acdd97c26a7936730f3c775cf9a84d9400b11717cd56c55123a4e"
+    "el"
+  end
+  language "en-GB", default: true do
+    sha256 arm:   "d5cdfa8863e8adcd97c8b9230c752a563daf40abc619745d7cd22c7d70cd712c",
+           intel: "03c460c81ec80e97875acf71dbe13da4c6d7a5de8cd9078145a8cf8bb2532769"
+    "en-GB"
+  end
+  language "en-ZA" do
+    sha256 arm:   "35157cdca934b24d121f4c1f78c7f7e109c61ba08d77a1baa3631b4034fbf6e2",
+           intel: "61de7b45ed8c913340bfd818ed20d856cdaee8fff9e526b11bdcbace3da4a785"
+    "en-ZA"
+  end
+  language "eo" do
+    sha256 arm:   "065fdcf954d9f3e307bcc708fb6308656d1e4b2088f986166974facb9375459a",
+           intel: "5c16f456af6a2d532341a7dde6f43cae2f9e413d13d1328f5061bb614cdca700"
+    "eo"
+  end
+  language "es" do
+    sha256 arm:   "a9297c4a5f17a4f69269087e678fb9a202b51e14ee00e8cb0e637672c78cec78",
+           intel: "5ba842c8d15c2d8c3f1a45105d8a7d080fe1e6eb424e8ef837f0eee7bcecbdc2"
+    "es"
+  end
+  language "et" do
+    sha256 arm:   "87685f03d04c3c9902239413fed4b6acb0e716c98886bce4865c79df8584a620",
+           intel: "13cada3e93d5393bd589e930cbd4ac36cc878df77d298b37910457e5f540ff88"
+    "et"
+  end
+  language "eu" do
+    sha256 arm:   "e069a968c5bc2878a2bd8576c369043d7d6f3d711643d9fca056cb4e9febed58",
+           intel: "947fdc3a50b72511e2e5747dd8a61f188ae793458a3f3b60ac27c043d53d0d7f"
+    "eu"
+  end
+  language "fa" do
+    sha256 arm:   "e7586e2fa61e1a79487344dda1c4c96a117756c8035040c352ce9edf7d87d9a5",
+           intel: "5e27d86cb7da64ce9903ad82f96fa573efacfd3b73cf248be4647802f91db7f5"
+    "fa"
+  end
+  language "fi" do
+    sha256 arm:   "c6633659c6495f9060f776b9e1fb023b6bb0dd971488f4ce74ffc8ed7b484aa9",
+           intel: "a7e52c99c8ec572fdc23c128832044c65c8f4d0f3a8571c82f623acd10000a8d"
+    "fi"
+  end
+  language "fr" do
+    sha256 arm:   "1d3da9bc4e4c2943d4a71edcd54033287c1e7a84f490357d2ed4b54b09d81ff6",
+           intel: "2ff80a74cab68858b2af9c826c32e404394e3934bfd8ac5f8538273eeb88d913"
+    "fr"
+  end
+  language "fy" do
+    sha256 arm:   "316d6c89b5202c0557460d4e86672354933401dcbcf8087e7ea2a0aa81453594",
+           intel: "85dd8eff9d927773ff38b708d97dfed8d1bbb43386f7fe0b1e8a324d72781ee4"
+    "fy"
+  end
+  language "ga" do
+    sha256 arm:   "93594065894f1169b5ceef837842af5209c2a336728bf541a220cd2e3003ce14",
+           intel: "c793d1d3f485e4ed9cc507c7b6ae56f5872fd1178be2fea3516b3159b25c2cbf"
+    "ga"
+  end
+  language "gd" do
+    sha256 arm:   "1c1c641a6907de5cfa31d49b48229eba385c7c5a655787fd702cf954e6eb95a2",
+           intel: "752df5affb7e927c9b1f1386c5abdf85635e1453fc9bda28ab64311fa79990fe"
+    "gd"
+  end
+  language "gl" do
+    sha256 arm:   "52e1638c9b6629da5ac943c451cc2909aba2d11608cada6ae4a386f23672c306",
+           intel: "ac163b5031c34439604168332db2d8fedac5a0206dd619ea98099f383355a290"
+    "gl"
+  end
+  language "gu" do
+    sha256 arm:   "0bd043868321376ae1f142e1eef0748d9302ea2da83fb66fa4b1ae314c2e3b93",
+           intel: "97e18825fd8cc48366d60424f86d5e238fa6ab699055cc9597cd200fa27a8004"
+    "gu"
+  end
+  language "he" do
+    sha256 arm:   "fa2697451a3f5a49a504ccb827978fefa69a9c6734f4bd5ba25a398766ec111e",
+           intel: "deb34f34d59ca348f0121832736c85160157b8508a5d5522c3464dfb8a2d34f3"
+    "he"
+  end
+  language "hi" do
+    sha256 arm:   "0730e104aaefaa0cdddb96f7675f9a2398e607c6ce6ae657ee0cf4a6da4c119b",
+           intel: "188e4d13ae3cbdebcd5467a4618dbe80f58e58a5268edd90f485b2436296ca99"
+    "hi"
+  end
+  language "hr" do
+    sha256 arm:   "d4a72a49dc3e9ffb45fd863b49860c958dc0bf19519c18a538e91c1728a15e65",
+           intel: "a4dcec9e1c3f2a72a9a2eec24498ed94567aa458d32cf32e9756716ec963d53e"
+    "hr"
+  end
+  language "hu" do
+    sha256 arm:   "3a1d1188868c6a434ef446d6f6580b918d18c236031687f16967eabb95a8414b",
+           intel: "0fe973de606e5f7f585db1981dea38a801e3a8f516b943be7352956f79b23760"
+    "hu"
+  end
+  language "id" do
+    sha256 arm:   "0c1c7063fb4bf836e3ffb2352bb28fa7c840acd7f872adc26ecaf8ec985f5557",
+           intel: "c07611921abacb90e82d997d92b67517ce949200884da48ecb2d0113e92f6d82"
+    "id"
+  end
+  language "is" do
+    sha256 arm:   "9f95434cf68c2e84be5e24f4f21318456761255aa2402a42f64b4d86171a2384",
+           intel: "07852d30c2c722439586a0ae96b27f179ebf2775e695f1c60b4b15d5f4ae8b80"
+    "is"
+  end
+  language "it" do
+    sha256 arm:   "1244c5957c937355b5f3fc760904162696eeefbf0aa58e808c1ac3a2946d6903",
+           intel: "b5e2442fd09715397e3c5e77c4a43c4ad7d8c735de9ba657cc3b686cc5e16e5e"
+    "it"
+  end
+  language "ja" do
+    sha256 arm:   "f57afbeaefefeedbebbfaa12a8b6df101e9825d1ae60da134772f9def5cb6752",
+           intel: "f7945fe8e6decd93af88ebb4277a3a24800a56f2bfdfa7ae06d1de5e7e4ee4aa"
+    "ja"
+  end
+  language "ka" do
+    sha256 arm:   "8f08bb346359ee6d6e554bf38f35afe23535dc1769ade335c87f286c6aeae989",
+           intel: "a5d5df053e2dced8f0db33474eac09dbbdfa5cfe2ec18f91351571f389a02793"
+    "ka"
+  end
+  language "kk" do
+    sha256 arm:   "0ade1a08ae4e33884a7a256be1002f5b9fa6c08c8d3335f25b6dcf0e07f2325c",
+           intel: "11393c448b48ce54f150f36c0c464d6a2b61fe48fba5666068abd6664bddb837"
+    "kk"
+  end
+  language "km" do
+    sha256 arm:   "495e4dee15dda07d268cff222b60f574c010575a4d8fd7d5dd6e2e79699c004d",
+           intel: "4bfb621e907d5a2d9dff10f8c9d9236b0aae0a4ec1f13e084a8ed709b9825fd0"
+    "km"
+  end
+  language "kn" do
+    sha256 arm:   "66a077d7a4483d603a4d41f6cab7cf91ce24b94b25285efcfc3b56c17bea1544",
+           intel: "6fdbcb5ccf74243de38124da53311772be73bdb3e4d9fdb5d713e7679f6101f4"
+    "kn"
+  end
+  language "ko" do
+    sha256 arm:   "49f936e1bb63711a234c39dd8cb73334b7af71ce23bbe4889718bd6db6ffcb36",
+           intel: "a84772712fd85f3542cad9ca30d3fce30c20d6346c607294eafc27e0f601bcb0"
+    "ko"
+  end
+  language "ks" do
+    sha256 arm:   "148237c4ce5060cd5077b3c412632bf68297d183445f7dc254f51ae8aec8eabc",
+           intel: "58bcb22460329d7691bf6213a20d48b502007f53398a8c4bc70e65b25da3bc41"
+    "ks"
+  end
+  language "lb" do
+    sha256 arm:   "1a6917efe06dc0fb33c8db66b4ae18a2ed30fad2aa9252a8975d7739e582d685",
+           intel: "af201cf202fd1d15d1d6cec8d3df78df319e8178f896695dcf3695386a62b2a9"
+    "lb"
+  end
+  language "lo" do
+    sha256 arm:   "a771364383a12d51a3f9a26c0c676a4b9ec86eb5d116fbf8dad3bd084a146450",
+           intel: "606ac7598c41631d7c3b1495e2f27903ae48d1960963c2c32108fbeece843ba4"
+    "lo"
+  end
+  language "lt" do
+    sha256 arm:   "2d3b1c232d865654a76defbc5ba3a20f8cd4d57374488ffc64a4b0f64be003d2",
+           intel: "ec72530c9120c4cc3a557b3bd0059f99ba9b431a14aee7e4ecaf814658d60690"
+    "lt"
+  end
+  language "lv" do
+    sha256 arm:   "7a7549407f20fd590e5afc590af0febea720217782e6796b79d148b0f8e7366f",
+           intel: "1d66deb707fc94acbee3ebf56c64763f6600637b7382f7a29d186904cdaf41d8"
+    "lv"
+  end
+  language "mk" do
+    sha256 arm:   "c423cde387cde9e5528c9e25f507fcaafd5b7e15d8dff2bc3a139397d007f669",
+           intel: "9ddf2d72d3801850abce49a0c9f75e3252be4595bd95557d04146be6d34445d1"
+    "mk"
+  end
+  language "ml" do
+    sha256 arm:   "d6cf1468f06ce71a9386137b71e489266a8316f50ef49e9cbf4d111d9ca6d61a",
+           intel: "9f22da5ad07450932911be1ca3ee8144f8f732bc5cd865061d9a589c26a2a4a0"
+    "ml"
+  end
+  language "mn" do
+    sha256 arm:   "1681829407e1dc47060fb228668c0c25d1db2b1f35899195c2cc8bc69cdc1810",
+           intel: "2b9853986757f469bf0529378edb4f468cb80f0d1105f447d387a2814ef027e6"
+    "mn"
+  end
+  language "mr" do
+    sha256 arm:   "0484b9252022d933d4c8442e54102c6800c8e9793bd0b09e092ca7aeb4cb8df0",
+           intel: "348c9a9c16ff01fada1f4001a6a807d507bf36c8d1fd17f7815d5683417d9d72"
+    "mr"
+  end
+  language "my" do
+    sha256 arm:   "3e53b9524b93868fca64d4226bbfc55c6facda025893b1c652afd82775fba5f4",
+           intel: "aaeab9692d43ad70eaa0f7aec3c38a1923ebc5c6a215c32c5a5559ba9e751874"
+    "my"
+  end
+  language "nb" do
+    sha256 arm:   "07250c6d192ed3d638c0641f34131fdc73eefb9f6d38a59b38109d1638a45885",
+           intel: "8a24eb103b017000fca35dd694ae05b3424cbeaf052455cfafdebdfe80da13ba"
+    "nb"
+  end
+  language "ne" do
+    sha256 arm:   "ff0da73906a44d60e0a293d65a48bce69733b0cbab841e711933497b6a3e7ab5",
+           intel: "3e30df919bd06b14b7bf1259f800a525091c229278a3c3e40fde16cdade2083a"
+    "ne"
+  end
+  language "nl" do
+    sha256 arm:   "24e85dbde23bd3d2f14db503e42a3109df5d2b62599abcb809cdfed5840327b9",
+           intel: "d407922b481e8668bf31ee63d896f1b9a1178aa7a7bd2cdc08d2651f6e2db97e"
+    "nl"
+  end
+  language "nn" do
+    sha256 arm:   "219dbee3e2f1eda45a3d5c39119bbd7792fca49991f076d4b04cba275ebf8710",
+           intel: "062365598437ea0af8542858cd40a573d52e0cafe3b8a4e2eebcabe47ddb4c3a"
+    "nn"
+  end
+  language "nr" do
+    sha256 arm:   "66ed8755fee2ee094b4575343e0d760b98a73bc7edb1950f2239049240e92743",
+           intel: "0b2ccf544dcfcd9789ddccf4f8c77d4a368b5a8a2cfff17c6745a0347151fef5"
+    "nr"
+  end
+  language "oc" do
+    sha256 arm:   "a256f34b000f8923916d78bfb6feb65a289ef35c6e3d7bd2a8b8819ce362dea9",
+           intel: "2d9a4c91bc9dd5a9c9f104b79b401447769b8471d31d6af53407dc400949e3e0"
+    "oc"
+  end
+  language "om" do
+    sha256 arm:   "bf76b9ec673341cb987046eaca0c615b11264cddeb4f67502f52b26d15d889d0",
+           intel: "134ef17e6a22f9259948f689de5201f5396e9966f4cd1dd74c970246df9d7257"
+    "om"
+  end
+  language "or" do
+    sha256 arm:   "2eb36549009a4f3af43f16c18397a0341b41e0b59957a549fc57c6ed53ea62ad",
+           intel: "9df13ed6fd3371c80e33c7960ba313aac018902268c20f5e1ce323c1aa56e031"
+    "or"
+  end
+  language "pa-IN" do
+    sha256 arm:   "45096867242f5d90c6e6cef78eb233e7f92c6b88da15a7a6aaf1b61e1955f377",
+           intel: "839b845a2dacfc33b0be0866e0e6a5686313164a625536042601eab88fb441e7"
+    "pa-IN"
+  end
+  language "pl" do
+    sha256 arm:   "c759fdec01a85fe245868847d3e27cc5adcf1da23f5ce4d6e82accaac274fa84",
+           intel: "5b9082a9c3b75bd66cbc24689c95121cb8a81aa36da2bde1452ca07e9b25f209"
+    "pl"
+  end
+  language "pt-BR" do
+    sha256 arm:   "ff06d99f1cd9cf292d04229d504abb585712848c56c9d838270beb9077dab83a",
+           intel: "c753b8069b33e3f9d7327ae042e95d22006fe95dc4c57d05a3dcdd3642f2ef2f"
+    "pt-BR"
+  end
+  language "pt" do
+    sha256 arm:   "87bd6621ff16f7b4c76be1457ac23d11f7add2e2bf22a2d71dace2fe94631601",
+           intel: "d70936e02db7242e1d582e31cd7bbef683f5ca8dcfd8b508e8e7fa747dd81ce8"
+    "pt"
+  end
+  language "ro" do
+    sha256 arm:   "bea6e2ac21c3281ad7a037fa7cd2612c6e9c4bba6e251be4e6773be0ed186634",
+           intel: "c1d11c1bf78d078d23498370ebe6cc1701be524984dea320e3d9ec4ece4a6f02"
+    "ro"
+  end
+  language "ru" do
+    sha256 arm:   "89595c1a3acf18bfb32bf189626a24239e7dde515b38708db3a6893386f56979",
+           intel: "0dd882cc4b073721fba43ad60d75ef91f662eb8fc444767691faf40c7dcf80f8"
+    "ru"
+  end
+  language "rw" do
+    sha256 arm:   "49daf077f13e67d2acc7ea31bdb2841e198e9e0fd43c8151f05b45b38306394e",
+           intel: "37c5741fa9925c9fae38ff73246067b830123218199a2ccf87e81d36435b1c11"
+    "rw"
+  end
+  language "sa-IN" do
+    sha256 arm:   "36795b4b1d1b1d28b617b5c1af86cb92f527d35c0eceeb24538acd40df41e798",
+           intel: "3ac5a7053ae9f82636e24fdb68ab20a3276190a0c48a55a7a3802450905addb8"
+    "sa-IN"
+  end
+  language "sd" do
+    sha256 arm:   "ca478380d78aa0df28f7bf5991a1cfd2af35fd5992517a94c11f03356da55561",
+           intel: "f8512283e2280dc314b54a5adabca61777a75ad635c6eda8552ab3daeb529a8e"
+    "sd"
+  end
+  language "si" do
+    sha256 arm:   "d5c6e96cba1ba54fd666cdba3dbd9dfd88f697d84fc87c6f73923c372489f5f4",
+           intel: "0eba5fd563522ddca0fa3fcbb2fe10393c06689e6caa77991068d612993790e8"
+    "si"
+  end
+  language "sk" do
+    sha256 arm:   "d216a825d3aa2df5c292ccb761843d274593f88d5df1d419d2b420159086b4d5",
+           intel: "11b9ad0a4b5e85055b52902ffc9562868637b7d39474b0a4e31a2f026d67af3f"
+    "sk"
+  end
+  language "sl" do
+    sha256 arm:   "0ac484b600f78f45ca27a5fa3d7715c392615a24f96eb8ab84713e1a9af2a17d",
+           intel: "6f05d8aeed57fad613e85d128343adb7283558e5c34cee1e60d52e2c29300f4b"
+    "sl"
+  end
+  language "sq" do
+    sha256 arm:   "e90d12d9ba314fb280923f30ec0fcf59e9a2b750e4778512b657c9536e0e5788",
+           intel: "7053cd43304d4d1c6173d41a4ef884c977d1b12cf4c5faa097b39bcd0487848c"
+    "sq"
+  end
+  language "sr" do
+    sha256 arm:   "12bb6feb8845249659faecd270f4a1ff7350919bbe986c00d79e469f665b50b5",
+           intel: "c4e9686f876ad56c491048101941523fe5388e0a380a2b29a9292062ba3e62f8"
+    "sr"
+  end
+  language "ss" do
+    sha256 arm:   "dd0ce40ccd2451c5cdfda67448ecd9223f4d5468a2315418abd0baf164aea844",
+           intel: "04733806686973c5ec3d32902447a0ea8ce0bb0ea45528835b933878fccb92b0"
+    "ss"
+  end
+  language "st" do
+    sha256 arm:   "ff95bb36fbbe0608dcd823ada62a2e86dbba2ee0646d7f9c3ec594a3c700ca9e",
+           intel: "fdf52712ee169600819e84bda336a6a55e01302cbe1aaa44229755a395dff3e4"
+    "st"
+  end
+  language "sv" do
+    sha256 arm:   "df4d5026474fda8ec3ca13308af5aa0368dda15b493fe58780754badb418a7f3",
+           intel: "c9f2a0033d4794439415b09544537f5acb5bda0fcdce84535d1adec3fbaca9d1"
+    "sv"
+  end
+  language "sw-TZ" do
+    sha256 arm:   "569112ea5b12477cc4277f3006c77a612a693979da4bc951233f9917828bee8b",
+           intel: "cc7ccaddf1db447ad3be249c052589d54a593a57ec37023fa8f486465c1c21c0"
+    "sw-TZ"
+  end
+  language "ta" do
+    sha256 arm:   "e9dac0a9910ff0546e150c4bcfb1463bfe83e11fd27435fc0db691ae39bc5761",
+           intel: "b11295b2d0ada7461ff4cdc8635ecfbd3e983e8784c4b4e957347b9adcf3e86c"
+    "ta"
+  end
+  language "te" do
+    sha256 arm:   "5143196b59f9afe32c58f76ec00a7a634335096f055b35b3cd7042b6e67ac1a8",
+           intel: "0f88a9da6927aff4a2f9d3caa79cbf6341cc7ca695bad510acd7d5e60e9b9485"
+    "te"
+  end
+  language "tg" do
+    sha256 arm:   "0611f3727d1249bf6a287c795d1a7979afaf72652d70d00839d23ef84f901589",
+           intel: "c65754bf431f932011de4ec2eb5773ab8f995311faec155dd9ea1b030bfe95e4"
+    "tg"
+  end
+  language "th" do
+    sha256 arm:   "e23f4bf636e1a99c8ae64274c3b3823eb14c0e8411339e06eb3d75576c61eb4a",
+           intel: "0bd577551150527cf3990858f683176d687f131430c1757abf4dbdc7f1baee96"
+    "th"
+  end
+  language "tn" do
+    sha256 arm:   "29cf9c84768fc769d8ef286a8df13a9f2ed2fc04ea55407c5133f8dc11dd56de",
+           intel: "a567e6969c57abd5efc1ea88d500e43c9a8c531003fceb91603d77e12cbf6500"
+    "tn"
+  end
+  language "tr" do
+    sha256 arm:   "f38e4e2ffe5d7ffd473a569e4e7aa84ab16a3d7fa492bf00070e24f8895d5ac4",
+           intel: "0d956d5ac9b7ac3cdc70de4645ee9d9df7c633b749467f9b412a435491f04c85"
+    "tr"
+  end
+  language "ts" do
+    sha256 arm:   "3072cd9268906936527de42a4c4bfae3722b50ef173e6a5bcd24b2a46b6c3eb3",
+           intel: "8c835462c9dbbff0245444698230d2c2bcb8f72f93020ae3f68e89077bffab40"
+    "ts"
+  end
+  language "tt" do
+    sha256 arm:   "850595c0b3f376d538675eba9d569a53226b78f756d705a72d08a2e745af688e",
+           intel: "331beffe8927f88f0eccdba906e514c6ed8b60953a82164a8a69371348dfc795"
+    "tt"
+  end
+  language "ug" do
+    sha256 arm:   "f2c17ce04432c5fa1f1ae2804456356545e4bd8ab883a7f211edb93b2f4990be",
+           intel: "4996578f044cd55f9666a6bab364648b03e04f967e263f64c3aad776a4afec1d"
+    "ug"
+  end
+  language "uk" do
+    sha256 arm:   "cfe49669c56f921f23ec3b254f99e904cdbca4e22b5e554d9ba54c398c5c0fc9",
+           intel: "0ad8bb885d4d05db184917f52b1be885187bbc3081a51b3ba785d945be24bfbc"
+    "uk"
+  end
+  language "uz" do
+    sha256 arm:   "5a51c8f1b0fa878c27fa076283c1f1523332a0bbd615614cb82c5dca99619b7c",
+           intel: "09b6fdd7e2d83ee8b46006c18f294278e5df7422339787fc2515c07cfd0f82b6"
+    "uz"
+  end
+  language "ve" do
+    sha256 arm:   "b3d323ab29dacf86001ca58d60099ddd1c1c72e75154128bdadabd8bb4ca3f04",
+           intel: "f03b3f2f926aa422100dcca21b2b4a673e2c1a5360d973e0f7cc5a94d981fe2b"
+    "ve"
+  end
+  language "vi" do
+    sha256 arm:   "3be538deb65381dc3fe4cd812a4168df22479ad87ff376f6a4247f84c8306736",
+           intel: "b58d2b1c0c4560516bcc4b849150c9658336822cede449704e4d89d018f7fffc"
+    "vi"
+  end
+  language "xh" do
+    sha256 arm:   "a5132f0dd649744c2e74a74905a15f294e419d51c4412bada8fc1f2566f282bd",
+           intel: "8e45e65119247a0c31c71c9b139fcdcf614fcbb65a3a8c2bad8f4bd6e42fa5f0"
+    "xh"
+  end
+  language "zh-CN" do
+    sha256 arm:   "674436e941212c10bb31df42c2a2570e9ce7ddaf1ec379f7b561b438e6529527",
+           intel: "cf5de5b6b877828d749f3ced138168a611ab38fe1d46f736f2f6848a9cb15123"
+    "zh-CN"
+  end
+  language "zh-TW" do
+    sha256 arm:   "fc649f04371a801c77d12859dc3f47bc1336948dfab29970114f32f3501a8134",
+           intel: "25ee96811cc9dc04ecde91fca02e5230f672d5f6cacb0ec87c3b445aacdc65cb"
+    "zh-TW"
+  end
+  language "zu" do
+    sha256 arm:   "46a4d3116915d56b4b454a0c819328b69779d1d4020a1af0c186ae9bb1fd631e",
+           intel: "b4f7dcf94cb5606548efbbcd543adc2274013a49b8e19439b2587eba2fa4c45f"
+    "zu"
   end
 
   url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}_langpack_#{language}.dmg",
@@ -848,6 +550,8 @@ cask "libreoffice-still-language-pack" do
   # No zap stanza required
 
   caveats <<~EOS
-    #{token} cannot be upgraded, use brew reinstall --cask #{token} instead
+    #{token} cannot be upgraded, instead use:
+
+      brew reinstall --cask #{token}
   EOS
 end


### PR DESCRIPTION
This reduces the length and complexity of each file. 