### PR TITLE
dmidiplayer: update macOS requirements

### DIFF
--- a/Casks/d/dmidiplayer.rb
+++ b/Casks/d/dmidiplayer.rb
@@ -14,8 +14,7 @@ cask "dmidiplayer" do
   end
 
   depends_on formula: "fluid-synth"
-  depends_on macos: ">= :sierra"
-  depends_on arch: :x86_64
+  depends_on macos: ">= :catalina"
 
   app "dmidiplayer.app"
 


### PR DESCRIPTION
Now requires 10.15+, will run on ARM.