### PR TITLE
voicenotes 1.3.8 (new cask)

### DIFF
--- a/Casks/v/voicenotes.rb
+++ b/Casks/v/voicenotes.rb
@@ -2,7 +2,8 @@ cask "voicenotes" do
   arch arm: "-arm64"
 
   version "1.3.8"
-  sha256 :no_check
+  sha256 arm:   "b8a366d6c6c310cf17c11ce05d7716d1cf6439b993f12c21d35769294e992817",
+         intel: "42251838a3728cce523d6e73499cb090112ed82dcae49fd3363f65935ca57ede"
 
   url "https://github.com/brewdotcom/vn-apps-release/releases/download/#{version}/Voicenotes-#{version}#{arch}.dmg",
       verified: "github.com/brewdotcom/vn-apps-release/"

--- a/Casks/v/voicenotes.rb
+++ b/Casks/v/voicenotes.rb
@@ -1,0 +1,30 @@
+cask "voicenotes" do
+  version :latest
+  sha256 :no_check
+
+  on_arm do
+    url "https://dl.voicenotes.com/release/latest/Voicenotes-latest-arm64.dmg"
+
+    depends_on arch: :arm64
+  end
+  on_intel do
+    url "https://dl.voicenotes.com/release/latest/Voicenotes-latest.dmg"
+
+    depends_on arch: :intel
+  end
+
+  name "Voicenotes"
+  desc "AI-powered app for recording, transcribing, and summarizing voice notes"
+  homepage "https://voicenotes.com/"
+
+  livecheck do
+    skip "No version information available in the download URL or headers"
+  end
+
+  app "Voicenotes.app"
+
+  zap trash: [
+    "~/Library/Application Support/Voicenotes",
+    "~/Library/Preferences/com.voicenotes.app.plist",
+  ]
+end

--- a/Casks/v/voicenotes.rb
+++ b/Casks/v/voicenotes.rb
@@ -1,16 +1,18 @@
 cask "voicenotes" do
   arch arm: "arm64", intel: "x86_64"
 
-  version :latest
+  version "1.3.8"
   sha256 :no_check
 
-  url "https://dl.voicenotes.com/release/latest/Voicenotes-latest#{on_arch_conditional arm: "-arm64", intel: ""}.dmg"
+  url "https://github.com/brewdotcom/vn-apps-release/releases/download/#{version}/Voicenotes-#{version}#{on_arch_conditional arm: "-arm64", intel: ""}.dmg"
+      verified: "github.com/brewdotcom/vn-apps-release/"
   name "Voicenotes"
   desc "AI-powered app for recording, transcribing, and summarizing voice notes"
   homepage "https://voicenotes.com/"
 
   livecheck do
-    skip "No version information available in the download URL or headers"
+    url :url
+    strategy :github_latest
   end
 
   depends_on macos: ">= :big_sur"

--- a/Casks/v/voicenotes.rb
+++ b/Casks/v/voicenotes.rb
@@ -8,7 +8,7 @@ cask "voicenotes" do
   url "https://github.com/brewdotcom/vn-apps-release/releases/download/#{version}/Voicenotes-#{version}#{arch}.dmg",
       verified: "github.com/brewdotcom/vn-apps-release/"
   name "Voicenotes"
-  desc "AI-powered app for recording, transcribing, and summarizing voice notes"
+  desc "AI-powered app for recording, transcribing and summarising voice notes"
   homepage "https://voicenotes.com/"
 
   livecheck do

--- a/Casks/v/voicenotes.rb
+++ b/Casks/v/voicenotes.rb
@@ -1,18 +1,10 @@
 cask "voicenotes" do
+  arch arm: "arm64", intel: "x86_64"
+
   version :latest
   sha256 :no_check
 
-  on_arm do
-    url "https://dl.voicenotes.com/release/latest/Voicenotes-latest-arm64.dmg"
-
-    depends_on arch: :arm64
-  end
-  on_intel do
-    url "https://dl.voicenotes.com/release/latest/Voicenotes-latest.dmg"
-
-    depends_on arch: :intel
-  end
-
+  url "https://dl.voicenotes.com/release/latest/Voicenotes-latest#{on_arch_conditional arm: "-arm64", intel: ""}.dmg"
   name "Voicenotes"
   desc "AI-powered app for recording, transcribing, and summarizing voice notes"
   homepage "https://voicenotes.com/"
@@ -20,6 +12,8 @@ cask "voicenotes" do
   livecheck do
     skip "No version information available in the download URL or headers"
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "Voicenotes.app"
 

--- a/Casks/v/voicenotes.rb
+++ b/Casks/v/voicenotes.rb
@@ -1,10 +1,10 @@
 cask "voicenotes" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "-arm64"
 
   version "1.3.8"
   sha256 :no_check
 
-  url "https://github.com/brewdotcom/vn-apps-release/releases/download/#{version}/Voicenotes-#{version}#{on_arch_conditional arm: "-arm64", intel: ""}.dmg"
+  url "https://github.com/brewdotcom/vn-apps-release/releases/download/#{version}/Voicenotes-#{version}#{arch}.dmg",
       verified: "github.com/brewdotcom/vn-apps-release/"
   name "Voicenotes"
   desc "AI-powered app for recording, transcribing, and summarizing voice notes"


### PR DESCRIPTION
This PR adds a new cask for the latest version of the Voicenotes app.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
  - Confirmation that this app version is a stable build is found [here](https://www.reddit.com/r/Voicenotesai/comments/1l8sf8g/changelog_mac_apps_first_stable_build_now_live/).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
