### PR TITLE
objective-see unavailable casks: disable

### DIFF
--- a/Casks/f/filemonitor.rb
+++ b/Casks/f/filemonitor.rb
@@ -6,7 +6,9 @@ cask "filemonitor" do
       verified: "bitbucket.org/objective-see/deploy/downloads/"
   name "FileMonitor"
   desc "Monitor filesystem activity"
-  homepage "https://objective-see.org/products/utilities.html"
+  homepage "https://objective-see.org/products/utilities.html#FileMonitor"
+
+  disable! date: "2025-06-12", because: :no_longer_available
 
   depends_on macos: ">= :catalina"
 

--- a/Casks/p/processmonitor.rb
+++ b/Casks/p/processmonitor.rb
@@ -6,7 +6,9 @@ cask "processmonitor" do
       verified: "bitbucket.org/objective-see/deploy/downloads/"
   name "ProcessMonitor"
   desc "Monitor process activity"
-  homepage "https://objective-see.org/products/utilities.html"
+  homepage "https://objective-see.org/products/utilities.html#ProcessMonitor"
+
+  disable! date: "2025-06-12", because: :no_longer_available
 
   depends_on macos: ">= :catalina"
 

--- a/Casks/r/ransomwhere.rb
+++ b/Casks/r/ransomwhere.rb
@@ -8,6 +8,8 @@ cask "ransomwhere" do
   desc "Protect your personal files"
   homepage "https://objective-see.org/products/ransomwhere.html"
 
+  disable! date: "2025-06-12", because: :no_longer_available
+
   installer script: {
     executable: "#{staged_path}/RansomWhere_Installer.app/Contents/MacOS/RansomWhere_Installer",
     args:       ["-install"],

--- a/Casks/r/reikey.rb
+++ b/Casks/r/reikey.rb
@@ -8,6 +8,8 @@ cask "reikey" do
   desc "Scans, detects, and monitors keyboard taps"
   homepage "https://objective-see.org/products/reikey.html"
 
+  disable! date: "2025-06-12", because: :no_longer_available
+
   depends_on macos: ">= :high_sierra"
 
   installer script: {


### PR DESCRIPTION
Bitbucket download links for Objective-See casks are no longer valid. Fixes #215504.