### PR TITLE
to-audio-converter: update livecheck, remove autobump

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1652,7 +1652,6 @@ tinderbox
 tinkerwell
 tinymediamanager
 tmpdisk
-to-audio-converter
 todoist
 topaz-gigapixel-ai
 topaz-photo-ai

--- a/Casks/t/to-audio-converter.rb
+++ b/Casks/t/to-audio-converter.rb
@@ -7,12 +7,10 @@ cask "to-audio-converter" do
   desc "Audio converter"
   homepage "https://amvidia.com/to-audio-converter"
 
+  # The upstream website no longer provides meaningful version information.
   livecheck do
-    url "https://amvidia.com/to-audio-converter/support"
-    regex(/Version:.*?v?(\d+(?:\.\d+)+)\s+\((\d+)\)/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
-    end
+    url :url
+    strategy :extract_plist
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `to-audio-converter` is giving an `Unable to get versions` error because the upstream page that it checks no longer provides any version information. I wasn't able to find any other source of version information, so the only alternative is the `ExtractPlist` strategy. We dislike using this strategy but it's the only way to identify new version information, as the dmg filename is unversioned, the app doesn't contain any update logic, and upstream doesn't publish version information anymore.

This also removes the cask from the autobump list because it uses the `ExtractPlist` strategy.