### PR TITLE
deepl: update livecheck and legacy versions

### DIFF
--- a/Casks/d/deepl.rb
+++ b/Casks/d/deepl.rb
@@ -6,16 +6,7 @@ cask "deepl" do
     url "https://www.deepl.com/macos/download/old/#{version.major_minor}/#{version.patch}/DeepL.zip"
 
     livecheck do
-      url "https://appdownload.deepl.com/macos/"
-      regex(%r{^old/v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.(?:zip|t)}i)
-      strategy :xml do |xml, regex|
-        xml.get_elements("//Contents/Key").map do |item|
-          match = item.text&.strip&.match(regex)
-          next if match.blank?
-
-          "#{match[1]}.#{match[2]}"
-        end
-      end
+      skip "Legacy version"
     end
   end
   on_big_sur do
@@ -28,28 +19,30 @@ cask "deepl" do
       skip "Legacy version"
     end
   end
-  on_monterey :or_newer do
+  on_monterey do
+    version "24.11.31463097"
+    sha256 "8e02db7b5f85d4020419a5bf7a44a39b7d1f321acabb9b8011407b3b462c0218"
+
+    url "https://www.deepl.com/macos/download/#{version.major_minor}/#{version.patch}/DeepL.tar.gz"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_ventura :or_newer do
     version "25.6.12145056"
     sha256 "bbe9d2e5969d62aa98068508dc2dfe5bbb637acb4d71927baa91dc5af63e0f45"
 
     url "https://www.deepl.com/macos/download/#{version.major_minor}/#{version.patch}/DeepL.tar.gz"
 
     livecheck do
-      url "https://appdownload.deepl.com/macos/"
-      regex(%r{^v?(\d+(?:\.\d+)+)/(\d+(?:\.\d+)*)/DeepL\.t}i)
-      strategy :xml do |xml, regex|
-        xml.get_elements("//Contents/Key").map do |item|
-          match = item.text&.strip&.match(regex)
-          next if match.blank?
-
-          "#{match[1]}.#{match[2]}"
-        end
-      end
+      url "https://appdownload.deepl.com/macos/appcast.xml"
+      strategy :sparkle
     end
   end
 
   name "DeepL"
-  desc "Trains AIs to understand and translate texts"
+  desc "AI-powered translator"
   homepage "https://www.deepl.com/"
 
   auto_updates true


### PR DESCRIPTION
The existing implementation of DeepL used regex to search for the 'most recent' version, which could often result in finding incorrect pre-release versions. (See https://github.com/mangerlahn/Latest/issues/447)

I've simplified this down to just using `https://www.deepl.com/macos/download/DeepL.dmg` which will always point to the latest release version, and I've removed the no longer supported legacy versions.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.