### PR TITLE
scrollapp 1.2 (new cask)

### DIFF
--- a/Casks/s/scrollapp.rb
+++ b/Casks/s/scrollapp.rb
@@ -1,0 +1,23 @@
+cask "scrollapp" do
+  version "1.2"
+  sha256 "72f9f97d42fe620d6b0996b5a38925cc711f7beda1685444605a9535a05d7072"
+
+  url "https://github.com/fromis-9/scrollapp/releases/download/v#{version}/Scrollapp-v#{version}.dmg"
+  name "Scrollapp"
+  desc "Windows-style auto-scrolling for macOS"
+  homepage "https://github.com/fromis-9/scrollapp"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Scrollapp.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.fromis-9.scrollapp.plist",
+    "~/Library/Application Support/Scrollapp",
+  ]
+end 


### PR DESCRIPTION
Scrollapp is a macOS utility that brings Windows-style auto-scrolling to macOS.

**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

**Note:** The audit and installation tests require updated Command Line Tools, but the cask has been manually verified and tested successfully.