### PR TITLE
objective-see casks: un-disable, add livechecks

### DIFF
--- a/Casks/f/filemonitor.rb
+++ b/Casks/f/filemonitor.rb
@@ -8,7 +8,10 @@ cask "filemonitor" do
   desc "Monitor filesystem activity"
   homepage "https://objective-see.org/products/utilities.html#FileMonitor"
 
-  disable! date: "2025-06-12", because: :no_longer_available
+  livecheck do
+    url :homepage
+    regex(/href=.*?FileMonitor[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   no_autobump! because: :requires_manual_review
 

--- a/Casks/l/lockdown.rb
+++ b/Casks/l/lockdown.rb
@@ -10,7 +10,7 @@ cask "lockdown" do
 
   no_autobump! because: :requires_manual_review
 
-  disable! date: "2025-06-09", because: :no_longer_available
+  deprecate! date: "2025-03-02", because: :unmaintained
 
   app "Lockdown.app"
 

--- a/Casks/p/processmonitor.rb
+++ b/Casks/p/processmonitor.rb
@@ -8,7 +8,10 @@ cask "processmonitor" do
   desc "Monitor process activity"
   homepage "https://objective-see.org/products/utilities.html#ProcessMonitor"
 
-  disable! date: "2025-06-12", because: :no_longer_available
+  livecheck do
+    url :homepage
+    regex(/href=.*?ProcessMonitor[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   no_autobump! because: :requires_manual_review
 

--- a/Casks/r/ransomwhere.rb
+++ b/Casks/r/ransomwhere.rb
@@ -8,7 +8,10 @@ cask "ransomwhere" do
   desc "Protect your personal files"
   homepage "https://objective-see.org/products/ransomwhere.html"
 
-  disable! date: "2025-06-12", because: :no_longer_available
+  livecheck do
+    url :homepage
+    regex(/href=.*?RansomWhere[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   installer script: {
     executable: "#{staged_path}/RansomWhere_Installer.app/Contents/MacOS/RansomWhere_Installer",

--- a/Casks/r/reikey.rb
+++ b/Casks/r/reikey.rb
@@ -8,7 +8,10 @@ cask "reikey" do
   desc "Scans, detects, and monitors keyboard taps"
   homepage "https://objective-see.org/products/reikey.html"
 
-  disable! date: "2025-06-12", because: :no_longer_available
+  livecheck do
+    url :homepage
+    regex(/href=.*?ReiKey[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
 
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
Bitbucket download links for Objective-See casks have been restored. Fixes #216531 and reverts #215611 and #216097.

See also: https://github.com/objective-see/ReiKey/issues/24