### PR TITLE
tailscale: Fix zap stanza

### DIFF
--- a/Casks/t/tailscale.rb
+++ b/Casks/t/tailscale.rb
@@ -33,6 +33,7 @@ cask "tailscale" do
             pkgutil:    "com.tailscale.ipn.macsys"
 
   zap trash: [
+    "/Library/Tailscale",
     "~/Library/Application Scripts/*.io.tailscale.ipn.macsys",
     "~/Library/Application Scripts/io.tailscale.ipn.macsys",
     "~/Library/Application Scripts/io.tailscale.ipn.macsys.login-item-helper",
@@ -47,7 +48,6 @@ cask "tailscale" do
     "~/Library/HTTPStorages/io.tailscale.ipn.macsys",
     "~/Library/HTTPStorages/io.tailscale.ipn.macsys.binarycookies",
     "~/Library/Preferences/io.tailscale.ipn.macsys.plist",
-    "~/Library/Tailscale",
   ]
 
   caveats do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

A little background on this PR: I was trying to reset Tailscale keychain on my new Mac (recovered from a Time Machine backup) but I found I wasn't able to do that with just a `brew uninstall --cask --zap --force tailscale`. I then realized that the `~/Library/Tailscale` line in the zap stanza is incorrect. It should be `/Library/Tailscale/`.

Reference: https://tailscale.com/kb/1069/uninstall?tab=macos+%28standalone%29

Pls kindly review. :)