### PR TITLE
langflow: update livecheck, `sha256`

### DIFF
--- a/Casks/l/langflow.rb
+++ b/Casks/l/langflow.rb
@@ -1,22 +1,26 @@
 cask "langflow" do
   version "1.4.2"
-  sha256 "42a7d642db5b75c671cbdf40faa5d87163cf34bb35b50e1537cd47fef49eb637"
+  sha256 "07da16749c0fe42c5d85bcf75dc7117d7d4b03c2de0acd414bcff643e568baa8"
 
-  url "https://github.com/langflow-ai/langflow/releases/download/#{version}/Langflow_#{version}_aarch64.dmg",
+  url "https://github.com/langflow-ai/langflow/releases/download/#{version}/Langflow_aarch64.dmg",
       verified: "github.com/langflow-ai/langflow/"
   name "Langflow Desktop"
   desc "Low-code AI-workflow building tool"
   homepage "https://www.langflow.org/desktop"
 
+  # GitHub releases may not always provide a file for macOS. We check the
+  # first-party download page, as it links directly to the latest macOS file
+  # (i.e., we don't have to check recent GitHub releases to find the newest
+  # version with a macOS file).
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://www.langflow.org/desktop-form-complete"
+    regex(%r{href=.*?/download/v?(\d+(?:\.\d+)+[^/]*?)/Langflow[^"' >]*?\.dmg}i)
   end
 
   no_autobump! because: :requires_manual_review
 
   depends_on arch: :arm64
-  depends_on macos: ">= :sonoma"
+  depends_on macos: ">= :ventura"
 
   app "Langflow.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Langflow doesn't appear to provide a macOS release immediately with updates, so this updates to a standard pattern to check releases for a macOS artifact.

Edit: looks like the release artifact was updated 2 weeks ago with a new URL and `sha256` and not noticed.