### PR TITLE
sync: revert to 2.2.48

### DIFF
--- a/Casks/s/sync.rb
+++ b/Casks/s/sync.rb
@@ -1,6 +1,6 @@
 cask "sync" do
-  version "2.2.50"
-  sha256 "a5ba6ef815c580899a1da934c78f7cff0b0893ef397b8247bee515787535f5cd"
+  version "2.2.48"
+  sha256 "9fec22de7091b64186cefac6f99c312df213fcc46034ae6e4c1631184cd97063"
 
   url "https://www10.sync.com/download/apple/Sync-#{version}.dmg"
   name "Sync"


### PR DESCRIPTION
Upstream found a bug in 2.2.50 and pulled the release: https://github.com/orgs/Homebrew/discussions/6224#discussioncomment-13503130

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.
