### PR TITLE
pixelsnap: update homepage

### DIFF
--- a/Casks/p/pixelsnap.rb
+++ b/Casks/p/pixelsnap.rb
@@ -2,10 +2,11 @@ cask "pixelsnap" do
   version "2.6.1"
   sha256 "248e903546d09f9d0388f8ddf720f0becbe14ea64a3f00bf61c5490069ee023c"
 
-  url "https://updates.getpixelsnap.com/v#{version.major}/PixelSnap-#{version.major}-#{version}.dmg"
+  url "https://updates.getpixelsnap.com/v#{version.major}/PixelSnap-#{version.major}-#{version}.dmg",
+      verified: "updates.getpixelsnap.com/"
   name "PixelSnap"
   desc "Screen measuring tool"
-  homepage "https://getpixelsnap.com/"
+  homepage "https://pixelsnap.com/"
 
   livecheck do
     url "https://updates.getpixelsnap.com/v#{version.major}/appcast.xml"


### PR DESCRIPTION
PixelSnap changed the domain from **getpixelsnap.com** to **pixelsnap.com**. I've updated the cask's homepage.