### PR TITLE
wch-ch34x-usb-serial-driver: various updates

### DIFF
--- a/Casks/w/wch-ch34x-usb-serial-driver.rb
+++ b/Casks/w/wch-ch34x-usb-serial-driver.rb
@@ -2,14 +2,16 @@ cask "wch-ch34x-usb-serial-driver" do
   version "1.9"
   sha256 :no_check
 
-  url "https://www.wch.cn/downloads/file/369.html"
+  url "https://www.wch.cn/download/file?id=369"
   name "WCH USB serial driver for CH340/CH341/CH342/CH343/CH344/CH9101/CH9102/CH9103/CH9143"
   desc "USB serial driver"
-  homepage "https://www.wch.cn/download/CH34XSER_MAC_ZIP.html"
+  homepage "https://www.wch.cn/downloads/CH34XSER_MAC_ZIP.html"
 
   livecheck do
-    url :homepage
-    regex(%r{<td>(\d+(?:\.\d+)+)</td>}i)
+    url "https://www.wch.cn/api/official/website/common/relationFiles?fileName=CH34XSER_MAC_ZIP.html"
+    strategy :json do |json|
+      json.dig("data", "version")
+    end
   end
 
   no_autobump! because: :requires_manual_review
@@ -22,6 +24,11 @@ cask "wch-ch34x-usb-serial-driver" do
               "cn.wch.CH34xVCPDriver",
             ],
             pkgutil: "cn.wch.pkg.CH34xVCPDriver"
+
+  zap trash: [
+    "~/Library/Application Scripts/cn.wch.CH34xVCPDriver",
+    "~/Library/Containers/cn.wch.CH34xVCPDriver",
+  ]
 
   caveats do
     reboot


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online wch-ch34x-usb-serial-driver` is error-free.
- [x] `brew style --fix wch-ch34x-usb-serial-driver` reports no offenses.
