### PR TITLE
webrecorder-player: add replacement_cask

### DIFF
--- a/Casks/w/webrecorder-player.rb
+++ b/Casks/w/webrecorder-player.rb
@@ -8,7 +8,7 @@ cask "webrecorder-player" do
 
   no_autobump! because: :requires_manual_review
 
-  disable! date: "2024-12-16", because: :discontinued
+  disable! date: "2024-12-16", because: :discontinued, replacement_cask: "replaywebpage"
 
   app "Webrecorder Player.app"
 


### PR DESCRIPTION
This adds [ReplayWeb.page](https://formulae.brew.sh/cask/replaywebpage) (also made by Webrecorder) as a suggested replacement for Webrecorder Player.

---

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


---
