### PR TITLE
veracrypt: update homepage, livecheck

### DIFF
--- a/Casks/v/veracrypt.rb
+++ b/Casks/v/veracrypt.rb
@@ -6,10 +6,10 @@ cask "veracrypt" do
       verified: "launchpad.net/veracrypt/trunk/"
   name "VeraCrypt"
   desc "Disk encryption software focusing on security based on TrueCrypt"
-  homepage "https://www.veracrypt.fr/"
+  homepage "https://veracrypt.io/"
 
   livecheck do
-    url "https://www.veracrypt.fr/en/Downloads.html"
+    url "https://veracrypt.io/en/Downloads.html"
     regex(/href=.*?VeraCrypt[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The www.veracrypt.fr URLs in the `veracrypt` cask now redirect to veracrypt.io, so this updates the homepage and `livecheck` block URLs to resolve the redirections.