### PR TITLE
Limit HP printer drivers up to Sonoma

### DIFF
--- a/Casks/a/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/a/apple-hewlett-packard-printer-drivers.rb
@@ -21,7 +21,7 @@ cask "apple-hewlett-packard-printer-drivers" do
 
   no_autobump! because: :requires_manual_review
 
-  depends_on macos: "<= 15.0.0"
+  depends_on macos: "<= '15.0.0'"
 
   pkg "HewlettPackardPrinterDrivers.pkg"
 

--- a/Casks/a/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/a/apple-hewlett-packard-printer-drivers.rb
@@ -19,9 +19,9 @@ cask "apple-hewlett-packard-printer-drivers" do
     end
   end
 
-  depends_on macos: "<= 15.0.0"
-
   no_autobump! because: :requires_manual_review
+
+  depends_on macos: "<= 15.0.0"
 
   pkg "HewlettPackardPrinterDrivers.pkg"
 

--- a/Casks/a/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/a/apple-hewlett-packard-printer-drivers.rb
@@ -19,7 +19,7 @@ cask "apple-hewlett-packard-printer-drivers" do
     end
   end
 
-  depends_on macos: "<= sequoia"
+  depends_on macos: "<= 15.0.0"
 
   no_autobump! because: :requires_manual_review
 

--- a/Casks/a/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/a/apple-hewlett-packard-printer-drivers.rb
@@ -21,7 +21,7 @@ cask "apple-hewlett-packard-printer-drivers" do
 
   no_autobump! because: :requires_manual_review
 
-  depends_on macos: "<= :sequoia"
+  depends_on macos: "<= :sonoma"
 
   pkg "HewlettPackardPrinterDrivers.pkg"
 

--- a/Casks/a/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/a/apple-hewlett-packard-printer-drivers.rb
@@ -21,7 +21,7 @@ cask "apple-hewlett-packard-printer-drivers" do
 
   no_autobump! because: :requires_manual_review
 
-  depends_on macos: "<= '15.0.0'"
+  depends_on macos: "<= :sequoia"
 
   pkg "HewlettPackardPrinterDrivers.pkg"
 

--- a/Casks/a/apple-hewlett-packard-printer-drivers.rb
+++ b/Casks/a/apple-hewlett-packard-printer-drivers.rb
@@ -19,6 +19,8 @@ cask "apple-hewlett-packard-printer-drivers" do
     end
   end
 
+  depends_on macos: "<= sequoia"
+
   no_autobump! because: :requires_manual_review
 
   pkg "HewlettPackardPrinterDrivers.pkg"


### PR DESCRIPTION
There is this check inside the installer:

```
    <script>
function InstallationCheck(prefix) {
	if (system.compareVersions(system.version.ProductVersion, '15.0') &gt; 0) {
		my.result.message = system.localizedStringWithFormat('ERROR_25CBFE41C7', '15.0');
		my.result.type = 'Fatal';
		return false;
	}
	return true;
}
</script>
```

So currently the installer fails on anything above 15.0 (even 15.0.1 – which is not covered by the `depends_on` check).

However, it can be bypassed by editing this file and repacking the installer again. Is this something that could be part of the cask?

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
