### PR TITLE
MsgFiler 4.1.5.39 (new cask)

### DIFF
--- a/Casks/m/msgfiler.rb
+++ b/Casks/m/msgfiler.rb
@@ -1,0 +1,28 @@
+cask "msgfiler" do
+  version "4.1.5.39,20241211,193312"
+  sha256 "9d33672d41948650bf32b388526f33242ce2010f35e92bb82f41248a72bdf0bd"
+
+  url "https://files.msgfiler.com/MsgFiler_#{version.csv.first}_#{version.csv.second}_#{version.csv.third}.dmg"
+  name "MsgFiler"
+  desc "Keyboard-based email filing application for Apple Mail"
+  homepage "https://msgfiler.com/"
+
+  livecheck do
+    url "https://files.msgfiler.com/"
+    regex(/href=.*?MsgFiler[._-]v?(\d+(?:\.\d+)+)[._-](\d+)[._-](\d+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
+    end
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "MsgFiler #{version.major}.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.atow.MsgFiler*",
+    "~/Library/Application Scripts/group.com.atow.msgfiler.group",
+    "~/Library/Containers/com.atow.MsgFiler*",
+    "~/Library/Group Containers/group.com.atow.msgfiler.group",
+  ]
+end


### PR DESCRIPTION
[MsgFiler](https://msgfiler.com/)

* * *

I set `sha256 :no_check` after getting:

```
audit for msgfiler: failed
 - Use `sha256 :no_check` when URL is unversioned.
msgfiler
  * Use `sha256 :no_check` when URL is unversioned.
Error: 1 problem in 1 cask detected.
```

(even though the URL is clearly versioned)