### PR TITLE
font-gentium-basic font-gentium-book-basic: deprecate

### DIFF
--- a/Casks/font/font-g/font-gentium-basic.rb
+++ b/Casks/font/font-g/font-gentium-basic.rb
@@ -6,12 +6,7 @@ cask "font-gentium-basic" do
   name "Gentium Basic"
   homepage "https://software.sil.org/gentium/"
 
-  livecheck do
-    url "https://software.sil.org/gentium/download/"
-    regex(/Gentium\s+Basic\s+v?(\d+(?:\.\d+)+)/i)
-  end
-
-  no_autobump! because: :requires_manual_review
+  deprecate! date: "2025-06-23", because: :discontinued
 
   font "GentiumBasic_#{version.no_dots}/GenBasB.ttf"
   font "GentiumBasic_#{version.no_dots}/GenBasBI.ttf"

--- a/Casks/font/font-g/font-gentium-book-basic.rb
+++ b/Casks/font/font-g/font-gentium-book-basic.rb
@@ -6,12 +6,7 @@ cask "font-gentium-book-basic" do
   name "Gentium Book Basic"
   homepage "https://software.sil.org/gentium/"
 
-  livecheck do
-    url "https://software.sil.org/gentium/download/"
-    regex(/Gentium\s+Basic\s+v?(\d+(?:\.\d+)+)/i)
-  end
-
-  no_autobump! because: :requires_manual_review
+  deprecate! date: "2025-06-23", because: :discontinued
 
   font "GentiumBasic_#{version.no_dots}/GenBkBasB.ttf"
   font "GentiumBasic_#{version.no_dots}/GenBkBasBI.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Deprecating because these fonts are no longer recommended for use by upstream.
https://software.sil.org/gentium/download/

![Screenshot 2025-06-23 at 11 14 48 pm](https://github.com/user-attachments/assets/f3100831-22ab-4699-973d-a514610b700f)


