### PR TITLE
Add missing language return values

### DIFF
--- a/Casks/b/battle-net.rb
+++ b/Casks/b/battle-net.rb
@@ -4,9 +4,13 @@ cask "battle-net" do
 
   language "en", default: true do
     url "https://www.battle.net/download/getInstallerForGame?os=mac&locale=enUS&version=LIVE&gameProgram=BATTLENET_APP"
+
+    "en-US"
   end
   language "zh", "CN" do
     url "https://www.battle.net/download/getInstallerForGame?os=mac&installer=Battle.net-Setup-zhCN.zip"
+
+    "zh-CN"
   end
 
   name "Blizzard Battle.net"

--- a/Casks/c/cave-story.rb
+++ b/Casks/c/cave-story.rb
@@ -25,6 +25,8 @@ cask "cave-story" do
 
     # Renamed for consistency: app name is different in the Finder and in a shell.
     app "Doukutsu.app", target: "Cave Story.app"
+
+    "en-US"
   end
   language "ja" do
     on_mojave :or_older do
@@ -53,6 +55,8 @@ cask "cave-story" do
 
     # Renamed for consistency: app name is different in the Finder and in a shell.
     app "Doukutsu.app", target: "洞窟物語.app"
+
+    "ja-JP-mac"
   end
 
   name "Cave Story"

--- a/Casks/c/clibor.rb
+++ b/Casks/c/clibor.rb
@@ -4,9 +4,13 @@ cask "clibor" do
 
   language "en", default: true do
     url "https://chigusa-web.com/clibor-for-mac-en/dl/clibor-for-mac/"
+
+    "en-US"
   end
   language "ja" do
     url "https://chigusa-web.com/clibor-for-mac/dl/clibor-for-mac/"
+
+    "ja-JP-mac"
   end
 
   name "Clibor for Mac"

--- a/Casks/t/typora@dev.rb
+++ b/Casks/t/typora@dev.rb
@@ -5,9 +5,13 @@ cask "typora@dev" do
   language "zh-Hans-CN" do # use official Chinese mirror
     url "https://download2.typoraio.cn/mac/Typora-#{version}.dmg",
         verified: "typoraio.cn/"
+
+    "zh-Hans-CN"
   end
   language "en", default: true do
     url "https://download.typora.io/mac/Typora-#{version}.dmg"
+
+    "en-US"
   end
 
   name "Typora"

--- a/Casks/w/wondershare-edrawmax.rb
+++ b/Casks/w/wondershare-edrawmax.rb
@@ -6,11 +6,15 @@ cask "wondershare-edrawmax" do
     url "https://cc-download.edrawsoft.cn/cbs_down/edraw-max_cn_full5381.zip"
     homepage "https://www.edrawsoft.cn/"
     app "亿图图示.app"
+
+    "zh-CN"
   end
   language "en", default: true do
     url "https://download.edrawsoft.com/cbs_down/edraw-max_full5380.zip"
     homepage "https://www.edrawsoft.com/"
     app "Wondershare EdrawMax.app"
+
+    "en-US"
   end
 
   name "EdrawMax"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`language` stanzas are expected to return a string for the language code but a few casks don't meet this requirement. I looked at other casks and used the same language strings from those but there isn't another example of `zh-Hans-CN`, so I made a best guess for `typora@dev` (after doing a little research). I don't know much of anything about Chinese but it seems like we typically use `language "zh"`/`"zh-CN"` in similar contexts, so I'm wondering if `zh-Hans-CN` is specifically needed there. Does anyone have any insight into this situation?

-----

I noticed these issues when running `brew readall homebrew/cask` while testing my work on expanding type signatures in `Cask::DSL`. These casks currently work okay because the `language` string isn't used anywhere but it will result in a type error when the aforementioned type signature changes are integrated into `Cask::DSL`, so this PR preemptively addresses these issues.

[For what it's worth, those type changes are done but I'm taking another pass through the code and doing some testing to try to surface issues like these that aren't covered by `brew tests`.]