### PR TITLE
spotmenu 2.0.2

### DIFF
--- a/Casks/s/spotmenu.rb
+++ b/Casks/s/spotmenu.rb
@@ -1,30 +1,31 @@
 cask "spotmenu" do
-  version "1.9"
-  sha256 "306fc07e2fa2987bd46eae15012808ab2341e47bc56c7b0ebef151752155fd6f"
+  version "2.0.2"
+  sha256 "499855efbc834ab99fc429a8355c4bc5da301c7a9116470bf39fa7e81d33ac95"
 
-  url "https://github.com/kmikiy/SpotMenu/releases/download/v#{version}/SpotMenu.zip"
+  url "https://github.com/kmikiy/SpotMenu/releases/download/v#{version}/SpotMenu.app.zip"
   name "SpotMenu"
   desc "Spotify and iTunes in the menu bar"
   homepage "https://github.com/kmikiy/SpotMenu"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   no_autobump! because: :requires_manual_review
 
   auto_updates true
+  depends_on macos: ">= :sonoma"
 
   app "SpotMenu.app"
 
-  uninstall quit:       "com.KMikiy.SpotMenu",
+  uninstall quit:       "com.github.kmikiy.SpotMenu",
             login_item: "SpotMenu"
 
   zap trash: [
-    "~/Library/Application Scripts/com.KMikiy.SpotMenu.SpotMenuToday",
-    "~/Library/Application Support/com.KMikiy.SpotMenu",
-    "~/Library/Containers/com.KMikiy.SpotMenu.SpotMenuToday",
-    "~/Library/Group Containers/group.KMikiy.SpotMenu",
-    "~/Library/Preferences/com.KMikiy.SpotMenu.plist",
+    "~/Library/Application Scripts/com.github.kmikiy.SpotMenu",
+    "~/Library/Application Support/com.github.kmikiy.SpotMenu",
+    "~/Library/Group Containers/com.github.kmikiy.SpotMenu",
+    "~/Library/Preferences/com.github.kmikiy.SpotMenu.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

## Notes

- SpotMenu depends on macOS 14 Sonoma
- Bundle ID is now `com.github.kmikiy.SpotMenu` instead of `com.KMikiy.SpotMenu`. I am not sure how this affects backward compatibility when running `quit` or `zap trash` now that it has changed.
- SpotMenu is now built as a Universal macOS binary, it no longer requires rosetta
- SpotMenu now doesn't support the option to add a login item from the app, so I'm not sure if `uninstall:  login_item: "SpotMenu"` is needed or not
