### PR TITLE
workflows/sync-default-branches: force push instead of force-with-lease.

### DIFF
--- a/.github/workflows/sync-default-branches.yml
+++ b/.github/workflows/sync-default-branches.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Push target branch
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        run: git push origin "${TARGET_SHA}:refs/heads/${TARGET_BRANCH}" --force-with-lease
+        run: git push origin "${TARGET_SHA}:refs/heads/${TARGET_BRANCH}" --force
         env:
           TARGET_SHA: ${{ steps.sha.outputs.target }}
           TARGET_BRANCH: ${{ steps.branches.outputs.target }}


### PR DESCRIPTION
Force-with-lease doesn't work as expected with a shallow clone.