### PR TITLE
kdeconnect 5140 (new cask)

### DIFF
--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -1,0 +1,24 @@
+cask "kdeconnect" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "25.04,4996"
+  sha256 arm:   "f75de03ef019f31849695ce787920b64a7e69c64c26725c7b827051a2c2a0476",
+         intel: "a05bc5eb2fea06199eac3e3b7a1e283407b4c26fa463bcc4fb120bf24a2f274e"
+
+  url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/release-#{version.major_minor}/macos-#{arch}/kdeconnect-kde-release_#{version.major_minor}-#{version.csv.second}-macos-clang-#{arch}.dmg",
+      verified: "cdn.kde.org/ci-builds/network/kdeconnect-kde/"
+  name "KDE Connect"
+  desc "Enabling communication between all your devices"
+  homepage "https://kdeconnect.kde.org/"
+
+  app "kdeconnect-indicator.app"
+
+  zap trash: [
+    "~/Library/Application Support/kdenconnect.sms",
+    "~/Library/Caches/kdeconnect-indicator",
+    "~/Library/Caches/kdeconnect.daemon",
+    "~/Library/Caches/kdeconnect.sms",
+    "~/Library/Preferences/kdeconnect",
+    "~/Library/Preferences/org.kde.kdeconnect.plist",
+  ]
+end

--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -14,6 +14,8 @@ cask "kdeconnect" do
     regex(/href=.*?kdeconnect-kde-master-(\d+)-macos-clang-\w+\.dmg/i)
   end
 
+  depends_on macos: :monterey
+
   app "KDE Connect.app"
 
   zap trash: [

--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -1,17 +1,17 @@
 cask "kdeconnect" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "25.04,4996"
-  sha256 arm:   "f75de03ef019f31849695ce787920b64a7e69c64c26725c7b827051a2c2a0476",
-         intel: "a05bc5eb2fea06199eac3e3b7a1e283407b4c26fa463bcc4fb120bf24a2f274e"
+  version "5140"
+  sha256 :no_check
 
-  url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/release-#{version.major_minor}/macos-#{arch}/kdeconnect-kde-release_#{version.major_minor}-#{version.csv.second}-macos-clang-#{arch}.dmg"
+  url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-#{arch}/kdeconnect-kde-master-#{version}-macos-clang-#{arch}.dmg"
   name "KDE Connect"
   desc "Enabling communication between all your devices"
   homepage "https://kdeconnect.kde.org/"
 
   livecheck do
-    skip "No version information available"
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
+    regex(/href=.*?kdeconnect-kde-master-(\d+)-macos-clang-\w+\.dmg/i)
   end
 
   app "KDE Connect.app"

--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -10,8 +10,8 @@ cask "kdeconnect" do
   homepage "https://kdeconnect.kde.org/"
 
   livecheck do
-    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-arm64/"
-    regex(/href=.*?kdeconnect-kde-master-(\d+)-macos-clang-\w+\.dmg/i)
+    url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/macos-#{arch}/"
+    regex(/href=.*?kdeconnect[._-]kde[._-]master[._-]v?(\d+(?:\.\d+)*)[._-]macos[._-]clang[._-]#{arch}\.dmg/i)
   end
 
   depends_on macos: :monterey

--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -19,7 +19,7 @@ cask "kdeconnect" do
   app "KDE Connect.app"
 
   zap trash: [
-    "~/Library/Application Support/kdenconnect.sms",
+    "~/Library/Application Support/kdeconnect.sms",
     "~/Library/Caches/kdeconnect-indicator",
     "~/Library/Caches/kdeconnect.daemon",
     "~/Library/Caches/kdeconnect.sms",

--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -14,7 +14,7 @@ cask "kdeconnect" do
     skip "No version information available"
   end
 
-  app "kdeconnect-indicator.app"
+  app "KDE Connect.app"
 
   zap trash: [
     "~/Library/Application Support/kdenconnect.sms",

--- a/Casks/k/kdeconnect.rb
+++ b/Casks/k/kdeconnect.rb
@@ -5,11 +5,14 @@ cask "kdeconnect" do
   sha256 arm:   "f75de03ef019f31849695ce787920b64a7e69c64c26725c7b827051a2c2a0476",
          intel: "a05bc5eb2fea06199eac3e3b7a1e283407b4c26fa463bcc4fb120bf24a2f274e"
 
-  url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/release-#{version.major_minor}/macos-#{arch}/kdeconnect-kde-release_#{version.major_minor}-#{version.csv.second}-macos-clang-#{arch}.dmg",
-      verified: "cdn.kde.org/ci-builds/network/kdeconnect-kde/"
+  url "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/release-#{version.major_minor}/macos-#{arch}/kdeconnect-kde-release_#{version.major_minor}-#{version.csv.second}-macos-clang-#{arch}.dmg"
   name "KDE Connect"
   desc "Enabling communication between all your devices"
   homepage "https://kdeconnect.kde.org/"
+
+  livecheck do
+    skip "No version information available"
+  end
 
   app "kdeconnect-indicator.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version). -> Mac OS is not officially supported yet, but these builds are signed  Usage of the builds is already widespread. There were already brew requests years ago, but builds were not signed at time.
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference). 
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field). -> many years ago, and from a third party git repository, instead of official builds.
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
