### PR TITLE
canon-mg2500-driver 16.90.0.0,04,0100011526,6 (new cask)

### DIFF
--- a/Casks/c/canon-mg2500-driver.rb
+++ b/Casks/c/canon-mg2500-driver.rb
@@ -1,0 +1,30 @@
+cask "canon-mg2500-driver" do
+  version "16.90.0.0,04,0100011526,6"
+  sha256 "93a2289b5c69017cc87289b972566411c802d0e73457fb33c8b88a9f2947d13b"
+
+  url "https://gdlp01.c-wss.com/gds/#{version.csv.fourth}/#{version.csv.third}/#{version.csv.second}/mcpd-mac-mg2500-#{version.csv.first.dots_to_underscores}-ea21_3.dmg",
+      verified: "gdlp01.c-wss.com/"
+  name "Canon PIXMA driver"
+  desc "CUPS driver for Canon PIXMA 2500 series"
+  homepage "https://ij.manual.canon/ij/webmanual/Manual/M/MG2500%20series/EN/CNT/Top.html"
+
+  livecheck do
+    url "https://pdisp01.c-wss.com/gdl/WWUFORedirectTarget.do?id=MDEwMDAxMTUyNjA0&cmp=ABR&lang=EN"
+    regex(%r{(\d+)/(\d+)/(\d+)/mcpd-mac-mg2500-(\d+(?:[_]\d+)+)-ea21_3\.dmg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[4].tr("_", ".")},#{match[3]},#{match[2]},#{match[1]}"
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  pkg "PrinterDriver_MG2500 series_#{version.csv.first.no_dots}.pkg"
+
+  uninstall pkgutil: "jp.co.canon.pkg.MG2500-*",
+            delete:  "/Library/Printers/PPDs/Contents/Resources/CanonIJMG2500series.ppd.gz"
+
+  zap trash: "/Library/Caches/Canon"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This cask installs the necessary drivers for the Canon PIXMA MG2520/MG2522/MG2525 models.

To explain why some of the checkboxes were not cleared, `brew audit --cask --new` failed on my local machine with a 403 HTTP code regarding the homepage being unreachable, but it turns out that Canon (likely) rate limits some of their pages (or maybe they ban some IPs and/or user agents); let me know what I can do regarding the homepage, as it's reachable within a reasonable browser, just not with the `brew` command. Other than that, all checks were successful.

As for the name of the cask, I juggled a couple while working on this recipe, but have decided to settle on this due to existing Canon software in Homebrew containing the `canon-` prefix. Some names I used prior to submitting were

- `canon-mg2522`
- `canon-mg2522-driver`
- `pixma-mg2500-driver`

Let me know if the name of the cask need renaming, as (even with following some of the documentation regarding cask naming) it was rather challenging to come up with a cask token 