### PR TITLE
manymc: suggest `prismlauncher` as replacement

### DIFF
--- a/Casks/m/manymc.rb
+++ b/Casks/m/manymc.rb
@@ -10,7 +10,7 @@ cask "manymc" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-01-07", because: :discontinued
-  disable! date: "2025-01-07", because: :discontinued
+  disable! date: "2025-01-07", because: :discontinued, replacement_cask: "prismlauncher"
 
   depends_on arch: :arm64
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
As per the [suggestion from its homepage](https://github.com/MinecraftMachina/ManyMC?tab=readme-ov-file#%EF%B8%8F-the-manymc-launcher-is-no-longer-being-updated).