### PR TITLE
quba: remove arch requirement

### DIFF
--- a/Casks/q/quba.rb
+++ b/Casks/q/quba.rb
@@ -13,7 +13,6 @@ cask "quba" do
     strategy :github_latest
   end
 
-  depends_on arch: :arm64
   depends_on macos: ">= :big_sur"
 
   app "Quba.app"


### PR DESCRIPTION
Has been [universal since v1.4.1](https://github.com/ZUGFeRD/quba-viewer/issues/23).