### PR TITLE
ungoogled-chromium: rename from eloston-chromium

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -459,7 +459,6 @@ elgato-camera-hub
 elgato-control-center
 elgato-stream-deck
 elgato-wave-link
-eloston-chromium
 elpass
 emacs-app@nightly
 embyserver
@@ -1710,6 +1709,7 @@ ultimaker-cura
 ultimate
 ultrastardeluxe
 understand
+ungoogled-chromium
 uninstallpkg
 unite
 unite-phone

--- a/Casks/u/ungoogled-chromium.rb
+++ b/Casks/u/ungoogled-chromium.rb
@@ -1,4 +1,4 @@
-cask "eloston-chromium" do
+cask "ungoogled-chromium" do
   arch arm: "arm64", intel: "x86_64"
 
   version "137.0.7151.119-1.1"

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -39,6 +39,7 @@
   "doxygen": "doxygen-app",
   "dymo-label": "dymo-connect",
   "easy-move-plus-resize": "easy-move+resize",
+  "eloston-chromium": "ungoogled-chromium",
   "emacs": "emacs-app",
   "emacs@nightly": "emacs-app@nightly",
   "emacs@pretest": "emacs-app@pretest",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
I realise that when this cask was originally accepted, there were [concerns](https://github.com/Homebrew/homebrew-cask/pull/24969#issuecomment-250848695) for the future of this project. Evidently though, it has persevered.  Furthermore, it's been a few years since the repo for the project was transferred from Eloston's personal account to the [`ungoogled-software`](https://github.com/ungoogled-software) org account.

The new name would still be in accordance with the token reference, and it would better match what users expect when looking for this particular package.
