### PR TITLE
procexp: various updates

### DIFF
--- a/Casks/p/procexp.rb
+++ b/Casks/p/procexp.rb
@@ -4,6 +4,7 @@ cask "procexp" do
 
   url "https://newosxbook.com/tools/procexp.tgz"
   name "Process Explorer"
+  desc "Jonathan Levin's procexp utility"
   homepage "https://www.newosxbook.com/tools/procexp.html"
 
   livecheck do
@@ -11,10 +12,10 @@ cask "procexp" do
     regex(/v(\d+(?:\.\d+)+)/i)
   end
 
-  no_autobump! because: :requires_manual_review
+  depends_on arch: :arm64
+  depends_on macos: ">= :sonoma"
 
-  binary "procexp.universal", target: "procexp"
-  manpage "procexp.1"
+  binary "procexp"
 
   # No zap stanza required
 end


### PR DESCRIPTION
The binary is named now "procexp" instead of "procexp.universal" and there is also no more manpage. Tested local installation and that worked.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
