### PR TITLE
prismlauncher: update macOS requirements

### DIFF
--- a/Casks/p/prismlauncher.rb
+++ b/Casks/p/prismlauncher.rb
@@ -1,13 +1,13 @@
 cask "prismlauncher" do
   version "9.4"
 
-  on_mojave :or_older do
+  on_catalina :or_older do
     sha256 "ad5e4d12d91631e4aeec69499e244b0c6fc255d9abe3e26f4f45571a6736206c"
 
     url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-Legacy-#{version}.zip",
         verified: "github.com/PrismLauncher/PrismLauncher/"
   end
-  on_catalina :or_newer do
+  on_big_sur :or_newer do
     sha256 "5cc0148e427d28c632978a9e83e2da3fc02f5072990d9e7732dff3fdb1912ae4"
 
     url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-#{version}.zip",


### PR DESCRIPTION
Current version now [requires 11.x or later](https://github.com/PrismLauncher/PrismLauncher/pull/3595).