### PR TITLE
texmaker: add macOS requirement

### DIFF
--- a/Casks/t/texmaker.rb
+++ b/Casks/t/texmaker.rb
@@ -25,6 +25,8 @@ cask "texmaker" do
 
   no_autobump! because: :requires_manual_review
 
+  depends_on macos: ">= :high_sierra"
+
   app "texmaker.app"
 
   zap trash: [


### PR DESCRIPTION
Found with `brew audit --cask --strict --online --only=min_os --arch=intel texmaker`. 