### PR TITLE
kicad, rio: link binaries from appdir

### DIFF
--- a/Casks/k/kicad.rb
+++ b/Casks/k/kicad.rb
@@ -16,18 +16,18 @@ cask "kicad" do
   depends_on macos: ">= :big_sur"
 
   suite "KiCad"
-  binary "KiCad/KiCad.app/Contents/MacOS/dxf2idf"
-  binary "KiCad/KiCad.app/Contents/MacOS/idf2vrml"
-  binary "KiCad/KiCad.app/Contents/MacOS/idfcyl"
-  binary "KiCad/KiCad.app/Contents/MacOS/idfrect"
-  binary "KiCad/KiCad.app/Contents/MacOS/kicad-cli"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/dxf2idf"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idf2vrml"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idfcyl"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/idfrect"
+  binary "#{appdir}/KiCad/KiCad.app/Contents/MacOS/kicad-cli"
   artifact "demos", target: "/Library/Application Support/kicad/demos"
 
-  zap trash: [
-    "/Library/Application Support/kicad",
-    "~/Library/Application Support/kicad",
-    "~/Library/Preferences/kicad",
-    "~/Library/Preferences/org.kicad-pcb.*",
-    "~/Library/Saved Application State/org.kicad-pcb.*",
-  ]
+  zap delete: "/Library/Application Support/kicad",
+      trash:  [
+        "~/Library/Application Support/kicad",
+        "~/Library/Preferences/kicad",
+        "~/Library/Preferences/org.kicad-pcb.*",
+        "~/Library/Saved Application State/org.kicad-pcb.*",
+      ]
 end

--- a/Casks/r/rio.rb
+++ b/Casks/r/rio.rb
@@ -16,8 +16,8 @@ cask "rio" do
   depends_on macos: ">= :catalina"
 
   app "rio.app"
-  binary "rio.app/Contents/MacOS/rio"
-  binary "rio.app/Contents/Resources/72/rio",
+  binary "#{appdir}/rio.app/Contents/MacOS/rio"
+  binary "#{appdir}/rio.app/Contents/Resources/72/rio",
          target: "#{ENV.fetch("TERMINFO", "~/.terminfo")}/72/rio"
 
   zap trash: "~/Library/Saved Application State/com.raphaelamorim.rio.savedState"


### PR DESCRIPTION
Matches convention in [other casks](https://github.com/Homebrew/homebrew-cask/pull/215544) and the [docs](https://docs.brew.sh/Cask-Cookbook#stanza-binary).