### PR TITLE
ryujinx/minecraft-bedrock: two new cask

### DIFF
--- a/Casks/m/minecraft-bedrock-launcher.rb
+++ b/Casks/m/minecraft-bedrock-launcher.rb
@@ -2,7 +2,7 @@ cask "minecraft-bedrock-launcher" do
   version "1.4.0-511"
   sha256 "0a153f435a026b0792e938eeb057484c1315dcde8a88d474ab815e9131eefb65"
 
-  url "https://github.com/minecraft-linux/macos-builder/releases/download/v1.4.0-511/Minecraft_Bedrock_Launcher_v1.4.0-macOS-x86_64-0.2.511_macOS_10.13.0.dmg",
+  url "https://github.com/minecraft-linux/macos-builder/releases/download/v#{version}/Minecraft_Bedrock_Launcher_v1.4.0-macOS-x86_64-0.2.511_macOS_10.13.0.dmg",
       verified: "github.com/minecraft-linux/macos-builder/"
   name "Minecraft Bedrock Launcher"
   desc "Launcher for Minecraft Bedrock Edition on macOS"
@@ -13,16 +13,15 @@ cask "minecraft-bedrock-launcher" do
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   app "Minecraft Bedrock Launcher.app"
 
   depends_on macos: ">= :high_sierra"
 
-  uninstall quit: "mcpelauncher-ui-qt"
-
   zap trash: [
-    "~/Library/Application Support/minecraft"
+    "~/Library/Application Support/minecraft",
+    "~/Library/Application Support/mcpelauncher",
+    "~/Library/Preferences/io.mrarm.Minecraft Linux Launcher UI.plist",
+    "~/Library/Preferences/io.mrarm.Minecraft Linux Launcher UI.helper.plist",
+    "~/Library/Saved Application State/io.mrarm.Minecraft Linux Launcher UI.savedState"
   ]
-
 end

--- a/Casks/m/minecraft-bedrock-launcher.rb
+++ b/Casks/m/minecraft-bedrock-launcher.rb
@@ -1,0 +1,28 @@
+cask "minecraft-bedrock-launcher" do
+  version "1.4.0-511"
+  sha256 "0a153f435a026b0792e938eeb057484c1315dcde8a88d474ab815e9131eefb65"
+
+  url "https://github.com/minecraft-linux/macos-builder/releases/download/v1.4.0-511/Minecraft_Bedrock_Launcher_v1.4.0-macOS-x86_64-0.2.511_macOS_10.13.0.dmg",
+      verified: "github.com/minecraft-linux/macos-builder/"
+  name "Minecraft Bedrock Launcher"
+  desc "Launcher for Minecraft Bedrock Edition on macOS"
+  homepage "https://github.com/minecraft-linux/macos-builder"
+
+  livecheck do
+    url "https://github.com/minecraft-linux/macos-builder/releases/latest"
+    strategy :github_latest
+  end
+
+  no_autobump! because: :requires_manual_review
+
+  app "Minecraft Bedrock Launcher.app"
+
+  depends_on macos: ">= :high_sierra"
+
+  uninstall quit: "mcpelauncher-ui-qt"
+
+  zap trash: [
+    "~/Library/Application Support/minecraft"
+  ]
+
+end

--- a/Casks/r/ryujinx.rb
+++ b/Casks/r/ryujinx.rb
@@ -6,8 +6,29 @@ cask "ryujinx" do
   name "Ryujinx"
   desc "Nintendo Switch emulator"
   homepage "https://ryujinx.app/"
+
+  livecheck do
+    url "https://git.ryujinx.app/api/v4/projects/ryubing%2Fryujinx/repository/tags"
+    regex(/^(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json|
+      json.map { |t| t["name"] }
+    end
+  end
+
+  no_autobump! because: :requires_manual_review
+
   app "Ryujinx.app"
-  
+
   depends_on macos: ">= :big_sur"
   depends_on arch: :arm64
+
+  uninstall quit: "org.ryujinx.Ryujinx"
+
+  zap trash: [
+    "~/Library/Application Support/Ryujinx",
+    "~/Library/Preferences/org.ryujinx.Ryujinx.plist",
+    "~/Library/Preferences/org.ryujinx.Ryujinx.helper.plist",
+    "~/Library/Saved Application State/org.ryujinx.Ryujinx.savedState",
+    "~/Library/Logs/Ryujinx/"
+  ]
 end

--- a/Casks/r/ryujinx.rb
+++ b/Casks/r/ryujinx.rb
@@ -1,0 +1,17 @@
+cask "ryujinx" do
+  version "1.3.2"
+  sha256 "c157907318348999ce4fb8c8fe8ddd511f0ddea643f22b1529527390180cb700"
+
+  url "https://git.ryujinx.app/api/v4/projects/1/packages/generic/Ryubing/#{version}/ryujinx-#{version}-macos_universal.app.tar.gz"
+  name "Ryujinx"
+  desc "Nintendo Switch emulator"
+  homepage "https://ryujinx.org/"
+
+  # Extrai o .app do tar.gz e instala na /Applications
+  app "Ryujinx.app"
+
+  # Dependências opcionais, se precisar
+  # depends_on macos: ">= :mojave"
+
+  # Você pode definir um uninstall zap, se quiser remover arquivos extras
+end

--- a/Casks/r/ryujinx.rb
+++ b/Casks/r/ryujinx.rb
@@ -5,13 +5,9 @@ cask "ryujinx" do
   url "https://git.ryujinx.app/api/v4/projects/1/packages/generic/Ryubing/#{version}/ryujinx-#{version}-macos_universal.app.tar.gz"
   name "Ryujinx"
   desc "Nintendo Switch emulator"
-  homepage "https://ryujinx.org/"
-
-  # Extrai o .app do tar.gz e instala na /Applications
+  homepage "https://ryujinx.app/"
   app "Ryujinx.app"
-
-  # Dependências opcionais, se precisar
-  # depends_on macos: ">= :mojave"
-
-  # Você pode definir um uninstall zap, se quiser remover arquivos extras
+  
+  depends_on macos: ">= :big_sur"
+  depends_on arch: :arm64
 end


### PR DESCRIPTION

**The ryujinx emulator from nsw**

**The launcher for minecraft bedrock based on the project https://github.com/minecraft-linux in its version for MacOs**

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
