### PR TITLE
Add klever-desktop v1.1.0

### DIFF
--- a/Casks/klever-desktop.rb
+++ b/Casks/klever-desktop.rb
@@ -1,0 +1,18 @@
+cask "klever-desktop" do
+  version "1.1.0"
+  sha256 "0645540b4d35dd6b35362cb6343d99dcccf9afb57fe2a0b5b71082d7790bce4a"
+
+  url "https://github.com/FigmaAI/KleverDesktop/releases/download/v#{version}/KleverDesktop-#{version}.dmg"
+  
+  name "KleverDesktop"
+  desc "Companion app for the Instant UT Figma plugin, Klever"
+  homepage "https://github.com/FigmaAI/KleverDesktop/"
+
+  app "KleverDesktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/KleverDesktop",
+    "~/Library/Preferences/com.klever.desktop.plist",
+    "~/Library/Saved Application State/com.klever.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
Hello Homebrew Maintainers,

This pull request adds a new Cask for `KleverDesktop`, a desktop companion application required for the "Klever" Figma plugin.

The [Klever Figma Plugin](https://www.figma.com/community/plugin/1466767342108031572/klever-desktop-beta-next-gen-ai-usability-testing) provides Next-Gen AI Usability Testing features, and this desktop application handles the necessary browser automation and back-end communication that the plugin relies on to function.

Here is a short video demonstrating the application and its purpose:

[![KleverDesktop Demo Video](https://img.youtube.com/vi/Dru78eszvsM/0.jpg)](https://youtu.be/Dru78eszvsM)

- **Homepage:** [https://github.com/FigmaAI/KleverDesktop](https://github.com/FigmaAI/KleverDesktop)
- **Plugin Page:** [Klever - Next-Gen AI Usability Testing](https://www.figma.com/community/plugin/1466767342108031572/klever-desktop-beta-next-gen-ai-usability-testing)

---
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
---

**Note on `brew audit`:**

As we discussed, `brew audit --cask --new klever-desktop` consistently failed to find the local Cask file, likely due to an environment or caching issue within the audit command itself. However, as demonstrated by the successful `brew install` and `brew uninstall` commands, the Cask file itself is valid and functional. The `brew style` check also passes without any offenses. We believe the Cask is ready for submission despite the localized audit command failure.

```
brew install --cask --debug Casks/klever-desktop.rb 
```

Thank you for your time and consideration.