### PR TITLE
protonvpn: update livecheck

### DIFF
--- a/Casks/p/protonvpn.rb
+++ b/Casks/p/protonvpn.rb
@@ -11,7 +11,7 @@ cask "protonvpn" do
   # The Sparkle feed can contain items on the "beta" channel, so we restrict
   # matching to the default channel.
   livecheck do
-    url "https://protonvpn.com/download/macos-update#{version.major}.xml"
+    url "https://protonvpn.com/download/macos/updates/v4/sparkle.xml"
     strategy :sparkle do |items|
       items.find { |item| item.channel.nil? }&.short_version
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block URL for `protonvpn` returns a 404 (Not Found) response. This addresses the issue by updating the `livecheck` block to use the appcast URL from the latest version of the app.