### PR TITLE
microsoft-word: Update zap stanza

### DIFF
--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -72,10 +72,12 @@ cask "microsoft-word" do
             ]
 
   zap trash: [
-    "~/Library/Application Scripts/com.microsoft.Word",
+    "~/Library/Application Scripts/com.microsoft.Word*",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.word.sfl*",
     "~/Library/Application Support/CrashReporter/Microsoft Word_*.plist",
-    "~/Library/Containers/com.microsoft.Word",
+    "~/Library/Application Support/Microsoft",
+    "~/Library/Containers/com.microsoft.Word*",
+    "~/Library/Group Containers/UBF8T346G9.ms/Microsoft Word.MERP.params.txt",
     "~/Library/Preferences/com.microsoft.Word.plist",
     "~/Library/Saved Application State/com.microsoft.Word.savedState",
   ]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Update the zap stanza of Microsoft Word by adding left over files after initial removal. These files were found using

```console
$ find ~/Library -iname "*microsoft*"
```

In no particular order, the files listed

```
Library/Application Support/Microsoft
Library/Application Scripts/com.microsoft.Word.widgetextension
Library/Group Containers/UBF8T346G9.ms/Microsoft Word.MERP.params.txt
Library/Containers/com.microsoft.Word.widgetextension
Library/Containers/com.microsoft.Word.widgetextension/Data/Library/Application Scripts/com.microsoft.Word.widgetextension
```

A file to consider is ``~/Library/Preferences/com.microsoft.office.plist``. Though it's already handled by `microsoft-office`, it may be of interest to be handled here as well; let me know if that change is desired.