### PR TITLE
microsoft-auto-update: Update zap stanza

### DIFF
--- a/Casks/m/microsoft-auto-update.rb
+++ b/Casks/m/microsoft-auto-update.rb
@@ -54,6 +54,7 @@ cask "microsoft-auto-update" do
             ]
 
   zap trash: [
+        "~/Library/Application Scripts/UBF8T346G9.com.microsoft.oneauth",
         "~/Library/Application Support/Microsoft AutoUpdate",
         "~/Library/Caches/com.microsoft.autoupdate.fba",
         "~/Library/Caches/com.microsoft.autoupdate2",
@@ -61,10 +62,13 @@ cask "microsoft-auto-update" do
         "~/Library/Caches/Microsoft/uls/com.microsoft.autoupdate2",
         "~/Library/Cookies/com.microsoft.autoupdate.fba.binarycookies",
         "~/Library/Cookies/com.microsoft.autoupdate2.binarycookies",
+        "~/Library/Group Containers/UBF8T346G9.com.microsoft.oneauth",
+        "~/Library/Group Containers/UBF8T346G9.ms",
         "~/Library/HTTPStorages/com.microsoft.autoupdate.fba",
         "~/Library/HTTPStorages/com.microsoft.autoupdate2",
         "~/Library/Preferences/com.microsoft.autoupdate.fba.plist",
         "~/Library/Preferences/com.microsoft.autoupdate2.plist",
+        "~/Library/Preferences/com.microsoft.shared.plist",
         "~/Library/Saved Application State/com.microsoft.autoupdate2.savedState",
       ],
       rmdir: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Update the zap stanza of `microsoft-auto-update` by adding left over files after initial removal. These files were found using

```console
$ find ~/Library -iname "*microsoft*"
```

In no particular order, the files listed

```
Library/Preferences/com.microsoft.shared.plist
Library/Application Scripts/UBF8T346G9.com.microsoft.oneauth
Library/Group Containers/UBF8T346G9.com.microsoft.oneauth
Library/Group Containers/UBF8T346G9.ms/Microsoft AutoUpdate.MERP.params.txt
```