### PR TITLE
macvim-app: change version number to match Vim version (and display version)

### DIFF
--- a/Casks/m/macvim-app.rb
+++ b/Casks/m/macvim-app.rb
@@ -1,15 +1,19 @@
 cask "macvim-app" do
-  version "181"
+  version "181,9.1.1128"
   sha256 "ebcab36471c0ddfb91630eae285f57ac9a9a7cb4b233413128aba9039e6a467f"
 
-  url "https://github.com/macvim-dev/macvim/releases/download/release-#{version}/MacVim.dmg"
+  url "https://github.com/macvim-dev/macvim/releases/download/release-#{version.csv.first}/MacVim.dmg"
   name "MacVim"
   desc "Text editor"
   homepage "https://github.com/macvim-dev/macvim"
 
   livecheck do
-    url :url
-    regex(/^release[._-]v?(\d+(?:\.\d+)*)$/i)
+    url "https://macvim.org/appcast/latest.xml"
+    strategy :sparkle do |items|
+      item = items.find { |item| item.channel.nil? }
+
+      "#{item.version},#{item.short_version}"
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
Change version number from release number to Vim version. This update matches what the [MacVim formula](https://github.com/Homebrew/homebrew-core/blob/556e5c3fd23537accbf49f2365e033f8e471f8f5/Formula/m/macvim.rb) uses.

MacVim has a "somewhat non-standard usage of bundle vs display version (bundle is release number, and display version is the upstream Vim version)"–from https://github.com/macvim-dev/macvim/pull/1396#issue-1631220706. The display version is what is visible in Finder. The About MacVim dialog displays a combined version number e.g. `MacVim r181 (Vim 9.1.1128)`. This would be a suitable alternative approach.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.