### PR TITLE
hdfview: update livecheck

### DIFF
--- a/Casks/h/hdfview.rb
+++ b/Casks/h/hdfview.rb
@@ -6,11 +6,18 @@ cask "hdfview" do
       verified: "github.com/HDFGroup/hdfview/"
   name "HDFView"
   desc "Tool for browsing and editing HDF files"
-  homepage "https://www.hdfgroup.org/downloads/hdfview/"
+  homepage "https://www.hdfgroup.org/download-hdfview/"
 
+  # The "latest" release on GitHub is set to the `snapshot` release instead of
+  # the latest stable version. This checks the version from the filename text
+  # on the homepage, so we don't have to use the `GithubReleases` strategy. If
+  # we used `GithubReleases`, we would have to create a somewhat involved
+  # `strategy` block to avoid releases where part of the version is 99, as
+  # upstream doesn't always reliably mark those versions as "pre-release" (e.g.
+  # `HDFView-3.3.99` isn't marked as pre-release).
   livecheck do
-    url :url
-    strategy :github_latest
+    url :homepage
+    regex(/HDFView[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `hdfview` uses the `GithubLatest` strategy but it's currently returning an "Unable to get versions" error, as the "latest" release on GitHub is the `snapshots` release instead of `v3.3.2`. We could use the `GithubReleases` strategy to identify the latest stable release but it would also require a somewhat involved `strategy` block, as upstream doesn't always reliably mark unstable releases as pre-release (e.g., `HDFView-3.3.99` isn't marked as pre-release, so livecheck returns it as the newest version when using the default `GithubReleases` strategy logic).

This addresses the issue by updating the `livecheck` block to check the homepage and match the version from the filename text (the download links are gated behind a login). This isn't ideal, as it doesn't align with the cask URL source (GitHub releases) and the hdfgroup.org server doesn't have compression enabled, so we download the full 180 KB each time. Hopefully this is only a temporary workaround but there are enough issues with how upstream handles GitHub releases and unstable versions that this may be the only reliable approach for now.