### PR TITLE
Correct version string for `postgres-unofficial` cask

### DIFF
--- a/Casks/p/postgres-unofficial.rb
+++ b/Casks/p/postgres-unofficial.rb
@@ -1,6 +1,6 @@
 cask "postgres-unofficial" do
-  version "2.8.2,13-14-15-16-17-18"
-  sha256 "f3c91c81298b9ae8c6aad21affe21f19a0813fcd361ffd3a149a9b223b69e63b"
+  version "2.8.2,13-14-15-16-17"
+  sha256 "9f27ba1f30916a45f2d801647de1f7dac6e4b4879403c225103258612eeb1105"
 
   url "https://github.com/PostgresApp/PostgresApp/releases/download/v#{version.csv.first}/Postgres-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "github.com/PostgresApp/PostgresApp/"
@@ -22,7 +22,7 @@ cask "postgres-unofficial" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :catalina"
 
   app "Postgres.app"
 


### PR DESCRIPTION
Prior to this change, the version includes `-18` but it appears that version has been split off into a separate download.

This commit corrects the version string.

Fixes https://github.com/Homebrew/homebrew-cask/issues/218751

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
