### PR TITLE
positron: update URL to use releases instead of prereleases

### DIFF
--- a/Casks/p/positron.rb
+++ b/Casks/p/positron.rb
@@ -1,14 +1,14 @@
 cask "positron" do
-  version "2025.06.0-167"
-  sha256 "813178aba2feec6581a78d11b52cb2830d031c3729e3735cf67a567122a1f1a5"
+  version "2025.07.0-204"
+  sha256 "7f5110c3a7ca1f8a60546efe61c2cfbfa15ac09d93379d3b8582c3d299fe3e53"
 
-  url "https://cdn.posit.co/positron/prereleases/mac/universal/Positron-#{version}.dmg"
+  url "https://cdn.posit.co/positron/releases/mac/universal/Positron-#{version}-universal.dmg"
   name "Positron"
   desc "Data science IDE"
   homepage "https://positron.posit.co/"
 
   livecheck do
-    url "https://cdn.posit.co/positron/prereleases/mac/universal/releases.json"
+    url "https://cdn.posit.co/positron/releases/mac/universal/releases.json"
     strategy :json do |json|
       json["version"]
     end


### PR DESCRIPTION
Updated the formula as positron is no longer in beta using prereleases:

- Change URL from prereleases to releases endpoint
- Update filename format to include -universal suffix

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
