### PR TITLE
script-debugger: update livecheck

### DIFF
--- a/Casks/s/script-debugger.rb
+++ b/Casks/s/script-debugger.rb
@@ -10,7 +10,7 @@ cask "script-debugger" do
 
   livecheck do
     url "https://latenightsw.com/download/"
-    regex(/action=.*?ScriptDebugger(\d+(?:\.\d+)+-\d+A\d+)\.dmg/i)
+    regex(/href=.*?ScriptDebugger[._-]?v?(\d+(?:\.\d+)+(?:-\d+A\d+)?)\.dmg/i)
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `script-debugger` is returning an `Unable to get versions` error, as the HTML structure of the download page has changed and the regex no longer matches. This updates the regex to replace the leading `action=` with `href=`, as the URLs are now found in `href` attributes. Besides that, this also tweaks the regex to align it more with prevailing standards and to make the trailing suffix optional (as older versions don't have this suffix and we don't want to miss future versions if it's omitted again).