### PR TITLE
cozy-drive: revert to 3.42.0

### DIFF
--- a/Casks/c/cozy-drive.rb
+++ b/Casks/c/cozy-drive.rb
@@ -1,16 +1,19 @@
 cask "cozy-drive" do
-  version "3.43.0"
-  sha256 "6512f3e479819815dd31aff380092286cdebac66a0e1dd01fff1ffc85c05a697"
+  arch arm: "-arm64"
 
-  url "https://github.com/cozy-labs/cozy-desktop/releases/download/v#{version}/Cozy-Drive-#{version}.dmg",
+  version "3.42.0"
+  sha256 arm:   "7815a2757937ac904b4d854996ed815affab62d474a69df3940e1c6a0502a7d8",
+         intel: "f69f9575a842f473d22a3669ff418f729a2ca092c109983ba084dddad1d4648b"
+
+  url "https://github.com/cozy-labs/cozy-desktop/releases/download/v#{version}/Cozy-Drive-#{version}#{arch}.dmg",
       verified: "github.com/cozy-labs/cozy-desktop/"
   name "Cozy Drive"
   desc "File synchronisation for Cozy Cloud"
   homepage "https://cozy.io/"
 
   livecheck do
-    url "https://nuts.cozycloud.cc/download/channel/stable/osx"
-    strategy :header_match
+    url :url
+    strategy :github_latest
   end
 
   depends_on macos: ">= :catalina"
@@ -23,8 +26,4 @@ cask "cozy-drive" do
     "~/Library/Preferences/io.cozy.desktop.plist",
     "~/Library/Saved Application State/io.cozy.desktop.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
