### PR TITLE
lycheeslicer: fix checksum

### DIFF
--- a/Casks/l/lycheeslicer.rb
+++ b/Casks/l/lycheeslicer.rb
@@ -1,6 +1,6 @@
 cask "lycheeslicer" do
   version "7.3.2"
-  sha256 "ee4b3b4447265ca5392210b8cf409117a1e589f0b13f2971000753a086f90f4c"
+  sha256 "feab2aed16b2f692d5c07b9542d1f6b4823e527de0962e8130ba4f0241cfd6d5"
 
   url "https://mango-lychee.nyc3.cdn.digitaloceanspaces.com/LycheeSlicer-#{version}.dmg",
       verified: "mango-lychee.nyc3.cdn.digitaloceanspaces.com/"


### PR DESCRIPTION
The checksum is no longer correct and needs to be updated.  You can verify the change with `curl https://mango-lychee.nyc3.cdn.digitaloceanspaces.com/LycheeSlicer-7.3.2.dmg | sha256sum`

---

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
