### PR TITLE
a-better-finder-rename: update zap

### DIFF
--- a/Casks/a/a-better-finder-rename.rb
+++ b/Casks/a/a-better-finder-rename.rb
@@ -20,9 +20,11 @@ cask "a-better-finder-rename" do
   zap trash: [
     "~/Library/Application Support/A Better Finder Rename #{version.major}",
     "~/Library/Caches/com.apple.helpd/Generated/net.publicspace.abfr#{version.major}.help*",
-    "~/Library/Caches/net.publicspace.abfr#{version.major}",
-    "~/Library/Cookies/net.publicspace.abfr#{version.major}.binarycookies",
-    "~/Library/Preferences/net.publicspace.abfr#{version.major}.plist",
-    "~/Library/Saved Application State/net.publicspace.abfr#{version.major}.savedState",
+    "~/Library/Caches/net.publicspace.abfr*",
+    "~/Library/Cookies/net.publicspace.abfr*.binarycookies",
+    "~/Library/HTTPStorages/net.publicspace.abfr*",
+    "~/Library/HTTPStorages/net.publicspace.abfr*.binarycookies",
+    "~/Library/Preferences/net.publicspace.abfr*.plist",
+    "~/Library/Saved Application State/net.publicspace.abfr*.savedState",
   ]
 end


### PR DESCRIPTION
Detected using AppCleaner.app on latest version of A Better Finder Rename

`brew createzap` does not find anything.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
