### PR TITLE
various: relocate sha256 stanzas & comments

### DIFF
--- a/Casks/a/amazon-workdocs-drive.rb
+++ b/Casks/a/amazon-workdocs-drive.rb
@@ -1,13 +1,13 @@
 cask "amazon-workdocs-drive" do
   arch arm: "mac_v2", intel: "mac"
 
+  sha256 :no_check
+
   on_arm do
     version "1.0.11931.0"
-    sha256 :no_check
   end
   on_intel do
     version "1.0.10729.0"
-    sha256 :no_check
   end
 
   url "https://d3f2hupz96ggz3.cloudfront.net/#{arch}/AmazonWorkDocsDrive.pkg",

--- a/Casks/b/bitrix24.rb
+++ b/Casks/b/bitrix24.rb
@@ -1,7 +1,7 @@
 cask "bitrix24" do
+  # NOTE: "24" is not a version number, but an intrinsic part of the product name
   arch arm: "macos_arm", intel: "desktop"
 
-  # NOTE: "24" is not a version number, but an intrinsic part of the product name
   version "17.1.10.86"
   sha256 :no_check
 

--- a/Casks/c/circuitjs1.rb
+++ b/Casks/c/circuitjs1.rb
@@ -1,7 +1,7 @@
 cask "circuitjs1" do
+  # NOTE: "1" is not a version number, but an intrinsic part of the product name
   arch arm: "arm"
 
-  # NOTE: "1" is not a version number, but an intrinsic part of the product name
   version "3.1.3js"
   sha256 :no_check
 

--- a/Casks/l/lulu.rb
+++ b/Casks/l/lulu.rb
@@ -17,8 +17,7 @@ cask "lulu" do
 
   app "LuLu.app"
 
-  # Lulu's uninstaller removes all preference files breaking brew upgrade
-
+  # Lulu's uninstaller removes all preference files which breaks `brew upgrade`
   zap trash: [
     "~/Library/Caches/com.objective-see.lulu",
     "~/Library/Caches/com.objective-see.lulu.helper",

--- a/Casks/o/orange.rb
+++ b/Casks/o/orange.rb
@@ -2,16 +2,18 @@ cask "orange" do
   arch arm: "arm64", intel: "x86_64"
 
   version "3.39.0"
-  sha256 arm:   "ca30cc7e05ca0f17df009485d6b377bcad2f6310c4c1cb887f58450278aeeb46",
-         intel: "8ec402992039d97683a44a37d7bd1b9fd508122404e497889861445d919d1582"
 
   on_arm do
+    sha256 "ca30cc7e05ca0f17df009485d6b377bcad2f6310c4c1cb887f58450278aeeb46"
+
     url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}-Python3.11.8-#{arch}.dmg",
         verified: "download.biolab.si/download/"
 
     app "Orange.app"
   end
   on_intel do
+    sha256 "8ec402992039d97683a44a37d7bd1b9fd508122404e497889861445d919d1582"
+
     url "https://download.biolab.si/download/files/Orange#{version.major}-#{version}-Python3.10.11-#{arch}.dmg",
         verified: "download.biolab.si/download/"
 

--- a/Casks/s/saoimageds9.rb
+++ b/Casks/s/saoimageds9.rb
@@ -1,7 +1,6 @@
 cask "saoimageds9" do
-  arch arm: "arm64", intel: "x86"
-
   # NOTE: "9" is not a version number, but an intrinsic part of the product name
+  arch arm: "arm64", intel: "x86"
 
   on_big_sur do
     version "8.5"

--- a/Casks/v/volt-app.rb
+++ b/Casks/v/volt-app.rb
@@ -1,13 +1,15 @@
 cask "volt-app" do
   version "0.96"
-  sha256 arm:   "f7c0eb75c4a7e93abc3b8cc248e31db5cdb1871d0936162e183f9f3e684af8a4",
-         intel: "7a52cb3dd08b82f4ae48777fa6625bc79c798a91714cbc0a5c0c1ab069c746bc"
 
   on_arm do
+    sha256 "f7c0eb75c4a7e93abc3b8cc248e31db5cdb1871d0936162e183f9f3e684af8a4"
+
     url "https://github.com/voltapp/volt/releases/download/#{version}/volt_macos_arm64.zip",
         verified: "github.com/voltapp/volt/"
   end
   on_intel do
+    sha256 "7a52cb3dd08b82f4ae48777fa6625bc79c798a91714cbc0a5c0c1ab069c746bc"
+
     url "https://github.com/voltapp/volt/releases/download/#{version}/Volt.dmg",
         verified: "github.com/voltapp/volt/"
   end

--- a/Casks/w/webplotdigitizer.rb
+++ b/Casks/w/webplotdigitizer.rb
@@ -2,13 +2,15 @@ cask "webplotdigitizer" do
   arch arm: "apple-silicon", intel: "darwin-x64"
 
   version "4.7"
-  sha256 arm:   "e5ea8537c7809cce52c4d841ae0be89436f651924c10ab944507bb0ccd3febdb",
-         intel: "1175eb93a78844e6cb9153856bb3a648c190eebc20347250eb23c4d049507fbf"
 
   on_arm do
+    sha256 "e5ea8537c7809cce52c4d841ae0be89436f651924c10ab944507bb0ccd3febdb"
+
     app "WebPlotDigitizer.app"
   end
   on_intel do
+    sha256 "1175eb93a78844e6cb9153856bb3a648c190eebc20347250eb23c4d049507fbf"
+
     app "WebPlotDigitizer-#{version}-#{arch}/WebPlotDigitizer-#{version}.app"
   end
 


### PR DESCRIPTION
Move `sha256` stanzas with arch-specific values to inside on_arch blocks, and move comments on naming to just below the cask declaration.