### PR TITLE
display-pilot 1.6.7.0

### DIFF
--- a/Casks/d/display-pilot.rb
+++ b/Casks/d/display-pilot.rb
@@ -1,6 +1,6 @@
 cask "display-pilot" do
-  version "1.6.2.0"
-  sha256 "d337333dc6f6df3bf7448c71a2eb493650c4cd844ebde2e6ad5a541712452d2a"
+  version "1.6.7.0"
+  sha256 "41d209f16f6c7f42f60d5d0496953ad0ac1d474f9d0d15ea6e2eceb249b0f5d9"
 
   url "https://qspublic.s3.ap-southeast-1.amazonaws.com/qspublic/qs_app/1001/Display%20Pilot%202Setup-#{version}-release.dmg",
       verified: "qspublic.s3.ap-southeast-1.amazonaws.com/qspublic/"

--- a/Casks/d/display-pilot.rb
+++ b/Casks/d/display-pilot.rb
@@ -8,9 +8,11 @@ cask "display-pilot" do
   desc "Display control utility"
   homepage "https://www.benq.com/en-ap/monitor/software/display-pilot-2.html"
 
+  # The only checkable source of version information requires a referer to work,
+  # so we're skipping this for now.
+  # See: https://github.com/Homebrew/homebrew-cask/pull/219373#issuecomment-3054380576
   livecheck do
-    url "https://www.benq.com/en-ap/monitor/software/display-pilot-2/spec.html"
-    regex(/macOS\s*<.*?>\s*v?(\d+(?:\.\d+)+)/im)
+    skip "Requires referer for request to work"
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions)
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Submitted through github website fork repo to edit file.