### PR TITLE
tizen-studio 6.1 (new cask)

### DIFF
--- a/Casks/t/tizen-studio.rb
+++ b/Casks/t/tizen-studio.rb
@@ -1,0 +1,42 @@
+cask "tizen-studio" do
+  version "6.1"
+  sha256 "a9b0afc01923dbd8bb8c927c6ffaeb4f108a3830a8be33ddc839e58f92ab2392"
+
+  url "https://download.tizen.org/sdk/Installer/tizen-studio_#{version}/web-ide_Tizen_Studio_#{version}_macos-64.dmg"
+  name "Tizen Studio"
+  desc "Official IDE for developing web and native applications for Tizen"
+  homepage "https://developer.tizen.org/development/tizen-studio"
+
+  livecheck do
+    url "https://developer.tizen.org/development/tizen-studio/download"
+    strategy :page_match
+    regex(/tizen-studio[._-]v?(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  installer manual: "installer.app"
+
+  uninstall delete: [
+    "~/tizen-studio",
+    "~/tizen-studio-data",
+  ]
+
+  zap trash: [
+    "~/.package-manager",
+    "~/Library/Preferences/org.tizen.sdk.ide.plist",
+    "~/workspace",
+  ]
+
+  caveats <<~EOS
+    This only downloads and stages the installer.
+    You will need to run the open command given later to finish installation.
+    For full functionality, you may need to install:
+        - Google Chrome (for Web Inspector): brew install --cask google-chrome
+        - gettext (for building PO files): brew install gettext
+    Please check the https://docs.tizen.org/application/tizen-studio/setup/prerequisites/ for a full list.
+
+    Note --zap will only remove the default workspace (~/workspace) Tizen recommends.
+
+  EOS
+end


### PR DESCRIPTION

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online tizen-studio` is error-free.
- [x] `brew style --fix tizen-studio` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new tizen-studio` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask tizen-studio` worked successfully.
- [x] `brew uninstall --cask tizen-studio` worked successfully.

---

Adds Homebrew Cask for Tizen Studio 6.1, Samsung's official IDE for developing Tizen applications. Uses manual installer approach since the DMG contains `installer.app`.

Includes optional dependencies via caveats for Google Chrome (Web Inspector) and gettext (building PO files). Also includes zap stanza for complete removal of user data and preferences, meant to clean up everything on a default install after the manual install is completed.

This is a follow up to https://github.com/Homebrew/homebrew-cask/pull/106208, I have hopefully addressed the comment there.

Note: I ran `(brew --repository homebrew/cask)/developer/bin/generate_cask_token "/Volumes/Tizen_Studio_6.1 1/installer.app` and it gave me an unintuitive `volumestizenstudio611installer` so I have just kept it to `tizen-studio`.
