### PR TITLE
aural: bump and deprecate

### DIFF
--- a/Casks/a/aural.rb
+++ b/Casks/a/aural.rb
@@ -1,13 +1,13 @@
 cask "aural" do
-  version "3.25.2"
+  version "4.0.0-preview28"
   sha256 "39687b8d068e435ef9253ed366b71250038bfe0927cad52650c5a5cf83cbb04d"
 
-  url "https://github.com/maculateConception/aural-player/releases/download/v#{version}/AuralPlayer-#{version}.dmg"
+  url "https://github.com/maculateConception/aural-player/releases/download/final/AuralPlayer-#{version}.dmg"
   name "Aural Player"
   desc "Audio player inspired by Winamp"
   homepage "https://github.com/maculateConception/aural-player"
 
-  no_autobump! because: :requires_manual_review
+  deprecate! date: "2025-06-22", because: :discontinued
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/a/aural.rb
+++ b/Casks/a/aural.rb
@@ -1,6 +1,6 @@
 cask "aural" do
   version "4.0.0-preview28"
-  sha256 "39687b8d068e435ef9253ed366b71250038bfe0927cad52650c5a5cf83cbb04d"
+  sha256 "5cacd6f1f5b6956bdb9c5ff7f9b05ebbb11516010000d1f0bc793e6045a17172"
 
   url "https://github.com/maculateConception/aural-player/releases/download/final/AuralPlayer-#{version}.dmg"
   name "Aural Player"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream has stopped development, with a final version available. Livecheck will likely fail here, but we're deprecating anyway. Previous releases aren't available anymore, so this version is our only option to move forward without disabling.