### PR TITLE
Updating surge cask to 6.0.0

### DIFF
--- a/Casks/s/surge.rb
+++ b/Casks/s/surge.rb
@@ -1,6 +1,6 @@
 cask "surge" do
-  version "5.10.3,3272,5cf851de0c9af2bf96ab410244010f9a"
-  sha256 "3d10b83ed65448797d57a238729063abc6b704c183cffd51408ce54e87066079"
+  version "6.0.0,7210,3c89094d79d9dcff8b276e7b55ecf004"
+  sha256 "014c6a15bf4b83e8146419c74f006cbc4ab31c2af6f73d75b0c46e06875cbcbf"
 
   url "https://dl.nssurge.com/mac/v#{version.major}/Surge-#{version.tr(",", "-")}.zip"
   name "Surge"
@@ -8,7 +8,8 @@ cask "surge" do
   homepage "https://nssurge.com/"
 
   livecheck do
-    url "https://www.nssurge.com/mac/v#{version.major}/appcast-signed.xml"
+    # The SPUFeedURL from Info.plist is https://nssurge.com/mac/latest/appcast-signed.xml
+    url "https://nssurge.com/mac/latest/appcast-signed.xml"
     regex(/[._-](\d+(?:\.\d+)+)[._-](\d+)[._-](\h+)\.zip/i)
     strategy :sparkle do |item, regex|
       match = item.url.match(regex)
@@ -20,7 +21,7 @@ cask "surge" do
 
   auto_updates true
   conflicts_with cask: "surge@4"
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :monterey" # Confirmed by LSMinimumSystemVersion "12.0"
 
   app "Surge.app"
 


### PR DESCRIPTION
Version: 6.0.0,7210,3c89094d79d9dcff8b276e7b55ecf004 SHA256: 014c6a15bf4b83e8146419c74f006cbc4ab31c2af6f73d75b0c46e06875cbcbf Livecheck URL updated to reflect Info.plist SUFeedURL. macOS dependency confirmed as >= :monterey.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
