### PR TITLE
Fix: apple container cask

### DIFF
--- a/Casks/c/container.rb
+++ b/Casks/c/container.rb
@@ -10,7 +10,7 @@ cask "container" do
   depends_on arch: :arm64
   depends_on macos: ">= :sequoia"
 
-  pkg "container-installer-signed.pkg"
+  pkg "container-#{version}-installer-signed.pkg"
 
   uninstall pkgutil: "com.apple.container-installer"
 


### PR DESCRIPTION
Fix cask apple container
```
$ brew install container                                                                                                  git:(main|…1
==> Downloading https://github.com/apple/container/releases/download/0.2.0/container-0.2.0-installer-signed.pkg
Already downloaded: /Users/ian/Library/Caches/Homebrew/downloads/e0a81c0ff129d5431a26b5a314e336822c1fce97f7a688599dd6a090bfa21b5c--container-0.2.0-installer-signed.pkg
==> Installing Cask container
==> Running installer for container with sudo; the password may be necessary.
==> Purging files for version 0.2.0 of Cask container
Error: Could not find PKG source file 'container-installer-signed.pkg', found 'container-0.2.0-installer-signed.pkg' instead.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
