### PR TITLE
google-cloud-sdk: renamed to `gcloud-cli` to align with the product name

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -1,4 +1,4 @@
-cask "google-cloud-sdk" do
+cask "gcloud-cli" do
   arch arm: "arm", intel: "x86_64"
 
   version "529.0.0"
@@ -6,9 +6,9 @@ cask "google-cloud-sdk" do
          intel: "d81c1740edd039004839e6eae4921c4fec0b5ff5fa104959c50e667c76a1a4b6"
 
   url "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-#{version}-darwin-#{arch}.tar.gz"
-  name "Google Cloud SDK"
+  name "Google Cloud CLI"
   desc "Set of tools to manage resources and applications hosted on Google Cloud"
-  homepage "https://cloud.google.com/sdk/"
+  homepage "https://cloud.google.com/cli/"
 
   livecheck do
     url "https://cloud.google.com/sdk/docs/install-sdk"

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -70,6 +70,7 @@
   "geekbench-ml": "geekbench-ai",
   "gitup": "gitup-app",
   "glaze": "glaze-app",
+  "google-cloud-sdk": "gcloud-cli",
   "gridtracker": "gridtracker2",
   "handbrake": "handbrake-app",
   "hepta": "heptabase",


### PR DESCRIPTION
Rename `google-cloud-sdk` to `gcloud-cli` to align with the [product name](http://cloud/sdk/docs/install)

Tested renaming working by running:
```
export HOMEBREW_NO_AUTO_UPDATE=1
export HOMEBREW_NO_INSTALL_FROM_API=1
brew install --cask gcloud-cli
brew uninstall --cask gcloud-cli

brew install --cask google-cloud-sdk
brew uninstall --cask google-cloud-sdk
```

Note: ran `brew audit --cask gcloud-cli` with no error. but with `--online` has some error `can't figure out the architecture type of` happening the same for the existing cask so it's not related to this changes.
 
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
