### PR TITLE
gcc-aarch64-embedded gcc-arm-embedded 14.3.rel1

### DIFF
--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -1,15 +1,10 @@
 cask "gcc-aarch64-embedded" do
-  # Exists as a cask because it is impractical as a formula:
-  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  arch arm: "arm64", intel: "x86_64"
+  version "14.3.rel1"
+  sha256 "82a4987c670f589d3c5b97bc579561365116670ff3c1c67a07fc29fa23aef3b2"
 
-  version "14.2.rel1"
-  pkg_version = "14.2.rel1"
-  gcc_version = "14.2.1"
-  sha256 arm:   "20d81586e22fa811b7052520e98fe0db44294b038d70c41693808db7818325fe",
-         intel: "4e0da7bc82d316deb7f385d249bf7f87ce06d31b9d6f8b63f9b981a2203cf2ce"
-
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg"
+  pkg_version = "14.3.rel1"
+  gcc_version = "14.3.1"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-arm64-aarch64-none-elf.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 64-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
@@ -21,7 +16,11 @@ cask "gcc-aarch64-embedded" do
 
   no_autobump! because: :requires_manual_review
 
-  pkg "arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg"
+  # Exists as a cask because it is impractical as a formula:
+  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
+  depends_on arch: :arm64
+
+  pkg "arm-gnu-toolchain-#{version}-darwin-arm64-aarch64-none-elf.pkg"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-addr2line"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-ar"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-as"
@@ -54,7 +53,7 @@ cask "gcc-aarch64-embedded" do
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-strings"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-strip"
 
-  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{arch}-aarch64-none-elf",
+  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-arm64-aarch64-none-elf",
             delete:  "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf",
             rmdir:   [
               "/Applications/ArmGNUToolchain",

--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -16,7 +16,7 @@ cask "gcc-aarch64-embedded" do
     end
   end
   on_intel do
-    version "14.2rel1"
+    version "14.2.rel1"
     sha256 "4e0da7bc82d316deb7f385d249bf7f87ce06d31b9d6f8b63f9b981a2203cf2ce"
     pkg_version = "14.2.rel1"
     gcc_version = "14.2.1"

--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -1,4 +1,6 @@
 cask "gcc-aarch64-embedded" do
+  # Exists as a cask because it is impractical as a formula:
+  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
   version "14.3.rel1"
   sha256 "82a4987c670f589d3c5b97bc579561365116670ff3c1c67a07fc29fa23aef3b2"
 
@@ -16,8 +18,6 @@ cask "gcc-aarch64-embedded" do
 
   no_autobump! because: :requires_manual_review
 
-  # Exists as a cask because it is impractical as a formula:
-  # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
   depends_on arch: :arm64
 
   pkg "arm-gnu-toolchain-#{version}-darwin-arm64-aarch64-none-elf.pkg"

--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -1,26 +1,38 @@
 cask "gcc-aarch64-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  version "14.3.rel1"
-  sha256 "82a4987c670f589d3c5b97bc579561365116670ff3c1c67a07fc29fa23aef3b2"
+  arch arm: "arm64", intel: "x86_64"
 
-  pkg_version = "14.3.rel1"
-  gcc_version = "14.3.1"
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-arm64-aarch64-none-elf.pkg"
+  pkg_version = nil
+  gcc_version = nil
+  on_arm do
+    version "14.3.rel1"
+    sha256 "82a4987c670f589d3c5b97bc579561365116670ff3c1c67a07fc29fa23aef3b2"
+    pkg_version = "14.3.rel1"
+    gcc_version = "14.3.1"
+    livecheck do
+      url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
+      regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-aarch64-none-elf\.pkg/i)
+    end
+  end
+  on_intel do
+    version "14.2rel1"
+    sha256 "4e0da7bc82d316deb7f385d249bf7f87ce06d31b9d6f8b63f9b981a2203cf2ce"
+    pkg_version = "14.2.rel1"
+    gcc_version = "14.2.1"
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 64-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
-  livecheck do
-    url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
-    regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-aarch64-none-elf\.pkg/i)
-  end
-
   no_autobump! because: :requires_manual_review
 
-  depends_on arch: :arm64
-
-  pkg "arm-gnu-toolchain-#{version}-darwin-arm64-aarch64-none-elf.pkg"
+  pkg "arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-addr2line"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-ar"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-as"
@@ -53,7 +65,7 @@ cask "gcc-aarch64-embedded" do
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-strings"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-strip"
 
-  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-arm64-aarch64-none-elf",
+  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{arch}-aarch64-none-elf",
             delete:  "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf",
             rmdir:   [
               "/Applications/ArmGNUToolchain",

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -1,13 +1,11 @@
 cask "gcc-arm-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  depends_on arch: :arm64
-
   version "14.3.rel1"
-  pkg_version = "14.3.rel1"
-  gcc_version = "14.3.1"
   sha256 "b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b"
 
+  pkg_version = "14.3.rel1"
+  gcc_version = "14.3.1"
   url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-arm64-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
@@ -19,6 +17,8 @@ cask "gcc-arm-embedded" do
   end
 
   no_autobump! because: :requires_manual_review
+
+  depends_on arch: :arm64
 
   pkg "arm-gnu-toolchain-#{version}-darwin-arm64-arm-none-eabi.pkg"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-addr2line"

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -5,15 +5,6 @@ cask "gcc-arm-embedded" do
 
   pkg_version = nil
   gcc_version = nil
-  on_intel do
-    version "14.2.rel1"
-    sha256 "5d2e9ee4e73350bda79accc69fcd5ee59ccb902804a3f81a01d4c543b1ad7de7"
-    pkg_version = "14.2.rel1"
-    gcc_version = "14.2.1"
-    livecheck do
-      skip "Legacy version"
-    end
-  end
   on_arm do
     version "14.3.rel1"
     sha256 "b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b"
@@ -24,15 +15,24 @@ cask "gcc-arm-embedded" do
       regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-arm-none-eabi\.pkg/i)
     end
   end
+  on_intel do
+    version "14.2.rel1"
+    sha256 "5d2e9ee4e73350bda79accc69fcd5ee59ccb902804a3f81a01d4c543b1ad7de7"
+    pkg_version = "14.2.rel1"
+    gcc_version = "14.2.1"
+    livecheck do
+      skip "Legacy version"
+    end
+  end
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{version}-arm-none-eabi.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
   no_autobump! because: :requires_manual_review
 
-  pkg "arm-gnu-toolchain-#{version}-darwin-#{version}-arm-none-eabi.pkg"
+  pkg "arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-addr2line"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ar"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-as"
@@ -65,7 +65,7 @@ cask "gcc-arm-embedded" do
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strings"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{version}-arm-none-eabi",
+  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{arch}-arm-none-eabi",
             delete:  "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi",
             rmdir:   [
               "/Applications/ArmGNUToolchain",

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -1,26 +1,38 @@
 cask "gcc-arm-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  version "14.3.rel1"
-  sha256 "b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b"
+  arch arm: "arm64", intel: "x86_64"
 
-  pkg_version = "14.3.rel1"
-  gcc_version = "14.3.1"
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-arm64-arm-none-eabi.pkg"
+  pkg_version = nil
+  gcc_version = nil
+  on_intel do
+    version "14.2.rel1"
+    sha256 "5d2e9ee4e73350bda79accc69fcd5ee59ccb902804a3f81a01d4c543b1ad7de7"
+    pkg_version = "14.2.rel1"
+    gcc_version = "14.2.1"
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_arm do
+    version "14.3.rel1"
+    sha256 "b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b"
+    pkg_version = "14.3.rel1"
+    gcc_version = "14.3.1"
+    livecheck do
+      url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
+      regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-arm-none-eabi\.pkg/i)
+    end
+  end
+
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{version}-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
 
-  livecheck do
-    url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
-    regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-arm-none-eabi\.pkg/i)
-  end
-
   no_autobump! because: :requires_manual_review
 
-  depends_on arch: :arm64
-
-  pkg "arm-gnu-toolchain-#{version}-darwin-arm64-arm-none-eabi.pkg"
+  pkg "arm-gnu-toolchain-#{version}-darwin-#{version}-arm-none-eabi.pkg"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-addr2line"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ar"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-as"
@@ -53,7 +65,7 @@ cask "gcc-arm-embedded" do
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strings"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-arm64-arm-none-eabi",
+  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{version}-arm-none-eabi",
             delete:  "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi",
             rmdir:   [
               "/Applications/ArmGNUToolchain",

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -1,15 +1,14 @@
 cask "gcc-arm-embedded" do
   # Exists as a cask because it is impractical as a formula:
   # https://github.com/Homebrew/homebrew-core/pull/45780#issuecomment-569246452
-  arch arm: "arm64", intel: "x86_64"
+  depends_on arch: :arm64
 
-  version "14.2.rel1"
-  pkg_version = "14.2.rel1"
-  gcc_version = "14.2.1"
-  sha256 arm:   "b62ea28a6ba69b9c34031595ed0b9ed4846d230dbe8ff0fbe182bb55d1d779f6",
-         intel: "5d2e9ee4e73350bda79accc69fcd5ee59ccb902804a3f81a01d4c543b1ad7de7"
+  version "14.3.rel1"
+  pkg_version = "14.3.rel1"
+  gcc_version = "14.3.1"
+  sha256 "b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b"
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-arm64-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"
@@ -21,7 +20,7 @@ cask "gcc-arm-embedded" do
 
   no_autobump! because: :requires_manual_review
 
-  pkg "arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
+  pkg "arm-gnu-toolchain-#{version}-darwin-arm64-arm-none-eabi.pkg"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-addr2line"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-ar"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-as"
@@ -54,7 +53,7 @@ cask "gcc-arm-embedded" do
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strings"
   binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-strip"
 
-  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-#{arch}-arm-none-eabi",
+  uninstall pkgutil: "arm-gnu-toolchain-#{pkg_version}-darwin-arm64-arm-none-eabi",
             delete:  "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi",
             rmdir:   [
               "/Applications/ArmGNUToolchain",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
Downloads no longer seem to be available for x86_64, so removed all mentions of the architecture in the cask. I will probably add a legacy version in another PR.