### PR TITLE
fontsmoothingadjuster: deprecate

### DIFF
--- a/Casks/f/fontsmoothingadjuster.rb
+++ b/Casks/f/fontsmoothingadjuster.rb
@@ -2,18 +2,13 @@ cask "fontsmoothingadjuster" do
   version "2.0.0"
   sha256 "187401950b827c58262a9bb86878c5dd5820550c00ca414f971ce82837d7419f"
 
-  url "https://font-smoothing-adjuster-updates.s3.amazonaws.com/Font+Smoothing+Adjuster+#{version}.dmg",
-      verified: "font-smoothing-adjuster-updates.s3.amazonaws.com/"
+  url "https://github.com/bouncetechnologies/Font-Smoothing-Adjuster/releases/download/v#{version}/Font.Smoothing.Adjuster.#{version}.dmg",
+      verified: "github.com/bouncetechnologies/Font-Smoothing-Adjuster/"
   name "Font Smoothing Adjuster"
   desc "Re-enable the font smoothing controls"
   homepage "https://www.fontsmoothingadjuster.com/"
 
-  livecheck do
-    url "https://font-smoothing-adjuster-updates.s3.amazonaws.com/appcast.xml"
-    strategy :sparkle
-  end
-
-  no_autobump! because: :requires_manual_review
+  deprecate! date: "2025-07-14", because: :unmaintained
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The download is no longer available through the upstream website link, so use the GitHub repo instead. Also deprecate, since this would suggest there may be similar issues moving forward.