### PR TITLE
Revert "google-ads-editor 2.10"

### DIFF
--- a/Casks/g/google-ads-editor.rb
+++ b/Casks/g/google-ads-editor.rb
@@ -1,5 +1,5 @@
 cask "google-ads-editor" do
-  version "2.10"
+  version "2.9"
   sha256 :no_check
 
   url "https://dl.google.com/adwords_editor/Google_AdWords_Editor.dmg"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#219116

Version has been downgraded.