### PR TITLE
dotnet-sdk@8 (new cask)

### DIFF
--- a/Casks/d/dotnet-sdk@8.rb
+++ b/Casks/d/dotnet-sdk@8.rb
@@ -1,0 +1,55 @@
+cask "dotnet-sdk@8" do
+  arch arm: "arm64", intel: "x64"
+
+  version "8.0.412"
+  sha256 arm:   "e5abf744d87cb45beac2ee5bfae701850cee2d401eee1c959b707a7f9af516b5",
+         intel: "0bdebfe09858c870114fc28ed576d16dda7e6aa16a5123b7a4423379ea2a1e33"
+
+  url "https://builds.dotnet.microsoft.com/dotnet/Sdk/#{version}/dotnet-sdk-#{version}-osx-#{arch}.pkg"
+  name ".NET SDK"
+  desc "Developer platform"
+  homepage "https://www.microsoft.com/net/core#macos"
+
+  # This identifies releases with the same major/minor version as the current
+  # cask version. New major/minor releases occur annually in November and the
+  # check will automatically update its behavior when the cask is updated.
+  livecheck do
+    url "https://builds.dotnet.microsoft.com/dotnet/release-metadata/#{version.major_minor}/releases.json"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json["releases"]&.map do |release|
+        version = release.dig("sdk", "version")
+        next unless version&.match(regex)
+
+        version
+      end
+    end
+  end
+
+  conflicts_with cask: [
+    "dotnet-runtime",
+    "dotnet-runtime@preview",
+    "dotnet-sdk",
+    "dotnet-sdk@preview",
+  ], formula: "dotnet"
+  depends_on macos: ">= :mojave"
+
+  pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
+  binary "/usr/local/share/dotnet/dotnet"
+
+  uninstall pkgutil: [
+    "com.microsoft.dotnet.*#{version.major_minor}*#{arch}",
+    "com.microsoft.dotnet.sharedhost*#{arch}",
+    "com.microsoft.netstandard.pack.targeting.*",
+  ]
+
+  zap pkgutil: "com.microsoft.dotnet.*",
+      delete:  [
+        "/etc/paths.d/dotnet",
+        "/etc/paths.d/dotnet-cli-tools",
+      ],
+      trash:   [
+        "~/.dotnet",
+        "~/.nuget",
+      ]
+end


### PR DESCRIPTION
This cask tracks .NET 8, the prior version of the SDK. (.NET 8 is an LTS version, but .NET 9 is not.)

The dotnet-sdk cask is tracking .NET 9. I am proposing a cask for the previous version because .NET 8 is an LTS version and .NET 9 is not. I am further using this nomenclature instead of something like dotnet-sdk@lts because once .NET 10 is released — it will be an LTS version — .NET 8 will still be supported and updated for an additional year and it will make sense to keep allowing updates for users that will want to stick on that version for a while (like myself!).

This is my first time submitting a cask to Homebrew. I followed the documentation steps to the best of my ability and the cask installs and uninstalls smoothly. (It was pretty easy for this one as I just had to make a few tweaks to the main dotnet-sdk cask.) Let me know if you see anything off.

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---
