### PR TITLE
subsurface@5 5.0.10-qt6-universal (new cask)

### DIFF
--- a/Casks/s/subsurface@5.rb
+++ b/Casks/s/subsurface@5.rb
@@ -1,0 +1,20 @@
+cask "subsurface@5" do
+  version "5.0.10-qt6-universal"
+  sha256 :no_check
+
+  url "https://subsurface-divelog.org/downloads/Subsurface-5.0.10-qt6-universal.dmg",
+      user_agent: :fake
+  name "Subsurface"
+  desc "Open source divelog program"
+  homepage "https://subsurface-divelog.org/"
+
+  depends_on macos: ">= :big_sur"
+
+  app "Subsurface.app"
+
+  zap trash: [
+    "~/Library/Application Support/Subsurface",
+    "~/Library/Caches/Subsurface",
+    "~/Library/Preferences/org.hohndel.subsurface.Subsurface.plist",
+  ]
+end


### PR DESCRIPTION
Apple Silicon is only supported by Qt6. Currently Subsurfaces is on version 6.0.x and it still uses Qt5. 
This release (version 5.0.x) was the latest attempt at moving to Qt6 https://github.com/subsurface/subsurface/issues/4553#issuecomment-3062554201


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---
