### PR TITLE
gamemaker 2024.13.1.193

### DIFF
--- a/Casks/g/gamemaker.rb
+++ b/Casks/g/gamemaker.rb
@@ -1,6 +1,6 @@
 cask "gamemaker" do
-  version "2024.13.0.190"
-  sha256 "ecaaa253dd5eb24b2ff1ac6e2cb415c7bdfabfa368fc37a94597ec06a8454d76"
+  version "2024.13.1.193"
+  sha256 "470d9beb8eb0afbb1eca298e7320df56d11bc4d55e76e2e806fe040c98bb35e3"
 
   url "https://gms.yoyogames.com/GameMaker-#{version}.pkg",
       verified: "gms.yoyogames.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
---

Creating a manual pull request as bump-cask-pr complains about this update being duplicated.
This happens because the previous update was rolled-back in https://github.com/Homebrew/homebrew-cask/pull/212841
At the time, the download URL was taken down. It is now back online and we can safely update to 2024.13.1.193