### PR TITLE
Set JOSM target on arm for consistency with intel

### DIFF
--- a/Casks/j/josm.rb
+++ b/Casks/j/josm.rb
@@ -1,48 +1,20 @@
 cask "josm" do
-  arch arm: "-aarch64"
-  app_arch = on_arch_conditional arm: "_24_arm64"
+  version "19423"
+  sha256 "f1ea6cd5e4d49fd1471d8c04087ffbe363d5ef09e744ed3c7656666b17756995"
 
-  on_arm do
-    version "19423"
-    sha256 "346f21f28b1ee68a746a38bcadd477222dcf28a20adf71c0d86eae33e9d2d882"
-
-    livecheck do
-      url :url
-      regex(/\D*?(\d+(?:\.\d+)*)/i)
-      strategy :github_latest
-    end
-  end
-  on_intel do
-    version "19412"
-    sha256 "7435e1409200095b7e74685691ce794d3a3934f4d3fce5adf6cc505e70e2fbe5"
-
-    # Not every GitHub release provides a file for both architectures, so we check
-    # multiple recent releases instead of only the "latest" release.
-    livecheck do
-      url :url
-      regex(/^JOSM[._-]macos[._-]java24[._-]v?(\d+(?:\.\d+)*)#{arch}\.zip$/i)
-      strategy :github_releases do |json, regex|
-        json.map do |release|
-          next if release["draft"] || release["prerelease"]
-
-          release["assets"]&.map do |asset|
-            match = asset["name"]&.match(regex)
-            next if match.blank?
-
-            match[1]
-          end
-        end.flatten
-      end
-    end
-  end
-
-  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java24-#{version}#{arch}.zip",
+  url "https://github.com/JOSM/josm/releases/download/#{version}-tested/JOSM-macOS-java21-#{version}.zip",
       verified: "github.com/JOSM/josm/"
   name "JOSM"
   desc "Extensible editor for OpenStreetMap"
   homepage "https://josm.openstreetmap.de/"
 
-  app "JOSM#{app_arch}.app"
+  livecheck do
+    url :url
+    regex(/\D*?(\d+(?:\.\d+)*)/i)
+    strategy :github_latest
+  end
+
+  app "JOSM.app"
 
   zap trash: [
     "~/Library/Caches/JOSM",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
---

The app name should be JOSM.app on both intel and arm. As per https://docs.brew.sh/Cask-Cookbook#target-should-only-be-used-in-select-cases this is for both consistency and as a developer suggestion - I'm one of the people guilty for JOSM's macOS packaging.
