### PR TITLE
Add conflict with "dotnet-sdk@8" to other dotnet casks

### DIFF
--- a/Casks/d/dotnet-runtime.rb
+++ b/Casks/d/dotnet-runtime.rb
@@ -29,6 +29,7 @@ cask "dotnet-runtime" do
   conflicts_with cask: [
     "dotnet-runtime@preview",
     "dotnet-sdk",
+    "dotnet-sdk@8",
     "dotnet-sdk@preview",
   ], formula: "dotnet"
   depends_on macos: ">= :mojave"

--- a/Casks/d/dotnet-runtime@preview.rb
+++ b/Casks/d/dotnet-runtime@preview.rb
@@ -22,6 +22,7 @@ cask "dotnet-runtime@preview" do
   conflicts_with cask: [
     "dotnet-runtime",
     "dotnet-sdk",
+    "dotnet-sdk@8",
     "dotnet-sdk@preview",
   ], formula: "dotnet"
   depends_on macos: ">= :mojave"

--- a/Casks/d/dotnet-sdk.rb
+++ b/Casks/d/dotnet-sdk.rb
@@ -29,6 +29,7 @@ cask "dotnet-sdk" do
   conflicts_with cask: [
     "dotnet-runtime",
     "dotnet-runtime@preview",
+    "dotnet-sdk@8",
     "dotnet-sdk@preview",
   ], formula: "dotnet"
   depends_on macos: ">= :mojave"

--- a/Casks/d/dotnet-sdk@preview.rb
+++ b/Casks/d/dotnet-sdk@preview.rb
@@ -23,6 +23,7 @@ cask "dotnet-sdk@preview" do
     "dotnet-runtime",
     "dotnet-runtime@preview",
     "dotnet-sdk",
+    "dotnet-sdk@8",
   ], formula: "dotnet"
   depends_on macos: ">= :mojave"
 


### PR DESCRIPTION
Add conflict with "dotnet-sdk@8" to other dotnet casks.

These casks already list each other as conflicting. The dotnet-sdk@8 cask was recently added and it conflicts for the same reason.

(This was discussed [yesterday](https://github.com/Homebrew/homebrew-cask/pull/219939#issuecomment-3070217697).)

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---
