### PR TITLE
Adding the rodecaster app cask as rode-central no longer supports

### DIFF
--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -1,5 +1,5 @@
 cask "rodecaster" do
-  version "2.0.94-145"
+  version "2.0.94"
   sha256 :no_check
 
   url "https://update.rode.com/rc-app/RODECaster_App_MACOS.zip"
@@ -7,9 +7,20 @@ cask "rodecaster" do
   desc "Easily manage your RØDECaster or Streamer X setup"
   homepage "https://rode.com/en/apps/rodecaster-app"
 
+  livecheck do
+    url "https://update.rode.com/rode-devices-manifest.json"
+    strategy :json do |json|
+      json.dig("rc-app-manifest", "macos", "main-version", "update-version")
+    end
+  end
+
   depends_on macos: ">= :catalina"
 
-  pkg "RØDECaster App (#{version}).pkg"
+  pkg "RØDECaster App.pkg"
+
+  preflight do
+    staged_path.glob("RØDECaster App*.pkg")&.first&.rename(staged_path/"RØDECaster App.pkg")
+  end
 
   uninstall quit:    "com.rode.rodecastercomp",
             pkgutil: "com.rodecastercomp.installer"

--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -1,0 +1,21 @@
+cask "rodecaster" do
+  version "2.0.94-145"
+  sha256 :no_check
+
+  url "https://update.rode.com/rc-app/RODECaster_App_MACOS.zip"
+  name "RODECaster App"
+  desc "Easily manage your RØDECaster or Streamer X setup"
+  homepage "https://rode.com/en/apps/rodecaster-app"
+
+  depends_on macos: ">= :catalina"
+
+  pkg "RØDECaster App (#{version}).pkg"
+
+  uninstall quit:    "com.rode.rodecastercomp",
+            pkgutil: "com.rodecastercomp.installer"
+
+  zap trash: [
+    "~/Library/Caches/com.rode.rodecastercomp",
+    "~/Library/HTTPStorages/com.rode.rodecastercomp",
+  ]
+end


### PR DESCRIPTION
Looks like there is a new app for the rodecaster devices instead of using the previous rode-central app. 
I will reach out to the vendor to provide a versioned download url instead of what they are currently doing.


- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
