### PR TITLE
focusrite-control 3.22.0

### DIFF
--- a/Casks/f/focusrite-control.rb
+++ b/Casks/f/focusrite-control.rb
@@ -1,8 +1,8 @@
 cask "focusrite-control" do
-  version "3.20.0"
-  sha256 "5f4c7eb36e1b62437f5b8c7a33fe82ebea5807095cd77df5d155090a4a0f1714"
+  version "3.22.0"
+  sha256 "1a4252611f72cf55a37a0df916079072775717ce6b6793099cc4b50584b6861f"
 
-  url "https://fael-downloads-prod.focusrite.com/customer/prod/downloads/focusrite_control_#{version}.dmg"
+  url "https://fael-downloads-prod.focusrite.com/customer/prod/downloads/focusrite_control_#{version}.dmg.zip"
   name "Focusrite Control"
   desc "Focusrite interface controller"
   homepage "https://focusrite.com/en"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`focusrite-control` is autobumped but the autobump workflow is failing to update the cask to the latest version because the file extension has changed. This manually updates the cask to 3.22.0 accordingly.