### PR TITLE
djv 3.0.0

### DIFF
--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -16,6 +16,7 @@ cask "djv" do
   depends_on arch: :arm64
 
   app "DJV.app"
+  binary "#{appdir}/Contents/Resources/bin/djv"
 
   zap trash: [
         "~/Documents/DJV/djv.log",

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -9,8 +9,6 @@ cask "djv" do
   homepage "https://darbyjohnston.github.io/DJV/"
   depends_on arch: :arm64
 
-  no_autobump! because: :requires_manual_review
-
   app "DJV.app"
 
   zap trash: [

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -9,6 +9,11 @@ cask "djv" do
   homepage "https://darbyjohnston.github.io/DJV/"
   depends_on arch: :arm64
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "DJV.app"
 
   zap trash: [

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -1,26 +1,21 @@
 cask "djv" do
-  version "2.0.8"
-  sha256 "5df641ad2eb27d2beb35ec6ebb05a1d2a14c2af19b65aee370a1eac6fa5ae056"
+  version "3.0.0"
+  sha256 "c5adbcb42f1c6b36e0031b6de9b7e1b3ffafbcb6b11abf5b4222a2b9320af3c9"
 
-  url "https://github.com/darbyjohnston/DJV/releases/download/#{version}/DJV-#{version}-Darwin.dmg",
+  url "https://github.com/darbyjohnston/DJV/releases/download/#{version}/DJV-#{version}-Darwin-arm64.dmg",
       verified: "github.com/darbyjohnston/DJV/"
-  name "DJV Imaging"
+  name "DJV"
   desc "Review software for VFX, animation, and film production"
   homepage "https://darbyjohnston.github.io/DJV/"
+  depends_on arch: :arm64
 
   no_autobump! because: :requires_manual_review
 
-  deprecate! date: "2024-11-17", because: :unmaintained
-
-  app "DJV#{version.major}.app"
+  app "DJV.app"
 
   zap trash: [
         "~/Documents/DJV/djv.log",
         "~/Library/Preferences/com.djv-sourceforge-net-*.plist",
       ],
       rmdir: "~/Documents/DJV"
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -7,12 +7,13 @@ cask "djv" do
   name "DJV"
   desc "Review software for VFX, animation, and film production"
   homepage "https://darbyjohnston.github.io/DJV/"
-  depends_on arch: :arm64
 
   livecheck do
     url :url
     strategy :github_latest
   end
+
+  depends_on arch: :arm64
 
   app "DJV.app"
 

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -16,7 +16,7 @@ cask "djv" do
   depends_on arch: :arm64
 
   app "DJV.app"
-  binary "#{appdir}/Contents/Resources/bin/djv"
+  binary "#{appdir}/DJV.app/Contents/Resources/bin/djv"
 
   zap trash: [
         "~/Documents/DJV/djv.log",

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -16,7 +16,6 @@ cask "djv" do
   depends_on arch: :arm64
 
   app "DJV.app"
-  binary "#{appdir}/DJV.app/Contents/Resources/bin/djv"
 
   zap trash: [
         "~/Documents/DJV/djv.log",

--- a/Casks/d/djv.rb
+++ b/Casks/d/djv.rb
@@ -16,7 +16,6 @@ cask "djv" do
   depends_on arch: :arm64
 
   app "DJV.app"
-  binary "#{appdir}/Contents/Resources/bin/djv"
 
   zap trash: [
         "~/Documents/DJV/djv.log",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Updates DJV to v3.0.0! :)