### PR TITLE
graalvm-jdk@21, oracle-jdk, oracle-jdk@21: update livechecks

### DIFF
--- a/Casks/g/graalvm-jdk@21.rb
+++ b/Casks/g/graalvm-jdk@21.rb
@@ -12,10 +12,13 @@ cask "graalvm-jdk@21" do
   homepage "https://www.graalvm.org/"
 
   livecheck do
-    url "https://docs.oracle.com/en/graalvm/jdk/21/docs/release-notes/"
-    regex(/<strong>v?(\d+(?:\.\d+)+)\+(\d+)[ "<]/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    url "https://java.oraclecloud.com/currentJavaReleases/#{version.major}"
+    regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
+    strategy :json do |json, regex|
+      match = json["releaseFullVersion"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]}"
     end
   end
 

--- a/Casks/o/oracle-jdk.rb
+++ b/Casks/o/oracle-jdk.rb
@@ -11,20 +11,9 @@ cask "oracle-jdk" do
   homepage "https://www.oracle.com/java/technologies/downloads/"
 
   livecheck do
-    url :homepage
-    regex(/<li>\s*JDK\s*v?(\d+(?:\.\d+)*)/i)
-    strategy :page_match do |page, regex|
-      major = page.scan(%r{href=.*?/javase/(\d+)u-relnotes\.html}i)
-                  .max_by { |match| Version.new(match[0]) }
-                  &.first
-      next if major.blank?
-
-      release_page = Homebrew::Livecheck::Strategy.page_content(
-        "https://www.oracle.com/java/technologies/javase/#{major}u-relnotes.html",
-      )
-      next if (release_page_content = release_page[:content]).blank?
-
-      release_page_content.scan(regex).map { |match| match[0] }
+    url "https://java.oraclecloud.com/currentJavaReleases"
+    strategy :json do |json|
+      json["items"]&.filter_map { |item| item["releaseVersion"] }
     end
   end
 

--- a/Casks/o/oracle-jdk@21.rb
+++ b/Casks/o/oracle-jdk@21.rb
@@ -11,8 +11,10 @@ cask "oracle-jdk@21" do
   homepage "https://www.oracle.com/java/technologies/downloads/"
 
   livecheck do
-    url "https://www.oracle.com/java/technologies/javase/#{version.major}u-relnotes.html"
-    regex(/<li>\s*JDK\s*v?(\d+(?:\.\d+)*)/i)
+    url "https://java.oraclecloud.com/currentJavaReleases/#{version.major}"
+    strategy :json do |json|
+      json["releaseVersion"]
+    end
   end
 
   depends_on macos: ">= :mojave"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Oracle has a [publicly documented API for fetching information about Java releases](https://docs.oracle.com/en-us/iaas/jms/doc/public-api-oracle-java-releases.html), let's use it.

I only started digging into this because the `graalvm-jdk` livecheck was failing and the HTML scraping behind it appeared incredibly fragile.

I haven't touched the `oracle-jdk-javadoc` casks because those also require an additional hash as part of the version string which isn't available from the API. Given those casks already use a two-stage livecheck, should I replace the HTML-scraping first stage with the new API?

Am I correct in assuming the `@17` variants of these casks shouldn't have a livecheck since they're marked for removal?