### PR TITLE
grafx: update livecheck

### DIFF
--- a/Casks/g/grafx.rb
+++ b/Casks/g/grafx.rb
@@ -40,6 +40,8 @@ cask "grafx" do
 
   app "Grafx#{version.major}.app"
 
+  zap trash: "~/Library/Preferences/com.googlecode.grafx2"
+
   caveats do
     requires_rosetta
   end

--- a/Casks/g/grafx.rb
+++ b/Casks/g/grafx.rb
@@ -24,11 +24,11 @@ cask "grafx" do
       next unless download_id
 
       # Fetch the headers for the download URL
-      download_headers = Homebrew::Livecheck::Strategy.page_headers("https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{download_id}")
-      next if download_headers.blank?
+      merged_headers = Homebrew::Livecheck::Strategy.page_headers(
+        "https://pulkomandy.tk/projects/GrafX#{version.major}/downloads/#{download_id}",
+      ).reduce(&:merge)
 
       # Match the version from the filename in the `Content-Disposition` header
-      merged_headers = download_headers.reduce(&:merge)
       version = merged_headers["content-disposition"]&.[](/Grafx\d+\.app.*?v?(\d+(?:\.\d+)+)/i, 1)
       next unless version
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This refactors the `livecheck` block for `grafx` to tidy up the `merged_headers` logic, bringing it in line with recent changes to `canon-eos-utility` (https://github.com/Homebrew/homebrew-cask/pull/219293). [To be clear, I already have the changes worked out for related `livecheck` blocks and I'm simply creating PRs for them as time permits.]