### PR TITLE
nao 0.4.1 (arm only)

### DIFF
--- a/Casks/n/nao.rb
+++ b/Casks/n/nao.rb
@@ -2,8 +2,8 @@ cask "nao" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "0.3.7"
-    sha256 "d83c13fc0ce6cd84c5fb8369e1631ce67bb2f467ff2db0cce003337d3b1de986"
+    version "0.4.1"
+    sha256 "ca01a475af58d06ebf9e9d98d21e98ab7241d8925e9d701b1839a0182f020eb9"
   end
   on_intel do
     version "0.3.6"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the ARM version for `nao` to 0.4.1, as the duplicate PR logic in `brew bump` is preventing the autobump workflow from handling newer versions for ARM while the Intel version remains on 0.3.6.