### PR TITLE
sqlcl 25.2.1.195.1751

### DIFF
--- a/Casks/s/sqlcl.rb
+++ b/Casks/s/sqlcl.rb
@@ -1,15 +1,15 @@
 cask "sqlcl" do
-  version "25.2.0.184.2054"
-  sha256 "7a3210bd78a48a7ef7e8353449c71ebf8c281e1148c840c554cfc286394a6898"
+  version "25.2.1.195.1751"
+  sha256 "d8be202824b0a368a9659f764c6fff299dfd2bc65cb90db2d80d160393bfdfec"
 
   url "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-#{version}.zip"
   name "sqlcl"
   desc "Oracle SQLcl is the modern command-line interface for the Oracle Database"
-  homepage "https://www.oracle.com/sqlcl"
+  homepage "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/"
 
   livecheck do
     url "https://www.oracle.com/database/sqldeveloper/technologies/sqlcl/download/"
-    regex(/p>Version.*?(\d+(?:\.\d+)+)/i)
+    regex(/href=.*?sqlcl[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   stage_only true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The autobump workflow isn't able to update `sqlcl` to the latest version because the existing homepage now returns a 404 (Not Found) response. This updates the homepage to the current URL while updating to the latest version, 25.2.1.195.1751.

Besides that, this also updates the `livecheck` block regex to match the version from the version in the zip file URL, which is more in line with typical patterns.