### PR TITLE
adding dependency of the beid-token to eid-viewer

### DIFF
--- a/Casks/e/eid-viewer.rb
+++ b/Casks/e/eid-viewer.rb
@@ -20,6 +20,7 @@ cask "eid-viewer" do
   end
 
   depends_on macos: ">= :high_sierra"
+  depends_on cask: "beid-token"
 
   app "eID Viewer.app"
   # No zap stanza required


### PR DESCRIPTION
To use your Belgian e-ID on the internet (log in with government stuff), you only need beid-token installed on your machine.

However, to use eid-viewer, you also need beid-token installed on your machine. Now that it has been merged, I can add the dependency :-)

