### PR TITLE
creative: update livecheck

### DIFF
--- a/Casks/c/creative.rb
+++ b/Casks/c/creative.rb
@@ -9,7 +9,7 @@ cask "creative" do
 
   livecheck do
     url "https://support.creative.com/Products/ProductDetails.aspx?catID=1&subCatID=1258&prodID=23677"
-    regex(/Creative\s(\d+(?:[._]\d)+)\sbuild\s(\d+(?:\d)+)+\.zip/i)
+    regex(/Creative\s+v?(\d+(?:[._]\d)+)\s+build\s+(\d+(?:\.\d+)*)\.zip/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block regex for `creative` contains an unusual `(\d+(?:\d)+)+` pattern that's intended to match the build number from text like "Creative 1.5.3 build 103.zip". This is flagged by code scanning as an inefficient regular expression and `\d+` would be sufficient here. I imagine this pattern was intended to be `(\d+(?:\.\d+)*)`, which is what we typically use when matching a number without dots (i.e., we allow for optional dots, so the regex doesn't break if upstream adds dots in the future).

This updates the regex accordingly, which may resolve the code scanning alert. Besides that, I've updated instances of `\s` to `\s+`, so the regex doesn't fail to match if the text contains more than one space at any point.