### PR TITLE
chore(cask): add caveats to Headlamp for unsigned macOS binary warning

### DIFF
--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -37,4 +37,17 @@ cask "headlamp" do
     "~/Library/Logs/Headlamp",
     "~/Library/Preferences/com.kinvolk.headlamp.plist",
   ]
+
+  caveats <<~EOS
+    ⚠️  MacOS may report Headlamp as being 'damaged' or 'corrupt'.
+
+    Code signing under Kubernetes/CNCF is still being finalized, after the
+    project's move under the Kubernetes SIG UI.
+
+    In the meantime, you may need to run:
+      xattr -dr com.apple.quarantine /Applications/Headlamp.app
+
+    For updates and full instructions, visit:
+      https://headlamp.dev/docs/latest/installation/desktop/
+  EOS
 end


### PR DESCRIPTION
Warn users that the app may be reported as 'damaged' due to lack of valid signature, with workaround instructions and link to official documentation.

https://github.com/kubernetes-sigs/headlamp/issues/3655

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
