### PR TITLE
wiso-steuer-2022: consistent app name

### DIFF
--- a/Casks/w/wiso-steuer-2022.rb
+++ b/Casks/w/wiso-steuer-2022.rb
@@ -24,7 +24,7 @@ cask "wiso-steuer-2022" do
   depends_on macos: ">= :mojave"
 
   # Renamed for consistency: app name differs in Finder to shell
-  app "SteuerMac 2022.app", target: "WISO Steuer-Mac 2022.app"
+  app "SteuerMac 2022.app", target: "WISO Steuer 2022.app"
 
   zap trash: [
     "~/Library/Application Support/BuhlData.com/WISOsteuerMac2022",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

- renamed app name of 2022 version for consistency (now, all apps are called 'WISO Steuer YYYY.app')