### PR TITLE
retroshare: update livecheck

### DIFF
--- a/Casks/r/retroshare.rb
+++ b/Casks/r/retroshare.rb
@@ -12,7 +12,7 @@ cask "retroshare" do
   # the `version` when necessary.
   livecheck do
     url "https://retroshare.cc/downloads.html"
-    regex(%r{/v?(\d+(?:\.\d+)+)/Retroshare[._-]v?(\d+(?:\.\d+)+[a-z]?)+(?:[._-]([^"' >]*?))?\.dmg}i)
+    regex(%r{/v?(\d+(?:\.\d+)+)/Retroshare[._-]v?(\d+(?:\.\d+)+[a-z]?)(?:[._-]([^"' >]*?))?\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         if match[2] && (match[0] != match[1])


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Code scanning has flagged the `livecheck` block regex for `retroshare` as an inefficient regular expression, specifically the `\d+` part of the `(\d+(?:\.\d+)+[a-z]?)+` group. We use `\d+(?:\.\d+)+[a-z]?` in other regexes without any issue, so this is either due to the regex having a preceding `(\d+(?:\.\d+)+)` group or because the aforementioned group is allowed to repeat and greedily (i.e., it has `+` on the end). From what I'm seeing in previous cask `version` values, it doesn't seem like that part of the regex needs to repeat (it works for the current filenames, at least), so let's make it non-repeating and see if that resolves the code scanning alert.