### PR TITLE
Install required external dependencies via virtualenv to make gcloud commands functions correctly

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -50,6 +50,20 @@ cask "gcloud-cli" do
     unless (latest_path = staged_path.dirname/"latest").directory?
       FileUtils.ln_s staged_path, latest_path, force: true
     end
+    # Install required external dependencies via virtualenv
+    if File.exist?(File.join(Dir.home, "/.config/gcloud/virtenv"))
+      puts "deleting existing virtual env before enabling virtual env with current Python version"
+      system_command "#{google_cloud_sdk_root}/bin/gcloud",
+                     args: ["config", "virtualenv", "delete", "-q"]
+    end
+    system_command  "#{google_cloud_sdk_root}/bin/gcloud",
+                    args: ["config", "virtualenv", "create", "--python-to-use",
+                           "#{HOMEBREW_PREFIX}/opt/python@3.12/libexec/bin/python3"]
+    system_command  "#{google_cloud_sdk_root}/bin/gcloud",
+                    args: ["config", "virtualenv", "enable"]
+
+    system_command  "#{google_cloud_sdk_root}/bin/gcloud",
+                    args: ["version"]
   end
 
   uninstall trash: staged_path.dirname/"latest"


### PR DESCRIPTION
We're using the `gcloud config virtualenv create` command to install essential external dependencies for gcloud commands function correctly, including grpcio, google_crc32c, cryptography, crcmode, pyopenssl, certifi, and setuptools. This installation ensures our environment stays consistent with a direct gcloud installation.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x ] `brew audit --cask --online <cask>` is error-free.
- [ x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x ] `brew audit --cask --new <cask>` worked successfully.
- [ x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ x] `brew uninstall --cask <cask>` worked successfully.

---
