### PR TITLE
ijhttp: enable autobumps again

### DIFF
--- a/Casks/i/ijhttp.rb
+++ b/Casks/i/ijhttp.rb
@@ -2,7 +2,7 @@ cask "ijhttp" do
   version "243.24978.46"
   sha256 "2fdbbf634a43fce0f6236597ea6815e6b88ff32ec893eeb355c33f59926ceeb1"
 
-  url "https://download.jetbrains.com/resources/intellij/http-client/#{version.major_minor_patch}/intellij-http-client.zip"
+  url "https://download.jetbrains.com/resources/intellij/http-client/#{version}/intellij-http-client.zip"
   name "IntelliJ HTTP Client CLI"
   desc "HTTP client from JetBrains IDEs available as a standalone CLI tool"
   homepage "https://www.jetbrains.com/ijhttp/download"
@@ -11,8 +11,6 @@ cask "ijhttp" do
     url "https://jb.gg/ijhttp/latest"
     strategy :header_match
   end
-
-  no_autobump! because: :requires_manual_review
 
   binary "ijhttp/ijhttp"
 


### PR DESCRIPTION
### Question

@botantony, why did you enable this option in the commit 98f18b7da60743a46e876bc44511d8938997b219?

I don't see any reason or justification in the commit.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
