### PR TITLE
elektron-overbridge 2.21.3

### DIFF
--- a/Casks/e/elektron-overbridge.rb
+++ b/Casks/e/elektron-overbridge.rb
@@ -1,17 +1,18 @@
 cask "elektron-overbridge" do
-  version "2.19.4,04,2025"
-  sha256 "df6185b93d33083b05f5ef5202f5afdb85fe18ecd2250486dbf9ae4354787eb9"
+  version "2.21.3,caf823ee-6ade-5704-9a60-e59196ab46b7"
+  sha256 "aa4b32ada6fdd0d5416bf6d0276842bdb8814d2f664acd7325c9fceadbaf8c3c"
 
-  url "https://elektron.se/wp-content/uploads/#{version.csv.third}/#{version.csv.second}/Elektron_Overbridge_#{version.csv.first}.dmg"
+  url "https://s3-eu-west-1.amazonaws.com/se-elektron-devops/release/#{version.csv.second}/Elektron_Overbridge_#{version.csv.first}.dmg",
+      verified: "s3-eu-west-1.amazonaws.com/se-elektron-devops/release/"
   name "Overbridge"
   desc "Integrate Elektron hardware into music software"
-  homepage "https://elektron.se/overbridge"
+  homepage "https://www.elektron.se/overbridge"
 
   livecheck do
-    url "https://elektron.se/support-downloads/overbridge"
-    regex(%r{uploads/(\d+)/(\d+)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
+    url "https://www.elektron.se/support-downloads/overbridge"
+    regex(%r{/([\h-]+)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[2]},#{match[1]},#{match[0]}" }
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `elektron-overbridge` to the latest version, 2.21.3. The cask is autobumped but it hasn't been updated to the newest version because the `livecheck` block isn't working.

The Mac link on the download page now points to a dmg file on S3 and the existing `livecheck` block regex no longer matches, so this brings it up to date with the new setup.

Besides that, this updates the homepage and `livecheck` block URLs to use www.elektron.se instead of elektron.se, to resolve the redirections.