### PR TITLE
tev 2.3.2

### DIFF
--- a/Casks/t/tev.rb
+++ b/Casks/t/tev.rb
@@ -2,20 +2,18 @@ cask "tev" do
   arch intel: "-intel"
 
   version "2.3.2"
-  sha256 arm:   "3d506f5b99d9dafc65d7bf784d3bcb0c4eab2440f4ace4089c47a7f22330cf1a",
-         intel: "392ad239912388f04b3521b91d7979148e3d11d9f09f4ae9a372f92e682670ee"
+  sha256 arm:   "3aee171b17e74c2bfe6ceb4bc504c2582dae58fc475dc6f8c4e6f140d3aa9a71",
+         intel: "4ca9bc5b8ce158668e32a6081f2290690cfd3b2d6716515bc235be09c1e911e6"
 
   url "https://github.com/Tom94/tev/releases/download/v#{version}/tev#{arch}.dmg"
   name "tev"
-  desc "HDR image comparison tool with an emphasis on OpenEXR images"
+  desc "High dynamic range (HDR) image viewer with accurate color management"
   homepage "https://github.com/Tom94/tev"
 
   livecheck do
     url :url
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
-
-  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
tev's 2.3.2 release's files were changed (added code signing and notarization), which broke the cask's hashes.

- Fixed sha256
- Removed disable! because binaries are now signed
- Updated `desc` field to upstream while I was at it

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
