### PR TITLE
various: update depends_on

### DIFF
--- a/Casks/b/brave-browser@nightly.rb
+++ b/Casks/b/brave-browser@nightly.rb
@@ -18,7 +18,7 @@ cask "brave-browser@nightly" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Brave Browser Nightly.app"
 

--- a/Casks/c/chromium.rb
+++ b/Casks/c/chromium.rb
@@ -11,7 +11,7 @@ cask "chromium" do
   homepage "https://www.chromium.org/Home"
 
   conflicts_with cask: "ungoogled-chromium"
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "chrome-mac/Chromium.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/c/chromium.rb
+++ b/Casks/c/chromium.rb
@@ -10,6 +10,8 @@ cask "chromium" do
   desc "Free and open-source web browser"
   homepage "https://www.chromium.org/Home"
 
+  disable! date: "2026-09-01", because: :unsigned
+
   conflicts_with cask: "ungoogled-chromium"
   depends_on macos: ">= :monterey"
 

--- a/Casks/g/google-chrome@beta.rb
+++ b/Casks/g/google-chrome@beta.rb
@@ -17,7 +17,7 @@ cask "google-chrome@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Google Chrome Beta.app"
 

--- a/Casks/g/google-chrome@canary.rb
+++ b/Casks/g/google-chrome@canary.rb
@@ -17,7 +17,7 @@ cask "google-chrome@canary" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Google Chrome Canary.app"
 

--- a/Casks/g/google-chrome@dev.rb
+++ b/Casks/g/google-chrome@dev.rb
@@ -17,7 +17,7 @@ cask "google-chrome@dev" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Google Chrome Dev.app"
 

--- a/Casks/m/microsoft-edge@beta.rb
+++ b/Casks/m/microsoft-edge@beta.rb
@@ -19,7 +19,7 @@ cask "microsoft-edge@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Microsoft Edge Beta.app"
 

--- a/Casks/m/microsoft-edge@canary.rb
+++ b/Casks/m/microsoft-edge@canary.rb
@@ -19,7 +19,7 @@ cask "microsoft-edge@canary" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Microsoft Edge Canary.app"
 

--- a/Casks/m/microsoft-edge@dev.rb
+++ b/Casks/m/microsoft-edge@dev.rb
@@ -19,7 +19,7 @@ cask "microsoft-edge@dev" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Microsoft Edge Dev.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The Chromium project has announced that [starting with Chr 139](https://chromestatus.com/feature/4504090090143744), support for macOS 11 will be removed. This PR updates the `depends_on` stanza for those that are already based on that version (or a higher one).