### PR TITLE
various: disable deprecated casks

### DIFF
--- a/Casks/c/camera-live.rb
+++ b/Casks/c/camera-live.rb
@@ -10,6 +10,7 @@ cask "camera-live" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :discontinued
+  disable! date: "2025-07-28", because: :discontinued
 
   app "Camera Live.app"
 

--- a/Casks/i/insomnium.rb
+++ b/Casks/i/insomnium.rb
@@ -10,6 +10,7 @@ cask "insomnium" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :discontinued
+  disable! date: "2025-07-28", because: :discontinued
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/p/panda.rb
+++ b/Casks/p/panda.rb
@@ -10,6 +10,7 @@ cask "panda" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   auto_updates true
 

--- a/Casks/p/pdfshaver.rb
+++ b/Casks/p/pdfshaver.rb
@@ -10,6 +10,7 @@ cask "pdfshaver" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "PDFShaver.app"
 

--- a/Casks/p/pennywise.rb
+++ b/Casks/p/pennywise.rb
@@ -9,6 +9,7 @@ cask "pennywise" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "Pennywise.app"
 

--- a/Casks/p/pineapple.rb
+++ b/Casks/p/pineapple.rb
@@ -10,6 +10,7 @@ cask "pineapple" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "Pineapple.app"
 

--- a/Casks/p/playback.rb
+++ b/Casks/p/playback.rb
@@ -11,6 +11,7 @@ cask "playback" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "Playback.app"
 

--- a/Casks/p/pngyu.rb
+++ b/Casks/p/pngyu.rb
@@ -10,6 +10,7 @@ cask "pngyu" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "Pngyu.app"
 

--- a/Casks/p/podcastmenu.rb
+++ b/Casks/p/podcastmenu.rb
@@ -10,6 +10,7 @@ cask "podcastmenu" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   auto_updates true
   depends_on macos: ">= :el_capitan"

--- a/Casks/p/processing@3.rb
+++ b/Casks/p/processing@3.rb
@@ -11,6 +11,7 @@ cask "processing@3" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   conflicts_with cask: "processing"
 

--- a/Casks/q/qsyncthingtray.rb
+++ b/Casks/q/qsyncthingtray.rb
@@ -10,6 +10,7 @@ cask "qsyncthingtray" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :unmaintained
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "QSyncthingTray.app"
 

--- a/Casks/r/remix-ide.rb
+++ b/Casks/r/remix-ide.rb
@@ -11,6 +11,7 @@ cask "remix-ide" do
   no_autobump! because: :requires_manual_review
 
   deprecate! date: "2024-07-28", because: :discontinued
+  disable! date: "2025-07-28", because: :unmaintained
 
   app "Remix IDE.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Disables casks after the 1 year deprecation period.