### PR TITLE
secure-pipes: update livecheck

### DIFF
--- a/Casks/s/secure-pipes.rb
+++ b/Casks/s/secure-pipes.rb
@@ -25,7 +25,7 @@ cask "secure-pipes" do
     end
   end
 
-  no_autobump! because: :requires_manual_review
+  disable! date: "2026-09-01", because: :unsigned
 
   app "Secure Pipes.app"
 

--- a/Casks/s/secure-pipes.rb
+++ b/Casks/s/secure-pipes.rb
@@ -11,15 +11,14 @@ cask "secure-pipes" do
     url :homepage
     regex(/filename.*?Secure\s+Pipes\s+v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :page_match do |page, regex|
-      download_hash = page.scan(%r{opoet.com/pyro/index.php/files/download/(.+)["'< ]}i).flatten.first
+      download_hash = page.scan(%r{opoet\.com/pyro/index.php/files/download/(.+)["'< ]}i).flatten.first
       next if download_hash.blank?
 
-      download_url = "https://www.opoet.com/pyro/index.php/files/download/#{download_hash}"
+      merged_headers = Homebrew::Livecheck::Strategy.page_headers(
+        "https://www.opoet.com/pyro/index.php/files/download/#{download_hash}",
+      ).reduce(&:merge)
 
-      headers = Homebrew::Livecheck::Strategy.page_headers(download_url)
-      next if headers.blank?
-
-      match = headers.first["content-disposition"]&.match(regex)
+      match = merged_headers["content-disposition"]&.match(regex)
       next if match.blank?
 
       "#{match[1]},#{download_hash}"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the existing `livecheck` block for `secure-pipes` to merge the response headers from `page_headers` (like the `HeaderMatch` strategy does) instead of relying on the first response always being the one that contains the `Content-Disposition` header we want.