### PR TITLE
Disable font-moralerspace-nf & font-moralerspace-hw-nf

### DIFF
--- a/Casks/font/font-m/font-moralerspace-hw-nf.rb
+++ b/Casks/font/font-m/font-moralerspace-hw-nf.rb
@@ -8,6 +8,8 @@ cask "font-moralerspace-hw-nf" do
 
   no_autobump! because: :requires_manual_review
 
+  disable! date: "2025-07-29", because: :discontinued, replacement_cask: "font-moralerspace-hw"
+
   font "MoralerspaceHWNF_v#{version}/MoralerspaceArgonHWNF-Bold.ttf"
   font "MoralerspaceHWNF_v#{version}/MoralerspaceArgonHWNF-BoldItalic.ttf"
   font "MoralerspaceHWNF_v#{version}/MoralerspaceArgonHWNF-Italic.ttf"

--- a/Casks/font/font-m/font-moralerspace-nf.rb
+++ b/Casks/font/font-m/font-moralerspace-nf.rb
@@ -8,6 +8,8 @@ cask "font-moralerspace-nf" do
 
   no_autobump! because: :requires_manual_review
 
+  disable! date: "2025-07-29", because: :discontinued, replacement_cask: "font-moralerspace"
+
   font "MoralerspaceNF_v#{version}/MoralerspaceArgonNF-Bold.ttf"
   font "MoralerspaceNF_v#{version}/MoralerspaceArgonNF-BoldItalic.ttf"
   font "MoralerspaceNF_v#{version}/MoralerspaceArgonNF-Italic.ttf"


### PR DESCRIPTION
Moralerspace v2.0.0 removed Nerd Font (NF) variants from releases, as their regular variants now include Nerd Font glyphs. This disables the corresponding casks `font-moralerspace-nf` and `font-moralerspace-hw-nf` which are no longer distributed upstream.
https://github.com/yuru7/moralerspace/releases/tag/v2.0.0
