### PR TITLE
gisto: add livecheck

### DIFF
--- a/Casks/g/gisto.rb
+++ b/Casks/g/gisto.rb
@@ -16,6 +16,10 @@ cask "gisto" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :unsigned
+
+  depends_on macos: ">= :high_sierra"
+
   app "Gisto.app"
 
   zap trash: [

--- a/Casks/g/gisto.rb
+++ b/Casks/g/gisto.rb
@@ -11,6 +11,11 @@ cask "gisto" do
   desc "Snippets management desktop application"
   homepage "https://www.gisto.org/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Gisto.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `gisto` and it's returning 2.2.6 as newest but it's been two days since the tag was created and there's no release on GitHub yet. This adds a `livecheck` block that uses the `GithubLatest` strategy, as there can be a notable gap between the tag and release.