### PR TITLE
mkvtoolnix-app 94.0

### DIFF
--- a/Casks/m/mkvtoolnix-app.rb
+++ b/Casks/m/mkvtoolnix-app.rb
@@ -16,8 +16,8 @@ cask "mkvtoolnix-app" do
     sha256 "bb6d0ba4e0052b2831de0ae29ef3d0d4c7b4d0933b258455c248c1a1c5f913a0"
   end
   on_catalina :or_newer do
-    version "93.0"
-    sha256 "4e98448e9e2bbe8bf5cb370ff922b75ceba15740b00815c2c17ef6caafd5aa04"
+    version "94.0"
+    sha256 "a3092ddfc240693b69aea5198196fd5c4115b4834ebb8bceebd01b8119d98cc2"
   end
 
   url "https://mkvtoolnix.download/macos/MKVToolNix-#{version}.dmg"
@@ -29,6 +29,8 @@ cask "mkvtoolnix-app" do
     url "https://mkvtoolnix.download/macos/"
     regex(%r{href=.*?/MKVToolNix-(\d+(?:\.\d+)+)\.dmg}i)
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   conflicts_with formula: "mkvtoolnix"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mkvtoolnix-app` is autobumped but the autobump workflow is failing to update to version 94.0 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.