### PR TITLE
olympus 4978

### DIFF
--- a/Casks/o/olympus.rb
+++ b/Casks/o/olympus.rb
@@ -1,6 +1,6 @@
 cask "olympus" do
-  version "4923"
-  sha256 "a8d2cbfc1129d5b3293996b6736a2a9863027a2ae3936875c9b63ae516f096fb"
+  version "4978"
+  sha256 "757d51aec461b0f52c7d210437211351f717a13ef4f3b6ce70e0869bc8de04bd"
 
   url "https://dev.azure.com/EverestAPI/Olympus/_apis/build/builds/#{version}/artifacts?artifactName=macos.main&$format=zip",
       verified: "dev.azure.com/EverestAPI/Olympus/_apis/build/builds/"
@@ -16,6 +16,8 @@ cask "olympus" do
       end
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   container nested: "macos.main/dist.zip"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`olympus` is autobumped but the autobump workflow is failing to update to version 4978 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.