### PR TITLE
qview 7.1

### DIFF
--- a/Casks/q/qview.rb
+++ b/Casks/q/qview.rb
@@ -1,11 +1,18 @@
 cask "qview" do
-  version "7.0"
-  sha256 "87a27f000dff7aed3e63a3da55a0a0f33637aec3b29556e5283de7a3e393a58b"
+  version "7.1"
+  sha256 "fa34d0e54601b8557f4e879527b9bb1e728ace5c7c1c69cf126700ca4d0b5817"
 
   url "https://github.com/jurplel/qView/releases/download/#{version}/qView-#{version}.dmg"
   name "qView"
   desc "Image viewer"
   homepage "https://github.com/jurplel/qView/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`qview` is autobumped but the autobump workflow is failing to update to version 7.1 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation. This also adds a `livecheck` block to ensure that the cask is still checked for new versions,  otherwise this will be skipped as deprecated (since `disable!` acts as a deprecation before reaching the disable date).