### PR TITLE
uvtools 5.1.6

### DIFF
--- a/Casks/u/uvtools.rb
+++ b/Casks/u/uvtools.rb
@@ -1,14 +1,22 @@
 cask "uvtools" do
   arch arm: "arm64", intel: "x64"
 
-  version "5.1.5"
-  sha256 arm:   "c051d9f1c970b3b4089984b9a3681701f7d1e832577cdc509f838c4ef0012538",
-         intel: "18818ff7250ea8a5d962f3adb866172c8118cadc5d37c2fa6e5f85054ffc0601"
+  version "5.1.6"
+  sha256 arm:   "3eb2aff8d50921dc0e060c41f56fd88842ac0f507c8b4f603a733554f3f960aa",
+         intel: "feed014fe1e82a1eed3ca59f67207adba31cb993bea3cc248ca28be1a430e2fa"
 
   url "https://github.com/sn4k3/UVtools/releases/download/v#{version}/UVtools_osx-#{arch}_v#{version}.zip"
   name "UVtools"
   desc "MSLA/DLP, file analysis, calibration, repair, conversion and manipulation"
   homepage "https://github.com/sn4k3/UVtools"
+
+  # This simply ensures that the cask continues to be checkable despite the
+  # implicit deprecation from the `disable!` call.
+  livecheck do
+    url :url
+  end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   auto_updates true
   depends_on macos: ">= :catalina"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`uvtools` is autobumped but the autobump workflow is failing to update to version 5.1.6 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation. This also adds a `livecheck` block to ensure that the cask is still checked for new versions,  otherwise this will be skipped as deprecated (since `disable!` acts as a deprecation before reaching the disable date).