### PR TITLE
finch: remove deprecated status

### DIFF
--- a/Casks/f/finch.rb
+++ b/Casks/f/finch.rb
@@ -15,8 +15,6 @@ cask "finch" do
     strategy :git
   end
 
-  disable! date: "2026-09-01", because: :unsigned
-
   pkg "Finch-v#{version}-#{arch}.pkg"
 
   uninstall script: {


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

We had an issue with our automated notarization process for finch v1.10.1. The issue has been fixed and the packages are properly notarized now.


As far as I understand, `brew audit` is running against the published version of the cask which shows that they are properly signed.

```
$ brew audit --cask --online finch 
==> Downloading and extracting artifacts
==> Downloading https://github.com/runfinch/finch/releases/download/v1.10.1/Finch-v1.10.1-aarch64.pkg
Already downloaded: /Users/walster/Library/Caches/Homebrew/downloads/aeff71e7e97fc275cd70681997114eb134fe59da01595d7fcdc2687eb24d28ad--Finch-v1.10.1-aarch64.pkg
==> Downloading https://github.com/runfinch/finch/releases/download/v1.10.1/Finch-v1.10.1-aarch64.pkg
Already downloaded: /Users/walster/Library/Caches/Homebrew/downloads/aeff71e7e97fc275cd70681997114eb134fe59da01595d7fcdc2687eb24d28ad--Finch-v1.10.1-aarch64.pkg
audit for finch: failed
 - Cask is deprecated as unsigned but artifacts are signed!
```