### PR TITLE
pale-moon: update livecheck

### DIFF
--- a/Casks/p/pale-moon.rb
+++ b/Casks/p/pale-moon.rb
@@ -8,8 +8,9 @@ cask "pale-moon" do
   homepage "https://www.palemoon.org/"
 
   livecheck do
-    url "https://repo.palemoon.org/MoonchildProductions/Pale-Moon.git"
-    regex(/^v?(\d+(?:\.\d+)+)[._-]Release$/i)
+    url "https://www.palemoon.org/download.php?mirror=us&bits=64&type=macarm"
+    regex(/palemoon[._-]v?(\d+(?:\.\d+)+)/i)
+    strategy :header_match
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `pale-moon` checks the Git repository tags but this can cause a version to be surfaced before the related dmg file is available from the website and this recently happened in the autobump workflow with 33.8.1. This updates the `livecheck` block to use the `HeaderMatch` strategy to check the `Location` header of the download URL, as it redirects to the latest dmg file.