### PR TITLE
schism-tracker 20250728

### DIFF
--- a/Casks/s/schism-tracker.rb
+++ b/Casks/s/schism-tracker.rb
@@ -1,11 +1,18 @@
 cask "schism-tracker" do
-  version "20250415"
-  sha256 "d531ecf95b4a06b83975aff00d7311ffb32d4dd04dfcd0f22af0fbcdb8d3ad72"
+  version "20250728"
+  sha256 "da183ba39ae38fe1fb4b2bdcb036b3487beb77bb67d0c54e9c9b437a00449a0f"
 
   url "https://github.com/schismtracker/schismtracker/releases/download/#{version}/schismtracker-#{version}-macos.zip"
   name "Schism Tracker"
   desc "Oldschool sample-based music composition tool"
   homepage "https://github.com/schismtracker/schismtracker"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
+  end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   app "Schism Tracker.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`schism-tracker` is autobumped but the autobump workflow is failing to update to version 20250728 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation. This also adds a `livecheck` block to ensure that the cask will continue to be updated and to avoid various Git tags in the repository that we don't want to match (but are currently matched by the default `Git` strategy regex).