### PR TITLE
dcp-o-matic: disable

### DIFF
--- a/Casks/d/dcp-o-matic-batch-converter.rb
+++ b/Casks/d/dcp-o-matic-batch-converter.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-batch-converter" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Batch converter.app"
 

--- a/Casks/d/dcp-o-matic-combiner.rb
+++ b/Casks/d/dcp-o-matic-combiner.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-combiner" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Combiner.app"
 

--- a/Casks/d/dcp-o-matic-disk-writer.rb
+++ b/Casks/d/dcp-o-matic-disk-writer.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-disk-writer" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Disk Writer.app"
 

--- a/Casks/d/dcp-o-matic-editor.rb
+++ b/Casks/d/dcp-o-matic-editor.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-editor" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Editor.app"
 

--- a/Casks/d/dcp-o-matic-encode-server.rb
+++ b/Casks/d/dcp-o-matic-encode-server.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-encode-server" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Encode Server.app"
 

--- a/Casks/d/dcp-o-matic-kdm-creator.rb
+++ b/Casks/d/dcp-o-matic-kdm-creator.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-kdm-creator" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} KDM Creator.app"
 

--- a/Casks/d/dcp-o-matic-player.rb
+++ b/Casks/d/dcp-o-matic-player.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-player" do
   desc "Play Digital Cinema Packages"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Player.app"
 

--- a/Casks/d/dcp-o-matic-playlist-editor.rb
+++ b/Casks/d/dcp-o-matic-playlist-editor.rb
@@ -7,9 +7,7 @@ cask "dcp-o-matic-playlist-editor" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    cask "dcp-o-matic"
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major} Playlist Editor.app"
 

--- a/Casks/d/dcp-o-matic.rb
+++ b/Casks/d/dcp-o-matic.rb
@@ -7,10 +7,7 @@ cask "dcp-o-matic" do
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  livecheck do
-    url "https://dcpomatic.com/download"
-    regex(/stable\s*release:\s*(\d+(?:\.\d+)+)/i)
-  end
+  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
 
   app "DCP-o-matic #{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

dcpomatic.com now has stronger Cloudflare protections enabled and this has rendered the DCP-o-matic casks unusable. Attempts to download the apps return a 403 (Forbidden) response, so this disables the casks accordingly.