### PR TITLE
blitz-gg 2.1.360

### DIFF
--- a/Casks/b/blitz-gg.rb
+++ b/Casks/b/blitz-gg.rb
@@ -1,6 +1,6 @@
 cask "blitz-gg" do
-  version "2.1.359"
-  sha256 "99b192cc8c732624b1359122b1bb6b2928f4451e12ae0cfacfe48fc4f4aaa55d"
+  version "2.1.360"
+  sha256 "5874bf3a1555c83c4c3802081fb2a3d831224c48248136f675b70bbc777cb859"
 
   url "https://blitz-main.blitz.gg/Blitz-x64-#{version}.dmg"
   name "Blitz"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`blitz-gg` is autobumped but a recent workflow run failed to update the cask to 2.1.360 due to a timeout when fetching the dmg. This manually updates the cask, simply to keep things moving forward.