### PR TITLE
geogebra 6.0.894.2

### DIFF
--- a/Casks/g/geogebra.rb
+++ b/Casks/g/geogebra.rb
@@ -1,6 +1,6 @@
 cask "geogebra" do
-  version "6.0.893.2"
-  sha256 "db622331fb2196736b40d8ee15678c542a3b9663ac47221b256e656051fd7828"
+  version "6.0.894.2"
+  sha256 "ba2a245dbd4ce323be47ad4dca477bcb7fa755fd674517befcc30e66cd6aaee6"
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-Classic-#{version.major}-MacOS-Portable-#{version.dots_to_hyphens}.zip"
   name "GeoGebra"
@@ -17,6 +17,8 @@ cask "geogebra" do
       match[1].tr("-", ".")
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`geogebra` is autobumped but the autobump workflow is failing to update to version 6.0.894.2 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.