### PR TITLE
geogebra@5 5.2.894.2

### DIFF
--- a/Casks/g/geogebra@5.rb
+++ b/Casks/g/geogebra@5.rb
@@ -1,6 +1,6 @@
 cask "geogebra@5" do
-  version "5.2.893.2"
-  sha256 "0942b08de850c4cf9bdeaeb4da5d7c2fab3f1892a7b6ed59f8f2ab6e3a2a5909"
+  version "5.2.894.2"
+  sha256 "79caffb618dd3eea11421107fa1611ab7451b4b14e0425aab3abfb0b7eb044dc"
 
   url "https://download.geogebra.org/installers/#{version.major_minor}/GeoGebra-MacOS-Installer-withJava-#{version.dots_to_hyphens}.zip"
   name "GeoGebra"
@@ -17,6 +17,8 @@ cask "geogebra@5" do
       match[1].tr("-", ".")
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   app "Geogebra.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`geogebra@5` is autobumped but the autobump workflow is failing to update to version 5.2.894.2 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.