### PR TITLE
insta360-studio 5.7.0

### DIFF
--- a/Casks/i/insta360-studio.rb
+++ b/Casks/i/insta360-studio.rb
@@ -1,8 +1,8 @@
 cask "insta360-studio" do
-  version "5.6.4,release_insta360,RC_build65,_20250630_151425_signed_1751267755970,a028cfd724beaf477ca68bd74321cc2a"
-  sha256 "8b353d9cdf254a87b6e0c9d180688000fa008336e0c5220672fa7ad70ebe9b9d"
+  version "5.7.0,release_insta360,RC_build17,_20250715_131847_signed_1752569382856,d5026524a1db23b06457626fc5549f86"
+  sha256 "098f962abe44ed4fc6cca66a35cd963c2743c8ac93e2585c84bf0cccfc70cc98"
 
-  url "https://file.insta360.com/static/#{version.csv.fifth}/Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.pkg"
+  url "https://file.insta360.com/static/#{version.csv.fifth}/Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.zip"
   name "Insta360 Studio"
   desc "Video and photo editor"
   homepage "https://www.insta360.com/"
@@ -15,8 +15,7 @@ cask "insta360-studio" do
   # that may be beta, RC, etc.
   livecheck do
     url "https://openapi.insta360.com/app/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
-    regex(%r{/(\h+)/Insta360(?:%20)?Studio(?:[._-]|%20)v?(?:\d+(?:\.\d+)+)[._-](.+)\.pkg}i)
-
+    regex(%r{/(\h+)/Insta360(?:%20)?Studio(?:[._-]|%20)v?(\d+(?:\.\d+)+)[._-](.+)\.(?:pkg|zip)}i)
     strategy :json do |json, regex|
       # Find the Insta360 Studio app
       app = json.dig("data", "apps")&.find { |item| item["app_id"] == 38 }
@@ -31,14 +30,14 @@ cask "insta360-studio" do
       channel = newest_release["channels"]&.find { |item| item["channel"] == "official" }
       next if channel.blank?
 
-      # Collect the version parts
-      version = newest_release["version"]
       match = channel["download_url"]&.match(regex)
-      next if version.blank? || match.blank?
+      next if match.blank?
 
-      "#{version},#{match[2].tr("()", ",")},#{match[1]}"
+      "#{match[2]},#{match[3].tr("()", ",")},#{match[1]}"
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   pkg "Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.pkg"
 

--- a/Casks/i/insta360-studio.rb
+++ b/Casks/i/insta360-studio.rb
@@ -37,9 +37,8 @@ cask "insta360-studio" do
     end
   end
 
-  disable! date: "2026-09-01", because: :unsigned
-
-  pkg "Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.pkg"
+  # FIXME: Change _20250715_131847_signed_1752556803354 back to #{version.csv.fourth} on the next release
+  pkg "Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})_20250715_131847_signed_1752556803354.pkg"
 
   uninstall quit:    "com.insta360.studio",
             pkgutil: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `insta360-studio` to the latest version, 5.7.0.

The `livecheck` block was broken partly because upstream switched from a pkg file to a zip but also because the newest channel object doesn't provide a `version` value. This updates the `livecheck` block regex to match zip files and capture the version from the filename, using that information in the `strategy` block in place of the previous `version` value.

Besides that, the app is unsigned, so this adds a `disable!` call with the future date we've been using for this situation.