### PR TITLE
invesalius: add livecheck

### DIFF
--- a/Casks/i/invesalius.rb
+++ b/Casks/i/invesalius.rb
@@ -10,6 +10,13 @@ cask "invesalius" do
   desc "3D medical imaging reconstruction software"
   homepage "https://github.com/invesalius/invesalius3/"
 
+  # Upstream marks some versions with a seemingly stable version format as
+  # pre-release on GitHub, so it's necessary to check releases instead of tags.
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   disable! date: "2026-09-01", because: :unsigned
 
   app "InVesalius.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`invesalius` is implicitly deprecated because it has a `disable!` call with a future date, so livecheck skips it as deprecated. This adds a `livecheck` block to ensure that livecheck will continue checking it in the mean time. I've used the `GithubLatest` strategy, as some of the tags with a seemingly stable version format are marked as "pre-release" on GitHub, so checking the tags isn't sufficient.