### PR TITLE
millie 2.5.5

### DIFF
--- a/Casks/m/millie.rb
+++ b/Casks/m/millie.rb
@@ -1,6 +1,6 @@
 cask "millie" do
-  version "2.5.3"
-  sha256 "0ed59cf448a82d9e566548cc2ade4530e436cd7064119b6839cb36b24ac797cd"
+  version "2.5.5"
+  sha256 "4dcff1052c63e33d7c3be261ae16f9a4b8f0101c0758e942bf1b2b29c9ad4615"
 
   url "https://install.millie.co.kr/flutter/#{version}/millie.dmg"
   name "Millie"
@@ -10,11 +10,7 @@ cask "millie" do
   livecheck do
     url "https://install.millie.co.kr/flutter/flutter_desktop_version.json"
     strategy :json do |json|
-      json["versions"]&.map do |version, platforms|
-        next if platforms["macos"] != "prod"
-
-        version
-      end
+      json.dig("min", "macos")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `millie` to the latest version, 2.5.5. `millie` is autobumped but the workflow hasn't been able to update to newer versions because the version returned from livecheck is outdated.

The existing `livecheck` block has been returning 2.4.1 as the newest version because the `versions` object in the JSON hasn't been updated to contain versions beyond 2.4.1. This updates the `livecheck` block to use the `macos` value in the `min` object, which correctly lists 2.5.5 as newest (corresponding to the app version in the unversioned dmg on the download page).