### PR TITLE
openshot-video-editor@daily 3.4.0,14124-6cea273b-0b018e34,release-candidate

### DIFF
--- a/Casks/o/openshot-video-editor@daily.rb
+++ b/Casks/o/openshot-video-editor@daily.rb
@@ -1,8 +1,8 @@
 cask "openshot-video-editor@daily" do
-  version "3.3.0,13909-7b4e9992-5bd5f2da"
-  sha256 "874a2c689eb6ac4bfa46a78a006b170892fc929a1145af7954d41750cdbdf118"
+  version "3.4.0,14124-6cea273b-0b018e34,release-candidate"
+  sha256 "66e6826df26ab01d378eccc00eb7f71b213b3f314195f30286a1c0abaf028aa7"
 
-  url "https://github.com/OpenShot/openshot-qt/releases/download/daily/OpenShot-v#{version.csv.first}-daily-#{version.csv.second}-x86_64.dmg",
+  url "https://github.com/OpenShot/openshot-qt/releases/download/daily/OpenShot-v#{version.csv.first}-#{version.csv.third || "daily"}-#{version.csv.second}-x86_64.dmg",
       verified: "github.com/OpenShot/openshot-qt/"
   name "OpenShot Video Editor (Daily Build)"
   desc "Cross-platform video editor"
@@ -10,9 +10,14 @@ cask "openshot-video-editor@daily" do
 
   livecheck do
     url "https://www.openshot.org/download/"
-    regex(/OpenShot[._-]v?(\d+(?:\.\d+)+)(?:[._-]dev)?[._-]daily[._-](.*)[._-]x86[._-]64\.dmg"/i)
+    regex(/
+      href=.*?OpenShot[._-]v?(\d+(?:\.\d+)+)
+      [._-]((?:dev-)?daily|release-candidate)[._-](.*)[._-]x86[._-]64\.dmg["' >]
+    /ix)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      page.scan(regex).map do |match|
+        (match[1] == "daily") ? "#{match[0]},#{match[2]}" : "#{match[0]},#{match[2]},#{match[1]}"
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The newest daily builds of OpenShot use a file format like OpenShot-v3.4.0-release-candidate-14124-6cea273b-0b018e34-x86_64.dmg, so they use a `-release-candidate` suffix instead of `-daily`. This updates `openshot-video-editor@daily` to the newest daily build, updating the `url` and `livecheck` block accordingly to handle this alternative suffix. With this setup, the suffix is only included as the third `version` part if it's something other than `-daily`.

Alternatively, we could adjust the second capture group of the regex to always capture that part of the suffix (e.g., `dev-daily-12745-d906231c-23713d3a`, `daily-13626-6722bc09-3f12f483`, `release-candidate-14124-6cea273b-0b018e34`). That would allow us to avoid the conditional logic in the `url` and `strategy` block but the `version` string will be a little longer if/when upstream returns to the `-daily` suffix. I don't have a strong preference either way and I'm open to opinions.