### PR TITLE
timecamp: fix sha256, add minimum macOS version

### DIFF
--- a/Casks/t/timecamp.rb
+++ b/Casks/t/timecamp.rb
@@ -1,6 +1,6 @@
 cask "timecamp" do
   version "1.8.0.0"
-  sha256 "4989d37fc2805d67245111ec725bc0a69e2b5af2b39895fc296ed439e74e6dfa"
+  sha256 "2bba2a29157f4f18802296ad4807db001bb2f06f7a66b831254049615086623e"
 
   url "https://timecamp.s3.amazonaws.com/downloadsoft/#{version}/TimeCampSetup_macOS.dmg",
       verified: "timecamp.s3.amazonaws.com/"
@@ -13,7 +13,7 @@ cask "timecamp" do
     strategy :header_match
   end
 
-  no_autobump! because: :requires_manual_review
+  depends_on macos: ">= :high_sierra"
 
   app "TimeCamp.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
