### PR TITLE
thunder 5.80.0.66533

### DIFF
--- a/Casks/t/thunder.rb
+++ b/Casks/t/thunder.rb
@@ -1,6 +1,6 @@
 cask "thunder" do
-  version "5.80.0.66529"
-  sha256 "7b4cfb1e90becf100001562772892949d5a4634f18c612c981d7877f8c1ac174"
+  version "5.80.0.66533"
+  sha256 "cfc7a9166283121569c867529bcbc6e78d8e4131ea02e36f5d9e321a89a57335"
 
   url "https://down.sandai.net/mac/thunder_#{version}.dmg",
       verified: "down.sandai.net/mac/"
@@ -31,8 +31,4 @@ cask "thunder" do
     "~/Library/Saved Application State/com.xunlei.XLPlayer.savedState",
     "~/Library/WebKit/com.xunlei.Thunder",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `thunder` to the latest version and removes the Rosetta caveat, as this version is a Universal binary like previous releases. There must have been a temporary issue in the 5.80.0.66529 release, as that version was Intel-only (which triggered the Rosetta audit).