### PR TITLE
visual-studio-code 1.102.3

### DIFF
--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -12,8 +12,8 @@ cask "visual-studio-code" do
   end
   on_big_sur :or_newer do
     version "1.102.3"
-    sha256 arm:   "73ae20079b7453482581c7cc942bd5069850debb17ef9f2f09414f54d5aa4c96",
-           intel: "74fb52b4b726166f597f7811633ff7eea1ef5778447d5de75bf37b4d58c8f01f"
+    sha256 arm:   "dbd8bffa6cf43425346423beb7395b4a5d622b1e7f1fcf5b1904ef451e7f3ee0",
+           intel: "3ab0eecd268fc6e79d852db51f1d4f3536e9e9e4297c57d46ced39808bb93aef"
 
     livecheck do
       url "https://update.code.visualstudio.com/api/update/#{arch}/stable/latest"

--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -11,7 +11,7 @@ cask "visual-studio-code" do
     end
   end
   on_big_sur :or_newer do
-    version "1.102.2"
+    version "1.102.3"
     sha256 arm:   "73ae20079b7453482581c7cc942bd5069850debb17ef9f2f09414f54d5aa4c96",
            intel: "74fb52b4b726166f597f7811633ff7eea1ef5778447d5de75bf37b4d58c8f01f"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---

This updates Visual Studio Code to version 1.102.3, which is the June 2025 Recovery 3 release.