### PR TITLE
semeru-jdk-open@8 8u462-b08

### DIFF
--- a/Casks/s/semeru-jdk-open@8.rb
+++ b/Casks/s/semeru-jdk-open@8.rb
@@ -1,6 +1,6 @@
 cask "semeru-jdk-open@8" do
-  version "8u452-b09,openj9-0.51.0"
-  sha256 "76a647efee5c0d38ba0a4b928a4e7390968b1472c77306c01b91f46f748ca09e"
+  version "8u462-b08,openj9-0.53.0"
+  sha256 "5316e041f6e803d8231e9418bee799cb95ed29d6a2466a4ada11fa47eec9cb33"
 
   url "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk#{version.csv.first}_#{version.csv.second}/ibm-semeru-open-jdk_x64_mac_#{version.csv.first.tr("-", "")}_#{version.csv.second}.pkg",
       verified: "github.com/ibmruntimes/semeru8-binaries/"
@@ -15,6 +15,8 @@ cask "semeru-jdk-open@8" do
       json["tag_name"]&.scan(regex)&.map { |match| "#{match[0]}-#{match[1]},#{match[2]}" }
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   pkg "ibm-semeru-open-jdk_x64_mac_#{version.csv.first.tr("-", "")}_#{version.csv.second}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`semeru-jdk-open@8` is autobumped but the autobump workflow is failing to update to version 8u462-b08 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this 
situation.

---

Closes https://github.com/Homebrew/homebrew-cask/issues/221884