### PR TITLE
tiger-trade 9.7.2

### DIFF
--- a/Casks/t/tiger-trade.rb
+++ b/Casks/t/tiger-trade.rb
@@ -1,9 +1,9 @@
 cask "tiger-trade" do
-  version "9.6.2,6AFE09"
-  sha256 "9e3aea6c0758e0169d0a4789dfabde75ea787dfa8d485125f6a97aac26b66d85"
+  version "9.7.2"
+  sha256 "406a8d8fb3f9067a7bba87ca00fde0f4e286e31cb005b679429709247fb8165f"
 
-  url "https://s.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version.tr(",", "_")}.dmg",
-      verified: "s.tigerfintech.com/"
+  url "https://download.tigerfintech.com/desktop/cdn/f/TigerTrade_#{version}.dmg",
+      verified: "download.tigerfintech.com/"
   name "Tiger Trade"
   name "老虎证券"
   desc "Trading platform"
@@ -11,12 +11,9 @@ cask "tiger-trade" do
 
   livecheck do
     url "https://up.play-analytics.com/app/upgrade/latest?lang=zh_CN&platform=darwin&appVer=1"
-    regex(/TigerTrade[._-]v?(\d+(?:\.\d+)+)[._-](\h+)\.dmg/i)
+    regex(/TigerTrade[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
     strategy :json do |json, regex|
-      match = json["downloadUrl"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+      json["downloadUrl"]&.[](regex, 1)
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tiger-trade` is autobumped but the workflow has been failing to update the cask to new versions because the download URL has changed (as seen in the `livecheck` URL response). This updates the cask to 9.7.2, modifying the cask `url` and `livecheck` block accordingly.