### PR TITLE
aptible: remove deprecation warning

### DIFF
--- a/Casks/a/aptible.rb
+++ b/Casks/a/aptible.rb
@@ -16,8 +16,6 @@ cask "aptible" do
     end
   end
 
-  disable! date: "2026-09-01", because: :unsigned
-
   depends_on formula: "libfido2"
 
   pkg "aptible-toolbelt-#{version.csv.first}+#{version.csv.second}-mac-os-x.10.15.7-1.pkg"


### PR DESCRIPTION
aptible was marked deprecated due to being unsigned; but it's a set of Ruby scripts that can't be signed!

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online aptible` is error-free.
- [x] `brew style --fix aptible` reports no offenses.