### PR TITLE
graalvm-jdk 24.0.2,12

### DIFF
--- a/Casks/g/graalvm-jdk.rb
+++ b/Casks/g/graalvm-jdk.rb
@@ -1,9 +1,9 @@
 cask "graalvm-jdk" do
   arch arm: "aarch64", intel: "x64"
 
-  version "24.0.1,9"
-  sha256 arm:   "875555f6063b4847b617504e8f8a36290a6726770be72388261f6118bcf28f81",
-         intel: "35852ef7040be5e73d4b8f23481c4f70e4dcb088d302e28f6a88e6a4d47de2b9"
+  version "24.0.2,12"
+  sha256 arm:   "2dc7634ed939c725d41a353f73443ff32e70f2fb577367f12a6936107e3494dc",
+         intel: "df0f9e5d101201c50bfa6baa3c657a81a2883c5b5097a9f5ab93dab86f7e3ba2"
 
   url "https://download.oracle.com/graalvm/#{version.major}/archive/graalvm-jdk-#{version.csv.first}_macos-#{arch}_bin.tar.gz",
       verified: "download.oracle.com/"
@@ -12,26 +12,20 @@ cask "graalvm-jdk" do
   homepage "https://www.graalvm.org/"
 
   livecheck do
-    url "https://www.oracle.com/java/technologies/downloads/"
-    regex(%r{/otn_software/java/jdk/(\d+(?:\.\d+)*)\+(\d+)/}i)
-    strategy :page_match do |page, regex|
-      major = page.scan(%r{href=.*?/technologies/javase-jdk(\d+)-doc-downloads\.html}i)
-                  .max_by { |match| Version.new(match[0]) }
-                  &.first
-      next if major.blank?
+    url "https://java.oraclecloud.com/currentJavaReleases"
+    regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
+    strategy :json do |json, regex|
+      json["items"]&.map do |item|
+        match = item["releaseFullVersion"]&.match(regex)
+        next if match.blank?
 
-      download_page = Homebrew::Livecheck::Strategy.page_content(
-        "https://www.oracle.com/java/technologies/javase-jdk#{major}-doc-downloads.html",
-      )
-      next if (download_page_content = download_page[:content]).blank?
-
-      download_page_content.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+        "#{match[1]},#{match[2]}"
+      end
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
-  artifact "graalvm-jdk-#{version.csv.first}+#{version.csv.second}.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"
+  # FIXME: Change 11 back to #{version.csv.second} on the next release
+  artifact "graalvm-jdk-#{version.csv.first}+11.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"
 
   # No zap stanza required
 


### PR DESCRIPTION
Split out from https://github.com/Homebrew/homebrew-cask/pull/220406 due to an incorrect folder name.