### PR TITLE
workflows/triage: remove autobump labelling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -64,10 +64,6 @@ jobs:
               path: Casks/.+
               missing_content: zap .+\n
 
-            - label: autobump
-              path: \.github/autobump\.txt
-              allow_any_match: true
-
             - label: linux cask
               path: Casks/.+
               content: (x86_64|arm64)_linux


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-cask/pull/219280