### PR TITLE
MakeraCAM 0.2.1.5 (new cask)

### DIFF
--- a/Casks/m/makeracam.rb
+++ b/Casks/m/makeracam.rb
@@ -1,0 +1,35 @@
+cask "makeracam" do
+  version "0.2.1.5"
+  sha256 "e3dafbee2124819a6db9375f82cf1d15190b2b46a3f2684df90269e4bcc0a42a"
+
+  url "https://github.com/MakeraInc/MakeraCAM/releases/download/v#{version}/MakeraCAM_Mac_v#{version}.dmg",
+      verified: "github.com/MakeraInc/MakeraCAM/"
+  name "MakeraCAM"
+  desc "CAM software for Makera CNCs"
+  homepage "https://www.makera.com/pages/software"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "MakeraCAM.app"
+
+  zap trash: "~/Library/Application Support/MakeraCAM"
+
+  caveats do
+    requires_rosetta
+  end
+end

--- a/Casks/m/makeracam.rb
+++ b/Casks/m/makeracam.rb
@@ -8,21 +8,6 @@ cask "makeracam" do
   desc "CAM software for Makera CNCs"
   homepage "https://www.makera.com/pages/software"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        match = release["tag_name"]&.match(regex)
-        next if match.blank?
-
-        match[1]
-      end
-    end
-  end
-
   depends_on macos: ">= :catalina"
 
   app "MakeraCAM.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This cask installs [MakeraCAM](https://www.makera.com/pages/software), computer-aided manufacturing (CAM) software from Makera, a vendor of desktop CNC machines such as the [Carvera Air](https://www.makera.com/products/carvera-air).

Notability exception: The GitHub repository is not notable because it is only used for binary releases. Their [Kickstarter campaign](https://www.kickstarter.com/projects/makera-inc/carvera-air) has over 2,000 backers; a recent [YouTube video](https://www.youtube.com/watch?v=e1AcpqRggh0) has 1.6M views.

The vendor's website calls the product "Makera CAM" however the application bundle and About window call it "MakeraCAM."

I've added `:verified` for the download URL; you can confirm that the download buttons on the [MakeraCAM website](https://www.makera.com/pages/software) link directly to the GitHub release artifacts.

The download can be fully unlocked with the e-mail address associated with a Carvera purchase; other e-mail addresses will activate a trial period.