### PR TITLE
CarveraController 0.9.11 (new cask)

### DIFF
--- a/Casks/c/carveracontroller.rb
+++ b/Casks/c/carveracontroller.rb
@@ -1,0 +1,35 @@
+cask "carveracontroller" do
+  version "0.9.11"
+  sha256 "6141e600df1ef28e2b13bdee2b55594e75dd2853bdb41a91a72ee88719e0d9a3"
+
+  url "https://github.com/MakeraInc/CarveraController/releases/download/v#{version}/CarveraController.#{version}-mac-64.dmg",
+      verified: "github.com/MakeraInc/CarveraController/"
+  name "CarveraController"
+  desc "Control software for Makera Carvera CNCs"
+  homepage "https://www.makera.com/pages/software"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "CarveraController.app"
+
+  # No zap stanza required
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Related to my [MakeraCAM](https://github.com/Homebrew/homebrew-cask/pull/222094) formula.

This cask installs [CarveraController](https://www.makera.com/pages/software), a tool for controlling Makera desktop CNC machines such as the [Carvera Air](https://www.makera.com/products/carvera-air).

> [!caution]
> The install command requires `--no-quarantine` but I don't know if there is a way to assert this in the formula.
>
> The vendor has [stated](https://github.com/MakeraInc/CarveraController/issues/34#issuecomment-2788157011) they are working on a signed release in the future.

Notability exception: The GitHub repository is not notable because it is only used for binary releases. Their [Kickstarter campaign](https://www.kickstarter.com/projects/makera-inc/carvera-air) has over 2,000 backers; a recent [YouTube video](https://www.youtube.com/watch?v=e1AcpqRggh0) has 1.6M views.

The vendor's marking materials call the program "Carvera Controller" or simply "Controller" but the application bundle is called "CarveraController". My preference would be "carvera-controller" for the token.

I've added `:verified` for the download URL; you can confirm that the download buttons on the [Makera website](https://www.makera.com/pages/software) link directly to the GitHub release artifacts.

I guessed as to the minimum macOS version, not seeing it documented anywhere or finding a requirement in the Info.plist. I think it is written in the same framework as their MakeraCAM software, for which they document a minimum of macOS 10.15.