### PR TITLE
dda 0.24.0 (new cask)

### DIFF
--- a/Casks/d/dda.rb
+++ b/Casks/d/dda.rb
@@ -1,0 +1,26 @@
+cask "dda" do
+  arch arm: "aarch64", intel: "x86_64"
+  os macos: "apple-darwin", linux: "unknown-linux-gnu"
+
+  version "0.24.0"
+  sha256 arm:          "15d2c19e93f0d5a71ea6c17013a91eec508ca25cdadb34697b06eddb023ec816",
+         intel:        "ecfc6715ce3018c5252e820a146c95b5506e9962833494abae78c7dd28ae18e4",
+         arm64_linux:  "2bb5c126aca68da1001fdd20469c3df2e06fcd8da162bd27e15c2d15dd1c4c85",
+         x86_64_linux: "8fce03114e90463a67eb9dfc6339c8378c51071bd81f1e80e954f350d5a94a96"
+
+  url "https://github.com/DataDog/datadog-agent-dev/releases/download/v#{version}/dda-#{arch}-#{os}.tar.gz"
+  name "dda"
+  desc "Tool for developing on the Datadog Agent platform"
+  homepage "https://github.com/DataDog/datadog-agent"
+
+  auto_updates true
+
+  binary "dda"
+
+  uninstall script: {
+    executable: "dda",
+    args:       ["self", "remove"],
+  }
+
+  # No zap stanza required
+end


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [X] `brew audit --cask --new <cask>` worked successfully.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.

---

Hello folks! This adds the tool that engineers/customers use to develop and extend the [Datadog Agent](https://github.com/DataDog/datadog-agent), most importantly for its cross-platform testing functionality. We've received requests to update our [installation docs](https://datadoghq.dev/datadog-agent/setup/#tooling) to include support for Homebrew in order to ease the contribution process.

This is a follow-up PR in response to the original formula PR [here](https://github.com/Homebrew/homebrew-core/pull/231677).