### PR TITLE
chromedriver@beta 139.0.7258.66

### DIFF
--- a/Casks/c/chromedriver@beta.rb
+++ b/Casks/c/chromedriver@beta.rb
@@ -1,13 +1,9 @@
 cask "chromedriver@beta" do
   arch arm: "arm64", intel: "x64"
 
-  version "139.0.7258.52"
-  sha256 arm:   "4374f53a4eb2f6164edb500077c5ba66784a46197fc874f8ad5c0d91afad09dd",
-         intel: "c25afc33fbb50d8809a85e157105a79c8bac8994a472d3c040639b5baf8fd913"
-
-  on_intel do
-    disable! date: "2026-09-01", because: :unsigned
-  end
+  version "139.0.7258.66"
+  sha256 arm:   "94fa1e4fb01e3355f23e427f59d49629df1cbd38e41347faf0738687d71b8c9f",
+         intel: "12ed690058dbffa45e0239675a7b70bf232de14f8c95c9a717ca33482cdd52b6"
 
   url "https://storage.googleapis.com/chrome-for-testing-public/#{version}/mac-#{arch}/chromedriver-mac-#{arch}.zip",
       verified: "storage.googleapis.com/chrome-for-testing-public/"
@@ -21,6 +17,8 @@ cask "chromedriver@beta" do
       json.dig("channels", "Beta", "version")
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   conflicts_with cask: "chromedriver"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`chromedriver@beta` is autobumped but the workflow is failing to update to the latest version because the ARM binary is unsigned and the related `disable!` call is gated to the Intel binary. This updates the cask and moves the `disable!` call to the top level, so it applies to both ARM and Intel.