### PR TITLE
double-commander 1.1.27

### DIFF
--- a/Casks/d/double-commander.rb
+++ b/Casks/d/double-commander.rb
@@ -1,9 +1,9 @@
 cask "double-commander" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "1.1.26"
-  sha256 arm:   "47bf0d7b1ac49d0df0396dc08f63037ebd69cf089cae9475446462e7558949e1",
-         intel: "b0f82a479c15bc8f2c7485b9147f6f11d86ebfe6128587f837ed455dba67a3ed"
+  version "1.1.27"
+  sha256 arm:   "445ee2752d2f0e4f398d362aea52efe569731c5abdacb3126c2ff125bdc21642",
+         intel: "d927a96d478c89536febeb5fe182a3bf1ad5445b316a81c0d551c24e5196d3a6"
 
   url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version.tr(",", "-")}.cocoa.#{arch}.dmg",
       verified: "downloads.sourceforge.net/doublecmd/"
@@ -18,6 +18,8 @@ cask "double-commander" do
       page.scan(regex).map { |match| match[0].tr("-", ",") }
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   app "Double Commander.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`double-commander` is autobumped but the autobump workflow is failing to update to version 1.1.27 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.