### PR TITLE
gitkraken-cli 3.1.9

### DIFF
--- a/Casks/g/gitkraken-cli.rb
+++ b/Casks/g/gitkraken-cli.rb
@@ -1,16 +1,16 @@
 cask "gitkraken-cli" do
   arch arm: "darwin_arm64", intel: "darwin_amd64"
 
-  version "3.1.5"
-  sha256 arm:   "85c54e8845e9a54ee98732bcd63a0019f4fc67646ba67d7a4a277c44ce706093",
-         intel: "5d785d6a434c5d7d44d5572a11690900146a447531c1f0ac8912dc8c27a17f31"
+  version "3.1.9"
+  sha256 arm:   "6942d543d698bbf2dd0ec6f7905c6f6432e0e10dda0cb07ec7cc4149c316b999",
+         intel: "6244e0997409ab1c7411b0b0b0fcd705396312d789fe3dcecabacdfce1d0cafd"
 
   url "https://github.com/gitkraken/gk-cli/releases/download/v#{version}/gk_#{version}_#{arch}.zip"
   name "GitKraken CLI"
   desc "CLI for GitKraken"
   homepage "https://github.com/gitkraken/gk-cli"
 
-  binary "gk_#{version}_#{arch}/gk"
+  binary "gk"
 
   zap trash: "~/.gitkraken"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gitkraken-cli` is autobumped but the workflow is failing to update to the newest version because the zip file no longer stores the files in a subdirectory. This updates the cask to the newest version and updates the `binary` call accordingly.