### PR TITLE
mihomo-party 1.7.7

### DIFF
--- a/Casks/m/mihomo-party.rb
+++ b/Casks/m/mihomo-party.rb
@@ -1,11 +1,11 @@
 cask "mihomo-party" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.7.6"
+  version "1.7.7"
 
   on_catalina :or_older do
-    sha256 arm:   "455ea2e95b10525453f72eff760331693534deb2420f8bccc2a3222bda180c6f",
-           intel: "64d22ad27467f7eaf890a40d5d16ac987b1af0fbd4c10c1b17d00f0186acde8f"
+    sha256 arm:   "e824d381a6c0380f36d088a356335d388c117af33f595c56b928a63a7675f52a",
+           intel: "7a2cf18edb6a1ba023b157189f2cbd048a9dd61928ae908f22a5be0e227e1114"
 
     url "https://github.com/mihomo-party-org/mihomo-party/releases/download/v#{version}/mihomo-party-catalina-#{version}-#{arch}.pkg",
         verified: "github.com/mihomo-party-org/mihomo-party/"
@@ -13,8 +13,8 @@ cask "mihomo-party" do
     pkg "mihomo-party-catalina-#{version}-#{arch}.pkg"
   end
   on_big_sur :or_newer do
-    sha256 arm:   "4c90507cd8ed9b8e7987ea4851a76430e3d2b0b67968a9790bc395c78c31917c",
-           intel: "9876bc07389c0b2e94cccc1dcc03c86560fbc7a0a34932c28148bb2b4bba6fd9"
+    sha256 arm:   "129444350da2d07cea64bd29fdd412eca2e7673f906d326511f6a56210979fd2",
+           intel: "86e19582769e17083c56daf076e95a89d11c2364dc05be39d90e7454ca6723b2"
 
     url "https://github.com/mihomo-party-org/mihomo-party/releases/download/v#{version}/mihomo-party-macos-#{version}-#{arch}.pkg",
         verified: "github.com/mihomo-party-org/mihomo-party/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mihomo-party` is autobumped but the autobump workflow encountered an error when trying to update to 1.7.7, so this manually updates the cask.