### PR TITLE
tencent-lemon 5.1.16,BC4FB28CB59D1A9FEE2D9EDB167B25A9

### DIFF
--- a/Casks/t/tencent-lemon.rb
+++ b/Casks/t/tencent-lemon.rb
@@ -1,6 +1,6 @@
 cask "tencent-lemon" do
-  version "5.1.16,2B4FA1C4B0E66FB8836BF700DA95C6E6"
-  sha256 "d69dee88ae91e34d365b0aff6b1e5a071b9026a642225ce9a0b936212b2c7846"
+  version "5.1.16,BC4FB28CB59D1A9FEE2D9EDB167B25A9"
+  sha256 "7d3ef369137bd51b6653b1fa154d2d8f64705ab8a8d1e8b294176d8b1c40c67b"
 
   url "https://pm.myapp.com/invc/xfspeed/qqpcmgr/module_update/#{version.csv.second}/Lemon#{version.csv.first}.dmg",
       verified: "pm.myapp.com/invc/xfspeed/qqpcmgr/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tencent-lemon` is autobumped but the workflow is failing to update to the newest version because the first version part is the same but the second part is seen as lower than the existing string. This addresses the issue by manually updating the cask.