### PR TITLE
time-to-leave 4.0.0

### DIFF
--- a/Casks/t/time-to-leave.rb
+++ b/Casks/t/time-to-leave.rb
@@ -15,7 +15,7 @@ cask "time-to-leave" do
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
+  disable! date: "2026-09-01", because: :unsigned
 
   app "Time To Leave.app"
 

--- a/Casks/t/time-to-leave.rb
+++ b/Casks/t/time-to-leave.rb
@@ -1,6 +1,6 @@
 cask "time-to-leave" do
-  version "3.0.0"
-  sha256 "25fef73ac373e37ba8c0363e25e7e0996afb048466698777e9f0a0e5bb8876a0"
+  version "4.0.0"
+  sha256 "c9550185217167a9257d05b550ff48780058d6c031a99660302528af205d2068"
 
   url "https://github.com/TTLApp/time-to-leave/releases/download/#{version}/time-to-leave-#{version}.dmg"
   name "Time To Leave"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I don't have a macos setup to test ;(