### PR TITLE
archy 2.35.1

### DIFF
--- a/Casks/a/archy.rb
+++ b/Casks/a/archy.rb
@@ -1,6 +1,6 @@
 cask "archy" do
-  version "2.35.0"
-  sha256 "f365ba0e96b9dc6a2d1b662f30ed1de20bb7e3285332c8e26f87fe268d8e95ab"
+  version "2.35.1"
+  sha256 "71bc39f6ff7b1831abf73a4f59c869bf234103fb421bbca141888b36fdcb1f1b"
 
   url "https://sdk-cdn.mypurecloud.com/archy/#{version}/archy-macos.zip",
       verified: "sdk-cdn.mypurecloud.com/archy/"
@@ -14,6 +14,8 @@ cask "archy" do
       json.map { |item| item["version"] }
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   binary "archyBin/archy-macos-#{version}", target: "archy"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`archy` is autobumped but the autobump workflow is failing to update to version 2.35.1 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.