### PR TITLE
slack-cli 3.5.2

### DIFF
--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -1,6 +1,6 @@
 cask "slack-cli" do
-  version "3.5.1"
-  sha256 "d1941e8cd81042b79db2369c85883e5096ccb9863aaecd9336b1862bf5de6a29"
+  version "3.5.2"
+  sha256 "1219def9e39f4ac125dea50434bfe6c83f3fee2aa9fdc4c17e077dbd90a2cb82"
 
   url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_64-bit.tar.gz",
       verified: "downloads.slack-edge.com/slack-cli/"
@@ -14,6 +14,8 @@ cask "slack-cli" do
       json.dig("slack-cli", "releases")&.map { |release| release["version"] }
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on formula: "deno"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`slack-cli` is autobumped but the autobump workflow is failing to update to version 3.5.2 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.