### PR TITLE
treesheets 2298

### DIFF
--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -1,8 +1,8 @@
 cask "treesheets" do
-  version "250711.2029,16229165273"
-  sha256 "5b263621c9c5a7a69de183cfed46dfc1c8e03ae6d89a1d80843417c8d5b4c0ad"
+  version "2298"
+  sha256 "1323dac5bb48d111375bfea83f5be186124a9d658ac7a3d7109df6c9635fff75"
 
-  url "https://github.com/aardappel/treesheets/releases/download/#{version.csv.second}/TreeSheets-#{version.csv.first}-Darwin.dmg",
+  url "https://github.com/aardappel/treesheets/releases/download/#{version.csv.second || version.csv.first}/TreeSheets-#{version.csv.first}-Darwin.dmg",
       verified: "github.com/aardappel/treesheets/"
   name "TreeSheets"
   desc "Hierarchical spreadsheet and outline application"
@@ -10,16 +10,18 @@ cask "treesheets" do
 
   livecheck do
     url :url
-    regex(%r{/v?(\d+(?:\.\d+)*)/TreeSheets[._-]v?(\d+(?:\.\d+)+)(?:[._-]Darwin)?\.dmg$}i)
+    regex(%r{/v?(\d+(?:\.\d+)*)/TreeSheets[._-]v?(\d+(?:\.\d+)*)(?:[._-]Darwin)?\.dmg$}i)
     strategy :github_latest do |json, regex|
       json["assets"]&.map do |asset|
         match = asset["browser_download_url"]&.match(regex)
         next if match.blank?
 
-        "#{match[2]},#{match[1]}"
+        (match[2] == match[1]) ? match[1] : "#{match[2]},#{match[1]}"
       end
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`treesheets` is autobumped but the workflow is unable to update to the newest version because upstream has changed their release tag/filename format. They've recently gone through a few variations but seem to have settled on using a simple number for the tag and filename (e.g., 2298), so this updates the cask accordingly. Besides that, the app is unsigned, so this also adds a `disable!` call with the future date we've been using for this situation.