### PR TITLE
Update unsigned deprecations to disable

### DIFF
--- a/Casks/d/deadbeef@nightly.rb
+++ b/Casks/d/deadbeef@nightly.rb
@@ -8,7 +8,7 @@ cask "deadbeef@nightly" do
   desc "Modular audio player"
   homepage "https://deadbeef.sourceforge.io/"
 
-  deprecate! date: "2025-05-01", because: :unsigned
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/m/mumble@snapshot.rb
+++ b/Casks/m/mumble@snapshot.rb
@@ -14,7 +14,7 @@ cask "mumble@snapshot" do
 
   no_autobump! because: :requires_manual_review
 
-  deprecate! date: "2025-05-01", because: :unsigned
+  disable! date: "2026-09-01", because: :unsigned
 
   conflicts_with cask: "mumble"
   depends_on macos: ">= :high_sierra"

--- a/Casks/o/openemu@experimental.rb
+++ b/Casks/o/openemu@experimental.rb
@@ -25,7 +25,7 @@ cask "openemu@experimental" do
 
   no_autobump! because: :requires_manual_review
 
-  deprecate! date: "2025-05-01", because: :unsigned
+  disable! date: "2026-09-01", because: :unsigned
 
   auto_updates true
   conflicts_with cask: "openemu"

--- a/Casks/p/playcover-community@beta.rb
+++ b/Casks/p/playcover-community@beta.rb
@@ -14,7 +14,7 @@ cask "playcover-community@beta" do
 
   no_autobump! because: :requires_manual_review
 
-  deprecate! date: "2025-05-01", because: :unsigned
+  disable! date: "2026-09-01", because: :unsigned
 
   auto_updates true
   conflicts_with cask: "playcover-community"

--- a/Casks/s/sonarr@beta.rb
+++ b/Casks/s/sonarr@beta.rb
@@ -14,7 +14,7 @@ cask "sonarr@beta" do
 
   no_autobump! because: :requires_manual_review
 
-  deprecate! date: "2025-05-01", because: :unsigned
+  disable! date: "2026-09-01", because: :unsigned
 
   conflicts_with cask: "sonarr"
   depends_on cask: "mono-mdk"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -47,6 +47,7 @@
   "opencloud": "any",
   "openra@playtest": "all",
   "openshot-video-editor@daily": "all",
+  "playcover-community@beta": "all",
   "plugdata": "all",
   "positron": "all",
   "powershell@preview": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

We have a few casks that were deprecated as unsigned in the past but we've recently been using `disable!` for this with a future date (i.e., `disable! date: "2026-09-01", because: :unsigned`). These casks have already reached the deprecation date, so this updates these `deprecate!` calls to use the `disable!` call we've standardized on for this situation. With this setup, the casks are still implicitly deprecated until the disable date but this change ensures that they will eventually be disabled like the other unsigned casks.