### PR TITLE
smcfancontrol@beta: undeprecate

### DIFF
--- a/Casks/s/smcfancontrol@beta.rb
+++ b/Casks/s/smcfancontrol@beta.rb
@@ -14,8 +14,6 @@ cask "smcfancontrol@beta" do
 
   no_autobump! because: :requires_manual_review
 
-  deprecate! date: "2025-05-01", because: :unsigned
-
   conflicts_with cask: "smcfancontrol"
 
   app "smcFanControl.app"
@@ -25,4 +23,8 @@ cask "smcfancontrol@beta" do
     "~/Library/Application Support/smcFanControl",
     "~/Library/Caches/com.eidac.smcFanControl#{version.major}",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`smcfancontrol@beta` was deprecated in the past as unsigned but it appears to be signed now, so this undeprecates the cask. Besides that, this adds a Rosetta caveat to address the related audit error.