### PR TITLE
Address livecheck block style issues

### DIFF
--- a/Casks/b/bcut.rb
+++ b/Casks/b/bcut.rb
@@ -21,7 +21,7 @@ cask "bcut" do
 
   livecheck do
     url "https://member.bilibili.com/x/bcut/pc/upgrade/v2?version=0&client_type=1"
-    regex(%r{/static/([^/]+)/BCUT[._-](\d+(?:\.\d+)+)[._-](\d+)[._-]#{arch}\.dmg})
+    regex(%r{/static/([^/]+)/BCUT[._-](\d+(?:\.\d+)+)[._-](\d+)[._-]#{arch}\.dmg}i)
     strategy :json do |json|
       match = json.dig("data", pkg_key)&.match(regex)
       next if match.blank? || version.blank?

--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -16,7 +16,7 @@ cask "claude-code" do
 
   livecheck do
     url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/stable"
-    regex(/^(\d+(?:\.\d+)+)$/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   auto_updates true

--- a/Casks/font/font-g/font-gd-highwaygothicja.rb
+++ b/Casks/font/font-g/font-gd-highwaygothicja.rb
@@ -9,7 +9,7 @@ cask "font-gd-highwaygothicja" do
 
   livecheck do
     url :homepage
-    regex(/GDHighwayGoJA[._-]Rev(\d+(?:\.\d+)*(?:b\d+)?)[._-]OTF\.zip/)
+    regex(/GDHighwayGoJA[._-]Rev(\d+(?:\.\d+)*(?:b\d+)?)[._-]OTF\.zip/i)
   end
 
   no_autobump! because: :requires_manual_review

--- a/Casks/j/jottacloud.rb
+++ b/Casks/j/jottacloud.rb
@@ -10,7 +10,7 @@ cask "jottacloud" do
 
   livecheck do
     url "https://sw.jotta.cloud/desktop/appcast/CUST/release"
-    regex(%r{/([^/]+)/Jottacloud(?:\s*Installer)?\.dmg})
+    regex(%r{/([^/]+)/Jottacloud(?:\s*Installer)?\.dmg}i)
     strategy :sparkle do |item, regex|
       id = item.url[regex, 1]
       next if id.blank?

--- a/Casks/l/lg-onscreen-control.rb
+++ b/Casks/l/lg-onscreen-control.rb
@@ -12,7 +12,7 @@ cask "lg-onscreen-control" do
   # so we return the downloads from one of the popular products
   livecheck do
     url "https://www.lg.com/us/support/product/lg-27GN950-B.AUS"
-    regex(/Mac[._-]OSC[._-]v?(\d+(?:\.\d+)+)\.zip/)
+    regex(/Mac[._-]OSC[._-]v?(\d+(?:\.\d+)+)\.zip/i)
     strategy :page_match do |page, regex|
       json_string = page[/NEXT[._-]DATA[^>]*>\s*([^<]+)\s*</i, 1]
       next if json_string.blank?

--- a/Casks/o/open-eid.rb
+++ b/Casks/o/open-eid.rb
@@ -8,7 +8,7 @@ cask "open-eid" do
   homepage "https://www.id.ee/en/article/install-id-software/"
 
   livecheck do
-    url "https://www.id.ee/en/article/install-id-software/"
+    url :homepage
     regex(/href=.*?Open[._-]EID[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/p/paper.rb
+++ b/Casks/p/paper.rb
@@ -9,8 +9,8 @@ cask "paper" do
   homepage "https://paper.photos/"
 
   livecheck do
-    url "https://paper.photos"
-    regex(/paper[._-]v?(\d+(?:\.\d+)+)\.dmg/)
+    url :homepage
+    regex(/paper[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   no_autobump! because: :requires_manual_review

--- a/Casks/u/uefitool.rb
+++ b/Casks/u/uefitool.rb
@@ -9,7 +9,7 @@ cask "uefitool" do
 
   livecheck do
     url :url
-    regex(/^(A\d+)$/)
+    regex(/^(A\d+)$/i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This addresses style issues with a few casks. The `brew style` checks for `livecheck` blocks don't apply to casks yet (I have some in-progress work that I need to finish up eventually) but I periodically run the checks locally to catch some simple issues. Namely:

* Regexes should be case-insensitive unless they require case sensitivity to work
* `url` should use a symbol (e.g., `:homepage`, `:url`) instead of a URL string if it's the same as a checkable URL in the cask

I ran these checks locally and confirmed that they still work as expected.