### PR TITLE
drawio: cli usage

### DIFF
--- a/Casks/d/drawio.rb
+++ b/Casks/d/drawio.rb
@@ -20,6 +20,16 @@ cask "drawio" do
   depends_on macos: ">= :big_sur"
 
   app "draw.io.app"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/drawio.wrapper.sh"
+  binary shimscript, target: "drawio"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/bash
+      exec '#{appdir}/draw.io.app/Contents/MacOS/draw.io' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/Library/Application Support/draw.io",


### PR DESCRIPTION
```
/Applications/draw.io.app/Contents/MacOS/draw.io --help
Usage: draw [options] <input file/folder>

Arguments:
  input file/folder                             input drawio file or a folder with drawio files

Options:
  -V, --version                                 output the version number
  -c, --create                                  creates a new empty file if no file is passed
  -k, --check                                   does not overwrite existing files
  -x, --export                                  export the input file/folder based on the given options
  -r, --recursive                               for a folder input, recursively convert all files in sub-folders also
  -o, --output <output file/folder>             specify the output file/folder. If omitted, the input file name is used for output with the specified format as
                                                extension
  -f, --format <format>                         if output file name extension is specified, this option is ignored (file type is determined from output extension,
                                                possible export formats are pdf, png, jpg, svg, and xml) (default: "pdf")
  -q, --quality <quality>                       output image quality for JPEG (default: 90)
  -t, --transparent                             set transparent background for PNG
  -e, --embed-diagram                           includes a copy of the diagram (for PNG, SVG and PDF formats only)
  --embed-svg-images                            Embed Images in SVG file (for SVG format only)
  --embed-svg-fonts <true/false>                Embed Fonts in SVG file (for SVG format only). Default is true (default: true)
  -b, --border <border>                         sets the border width around the diagram (default: 0)
  -s, --scale <scale>                           scales the diagram size
  --width <width>                               fits the generated image/pdf into the specified width, preserves aspect ratio.
  --height <height>                             fits the generated image/pdf into the specified height, preserves aspect ratio.
  --crop                                        crops PDF to diagram size
  -a, --all-pages                               export all pages (for PDF format only)
  -p, --page-index <pageIndex>                  selects a specific page (1-based); if not specified and the format is an image, the first page is selected
  -l, --layers <comma separated layer indexes>  selects which layers to export (applies to all pages), if not specified, all layers are selected
  -g, --page-range <from>..<to>                 selects a page range (1-based, for PDF format only)
  -u, --uncompressed                            Uncompressed XML output (for XML format only)
  -z, --zoom <zoom>                             scales the application interface
  --svg-theme <theme>                           Theme of the exported SVG image (dark, light, auto [default]) (default: "auto")
  --svg-links-target <target>                   Target of links in the exported SVG image (auto [default], new-win, same-win) (default: "auto")
  --enable-plugins                              Enable Plugins
  -h, --help                                    display help for command
```
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
