### PR TITLE
010-editor: Update for ARM binary

### DIFF
--- a/Casks/0/010-editor.rb
+++ b/Casks/0/010-editor.rb
@@ -1,8 +1,11 @@
 cask "010-editor" do
-  version "16.0"
-  sha256 "4d66ad495aa6f5af9b54b5ed26389602d91c07ba99aa8789ec69abeb65d4573e"
+  arch arm: "ARM64", intel: "64"
 
-  url "https://download.sweetscape.com/010EditorMac64Installer#{version}.dmg"
+  version "16.0"
+  sha256 arm:   "0ad13106ebba10bf2296adfe82dc233709ccc5790a80f76b937e2d62f8cdda9b",
+         intel: "4d66ad495aa6f5af9b54b5ed26389602d91c07ba99aa8789ec69abeb65d4573e"
+
+  url "https://download.sweetscape.com/010EditorMac#{arch}Installer#{version}.dmg"
   name "010 Editor"
   desc "Text editor"
   homepage "https://www.sweetscape.com/"
@@ -22,8 +25,4 @@ cask "010-editor" do
         "~/Library/Saved Application State/com.SweetScape.010Editor.savedState",
       ],
       rmdir: "~/Documents/SweetScape"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

Per the [release notes](https://www.sweetscape.com/010editor/release_notes.html) for 16.0, 010 Editor now has native ARM binaries for Mac.  This updates the cask to use those when appropriate.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
