### PR TITLE
chirp 20250801

### DIFF
--- a/Casks/c/chirp.rb
+++ b/Casks/c/chirp.rb
@@ -9,10 +9,7 @@ cask "chirp" do
   desc "Tool for programming amateur radio"
   homepage "https://chirp.danplanet.com/projects/chirp/wiki/Home"
 
-  livecheck do
-    url "https://archive.chirpmyradio.com/chirp_next/"
-    regex(/next[._-]v?(\d+(?:\.\d+)*)/i)
-  end
+  disable! date: "2025-08-05", because: "cannot be reliably fetched due to Cloudflare protections"
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/c/chirp.rb
+++ b/Casks/c/chirp.rb
@@ -1,6 +1,6 @@
 cask "chirp" do
-  version "20250718"
-  sha256 "de657f92563b61116982f23954e7015da1f94779f9e38e2909c2b190dddd35a5"
+  version "20250801"
+  sha256 "07809e2558bfd248e65c69f4b56a7c9a08b5d262730900b5f5020912ed282868"
 
   url "https://archive.chirpmyradio.com/chirp_next/next-#{version}/chirp-next-#{version}.app.zip",
       verified: "archive.chirpmyradio.com/",
@@ -14,7 +14,7 @@ cask "chirp" do
     regex(/next[._-]v?(\d+(?:\.\d+)*)/i)
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :high_sierra"
 
   app "CHIRP.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`chirp` is in the autobump list but livecheck may be a bit unreliable for the upstream website, as it's sometimes unable to identify new versions. The check worked fine when I ran it locally, so this updates the cask to the latest version.

I'm not sure what's failing in the CI environment (and haven't looked into whether it's intermittent or persistent) but this is maybe something to keep an eye on. If the check persistently fails in the autobump environment but works locally, then we can add a `no_autobump!` call and rely on manual updates.