### PR TITLE
sourcetree@beta 4.2.13b23,294

### DIFF
--- a/Casks/s/sourcetree@beta.rb
+++ b/Casks/s/sourcetree@beta.rb
@@ -1,6 +1,6 @@
 cask "sourcetree@beta" do
-  version "4.2.13b38,291"
-  sha256 "596a7d332c8d79dadec65b86def8c03227a5edf20dd250d76c754f82040263f0"
+  version "4.2.13b23,294"
+  sha256 "fedcea1fe4a7aea72b7656ca1b30949aca8edfac56423a7f4bf731b7d4707dfb"
 
   url "https://product-downloads.atlassian.com/software/sourcetree/beta/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
       verified: "product-downloads.atlassian.com/software/sourcetree/beta/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Seems to have been an oddity where the Sparkle version increased, but the main version number regressed from `b38` to `b23`.  Updating to the latest version identified in Sparkle.