### PR TITLE
finch: remove livecheck

### DIFF
--- a/Casks/f/finch.rb
+++ b/Casks/f/finch.rb
@@ -10,11 +10,6 @@ cask "finch" do
   desc "Open source container development tool"
   homepage "https://github.com/runfinch/finch"
 
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   pkg "Finch-v#{version}-#{arch}.pkg"
 
   uninstall script: {


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `finch` cask was previously deprecated as unsigned and a `livecheck` block was added that replicates the default livecheck behavior to allow the cask to continue to be checked despite the implicit deprecation from the `disable!` call. The cask was later undeprecated but the `livecheck` block wasn't removed in the process. This removes the `livecheck` block, as it's no longer necessary.