### PR TITLE
Remove redundant livecheck blocks for unsigned casks

### DIFF
--- a/Casks/a/ariang.rb
+++ b/Casks/a/ariang.rb
@@ -10,13 +10,6 @@ cask "ariang" do
   desc "Better aria2 desktop frontend than AriaNg"
   homepage "https://github.com/mayswind/AriaNg-Native"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/c/chromium-gost.rb
+++ b/Casks/c/chromium-gost.rb
@@ -10,13 +10,6 @@ cask "chromium-gost" do
   desc "Browser based on Chromium with support for GOST cryptographic algorithms"
   homepage "https://github.com/deemru/Chromium-Gost"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :big_sur"

--- a/Casks/e/electronmail.rb
+++ b/Casks/e/electronmail.rb
@@ -10,13 +10,6 @@ cask "electronmail" do
   desc "Unofficial ProtonMail Desktop App"
   homepage "https://github.com/vladimiry/ElectronMail"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :big_sur"

--- a/Casks/f/fishing-funds.rb
+++ b/Casks/f/fishing-funds.rb
@@ -11,13 +11,6 @@ cask "fishing-funds" do
   desc "Display real-time trends of Chinese funds in the menubar"
   homepage "https://ff.1zilc.top/"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :big_sur"

--- a/Casks/n/nanoem.rb
+++ b/Casks/n/nanoem.rb
@@ -7,13 +7,6 @@ cask "nanoem" do
   desc "Cross-platform MMD (MikuMikuDance) compatible implementation"
   homepage "https://github.com/hkrn/nanoem"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   app "nanoem.app"

--- a/Casks/s/stretchly.rb
+++ b/Casks/s/stretchly.rb
@@ -11,13 +11,6 @@ cask "stretchly" do
   desc "Break time reminder app"
   homepage "https://hovancik.net/stretchly/"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :big_sur"

--- a/Casks/t/tiddly.rb
+++ b/Casks/t/tiddly.rb
@@ -10,13 +10,6 @@ cask "tiddly" do
   desc "Browser for TiddlyWiki"
   homepage "https://github.com/Jermolene/TiddlyDesktop"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   app "TiddlyDesktop-mac#{arch}-v#{version}/TiddlyDesktop.app"

--- a/Casks/t/tlv.rb
+++ b/Casks/t/tlv.rb
@@ -7,13 +7,6 @@ cask "tlv" do
   desc "Tool for working with Tableau logs"
   homepage "https://github.com/tableau/tableau-log-viewer"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :mojave"

--- a/Casks/t/toinane-colorpicker.rb
+++ b/Casks/t/toinane-colorpicker.rb
@@ -11,13 +11,6 @@ cask "toinane-colorpicker" do
   desc "Get and save colour codes"
   homepage "https://colorpicker.fr/"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   app "Colorpicker.app"

--- a/Casks/u/ultrastardeluxe.rb
+++ b/Casks/u/ultrastardeluxe.rb
@@ -11,13 +11,6 @@ cask "ultrastardeluxe" do
   desc "Karaoke game"
   homepage "https://usdx.eu/"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   app "UltraStarDeluxe.app"

--- a/Casks/u/uvtools.rb
+++ b/Casks/u/uvtools.rb
@@ -10,12 +10,6 @@ cask "uvtools" do
   desc "MSLA/DLP, file analysis, calibration, repair, conversion and manipulation"
   homepage "https://github.com/sn4k3/UVtools"
 
-  # This simply ensures that the cask continues to be checkable despite the
-  # implicit deprecation from the `disable!` call.
-  livecheck do
-    url :url
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   auto_updates true

--- a/Casks/v/vieb.rb
+++ b/Casks/v/vieb.rb
@@ -11,13 +11,6 @@ cask "vieb" do
   desc "Vim Inspired Electron Browser"
   homepage "https://vieb.dev/"
 
-  # This is the default strategy, but we need to explicitly
-  # specify it to continue checking it while it is deprecated
-  livecheck do
-    url :url
-    strategy :git
-  end
-
   disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

We recently modified livecheck's skip conditions to make a special exception for casks that have a future disable date using the `:unsigned` reason. These casks would normally be skipped as deprecated unless they have a `livecheck` block, so we previously added `livecheck` blocks that replicated the default check as a way of allowing these casks to continue to be checked. The aforementioned exception has been merged in the brew repository and these casks no longer need a `livecheck` block to continue using the default check, so this removes them accordingly.