### PR TITLE
vial 0.7.5

### DIFF
--- a/Casks/v/vial.rb
+++ b/Casks/v/vial.rb
@@ -1,12 +1,14 @@
 cask "vial" do
-  version "0.7.4"
-  sha256 "3e8ca8c3658e197d04a51260d881d59a1829a6b0a0c0b2a7980aaeb6c61805ad"
+  version "0.7.5"
+  sha256 "b628db11f8df012faafcceef7deb36b54821b507d4c970336f85a56c800e8876"
 
   url "https://github.com/vial-kb/vial-gui/releases/download/v#{version}/Vial-v#{version}.dmg",
       verified: "github.com/vial-kb/vial-gui/"
   name "Vial"
   desc "Configurator of compatible keyboards in real time"
   homepage "https://get.vial.today/"
+
+  disable! date: "2026-09-01", because: :unsigned
 
   app "Vial.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vial` is autobumped but the autobump workflow is failing to update to version 0.7.5 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.