### PR TITLE
Remove livecheck from disabled casks

### DIFF
--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -1,6 +1,5 @@
 cask "dropbox-capture" do
   arch arm: "arm64", intel: "x86_64"
-  livecheck_arch = on_arch_conditional arm: "arm64", intel: "x64"
 
   version "116.3.0"
   sha256 arm:   "3ef49cad0ade501f75bea5ff3fc260d55f59664c2db93d48974279779c35f0d3",

--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -12,13 +12,6 @@ cask "dropbox-capture" do
   desc "Share your work and ideas with video messages and screenshots"
   homepage "https://dropbox.com/capture/"
 
-  livecheck do
-    url "https://client.dropbox.com/squirrel/dropbox-capture/update_check/stable?localversion=0&arch=#{livecheck_arch}"
-    strategy :json do |json|
-      json["version"]
-    end
-  end
-
   no_autobump! because: :requires_manual_review
 
   disable! date: "2025-03-24", because: :discontinued

--- a/Casks/y/yubico-yubikey-manager.rb
+++ b/Casks/y/yubico-yubikey-manager.rb
@@ -7,11 +7,6 @@ cask "yubico-yubikey-manager" do
   desc "Application for configuring any YubiKey"
   homepage "https://developers.yubico.com/yubikey-manager-qt/"
 
-  livecheck do
-    url "https://developers.yubico.com/yubikey-manager-qt/Releases/"
-    regex(/href=.*?yubikey[._-]manager[._-]qt[._-]v?(\d+(?:\.\d+)+[a-z]?)[._-]mac\.pkg/i)
-  end
-
   no_autobump! because: :requires_manual_review
 
   disable! date: "2025-07-27", because: :discontinued, replacement_cask: "yubico-authenticator"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This removes `livecheck` blocks from disabled casks, so they will be automatically skipped as disabled.