### PR TITLE
Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,4 +1,6 @@
 name: Scheduled online check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-cask/security/code-scanning/48](https://github.com/Homebrew/homebrew-cask/security/code-scanning/48)

To fix the problem, we should add a top-level `permissions` block to the workflow in `.github/workflows/scheduled.yml`. This block will apply to all jobs that do not have their own `permissions` block, such as `create_matrix`. Since `create_matrix` only reads repository data and does not need to write to the repository or interact with issues, the minimal required permission is `contents: read`. This change should be made at the top level of the workflow, ideally after the `name` and before the `on` block, to ensure it applies to all jobs by default. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
