### PR TITLE
Potential fix for code scanning alert no. 70: Jinja2 templating with autoescape=False

### DIFF
--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -32,6 +32,7 @@ def parse_metadata(filename):
 class FontCask:
     ENVIRONMENT = jinja2.Environment(
         keep_trailing_newline=True, trim_blocks=True, undefined=jinja2.StrictUndefined,
+        autoescape=jinja2.select_autoescape(['html', 'xml']),
     )
     TEMPLATE = ENVIRONMENT.from_string(
         """cask "{{token}}" do


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-cask/security/code-scanning/70](https://github.com/Homebrew/homebrew-cask/security/code-scanning/70)

To fix the problem, explicitly set the `autoescape` parameter when creating the Jinja2 `Environment`. The recommended approach is to use `autoescape=jinja2.select_autoescape(['html', 'xml'])`, which will enable autoescaping for templates with HTML or XML file extensions. Since the template here is defined as a string (not loaded from a file), autoescaping will not be enabled by default, but this is still the safest and most future-proof configuration. This change should be made on line 33, where the `Environment` is instantiated. Additionally, ensure that `select_autoescape` is imported from `jinja2` (or accessed as `jinja2.select_autoescape`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
