### PR TITLE
hoppscotch-selfhost 25.7.0 (new cask)

### DIFF
--- a/Casks/h/hoppscotch-selfhost.rb
+++ b/Casks/h/hoppscotch-selfhost.rb
@@ -1,0 +1,25 @@
+cask "hoppscotch-selfhost" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "25.7.1-0"
+  sha256 arm:   "1d96349a44978b25eb62088a3ac35522943af5fe280eeae175da3f764ea61cf2",
+         intel: "a3e798c8dd0fbefb986db3538ab4108026ce0db55581dd89214f814eecc88abe"
+
+  url "https://github.com/hoppscotch/releases/releases/download/v#{version}/Hoppscotch_SelfHost_mac_#{arch}.dmg",
+      verified: "github.com/hoppscotch/releases/"
+  name "Hoppscotch SelfHost"
+  desc "Desktop client for SelfHost version of the Hoppscotch API development ecosystem"
+  homepage "https://hoppscotch.com/"
+
+  conflicts_with cask: "hoppscotch"
+  depends_on macos: ">= :high_sierra"
+
+  app "Hoppscotch.app"
+
+  zap trash: [
+    "~/Library/Application Support/io.hoppscotch.desktop",
+    "~/Library/Caches/io.hoppscotch.desktop",
+    "~/Library/Saved Application State/io.hoppscotch.desktop.savedState",
+    "~/Library/WebKit/io.hoppscotch.desktop",
+  ]
+end


### PR DESCRIPTION
Hoppscotch now has official desktop client for SelfHost version of Hoppscotch API client.

Note: `brew audit` complains about the releases repository not being notable enough, however the [main repository where all of the development happens](https://github.com/hoppscotch/hoppscotch) has 73.3k stars and 5.1k forks at this time of writing.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
