### PR TITLE
naver-whale: update depends_on

### DIFF
--- a/Casks/n/naver-whale.rb
+++ b/Casks/n/naver-whale.rb
@@ -18,7 +18,7 @@ cask "naver-whale" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Whale.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
Support for macOS 10.15 was dropped with the upgrade to Chr 130 (`naver-whale` is currently based on Chr 136).