### PR TITLE
Potential fix for code scanning alert no. 47: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/google-fonts.yml
+++ b/.github/workflows/google-fonts.yml
@@ -1,4 +1,7 @@
 name: Google Fonts
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-cask/security/code-scanning/47](https://github.com/Homebrew/homebrew-cask/security/code-scanning/47)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimum required permissions for the GITHUB_TOKEN. Since the workflow pushes commits and creates pull requests, it needs `contents: write` and `pull-requests: write`. The `permissions` block should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No changes to the steps or logic are required; only the addition of the `permissions` block is needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
