### PR TITLE
bettertouchtool: stable releases

### DIFF
--- a/Casks/b/bettertouchtool.rb
+++ b/Casks/b/bettertouchtool.rb
@@ -1,6 +1,6 @@
 cask "bettertouchtool" do
-  version "5.548,2025080602"
-  sha256 "836d801b55900e7080b01e82395c416551d1f55face27670df33b12f76a9ed07"
+  version "5.444,2025052805"
+  sha256 "3221ea74fa2ac66658755f3739ee241ede5237e63860b053d7ff78b785011434"
 
   url "https://folivora.ai/releases/btt#{version.csv.first}-#{version.csv.second}.zip"
   name "BetterTouchTool"
@@ -8,23 +8,12 @@ cask "bettertouchtool" do
   homepage "https://folivora.ai/"
 
   livecheck do
-    url "https://folivora.ai/releases/"
-    regex(/btt(\d+(?:[._-]\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
-    strategy :page_match do |page, regex|
-      current_version, current_build = version.csv
-      version, build = page.scan(regex).max_by { |match| Time.parse(match[1]) }&.first&.split("-", 2)
-
-      # Throttle updates to every 5th release.
-      if build && current_build.to_i + 5 > build.to_i
-        version = current_version
-        build = current_build
-      end
-
-      "#{version},#{build}"
-    end
+    url "https://updates.folivora.ai/appcast_macupdater.xml"
+    strategy :sparkle
   end
 
   auto_updates true
+  conflicts_with cask: "bettertouchtool@alpha"
   depends_on macos: ">= :big_sur"
 
   app "BetterTouchTool.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Hello 👋, this PR separates the stable and alpha versions of [BetterTouchTool](https://folivora.ai/). Until now this cask was installing alpha versions which I have found problematic as the releases are still undergoing testing.

This PR updates the cask `bettertouchtool` to track the stable release cycle as specified by the developer [here](https://community.folivora.ai/t/some-window-resize-moving-action-dont-work-in-sequoia-15-0/39225/19?u=yougotwill).

For users who do want alpha releases, I have added a new `bettertouchtool@alpha` cask which uses the previous update logic in a separate PR https://github.com/Homebrew/homebrew-cask/pull/222993. 