### PR TITLE
bettertouchtool@alpha (new cask)

### DIFF
--- a/Casks/b/bettertouchtool@alpha.rb
+++ b/Casks/b/bettertouchtool@alpha.rb
@@ -1,0 +1,39 @@
+cask "bettertouchtool@alpha" do
+  version "5.548,2025080602"
+  sha256 "836d801b55900e7080b01e82395c416551d1f55face27670df33b12f76a9ed07"
+
+  url "https://folivora.ai/releases/btt#{version.csv.first}-#{version.csv.second}.zip"
+  name "BetterTouchTool"
+  desc "Tool to customise input devices and automate computer systems"
+  homepage "https://folivora.ai/"
+
+  livecheck do
+    url "https://folivora.ai/releases/"
+    regex(/btt(\d+(?:[._-]\d+)*)\.zip.*?(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/i)
+    strategy :page_match do |page, regex|
+      current_version, current_build = version.csv
+      version, build = page.scan(regex).max_by { |match| Time.parse(match[1]) }&.first&.split("-", 2)
+
+      # Throttle updates to every 5th release.
+      if build && current_build.to_i + 5 > build.to_i
+        version = current_version
+        build = current_build
+      end
+
+      "#{version},#{build}"
+    end
+  end
+
+  auto_updates true
+  conflicts_with cask: "bettertouchtool"
+  depends_on macos: ">= :big_sur"
+
+  app "BetterTouchTool.app"
+
+  uninstall quit: "com.hegenberg.BetterTouchTool"
+
+  zap trash: [
+    "~/Library/Application Support/BetterTouchTool",
+    "~/Library/Preferences/com.hegenberg.BetterTouchTool.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Hello 👋, this PR along with https://github.com/Homebrew/homebrew-cask/pull/222989 separates the stable and alpha versions of [BetterTouchTool](https://folivora.ai/). 

This PR creates a new cask for users who still want the alpha releases.