### PR TITLE
darktable 5.2.1

### DIFF
--- a/Casks/d/darktable.rb
+++ b/Casks/d/darktable.rb
@@ -1,9 +1,9 @@
 cask "darktable" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "5.2.0"
-  sha256 arm:   "8dabf58b6d76c04800be8ab540d3c2f1e772123279e22629a7396fe3e26273de",
-         intel: "bdffebcf758cd1ec6d4ee26eb031d52b1d7e4fe8fe000e728edb14bec91f3a35"
+  version "5.2.1"
+  sha256 arm:   "b7d45bb3d2550695e4eba4d260580561b51c18d612d5e2b2c9e67a432ae2516c",
+         intel: "5060d73c03b3c7f4ca69a77039e69653fd2310df8cb649d66fc89f4c45289b0c"
 
   url "https://github.com/darktable-org/darktable/releases/download/release-#{version.major_minor_patch}/darktable-#{version}-#{arch}.dmg",
       verified: "github.com/darktable-org/darktable/"
@@ -15,6 +15,8 @@ cask "darktable" do
     url "https://www.darktable.org/install/"
     regex(/href=.*?darktable[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`darktable` is autobumped but the autobump workflow is failing to update to version 5.2.1 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.

For what it's worth, `brew audit` failed for me locally because the ARM version has defined Sonoma as the minimum macOS version but the Intel version appears to still be Ventura. `brew style` disallows using `depends_on macos:` in an on_system block (e.g., `on_arm`/`on_intel`), so I'm not sure how to account for this if it fails CI but I figured I would mention it.