### PR TITLE
tailscale-app: Generate completions for the installed CLI.

### DIFF
--- a/Casks/t/tailscale-app.rb
+++ b/Casks/t/tailscale-app.rb
@@ -28,7 +28,7 @@ cask "tailscale-app" do
     EOS
   end
 
-  def install
+  def postflight
     generate_completions_from_executable("#{appdir}/Tailscale.app/Contents/MacOS/Tailscale", "completion")
   end
 

--- a/Casks/t/tailscale-app.rb
+++ b/Casks/t/tailscale-app.rb
@@ -28,6 +28,10 @@ cask "tailscale-app" do
     EOS
   end
 
+  def install
+    generate_completions_from_executable("#{appdir}/Tailscale.app/Contents/MacOS/Tailscale", "completion")
+  end
+
   uninstall quit:       "io.tailscale.ipn.macsys",
             login_item: "Tailscale",
             pkgutil:    "com.tailscale.ipn.macsys"

--- a/Casks/t/tailscale-app.rb
+++ b/Casks/t/tailscale-app.rb
@@ -28,7 +28,7 @@ cask "tailscale-app" do
     EOS
   end
 
-  def postflight
+  install do
     generate_completions_from_executable("#{appdir}/Tailscale.app/Contents/MacOS/Tailscale", "completion")
   end
 


### PR DESCRIPTION
The `tailscale-app` cask wraps `/Applications/Tailscale.app/Contents/MacOS/Tailscale` and places it into the path as `tailscale`.

This command can generate its own completions. Support for this was added to the headless `tailscale` *formula* at https://github.com/Homebrew/homebrew-core/pull/172679

This PR adds the same support to the `tailscale-app` cask, using the same mechanism.

--------

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

