### PR TITLE
audacity: fix checksums

### DIFF
--- a/Casks/a/audacity.rb
+++ b/Casks/a/audacity.rb
@@ -2,8 +2,8 @@ cask "audacity" do
   arch arm: "arm64", intel: "x86_64"
 
   version "3.7.5"
-  sha256 arm:   "faa9cb53bd2515447b5e4f71d1220e258f484489cd8db4939b8ffbc255c9c0b3",
-         intel: "e910e80f2e395f77a81d94ea8b2592ac018605dc15d480cc4ddb7c1adb3dea70"
+  sha256 arm:   "20beb5515153a0df8cb02c270a39a90efbfaaa5f2d21fe1db06c7b0d987ea653",
+         intel: "d9ba4c5b61030151953bfd0c0611fbb340208d3a3f149a9a6c297155e1f57289"
 
   url "https://github.com/audacity/audacity/releases/download/Audacity-#{version}/audacity-macOS-#{version}-#{arch}.dmg",
       verified: "github.com/audacity/audacity/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Checksums added by https://github.com/Homebrew/homebrew-cask/pull/222735 do not match the officially [published ones](https://github.com/audacity/audacity/releases/tag/Audacity-3.7.5), causing an error when attempting to install the latest version:

```sh
$ brew install audacity
==> Downloading https://formulae.brew.sh/api/formula.jws.json
==> Downloading https://formulae.brew.sh/api/cask.jws.json
==> Downloading https://github.com/audacity/audacity/releases/download/Audacity-3.7.5/audacity-macOS-3.7.5-arm64.dm
Already downloaded: /Users/fickledogfish/Library/Caches/Homebrew/downloads/fa502bf9c938519952ebfa4e51c4297ac5ebfa931aa4f40785a85d4a59897f02--audacity-macOS-3.7.5-arm64.dmg
Error: SHA-256 mismatch
Expected: faa9cb53bd2515447b5e4f71d1220e258f484489cd8db4939b8ffbc255c9c0b3
  Actual: 20beb5515153a0df8cb02c270a39a90efbfaaa5f2d21fe1db06c7b0d987ea653
    File: /Users/fickledogfish/Library/Caches/Homebrew/downloads/fa502bf9c938519952ebfa4e51c4297ac5ebfa931aa4f40785a85d4a59897f02--audacity-macOS-3.7.5-arm64.dmg
To retry an incomplete download, remove the file above.
```

Additionally, the audit command fails with:

```sh
$ brew audit --cask --online audacity
Error: Cask 'audacity' is unavailable: No Cask with this name exists.
```