### PR TITLE
mochi: fix sha256

### DIFF
--- a/Casks/m/mochi.rb
+++ b/Casks/m/mochi.rb
@@ -2,8 +2,8 @@ cask "mochi" do
   arch arm: "-arm64"
 
   version "1.19.1"
-  sha256 arm:   "a0d7fa30e64fed2761d1134e8ef5f54d4bf9f8753d54984d7c7b77b3414ec316",
-         intel: "4b13c9ece0edbddc840bb26dc12a12b2b457965912052bc0083b72f54ad98aa3"
+  sha256 arm:   "12589c1d4b5cc9c97117d6807575b36ee666264ffb67960d99b4aed87708834a",
+         intel: "6cefb1976b400191ebf16fe8de3fbe8a3fe04d434a174ec44e068b1da99a9961"
 
   url "https://mochi.cards/releases/Mochi-#{version}#{arch}.dmg"
   name "Mochi"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.

-> NOT error free. Can't install because of SHA mismatch

- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
