### PR TITLE
gcloud-cli: Add `--update-installed-components` flag to install script to  ensure updating all installed components

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -28,7 +28,8 @@ cask "gcloud-cli" do
       "--bash-completion", "false",
       "--path-update", "false",
       "--rc-path", "false",
-      "--install-python", "false"
+      "--install-python", "false",
+      "--update-installed-components"
     ],
   }
   binary "google-cloud-sdk/bin/bq"


### PR DESCRIPTION
Previously, invoking `brew upgrade gcloud-cli` wasn't updating all installed gcloud components to the latest versions. 
This change adds the `--update-installed-components` flag to the install.sh script to ensure all components are now properly updated.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
