### PR TITLE
cursor-cli 2025.08.08-f57cb59 (new cask)

### DIFF
--- a/Casks/c/cursor-cli.rb
+++ b/Casks/c/cursor-cli.rb
@@ -1,0 +1,25 @@
+cask "cursor-cli" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2025.08.08-f57cb59"
+  sha256 arm:   "bc06b2336c7bb55c1a5037cbec15cb64605beb87a90053fb261ade4f33181c30",
+         intel: "07a2b0724ca4767eabc647148efc415bd40b0cd0fddc06258a881bb2728b1857"
+
+  url "https://downloads.cursor.com/lab/#{version}/darwin/#{arch}/agent-cli-package.tar.gz"
+  name "Cursor CLI"
+  desc "Command-line agent for Cursor"
+  homepage "https://cursor.com/"
+
+  livecheck do
+    url "https://cursor.com/install"
+    regex(%r{downloads\.cursor\.com/lab/v?(\d+(?:\.\d+)+(?:[._-]\h+)?)/})
+  end
+
+  binary "#{staged_path}/dist-package/cursor-agent", target: "cursor-agent"
+
+  zap trash: [
+    "~/.config/cursor-agent",
+    "~/.local/share/cursor-agent",
+    "~/Library/Logs/CursorAgent",
+  ]
+end

--- a/Casks/c/cursor-cli.rb
+++ b/Casks/c/cursor-cli.rb
@@ -2,8 +2,8 @@ cask "cursor-cli" do
   arch arm: "arm64", intel: "x64"
 
   version "2025.08.08-f57cb59"
-  sha256 arm:   "bc06b2336c7bb55c1a5037cbec15cb64605beb87a90053fb261ade4f33181c30",
-         intel: "07a2b0724ca4767eabc647148efc415bd40b0cd0fddc06258a881bb2728b1857"
+  sha256 arm:   "8ead37ee1e7205f2887310d12ec000956159dd653e7f0c93c51324362b6087f7",
+         intel: "7373847d6fbe0cfb989c2e1fae7af2b49292bae3ed279cd70b0ffec9e4d86fcc"
 
   url "https://downloads.cursor.com/lab/#{version}/darwin/#{arch}/agent-cli-package.tar.gz"
   name "Cursor CLI"


### PR DESCRIPTION
# Summary
- Adds a new cask “cursor-cli” for the Cursor command-line agent.
- Direct, versioned downloads for macOS arm64 and x64; cask links the binary dist-package/cursor-agent as cursor-agent.

# Cask details
- Token: cursor-cli
- Version: 2025.08.08-562252e
- URLs:
  - https://downloads.cursor.com/lab/2025.08.08-562252e/darwin/arm64/agent-cli-package.tar.gz
  - https://downloads.cursor.com/lab/2025.08.08-562252e/darwin/x64/agent-cli-package.tar.gz
- SHA256:
  - arm64: bc06b2336c7bb55c1a5037cbec15cb64605beb87a90053fb261ade4f33181c30
  - x64: 07a2b0724ca4767eabc647148efc415bd40b0cd0fddc06258a881bb2728b1857
- Homepage: https://cursor.com/
- Artifact: binary "dist-package/cursor-agent", target: "cursor-agent"

## Notes
- Cursor packages cli agent with platform-specific node binary

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
