### PR TITLE
izip 25.8

### DIFF
--- a/Casks/i/izip.rb
+++ b/Casks/i/izip.rb
@@ -1,15 +1,16 @@
 cask "izip" do
-  version "5.0.53"
+  version "25.8"
   sha256 :no_check
 
-  url "https://www.izip.com/izip.dmg"
+  url "https://www.izip.com/izip.dmg",
+      user_agent: :browser
   name "iZip"
   desc "App to manage ZIP, ZIPX, RAR, TAR, 7ZIP and other compressed files"
   homepage "https://www.izip.com/"
 
   livecheck do
     url "https://www.izip.com/updates"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`izip` is autobumped but the workflow is failing to update to 25.8 because downloading the dmg file fails due to Cloudflare protections but it works if we use a browser user agent. Besides that, it seems like upstream has changed their versioning format and this has affected the Sparkle feed, so we also need to adjust the `livecheck` block.