### PR TITLE
ovito 3.13.1

### DIFF
--- a/Casks/o/ovito.rb
+++ b/Casks/o/ovito.rb
@@ -2,8 +2,8 @@ cask "ovito" do
   arch arm: "arm64", intel: "intel"
 
   on_arm do
-    version "3.13.0"
-    sha256 "57c062313d6810a99bed80eb39ce660dff093c6854fece4a577942f6c1593555"
+    version "3.13.1"
+    sha256 "171568b7134cfa12066acc79e69bcb4aa2f660a24ed13740bc70b599e728dcb2"
   end
   on_intel do
     version "3.12.0"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ovito` is autobumped but the workflow isn't able to update to 3.13.1 because upstream hasn't been publishing Intel updates since 3.12.0. This manually updates the ARM version accordingly.