### PR TITLE
pixelorama 1.1.3

### DIFF
--- a/Casks/p/pixelorama.rb
+++ b/Casks/p/pixelorama.rb
@@ -1,6 +1,6 @@
 cask "pixelorama" do
-  version "1.1.2"
-  sha256 "fdd30bb412523979ace21256e50801e13fcccada3f0dc4a0dcb72e166175e6d1"
+  version "1.1.3"
+  sha256 "9e6c5db431623acd0824d5a99e3d782ecdf9b22afb9c2e262ba2477c85f6e13a"
 
   url "https://github.com/Orama-Interactive/Pixelorama/releases/download/v#{version}/Pixelorama-Mac.dmg",
       verified: "github.com/Orama-Interactive/Pixelorama/"
@@ -8,7 +8,9 @@ cask "pixelorama" do
   desc "2D sprite editor made with the Godot Engine"
   homepage "https://orama-interactive.itch.io/pixelorama"
 
-  depends_on macos: ">= :sierra"
+  disable! date: "2026-09-01", because: :unsigned
+
+  depends_on macos: ">= :high_sierra"
 
   app "Pixelorama.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`pixelorama` is autobumped but the autobump workflow is failing to update to version 1.1.3 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.