### PR TITLE
psychopy 2025.2.0

### DIFF
--- a/Casks/p/psychopy.rb
+++ b/Casks/p/psychopy.rb
@@ -1,27 +1,20 @@
 cask "psychopy" do
-  version "2025.1.1"
-  sha256 "9e791fb5323b2ae56f470a37f2a47738282bf2e853b653f44ff793094f3402fc"
+  version "2025.2.0"
+  sha256 "d47410cc67ff2382278c34082300c0811a13ab5a8ce0b96df689094298df507b"
 
-  url "https://github.com/psychopy/psychopy/releases/download/#{version.csv.first.major_minor_patch}/StandalonePsychoPy-#{version.csv.first}-macOS#{"_#{version.csv.second}" if version.csv.second}-py3.10.dmg",
+  url "https://github.com/psychopy/psychopy/releases/download/#{version.csv.first.major_minor_patch}/StandalonePsychoPy-#{version.csv.first}-macOS#{"_#{version.csv.second}" if version.csv.second}-3.10.dmg",
       verified: "github.com/psychopy/psychopy/"
   name "PsychoPy"
   desc "Create experiments in behavioral science"
   homepage "https://www.psychopy.org/"
 
   livecheck do
-    url :url
+    url "https://www.psychopy.org/download.html"
     regex(/StandalonePsychoPy[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]?(\d+(?:[._-]\d+)+)?[._-](?:py)?3\.10\.dmg/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        release["assets"]&.map do |asset|
-          match = asset["name"]&.match(regex)
-          next if match.blank?
-
-          match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
-        end
-      end.flatten
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`psychopy` is autobumped but the workflow is failing to update to 2025.2.0 because the filename omits `py` from the `-py3.10` suffix (upstream is inconsistent from one version to the next). There may be something to be said for including the suffix after `-macOS` as the second part of the `version`, as that should help to reduce the need for us to manually update this due to suffix variations.

This also updates the `livecheck` block to check the first-party download page, as it links to the latest dmg file on GitHub, so we don't have to use the `GithubReleases` strategy.