### PR TITLE
Add conflict in hoppscotch cask

### DIFF
--- a/Casks/h/hoppscotch.rb
+++ b/Casks/h/hoppscotch.rb
@@ -11,6 +11,7 @@ cask "hoppscotch" do
   desc "Open source API development ecosystem"
   homepage "https://hoppscotch.com/"
 
+  conflicts_with cask: "hoppscotch-selfhost"
   depends_on macos: ">= :high_sierra"
 
   app "Hoppscotch.app"


### PR DESCRIPTION
Add conflict in `hoppscotch` cask with `hoppscotch-selfhost` cask.
`hoppscotch-selfhost` cask was added recently and it conflicts with `hoppscotch` client. 
Hence, adding the conflict in `hoppscotch` cask now that the `hoppscotch-selfhost` cask is available. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
