### PR TITLE
iina+ 0.8.8

### DIFF
--- a/Casks/i/iina+.rb
+++ b/Casks/i/iina+.rb
@@ -1,11 +1,13 @@
 cask "iina+" do
-  version "0.8.7"
-  sha256 "0bdfd0436774cd6bbe714f5505e978cbe1a6f49fcd930dcb527a3e6a6f182507"
+  version "0.8.8"
+  sha256 "6ef0582c269f50b80bd996663ed317c39cf2804b06d0d7eeaa54ebffba89691a"
 
   url "https://github.com/xjbeta/iina-plus/releases/download/#{version}/IINA+.#{version}.dmg"
   name "IINA+"
   desc "Extra danmaku support for iina (iina 弹幕支持)"
   homepage "https://github.com/xjbeta/iina-plus"
+
+  disable! date: "2026-09-01", because: :unsigned
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`iina+` is autobumped but the autobump workflow is failing to update to version 0.8.8 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.