### PR TITLE
ovito-pro 3.13.1

### DIFF
--- a/Casks/o/ovito-pro.rb
+++ b/Casks/o/ovito-pro.rb
@@ -2,8 +2,8 @@ cask "ovito-pro" do
   arch arm: "arm64", intel: "intel"
 
   on_arm do
-    version "3.13.0"
-    sha256 "45645bba7c9201fb98db0251c94a214ea3d9354ec4d31c4749c301e35a781f83"
+    version "3.13.1"
+    sha256 "3b5c5525d1918b85284416eeee6001cb3922f1a57f20a71e9e16e79d569d754e"
   end
   on_intel do
     version "3.12.0"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ovito-pro` is autobumped but the workflow isn't able to update to 3.13.1 because upstream hasn't been publishing Intel updates since 3.12.0. This manually updates the ARM version accordingly.