### PR TITLE
vamiga 4.3

### DIFF
--- a/Casks/v/vamiga.rb
+++ b/Casks/v/vamiga.rb
@@ -1,6 +1,6 @@
 cask "vamiga" do
-  version "4.2.1"
-  sha256 "f086416d083373ac73314e79a8cbe0a4aad54a228e34e3e7af3fdf79f4ad38df"
+  version "4.3"
+  sha256 "0191fa3a7b0510552182c8a37197a324d2c759b128e2e94fbba8f773486087fd"
 
   url "https://github.com/dirkwhoffmann/vAmiga/releases/download/v#{version}/vAmiga.app.zip",
       verified: "github.com/dirkwhoffmann/vAmiga/"
@@ -12,6 +12,8 @@ cask "vamiga" do
     url :url
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vamiga` is autobumped but the autobump workflow is failing to update to version 4.3 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.