### PR TITLE
textbar: deprecate unsigned cask, updates

### DIFF
--- a/Casks/t/textbar.rb
+++ b/Casks/t/textbar.rb
@@ -5,12 +5,16 @@ cask "textbar" do
   url "http://richsomerfield.com/apps/textbar/TextBar.app-#{version}.zip"
   name "TextBar"
   desc "Add any text to menu bar"
-  homepage "http://richsomerfield.com/apps/"
+  homepage "http://richsomerfield.com/apps/textbar/"
 
   livecheck do
     url "http://richsomerfield.com/apps/textbar/sparkle_textbar.xml"
     strategy :sparkle
   end
+
+  disable! date: "2026-09-01", because: :unsigned
+
+  auto_updates true
 
   app "TextBar.app"
 


### PR DESCRIPTION
App does have an auto-updater (seen in-app). Can be checked in #170994. Also fixed the homepage to link to the specific app.