### PR TITLE
bitcoin-core: update livecheck

### DIFF
--- a/Casks/b/bitcoin-core.rb
+++ b/Casks/b/bitcoin-core.rb
@@ -11,8 +11,8 @@ cask "bitcoin-core" do
   homepage "https://bitcoincore.org/"
 
   livecheck do
-    url "https://bitcoincore.org/bin/"
-    regex(/href=.*?bitcoin[._-]core[._-]v?(\d+(?:\.\d+)+)/i)
+    url "https://bitcoincore.org/en/download/"
+    regex(/href=.*?bitcoin[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}[^"' >]*?[._-]darwin\.zip/i)
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `bitcoin-core` checks the upstream `/bin/` directory listing page and is returning 29.1 as newest but this directory doesn't have any expected assets because the version isn't released yet. This updates the `livecheck` block to return to checking the first-party download page, which lists the newest released version.

This `livecheck` block originally checked the download page but it was modified to check the `/bin/` page instead because the download page hadn't yet been updated when a contributor created a version bump PR for 28.1. The page was seemingly updated for the newest version not too long afterward, so we should have simply waited for it to be updated as the directory listing page doesn't distinguish between released and unreleased versions.