### PR TITLE
typora@dev 1.11.2-dev

### DIFF
--- a/Casks/t/typora@dev.rb
+++ b/Casks/t/typora@dev.rb
@@ -1,15 +1,15 @@
 cask "typora@dev" do
-  version "1.11.1-dev"
-  sha256 "caa5bd5daa07e55cd1a7e872c95df01383c308d7e695fae8fbdaf8ef967497b3"
+  version "1.11.2-dev"
+  sha256 "db25c717eb28d6c23c0b56669fe09fa075065b8ae281704de323257b7fca7db6"
 
   language "zh-Hans-CN" do # use official Chinese mirror
-    url "https://download2.typoraio.cn/mac/Typora-#{version}.dmg",
+    url "https://downloads.typoraio.cn/mac/Typora-#{version}.dmg",
         verified: "typoraio.cn/"
 
     "zh-Hans-CN"
   end
   language "en", default: true do
-    url "https://download.typora.io/mac/Typora-#{version}.dmg"
+    url "https://downloads.typora.io/mac/Typora-#{version}.dmg"
 
     "en-US"
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`typora@dev` is autobumped but the workflow is unable to update to 1.11.2-dev because the domain for the zh-Hans-CN URL no longer resolves. Checking the upstream websites, both websites now use a "downloads" subdomain for download URLs. This updates the version and URLs accordingly.