### PR TITLE
baidunetdisk 4.52.5

### DIFF
--- a/Casks/b/baidunetdisk.rb
+++ b/Casks/b/baidunetdisk.rb
@@ -1,11 +1,11 @@
 cask "baidunetdisk" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "_arm64"
 
-  version "4.51.2"
-  sha256 arm:   "bbb337138666e07aeda2daae9ce3fb01fe3581a53a4f27253eeaa2d7f03f1f0a",
-         intel: "09012ce7cfbb64a5763ee91eac46a4027a2a2358e68c5314a70f6c2dc6b4ef08"
+  version "4.52.5"
+  sha256 arm:   "924c7eafce02ba73fec0e822d1090a6a8d5f5f7928c3512b96f77a70d44104fe",
+         intel: "95e4904f044cf73bbb4157c09e11038ede9c1558d359166ff5576b0c4974faff"
 
-  url "https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}_#{arch}.dmg",
+  url "https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}#{arch}.dmg",
       verified: "issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/"
   name "Baidu NetDisk"
   name "百度网盘"
@@ -14,7 +14,7 @@ cask "baidunetdisk" do
 
   livecheck do
     url "https://pan.baidu.com/disk/cmsdata?do=client"
-    regex(/BaiduNetdisk[._-]mac[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
+    regex(/BaiduNetdisk[._-]mac[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`baidunetdisk` is autobumped but the workflow is failing to update to version 4.52.5 because the `livecheck` block may not work in the CI environment (or it may fail intermittently). The check works locally, so this updates the cask to the latest version. The Intel dmg file no longer has an `x64` suffix, so this updates the cask accordingly.