### PR TITLE
rodecaster: undeprecate, new dsl test

### DIFF
--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -14,15 +14,11 @@ cask "rodecaster" do
     end
   end
 
-  disable! date: "2026-09-01", because: :unsigned
-
   depends_on macos: ">= :catalina"
 
-  pkg "RØDECaster App.pkg"
+  rename "RØDECaster App*.pkg", "RØDECaster App.pkg"
 
-  preflight do
-    staged_path.glob("RØDECaster App*.pkg")&.first&.rename(staged_path/"RØDECaster App.pkg")
-  end
+  pkg "RØDECaster App.pkg"
 
   uninstall quit:    "com.rode.rodecastercomp",
             pkgutil: "com.rodecastercomp.installer"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Companion to https://github.com/Homebrew/brew/pull/20421
The deprecation due to being unsigned was a false positive.