### PR TITLE
scrub-utility 1.3 (new cask)

### DIFF
--- a/Casks/s/scrub-utility.rb
+++ b/Casks/s/scrub-utility.rb
@@ -1,0 +1,29 @@
+cask "scrub-utility" do
+  version "1.3,2023.06"
+  sha256 "d4537bc05615fcb4ef2a00b042a494b071b9cfaeb4ced7e8884fd3945034655d"
+
+  url "https://eclecticlight.co/wp-content/uploads/#{version.csv.second.major}/#{version.csv.second.minor}/scrub#{version.csv.first.no_dots}.zip"
+  name "Scrub"
+  desc "Cleans folders and volumes to guard against potential leaks of sensitive data"
+  homepage "https://eclecticlight.co/lockrattler-systhist/"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/(\d+)/(\d+)/scrub[^"' >]*?\.zip[^>]*?>\s*scrub\s+v?(\d+(?:\.\d+)*)[^a-z)]}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        "#{match[2]},#{match[0]}.#{match[1]}"
+      end
+    end
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "scrub#{version.csv.first.no_dots}/Scrub.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.eclecticlight.scrub.sfl*",
+    "~/Library/Preferences/co.eclecticlight.Scrub.plist",
+    "~/Library/Saved Application State/co.eclecticlight.Scrub.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
[`scrub`](https://formulae.brew.sh/formula/scrub) already exists, so open to renaming suggestions. It was refused [six years ago](https://github.com/Homebrew/homebrew-cask/pull/58707) for notability, but it's been long enough that it's worth another look.