### PR TITLE
fly 7.14.0

### DIFF
--- a/Casks/f/fly.rb
+++ b/Casks/f/fly.rb
@@ -1,11 +1,13 @@
 cask "fly" do
-  version "7.13.2"
-  sha256 "01c071de4d22b421de8fcb10b6a47335264e7f106743e50c99e10d79fa3fab3a"
+  version "7.14.0"
+  sha256 "a6e48d39f4d1269926a16d67e89669278b48cd92beeef144d3419354e5b743c9"
 
   url "https://github.com/concourse/concourse/releases/download/v#{version}/fly-#{version}-darwin-amd64.tgz"
   name "fly"
   desc "Official CLI tool for Concourse CI"
   homepage "https://github.com/concourse/concourse"
+
+  disable! date: "2026-09-01", because: :unsigned
 
   binary "fly"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`fly` is autobumped but the autobump workflow is failing to update to version 7.14.0 because the app is unsigned. This updates the version and adds a `disable!` call with the future date we've been using for this situation.