### PR TITLE
native-access 3.20.0

### DIFF
--- a/Casks/n/native-access.rb
+++ b/Casks/n/native-access.rb
@@ -2,10 +2,10 @@ cask "native-access" do
   arch arm: "arm64", intel: "x64"
   folder = on_arch_conditional arm: "arm64/"
 
-  version "3.19.1"
+  version "3.20.0"
   sha256 :no_check
 
-  url "https://na-update.native-instruments.com/#{folder}Native-Access-#{arch}-mac.zip"
+  url "https://na-update.native-instruments.com/#{folder}Native-Access-#{arch}-mac-latest.zip"
   name "Native Access"
   desc "Administration tool for Native Instruments products"
   homepage "https://www.native-instruments.com/en/specials/native-access-2/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`native-access` is autobumped but the workflow is failing to update to 3.20.0 because the filename suffix changed to also include `-latest` (as seen in the appcast). This updates the version and URL accordingly.