### PR TITLE
steelseries-gg 92.0.0

### DIFF
--- a/Casks/s/steelseries-gg.rb
+++ b/Casks/s/steelseries-gg.rb
@@ -1,6 +1,6 @@
 cask "steelseries-gg" do
-  version "91.0.0"
-  sha256 "f6b3c4dda4f049231fa0e8f952ea85bfd28a91ba89ff474ccdf91a36f2b5d8fd"
+  version "92.0.0"
+  sha256 "eea4c80d86fd8265c778c30431056c6b0bf61403203088f5135bd5165f632e7b"
 
   url "https://engine.steelseriescdn.com/SteelSeriesGG#{version}.pkg",
       verified: "engine.steelseriescdn.com/"
@@ -44,8 +44,4 @@ cask "steelseries-gg" do
     "~/Library/Saved Application State/com.steelseries.gg.client.savedState",
     "~/Library/Saved Application State/com.steelseries.gg.uninstaller.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`steelseries-gg` is autobumped but the workflow is failing to update to version 92.0.0 because `brew audit` is failing with "No artifacts require Rosetta 2 but the caveats say otherwise!" This updates the version and removes the Rosetta caveat accordingly.