### PR TITLE
.github/workflows/autobump.yml: set `HOMEBREW_DEVELOPER=1`

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   autobump:
     if: github.repository == 'Homebrew/homebrew-cask'
+    env:
+      HOMEBREW_DEVELOPER: 1
     runs-on: macos-15
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The autobump workflow is currently failing because it isn't allowed to load a cask from a path.

Failed Run: https://github.com/Homebrew/homebrew-cask/actions/runs/16917714424
Successful Run (from this branch): https://github.com/Homebrew/homebrew-cask/actions/runs/16923522459