### PR TITLE
Tuta Mail: use GitHub releases

### DIFF
--- a/Casks/t/tuta-mail.rb
+++ b/Casks/t/tuta-mail.rb
@@ -1,15 +1,16 @@
 cask "tuta-mail" do
   version "301.250806.1"
-  sha256 :no_check
+  sha256 "36b0b9ff7efa5b33f39bf4c426470b1bb523f8e32eaef146a5eca81715dc4c2c"
 
-  url "https://app.tuta.com/desktop/tutanota-desktop-mac.dmg"
+  url "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-#{version}/tutanota-desktop-mac.dmg",
+      verified: "github.com/tutao/tutanota/releases/download/"
   name "Tuta Mail"
-  desc "Email client"
+  desc "Secure email client"
   homepage "https://tuta.com/"
 
   livecheck do
-    url "https://app.tuta.com/desktop/latest-mac.yml"
-    strategy :electron_builder
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true
@@ -22,6 +23,8 @@ cask "tuta-mail" do
     "~/Library/Application Support/tutanota-desktop",
     "~/Library/Caches/de.tutao.tutanota",
     "~/Library/Caches/de.tutao.tutanota.ShipIt",
+    "~/Library/Caches/tutanota-desktop-updater",
+    "~/Library/HTTPStorages/de.tutao.tutanota",
     "~/Library/Preferences/de.tutao.tutanota.plist",
   ]
 end


### PR DESCRIPTION
Downloading Tuta Mail directly from `app.tuta.com` (which is what we previously did) means that you always get the latest version, regardless of what version Homebrew says you have.  This is a flaw that arose in discussion with @bevanjkay in #221462 (in my case, Homebrew had downloaded version 301.250806.1 of the cask but was reporting it as version 299.250725.1).

Instead, using Tuta Mail's GitHub releases, we can specify the specific version we wish to download.  This means that Homebrew will always download the correct version specified by the formula, rather than the latest.

Note that we could do dynamic hash checking by parsing the release notes, but I think this is more effort than it's worth.
```shell
curl -s https://api.github.com/repos/tutao/tutanota/releases/tags/tutanota-desktop-release-301.250806.1 | \
    jq -r '.body' | \
    awk '/tutanota-desktop-mac\.dmg/{getline; print}'
```

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

~~Additionally, **if adding a new cask**:~~

- [ ] ~~Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).~~
- [ ] ~~Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).~~
- [ ] ~~`brew audit --cask --new <cask>` worked successfully.~~
- [ ] ~~`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.~~
- [ ] ~~`brew uninstall --cask <cask>` worked successfully.~~
