### PR TITLE
garmin-express 7.26.0

### DIFF
--- a/Casks/g/garmin-express.rb
+++ b/Casks/g/garmin-express.rb
@@ -10,7 +10,7 @@ cask "garmin-express" do
     end
   end
   on_big_sur :or_newer do
-    version "7.25.0"
+    version "7.26.0"
     sha256 :no_check
 
     url "https://download.garmin.com/omt/express/GarminExpress.dmg"
@@ -49,8 +49,4 @@ cask "garmin-express" do
     "~/Library/Caches/com.garmin.renu.service.crashreporter",
     "~/Library/Preferences/com.garmin.renu*",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`garmin-express` is autobumped but the workflow is failing to update to version 7.26.0 because `brew audit` is failing with "No artifacts require Rosetta 2 but the caveats say otherwise!" This updates the version and removes the Rosetta caveat accordingly.