### PR TITLE
miaoyan 1.18.3

### DIFF
--- a/Casks/m/miaoyan.rb
+++ b/Casks/m/miaoyan.rb
@@ -1,8 +1,8 @@
 cask "miaoyan" do
-  version "1.18.1"
-  sha256 "f275efee7e5ec0757f4c7081798d2d4b565f195d797dee21184be2857be587ca"
+  version "1.18.3"
+  sha256 "04180678da7a6d1d737148b6675a59f251058855ce1ca728d4e69f584e5bb612"
 
-  url "https://gw.alipayobjects.com/os/k/app1/MiaoYan_V#{version}.zip",
+  url "https://gw.alipayobjects.com/os/k/app/MiaoYan_V#{version}.zip",
       verified: "gw.alipayobjects.com/"
   name "MiaoYan"
   desc "Markdown editor"
@@ -18,7 +18,7 @@ cask "miaoyan" do
   disable! date: "2026-09-01", because: :unsigned
 
   auto_updates true
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "MiaoYan.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`miaoyan` is autobumped but the workflow is failing to update to 1.18.3 because the URL has changed (the path uses `/app/` instead of `/app1/`). This updates the version and URL accordingly and updates the `depends_on macos:` value to resolve the `brew audit` error.