### PR TITLE
hydrus-network 634

### DIFF
--- a/Casks/h/hydrus-network.rb
+++ b/Casks/h/hydrus-network.rb
@@ -1,6 +1,6 @@
 cask "hydrus-network" do
-  version "633a"
-  sha256 "724eee4df12d0d505102e3314e710548f7d34da96bd5a3bf2af0854a2e60d223"
+  version "634"
+  sha256 "89e7bc63e1612dbe71da372b19b32d656dca87617ece8562de9b61aadf4f26b8"
 
   url "https://github.com/hydrusnetwork/hydrus/releases/download/v#{version}/Hydrus.Network.#{version}.-.macOS.-.App.zip",
       verified: "github.com/hydrusnetwork/hydrus/"
@@ -13,8 +13,6 @@ cask "hydrus-network" do
     regex(/v?(\d+(?:\.\d+)*[a-z]?)/i)
     strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :unsigned
 
   app "Hydrus Network.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`hydrus-network` is autobumped but the workflow is failing to update to the latest version because the app is now signed. This updates the version and removes the `disable!` call to resolve the `brew audit` error.