### PR TITLE
serial-studio 3.1.8

### DIFF
--- a/Casks/s/serial-studio.rb
+++ b/Casks/s/serial-studio.rb
@@ -1,8 +1,8 @@
 cask "serial-studio" do
-  version "3.1.7"
-  sha256 "a005d0d44c7424bccdea17cfec7e11e33c11e5884fe84ac05122d35ac4a9834e"
+  version "3.1.8"
+  sha256 "2e34bf1909d91d3b94b76f2fe418ef597c3046647389d7f0333bf887b217ffcd"
 
-  url "https://github.com/Serial-Studio/Serial-Studio/releases/download/v#{version}/Serial-Studio-#{version}-macOS-Universal.dmg",
+  url "https://github.com/Serial-Studio/Serial-Studio/releases/download/v#{version}/Serial-Studio-Pro-#{version}-macOS.dmg",
       verified: "github.com/Serial-Studio/Serial-Studio/"
   name "Serial Studio"
   desc "Data visualisation software for embedded devices and projects"
@@ -13,7 +13,9 @@ cask "serial-studio" do
     strategy :github_latest
   end
 
-  app "Serial Studio.app"
+  depends_on macos: ">= :ventura"
+
+  app "Serial Studio Pro.app"
 
   zap trash: [
     "~/Library/Caches/Alex Spataru/Serial-Studio",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`serial-studio` is autobumped but the workflow is failing to update to version 3.1.8 because the upstream filename now uses `Serial-Studio-Pro-` as the prefix and dropped `-Universal` from the suffix. This updates the version and adjusts the cask to align with the changes to the new filename, app name, and macOS version requirements.