### PR TITLE
mihomo-party: update Catalina checksums for 1.8.4

### DIFF
--- a/Casks/m/mihomo-party.rb
+++ b/Casks/m/mihomo-party.rb
@@ -4,8 +4,8 @@ cask "mihomo-party" do
   version "1.8.4"
 
   on_catalina :or_older do
-    sha256 arm:   "ff6951cfc7140e42162153df521bfd35a29f2c31292aea4f1c80bc595722996e",
-           intel: "7e9ac60dbafb8edac549ce342353148c529c4cb05022805488f5405eabfc3e55"
+    sha256 arm:   "2fe713eda313665cdcbb3cc3cb0770d3a78927bbbe25ab4139f42c1995fca029",
+           intel: "41fe40307a8e1a7b1315e8ad9000da7020cb7db16f1efe59cde1b3fd715e471d"
 
     url "https://github.com/mihomo-party-org/mihomo-party/releases/download/v#{version}/mihomo-party-catalina-#{version}-#{arch}.pkg",
         verified: "github.com/mihomo-party-org/mihomo-party/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

For whatever reason, `brew bump-cask-pr` only updates the checksums for the Big Sur or newer block but doesn't update the Catalina or older block. This manually updates the checksums for the Catalina or older block.