### PR TITLE
treesheets 2386

### DIFF
--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -1,6 +1,6 @@
 cask "treesheets" do
-  version "2370"
-  sha256 "10e20dad562bba2a25af027dce656d0a6f38e61b801796e00c945ad0eef0d0bc"
+  version "2386"
+  sha256 "939783ab30a99b36351669e8c2097f42b833ba784b3576a16d3892295c078e3d"
 
   url "https://github.com/aardappel/treesheets/releases/download/#{version.csv.second || version.csv.first}/TreeSheets-#{version.csv.first}-Darwin.dmg",
       verified: "github.com/aardappel/treesheets/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`treesheets` is autobumped but the workflow is failing to update to version 2386 because the app is now signed but it was previously deprecated as unsigned. This updates the version and removes the `disable!` call to resolve the `brew audit` error.