### PR TITLE
Restore recently removed disable! calls

### DIFF
--- a/Casks/h/hydrus-network.rb
+++ b/Casks/h/hydrus-network.rb
@@ -14,6 +14,8 @@ cask "hydrus-network" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :unsigned
+
   app "Hydrus Network.app"
 
   zap trash: "~/Library/Hydrus"

--- a/Casks/q/qownnotes.rb
+++ b/Casks/q/qownnotes.rb
@@ -13,6 +13,8 @@ cask "qownnotes" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :unsigned
+
   auto_updates true
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This restores the `disable!` calls for `hydrus-network` and `qownnotes`, which I recently removed because `brew audit` was erroneously saying that the apps were signed. I'm creating this as a draft until the bug fix PR in the brew repository is merged.