### PR TITLE
Preserve Conda environments during Miniforge Cask upgrades

### DIFF
--- a/Casks/m/miniforge.rb
+++ b/Casks/m/miniforge.rb
@@ -11,12 +11,12 @@ cask "miniforge" do
   homepage "https://github.com/conda-forge/miniforge"
 
   livecheck do
-    url :homepage
-    regex(/v?(\d+(?:[.-]\d+)+)/i)
+    url :url
     strategy :github_latest
   end
 
   auto_updates true
+  
   conflicts_with cask: [
     "mambaforge",
     "miniconda",
@@ -30,7 +30,7 @@ cask "miniforge" do
   binary "#{caskroom_path}/base/condabin/conda"
   binary "#{caskroom_path}/base/condabin/mamba"
 
-  uninstall delete: "#{caskroom_path}/base"
+  uninstall rmdir: "#{caskroom_path}/base"
 
   zap trash: [
     "~/.conda",
@@ -38,7 +38,7 @@ cask "miniforge" do
   ]
 
   caveats <<~EOS
-    Please run the following to setup your shell:
+    To initialize your shell, run:
       conda init "$(basename "${SHELL}")"
   EOS
 end


### PR DESCRIPTION
Replaced the destructive `uninstall delete: "#{caskroom_path}/base"` with `uninstall rmdir: "#{caskroom_path}/base"`, ensuring the prefix is only removed if it’s empty

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
