### PR TITLE
font-stix: revert to 2.13b171

### DIFF
--- a/Casks/font/font-s/font-stix.rb
+++ b/Casks/font/font-s/font-stix.rb
@@ -1,21 +1,27 @@
 cask "font-stix" do
-  version "2.14"
-  sha256 "b9ce7effe9cf97185bc3bfd9b3c5e79e0928a500127d1f55d0a704e04d274420"
+  version "2.13b171"
+  sha256 "1e76b9ab0bb08372ff73ad5b58d9116260e9058d1fce4b83fe1e213c3b9c947f"
 
-  url "https://github.com/stipub/stixfonts/releases/download/v#{version}/fonts.zip",
+  url "https://github.com/stipub/stixfonts/archive/refs/tags/v#{version}.tar.gz",
       verified: "github.com/stipub/stixfonts/"
   name "STIX"
   homepage "https://stixfonts.org/"
 
-  font "fonts/STIXTwoMath/OTF/STIXTwoMath.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-Bold.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-BoldItalic.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-Italic.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-Medium.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-MediumItalic.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-Regular.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-SemiBold.otf"
-  font "fonts/STIXTwoText/OTF/STIXTwoText-SemiBoldItalic.otf"
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
+    strategy :github_latest
+  end
+
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoMath-Regular.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-Bold.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-BoldItalic.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-Italic.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-Medium.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-MediumItalic.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-Regular.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-SemiBold.otf"
+  font "stixfonts-#{version}/fonts/static_otf/STIXTwoText-SemiBoldItalic.otf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  I'm not sure how to run this. `brew audit --online font-stix.rb` says `brew audit [path ...]` is disabled.
- [x] `brew style --fix <cask>` reports no offenses.

---

Version 2.14 was withdrawn (https://github.com/stipub/stixfonts/issues/279) and the release was removed, so the cask did not install anymore. Reverted to 2.13 and updated to newest 2.13b171.

PS. First time contributing here. Thank you for Homebrew!