### PR TITLE
casks: use ftpmirror.gnu.org URL

### DIFF
--- a/Casks/e/electricbinary.rb
+++ b/Casks/e/electricbinary.rb
@@ -2,7 +2,7 @@ cask "electricbinary" do
   version "9.08.1"
   sha256 "fcfd8b543aa0124f764945f2eba3a2c76dd7bd8db403dee2b1a3ddbc70875e5a"
 
-  url "https://ftp.gnu.org/gnu/electric/electricBinary-#{version}.jar"
+  url "https://ftpmirror.gnu.org/gnu/electric/electricBinary-#{version}.jar"
   name "Electric VLSI Design System"
   desc "Electrical CAD system for the design of integrated circuits"
   homepage "https://www.gnu.org/software/electric/electric.html"

--- a/Casks/font/font-f/font-freefont.rb
+++ b/Casks/font/font-f/font-freefont.rb
@@ -2,7 +2,7 @@ cask "font-freefont" do
   version "20120503"
   sha256 "3a6c51868c71b006c33c4bcde63d90927e6fcca8f51c965b8ad62d021614a860"
 
-  url "https://ftp.gnu.org/gnu/freefont/freefont-otf-#{version}.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/freefont/freefont-otf-#{version}.tar.gz"
   name "FreeFont"
   homepage "https://www.gnu.org/software/freefont/"
 

--- a/Casks/font/font-g/font-gnu-unifont.rb
+++ b/Casks/font/font-g/font-gnu-unifont.rb
@@ -2,8 +2,8 @@ cask "font-gnu-unifont" do
   version "16.0.04"
   sha256 "2bd4e4679757126f48e1bf2c1be40b09aa92162bfedda4683ce5fbc70a2a5972"
 
-  url "https://ftp.gnu.org/gnu/unifont/unifont-#{version}/unifont-#{version}.tar.gz",
-      verified: "ftp.gnu.org/gnu/unifont/"
+  url "https://ftpmirror.gnu.org/gnu/unifont/unifont-#{version}/unifont-#{version}.tar.gz",
+      verified: "ftpmirror.gnu.org/gnu/unifont/"
   name "GNU Unifont"
   homepage "https://unifoundry.com/unifont.html"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

We should prefer ftpmirror.gnu.org URLs over ftp.gnu.org; see https://github.com/Homebrew/brew/issues/20456 for context.

Unblocks https://github.com/Homebrew/brew/pull/20463.
