### PR TITLE
unite-phone 2025.8.1

### DIFF
--- a/Casks/u/unite-phone.rb
+++ b/Casks/u/unite-phone.rb
@@ -1,16 +1,16 @@
 cask "unite-phone" do
-  version "2025.1.3"
-  sha256 "68ac9ce3255b4173ac78845aa8b06ce33552c853daa79eee503b8b75a893c4b2"
+  version "2025.8.1"
+  sha256 "53bc7f948d5c4606f37ee2dee959df802d892c6c1be2411cdf6ca897c9f147b7"
 
-  url "https://update.unitephone.nl/download/unite_phone-#{version}-universal.dmg",
+  url "https://update.unitephone.nl/updates/unite_phone-#{version}-universal-mac.zip",
       user_agent: :fake
   name "Unite Phone"
   desc "Video and voice calling application"
   homepage "https://unitephone.nl/"
 
   livecheck do
-    url "https://unitephone.nl/unitephone-app/macos"
-    strategy :header_match
+    url "https://update.unitephone.nl/updates/latest-mac.yml"
+    strategy :electron_builder
   end
 
   app "Unite Phone.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`unite-phone` is autobumped but the workflow is failing to update to version 2025.8.1 because the filename format has changed. This updates the version and `url` accordingly and adds a `depends_on macos:` value to resolve the related `brew audit` failure.

For what it's worth, the download was a little flaky when running `brew audit` locally, so I'm not surprised that the tests failed.