### PR TITLE
cursor-cli: update arm64 sha256

### DIFF
--- a/Casks/c/cursor-cli.rb
+++ b/Casks/c/cursor-cli.rb
@@ -2,7 +2,7 @@ cask "cursor-cli" do
   arch arm: "arm64", intel: "x64"
 
   version "2025.08.15-dbc8d73"
-  sha256 arm:   "230ab1f3be57b0085bf071b02c2b2678b7123e8bd85d6f5118b69e3f355cbc6c",
+  sha256 arm:   "e5c5b2a0a0715bad90a9c02e91c7b96785c0fad70dbe861702c2aac978f1201f",
          intel: "24dddb99177adf6e445aaac338999cec7d73e5c687d4cb5621d700f42183129f"
 
   url "https://downloads.cursor.com/lab/#{version}/darwin/#{arch}/agent-cli-package.tar.gz"


### PR DESCRIPTION
Bad sha for `arm64` introduced in:
https://github.com/Homebrew/homebrew-cask/pull/224115

```
➜  brew install --cask cursor-cli                                                                                              ➜  brew install --cask cursor-cli                                                                                              8:36:22 pm
==> Downloading https://downloads.cursor.com/lab/2025.08.15-dbc8d73/darwin/arm64/agent-cli-package.tar.gz
#################################################################################################################################### 100.0%
Error: SHA-256 mismatch
Expected: 230ab1f3be57b0085bf071b02c2b2678b7123e8bd85d6f5118b69e3f355cbc6c
  Actual: e5c5b2a0a0715bad90a9c02e91c7b96785c0fad70dbe861702c2aac978f1201f
    File: ../Library/Caches/Homebrew/downloads/6268fba6cd1f418011c3b0b395bc4ebbc4128877753730d7c3e22926cbe53ff4--agent-cli-package.tar.gz
To retry an incomplete download, remove the file above.

```


Fixed arm64.
intel arch was correct.

```
➜  wget https://downloads.cursor.com/lab/2025.08.15-dbc8d73/darwin/arm64/agent-cli-package.tar.gz                              8:22:25 pm
--2025-08-15 20:23:14--  https://downloads.cursor.com/lab/2025.08.15-dbc8d73/darwin/arm64/agent-cli-package.tar.gz
Resolving downloads.cursor.com (downloads.cursor.com)... 104.18.16.128, 104.18.17.128, 2606:4700::6812:1080, ...
Connecting to downloads.cursor.com (downloads.cursor.com)|104.18.16.128|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 43739317 (42M) [application/x-tar]
Saving to: ‘agent-cli-package.tar.gz’

agent-cli-package.tar.gz           100%[===============================================================>]  41.71M  26.9MB/s    in 1.6s

2025-08-15 20:23:16 (26.9 MB/s) - ‘agent-cli-package.tar.gz’ saved [43739317/43739317]



/tmp
➜  sha256 ‘agent-cli-package.tar.gz’                                                                                           8:23:18 pm
sha256: ‘agent-cli-package.tar.gz’: No such file or directory


/tmp
➜  sha256 agent-cli-package.tar.gz                                                                                             8:23:26 pm
SHA256 (agent-cli-package.tar.gz) = e5c5b2a0a0715bad90a9c02e91c7b96785c0fad70dbe861702c2aac978f1201f


/tmp
➜  wget https://downloads.cursor.com/lab/2025.08.15-dbc8d73/darwin/x64/agent-cli-package.tar.gz                                8:23:32 pm
--2025-08-15 20:24:39--  https://downloads.cursor.com/lab/2025.08.15-dbc8d73/darwin/x64/agent-cli-package.tar.gz
Resolving downloads.cursor.com (downloads.cursor.com)... 104.18.16.128, 104.18.17.128, 2606:4700::6812:1080, ...
Connecting to downloads.cursor.com (downloads.cursor.com)|104.18.16.128|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 45834460 (44M) [application/x-tar]
Saving to: ‘agent-cli-package.tar.gz.1’

agent-cli-package.tar.gz.1         100%[===============================================================>]  43.71M  30.4MB/s    in 1.4s

2025-08-15 20:24:41 (30.4 MB/s) - ‘agent-cli-package.tar.gz.1’ saved [45834460/45834460]


took 2s121ms
/tmp
➜  sha256 agent-cli-package.tar.gz.1                                                                                           8:24:43 pm
SHA256 (agent-cli-package.tar.gz.1) = 24dddb99177adf6e445aaac338999cec7d73e5c687d4cb5621d700f42183129f

````

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
