### PR TITLE
the-unofficial-homestuck-collection 2.7.2

### DIFF
--- a/Casks/t/the-unofficial-homestuck-collection.rb
+++ b/Casks/t/the-unofficial-homestuck-collection.rb
@@ -1,6 +1,6 @@
 cask "the-unofficial-homestuck-collection" do
-  version "2.7.0"
-  sha256 "6ab7030ee74e561d0a1f03f081d38689392b77d239ed354aea3cf47c83d29205"
+  version "2.7.2"
+  sha256 "a71d5a14e631c3721a96302679e0531fbc367b7712886e28fc2547fa988f44c2"
 
   url "https://github.com/Bambosh/unofficial-homestuck-collection/releases/download/v#{version}/The-Unofficial-Homestuck-Collection-#{version}.dmg",
       verified: "github.com/Bambosh/unofficial-homestuck-collection/"
@@ -12,6 +12,8 @@ cask "the-unofficial-homestuck-collection" do
     url :url
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   app "The Unofficial Homestuck Collection.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`the-unofficial-homestuck-collection` is autobumped but the workflow is failing to update to 2.7.2 because it is failing `brew audit` due to the app being unsigned. This updates the version and adds a `disable!` call with the date we've been using for this situation.