### PR TITLE
picoscope@beta 7.2.3.6884

### DIFF
--- a/Casks/p/picoscope@beta.rb
+++ b/Casks/p/picoscope@beta.rb
@@ -1,20 +1,20 @@
 cask "picoscope@beta" do
-  version "7.1.58.6335"
-  sha256 "4039275fc877e258bfc50f3dee577a709a11da87432d8bf8a6b91f032e76c281"
+  version "7.2.3.6884"
+  sha256 "52a61fcd36c39c1c7c04dd5028220f22dffaddb3565bc25f65f5a6c8e5287097"
 
-  url "https://www.picotech.com/download/software/beta/PicoScope_#{version.major}_TandM_Early_Access_#{version}.pkg"
+  url "https://www.picotech.com/download/software/beta/PicoScope_#{version.major}_TandM_Early_Access_#{version}.x64.pkg"
   name "PicoScope beta"
   desc "Test and measurement oscilloscope software for PicoScope oscilloscopes"
   homepage "https://www.picotech.com/"
 
   livecheck do
     url "https://www.picotech.com/downloads/picoscope#{version.major}-early-access"
-    regex(/href=.*?PicoScope[._-]#{version.major}.*?Access[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
+    regex(/href=.*?PicoScope[._-][^"' >]*?[._-]v?(#{version.major}(?:\.\d+)+)[^"' >]*?\.pkg/i)
   end
 
   conflicts_with cask: "picoscope"
 
-  pkg "PicoScope_#{version.major}_TandM_Early_Access_#{version}.pkg"
+  pkg "PicoScope_#{version.major}_TandM_Early_Access_#{version}.x64.pkg"
 
   uninstall pkgutil: "com.picotech.picoscope#{version.major}tnmbeta"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`picoscope@beta` is autobumped but the workflow is unable to update to the latest version because the `livecheck` block regex isn't able to match the current file URL on the upstream download page. This updates the regex to be able to match the current file URL and updates the cask to the latest version.