### PR TITLE
nordvpn: revert to 9.2.1

### DIFF
--- a/Casks/n/nordvpn.rb
+++ b/Casks/n/nordvpn.rb
@@ -1,6 +1,6 @@
 cask "nordvpn" do
-  version "9.3.0"
-  sha256 "effda8c102dc9184820cea02cf76397554ddb2913d6fcc9e098dae27d466971b"
+  version "9.2.1"
+  sha256 "c0ee1f360209b08c9d8281293fe3c03c3657740aad42462c9efab6ac2b42bfc5"
 
   url "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/#{version}/NordVPN.pkg",
       verified: "downloads.nordcdn.com/apps/macos/generic/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

---

Appears upstream has pulled version `9.3.0`.

Reverts #223679
Fixes #224253