### PR TITLE
kstars 3.7.8

### DIFF
--- a/Casks/k/kstars.rb
+++ b/Casks/k/kstars.rb
@@ -1,9 +1,10 @@
 cask "kstars" do
-  version "3.7.7"
+  version "3.7.8"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.indilib.org/jdownloads/kstars/kstars-#{version}.dmg",
-      verified: "indilib.org/jdownloads/kstars/"
+      user_agent: :browser,
+      verified:   "indilib.org/jdownloads/kstars/"
   name "KStars"
   desc "Astronomy software"
   homepage "https://kstars.kde.org/"
@@ -13,7 +14,7 @@ cask "kstars" do
     regex(/href=.*?kstars[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :monterey"
 
   app "kstars.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kstars` is autobumped but the workflow is failing to update to version 3.7.8 because download the dmg file seems to require a browser user agent now. This adds a `user_agent` option to the cask `url` and updates the macOS dependency to resolve the `brew audit` failure.