### PR TITLE
wine@devel 10.13

### DIFF
--- a/Casks/w/wine@devel.rb
+++ b/Casks/w/wine@devel.rb
@@ -1,6 +1,6 @@
 cask "wine@devel" do
-  version "10.12"
-  sha256 "4f3f28215363382dccb0b7681969a0aa4d3326e2cf682b5af524def245810811"
+  version "10.13"
+  sha256 "e95e45c9b67d478583c1745f5d822d36a0533d1dd29887844feed6cc8773a8b9"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.
@@ -30,6 +30,8 @@ cask "wine@devel" do
       end
     end
   end
+
+  disable! date: "2026-09-01", because: :unsigned
 
   conflicts_with cask: [
     "wine-stable",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wine@devel` is autobumped but the workflow is failing to update to version 10.13 because the app is unsigned. This updates the version and adds a `disable!` call with the date we've been using for this scenario.