### PR TITLE
suspicious-package@preview: disable

### DIFF
--- a/Casks/s/suspicious-package@preview.rb
+++ b/Casks/s/suspicious-package@preview.rb
@@ -15,6 +15,8 @@ cask "suspicious-package@preview" do
     end
   end
 
+  disable! date: "2025-08-18", because: :discontinued, replacement_cask: "suspicious-package"
+
   conflicts_with cask: "suspicious-package"
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

It looks as if the `preview` branch was just a temporary availability to test some specific things for Tahoe.
Let's just disable it straight away, and suggest moving back to the main release.