### PR TITLE
Revert "rodecaster: undeprecate, new dsl test"

### DIFF
--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -14,11 +14,15 @@ cask "rodecaster" do
     end
   end
 
+  disable! date: "2026-09-01", because: :unsigned
+
   depends_on macos: ">= :catalina"
 
-  rename "RØDECaster App*.pkg", "RØDECaster App.pkg"
-
   pkg "RØDECaster App.pkg"
+
+  preflight do
+    staged_path.glob("RØDECaster App*.pkg")&.first&.rename(staged_path/"RØDECaster App.pkg")
+  end
 
   uninstall quit:    "com.rode.rodecastercomp",
             pkgutil: "com.rodecastercomp.installer"


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#223510

Needs a fix to be supported by the API, and waiting until the next Brew release.