### PR TITLE
vagrant: unify sha256

### DIFF
--- a/Casks/v/vagrant.rb
+++ b/Casks/v/vagrant.rb
@@ -2,8 +2,7 @@ cask "vagrant" do
   arch arm: "arm64", intel: "amd64"
 
   version "2.4.8"
-  sha256 arm:   "e9c42af33ddcec9adf1401b2fe44fd09c167e8d846b30f67a1a4185912f11a9e",
-         intel: "e9c42af33ddcec9adf1401b2fe44fd09c167e8d846b30f67a1a4185912f11a9e"
+  sha256 "e9c42af33ddcec9adf1401b2fe44fd09c167e8d846b30f67a1a4185912f11a9e"
 
   url "https://releases.hashicorp.com/vagrant/#{version}/vagrant_#{version}_darwin_#{arch}.dmg",
       verified: "hashicorp.com/vagrant/"


### PR DESCRIPTION
There's no reason to list the same hash twice. Will see about an audit to catch these in the future.