### PR TITLE
angry-ip-scanner 3.9.2

### DIFF
--- a/Casks/a/angry-ip-scanner.rb
+++ b/Casks/a/angry-ip-scanner.rb
@@ -1,9 +1,9 @@
 cask "angry-ip-scanner" do
   arch arm: "Arm64", intel: "X86"
 
-  version "3.9.1"
-  sha256 arm:   "bc75191718b8556c1c8610987285d98f7421044d7be117252d5f35516af3205c",
-         intel: "e1c6aea6094d317f351d9260fd6ea1a148f8a102c919c7067e2d39cd1016a8f7"
+  version "3.9.2"
+  sha256 arm:   "732ce7b539dea17dd1e7561ee74c51b514afdf4d449f7f766526e45a01ae454a",
+         intel: "6149c40b26184ccaf19f11fbea3d4712bc2764301c601b3252dc88045ca2d6eb"
 
   url "https://github.com/angryip/ipscan/releases/download/#{version}/ipscan-mac#{arch}-#{version}.zip",
       verified: "github.com/angryip/ipscan/"
@@ -11,11 +11,11 @@ cask "angry-ip-scanner" do
   desc "Network scanner"
   homepage "https://angryip.org/"
 
+  disable! date: "2026-09-01", because: :unsigned
+
+  depends_on macos: ">= :big_sur"
+
   app "Angry IP Scanner.app"
 
   # No zap stanza required
-
-  caveats do
-    depends_on_java "11"
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

`angry-ip-scanner` failed to autobump due to the application not being signed.  This updates to the latest version and marks for an `unsigned` deprecation.

While we are here, make a couple small updates by specifying a minimum macOS version, and remove the Java caveat as `angry-ip-scanner` ships with its own JRE.