### PR TITLE
flowdown 3.1.394

### DIFF
--- a/Casks/f/flowdown.rb
+++ b/Casks/f/flowdown.rb
@@ -1,8 +1,8 @@
 cask "flowdown" do
-  version "3.0.388"
-  sha256 "fe926e48349fd90528ad14505f93558e049926a484270b7d76696ae0b918842b"
+  version "3.1.394"
+  sha256 "8a727ec0a147e40afffb61432f8235d7a4bf2132eb2610cfe22c94e8271fd11f"
 
-  url "https://github.com/Lakr233/FlowDown/releases/download/#{version}/FlowDown-v#{version}.zip",
+  url "https://github.com/Lakr233/FlowDown/releases/download/#{version}/FlowDown-#{version}.zip",
       verified: "github.com/Lakr233/FlowDown/"
   name "FlowDown"
   desc "AI agent"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`flowdown` is autobumped but the workflow is failing to update to 3.1.394 because the zip filename doesn't contain the expected `v` before the version. This updates the version and URL accordingly.