### PR TITLE
displaylink: undeprecate

### DIFF
--- a/Casks/d/displaylink.rb
+++ b/Casks/d/displaylink.rb
@@ -59,18 +59,14 @@ cask "displaylink" do
       end
     end
 
-    pkg "DisplayLinkManager.pkg"
+    rename "DisplayLinkManager-#{version.csv.first}*pkg", "DisplayLinkManager-#{version.csv.first}.pkg"
 
-    preflight do
-      staged_path.glob("DisplayLinkManager-*.pkg").first.rename("#{staged_path}/DisplayLinkManager.pkg")
-    end
+    pkg "DisplayLinkManager-#{version.csv.first}.pkg"
   end
 
   name "DisplayLink USB Graphics Software"
   desc "Drivers for DisplayLink docks, adapters and monitors"
   homepage "https://www.synaptics.com/products/displaylink-graphics"
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   uninstall launchctl: [
               "73YQY62QM3.com.displaylink.DisplayLinkAPServer",


### PR DESCRIPTION
Reverts Homebrew/homebrew-cask#224357

The new `rename` dsl appears to now be available and [cask/dsl/rename: add api support](https://github.com/Homebrew/brew/pull/20491) has been merged to `main`.

FYI, Synaptics team confirms that DisplayLink releases **are** signed and notorized.