### PR TITLE
atv-remote: add livecheck

### DIFF
--- a/Casks/a/atv-remote.rb
+++ b/Casks/a/atv-remote.rb
@@ -10,6 +10,13 @@ cask "atv-remote" do
   desc "Control Apple TV from your desktop"
   homepage "https://github.com/bsharper/atv-desktop-remote"
 
+  # Upstream marks some releases that use a stable version format (v1.2.3) as
+  # pre-release on GitHub.
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :high_sierra"
 
   app "ATV Remote.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `atv-remote` but upstream marks some releases that use a stable version format (e.g., v1.2.3) as pre-release on GitHub. The newest release, v1.4.1, is pre-release and the description contains a "this should probably be a release version" comment, which seems to suggest that releases marked as pre-release aren't considered stable versions.

This adds a `livecheck` block that uses the `GithubLatest` strategy, so livecheck will return the newest non-pre-release version (1.3.7).