### PR TITLE
hstracker 3.3.7

### DIFF
--- a/Casks/h/hstracker.rb
+++ b/Casks/h/hstracker.rb
@@ -1,6 +1,6 @@
 cask "hstracker" do
-  version "3.3.6"
-  sha256 "2810834d8b59e1157cb74c55e04951add4094f8dcd24b74641e5cd81e28bc300"
+  version "3.3.7"
+  sha256 "7e23d5d77400351c8320cc7f204649fd166b5a825a7813011493c9b4abdb62e0"
 
   url "https://github.com/HearthSim/HSTracker/releases/download/#{version}/HSTracker.app.zip",
       verified: "github.com/HearthSim/HSTracker/"
@@ -30,4 +30,8 @@ cask "hstracker" do
     "~/Library/Preferences/net.hearthsim.hstracker.plist",
     "~/Library/Saved Application State/net.hearthsim.hstracker.savedState",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`hstracker` is autobumped but the workflow is failing to update to version 3.3.7 because `brew audit` is giving an error: "At least one artifact requires Rosetta 2 but this is not indicated by the caveats!" This updates the cask to the latest version and adds the Rosetta caveat to resolve the audit error.