### PR TITLE
openboardview 9.95.2

### DIFF
--- a/Casks/o/openboardview.rb
+++ b/Casks/o/openboardview.rb
@@ -1,8 +1,8 @@
 cask "openboardview" do
-  version "9.95.1"
-  sha256 "dcc5646053f2635ece1a88a8412c87aca738519d16becc38870520549b72db1a"
+  version "9.95.2"
+  sha256 "0d70f9a2c87ff40217385976d51795f21cb45476383c8b36f1e380e3cd2b6b40"
 
-  url "https://github.com/OpenBoardView/OpenBoardView/releases/download/#{version}/OpenBoardView-#{version}-Darwin.dmg",
+  url "https://github.com/OpenBoardView/OpenBoardView/releases/download/#{version}/OpenBoardView-#{version}-Darwin-x86_64.dmg",
       verified: "github.com/OpenBoardView/OpenBoardView/"
   name "OpenBoardView"
   desc "File viewer for .brd files"
@@ -13,7 +13,13 @@ cask "openboardview" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :unsigned
+
   app "openboardview.app"
 
   zap trash: "~/Library/Application Support/OpenBoardView"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`openboardview` is autobumped but the workflow is failing to update to version 9.95.2 because the dmg filename now includes an `-x86_64` suffix. Besides that, this also fails `brew audit` because the cask needs a Rosetta caveat and the app is unsigned. This updates the version, adds a Rosetta caveat, and adds a `disable!` call using the date that we've been using for this situation.