### PR TITLE
swinsian 3.0.0

### DIFF
--- a/Casks/s/swinsian.rb
+++ b/Casks/s/swinsian.rb
@@ -1,6 +1,6 @@
 cask "swinsian" do
-  version "2.3.6"
-  sha256 "750efa71b9c806cdc2c572ebb5f16a25deb83033d9a8cb4dffe347da758bd1e3"
+  version "3.0.0"
+  sha256 "0d178cf77177e37c5bb46b924d9b9f41f9efaa2ffaa6d2844d2af714f3e4d2fc"
 
   url "https://www.swinsian.com/sparkle/Swinsian_#{version}.zip"
   name "Swinsian"
@@ -13,6 +13,7 @@ cask "swinsian" do
   end
 
   auto_updates true
+  depends_on macos: ">= :high_sierra"
 
   app "Swinsian.app"
 
@@ -24,8 +25,4 @@ cask "swinsian" do
     "~/Library/Containers/com.swinsian.SwinsianChapterReader",
     "~/Library/Preferences/com.swinsian.Swinsian.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`swinsian` is autobumped but the workflow is failing to update to version 3.0.0 because of `brew audit` errors. This updates the version, adds a `depends_on macos` value, and removes the Rosetta caveat (as the app is now a universal binary).