### PR TITLE
messauto 1.1.5 (new cask)

### DIFF
--- a/Casks/m/messauto.rb
+++ b/Casks/m/messauto.rb
@@ -3,10 +3,12 @@ cask "messauto" do
 
   on_arm do
     sha256 "b046cfa7fdb6556136ab696402275e54f8b9fe773feaee4b20267dcf19a3ca4e"
+
     url "https://github.com/LeeeSe/MessAuto/releases/download/v#{version}/MessAuto_#{version}_aarch64.app.tar.gz"
   end
   on_intel do
     sha256 "cc5e4f36d0fce57caccd639675dde1ca4e9b0fd93047f8eeda66c97d06c2e75e"
+
     url "https://github.com/LeeeSe/MessAuto/releases/download/v#{version}/MessAuto_#{version}_x64.app.tar.gz"
   end
 

--- a/Casks/m/messauto.rb
+++ b/Casks/m/messauto.rb
@@ -1,0 +1,28 @@
+cask "messauto" do
+  version "1.1.5"
+
+  on_arm do
+    sha256 "b046cfa7fdb6556136ab696402275e54f8b9fe773feaee4b20267dcf19a3ca4e"
+    url "https://github.com/LeeeSe/MessAuto/releases/download/v#{version}/MessAuto_#{version}_aarch64.app.tar.gz"
+  end
+  on_intel do
+    sha256 "cc5e4f36d0fce57caccd639675dde1ca4e9b0fd93047f8eeda66c97d06c2e75e"
+    url "https://github.com/LeeeSe/MessAuto/releases/download/v#{version}/MessAuto_#{version}_x64.app.tar.gz"
+  end
+
+  name "MessAuto"
+  desc "Automatic extraction of 2FA codes from iMassage and Mail App"
+  homepage "https://github.com/LeeeSe/MessAuto"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  artifact ".", target: "/Applications/MessAuto.app"
+
+  zap trash: "~/Library/Application Support/messauto"
+end


### PR DESCRIPTION
Adds MessAuto, an automatic extractor of 2FA codes from iMessage and Mail.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
