### PR TITLE
Kaleidoscope 6.2,8595

### DIFF
--- a/Casks/k/kaleidoscope.rb
+++ b/Casks/k/kaleidoscope.rb
@@ -1,6 +1,6 @@
 cask "kaleidoscope" do
-  version "6.0.1,8139"
-  sha256 "f22ed20e263af90b13c7d53d28b2410f36e765643e4466093198035eedebe0f5"
+  version "6.2,8595"
+  sha256 "673eb8426088fcffa155c53fbbb8500e70b3bec9ec101d8d0072feb4644bf139"
 
   url "https://updates.kaleidoscope.app/v#{version.major}/prod/Kaleidoscope-#{version.csv.first}-#{version.csv.second}.app.zip"
   name "Kaleidoscope"
@@ -8,7 +8,7 @@ cask "kaleidoscope" do
   homepage "https://kaleidoscope.app/"
 
   livecheck do
-    url "https://updates.kaleidoscope.app/v5/prod/appcast"
+    url "https://updates.kaleidoscope.app/v6/prod/appcast"
     strategy :sparkle
   end
 

--- a/Casks/k/kaleidoscope.rb
+++ b/Casks/k/kaleidoscope.rb
@@ -8,7 +8,7 @@ cask "kaleidoscope" do
   homepage "https://kaleidoscope.app/"
 
   livecheck do
-    url "https://updates.kaleidoscope.app/v6/prod/appcast"
+    url "https://updates.kaleidoscope.app/v#{version.major}/prod/appcast"
     strategy :sparkle
   end
 


### PR DESCRIPTION
Update Kaleidoscope to version 6.2

Note that the livecheck URL must be changed from https://updates.kaleidoscope.app/v5/prod/appcast to https://updates.kaleidoscope.app/v6/prod/appcast in order to get the latest version because the v5 appcast points to version 6.0.1

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online kaleidoscope` is error-free.
- [x] `brew style --fix kaleidoscope` reports no offenses.