### PR TITLE
LibreOffice language packs: remove `--no-quarantine` message

### DIFF
--- a/Casks/l/libreoffice-language-pack.rb
+++ b/Casks/l/libreoffice-language-pack.rb
@@ -528,7 +528,6 @@ cask "libreoffice-language-pack" do
           /usr/bin/tar -C $pathOfApp -xjf "#{staged_path}/LibreOffice Language Pack.app/Contents/Resources/tarball.tar.bz2" && touch $pathOfApp
         else
           echo "You need to run $pathOfApp once before you can silently install language pack"
-          echo "or you can also reinstall libreoffice with --no-quarantine parameters"
         fi
       else
         echo 'Silent installation cannot match the prerequisite'

--- a/Casks/l/libreoffice-still-language-pack.rb
+++ b/Casks/l/libreoffice-still-language-pack.rb
@@ -528,7 +528,6 @@ cask "libreoffice-still-language-pack" do
           /usr/bin/tar -C $pathOfApp -xjf "#{staged_path}/LibreOffice Language Pack.app/Contents/Resources/tarball.tar.bz2" && touch $pathOfApp
         else
           echo "You need to run $pathOfApp once before you can silently install language pack"
-          echo "or you can also reinstall libreoffice with --no-quarantine parameters"
         fi
       else
         echo 'Silent installation cannot match the prerequisite'


### PR DESCRIPTION
We have a policy of not recommending users bypass macOS security measures, so these need to be removed.