### PR TITLE
feat: add krux-installer cask

### DIFF
--- a/Casks/k/krux-installer.rb
+++ b/Casks/k/krux-installer.rb
@@ -1,0 +1,25 @@
+cask "krux-installer" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "0.0.20"
+  sha256 arm:   "b18128e4f7666fa39c61198c42aee83fccf2f2abd8c9d161ee5ff498ef9b9ac9",
+         intel: "a20407ddcc15384a939be5528bdbc2f4ac711531377111d413a81eadadf12496"
+
+  url "https://github.com/selfcustody/krux-installer/releases/download/v#{version}/krux-installer_#{version}_#{arch}.dmg"
+  name "Krux Installer"
+  desc "GUI based application to flash Krux firmware on K210 based devices"
+  homepage "https://github.com/selfcustody/krux-installer"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "krux-installer.app"
+
+  zap trash: [
+    "~/.config/krux-installer",
+    "~/.kivy",
+    "~/.local/krux-installer/",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.


- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

[Krux-Installer](https://github.com/selfcustody/krux-installer) is a GUI that help users to install the [krux](https://github.com/selfcustody/krux) firmware on K210 based devices. It's a Kivy based software compiled through PyInstaller.

This PR aims to facilitate the installation procedure for Mac Users instead following the [current procedure](https://selfcustody.github.io/krux/getting-started/installing/from-gui/).

While the `brew audit --cask --online <cask>`, `brew audit --cask --new <cask>` didn't pass due to lack of mac developer signature and notarization, it is possible to [verify authenticity through pgp](https://github.com/selfcustody/krux-installer/releases/tag/v0.0.20). 

Also, the `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask krux-installer --no-quarantine` passed without issues, at least locally.

Therefore, I would like to kindly request that, although the software in question is not very notable and is not signed by the means required by GateKeeper (but still verifiable through pgp), its inclusion may help new krux users.
