### PR TITLE
copyq 11.0.0

### DIFF
--- a/Casks/c/copyq.rb
+++ b/Casks/c/copyq.rb
@@ -1,9 +1,9 @@
 cask "copyq" do
-  arch arm: "12-m1", intel: "10"
+  arch arm: "12-m1", intel: "13"
 
-  version "10.0.0"
-  sha256 arm:   "f535cc45a1df777643fe47200c206b3a9d461b7b58869b1783ab7de1c95eccdc",
-         intel: "5565ba19d59ab2bd4c54bb023dbf3fdf2b80b9706b25bc2021358f65c0cde5d4"
+  version "11.0.0"
+  sha256 arm:   "3471c6bbafaf08e720812dd20054c3b46b2f1b664a8ddeb87963157e64eeee26",
+         intel: "9f6749bab19540f2936a408d3c66dff6434409b8db067456ec229f8c8a260179"
 
   url "https://github.com/hluk/CopyQ/releases/download/v#{version}/CopyQ-macos-#{arch}.dmg.zip",
       verified: "github.com/hluk/CopyQ/"
@@ -18,7 +18,7 @@ cask "copyq" do
 
   disable! date: "2026-09-01", because: :unsigned
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :monterey"
 
   app "CopyQ.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`copyq` is autobumped but the workflow fails to update to version 11.0.0 because the Intel filename changed. Besides updating the cask version, this updates the `arch` value for Intel and uses the lower of the two macOS version requirements in the `depends_on macos:` string.