### PR TITLE
font-junicode 2.218

### DIFF
--- a/Casks/font/font-j/font-junicode.rb
+++ b/Casks/font/font-j/font-junicode.rb
@@ -1,8 +1,8 @@
 cask "font-junicode" do
-  version "2.217"
-  sha256 "452e62996b7b76b9c0a61706829b2332e2712c41b26f7a46f3b5e4481c502db8"
+  version "2.218"
+  sha256 "64b5a8a654bb0c75110d7363eaddbcfbbb0bfb2b1e0261b6c75ed8fd406c8b30"
 
-  url "https://github.com/psb1558/Junicode-font/releases/download/v.#{version}/Junicode_#{version}.zip"
+  url "https://github.com/psb1558/Junicode-font/releases/download/v#{version}/Junicode_#{version}.zip"
   name "Junicode"
   homepage "https://github.com/psb1558/Junicode-font"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`font-junicode` is autobumped but the workflow is failing to update to 2.218 because the tag format has returned to the previous setup where there isn't a dot between "v" and the version. This updates the version and `url` accordingly.