### PR TITLE
popo 4.23.0

### DIFF
--- a/Casks/p/popo.rb
+++ b/Casks/p/popo.rb
@@ -1,24 +1,23 @@
 cask "popo" do
-  arch arm: "arm64", intel: "x86_64"
-  livecheck_arch = on_arch_conditional arm: "arm", intel: "intel"
+  arch arm: "arm", intel: "intel"
 
   on_arm do
-    version "4.22.0,1751466386875"
-    sha256 "7dad1147ee06a583b09efb5a21672a1631f7c6ef76ea2f13b30cc0ed1b77c97d"
+    version "4.23.0,1755519794983"
+    sha256 "85c2c205cc5da597dc1a5e977044fed11c736923bc46ee179b669dbaecc5649b"
   end
   on_intel do
-    version "4.22.0,1751466391344"
-    sha256 "c0d08ecb6b2b2118bfc4af7ad482638e1ab8805f79e6bd865915c76fbef01ad3"
+    version "4.23.0,1755519682487"
+    sha256 "70002faadcc50ca70b4531ab5db6b33ef9c585c8e8c1421aad209918b2302bf6"
   end
 
-  url "https://popo.netease.com/file/popomac/POPO_Mac_#{arch}_prod_#{version.csv.second}.dmg"
+  url "https://popo.netease.com/file/popomac/POPO-setup_#{version.csv.first}_#{arch}_prod_#{version.csv.second}.dmg"
   name "NetEase POPO"
   desc "Instant messaging platform"
   homepage "https://popo.netease.com/"
 
   livecheck do
     url "https://popo.netease.com/api/open/jsonp/check_version?device=4&callback=callback"
-    regex(/POPO[._-]Mac[._-]#{arch}[._-]prod[._-](\d+)\.dmg/i)
+    regex(/POPO[._-]setup[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}[._-]prod[._-](\d+)\.dmg/i)
     strategy :page_match do |page, regex|
       json_regex = /callback\((.+)\)/i
 
@@ -26,13 +25,10 @@ cask "popo" do
       next if match.blank?
 
       json = Homebrew::Livecheck::Strategy::Json.parse_json(match[1])
-      version = json.dig("data", "version")
-      next if version.blank?
-
-      match = json.dig("data", "#{livecheck_arch}Url")&.match(regex)
+      match = json.dig("data", "#{arch}Url")&.match(regex)
       next if match.blank?
 
-      "#{version},#{match[1]}"
+      "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`popo` is autobumped but the workflow is failing to update to version 4.23.0 because the filename format has changed. This updates the version and `url` accordingly.

This also updates the `livecheck` block, as the filename now contains both parts of the `version`, so we can simplify the `strategy` block.