### PR TITLE
alcove: update sha256

### DIFF
--- a/Casks/a/alcove.rb
+++ b/Casks/a/alcove.rb
@@ -1,6 +1,6 @@
 cask "alcove" do
   version "1.2.6"
-  sha256 "dfb14720c510bb9b049f192814171777b611efbea4bed31b7f767326ac7a7a05"
+  sha256 "35198238d58af429fe21400c3be0bea6b0348b29a097fcc4186bd8f9d5c72063"
 
   url "https://github.com/henrikruscon/alcove-releases/releases/download/#{version}/Alcove.zip",
       verified: "github.com/henrikruscon/alcove-releases/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

This PR fixes a mismatch in the SHA256 between the Alcove cask and the Alcove `zip` file from the [Alcove Github repository](https://github.com/henrikruscon/alcove-releases)

_In the following questions `alcove` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
