### PR TITLE
poedit: update sha256

### DIFF
--- a/Casks/p/poedit.rb
+++ b/Casks/p/poedit.rb
@@ -1,6 +1,6 @@
 cask "poedit" do
   version "3.7"
-  sha256 "2b9a38f15c074c5367cc52b063a3c5b3120c6c59ecce246edb46bdd3a981552b"
+  sha256 "2e9dc6bf84ff4fd653189a69182360e8e3fdf1dcf54c673698a81562e9ace6d8"
 
   url "https://download.poedit.net/Poedit-#{version}.zip"
   name "Poedit"


### PR DESCRIPTION
Installation of Poedit fails with:

```
Error: SHA-256 mismatch
Expected: 2b9a38f15c074c5367cc52b063a3c5b3120c6c59ecce246edb46bdd3a981552b
  Actual: 2e9dc6bf84ff4fd653189a69182360e8e3fdf1dcf54c673698a81562e9ace6d8
    File: /Users/mac/Library/Caches/Homebrew/downloads/e926bd3c996a7f63ad11fcdbab9810b148e730feb1371b586d885c4081156f97--Poedit-3.7.zip
To retry an incomplete download, remove the file above.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
