### PR TITLE
add orcaslicer@nightly conflict to orcaslicer

### DIFF
--- a/Casks/o/orcaslicer.rb
+++ b/Casks/o/orcaslicer.rb
@@ -10,6 +10,8 @@ cask "orcaslicer" do
   desc "G-code generator for 3D printers"
   homepage "https://github.com/SoftFever/OrcaSlicer"
 
+  conflicts_with cask: "orcaslicer@nightly"
+
   app "OrcaSlicer.app"
 
   zap trash: [


### PR DESCRIPTION
This is a follow up to #225117 to add the conflict to orcaslicer now that the @nightly tag exists in the API (see https://github.com/Homebrew/homebrew-cask/pull/225117#issuecomment-3218041661)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
