### PR TITLE
labplot: update sha256 for 2.12.1

### DIFF
--- a/Casks/l/labplot.rb
+++ b/Casks/l/labplot.rb
@@ -2,8 +2,8 @@ cask "labplot" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.12.1"
-  sha256 arm:   "5bf80348d44a6d2921468a23f476a6c76fdbf47dc8199eac54db533ea6593de3",
-         intel: "886bcecff99e75d3930cf2449c341d8d8f2cd5b12f70002b372bad5ea78436f4"
+  sha256 arm:   "6f6f8675189059d08a6a6cfe33b14ff8b864ce18ea2987d412f120a31e32aa56",
+         intel: "61d1bca44121bfdf87252feb76673d8f7719b4597dc16a7434563550371b9711"
 
   url "https://download.kde.org/stable/labplot/labplot-#{version}-#{arch}.dmg"
   name "LabPlot"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

For whatever reason, the sha256 checksums for both the ARM and Intel dmg files for `labplot` have changed since the cask was updated to 2.12.1. This updates the `sha256` arguments to the current values.

Fixes #225296.