### PR TITLE
cilicon 2.3.0

### DIFF
--- a/Casks/c/cilicon.rb
+++ b/Casks/c/cilicon.rb
@@ -1,11 +1,13 @@
 cask "cilicon" do
-  version "2.2.3"
-  sha256 "5e9f4524e77688105432217c167c49edd8c8629c05e73379701c2974aceb3a7c"
+  version "2.3.0"
+  sha256 "bc8217c2429341e196ef1cba48a29cae56f2f5c03fd69dd0c3cc2a5360041d5e"
 
   url "https://github.com/traderepublic/Cilicon/releases/download/v#{version}/Cilicon.zip"
   name "Cilicon"
   desc "Self-Hosted ephemeral CI on Apple Silicon"
   homepage "https://github.com/traderepublic/Cilicon"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :ventura"
   depends_on arch: :arm64


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`cilicon` is autobumped but the workflow is unable to update to version 2.3.0 as `brew audit` is erroring due to the app failing Gatekeeper checks. This updates the version and adds a `disable!` call with the date we've been using for this situation.