### PR TITLE
green-go-control 5.2.0

### DIFF
--- a/Casks/g/green-go-control.rb
+++ b/Casks/g/green-go-control.rb
@@ -1,6 +1,6 @@
 cask "green-go-control" do
-  version "5.1.3"
-  sha256 "51c46984a3f9e00b5eb61bbb6af9b53e8c0118dfd08afef66d6b2c60a42fbc89"
+  version "5.2.0"
+  sha256 "243b2efcfea697130e55c7b9694d0b77882af6b125de676ef78b55b48fbed475"
 
   url "https://downloads.greengoconnect.com/#{version}/macos/green-go-control.dmg",
       verified: "downloads.greengoconnect.com/"
@@ -23,8 +23,4 @@ cask "green-go-control" do
     "~/Library/Preferences/com.green-go.control.plist",
     "~/Library/Saved Application State/com.green-go.control.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`green-go-control` is autobumped but the workflow failed to update to version 5.2.0 as `brew audit` gives an error about the Rosetta caveat not being needed anymore. I confirmed that 5.2.0 is a universal binary, so this updates the version and removes the Rosetta caveat.