### PR TITLE
rodecaster 2.0.101

### DIFF
--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -1,5 +1,5 @@
 cask "rodecaster" do
-  version "2.0.98"
+  version "2.0.101"
   sha256 :no_check
 
   url "https://update.rode.com/rc-app/RODECaster_App_MACOS.zip"
@@ -13,8 +13,6 @@ cask "rodecaster" do
       json.dig("rc-app-manifest", "macos", "main-version", "update-version")
     end
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`rodecaster` is autobumped but the workflow failed to update to version 2.0.101 as `brew audit` fails because the cask is deprecated due to failing Gatekeeper checks and version 2.0.101 now passes these checks. I checked the app and it's notarized and signed, so this updates the version and removes the `disable!` call.