### PR TITLE
siyuan 3.3.0

### DIFF
--- a/Casks/s/siyuan.rb
+++ b/Casks/s/siyuan.rb
@@ -1,14 +1,16 @@
 cask "siyuan" do
   arch arm: "-arm64"
 
-  version "3.2.1"
-  sha256 arm:   "6153d6189302135f39c836e160a4a036ff495df81c3af1492d219d0d7818cb04",
-         intel: "fbe6115ef044d451623c8885078172d6adc1318db6baf88e6b1fe379630a2da9"
+  version "3.3.0"
+  sha256 arm:   "59a6ec4017ba4b9042e1e852420c4bef32cb4e32ce86d4ae0769ea169b22c9ee",
+         intel: "1d6913de40c83aeef2fc6f679db51b40b7009d34daf08528d85f2571a6b58793"
 
   url "https://github.com/siyuan-note/siyuan/releases/download/v#{version}/siyuan-#{version}-mac#{arch}.dmg"
   name "SiYuan"
   desc "Local-first personal knowledge management system"
   homepage "https://github.com/siyuan-note/siyuan"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`siyuan` is autobumped but the workflow failed to update to version 3.3.0 because the app isn't notarized and fails Gatekeeper checks, so `brew audit` errors. This updates the version to 3.3.0 and adds a `disable!` call with the future date we've been using for this situation.