### PR TITLE
soulseek 2024-6-30

### DIFF
--- a/Casks/s/soulseek.rb
+++ b/Casks/s/soulseek.rb
@@ -1,15 +1,16 @@
 cask "soulseek" do
-  version "2024-2-1"
-  sha256 "2daa09953aa9bbb62ffa4dee87b8cc219c3f8f88f349309d47faa3aaed213e70"
+  version "2024-6-30"
+  sha256 "43a788bf49e50f7a1d23bd4b9df89db5835edf431328b88f502619a7a5818cf1"
 
-  url "https://www.slsknet.org/SoulseekQt/Mac/SoulseekQt-#{version}.dmg"
+  url "https://f004.backblazeb2.com/file/SoulseekQt/SoulseekQt-#{version}.dmg",
+      verified: "f004.backblazeb2.com/file/SoulseekQt/"
   name "Soulseek"
   desc "File sharing network"
   homepage "https://www.slsknet.org/"
 
   livecheck do
     url "https://www.slsknet.org/news/node/1"
-    regex(%r{href=.*?/SoulseekQt[._-]v?(\d+(?:-\d+)+)\.dmg}i)
+    regex(/href=.*?SoulseekQt[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`soulseek` is autobumped but the workflow failed to update to version 2024-6-30 because the download files are now hosted on Backblaze B2. This updates the version and URL accordingly.

Besides that, this tweaks the `livecheck` block regex to use a more standard pattern, which will also continue to match if the `href` attribute only contains the filename instead of being absolute. In this particular context, we don't need to strictly delimit the start of the filename (i.e., using `/`) to accurately match the dmg version.