### PR TITLE
phocus 4.0.0

### DIFF
--- a/Casks/p/phocus.rb
+++ b/Casks/p/phocus.rb
@@ -1,26 +1,26 @@
 cask "phocus" do
-  version "3.8.3"
-  sha256 "aacaafe8ec095dbcf6eab73f751981c887e05756e8fe4f9a493a6a1d529f5acb"
+  version "4.0.0,4.0"
+  sha256 "3c4ca529d8ee6f43ae58fcc19bedb0a5749d076d24dd4edc077b15449f947332"
 
-  url "https://cdn.hasselblad.com/software/Phocus_for_Mac/#{version}/Phocus-#{version}.dmg"
+  url "https://cdn.hasselblad.com/software/Phocus_for_Mac/#{version.csv.first}/Phocus_#{version.csv.second || version.csv.first}.dmg"
   name "Hasselblad Phocus"
   desc "RAW file image processing software for Hasselblad cameras"
   homepage "https://www.hasselblad.com/phocus/"
 
   livecheck do
     url "https://api.hasselblad.com/products/downloads/133/all"
-    regex(/Phocus[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(%r{/v?(\d+(?:\.\d+)+)/Phocus[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :json do |json, regex|
       json.map do |item|
         match = item["url"]&.match(regex)
         next if match.blank?
 
-        match[1]
+        (match[1] == match[2]) ? match[1] : "#{match[1]},#{match[2]}"
       end
     end
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :monterey"
 
   app "Phocus.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`phocus` is autobumped but the workflow failed to update to version 4.0.0 because the filename format has changed (e.g., the delimiter between the name and version changed) and the URL is using 4.0.0 in the path but only 4.0 in the filename. This updates the version and adjusts it to include an optional second part when the versions in the URL aren't the same (updating the `url` and `livecheck` block accordingly). Besides that, this updates the macOS dependency to resolve the `brew audit` error.