### PR TITLE
fix kindaVim new release link

### DIFF
--- a/Casks/k/kindavim.rb
+++ b/Casks/k/kindavim.rb
@@ -2,7 +2,7 @@ cask "kindavim" do
   version "78"
   sha256 :no_check
 
-  url "http://releases.kindavim.app/kindaVim.zip"
+  url "https://releases.kindavim.app/kindaVim.zip"
   name "kindaVim"
   desc "Use Vim in input fields and non input fields"
   homepage "https://kindavim.app/"

--- a/Casks/k/kindavim.rb
+++ b/Casks/k/kindavim.rb
@@ -1,14 +1,14 @@
 cask "kindavim" do
-  version "71"
+  version "78"
   sha256 :no_check
 
-  url "https://kindavim.app/releases/kindaVim.zip"
+  url "http://releases.kindavim.app/kindaVim.zip"
   name "kindaVim"
   desc "Use Vim in input fields and non input fields"
   homepage "https://kindavim.app/"
 
   livecheck do
-    url "https://kindavim.app/releases/appcast.xml"
+    url "https://releases.kindavim.app/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

i'm the author of kindaVim. realized i had never updated the new links to the release files in homebrew...