### PR TITLE
fix Wooshy release links

### DIFF
--- a/Casks/w/wooshy.rb
+++ b/Casks/w/wooshy.rb
@@ -1,14 +1,14 @@
 cask "wooshy" do
-  version "32"
+  version "37"
   sha256 :no_check
 
-  url "https://wooshy.app/releases/Wooshy.zip"
+  url "https://releases.wooshy.app/Wooshy.zip"
   name "Wooshy"
   desc "Click and more on UI Elements through typing"
   homepage "https://wooshy.app/"
 
   livecheck do
-    url "https://wooshy.app/releases/appcast.xml"
+    url "https://releases.wooshy.app/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

author of Wooshy. realized i hadn't updated the release links in homebrew.