### PR TITLE
fix Scrolla release links

### DIFF
--- a/Casks/s/scrolla.rb
+++ b/Casks/s/scrolla.rb
@@ -1,14 +1,14 @@
 cask "scrolla" do
-  version "21"
+  version "25"
   sha256 :no_check
 
-  url "https://scrolla.app/releases/Scrolla.zip"
+  url "https://releases.scrolla.app/Scrolla.zip"
   name "Scrolla"
   desc "Scroll with the keyboard using Vim motions"
   homepage "https://scrolla.app/"
 
   livecheck do
-    url "https://scrolla.app/releases/appcast.xml"
+    url "https://releases.scrolla.app/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

author of Scrolla. fixing release links.
