### PR TITLE
dyad 0.18.0

### DIFF
--- a/Casks/d/dyad.rb
+++ b/Casks/d/dyad.rb
@@ -1,9 +1,9 @@
 cask "dyad" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.17.0"
-  sha256 arm:   "42389c3993f0591d5f36a08d7863d59cb91c8089e45986a7a286208e00fc0d8d",
-         intel: "9a6f6e8a1c53084241f89acfce760ecd4b1db3351f25a6eecdf27488aee0b3ff"
+  version "0.18.0"
+  sha256 arm:   "5bd7d5a6d563f8a59f1035fd55d0640d8887f42e3508a7bc5b89a7564fda23d8",
+         intel: "36ac0c0bceffa172cc47839813d078c7a7c357c62fca8bb782ecc51d6d6133bc"
 
   url "https://github.com/dyad-sh/dyad/releases/download/v#{version}/dyad-darwin-#{arch}-#{version}.zip",
       verified: "github.com/dyad-sh/dyad/"
@@ -13,8 +13,9 @@ cask "dyad" do
 
   livecheck do
     url "https://api.dyad.sh/v1/update/stable/dyad-sh/dyad/darwin-#{arch}/0.0.0"
+    regex(%r{/v?(\d+(?:\.\d+)+)/}i)
     strategy :json do |json|
-      json["name"]&.tr("v", "")
+      json["url"]&.[](regex, 1)
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dyad` is autobumped but the workflow failed to update to version 0.18.0 because the `livecheck` block simply removes any leading `v` from the `name` field in the JSON response and incorrectly returns "0.18.0 - create your own library of prompts to reuse across apps!" as the newest version. This updates the version and reworks the `livecheck` block to match the version from the tag in the file URL path instead.