### PR TITLE
qqmusic 10.7.1

### DIFF
--- a/Casks/q/qqmusic.rb
+++ b/Casks/q/qqmusic.rb
@@ -1,19 +1,20 @@
 cask "qqmusic" do
-  version "10.4.0,01"
-  sha256 "3a4df83492190f40e4dfe5a02fe5c929cf1e291870082df08312f594c09ab122"
+  version "10.7.1,00,1-0cb9ee4c40e7447e2113cfdee2dc11c88487b0e31fe37cfe1c59e12c20956dce-689e9373"
+  sha256 "6b1cf6a1d6c28b56fdb61b1b5d9f7d5880e66ad50c76c70e62afda96a8cfba0e"
 
-  url "https://dldir1.qq.com/music/clntupate/mac/QQMusicMac#{version.csv.first}Build#{version.csv.second}.dmg"
+  url "https://c.y.qq.com/cgi-bin/file_redirect.fcg?bid=dldir&file=ecosfile%2Fmusic_clntupate%2Fmac%2Fother%2FQQMusicMac#{version.csv.first}Build#{version.csv.second}.dmg&sign=#{version.csv.third}"
   name "QQ音乐"
   desc "Chinese music streaming application"
   homepage "https://y.qq.com/"
 
+  # NOTE: The download URL that we match redirects to another URL that includes
+  # a different `sign` query string parameter and that value can change across
+  # requests, so we have to use the redirecting URL.
   livecheck do
     url "https://y.qq.com/download/download.js"
-    regex(/QQMusicMac[._-]?v?(\d+(?:[._]\d+)+)[._-]?build[._-]?(\d+)\.dmg/i)
+    regex(/QQMusicMac[._-]?v?(\d+(?:[._]\d+)+)[._-]?build[._-]?(\d+)\.dmg[^"' ]*?[?&]sign=([^&"' ]+)/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        "#{match[0]},#{match[1]}"
-      end
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This attempts to update `qqmusic` to the latest version but it may not be technically possible, so I'm opening this as a draft for discussion.

The homepage download button for macOS loads a redirecting URL for the dmg file which contains a `sign` query string parameter. This redirects to the download URL with a different `sign` query string parameter that seems to sometimes change between requests, so we seemingly can't use the final URL in the cask and have to use the redirecting URL instead. This works as expected but the trouble is that we end up with a "download not possible: File name too long" error:

> exception while auditing qqmusic: File name too long @ rb_file_s_symlink - (../downloads/ab2ba3ac2e9004a8c536c2922f9d6982d845215106b7add72e8b2b0f3a5bb2ab--QQMusicMac10.7.1Build00.dmg, /Users/[user]/Library/Caches/Homebrew/Cask/file_redirect.fcg?bid=dldir&file=ecosfile%2Fmusic_clntupate%2Fmac%2Fother%2FQQMusicMac10.7.1Build00.dmg&sign=1-0cb9ee4c40e7447e2113cfdee2dc11c88487b0e31fe37cfe1c59e12c20956dce-689e9373--10.7.1,00,1-0cb9ee4c40e7447e2113cfdee2dc11c88487b0e31fe37cfe1c59e12c20956dce-689e9373.dmg)

Unless there's a way to override the filename (or we implement one), it seems like we don't have any choice other than to deprecate/disable this cask (and other Tencent/QQ casks with the same issue, like `tencent-docs`). These URLs don't work without the `sign` query string parameter and it's not clear to me whether it's a security thing or just a hurdle to make it harder for folks to download the file from anywhere other than the first-party website.