### PR TITLE
shattered-pixel-dungeon 3.2.2

### DIFF
--- a/Casks/s/shattered-pixel-dungeon.rb
+++ b/Casks/s/shattered-pixel-dungeon.rb
@@ -1,8 +1,8 @@
 cask "shattered-pixel-dungeon" do
-  version "3.2.1"
-  sha256 "3b5a4e7fcd2fc075306e362496daab2c1fd76c1593569690271da2a11156e82c"
+  version "3.2.2"
+  sha256 "a9afef11583258c1c34179b0fc8620c434ace353bdc87dfb8f29295acb726847"
 
-  url "https://github.com/00-Evan/shattered-pixel-dungeon/releases/download/v#{version}/ShatteredPD-v#{version}-macOS.zip",
+  url "https://github.com/00-Evan/shattered-pixel-dungeon/releases/download/#{version}/ShatteredPD-v#{version}-macOS.zip",
       verified: "github.com/00-Evan/shattered-pixel-dungeon/"
   name "Shattered Pixel Dungeon"
   desc "Traditional roguelike dungeon crawler with randomised levels, enemies and items"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`shattered-pixel-dungeon` is autobumped but the latest release tag omits the usual leading `v` (i.e., `3.2.2` instead of the expected `v3.2.2`), so the workflow fails to update to version 3.2.2. This updates the version and modifies the cask URL accordingly.