### PR TITLE
xcodes-app: add livecheck

### DIFF
--- a/Casks/x/xcodes-app.rb
+++ b/Casks/x/xcodes-app.rb
@@ -7,6 +7,14 @@ cask "xcodes-app" do
   desc "Install and switch between multiple versions of Xcode"
   homepage "https://github.com/XcodesOrg/XcodesApp"
 
+  # Upstream marks some releases that use a stable version format (v1.2.3b45)
+  # as pre-release on GitHub.
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:b\d+)?)$/i)
+    strategy :github_latest
+  end
+
   auto_updates true
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `xcodes-app` and returns 3.0.0b32 as the newest version but the related GitHub release is titled "v3.0.0 Beta 1" and marked as pre-release. This adds a `livecheck` block that uses the `GithubLatest` strategy, which correctly returns 2.4.2b31 as the newest stable version (though we need a regex to handle the version format).