### PR TITLE
gcloud-cli: fix UID handling

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -55,16 +55,20 @@ cask "gcloud-cli" do
     if File.exist?(File.join(Dir.home, "/.config/gcloud/virtenv"))
       puts "deleting existing virtual env before enabling virtual env with current Python version"
       system_command "#{google_cloud_sdk_root}/bin/gcloud",
-                     args: ["config", "virtualenv", "delete", "-q"]
+                     args:      ["config", "virtualenv", "delete", "-q"],
+                     reset_uid: true
     end
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
-                    args: ["config", "virtualenv", "create", "--python-to-use",
-                           "#{HOMEBREW_PREFIX}/opt/python@3.12/libexec/bin/python3"]
+                    args:      ["config", "virtualenv", "create", "--python-to-use",
+                                "#{HOMEBREW_PREFIX}/opt/python@3.12/libexec/bin/python3"],
+                    reset_uid: true
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
-                    args: ["config", "virtualenv", "enable"]
+                    args:      ["config", "virtualenv", "enable"],
+                    reset_uid: true
 
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
-                    args: ["version"]
+                    args:      ["version"],
+                    reset_uid: true
   end
 
   uninstall trash: staged_path.dirname/"latest"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

When UID != EUID, the `postflight` block doesn't work correctly. We can
ensure it does by setting `reset_uid: true`.
