### PR TITLE
Update ForkLift OS requirement

### DIFF
--- a/Casks/f/forklift.rb
+++ b/Casks/f/forklift.rb
@@ -13,7 +13,7 @@ cask "forklift" do
   end
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :sonoma"
 
   app "ForkLift.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I haven't set up an environment to test this as it's only an OS version bump omitted [from the 4.4 update](https://binarynights.com/versionhistory). Which happened to bite me on macOS 13.