### PR TITLE
86box: update zap, un-deprecate

### DIFF
--- a/Casks/8/86box.rb
+++ b/Casks/8/86box.rb
@@ -21,11 +21,9 @@ cask "86box" do
     end
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
   depends_on macos: ">= :mojave"
 
-  app "86Box.app", target: "86Box/86Box.app"
+  app "86Box.app"
 
   roms_dir = Pathname("~/Library/Application Support/net.86box.86Box/roms")
 
@@ -33,9 +31,13 @@ cask "86box" do
     roms_dir.expand_path.mkpath
   end
 
+  uninstall trash: "#{appdir}/86box"
+
   zap trash: [
-    "/Applications/86Box",
+    "~/Library/Application Support/86Box",
     "~/Library/Application Support/net.86box.86Box",
+    "~/Library/Preferences/86Box",
+    "~/Library/Preferences/net.86Box.86Box.plist",
     "~/Library/Saved Application State/net.86Box.86Box.savedState",
   ]
 


### PR DESCRIPTION
The VM manager included with v5 no longer places a `86box.cfg` in the same dir as the app, so the enclosing folder is no longer needed. (It'll still stick around on upgrade, but will be removed on uninstall.) Also, the app is now signed and notarized.