### PR TITLE
gcloud-cli: Add gcloud bin path and completion to bash profile

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -25,17 +25,14 @@ cask "gcloud-cli" do
     args:       [
       "--quiet",
       "--usage-reporting", "false",
-      "--bash-completion", "false",
-      "--path-update", "false",
-      "--rc-path", "false",
+      "--bash-completion", "true",
+      "--path-update", "true",
       "--install-python", "false",
       "--update-installed-components"
     ],
   }
   binary "google-cloud-sdk/bin/bq"
-  binary "google-cloud-sdk/bin/docker-credential-gcloud"
   binary "google-cloud-sdk/bin/gcloud"
-  binary "google-cloud-sdk/bin/git-credential-gcloud.sh", target: "git-credential-gcloud"
   binary "google-cloud-sdk/bin/gsutil"
   bash_completion "google-cloud-sdk/completion.bash.inc", target: "google-cloud-sdk"
   zsh_completion "google-cloud-sdk/completion.zsh.inc", target: "_google_cloud_sdk"
@@ -47,7 +44,7 @@ cask "gcloud-cli" do
   end
 
   postflight do
-    # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.
+    # Allow existing shell profiles to work by linking the current version to the `latest` directory.
     unless (latest_path = staged_path.dirname/"latest").directory?
       FileUtils.ln_s staged_path, latest_path, force: true
     end


### PR DESCRIPTION
- Updated installation script to add gcloud bin path to user’s bash profile to ensure gcloud and its binary components are accessible from the command line and bash completion to improve usability by allowing users to auto-complete commands, flags, and resource names.
- Removed linking unnecessary binary components individually since gcloud bin path will now be accessible.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
