### PR TITLE
lidarr 2.13.3.4711

### DIFF
--- a/Casks/l/lidarr.rb
+++ b/Casks/l/lidarr.rb
@@ -1,9 +1,9 @@
 cask "lidarr" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.12.4.4658"
-  sha256 arm:   "6ccd80bb17ecb155762d3ff2a278d9ee4c1e347b4da07f34c1af431a36b38a95",
-         intel: "27a5d313d6ac4777a2274454d96eb28469f212a54cf50de9c7a7b26632bc6ad2"
+  version "2.13.3.4711"
+  sha256 arm:   "2d302b9537196033aaf7a3dfa4e4f307e5b323cef1035fb399f0df293710b2dc",
+         intel: "d265409e1d769c85d04785f2a967779a7ee2dd0734c416c6761eca35a64998a2"
 
   url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.master.#{version}.osx-app-core-#{arch}.zip",
       verified: "github.com/lidarr/Lidarr/"
@@ -17,6 +17,8 @@ cask "lidarr" do
       json.map { |item| item["version"] }
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`lidar` is autobumped but the workflow failed to update to 2.13.3.4711 because the app is unsigned and fails `brew audit`. This updates the cask and adds a `disable!` call with the future date we've been using for this scenario.