### PR TITLE
slack-cli 3.6.1

### DIFF
--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -1,6 +1,6 @@
 cask "slack-cli" do
-  version "3.6.0"
-  sha256 "a8842a36732a469e03e62d21e9f79ef68aad53a79eaf65679a569b248173815c"
+  version "3.6.1"
+  sha256 "638321246094989758394b150be5f24d7d1fcd2bdf0d3e33bfd47644454c9c40"
 
   url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_64-bit.tar.gz",
       verified: "downloads.slack-edge.com/slack-cli/"
@@ -14,8 +14,6 @@ cask "slack-cli" do
       json.dig("slack-cli", "releases")&.map { |release| release["version"] }
     end
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on formula: "deno"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`slack-cli` is autobumped but the workflow failed to update to version 3.6.1 because `brew audit` is giving a "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. This manually updates the cask and removes the `disable!` call, as the binary is signed and notarized.