### PR TITLE
netbeans 27,27-build1

### DIFF
--- a/Casks/n/netbeans.rb
+++ b/Casks/n/netbeans.rb
@@ -1,9 +1,9 @@
 cask "netbeans" do
-  arch arm: "aarch64", intel: "x86_64"
+  arch arm: "arm64", intel: "x86_64"
 
-  version "26,26-build1"
-  sha256 arm:   "174943c8f822ad08621075b3c20f97ba2fb27e91f6ef5961ccd92228a088607d",
-         intel: "99285de7707eecbe49ffd60bf01fd30441ebad4027faaf503ca323097396787f"
+  version "27,27-build1"
+  sha256 arm:   "1b5471269111bd546854008d8b0e067aa7fc72b885563dff99c35274c956233d",
+         intel: "7552a2a365e828bcf40ebddd561c75ed10542474b9329f5412aded6bab437dd8"
 
   url "https://github.com/Friends-of-Apache-NetBeans/netbeans-installers/releases/download/v#{version.csv.second || version.csv.first}/Apache-NetBeans-#{version.csv.first}-#{arch}.pkg",
       verified: "github.com/Friends-of-Apache-NetBeans/netbeans-installers/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`netbeans` is autobumped but the workflow is failing to update to version 27 because the `livecheck` block isn't matching the ARM file due to the arch suffix changing from "aarch64" to "arm64". This updates the version and ARM `arch` value accordingly.

Fixes https://github.com/Homebrew/homebrew-cask/issues/225749.