### PR TITLE
idrive 4.0.0.42,082925

### DIFF
--- a/Casks/i/idrive.rb
+++ b/Casks/i/idrive.rb
@@ -1,6 +1,6 @@
 cask "idrive" do
-  version "4.0.0.41,081225"
-  sha256 "2efaecb9c5a0be576ea65a08513fe8faa63774e6c59a1b81de4ee20ed9c0bbba"
+  version "4.0.0.42,082925"
+  sha256 "4612b2d87a1761bc276e602d46f2ec287bb3fcb88c34c8b6e35064b44cecba55"
 
   url "https://static.idriveonlinebackup.com/downloads/#{version.csv.second}/IDrive.dmg",
       verified: "static.idriveonlinebackup.com/downloads/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`idrive` is autobumped but the download for the dmg file failed in the workflow run, so this manually updates the cask to version 4.0.0.42.