### PR TITLE
opencore-configurator 2.78.1.0

### DIFF
--- a/Casks/o/opencore-configurator.rb
+++ b/Casks/o/opencore-configurator.rb
@@ -1,5 +1,5 @@
 cask "opencore-configurator" do
-  version "2.78.0.2"
+  version "2.78.1.0"
   sha256 :no_check
 
   url "https://mackie100projects.altervista.org/apps/opencoreconf/download-new-build.php?version=last",
@@ -12,6 +12,8 @@ cask "opencore-configurator" do
     url "https://mackie100projects.altervista.org/apps/opencoreconf/OCC/update-data-builds.xml"
     strategy :sparkle
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`opencore-configurator` is autobumped but the workflow failed to update to version 2.78.1.0 because the app fails Gatekeeper checks (it's ad-hoc signed and not notarized). This manually updates the version and adds a `disable!` call using the future date we've been using for this situation.