### PR TITLE
1password@beta 8.11.8

### DIFF
--- a/Casks/1/1password@beta.rb
+++ b/Casks/1/1password@beta.rb
@@ -1,9 +1,9 @@
 cask "1password@beta" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "8.11.8-39.BETA"
-  sha256 arm:   "3bac665bcea75c5c3603ed85cfc7f77f31c5b4594dca1ead55b4c23e497c05d0",
-         intel: "9e4199470a1260514c6b4c00b8488b53a6b337b83e9c1e5d9c6d6dffa0271759"
+  version "8.11.8"
+  sha256 arm:   "c228bdf3708ea280425f2895d9ad8c0bb48a9c524ba7525ab21b0ecd3dfe6510",
+         intel: "318c96a1fd7b28b551b673ea4880a79f2db87fc6285c959e1b012b585adbe82e"
 
   url "https://downloads.1password.com/mac/1Password-#{version}-#{arch}.zip"
   name "1Password"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`1password@beta` is autobumped but the workflow failed to update to 8.11.8 because the version is seen as lower than 8.11.8-39.BETA. This manually updates the cask to get it back on track.