### PR TITLE
blender@lts 4.5.2

### DIFF
--- a/Casks/b/blender@lts.rb
+++ b/Casks/b/blender@lts.rb
@@ -1,9 +1,9 @@
 cask "blender@lts" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.5.1"
-  sha256 arm:   "99dcd51528cc06bd872bb28867f6663c21332f4986cc87bea95131da93a23e0f",
-         intel: "c7922b8afc194d82800a8926f842162007e365d72e955a319164cb2c4662e049"
+  version "4.5.2"
+  sha256 arm:   "e5191d01da15c66c2b3d18a289fcc0a5721bc008baaa7321a91d6dae6c07822d",
+         intel: "7b249ff2474d9595fcad174dc883a1ee9d5d291bbb28513602a5fd6f085929e9"
 
   url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg"
   name "Blender"
@@ -44,7 +44,7 @@ cask "blender@lts" do
   end
 
   conflicts_with cask: "blender"
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :big_sur"
 
   app "Blender.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`blender@lts` is autobumped but the workflow failed to update to 4.5.2 because the livecheck temporarily failed during the most recent run. This manually updates the version and the `depends_on macos:` value.