### PR TITLE
hotovo-aider-desk 0.28.1 (new cask)

### DIFF
--- a/Casks/h/hotovo-aider-desk.rb
+++ b/Casks/h/hotovo-aider-desk.rb
@@ -1,0 +1,29 @@
+cask "hotovo-aider-desk" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.28.1"
+  sha256 arm:   "e5a2f452b509473cab315827b73b000f21c1d984c8b3303cb462fac4764ab73f",
+         intel: "50195bac468d93de90a8f59ee13691c479858bb62159025cb03d553c3117755c"
+
+  url "https://github.com/hotovo/aider-desk/releases/download/v#{version}/aider-desk-#{version}-macos-#{arch}.dmg"
+  name "AiderDesk"
+  desc "Desktop GUI for Aider AI pair programming"
+  homepage "https://github.com/hotovo/aider-desk"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "aider-desk.app"
+
+  zap trash: [
+    "~/Library/Application Support/aider-desk",
+    "~/Library/Logs/aider-desk",
+    "~/Library/Preferences/com.hotovo.aider-desk.plist",
+    "~/Library/Saved Application State/com.hotovo.aider-desk.savedState",
+  ]
+end


### PR DESCRIPTION
Add [AiderDesk](https://github.com/hotovo/aider-desk) macOS app (arm64 and x64 DMGs from GitHub Releases). Includes livecheck, auto_updates, and zap stanzas. Upstream also provides Linux/Windows builds, but casks are macOS-only.

NB: The project releases artifacts for Linux (.deb, .rpm, and .AppImage), but I didn't include them because my understanding is that casks are Mac-only.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
