### PR TITLE
encryptme: revert to 4.4.0

### DIFF
--- a/Casks/e/encryptme.rb
+++ b/Casks/e/encryptme.rb
@@ -1,6 +1,6 @@
 cask "encryptme" do
-  version "4.4.1"
-  sha256 "5fc959899e2c011df822ec55b999ce853d9e7dc56577b2cac759286fb89220e4"
+  version "4.4.0"
+  sha256 "3dda64ebde80fea167184e18647b0a42ff8d190c6119197e58e3883245ebf477"
 
   url "https://static.encrypt.me/downloads/osx/updates/Release/EncryptMe-#{version}.dmg"
   name "EncryptMe"
@@ -12,6 +12,8 @@ cask "encryptme" do
     url "https://www.getcloak.com/updates/osx/public/"
     strategy :sparkle, &:short_version
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Livecheck failed, and both the Sparkle feed and the site download point to `4.4.0` as the latest.  The app appears to no longer be developed (pointing to use StrongVPN).  This also marks the app as future disabled due to failing Gatekeeper checks.