### PR TITLE
kui: deprecate due to repository archived

### DIFF
--- a/Casks/k/kui.rb
+++ b/Casks/k/kui.rb
@@ -10,10 +10,7 @@ cask "kui" do
   desc "CLI graphics framework"
   homepage "https://github.com/kubernetes-sigs/kui"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2025-08-30", because: :discontinued
 
   depends_on macos: ">= :high_sierra"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Upstream has archived the repository on 2025-07-30.