### PR TITLE
gologin 3.4.5

### DIFF
--- a/Casks/g/gologin.rb
+++ b/Casks/g/gologin.rb
@@ -2,9 +2,9 @@ cask "gologin" do
   arch arm: "-arm64"
   livecheck_arch = on_arch_conditional arm: "-arm"
 
-  version "3.4.4"
-  sha256 arm:   "cd73d5d6f5763ae21b959fabbd0f49a60a6a94d37321397cdae37d38d2c810e5",
-         intel: "019086438f8d337971b45e331532e82e6b9c191f919ebbdf2024c4868f52f776"
+  version "3.4.5"
+  sha256 arm:   "a2cb9756c56a5e168266ea70ae7b37effb972b453dd649886eeb094a50fd212b",
+         intel: "80de32ad439c182c98f0909ff6de168c7b6efcc04e3e8d85a4d501dacd73d631"
 
   url "https://releases#{livecheck_arch}.gologin.com/GoLogin-#{version}#{arch}.dmg"
   name "GoLogin"
@@ -13,10 +13,10 @@ cask "gologin" do
 
   # The `latest-mac.yml` file is served with a `Content-Encoding: aws-chunked`
   # header, which will cause curl to error if the `--compressed` option is used.
-  # This checks the version on the first-party download page until we can
+  # This checks the version on the first-party release notes page until we can
   # account for this situation in livecheck.
   livecheck do
-    url "https://gologin.com/download/"
+    url "https://gologin.com/release-notes/"
     regex(%r{href=.*?/release/gologin[._-]v?(\d+(?:[.-]\d+)+)}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match[0].tr("-", ".") }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gologin` is autobumped but the livecheck block is returning an `Unable to get versions` error as the download page no longer contains version information. This updates the `livecheck` block to check the first-party release notes page for now and updates the cask to version 3.4.5.