### PR TITLE
joplin: downgrade to 3.3.13

### DIFF
--- a/Casks/j/joplin.rb
+++ b/Casks/j/joplin.rb
@@ -1,9 +1,9 @@
 cask "joplin" do
   arch arm: "-arm64"
 
-  version "3.4.6"
-  sha256 arm:   "ecd411b799bc3c887638cee5a9f7547a5549e65389afb14af4130fad97beb1cc",
-         intel: "159273d10d94c2d5d57467e9ecce712ed7e9b89810eb397ddcd94796c3b350f9"
+  version "3.3.13"
+  sha256 arm:   "070884eb242981626e6309e247d804ffdf9f1211b70ebc3a24bc6160c7c04ead",
+         intel: "c5198a23b605a155868c30aa748cb980d9d08ceea288ae06529e4a65718b6517"
 
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}#{arch}.DMG",
       verified: "github.com/laurent22/joplin/"
@@ -11,12 +11,15 @@ cask "joplin" do
   desc "Note taking and to-do application with synchronisation capabilities"
   homepage "https://joplinapp.org/"
 
+  # Upstream has created seemingly stable releases on GitHub only to later mark
+  # them as pre-release. This checks the first-party download page, hoping
+  # that this will help to avoid this situation in the future.
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://joplinapp.org/download/"
+    regex(/href=.*?Joplin[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: ">= :big_sur"
 
   app "Joplin.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The 3.4.x releases of Joplin are currently all marked as pre-release on GitHub. We updated the cask to 3.4.6 when it was the "latest" release but it apparently has some bugs, so this downgrades the cask to 3.3.13 for the time being.

Besides that, I've updated the `livecheck` block to check the first-party download page, in hopes that this page is only updated to link to a new dmg when the version is properly stable. There's no guarantee that it will avoid this particular release issue but it's worth a shot.