### PR TITLE
tiled: update SHA256

### DIFF
--- a/Casks/t/tiled.rb
+++ b/Casks/t/tiled.rb
@@ -2,7 +2,7 @@ cask "tiled" do
   version "1.11.2"
 
   on_catalina :or_older do
-    sha256 "9cd3dae263fd142c72ede7d6b78190860e25580f7ae645145daa39d918aa1ce5"
+    sha256 "779bf4e4f598933014e08a4e48297a918e4a8847b749147fed803884377c3091"
 
     url "https://github.com/mapeditor/tiled/releases/download/v#{version}/Tiled-#{version}_macOS-10.12-10.15.zip",
         verified: "github.com/mapeditor/tiled/"


### PR DESCRIPTION
Updated SHA256 checksum for Tiled version 1.11.2 on Catalina or older.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

I've just used GitHub to edit the file to fix the sha256sum, so for now I can't run the above checks, but the update of the sha256sum was clearly forgotten in https://github.com/Homebrew/homebrew-cask/pull/199816.