### PR TITLE
joplin 3.4.10

### DIFF
--- a/Casks/j/joplin.rb
+++ b/Casks/j/joplin.rb
@@ -1,9 +1,9 @@
 cask "joplin" do
   arch arm: "-arm64"
 
-  version "3.3.13"
-  sha256 arm:   "070884eb242981626e6309e247d804ffdf9f1211b70ebc3a24bc6160c7c04ead",
-         intel: "c5198a23b605a155868c30aa748cb980d9d08ceea288ae06529e4a65718b6517"
+  version "3.4.10"
+  sha256 arm:   "85f62ab5a17c58a3dd2f4a86f0524e3750c772bcdb686aa9c344fb8e1dcaaa48",
+         intel: "a49caa022b23087fe8ecf3226f266184b1db2823741af9dfe78b9ee19a8f5677"
 
   url "https://github.com/laurent22/joplin/releases/download/v#{version}/Joplin-#{version}#{arch}.DMG",
       verified: "github.com/laurent22/joplin/"
@@ -11,12 +11,9 @@ cask "joplin" do
   desc "Note taking and to-do application with synchronisation capabilities"
   homepage "https://joplinapp.org/"
 
-  # Upstream has created seemingly stable releases on GitHub only to later mark
-  # them as pre-release. This checks the first-party download page, hoping
-  # that this will help to avoid this situation in the future.
   livecheck do
-    url "https://joplinapp.org/download/"
-    regex(/href=.*?Joplin[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
+    url :url
+    strategy :github_latest
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `joplin` to 3.4.10, as this release is marked as "latest" on GitHub (not another "pre-release"). Downgrading to 3.3.x naturally caused problems for users and this should resolve the issue for anyone who was using 3.4.x before the downgrade.

This restores the previous `GithubLatest` `livecheck` block for the time being, as the upstream download page is still reporting 3.3.13 as newest and this will fail in CI as a result.