### PR TITLE
muteme: update livecheck

### DIFF
--- a/Casks/m/muteme.rb
+++ b/Casks/m/muteme.rb
@@ -12,10 +12,8 @@ cask "muteme" do
   homepage "https://muteme.com/"
 
   livecheck do
-    url "https://muteme.io/update/osx_#{arch}/0.0.0"
-    strategy :json do |json|
-      json["name"]
-    end
+    url "https://muteme.com/pages/downloads"
+    regex(/href=.*?MuteMe[._-]Client[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block URL for `muteme` is failing because the muteme.io server is no longer available. The latest version of the app still checks these update URLs and predictably fails. Substituting muteme.com in these URLs does not work either.

Presumably upstream will update the in-app update URL in the future but this updates the `livecheck` block to check the first-party download page in the interim time, as it links to the latest dmg files.