### PR TITLE
witsy 2.14.0

### DIFF
--- a/Casks/w/witsy.rb
+++ b/Casks/w/witsy.rb
@@ -1,9 +1,9 @@
 cask "witsy" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.13.2"
-  sha256 arm:   "777e0156534fa6f51e5a3bce3288f89ba80edd09438a628afc6ec4714b7d6b03",
-         intel: "d117eaf28887dd0bed8b25c2d83e34c1a1917bed0a53ad793ff89e4c93b21e6d"
+  version "2.14.0"
+  sha256 arm:   "5ce69b66025ea7464f6a16963eca1e65dbfe10b289030f66270da355e217d885",
+         intel: "24555774cac710e80f2a7a7b8b9afc58721d1d5d8307a3bbc90a2eab3a267f54"
 
   url "https://github.com/nbonamy/witsy/releases/download/v#{version}/Witsy-#{version}-darwin-#{arch}.dmg",
       verified: "github.com/nbonamy/witsy/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`witsy` is autobumped but the workflow failed to update to 2.14.0 because the homepage is currently unavailable. This manually updates the cask to work around the issue.

I've set this to skip the homepage on CI in hopes that upstream will fix the issue between now and the next release. Otherwise, we could simply update the homepage to the GitHub repository for now but I figured we probably wouldn't remember to switch it back later.