### PR TITLE
Fix zen@twilight cask recognizing a new build based on 'buildID'

### DIFF
--- a/Casks/z/zen@twilight.rb
+++ b/Casks/z/zen@twilight.rb
@@ -1,5 +1,5 @@
 cask "zen@twilight" do
-  version "1.15t"
+  version "1.15t,20250901110611"
   sha256 :no_check
 
   url "https://github.com/zen-browser/desktop/releases/download/twilight/zen.macos-universal.dmg",
@@ -11,7 +11,7 @@ cask "zen@twilight" do
   livecheck do
     url "https://updates.zen-browser.app/updates/browser/Darwin_aarch64-gcc3/twilight/update.xml"
     strategy :xml do |xml|
-      xml.get_elements("//update").map { |item| item.attributes["appVersion"] }
+      xml.get_elements("//update").map { |item| "#{item.attributes["appVersion"]},#{item.attributes["buildID"]}" }
     end
   end
 


### PR DESCRIPTION
I installed zen (twilight version) using this cask. Though the app has an in-built updater, I still like to use the `--greedy` flag to update the installed casks. This PR is supposed to fix that update-detection which seems to not work since the `1.15t` version string doesn't handle the nightly updates/builds.


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
