### PR TITLE
nova: Fix download locations

### DIFF
--- a/Casks/n/nova.rb
+++ b/Casks/n/nova.rb
@@ -3,7 +3,8 @@ cask "nova" do
   sha256 "91290ff747afd61b9ccadb3d797569ed27503726ee84e25bc6986ed4eaf17c16"
 
   url "https://panic.com/download/nova/Nova%20#{version}.zip",
-      verified: "panic.com/download/nova/"
+      verified:   "panic.com/download/nova/",
+      user_agent: :browser
   name "Panic Nova"
   desc "Native code editor"
   homepage "https://nova.app/"

--- a/Casks/n/nova.rb
+++ b/Casks/n/nova.rb
@@ -2,8 +2,8 @@ cask "nova" do
   version "13.2"
   sha256 "91290ff747afd61b9ccadb3d797569ed27503726ee84e25bc6986ed4eaf17c16"
 
-  url "https://download-cdn.panic.com/nova/Nova%20#{version}.zip",
-      verified: "download-cdn.panic.com/nova/"
+  url "https://panic.com/download/nova/Nova%20#{version}.zip",
+      verified: "panic.com/download/nova/"
   name "Panic Nova"
   desc "Native code editor"
   homepage "https://nova.app/"


### PR DESCRIPTION
I noticed that I was getting a 404 when trying to reinstall this cask.  Taking a look at the Sparkle feed, it seems that they changed the path to `https://panic.com/download/nova/Nova%20#{version}.zip` rather than the previous `https://download-cdn.panic.com/nova/Nova%20#{version}.zip`.  This fixes that.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
