### PR TITLE
transmit: Fix download locations

### DIFF
--- a/Casks/t/transmit.rb
+++ b/Casks/t/transmit.rb
@@ -2,7 +2,8 @@ cask "transmit" do
   version "5.10.9"
   sha256 "3986ff26c049950550b5caf034d920cd201d7e4943ea6ff07c4f6c88485e96f8"
 
-  url "https://download-cdn.panic.com/transmit/Transmit%20#{version}.zip"
+  url "https://download-cdn.panic.com/transmit/Transmit%20#{version}.zip",
+      user_agent: :browser
   name "Transmit"
   desc "File transfer application"
   homepage "https://panic.com/transmit/"

--- a/Casks/t/transmit.rb
+++ b/Casks/t/transmit.rb
@@ -2,8 +2,7 @@ cask "transmit" do
   version "5.10.9"
   sha256 "3986ff26c049950550b5caf034d920cd201d7e4943ea6ff07c4f6c88485e96f8"
 
-  url "https://download-cdn.panic.com/transmit/Transmit%20#{version}.zip",
-      verified: "download-cdn.panic.com/transmit/"
+  url "https://download-cdn.panic.com/transmit/Transmit%20#{version}.zip"
   name "Transmit"
   desc "File transfer application"
   homepage "https://panic.com/transmit/"

--- a/Casks/t/transmit.rb
+++ b/Casks/t/transmit.rb
@@ -2,7 +2,8 @@ cask "transmit" do
   version "5.10.9"
   sha256 "3986ff26c049950550b5caf034d920cd201d7e4943ea6ff07c4f6c88485e96f8"
 
-  url "https://www.panic.com/transmit/d/Transmit%20#{version}.zip"
+  url "https://download-cdn.panic.com/transmit/Transmit%20#{version}.zip",
+      verified: "download-cdn.panic.com/transmit/"
   name "Transmit"
   desc "File transfer application"
   homepage "https://panic.com/transmit/"


### PR DESCRIPTION
Panic software seems to have changed the Transmit download locations, too.  This fixes that as well.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
