### PR TITLE
container: stop system service when upgrading

### DIFF
--- a/Casks/c/container.rb
+++ b/Casks/c/container.rb
@@ -17,6 +17,14 @@ cask "container" do
 
   pkg "container-#{version}-installer-signed.pkg"
 
+  # container APIs aren't guaranteed to be backward compatible,
+  # so we stop the system service to ensure no components are out of sync.
+  # Ref: https://github.com/apple/container/issues/551#issuecomment-3246928923
+  postflight do
+    system_command "/usr/local/bin/container",
+                   args: ["system", "stop"]
+  end
+
   uninstall pkgutil: "com.apple.container-installer"
 
   zap trash: "~/Library/Application Support/com.apple.container"


### PR DESCRIPTION
I opened https://github.com/apple/container/issues/551 after finding `container` to no longer be usable after an upgrade. Upstream has confirmed the APIs are not currently guaranteed to be backward compatible.

When upgrading using this cask, the system service persists, causing components to be out of sync. This PR adds a `postflight` stanza to stop the system service. I've tested this locally and upgrades now work as expected. Installing the .pkg still requires the service to be manually started, so I didn't include any changes on that front.