### PR TITLE
hydrus-network: deprecate

### DIFF
--- a/Casks/h/hydrus-network.rb
+++ b/Casks/h/hydrus-network.rb
@@ -8,12 +8,16 @@ cask "hydrus-network" do
   desc "Booru-style media tagger"
   homepage "https://hydrusnetwork.github.io/hydrus/"
 
+  # The `disable!` call overwrites the `deprecation_reason` and livecheck will
+  # continue checking this cask (as the reason is `:fails_gatekeeper_check`).
+  # This manually skips the cask as a workaround.
   livecheck do
-    url :url
-    regex(/v?(\d+(?:\.\d+)*[a-z]?)/i)
-    strategy :github_latest
+    skip "discontinued"
   end
 
+  # Version 636 was the last version with a macOS app (see:
+  # https://github.com/hydrusnetwork/hydrus/releases/tag/v636).
+  deprecate! date: "2025-09-03", because: :discontinued
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Hydrus Network.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Version 636 was the last release of `hydrus-network` with a macOS app, so this deprecates the cask as discontinued. Unfortunately, the `disable!` call overwrites the `deprecation_reason` and it will be `:fails_gatekeeper_check` instead of `:discontinued`. This causes livecheck to continue to check the cask, so I've added a `skip` call to manually skip the cask until we address this `brew` bug.