### PR TITLE
swift-craft-launcher 0.2.2-beta (new cask)

### DIFF
--- a/Casks/s/swift-craft-launcher.rb
+++ b/Casks/s/swift-craft-launcher.rb
@@ -2,12 +2,12 @@ cask "swift-craft-launcher" do
   version "0.2.2-beta"
 
   on_arm do
-    sha256 :no_check
+    sha256 "22446f9c018a67b566e90ffe45a2b5541c1ce53416270ff3f3a5bdbc6bfd312c"
     url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/download/#{version}/Swift_Craft_Launcher_arm64_#{version}.dmg"
   end
 
   on_intel do
-    sha256 :no_check
+    sha256 "1595496909251c159891e60caf4da29c91b697c2b2aeefef33505e7f0bf95acc"
     url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/download/#{version}/Swift_Craft_Launcher_x86_64_#{version}.dmg"
   end
 
@@ -16,7 +16,7 @@ cask "swift-craft-launcher" do
   homepage "https://suhang12332.github.io/swift-craft-launcher-web.github.io/"
 
   livecheck do
-    url :url
+    url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/latest"
     strategy :github_latest
   end
 
@@ -31,6 +31,6 @@ cask "swift-craft-launcher" do
     "~/Library/Caches/com.su.code.SwiftCraftLauncher",
     "~/Library/Logs/Swift Craft Launcher",
     "~/Library/Preferences/com.su.code.SwiftCraftLauncher.plist",
-    "~/Library/Saved Application State/com.su.code.SwiftCraftLauncher.savedState"
+    "~/Library/Saved Application State/com.su.code.SwiftCraftLauncher.savedState",
   ]
 end

--- a/Casks/s/swift-craft-launcher.rb
+++ b/Casks/s/swift-craft-launcher.rb
@@ -2,17 +2,18 @@ cask "swift-craft-launcher" do
   version "0.2.2-beta"
 
   on_arm do
-    sha256 "22446f9c018a67b566e90ffe45a2b5541c1ce53416270ff3f3a5bdbc6bfd312c"
+    sha256 "b1715f7675bb3fdb55ae222aeb89710e11e0b63604b73dfd11f32fb9b048e359"
+
     url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/download/#{version}/Swift_Craft_Launcher_arm64_#{version}.dmg"
   end
-
   on_intel do
-    sha256 "1595496909251c159891e60caf4da29c91b697c2b2aeefef33505e7f0bf95acc"
+    sha256 "d9ce2fa1aad1daaf3b4c2103899396d665b7669f523a32002bf97dc7e009a217"
+
     url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/download/#{version}/Swift_Craft_Launcher_x86_64_#{version}.dmg"
   end
 
   name "Swift Craft Launcher"
-  desc "Modern Minecraft launcher for macOS built with SwiftUI"
+  desc "Modern Minecraft launcher built with SwiftUI"
   homepage "https://suhang12332.github.io/swift-craft-launcher-web.github.io/"
 
   livecheck do

--- a/Casks/s/swift-craft-launcher.rb
+++ b/Casks/s/swift-craft-launcher.rb
@@ -1,0 +1,36 @@
+cask "swift-craft-launcher" do
+  version "0.1.9-beta"
+
+  on_arm do
+    sha256 :no_check
+    url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/download/#{version}/Swift_Craft_Launcher_arm64_#{version}.dmg"
+  end
+
+  on_intel do
+    sha256 :no_check
+    url "https://github.com/suhang12332/Swift-Craft-Launcher/releases/download/#{version}/Swift_Craft_Launcher_x86_64_#{version}.dmg"
+  end
+
+  name "Swift Craft Launcher"
+  desc "Modern Minecraft launcher for macOS built with SwiftUI"
+  homepage "https://suhang12332.github.io/swift-craft-launcher-web.github.io/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Swift Craft Launcher.app"
+
+  uninstall quit: "com.su.code.SwiftCraftLauncher"
+
+  zap trash: [
+    "~/Library/Application Support/Swift Craft Launcher",
+    "~/Library/Caches/com.su.code.SwiftCraftLauncher",
+    "~/Library/Logs/Swift Craft Launcher",
+    "~/Library/Preferences/com.su.code.SwiftCraftLauncher.plist",
+    "~/Library/Saved Application State/com.su.code.SwiftCraftLauncher.savedState"
+  ]
+end

--- a/Casks/s/swift-craft-launcher.rb
+++ b/Casks/s/swift-craft-launcher.rb
@@ -1,5 +1,5 @@
 cask "swift-craft-launcher" do
-  version "0.1.9-beta"
+  version "0.2.2-beta"
 
   on_arm do
     sha256 :no_check


### PR DESCRIPTION
**New Cask: Swift Craft Launcher**

- Name: Swift Craft Launcher
- Version: 0.2.2-beta
- Description: Modern Minecraft launcher for macOS built with SwiftUI
- Homepage: https://suhang12332.github.io/swift-craft-launcher-web.github.io/
- License: GNU Affero General Public License v3.0 

Notes:
- Provides both Apple Silicon (arm64) and Intel (x86_64) builds.
- Uses GitHub Releases as source with `github_latest` livecheck strategy.
- Includes uninstall and zap stanzas for a clean removal.