### PR TITLE
epson-print-layout 1.5.12 (new cask)

### DIFF
--- a/Casks/e/epson-print-layout.rb
+++ b/Casks/e/epson-print-layout.rb
@@ -1,0 +1,30 @@
+cask "epson-print-layout" do
+  version "1.5.12"
+  sha256 "86c69e14830a0bd232ed2376ae07557fbc712319c93b29902fc654ee3f3c1c71"
+
+  url "https://ftp.epson.com/drivers/EPL_#{version.no_dots}.dmg"
+  name "Epson Print Layout"
+  desc "Software to layout and print images with Epson printers"
+  homepage "https://epson.com/epson-print-layout"
+
+  # This checks the download support page for the newest macOS version that
+  # lists the Epson Print Layout version. NOTE: We will need to periodically
+  # review the download pages for the newest macOS versions to keep this check
+  # up to date, otherwise it could end up persistently returning an older
+  # version as newest.
+  livecheck do
+    url "https://epson.com/c/Epson-Print-Layout/s/SPT_PRINTLAYOUT?review-filter=macOS+14.x"
+    regex(/Epson(?:\s|&nbsp;)*Print(?:\s|&nbsp;)*Layout(?:\s|&nbsp;)*v?(\d+(?:\.\d+)+)/im)
+  end
+
+  depends_on macos: ">= :el_capitan"
+
+  pkg "Epson Print Layout.pkg"
+
+  uninstall pkgutil: "com.epson.printlayout.pkg"
+
+  zap trash: [
+    "~/Library/Application Support/com.epson.printlayout",
+    "~/Library/HTTPStorages/com.epson.printlayout",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
I have thought about the live check being not very optimal. It does have a version number in the download link (i.e. `https://ftp.epson.com/drivers/EPL_1512.dmg`), however, this version number does not have any separation between major, minor, and patch, which makes a bit difficult on comparing.
I have also checked
1) The actual, well-separated, version is not on the homepage.
2) The software itself can not check for updates. (no GET or POST way to check for latest release).
3) No public directory.

Thus, I followed livecheck method used by [this cask](https://github.com/Homebrew/homebrew-cask/blob/211debe134410d98c0c92af42b3ef655706d21fc/Casks/w/winzip.rb#L19) (use regex to find the latest download link, then download and extract version number from plist).

Any feedback is appreciated, thanks!
