### PR TITLE
Add Tod 0.0.2

### DIFF
--- a/Casks/t/tod.rb
+++ b/Casks/t/tod.rb
@@ -1,6 +1,6 @@
 cask "tod" do
-  version "0.0.1"
-  sha256 "1b067aa4403bfad432ed6e69e67f9f46b2dac5a1335ba647ec424d79a477d461"
+  version "0.0.2"
+  sha256 "69be67fce303495cd4cb4f1db47e3db9ae2ba0f933579bf0a7d8083f0b4aac66"
 
   url "https://github.com/lance13c/tod-releases/releases/download/v#{version}/tod-#{version}.dmg"
   name "Tod"

--- a/Casks/t/tod.rb
+++ b/Casks/t/tod.rb
@@ -1,0 +1,25 @@
+cask "tod" do
+  version "0.0.1"
+  sha256 "1b067aa4403bfad432ed6e69e67f9f46b2dac5a1335ba647ec424d79a477d461"
+
+  url "https://github.com/lance13c/tod-releases/releases/download/v#{version}/tod-#{version}.dmg"
+  name "Tod"
+  desc "Agentic TUI manual tester - A text-adventure interface for E2E testing"
+  homepage "https://tod.dev"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Tod.app"
+
+  # Add tod binary to PATH by creating a symlink
+  binary "#{appdir}/Tod.app/Contents/MacOS/tod"
+
+  zap trash: [
+    "~/Library/Application Support/tod",
+    "~/Library/Caches/tod",
+    "~/Library/Preferences/com.ciciliostudio.tod.plist",
+  ]
+end


### PR DESCRIPTION
## New Cask: Tod

Tod is an agentic TUI manual tester - a text-adventure interface for E2E testing.

### Pre-submission checklist
- [x] The cask is for a stable version (0.0.2)
- [x] The cask file follows the template structure
- [x] The download URL is publicly accessible
- [x] The SHA256 checksum is correct (69be67fce303495cd4cb4f1db47e3db9ae2ba0f933579bf0a7d8083f0b4aac66)
- [x] The application installs and runs correctly

### Additional Notes
- Proprietary software from Ciciliostudio LLC
- Homepage: https://tod.dev
- Public releases hosted at: https://github.com/lance13c/tod-releases
- Version 0.0.2 includes bug fixes and improvements over 0.0.1

Thank you for reviewing this submission!