### PR TITLE
readyapi 3.62.0

### DIFF
--- a/Casks/r/readyapi.rb
+++ b/Casks/r/readyapi.rb
@@ -1,15 +1,15 @@
 cask "readyapi" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.61.0"
-  sha256 arm:   "0e7c79c0921d0d6d926afb81fb66dfea305d2f734d11369a8af65d236b651250",
-         intel: "f2acc6eb9dad152d8ed5e9fb4ae227b8ad96c9fff47117e2d294b0b1be133af5"
+  version "3.62.0"
+  sha256 arm:   "66c73191a5353db667f790f62d2f2a0cbb20343268b59cb3165f0c61dda8c07b",
+         intel: "6d795a18c79e7c1ccb3dd4b4b660f80ac47ad81a39675157118ec3d5082d0f2d"
 
   url "https://dl.eviware.com/ready-api/#{version}/ReadyAPI-#{arch}-#{version}.dmg",
       verified: "dl.eviware.com/ready-api/"
   name "ReadyAPI Desktop"
   desc "Automated API testing platform"
-  homepage "https://smartbear.com/product/ready-api/overview/"
+  homepage "https://smartbear.com/product/ready-api/"
 
   livecheck do
     url "https://support.smartbear.com/readyapi/docs/en/what-s-new/version-history.html"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

CI failed due to 404 of the homepage.  This updates the homepage to drop the unneeded suffix and point to the product mainpage.

While we're here, perform the version bump to `3.62.0`