### PR TITLE
sql-tabs: deprecate

### DIFF
--- a/Casks/s/sql-tabs.rb
+++ b/Casks/s/sql-tabs.rb
@@ -2,10 +2,12 @@ cask "sql-tabs" do
   version "1.1.0"
   sha256 "692b0c27a596d049dd64e158a543b768f7d4bd9df869b4365c9d8efc36b59b8e"
 
-  url "https://github.com/sasha-alias/sqltabs/releases/download/v#{version}/SQL-Tabs-#{version}.dmg",
-      verified: "github.com/sasha-alias/sqltabs/"
+  url "https://github.com/sasha-alias/sqltabs/releases/download/v#{version}/SQL-Tabs-#{version}.dmg"
   name "SQL Tabs"
-  homepage "https://www.sqltabs.com/"
+  desc "SQL client"
+  homepage "https://github.com/sasha-alias/sqltabs"
+
+  deprecate! date: "2025-09-07", because: :unmaintained
 
   app "SQL Tabs.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This deprecates `sql-tabs` due to being unmaintained.  I noticed the homepage was unreachable, and found unaddresed issues in the repository going back to 2022 regarding the homepage.  I've set the homepage to the GitHub repository.

There don't appear to have been any app updates since 2020, before Apple Silicon.