### PR TITLE
lyric-fever 3.0

### DIFF
--- a/Casks/l/lyric-fever.rb
+++ b/Casks/l/lyric-fever.rb
@@ -1,8 +1,8 @@
 cask "lyric-fever" do
-  version "2.2"
-  sha256 "1631c25f3a7bcd965e41d66208fa89b60452eb33a3343c7ffe1fe46df7430cca"
+  version "3.0,3"
+  sha256 "5669aa907934f3b565cfea310421802713e7d44c18a5b64dd545dae8ce900d44"
 
-  url "https://github.com/aviwad/LyricFever/releases/download/v#{version}/Lyric.Fever.#{version}.dmg",
+  url "https://github.com/aviwad/LyricFever/releases/download/v#{version.csv.second || version.csv.first}/Lyric.Fever.#{version.csv.first}.dmg",
       verified: "github.com/aviwad/LyricFever/releases/download/"
   name "Lyric Fever"
   desc "Lyrics for Apple Music and Spotify"
@@ -10,11 +10,17 @@ cask "lyric-fever" do
 
   livecheck do
     url "https://aviwad.github.io/SpotifyLyricsInMenubar/appcast.xml"
-    strategy :sparkle
+    regex(%r{/v?(\d+(?:\.\d+)*[^/]*)/Lyric[._-]Fever[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next if match.blank?
+
+      (match[2] == match[1]) ? match[2] : "#{match[2]},#{match[1]}"
+    end
   end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: ">= :sequoia"
 
   app "Lyric Fever.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`lyric-fever` is autobumped but the workflow failed to update to version 3.0 because upstream used a `v3` tag format for this release instead of the expected `v3.0`. This updates the cask to the newest version and adapts the `livecheck` block to be able to handle this situation (as we have done in other casks facing this situation).