### PR TITLE
nvidia-nsight-*: update livecheck

### DIFF
--- a/Casks/n/nvidia-nsight-compute.rb
+++ b/Casks/n/nvidia-nsight-compute.rb
@@ -11,20 +11,8 @@ cask "nvidia-nsight-compute" do
   homepage "https://developer.nvidia.com/nsight-compute"
 
   livecheck do
-    url "https://developer.nvidia.com/tools-downloads.json"
+    url "https://developer.nvidia.com/tools-overview/nsight-compute/get-started"
     regex(/nsight[._-]compute[._-]mac[._-]#{arch}[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
-    strategy :json do |json, regex|
-      json["downloads"]&.map do |download|
-        next unless download["development_platform"]&.include?("osx")
-
-        download["files"]&.map do |file|
-          match = file["url"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end&.flatten
-    end
   end
 
   depends_on macos: ">= :high_sierra"

--- a/Casks/n/nvidia-nsight-systems.rb
+++ b/Casks/n/nvidia-nsight-systems.rb
@@ -11,20 +11,8 @@ cask "nvidia-nsight-systems" do
   homepage "https://developer.nvidia.com/nsight-systems"
 
   livecheck do
-    url "https://developer.nvidia.com/tools-downloads.json"
+    url "https://developer.nvidia.com/nsight-systems/get-started"
     regex(/NsightSystems[._-]macos#{arch}[._-]public[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
-    strategy :json do |json, regex|
-      json["downloads"]&.map do |download|
-        next unless download["development_platform"]&.include?("osx")
-
-        download["files"]&.map do |file|
-          match = file["url"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end&.flatten
-    end
   end
 
   depends_on macos: ">= :high_sierra"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

While looking into the `nvidia-nsight-compute` situation, I noticed that the `livecheck` block for it and the `nvidia-nsight-systems` cask check a JSON file that contains a lot of information on various Nvidia tools and it's currently ~2.5 MB in size (~1.5 MB compressed). This is quite large for a check (to put it lightly), so this updates the `livecheck` blocks to check the related "Get(ting) Started" pages instead. These pages link to their respective cask URLs and are only ~18-24 KB compressed (i.e., less data to transfer and we don't have to parse all that JSON, so they're lighter checks overall).

We're probably going to have to deprecate the `nvidia-nsight-compute` cask because the URL for the newest version (2025.3.1.4-36398880) redirects to an Nvidia login page again (an issue previously discussed in https://github.com/Homebrew/homebrew-cask/pull/194357#issuecomment-2523033757), so it effectively breaks the cask. If Nvidia only gates the newest version behind a login, then it may be technically possible to track the second-newest version if we continue to check this huge JSON file but that doesn't feel like a great solution.

[Running this as syntax-only, as we would have to skip livecheck for this to pass in CI anyway due to the newer `nvidia-nsight-compute` version.]