### PR TITLE
mullvad-vpn bump version to 2025.9 and enable auto update

### DIFF
--- a/Casks/m/mullvad-vpn.rb
+++ b/Casks/m/mullvad-vpn.rb
@@ -1,6 +1,6 @@
 cask "mullvad-vpn" do
-  version "2025.8"
-  sha256 "1a5fe37101923611bb3f1081190db023b66c3d44b0dc89e4c21a9f1a3bc7dcc4"
+  version "2025.9"
+  sha256 "45ff796643996488015dbab277eb4780c17d61317c13bad6cac66d1b9ffdd7e4"
 
   url "https://cdn.mullvad.net/app/desktop/releases/#{version}/MullvadVPN-#{version}.pkg"
   name "Mullvad VPN"
@@ -17,6 +17,7 @@ cask "mullvad-vpn" do
     end
   end
 
+  auto_updates true
   conflicts_with cask: "mullvad-vpn@beta"
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

—

The Mullvad app supports auto update as of August ’25 (https://mullvad.net/en/blog/updating-the-mullvad-vpn-app-just-got-easier)
