### PR TITLE
slack-cli: fix homepage

### DIFF
--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -9,7 +9,7 @@ cask "slack-cli" do
       verified: "downloads.slack-edge.com/slack-cli/"
   name "Slack CLI"
   desc "CLI to create, run, and deploy Slack apps"
-  homepage "https://tools.slack.dev/slack-cli/"
+  homepage "https://docs.slack.dev/tools/slack-cli/"
 
   livecheck do
     url "https://api.slack.com/slackcli/metadata.json"


### PR DESCRIPTION
👋 This PR updates the `slack-cli` package documentation link to the current docs.

🔗 Previous: https://tools.slack.dev/slack-cli/ (redirects)
🔗 Current: https://docs.slack.dev/tools/slack-cli/

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
