### PR TITLE
slack-cli: separate arch installations

### DIFF
--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -1,8 +1,11 @@
 cask "slack-cli" do
-  version "3.6.1"
-  sha256 "638321246094989758394b150be5f24d7d1fcd2bdf0d3e33bfd47644454c9c40"
+  arch arm: "arm64", intel: "amd64"
 
-  url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_64-bit.tar.gz",
+  version "3.6.1"
+  sha256 arm:   "5560042d7b7dd04d4988eacb3ab7b2120bb953ecb50f3515b0164aa2aa027f64",
+         intel: "a19b45752a8941a17b7addd4ecc3be790288cdace52ac18dfbd2e537b8ee4b74"
+
+  url "https://downloads.slack-edge.com/slack-cli/slack_cli_#{version}_macOS_#{arch}.tar.gz",
       verified: "downloads.slack-edge.com/slack-cli/"
   name "Slack CLI"
   desc "CLI to create, run, and deploy Slack apps"


### PR DESCRIPTION
Target builds for both "amd64" and "arm64" architectures for macOS

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

### Notes

Versions prior to 3.3.0 require the universal binary found at the "64-bit" download but these changes should match what's current! 🤖 