### PR TITLE
slack-cli: remove depends_on deno

### DIFF
--- a/Casks/s/slack-cli.rb
+++ b/Casks/s/slack-cli.rb
@@ -18,8 +18,6 @@ cask "slack-cli" do
     end
   end
 
-  depends_on formula: "deno"
-
   binary "bin/slack"
 
   # No zap stanza required


### PR DESCRIPTION
The Deno runtime is no longer included with the Slack CLI installation

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

### Notes

This change matches a recent change to the installation script: https://docs.slack.dev/changelog/2025/08/28/slack-cli

> The `deno` runtime is no longer installed with the Slack CLI installation script.