### PR TITLE
ccstudio: deprecate

### DIFF
--- a/Casks/c/ccstudio.rb
+++ b/Casks/c/ccstudio.rb
@@ -8,10 +8,7 @@ cask "ccstudio" do
   desc "Color management tool for accurate monitor and printer calibration"
   homepage "https://calibrite.com/us/software-downloads/"
 
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/mac/ccStudio\.zip}i)
-  end
+  deprecate! date: "2025-09-09", because: :no_longer_available, replacement_cask: "calibrite-profiler"
 
   depends_on macos: ">= :catalina"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The [homepage](https://calibrite.com/us/software-downloads/) of this software has removed ccstudio being an option to download. Although the download URL still exists, I believe this cask should still be marked as either deprecated or disabled.
I'm not exactly sure which category this cask will fall under, but it seems most likely disabled.

Any feedback are welcomed!
