### PR TITLE
Renamed and Split 'ui' cask to match updated versions/branding

### DIFF
--- a/Casks/u/unifi-identity-endpoint.rb
+++ b/Casks/u/unifi-identity-endpoint.rb
@@ -1,0 +1,33 @@
+cask "unifi-identity-endpoint" do
+  version "3.3.1,16645096-85aa-42af-9593-2c13f3280dda,a73c"
+  sha256 "4e6476bb27808f38d1a3769d49b5c0862cec8a8d9e0c0b0ab74913804643b675"
+
+  url "https://fw-download.ubnt.com/data/uid-identity-standard-desktop-app/#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg",
+      verified: "fw-download.ubnt.com/data/uid-identity-standard-desktop-app/"
+  name "UniFi Identity Endpoint"
+  desc "License free Wi-Fi, VPN, and Access Application for Orgnizations"
+  homepage "https://www.ui.com/identity"
+
+  livecheck do
+    url "https://download.uid.ui.com/?app=DESKTOP-IDENTITY-STANDARD-MACOS"
+    regex(/(\w+)[._-]macOS[._-](\d+(?:\.\d+)+)[._-](\h{8}-\h{4}-\h{4}-\h{4}-\h{12})/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      "#{match[2]},#{match[3]},#{match[1]}"
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  pkg "#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg"
+
+  uninstall launchctl: [
+              "application.com.ui.uid.standard-desktop.93942643.93942648",
+              "com.ui.uid.standard-desktop.startup",
+            ],
+            quit:      "com.ui.uid.standard-desktop",
+            pkgutil:   "com.ui.uid.standard-desktop",
+            delete:    "/Applications/Identity.app"
+end

--- a/Casks/u/unifi-identity-endpoint.rb
+++ b/Casks/u/unifi-identity-endpoint.rb
@@ -25,6 +25,7 @@ cask "unifi-identity-endpoint" do
 
   uninstall launchctl: [
               "application.com.ui.uid.standard-desktop.93942643.93942648",
+              "com.ui.uid.standard-desktop.privilegedtool",
               "com.ui.uid.standard-desktop.startup",
             ],
             quit:      "com.ui.uid.standard-desktop",

--- a/Casks/u/unifi-identity-enterprise.rb
+++ b/Casks/u/unifi-identity-enterprise.rb
@@ -1,15 +1,15 @@
-cask "ui" do
+cask "unifi-identity-enterprise" do
   version "0.89.1,7ee8d102-d6c2-472d-9d0b-38b3627d11be,6ae9"
   sha256 "789da27b3ee0b02768317e5fee441a0cb28d3298ac9e2e792e62afd9a5e6ba17"
 
   url "https://fw-download.ubnt.com/data/uid-ui-desktop-app/#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg",
       verified: "fw-download.ubnt.com/data/uid-ui-desktop-app/"
-  name "UI Desktop"
+  name "UniFi Identity Enterprise"
   desc "Corporate Wi-Fi, VPN, SSO, and HR Application"
-  homepage "https://www.ui.com/uid"
+  homepage "https://www.ui.com/identity"
 
   livecheck do
-    url "https://api-gw.uid.alpha.ui.com:443/location/api/v1/public/fw/download/latest/?app=UI-DESKTOP-MACOS"
+    url "https://download.uid.ui.com/?app=UI-DESKTOP-MACOS"
     regex(/(\w+)[._-]macOS[._-](\d+(?:\.\d+)+)[._-](\h{8}-\h{4}-\h{4}-\h{4}-\h{12})/i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)

--- a/Casks/u/unifi-identity-enterprise.rb
+++ b/Casks/u/unifi-identity-enterprise.rb
@@ -19,7 +19,7 @@ cask "unifi-identity-enterprise" do
     end
   end
 
-  depends_on macos: ">= :mojave"
+  depends_on macos: ">= :big_sur"
 
   pkg "#{version.csv.third}-macOS-#{version.csv.first}-#{version.csv.second}.pkg"
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -188,6 +188,7 @@
   "triliumnext-notes": "trilium-notes",
   "tutanota": "tuta-mail",
   "twine": "twine-app",
+  "ui": "unifi-identity-enterprise",
   "unison": "unison-app",
   "usage": "usage-app",
   "vapor": "vapor-app",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Ubiquiti has rebranded the **UI** application to **UniFi Identity**, and split it into two different applications for different types of organizations:
- UniFi Identity Endpoint
- UniFi Identity Enterprise

I've updated the metadata for the legacy cask which still points to the **Enterprise** version, and added the new **Endpoint** version. I've followed all steps above for validating both casks, but wasn't quite sure about best practices when it comes to renaming/splitting casks in this weird edge case so if changes need to be made I am happy to.

Thanks!