### PR TITLE
Revert "gcloud-cli: Add gcloud bin path and completion to bash profile"

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -25,14 +25,17 @@ cask "gcloud-cli" do
     args:       [
       "--quiet",
       "--usage-reporting", "false",
-      "--bash-completion", "true",
-      "--path-update", "true",
+      "--bash-completion", "false",
+      "--path-update", "false",
+      "--rc-path", "false",
       "--install-python", "false",
       "--update-installed-components"
     ],
   }
   binary "google-cloud-sdk/bin/bq"
+  binary "google-cloud-sdk/bin/docker-credential-gcloud"
   binary "google-cloud-sdk/bin/gcloud"
+  binary "google-cloud-sdk/bin/git-credential-gcloud.sh", target: "git-credential-gcloud"
   binary "google-cloud-sdk/bin/gsutil"
   bash_completion "google-cloud-sdk/completion.bash.inc", target: "google-cloud-sdk"
   zsh_completion "google-cloud-sdk/completion.zsh.inc", target: "_google_cloud_sdk"
@@ -44,7 +47,7 @@ cask "gcloud-cli" do
   end
 
   postflight do
-    # Allow existing shell profiles to work by linking the current version to the `latest` directory.
+    # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.
     unless (latest_path = staged_path.dirname/"latest").directory?
       FileUtils.ln_s staged_path, latest_path, force: true
     end


### PR DESCRIPTION
Shell file adjustments from a cask are way too invasive for homebrew, reverting this to bring back the old behaviour.

Reverts Homebrew/homebrew-cask#225765
Fixes https://github.com/Homebrew/homebrew-cask/issues/226676