### PR TITLE
longplay 1.1.0

### DIFF
--- a/Casks/l/longplay.rb
+++ b/Casks/l/longplay.rb
@@ -1,8 +1,8 @@
 cask "longplay" do
-  version "1.0.5,485"
-  sha256 "a6d42edb19029209979c5a5942dc5d160fceb8e2b36877bb8373170455f4dbc6"
+  version "1.1.0,490"
+  sha256 "808ecd2e5b7a24ace0ff6bf7790af096d4740ca3f3f540334b472205031303bd"
 
-  url "https://download.longplay.app/mac/longplay-#{version.csv.first}-#{version.csv.second}.zip",
+  url "https://download.longplay.app/mac/longplay-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "download.longplay.app/"
   name "Longplay"
   desc "Album-focused music player"
@@ -10,8 +10,12 @@ cask "longplay" do
 
   livecheck do
     url "https://download.longplay.app/mac/appcast.xml"
+    regex(/longplay[._-]v?(\d+(?:[.-]\d+)+)/i)
     strategy :sparkle do |items|
-      items.find { |item| item.channel.nil? }&.nice_version
+      stable_item = items.find { |item| item.channel.nil? }
+      next unless stable_item
+
+      stable_item.url&.[](regex, 1)&.tr("-", ",")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`longplay` is autobumped but the workflow failed to update to version 1.1.0 because the appcast uses a 1.1 `shortVersionString` while the file name uses 1.1.0 and also the file type has changed from zip to dmg. This updates the cask and modifies the `livecheck` block to match the version from the file name instead.