### PR TITLE
DrawPen 0.0.23 (new cask)

### DIFF
--- a/Casks/d/drawpen.rb
+++ b/Casks/d/drawpen.rb
@@ -1,0 +1,24 @@
+cask "drawpen" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.0.23"
+  sha256 arm:   "b40dd4c547fc2fbc9da9b3c06cbfe651d760dc9c62e7a39e171a9e997131402a",
+         intel: "600c81b39c849d57ae422143bf4d5a088f4f4661f2e20c7f87d34abed44327bd"
+
+  url "https://github.com/DmytroVasin/DrawPen/releases/download/v#{version}/DrawPen-#{version}-#{arch}.dmg"
+  name "DrawPen"
+  desc "Screen annotation tool"
+  homepage "https://github.com/DmytroVasin/DrawPen"
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "DrawPen.app"
+
+  zap trash: [
+    "~/Library/Application Support/DrawPen",
+    "~/Library/Logs/DrawPen",
+    "~/Library/Preferences/*drawpen*.plist",
+    "~/Library/Saved Application State/*DrawPen*.savedState",
+  ]
+end


### PR DESCRIPTION
**New Cask: drawpen 0.0.23**

Adds a new cask for [DrawPen](https://github.com/DmytroVasin/DrawPen), a simple screen annotation.

### Features of this Cask
- Supports both Apple Silicon (`arm64`) and Intel (`x64`) DMGs.
- Uses stable, versioned GitHub release URLs.
- Includes `livecheck` stanza to follow GitHub releases.
- Includes `zap` stanza for user data cleanup on uninstall.
- Application is signed and notarized.

### Checklist
- [x] The submission is for a [stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions).
- [x] `brew audit --cask --online drawpen` is error-free.
- [x] `brew style --fix drawpen` reports no offenses.
- [x] Cask token follows the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked that `drawpen` was not previously refused.
- [x] `brew audit --cask --new drawpen` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask drawpen` worked successfully.
- [x] `brew uninstall --cask drawpen` worked successfully.

Thank you for reviewing! Happy to make any changes if required.