### PR TITLE
dash 8.0.0

### DIFF
--- a/Casks/d/dash.rb
+++ b/Casks/d/dash.rb
@@ -1,6 +1,6 @@
 cask "dash" do
-  version "7.3.5"
-  sha256 "881d3210ff71cc0ba03fabdf04d84defeb77d7edc688045d29312e59c82f649d"
+  version "8.0.0"
+  sha256 "8554e3ad07ca3fdbb0b8a607ca3ccd869a2962ba84ee96291ce51af24b52a8c5"
 
   url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
   name "Dash"
@@ -8,7 +8,7 @@ cask "dash" do
   homepage "https://kapeli.com/dash"
 
   livecheck do
-    url "https://kapeli.com/Dash#{version.major}.xml"
+    url "https://kapeli.com/Dash.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dash` is autobumped but the workflow failed to update to 8.0.0 because the appcast URL is no longer versioned in this release. 8.0.0 is a major version update, so this also creates a `dash@7` cask and updates the `dash@6` `conflicts_with` value accordingly.