### PR TITLE
dash@7 7.3.5 (new cask)

### DIFF
--- a/Casks/d/dash@7.rb
+++ b/Casks/d/dash@7.rb
@@ -1,0 +1,37 @@
+cask "dash@7" do
+  version "7.3.5"
+  sha256 "881d3210ff71cc0ba03fabdf04d84defeb77d7edc688045d29312e59c82f649d"
+
+  url "https://kapeli.com/downloads/v#{version.major}/Dash.zip"
+  name "Dash"
+  desc "API documentation browser and code snippet manager"
+  homepage "https://kapeli.com/dash"
+
+  livecheck do
+    url "https://kapeli.com/Dash#{version.major}.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  conflicts_with cask: [
+    "dash",
+    "dash@6",
+  ]
+  depends_on macos: ">= :high_sierra"
+
+  app "Dash.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.kapeli.dashdoc",
+    "~/Library/Application Support/Dash",
+    "~/Library/Caches/com.kapeli.dashdoc",
+    "~/Library/Caches/com.plausiblelabs.crashreporter.data/com.kapeli.dashdoc",
+    "~/Library/Cookies/com.kapeli.dashdoc.binarycookies",
+    "~/Library/HTTPStorages/com.kapeli.dashdoc",
+    "~/Library/HTTPStorages/com.kapeli.dashdoc.binarycookies",
+    "~/Library/Logs/Dash",
+    "~/Library/Preferences/com.kapeli.dashdoc.plist",
+    "~/Library/Saved Application State/com.kapeli.dashdoc.savedState",
+    "~/Library/WebKit/com.kapeli.dashdoc",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This creates a `dash@7` cask using the existing `dash` cask, as it apparently needs to exist before updating the `dash` and `dash@6` casks to reference `dash@7`. This is necessary as part of updating `dash` to version 8.0.0.