### PR TITLE
xppen-pentablet 4.0.10

### DIFF
--- a/Casks/x/xppen-pentablet.rb
+++ b/Casks/x/xppen-pentablet.rb
@@ -1,17 +1,48 @@
 cask "xppen-pentablet" do
-  version "4.0.8,250414"
-  sha256 "c792fc0c5df8c38b75267d302d0c3ced49371ac7be73998875279bc627dad3ca"
+  version "4.0.10,250829,2025,09"
+  sha256 "60fbb808854210e1a12f7b26270792194fbde3daf2d5b863674e2b04edc7cb24"
 
-  url "https://download01.xp-pen.com/file/20#{version.csv.second[0, 2]}/#{version.csv.second[2, 2]}/XPPenMac_#{version.csv.first}_#{version.csv.second}.zip"
+  url "https://download01.xp-pen.com/file/#{version.csv.third}/#{version.csv.fourth}/XPPenMac_#{version.csv.first}_#{version.csv.second}.zip"
   name "XPPen PenTablet"
   desc "Universal driver for XPPen drawing tablets and pen displays"
   homepage "https://www.xp-pen.com/"
 
+  # The file used in the cask has a date-based suffix and this has historically
+  # aligned with the date in the URL path (e.g. _250102 in the file name and
+  # /2025/01/ in the path). Unfortunately, this isn't always the case, so we
+  # have to painstakingly recreate the upstream download page logic to generate
+  # the download URL for the newest version to be able to match all the version
+  # parts from the file URL.
   livecheck do
     url "https://www.xp-pen.com/download/star-g640.html"
     regex(/XPPenMac[._-]v?(\d+(?:\.\d+)+)[._-](\d+)/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      redirection_regex = Regexp.new(
+        regex.source +
+          ".*?data-id=[\"']?(\\d+)[\"']?" \
+          "\\s+data-pid=[\"']?(\\d+)[\"']?" \
+          "\\s+data-ext=[\"']?([^\"' >]+)[\"']?",
+        "im",
+      )
+
+      # Find the newest XPPenMac version on the page and capture the `data`
+      # attributes from the Download link after it
+      match = page.scan(redirection_regex)
+                  .max_by { |match| Version.new("#{match[0]}_#{match[1]}") }
+      next if match.blank?
+
+      # Generate the URL that redirects to the file and fetch the headers
+      merged_headers = Homebrew::Livecheck::Strategy.page_headers(
+        "https://www.xp-pen.com/download/file.html?id=#{match[2]}&pid=#{match[3]}&ext=#{match[4]}",
+      ).reduce(&:merge)
+      next if merged_headers.blank?
+
+      # Collect the `version` parts from the file URL
+      file_url_regex = Regexp.new("/(\\d+)/(\\d+)/" + regex.source, "i")
+      match = merged_headers["location"]&.match(file_url_regex)
+      next if match.blank?
+
+      "#{match[3]},#{match[4]},#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`xppen-pentablet` is autobumped but the workflow failed to update to 4.0.10 because the date path in the file URL doesn't align with the date suffix in the file name like the cask expects (i.e., the path is /file/2025/09/ but the date suffix is 250829). Using the date suffix, the path in the cask URL was /file/2025/08/, which isn't correct for this version and the server returns a 404 (Not Found) error.

This updates the cask and reworks it to include the year/month date path parts in the cask `version`. The related `livecheck` block is a monster but it works as expected for now (please don't ask me how long I spent on this because I would like to forget, if possible). [This approach is unfortunately more brittle than I would like, as it can easily fail if upstream changes the order of the `data` attributes on the download links, but this may be the best we can do until a better option appears.]