### PR TITLE
Add support for Linux to visual-studio-code cask

### DIFF
--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -61,7 +61,7 @@ cask "visual-studio-code" do
   auto_updates true
 
   app "Visual Studio Code.app" if os == "darwin"
-  binary "#{Utils.binary_path("", os, arch, version)}/code"
+  binary "#{Utils.binary_path(appdir, os, arch, version)}/code"
   binary "#{Utils.binary_path(appdir, os, arch, version)}/code-tunnel"
 
   if os == "linux"

--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -1,5 +1,21 @@
+module Utils
+  define_singleton_method(:os_arch_combo) do |os, arch|
+    return "#{os}-#{arch}" if os == "linux"
+    return "#{os}-#{arch}" if os == "darwin" && arch == "arm64"
+
+    os.to_s
+  end
+
+  define_singleton_method(:binary_path) do |appdir, os, arch, version|
+    return "/home/linuxbrew/.linuxbrew/Caskroom/visual-studio-code/#{version}/VSCode-linux-#{arch}/bin" if os == "linux"
+
+    "#{appdir}/Visual Studio Code.app/Contents/Resources/app/bin"
+  end
+end
+
 cask "visual-studio-code" do
-  arch arm: "darwin-arm64", intel: "darwin"
+  arch arm: "arm64", intel: "x64"
+  os macos: "darwin", linux: "linux"
 
   on_catalina :or_older do
     version "1.97.2"
@@ -16,39 +32,62 @@ cask "visual-studio-code" do
            intel: "79531e3edb4c1bdcff829bc7ecfada215eee34bee6bc110fcdbfb68a57926974"
 
     livecheck do
-      url "https://update.code.visualstudio.com/api/update/#{arch}/stable/latest"
+      url "https://update.code.visualstudio.com/api/update/#{Utils.os_arch_combo(os, arch)}/stable/latest"
       strategy :json do |json|
         json["productVersion"]
       end
     end
   end
 
-  url "https://update.code.visualstudio.com/#{version}/#{arch}/stable"
+  on_linux do
+    version "1.104.0"
+    sha256 arm64_linux:  "92d29b2206c5d5e979c4707e012dee3f7a37e47d9d221509e0d1cd0a8421237b",
+           x86_64_linux: "0019db2e217c00a0a5b068e11dbff22b88c3dd3b7ccbf35d6f189c4a4a7e1dbb"
+
+    livecheck do
+      url "https://update.code.visualstudio.com/api/update/#{Utils.os_arch_combo(os, arch)}/stable/latest"
+      strategy :json do |json|
+        json["productVersion"]
+      end
+    end
+  end
+
+  url "https://update.code.visualstudio.com/#{version}/#{Utils.os_arch_combo(os, arch)}/stable"
   name "Microsoft Visual Studio Code"
   name "VS Code"
   desc "Open-source code editor"
   homepage "https://code.visualstudio.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
-  app "Visual Studio Code.app"
-  binary "#{appdir}/Visual Studio Code.app/Contents/Resources/app/bin/code"
-  binary "#{appdir}/Visual Studio Code.app/Contents/Resources/app/bin/code-tunnel"
+  app "Visual Studio Code.app" if os == "darwin"
+  binary "#{Utils.binary_path("", os, arch, version)}/code"
+  binary "#{Utils.binary_path(appdir, os, arch, version)}/code-tunnel"
 
-  uninstall launchctl: "com.microsoft.VSCode.ShipIt",
-            quit:      "com.microsoft.VSCode"
+  if os == "linux"
+    zap trash: [
+      "~/.config/Code",
+      "~/.vscode",
+    ]
+  end
 
-  zap trash: [
-    "~/.vscode",
-    "~/Library/Application Support/Code",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.vscode.sfl*",
-    "~/Library/Caches/com.microsoft.VSCode",
-    "~/Library/Caches/com.microsoft.VSCode.ShipIt",
-    "~/Library/HTTPStorages/com.microsoft.VSCode",
-    "~/Library/Preferences/ByHost/com.microsoft.VSCode.ShipIt.*.plist",
-    "~/Library/Preferences/com.microsoft.VSCode.helper.plist",
-    "~/Library/Preferences/com.microsoft.VSCode.plist",
-    "~/Library/Saved Application State/com.microsoft.VSCode.savedState",
-  ]
+  if os == "darwin"
+    depends_on macos: ">= :catalina"
+
+    uninstall launchctl: "com.microsoft.VSCode.ShipIt",
+              quit:      "com.microsoft.VSCode"
+
+    zap trash: [
+      "~/.vscode",
+      "~/Library/Application Support/Code",
+      "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.microsoft.vscode.sfl*",
+      "~/Library/Caches/com.microsoft.VSCode",
+      "~/Library/Caches/com.microsoft.VSCode.ShipIt",
+      "~/Library/HTTPStorages/com.microsoft.VSCode",
+      "~/Library/Preferences/ByHost/com.microsoft.VSCode.ShipIt.*.plist",
+      "~/Library/Preferences/com.microsoft.VSCode.helper.plist",
+      "~/Library/Preferences/com.microsoft.VSCode.plist",
+      "~/Library/Saved Application State/com.microsoft.VSCode.savedState",
+    ]
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: (since linux support is new, I tested this also)

- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

I wanted to add Linux support to this cask. It can be quite useful for Immutable systems and other linux usecases that can't use the DEB/RPM route.

I am new to making homebrew recipes and cask, and I am sure I have made many mistakes, so I would appreciate any feedback.

I am particularly concerned if it is ok to even use the `if os ==` code, or if there is a better way to organize the file, as I am also concerned about the order of directives. Maybe I do a bit more duplication and put more stuff in `on_linux` and move the macos stuff to `on_macos`? 

Also I don't know if there is a variable or function i can use to get `/home/linuxbrew/.linuxbrew/Caskroom/<cask>` as a path, instead of hardcoding it.

I also had to use some methods to handle the difference in naming for linux and macos on the VSCode URLs. For macos it is `darwin` and `darwin-arm64` while linux is `linux-x64` and `linux-arm64`

The Cask cookbook docs were a little incorrect, as it instructed me to put the `module Utils` inside the `cask` block, and used `self.` methods, while the stylecheck changed things up. Let me know if there is a different way to do this.

**EDIT**: I forgot to ask, is there a way to add one-off files that are not part of the package? There are 2 `.desktop` files I need to add to `~/.local/share/application` so that this app shows up in the Launchers in linux, but they are not included in the `tar.gz` file option on the vscode download, only in the `rpm` and `deb`. Or a way to download extra files?

**EDIT2**: I also don't have a mac to test the mac side of things.