### PR TITLE
zappy 4.8.9

### DIFF
--- a/Casks/z/zappy.rb
+++ b/Casks/z/zappy.rb
@@ -1,8 +1,8 @@
 cask "zappy" do
-  version "4.8.8"
-  sha256 "d5b543fb8a77df06f42d1a9a904ec44378e306f982914accf610b9340a722da6"
+  version "4.8.9"
+  sha256 "7927aa6d595b5ed1d9efdbb87130d8ed562ee29a5d0d60a678b70c9135af2959"
 
-  url "https://zappy.zapier.com/releases/zappy-#{version}.dmg"
+  url "https://zappy.zapier.com/releases/zappy_#{version}.dmg"
   name "Zappy"
   desc "Screen capture tool for remote teams"
   homepage "https://zapier.com/zappy"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`zappy` is autobumped but the workflow failed to update to 4.8.9 because the delimiter in the file name changed from a hyphen to an underscore. This updates the version and `url` accordingly.