### PR TITLE
[#]: remove pre-Catalina references

### DIFF
--- a/Casks/0/0-ad.rb
+++ b/Casks/0/0-ad.rb
@@ -16,8 +16,6 @@ cask "0-ad" do
     regex(/href=.*?0ad[._-]v?(.*?)[._-]macos[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "0 A.D..app"
 
   zap trash: "~/Library/Saved Application State/com.wildfiregames.0ad.savedState"

--- a/Casks/1/115browser.rb
+++ b/Casks/1/115browser.rb
@@ -19,7 +19,6 @@ cask "115browser" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "115Browser.app"
 

--- a/Casks/1/1password@7.rb
+++ b/Casks/1/1password@7.rb
@@ -15,7 +15,6 @@ cask "1password@7" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "1Password #{version.major}.app"
 

--- a/Casks/4/4k-slideshow-maker.rb
+++ b/Casks/4/4k-slideshow-maker.rb
@@ -12,8 +12,6 @@ cask "4k-slideshow-maker" do
     regex(/href=.*?4kslideshowmaker[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "4K Slideshow Maker.app"
 
   zap trash: [

--- a/Casks/4/4k-stogram.rb
+++ b/Casks/4/4k-stogram.rb
@@ -16,7 +16,6 @@ cask "4k-stogram" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "4K Stogram.app"
 

--- a/Casks/4/4k-video-downloader+.rb
+++ b/Casks/4/4k-video-downloader+.rb
@@ -15,8 +15,6 @@ cask "4k-video-downloader+" do
     regex(%r{href=.*?/4kvideodownloaderplus[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "4K Video Downloader+.app"
 
   zap trash: [

--- a/Casks/4/4k-video-downloader.rb
+++ b/Casks/4/4k-video-downloader.rb
@@ -12,8 +12,6 @@ cask "4k-video-downloader" do
     regex(%r{href=.*?/4kvideodownloader[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "4K Video Downloader.app"
 
   zap trash: [

--- a/Casks/4/4k-video-to-mp3.rb
+++ b/Casks/4/4k-video-to-mp3.rb
@@ -12,8 +12,6 @@ cask "4k-video-to-mp3" do
     regex(%r{href=.*?/4kvideotomp3_(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "4K Video to MP3.app"
 
   zap trash: [

--- a/Casks/4/4k-youtube-to-mp3.rb
+++ b/Casks/4/4k-youtube-to-mp3.rb
@@ -16,8 +16,6 @@ cask "4k-youtube-to-mp3" do
     regex(%r{href=.*?/4kyoutubetomp3[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "4K YouTube to MP3.app"
 
   zap trash: [

--- a/Casks/5/5ire.rb
+++ b/Casks/5/5ire.rb
@@ -18,8 +18,6 @@ cask "5ire" do
     regex(/5ire[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "5ire.app"
 
   zap trash: [

--- a/Casks/8/86box.rb
+++ b/Casks/8/86box.rb
@@ -21,8 +21,6 @@ cask "86box" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "86Box.app"
 
   roms_dir = Pathname("~/Library/Application Support/net.86box.86Box/roms")

--- a/Casks/8/8bitdo-ultimate-software.rb
+++ b/Casks/8/8bitdo-ultimate-software.rb
@@ -13,7 +13,6 @@ cask "8bitdo-ultimate-software" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "8BitDo Ultimate Software.app"
 

--- a/Casks/8/8x8-work.rb
+++ b/Casks/8/8x8-work.rb
@@ -15,8 +15,6 @@ cask "8x8-work" do
     regex(/work[._-]dmg[._-]v(\d+(?:[.-]\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "8x8 Work.app"
 
   zap trash: "~/Library/Application Support/8x8 Work"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.