### PR TITLE
[a]: remove pre-Catalina references

### DIFF
--- a/Casks/a/a-better-finder-attributes.rb
+++ b/Casks/a/a-better-finder-attributes.rb
@@ -13,7 +13,6 @@ cask "a-better-finder-attributes" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "A Better Finder Attributes #{version.major}.app"
 

--- a/Casks/a/a-better-finder-rename.rb
+++ b/Casks/a/a-better-finder-rename.rb
@@ -13,7 +13,6 @@ cask "a-better-finder-rename" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "A Better Finder Rename #{version.major}.app"
 

--- a/Casks/a/ableset.rb
+++ b/Casks/a/ableset.rb
@@ -17,7 +17,6 @@ cask "ableset" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "AbleSet.app"
 

--- a/Casks/a/ableton-live-intro@11.rb
+++ b/Casks/a/ableton-live-intro@11.rb
@@ -12,7 +12,6 @@ cask "ableton-live-intro@11" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Intro.app"
 

--- a/Casks/a/ableton-live-lite@11.rb
+++ b/Casks/a/ableton-live-lite@11.rb
@@ -12,7 +12,6 @@ cask "ableton-live-lite@11" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Lite.app"
 

--- a/Casks/a/ableton-live-standard@11.rb
+++ b/Casks/a/ableton-live-standard@11.rb
@@ -12,7 +12,6 @@ cask "ableton-live-standard@11" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Standard.app"
 

--- a/Casks/a/ableton-live-suite@10.rb
+++ b/Casks/a/ableton-live-suite@10.rb
@@ -13,7 +13,6 @@ cask "ableton-live-suite@10" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Suite.app"
 

--- a/Casks/a/ableton-live-suite@11.rb
+++ b/Casks/a/ableton-live-suite@11.rb
@@ -13,7 +13,6 @@ cask "ableton-live-suite@11" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ableton Live #{version.major} Suite.app"
 

--- a/Casks/a/abscissa.rb
+++ b/Casks/a/abscissa.rb
@@ -9,8 +9,6 @@ cask "abscissa" do
 
   disable! date: "2025-04-03", because: :no_longer_available
 
-  depends_on macos: ">= :sierra"
-
   app "Abscissa.app"
 
   zap trash: [

--- a/Casks/a/accordance.rb
+++ b/Casks/a/accordance.rb
@@ -14,7 +14,6 @@ cask "accordance" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Accordance.app"
 

--- a/Casks/a/ace-link.rb
+++ b/Casks/a/ace-link.rb
@@ -12,7 +12,6 @@ cask "ace-link" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
   depends_on cask: "docker"
 
   app "Ace Link.app"

--- a/Casks/a/ace-studio.rb
+++ b/Casks/a/ace-studio.rb
@@ -24,8 +24,6 @@ cask "ace-studio" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "ACE Studio.app"
 
   zap trash: [

--- a/Casks/a/acreom.rb
+++ b/Casks/a/acreom.rb
@@ -16,8 +16,6 @@ cask "acreom" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "acreom.app"
 
   zap trash: [

--- a/Casks/a/active-trader-pro.rb
+++ b/Casks/a/active-trader-pro.rb
@@ -12,8 +12,6 @@ cask "active-trader-pro" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Active Trader Pro.app"
 
   uninstall quit: "com.fmr.activetrader"

--- a/Casks/a/activedock.rb
+++ b/Casks/a/activedock.rb
@@ -14,7 +14,6 @@ cask "activedock" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "ActiveDock #{version.major}.app"
 

--- a/Casks/a/actual.rb
+++ b/Casks/a/actual.rb
@@ -11,8 +11,6 @@ cask "actual" do
   desc "Privacy-focused app for managing your finances"
   homepage "https://actualbudget.org/"
 
-  depends_on macos: ">= :catalina"
-
   app "Actual.app"
 
   zap trash: [

--- a/Casks/a/adguard-vpn.rb
+++ b/Casks/a/adguard-vpn.rb
@@ -16,7 +16,6 @@ cask "adguard-vpn" do
 
   auto_updates true
   conflicts_with cask: "adguard-vpn@nightly"
-  depends_on macos: ">= :catalina"
 
   pkg "AdGuard VPN.pkg"
 

--- a/Casks/a/adguard-vpn@nightly.rb
+++ b/Casks/a/adguard-vpn@nightly.rb
@@ -16,7 +16,6 @@ cask "adguard-vpn@nightly" do
 
   auto_updates true
   conflicts_with cask: "adguard-vpn"
-  depends_on macos: ">= :catalina"
 
   pkg "AdGuard VPN.pkg"
 

--- a/Casks/a/adguard.rb
+++ b/Casks/a/adguard.rb
@@ -16,7 +16,6 @@ cask "adguard" do
 
   auto_updates true
   conflicts_with cask: "adguard@nightly"
-  depends_on macos: ">= :catalina"
 
   pkg "AdGuard.pkg"
 

--- a/Casks/a/adguard@nightly.rb
+++ b/Casks/a/adguard@nightly.rb
@@ -16,7 +16,6 @@ cask "adguard@nightly" do
 
   auto_updates true
   conflicts_with cask: "adguard"
-  depends_on macos: ">= :catalina"
 
   pkg "AdGuard.pkg"
 

--- a/Casks/a/adlock.rb
+++ b/Casks/a/adlock.rb
@@ -19,7 +19,6 @@ cask "adlock" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   pkg "AdLock-Installer.pkg"
 

--- a/Casks/a/adobe-creative-cloud-cleaner-tool.rb
+++ b/Casks/a/adobe-creative-cloud-cleaner-tool.rb
@@ -12,8 +12,6 @@ cask "adobe-creative-cloud-cleaner-tool" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Adobe Creative Cloud Cleaner Tool.app"
 
   uninstall quit: "com.Adobe.Installers.AdobeCreativeCloudCleanerTool"

--- a/Casks/a/adobe-dng-converter.rb
+++ b/Casks/a/adobe-dng-converter.rb
@@ -12,8 +12,6 @@ cask "adobe-dng-converter" do
     regex(%r{Adobe\s+DNG\s+Converter\s+(?:is\s+)?(?:<[^>]+?>)?v?(\d+(?:\.\d+)+)(?:</[^>]+?>)?}im)
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "DNGConverter_#{version.dots_to_underscores}.pkg"
 
   uninstall quit:    "com.adobe.DNGConverter",

--- a/Casks/a/adrive.rb
+++ b/Casks/a/adrive.rb
@@ -19,7 +19,6 @@ cask "adrive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "aDrive.app"
 

--- a/Casks/a/advantagescope.rb
+++ b/Casks/a/advantagescope.rb
@@ -11,8 +11,6 @@ cask "advantagescope" do
   desc "FRC log analysis tool"
   homepage "https://docs.advantagescope.org/"
 
-  depends_on macos: ">= :catalina"
-
   app "AdvantageScope.app"
 
   zap trash: [

--- a/Casks/a/adze.rb
+++ b/Casks/a/adze.rb
@@ -13,7 +13,6 @@ cask "adze" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Adze.app"
 

--- a/Casks/a/aerial.rb
+++ b/Casks/a/aerial.rb
@@ -14,7 +14,6 @@ cask "aerial" do
   end
 
   conflicts_with cask: "aerial@beta"
-  depends_on macos: ">= :sierra"
 
   screen_saver "Aerial.saver"
 

--- a/Casks/a/aerial@beta.rb
+++ b/Casks/a/aerial@beta.rb
@@ -14,7 +14,6 @@ cask "aerial@beta" do
   end
 
   conflicts_with cask: "aerial"
-  depends_on macos: ">= :sierra"
 
   screen_saver "Aerial.saver"
 

--- a/Casks/a/affine.rb
+++ b/Casks/a/affine.rb
@@ -17,7 +17,6 @@ cask "affine" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "AFFiNE.app"
 

--- a/Casks/a/affinity-designer.rb
+++ b/Casks/a/affinity-designer.rb
@@ -14,7 +14,6 @@ cask "affinity-designer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Affinity Designer #{version.csv.first.major}.app"
 

--- a/Casks/a/affinity-photo.rb
+++ b/Casks/a/affinity-photo.rb
@@ -14,7 +14,6 @@ cask "affinity-photo" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Affinity Photo #{version.csv.first.major}.app"
 

--- a/Casks/a/affinity-publisher.rb
+++ b/Casks/a/affinity-publisher.rb
@@ -14,7 +14,6 @@ cask "affinity-publisher" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Affinity Publisher #{version.csv.first.major}.app"
 

--- a/Casks/a/agenda.rb
+++ b/Casks/a/agenda.rb
@@ -9,8 +9,6 @@ cask "agenda" do
 
   disable! date: "2024-12-16", because: :moved_to_mas
 
-  depends_on macos: ">= :mojave"
-
   app "Agenda.app"
 
   zap trash: [

--- a/Casks/a/agentkube.rb
+++ b/Casks/a/agentkube.rb
@@ -12,7 +12,6 @@ cask "agentkube" do
   homepage "https://agentkube.com/"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Agentkube.app"
 

--- a/Casks/a/aide-app.rb
+++ b/Casks/a/aide-app.rb
@@ -19,7 +19,6 @@ cask "aide-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Aide.app"
   binary "#{appdir}/Aide.app/Contents/Resources/app/bin/aide"

--- a/Casks/a/aifun.rb
+++ b/Casks/a/aifun.rb
@@ -16,7 +16,6 @@ cask "aifun" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "AiFun.app"
 

--- a/Casks/a/aigcpanel.rb
+++ b/Casks/a/aigcpanel.rb
@@ -24,8 +24,6 @@ cask "aigcpanel" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "AigcPanel.app"
 
   zap trash: [

--- a/Casks/a/airbuddy.rb
+++ b/Casks/a/airbuddy.rb
@@ -13,7 +13,6 @@ cask "airbuddy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "AirBuddy.app"
 

--- a/Casks/a/aircall.rb
+++ b/Casks/a/aircall.rb
@@ -15,7 +15,6 @@ cask "aircall" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Aircall.app"
 

--- a/Casks/a/airdisplay.rb
+++ b/Casks/a/airdisplay.rb
@@ -9,8 +9,6 @@ cask "airdisplay" do
 
   disable! date: "2024-09-30", because: :no_longer_available
 
-  depends_on macos: ">= :mojave"
-
   pkg "Air Display Installer.pkg"
 
   uninstall pkgutil: [

--- a/Casks/a/airflow.rb
+++ b/Casks/a/airflow.rb
@@ -14,7 +14,6 @@ cask "airflow" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Airflow.app"
 

--- a/Casks/a/airmedia.rb
+++ b/Casks/a/airmedia.rb
@@ -14,8 +14,6 @@ cask "airmedia" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "airmedia_osx_#{version}_installer.pkg"
 
   uninstall launchctl: "com.crestron.AirMedia2",

--- a/Casks/a/airtable.rb
+++ b/Casks/a/airtable.rb
@@ -15,7 +15,6 @@ cask "airtable" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Airtable.app"
 

--- a/Casks/a/airtame.rb
+++ b/Casks/a/airtame.rb
@@ -13,7 +13,6 @@ cask "airtame" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Airtame.app"
 

--- a/Casks/a/airtool.rb
+++ b/Casks/a/airtool.rb
@@ -13,7 +13,6 @@ cask "airtool" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   pkg "Airtool_#{version}.pkg"
 

--- a/Casks/a/akiflow.rb
+++ b/Casks/a/akiflow.rb
@@ -21,7 +21,6 @@ cask "akiflow" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Akiflow.app"
 

--- a/Casks/a/alacritty.rb
+++ b/Casks/a/alacritty.rb
@@ -12,8 +12,6 @@ cask "alacritty" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Alacritty.app"
   binary "#{appdir}/Alacritty.app/Contents/MacOS/alacritty"
   binary "#{appdir}/Alacritty.app/Contents/Resources/61/alacritty",

--- a/Casks/a/alcom.rb
+++ b/Casks/a/alcom.rb
@@ -13,8 +13,6 @@ cask "alcom" do
     regex(/^gui[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "ALCOM.app"
 
   zap trash: [

--- a/Casks/a/aleph-one.rb
+++ b/Casks/a/aleph-one.rb
@@ -13,8 +13,6 @@ cask "aleph-one" do
     regex(%r{href=.*?/AlephOne[._-]v?(\d+(?:\.\d+)*)[._-]Mac\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Aleph One.app"
 
   zap trash: [

--- a/Casks/a/alfaview.rb
+++ b/Casks/a/alfaview.rb
@@ -14,8 +14,6 @@ cask "alfaview" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "alfaview-mac-production-#{version}.pkg"
 
   uninstall quit:    "com.alfaview.desktop",

--- a/Casks/a/alfred.rb
+++ b/Casks/a/alfred.rb
@@ -19,7 +19,6 @@ cask "alfred" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Alfred #{version.major}.app"
 

--- a/Casks/a/alfred@prerelease.rb
+++ b/Casks/a/alfred@prerelease.rb
@@ -20,7 +20,6 @@ cask "alfred@prerelease" do
 
   auto_updates true
   conflicts_with cask: "alfred"
-  depends_on macos: ">= :mojave"
 
   app "Alfred #{version.major}.app"
 

--- a/Casks/a/algoapp.rb
+++ b/Casks/a/algoapp.rb
@@ -13,7 +13,6 @@ cask "algoapp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "AlgoApp.app"
 

--- a/Casks/a/algodoo.rb
+++ b/Casks/a/algodoo.rb
@@ -15,8 +15,6 @@ cask "algodoo" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Algodoo.app"
 
   zap trash: [

--- a/Casks/a/alifix.rb
+++ b/Casks/a/alifix.rb
@@ -15,8 +15,6 @@ cask "alifix" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "alifix#{version.csv.first.no_dots}/Alifix.app"
 
   zap trash: [

--- a/Casks/a/aliwangwang.rb
+++ b/Casks/a/aliwangwang.rb
@@ -15,7 +15,6 @@ cask "aliwangwang" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "AliWangwang.app"
 

--- a/Casks/a/aliworkbench.rb
+++ b/Casks/a/aliworkbench.rb
@@ -21,8 +21,6 @@ cask "aliworkbench" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "AliWorkBench.app"
 
   zap trash: [

--- a/Casks/a/allen-and-heath-midi-control.rb
+++ b/Casks/a/allen-and-heath-midi-control.rb
@@ -18,7 +18,6 @@ cask "allen-and-heath-midi-control" do
 
   disable! date: "2025-09-15", because: :unreachable
 
-  depends_on macos: ">= :high_sierra"
   container nested: "Allen and Heath MIDI Control #{version.csv.first}.dmg"
 
   app "Allen and Heath MIDI Control.app"

--- a/Casks/a/alt-tab.rb
+++ b/Casks/a/alt-tab.rb
@@ -14,7 +14,6 @@ cask "alt-tab" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "AltTab.app"
 

--- a/Casks/a/altair-graphql-client.rb
+++ b/Casks/a/altair-graphql-client.rb
@@ -16,8 +16,6 @@ cask "altair-graphql-client" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Altair GraphQL Client.app"
 
   zap trash: [

--- a/Casks/a/altdeploy.rb
+++ b/Casks/a/altdeploy.rb
@@ -8,7 +8,5 @@ cask "altdeploy" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "AltDeploy.app"
 end

--- a/Casks/a/amadine.rb
+++ b/Casks/a/amadine.rb
@@ -14,7 +14,6 @@ cask "amadine" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Amadine.app"
 

--- a/Casks/a/amazon-chime.rb
+++ b/Casks/a/amazon-chime.rb
@@ -14,7 +14,6 @@ cask "amazon-chime" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Amazon Chime.app"
 

--- a/Casks/a/amazon-luna.rb
+++ b/Casks/a/amazon-luna.rb
@@ -11,7 +11,6 @@ cask "amazon-luna" do
   disable! date: "2025-07-23", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Amazon Luna.app"
 

--- a/Casks/a/amazon-photos.rb
+++ b/Casks/a/amazon-photos.rb
@@ -14,8 +14,6 @@ cask "amazon-photos" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Amazon Photos.app"
 
   uninstall launchctl: "com.amazon.clouddrive",

--- a/Casks/a/amazon-q.rb
+++ b/Casks/a/amazon-q.rb
@@ -16,7 +16,6 @@ cask "amazon-q" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Amazon Q.app"
 

--- a/Casks/a/amazon-workdocs-drive.rb
+++ b/Casks/a/amazon-workdocs-drive.rb
@@ -18,8 +18,6 @@ cask "amazon-workdocs-drive" do
 
   disable! date: "2025-04-25", because: :discontinued
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "AmazonWorkDocsDrive.pkg"
 
   uninstall launchctl: [

--- a/Casks/a/amazon-workspaces.rb
+++ b/Casks/a/amazon-workspaces.rb
@@ -14,7 +14,6 @@ cask "amazon-workspaces" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "WorkSpaces.pkg"
 

--- a/Casks/a/amd-power-gadget.rb
+++ b/Casks/a/amd-power-gadget.rb
@@ -7,7 +7,6 @@ cask "amd-power-gadget" do
   desc "Power management, monitoring and VirtualSMC plugin for AMD processors"
   homepage "https://github.com/trulyspinach/SMCAMDProcessor"
 
-  depends_on macos: ">= :high_sierra"
   depends_on arch: :x86_64
 
   app "AMD Power Gadget.app"

--- a/Casks/a/amethyst.rb
+++ b/Casks/a/amethyst.rb
@@ -1,15 +1,5 @@
 cask "amethyst" do
-  on_mojave :or_older do
-    version "0.16.1"
-    sha256 "52663893e6547d2dd85ba15b871ec222ce4f62dc7150e5ff20d592f9b85a47c5"
-
-    url "https://ianyh.com/amethyst/versions/Amethyst-#{version}.zip"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "0.22.2"
     sha256 "43b16fadf9d349c5d3f5a406917f60e31d0ea65b1f9fc529b09292e906f75e50"
 
@@ -38,7 +28,6 @@ cask "amethyst" do
   homepage "https://ianyh.com/amethyst/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Amethyst.app"
 

--- a/Casks/a/amitv87-pip.rb
+++ b/Casks/a/amitv87-pip.rb
@@ -7,8 +7,6 @@ cask "amitv87-pip" do
   desc "Always on top window preview"
   homepage "https://github.com/amitv87/PiP"
 
-  depends_on macos: ">= :sierra"
-
   app "PiP.app"
 
   zap trash: "~/Library/Saved Application State/com.boggyb.PiP.savedState"

--- a/Casks/a/amneziavpn.rb
+++ b/Casks/a/amneziavpn.rb
@@ -13,8 +13,6 @@ cask "amneziavpn" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "AmneziaVPN.pkg"
 
   uninstall launchctl: ["AmneziaVPN-service", "AmneziaVPN"],

--- a/Casks/a/ampps.rb
+++ b/Casks/a/ampps.rb
@@ -14,8 +14,6 @@ cask "ampps" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   suite "AMPPS"
 
   uninstall_preflight do

--- a/Casks/a/anchor-wallet.rb
+++ b/Casks/a/anchor-wallet.rb
@@ -14,7 +14,6 @@ cask "anchor-wallet" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Anchor Wallet.app"
 

--- a/Casks/a/android-studio-preview@beta.rb
+++ b/Casks/a/android-studio-preview@beta.rb
@@ -17,7 +17,6 @@ cask "android-studio-preview@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Android Studio.app", target: "Android Studio Preview Beta.app"
   binary "#{appdir}/Android Studio Preview Beta.app/Contents/MacOS/studio", target: "studio-beta"

--- a/Casks/a/android-studio-preview@canary.rb
+++ b/Casks/a/android-studio-preview@canary.rb
@@ -17,7 +17,6 @@ cask "android-studio-preview@canary" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Android Studio Preview.app", target: "Android Studio Preview Canary.app"
   binary "#{appdir}/Android Studio Preview Canary.app/Contents/MacOS/studio", target: "studio-canary"

--- a/Casks/a/android-studio.rb
+++ b/Casks/a/android-studio.rb
@@ -17,7 +17,6 @@ cask "android-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Android Studio.app"
   binary "#{appdir}/Android Studio.app/Contents/MacOS/studio"

--- a/Casks/a/angband-app.rb
+++ b/Casks/a/angband-app.rb
@@ -13,8 +13,6 @@ cask "angband-app" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Angband.app"
 
   zap trash: [

--- a/Casks/a/ankerwork.rb
+++ b/Casks/a/ankerwork.rb
@@ -15,8 +15,6 @@ cask "ankerwork" do
     regex(/For\s+Mac.*?>\s*V?(\d+(?:\.\d+)+)\s*</im)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "AnkerWork.app"
 
   zap trash: [

--- a/Casks/a/anki.rb
+++ b/Casks/a/anki.rb
@@ -41,8 +41,6 @@ cask "anki" do
   desc "Memory training application"
   homepage "https://apps.ankiweb.net/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Anki.app"
 
   zap trash: [

--- a/Casks/a/antconc.rb
+++ b/Casks/a/antconc.rb
@@ -22,8 +22,6 @@ cask "antconc" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "AntConc.app"
 
   zap trash: "~/Library/Preferences/AntConc.plist"

--- a/Casks/a/anydesk.rb
+++ b/Casks/a/anydesk.rb
@@ -12,8 +12,6 @@ cask "anydesk" do
     regex(/>v(\d+(?:\.\d+)+)[\s<]/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "AnyDesk.app"
 
   uninstall quit:   [

--- a/Casks/a/anydo.rb
+++ b/Casks/a/anydo.rb
@@ -13,7 +13,6 @@ cask "anydo" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Anydo.app"
 

--- a/Casks/a/anythingllm.rb
+++ b/Casks/a/anythingllm.rb
@@ -15,8 +15,6 @@ cask "anythingllm" do
     regex(/(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "AnythingLLM.app"
 
   zap trash: "~/Library/Application Support/anythingllm-desktop"

--- a/Casks/a/anytype.rb
+++ b/Casks/a/anytype.rb
@@ -21,7 +21,6 @@ cask "anytype" do
     "anytype@alpha",
     "anytype@beta",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Anytype.app"
 

--- a/Casks/a/anytype@alpha.rb
+++ b/Casks/a/anytype@alpha.rb
@@ -21,7 +21,6 @@ cask "anytype@alpha" do
     "anytype",
     "anytype@beta",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Anytype.app"
 

--- a/Casks/a/anytype@beta.rb
+++ b/Casks/a/anytype@beta.rb
@@ -21,7 +21,6 @@ cask "anytype@beta" do
     "anytype",
     "anytype@alpha",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Anytype.app"
 

--- a/Casks/a/apidog-europe.rb
+++ b/Casks/a/apidog-europe.rb
@@ -17,7 +17,6 @@ cask "apidog-europe" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Apidog Europe.app"
 

--- a/Casks/a/apidog.rb
+++ b/Casks/a/apidog.rb
@@ -17,7 +17,6 @@ cask "apidog" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Apidog.app"
 

--- a/Casks/a/apifox.rb
+++ b/Casks/a/apifox.rb
@@ -17,7 +17,6 @@ cask "apifox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Apifox.app"
 

--- a/Casks/a/apipost.rb
+++ b/Casks/a/apipost.rb
@@ -16,7 +16,6 @@ cask "apipost" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "ApiPost.app"
 

--- a/Casks/a/app-cleaner.rb
+++ b/Casks/a/app-cleaner.rb
@@ -13,7 +13,6 @@ cask "app-cleaner" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "App Cleaner #{version.major}.app"
 

--- a/Casks/a/app-tamer.rb
+++ b/Casks/a/app-tamer.rb
@@ -13,7 +13,6 @@ cask "app-tamer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "App Tamer.app"
 

--- a/Casks/a/apparency.rb
+++ b/Casks/a/apparency.rb
@@ -1,12 +1,6 @@
 cask "apparency" do
   on_big_sur :or_older do
-    on_mojave do
-      version "1.3"
-      sha256 "31704bc2d9594bf185bd6dfa6541c986749d524ecdab11cff18c5a5c095e0157"
-
-      url "https://www.mothersruin.com/software/downloads/Apparency-#{version}.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "1.4.1"
       sha256 "850d19c6d6a86380211d9acdb3d8b0ee3b2a4c8af833126c28141f105823c59a"
 
@@ -44,8 +38,6 @@ cask "apparency" do
   name "Apparency"
   desc "Inspect application bundles"
   homepage "https://www.mothersruin.com/software/Apparency/"
-
-  depends_on macos: ">= :mojave"
 
   app "Apparency.app"
   binary "#{appdir}/Apparency.app/Contents/MacOS/appy"

--- a/Casks/a/appcleaner.rb
+++ b/Casks/a/appcleaner.rb
@@ -1,34 +1,16 @@
 cask "appcleaner" do
-  on_sierra :or_older do
-    version "3.4"
-    sha256 "0c60d929478c1c91e0bad76d3c04795665c07a05e45e33321db845429c9aefa8"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_high_sierra do
-    version "3.6"
-    sha256 "812bcacd845fac07e073130d3fe4c5f037815d0774a9782e0e309fced1bded1c"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave :or_newer do
-    version "3.6.8"
-    sha256 "e012f729442473c20e7cce334b00182521e4b6672ea681b34931b180feb3d6be"
-
-    livecheck do
-      url "https://freemacsoft.net/appcleaner/Updates.xml"
-      strategy :sparkle, &:short_version
-    end
-  end
+  version "3.6.8"
+  sha256 "e012f729442473c20e7cce334b00182521e4b6672ea681b34931b180feb3d6be"
 
   url "https://www.freemacsoft.net/downloads/AppCleaner_#{version}.zip"
   name "FreeMacSoft AppCleaner"
   desc "Application uninstaller"
   homepage "https://freemacsoft.net/appcleaner/"
+
+  livecheck do
+    url "https://freemacsoft.net/appcleaner/Updates.xml"
+    strategy :sparkle, &:short_version
+  end
 
   auto_updates true
 

--- a/Casks/a/appcode.rb
+++ b/Casks/a/appcode.rb
@@ -13,7 +13,6 @@ cask "appcode" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "AppCode.app"
 

--- a/Casks/a/appflowy.rb
+++ b/Casks/a/appflowy.rb
@@ -16,8 +16,6 @@ cask "appflowy" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :mojave"
-
   app "AppFlowy.app"
 
   zap trash: [

--- a/Casks/a/appgate-sdp-client.rb
+++ b/Casks/a/appgate-sdp-client.rb
@@ -1,13 +1,5 @@
 cask "appgate-sdp-client" do
-  on_mojave :or_older do
-    version "5.4.4"
-    sha256 "d9d0ffbaf628ee0b8e2d3457dc7b82d1a65ce34952d1f5edc4c4bf407a3d0f1b"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "6.0.4"
     sha256 "bceed509db9fd8dab10f31686264ff7f073048d78470f85f06bbd6233eb9b111"
 
@@ -48,8 +40,6 @@ cask "appgate-sdp-client" do
   name "AppGate SDP Client for macOS"
   desc "Software-defined perimeter for secure network access"
   homepage "https://www.appgate.com/support/software-defined-perimeter-support"
-
-  depends_on macos: ">= :mojave"
 
   pkg "AppGate SDP Installer.pkg"
 

--- a/Casks/a/apple-juice.rb
+++ b/Casks/a/apple-juice.rb
@@ -13,7 +13,6 @@ cask "apple-juice" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Apple Juice.app"
 

--- a/Casks/a/appzapper.rb
+++ b/Casks/a/appzapper.rb
@@ -16,7 +16,6 @@ cask "appzapper" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "AppZapper.app"
 

--- a/Casks/a/aptakube.rb
+++ b/Casks/a/aptakube.rb
@@ -15,7 +15,6 @@ cask "aptakube" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Aptakube.app"
 

--- a/Casks/a/aqua-app.rb
+++ b/Casks/a/aqua-app.rb
@@ -14,7 +14,6 @@ cask "aqua-app" do
   deprecate! date: "2025-08-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Aqua.app"
   binary "#{appdir}/Aqua.app/Contents/MacOS/aqua"

--- a/Casks/a/aqua-voice.rb
+++ b/Casks/a/aqua-voice.rb
@@ -19,7 +19,6 @@ cask "aqua-voice" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Aqua Voice.app"
 

--- a/Casks/a/aquaterm.rb
+++ b/Casks/a/aquaterm.rb
@@ -11,8 +11,6 @@ cask "aquaterm" do
   deprecate! date: "2024-01-04", because: :unmaintained
   disable! date: "2025-01-06", because: :unmaintained
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "AquaTermInstaller.pkg"
 
   uninstall pkgutil: "net.sourceforge.aquaterm.aquaterm.*",

--- a/Casks/a/araxis-merge.rb
+++ b/Casks/a/araxis-merge.rb
@@ -1,10 +1,6 @@
 cask "araxis-merge" do
   on_big_sur :or_older do
-    on_mojave :or_older do
-      version "2021.5602"
-      sha256 "06c56e6d08057090f3718b6db560e2a79551f953d4c83c0fad8b60f415c59347"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "2022.5786"
       sha256 "a8a65089d7965a3ecdf3b65dbeaed54f4f31d0bc7b85c9d970aa999ab5cfa4df"
     end
@@ -31,8 +27,6 @@ cask "araxis-merge" do
   name "Araxis Merge"
   desc "Two and three-way file comparison, merging and folder synchronisation"
   homepage "https://www.araxis.com/merge/"
-
-  depends_on macos: ">= :mojave"
 
   app "Araxis Merge.app"
   binary "#{appdir}/Araxis Merge.app/Contents/Utilities/araxishgmerge"

--- a/Casks/a/archivewebpage.rb
+++ b/Casks/a/archivewebpage.rb
@@ -13,8 +13,6 @@ cask "archivewebpage" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "ArchiveWeb.page.app"
 
   zap trash: [

--- a/Casks/a/arctype.rb
+++ b/Casks/a/arctype.rb
@@ -14,7 +14,6 @@ cask "arctype" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Arctype.app"
 

--- a/Casks/a/arduino-ide.rb
+++ b/Casks/a/arduino-ide.rb
@@ -17,7 +17,6 @@ cask "arduino-ide" do
   end
 
   conflicts_with cask: "arduino-ide@nightly"
-  depends_on macos: ">= :catalina"
 
   app "Arduino IDE.app"
 

--- a/Casks/a/arduino-ide@nightly.rb
+++ b/Casks/a/arduino-ide@nightly.rb
@@ -8,7 +8,6 @@ cask "arduino-ide@nightly" do
   homepage "https://www.arduino.cc/en/software"
 
   conflicts_with cask: "arduino-ide"
-  depends_on macos: ">= :catalina"
 
   app "Arduino IDE.app"
 

--- a/Casks/a/ares-emulator.rb
+++ b/Casks/a/ares-emulator.rb
@@ -8,8 +8,6 @@ cask "ares-emulator" do
   desc "Cross-platform, multi-system emulator, focusing on accuracy and preservation"
   homepage "https://ares-emu.net/"
 
-  depends_on macos: ">= :catalina"
-
   app "ares-v#{version}/ares.app"
 
   zap trash: [

--- a/Casks/a/aria2d.rb
+++ b/Casks/a/aria2d.rb
@@ -14,8 +14,6 @@ cask "aria2d" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Aria2D.app"
 
   zap trash: [

--- a/Casks/a/ariang.rb
+++ b/Casks/a/ariang.rb
@@ -12,8 +12,6 @@ cask "ariang" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "AriaNg Native.app"
 
   zap trash: [

--- a/Casks/a/around.rb
+++ b/Casks/a/around.rb
@@ -12,7 +12,6 @@ cask "around" do
   disable! date: "2025-04-20", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Around.app"
 

--- a/Casks/a/as-timer.rb
+++ b/Casks/a/as-timer.rb
@@ -12,8 +12,6 @@ cask "as-timer" do
     regex(/AS\s+Timer\s+V?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "AS Timer.app"
 
   zap trash: [

--- a/Casks/a/asana.rb
+++ b/Casks/a/asana.rb
@@ -18,7 +18,6 @@ cask "asana" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Asana.app"
 

--- a/Casks/a/assinador-serpro.rb
+++ b/Casks/a/assinador-serpro.rb
@@ -14,8 +14,6 @@ cask "assinador-serpro" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   pkg "AssinadorSerpro-#{version}.mpkg/Contents/Packages/AssinadorSerpro.pkg"
 
   uninstall pkgutil: "br.gov.serpro.desktop.assinador"

--- a/Casks/a/astah-professional.rb
+++ b/Casks/a/astah-professional.rb
@@ -19,8 +19,6 @@ cask "astah-professional" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "astah professional ver #{version.csv.first.dots_to_underscores}.pkg"
 
   uninstall pkgutil: "com.change-vision.astah.professional"

--- a/Casks/a/astro-command-center.rb
+++ b/Casks/a/astro-command-center.rb
@@ -11,8 +11,6 @@ cask "astro-command-center" do
     skip "unversioned QT application"
   end
 
-  depends_on macos: ">= :mojave"
-
   app "ASTRO Command Center.app"
 
   zap trash: [

--- a/Casks/a/astropad-studio.rb
+++ b/Casks/a/astropad-studio.rb
@@ -13,7 +13,6 @@ cask "astropad-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Astropad Studio.app"
 

--- a/Casks/a/atemosc.rb
+++ b/Casks/a/atemosc.rb
@@ -16,7 +16,6 @@ cask "atemosc" do
   end
 
   auto_updates true # Requires a license key to enable
-  depends_on macos: ">= :high_sierra"
 
   app "atemOSC.app"
 

--- a/Casks/a/atext.rb
+++ b/Casks/a/atext.rb
@@ -13,7 +13,6 @@ cask "atext" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "aText.app"
 

--- a/Casks/a/atomic-wallet.rb
+++ b/Casks/a/atomic-wallet.rb
@@ -12,8 +12,6 @@ cask "atomic-wallet" do
     regex(/v?(\d+(?:[.-]\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Atomic Wallet.app"
 
   zap trash: [

--- a/Casks/a/attachecase.rb
+++ b/Casks/a/attachecase.rb
@@ -21,8 +21,6 @@ cask "attachecase" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "AttacheCase.app"
 
   zap trash: [

--- a/Casks/a/atv-remote.rb
+++ b/Casks/a/atv-remote.rb
@@ -17,8 +17,6 @@ cask "atv-remote" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "ATV Remote.app"
 
   zap trash: [

--- a/Casks/a/audacity.rb
+++ b/Casks/a/audacity.rb
@@ -16,8 +16,6 @@ cask "audacity" do
     regex(/^Audacity[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Audacity.app"
 
   zap trash: [

--- a/Casks/a/audio-modeling-software-center.rb
+++ b/Casks/a/audio-modeling-software-center.rb
@@ -12,8 +12,6 @@ cask "audio-modeling-software-center" do
     regex(/AudioModelingSoftwareCenter[._-](\d+(?:\.\d+)+-\d+)-osx-installer\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   installer script: {
     executable: "AudioModelingSoftwareCenter-#{version}-osx-installer.app/Contents/MacOS/installbuilder.sh",
     args:       ["--mode", "unattended"],

--- a/Casks/a/audiobook-builder.rb
+++ b/Casks/a/audiobook-builder.rb
@@ -12,8 +12,6 @@ cask "audiobook-builder" do
     regex(/class=.*["' >]Audiobook\sBuilder\s?(\d+(?:\.\d+)+)</i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Audiobook Builder.app"
 
   zap trash: [

--- a/Casks/a/audiorelay.rb
+++ b/Casks/a/audiorelay.rb
@@ -19,7 +19,6 @@ cask "audiorelay" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "AudioRelay.app"
 

--- a/Casks/a/audirvana.rb
+++ b/Casks/a/audirvana.rb
@@ -13,7 +13,6 @@ cask "audirvana" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Audirvana.app"
 

--- a/Casks/a/audius.rb
+++ b/Casks/a/audius.rb
@@ -25,7 +25,6 @@ cask "audius" do
   homepage "https://audius.co/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Audius.app"
 

--- a/Casks/a/aural.rb
+++ b/Casks/a/aural.rb
@@ -9,8 +9,6 @@ cask "aural" do
 
   deprecate! date: "2025-06-22", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "Aural.app"
 
   zap trash: "~/Library/Preferences/anon.Aural.plist"

--- a/Casks/a/autodmg.rb
+++ b/Casks/a/autodmg.rb
@@ -12,8 +12,6 @@ cask "autodmg" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "AutoDMG.app"
 
   zap trash: [

--- a/Casks/a/automattic-texts.rb
+++ b/Casks/a/automattic-texts.rb
@@ -26,8 +26,6 @@ cask "automattic-texts" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Texts.app"
 
   zap trash: [

--- a/Casks/a/autopkgr.rb
+++ b/Casks/a/autopkgr.rb
@@ -14,7 +14,6 @@ cask "autopkgr" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "AutoPkgr.app"
 

--- a/Casks/a/autovolume.rb
+++ b/Casks/a/autovolume.rb
@@ -9,8 +9,6 @@ cask "autovolume" do
 
   deprecate! date: "2024-09-30", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "AutoVolume.app"
 
   caveats do

--- a/Casks/a/autumn.rb
+++ b/Casks/a/autumn.rb
@@ -10,8 +10,6 @@ cask "autumn" do
 
   deprecate! date: "2025-04-21", because: :unmaintained
 
-  depends_on macos: ">= :high_sierra"
-
   app "Autumn.app"
 
   zap trash: [

--- a/Casks/a/avbeam.rb
+++ b/Casks/a/avbeam.rb
@@ -12,8 +12,6 @@ cask "avbeam" do
     regex(/AVbeam\s+version\s+(\d+(?:\.\d+)+)\s+release/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "avbeam.app"
 
   zap trash: [

--- a/Casks/a/avocode.rb
+++ b/Casks/a/avocode.rb
@@ -10,7 +10,6 @@ cask "avocode" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Avocode.app"
 

--- a/Casks/a/avtouchbar.rb
+++ b/Casks/a/avtouchbar.rb
@@ -19,7 +19,6 @@ cask "avtouchbar" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "AVTouchBar.app"
 

--- a/Casks/a/aw-edid-editor.rb
+++ b/Casks/a/aw-edid-editor.rb
@@ -19,8 +19,6 @@ cask "aw-edid-editor" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "AW EDID Editor.app"
 
   zap trash: [

--- a/Casks/a/axure-rp.rb
+++ b/Casks/a/axure-rp.rb
@@ -13,8 +13,6 @@ cask "axure-rp" do
     regex(/>\s*(?:Version|Axure\s*RP)\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Axure RP #{version.major}.app"
 
   zap trash: [

--- a/Casks/a/ayugram.rb
+++ b/Casks/a/ayugram.rb
@@ -7,8 +7,6 @@ cask "ayugram" do
   desc "Telegram client with ghost mode and message history"
   homepage "https://github.com/AyuGram/AyuGramDesktop"
 
-  depends_on macos: ">= :high_sierra"
-
   app "AyuGram.app"
 
   zap trash: [

--- a/Casks/a/azure-data-studio.rb
+++ b/Casks/a/azure-data-studio.rb
@@ -19,7 +19,6 @@ cask "azure-data-studio" do
   disable! date: "2026-02-28", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Azure Data Studio.app"
   binary "#{appdir}/Azure Data Studio.app/Contents/Resources/app/bin/code", target: "azuredatastudio"

--- a/Casks/a/azure-data-studio@insiders.rb
+++ b/Casks/a/azure-data-studio@insiders.rb
@@ -12,8 +12,6 @@ cask "azure-data-studio@insiders" do
 
   disable! date: "2024-12-22", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "Azure Data Studio - Insiders.app"
   binary "#{appdir}/Azure Data Studio - Insiders.app/Contents/Resources/app/bin/code",
          target: "azuredatastudio-insiders"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.