### PR TITLE
[b]: remove pre-Catalina references

### DIFF
--- a/Casks/b/backuploupe.rb
+++ b/Casks/b/backuploupe.rb
@@ -13,7 +13,6 @@ cask "backuploupe" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "BackupLoupe.app"
 

--- a/Casks/b/badgeify.rb
+++ b/Casks/b/badgeify.rb
@@ -16,7 +16,6 @@ cask "badgeify" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Badgeify.app"
 

--- a/Casks/b/baidunetdisk.rb
+++ b/Casks/b/baidunetdisk.rb
@@ -18,7 +18,6 @@ cask "baidunetdisk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "BaiduNetdisk_mac.app"
 

--- a/Casks/b/balance-lock.rb
+++ b/Casks/b/balance-lock.rb
@@ -13,7 +13,6 @@ cask "balance-lock" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Balance Lock.app"
 

--- a/Casks/b/balenaetcher.rb
+++ b/Casks/b/balenaetcher.rb
@@ -16,8 +16,6 @@ cask "balenaetcher" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "balenaEtcher.app"
 
   uninstall quit: "io.balena.etcher.*"

--- a/Casks/b/balsamiq-wireframes.rb
+++ b/Casks/b/balsamiq-wireframes.rb
@@ -19,8 +19,6 @@ cask "balsamiq-wireframes" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Balsamiq Wireframes.app"
 
   zap trash: [

--- a/Casks/b/bambu-studio.rb
+++ b/Casks/b/bambu-studio.rb
@@ -21,8 +21,6 @@ cask "bambu-studio" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "BambuStudio.app"
 
   zap trash: [

--- a/Casks/b/banana-cake-pop.rb
+++ b/Casks/b/banana-cake-pop.rb
@@ -16,7 +16,6 @@ cask "banana-cake-pop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Banana Cake Pop.app"
 

--- a/Casks/b/bananas.rb
+++ b/Casks/b/bananas.rb
@@ -8,8 +8,6 @@ cask "bananas" do
   desc "Cross-platform screen sharing tool"
   homepage "https://getbananas.net/"
 
-  depends_on macos: ">= :catalina"
-
   app "bananas.app"
 
   zap trash: [

--- a/Casks/b/banktivity.rb
+++ b/Casks/b/banktivity.rb
@@ -17,8 +17,6 @@ cask "banktivity" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Banktivity.app"
 
   zap trash: [

--- a/Casks/b/barrier.rb
+++ b/Casks/b/barrier.rb
@@ -9,8 +9,6 @@ cask "barrier" do
 
   deprecate! date: "2025-05-13", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "Barrier.app"
 
   zap trash: [

--- a/Casks/b/base.rb
+++ b/Casks/b/base.rb
@@ -12,8 +12,6 @@ cask "base" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Base.app"
 
   zap trash: [

--- a/Casks/b/basecamp.rb
+++ b/Casks/b/basecamp.rb
@@ -23,7 +23,6 @@ cask "basecamp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Basecamp.app"
 

--- a/Casks/b/basictex.rb
+++ b/Casks/b/basictex.rb
@@ -20,7 +20,6 @@ cask "basictex" do
     "mactex-no-gui",
     "mactex",
   ]
-  depends_on macos: ">= :mojave"
 
   pkg "mactex-basictex-#{version.no_dots}.pkg"
 

--- a/Casks/b/batchoutput-pdf.rb
+++ b/Casks/b/batchoutput-pdf.rb
@@ -12,8 +12,6 @@ cask "batchoutput-pdf" do
     regex(/BatchOutput\s*PDF\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "BatchOutput PDF.app"
 
   zap trash: [

--- a/Casks/b/battery.rb
+++ b/Casks/b/battery.rb
@@ -8,7 +8,6 @@ cask "battery" do
   homepage "https://github.com/actuallymentor/battery/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
   depends_on arch: :arm64
 
   app "battery.app"

--- a/Casks/b/bazecor.rb
+++ b/Casks/b/bazecor.rb
@@ -16,8 +16,6 @@ cask "bazecor" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Bazecor.app"
 
   zap trash: [

--- a/Casks/b/bbedit@14.rb
+++ b/Casks/b/bbedit@14.rb
@@ -19,7 +19,6 @@ cask "bbedit@14" do
 
   auto_updates true
   conflicts_with cask: "bbedit"
-  depends_on macos: ">= :catalina"
 
   app "BBEdit.app"
   binary "#{appdir}/BBEdit.app/Contents/Helpers/bbedit_tool", target: "bbedit"

--- a/Casks/b/bcut.rb
+++ b/Casks/b/bcut.rb
@@ -31,7 +31,6 @@ cask "bcut" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "BCUT.app"
 

--- a/Casks/b/beamer.rb
+++ b/Casks/b/beamer.rb
@@ -13,7 +13,6 @@ cask "beamer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Beamer.app"
 

--- a/Casks/b/bean.rb
+++ b/Casks/b/bean.rb
@@ -14,8 +14,6 @@ cask "bean" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Bean-Install-#{version.dots_to_hyphens}/Bean.app"
 
   zap trash: [

--- a/Casks/b/beardie.rb
+++ b/Casks/b/beardie.rb
@@ -8,7 +8,6 @@ cask "beardie" do
   homepage "https://github.com/Stillness-2/beardie"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Beardie.app"
 

--- a/Casks/b/beatunes.rb
+++ b/Casks/b/beatunes.rb
@@ -15,8 +15,6 @@ cask "beatunes" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "beaTunes#{version.major}.app"
 
   zap trash: [

--- a/Casks/b/beekeeper-studio.rb
+++ b/Casks/b/beekeeper-studio.rb
@@ -17,7 +17,6 @@ cask "beekeeper-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Beekeeper Studio.app"
 

--- a/Casks/b/beersmith.rb
+++ b/Casks/b/beersmith.rb
@@ -16,8 +16,6 @@ cask "beersmith" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "BeerSmith#{version.major}.app"
 
   zap trash: [

--- a/Casks/b/beid-token.rb
+++ b/Casks/b/beid-token.rb
@@ -21,8 +21,6 @@ cask "beid-token" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "eID-Quickinstaller-signed.pkg"
 
   postflight do

--- a/Casks/b/bespoke.rb
+++ b/Casks/b/bespoke.rb
@@ -8,8 +8,6 @@ cask "bespoke" do
   desc "Software modular synth"
   homepage "https://www.bespokesynth.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "BespokeSynth.app"
 
   zap trash: [

--- a/Casks/b/betaflight-configurator.rb
+++ b/Casks/b/betaflight-configurator.rb
@@ -14,8 +14,6 @@ cask "betaflight-configurator" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Betaflight Configurator.app"
 
   zap trash: [

--- a/Casks/b/betterandbetter.rb
+++ b/Casks/b/betterandbetter.rb
@@ -15,7 +15,6 @@ cask "betterandbetter" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "BetterAndBetter.app"
 

--- a/Casks/b/betterdisplay.rb
+++ b/Casks/b/betterdisplay.rb
@@ -34,7 +34,6 @@ cask "betterdisplay" do
   homepage "https://betterdisplay.pro/"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "BetterDisplay.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/b/betterzip.rb
+++ b/Casks/b/betterzip.rb
@@ -13,7 +13,6 @@ cask "betterzip" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "BetterZip.app"
 

--- a/Casks/b/bias-fx.rb
+++ b/Casks/b/bias-fx.rb
@@ -15,7 +15,6 @@ cask "bias-fx" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   pkg "BIAS_FX_#{version.major}_App.pkg"
 

--- a/Casks/b/bibdesk.rb
+++ b/Casks/b/bibdesk.rb
@@ -14,7 +14,6 @@ cask "bibdesk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "BibDesk.app"
 

--- a/Casks/b/biglybt.rb
+++ b/Casks/b/biglybt.rb
@@ -12,7 +12,6 @@ cask "biglybt" do
   homepage "https://www.biglybt.com/"
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   installer script: {
     executable:   "BiglyBT Installer.app/Contents/MacOS/JavaApplicationStub",

--- a/Casks/b/bilibili.rb
+++ b/Casks/b/bilibili.rb
@@ -15,7 +15,6 @@ cask "bilibili" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "哔哩哔哩.app"
 

--- a/Casks/b/billings-pro.rb
+++ b/Casks/b/billings-pro.rb
@@ -12,8 +12,6 @@ cask "billings-pro" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Billings Pro.app"
 
   zap trash: [

--- a/Casks/b/binance.rb
+++ b/Casks/b/binance.rb
@@ -16,7 +16,6 @@ cask "binance" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Binance.app"
 

--- a/Casks/b/bingpaper.rb
+++ b/Casks/b/bingpaper.rb
@@ -9,8 +9,6 @@ cask "bingpaper" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :catalina"
-
   app "BingPaper.app"
 
   uninstall launchctl: "io.pjw.mac.BingPaperLoginItem",

--- a/Casks/b/birdfont.rb
+++ b/Casks/b/birdfont.rb
@@ -1,26 +1,15 @@
 cask "birdfont" do
-  on_mojave :or_older do
-    version "4.17.0"
-    sha256 "74c778e3b7598a66b9ddb11b189ba6a21d68263fb0499a965dcedd0ac987b051"
+  on_ventura :or_older do
+    version "5.2.1"
+    sha256 "e68b64679b8cdfbc193304edb83389e9546210ad77e886c903c30c3db89597e5"
 
     livecheck do
       url "https://birdfont.org/purchase.php"
-      regex(%r{Mac\s*OS\s*10\.12.*?/birdfont[._-]v?(\d+(?:\.\d+)+)[._-]free\.dmg}i)
+      regex(%r{Mac\s*OS\s*10\.15.*?/birdfont[._-]v?(\d+(?:\.\d+)+)[._-]free\.dmg}i)
     end
-  end
-  on_catalina :or_newer do
-    on_ventura :or_older do
-      version "5.2.1"
-      sha256 "e68b64679b8cdfbc193304edb83389e9546210ad77e886c903c30c3db89597e5"
 
-      livecheck do
-        url "https://birdfont.org/purchase.php"
-        regex(%r{Mac\s*OS\s*10\.15.*?/birdfont[._-]v?(\d+(?:\.\d+)+)[._-]free\.dmg}i)
-      end
-
-      caveats do
-        requires_rosetta
-      end
+    caveats do
+      requires_rosetta
     end
   end
   on_sonoma :or_newer do
@@ -37,8 +26,6 @@ cask "birdfont" do
   name "BirdFont"
   desc "Font editor"
   homepage "https://birdfont.org/"
-
-  depends_on macos: ">= :sierra"
 
   app "BirdFontNonCommercial.app"
 

--- a/Casks/b/biscuit.rb
+++ b/Casks/b/biscuit.rb
@@ -12,7 +12,6 @@ cask "biscuit" do
   homepage "https://eatbiscuit.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Biscuit.app"
 

--- a/Casks/b/bison-wallet.rb
+++ b/Casks/b/bison-wallet.rb
@@ -10,8 +10,6 @@ cask "bison-wallet" do
   desc "Multi-coin wallet with feeless DEX, atomic swaps, and arbitrage tools"
   homepage "https://github.com/decred/dcrdex"
 
-  depends_on macos: ">= :sierra"
-
   app "Bison Wallet.app"
 
   zap trash: [

--- a/Casks/b/bit-slicer.rb
+++ b/Casks/b/bit-slicer.rb
@@ -7,8 +7,6 @@ cask "bit-slicer" do
   desc "Universal game trainer"
   homepage "https://github.com/zorgiepoo/bit-slicer/"
 
-  depends_on macos: ">= :mojave"
-
   app "Bit Slicer.app"
 
   zap trash: [

--- a/Casks/b/bitfocus-buttons.rb
+++ b/Casks/b/bitfocus-buttons.rb
@@ -26,8 +26,6 @@ cask "bitfocus-buttons" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "bitfocus-buttons-mac-#{arch}-#{version.csv.second}-#{version.csv.third}.pkg"
 
   uninstall pkgutil: "io.bitfocus.buttons.pkg"

--- a/Casks/b/bitrix24.rb
+++ b/Casks/b/bitrix24.rb
@@ -15,8 +15,6 @@ cask "bitrix24" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Bitrix24.app"
 
   zap trash: [

--- a/Casks/b/bitwarden.rb
+++ b/Casks/b/bitwarden.rb
@@ -14,7 +14,6 @@ cask "bitwarden" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Bitwarden.app"
 

--- a/Casks/b/bitwig-studio.rb
+++ b/Casks/b/bitwig-studio.rb
@@ -12,8 +12,6 @@ cask "bitwig-studio" do
     regex(/Bitwig\s*Studio\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Bitwig Studio.app"
 
   zap trash: [

--- a/Casks/b/black-ink.rb
+++ b/Casks/b/black-ink.rb
@@ -12,8 +12,6 @@ cask "black-ink" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Black Ink.app"
 
   zap trash: [

--- a/Casks/b/black-light.rb
+++ b/Casks/b/black-light.rb
@@ -12,8 +12,6 @@ cask "black-light" do
     regex(/href=.*?black-light[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "BLack Light.app"
 
   zap trash: [

--- a/Casks/b/blender-benchmark.rb
+++ b/Casks/b/blender-benchmark.rb
@@ -15,8 +15,6 @@ cask "blender-benchmark" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Blender Benchmark Launcher.app"
 
   zap trash: [

--- a/Casks/b/bleunlock.rb
+++ b/Casks/b/bleunlock.rb
@@ -7,8 +7,6 @@ cask "bleunlock" do
   desc "Lock/unlock Apple computers using the proximity of a bluetooth low energy device"
   homepage "https://github.com/ts1/BLEUnlock"
 
-  depends_on macos: ">= :high_sierra"
-
   app "BLEUnlock.app"
 
   zap trash: [

--- a/Casks/b/blink1control.rb
+++ b/Casks/b/blink1control.rb
@@ -12,8 +12,6 @@ cask "blink1control" do
   desc "Utility to control blink(1) USB RGB LED devices"
   homepage "https://blink1.thingm.com/"
 
-  depends_on macos: ">= :el_capitan"
-
   app "Blink1Control#{version.major}.app"
 
   zap trash: [

--- a/Casks/b/blisk.rb
+++ b/Casks/b/blisk.rb
@@ -16,8 +16,6 @@ cask "blisk" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Blisk.app"
 
   zap trash: [

--- a/Casks/b/blitz-gg.rb
+++ b/Casks/b/blitz-gg.rb
@@ -13,7 +13,6 @@ cask "blitz-gg" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Blitz.app"
 

--- a/Casks/b/blockbench.rb
+++ b/Casks/b/blockbench.rb
@@ -16,8 +16,6 @@ cask "blockbench" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Blockbench.app"
 
   zap trash: [

--- a/Casks/b/blockblock.rb
+++ b/Casks/b/blockblock.rb
@@ -8,8 +8,6 @@ cask "blockblock" do
   desc "Monitors common persistence locations"
   homepage "https://objective-see.org/products/blockblock.html"
 
-  depends_on macos: ">= :catalina"
-
   installer script: {
     executable: "#{staged_path}/BlockBlock Installer.app/Contents/MacOS/BlockBlock Installer",
     args:       ["-install"],

--- a/Casks/b/blockstack.rb
+++ b/Casks/b/blockstack.rb
@@ -10,7 +10,5 @@ cask "blockstack" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Blockstack.app"
 end

--- a/Casks/b/blocs.rb
+++ b/Casks/b/blocs.rb
@@ -13,7 +13,6 @@ cask "blocs" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
   container nested: "Blocs/Blocs-#{version.major}.dmg"
 
   app "Blocs.app"

--- a/Casks/b/blood-on-the-clocktower-online.rb
+++ b/Casks/b/blood-on-the-clocktower-online.rb
@@ -11,8 +11,6 @@ cask "blood-on-the-clocktower-online" do
   desc "Client for the game Blood on the Clocktower"
   homepage "https://bloodontheclocktower.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Blood on the Clocktower Online.app"
 
   zap trash: [

--- a/Casks/b/bluebubbles.rb
+++ b/Casks/b/bluebubbles.rb
@@ -18,8 +18,6 @@ cask "bluebubbles" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "BlueBubbles.app"
 
   uninstall launchctl:  "com.BlueBubbles.BlueBubbles-Server.ShipIt",

--- a/Casks/b/blueharvest.rb
+++ b/Casks/b/blueharvest.rb
@@ -19,7 +19,6 @@ cask "blueharvest" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "BlueHarvest.app"
 

--- a/Casks/b/bluej.rb
+++ b/Casks/b/bluej.rb
@@ -16,8 +16,6 @@ cask "bluej" do
     regex(/Version\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "BlueJ.app"
 
   zap trash: "~/Library/Preferences/org.bluej"

--- a/Casks/b/bluetility.rb
+++ b/Casks/b/bluetility.rb
@@ -12,8 +12,6 @@ cask "bluetility" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Bluetility.app"
 
   zap trash: [

--- a/Casks/b/bluos-controller.rb
+++ b/Casks/b/bluos-controller.rb
@@ -13,8 +13,6 @@ cask "bluos-controller" do
     regex(%r{uploads/BluOS[._-]Controller[._-]v?(\d+(?:\.\d+)+)[._-]MacOS\.zip}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "BluOS Controller.app"
 
   zap trash: [

--- a/Casks/b/blurred.rb
+++ b/Casks/b/blurred.rb
@@ -7,8 +7,6 @@ cask "blurred" do
   desc "Utility to dim background/inactive content in the screen"
   homepage "https://github.com/dwarvesf/blurred/"
 
-  depends_on macos: ">= :catalina"
-
   app "Blurred.app"
 
   uninstall launchctl: "foundation.dwarves.blurredlaunche",

--- a/Casks/b/blurscreen.rb
+++ b/Casks/b/blurscreen.rb
@@ -13,7 +13,6 @@ cask "blurscreen" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   pkg "BlurScreen-v2.pkg"
 

--- a/Casks/b/bob-app.rb
+++ b/Casks/b/bob-app.rb
@@ -10,7 +10,6 @@ cask "bob-app" do
   deprecate! date: "2025-04-15", because: :moved_to_mas
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Bob.app"
 

--- a/Casks/b/bobhelper.rb
+++ b/Casks/b/bobhelper.rb
@@ -13,8 +13,6 @@ cask "bobhelper" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "BobHelper.app"
 
   uninstall quit:       "com.hezongyidev.BobHelper",

--- a/Casks/b/bonjeff.rb
+++ b/Casks/b/bonjeff.rb
@@ -7,8 +7,6 @@ cask "bonjeff" do
   desc "Shows a live display of the Bonjour services published on your network"
   homepage "https://github.com/lapcat/Bonjeff"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Bonjeff.app"
 
   zap trash: [

--- a/Casks/b/bookends.rb
+++ b/Casks/b/bookends.rb
@@ -14,8 +14,6 @@ cask "bookends" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Bookends.app"
 
   zap trash: [

--- a/Casks/b/bookletcreator.rb
+++ b/Casks/b/bookletcreator.rb
@@ -13,7 +13,6 @@ cask "bookletcreator" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "BookletCreator.app"
 

--- a/Casks/b/bookwright.rb
+++ b/Casks/b/bookwright.rb
@@ -16,8 +16,6 @@ cask "bookwright" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "BookWright.app"
 
   zap trash: [

--- a/Casks/b/boom-3d.rb
+++ b/Casks/b/boom-3d.rb
@@ -15,8 +15,6 @@ cask "boom-3d" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Boom 3D.app"
 
   uninstall launchctl: [

--- a/Casks/b/boom.rb
+++ b/Casks/b/boom.rb
@@ -15,8 +15,6 @@ cask "boom" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Boom 2.app"
 
   uninstall launchctl: "com.globaldelight.Boom2Daemon",

--- a/Casks/b/boop.rb
+++ b/Casks/b/boop.rb
@@ -15,8 +15,6 @@ cask "boop" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Boop.app"
 
   zap trash: [

--- a/Casks/b/boosteroid.rb
+++ b/Casks/b/boosteroid.rb
@@ -16,8 +16,6 @@ cask "boosteroid" do
     regex(/\[\s*\v?(\d+(?:\.\d+)+)\s*\]/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Boosteroid.app"
 
   zap trash: [

--- a/Casks/b/bootstrap-studio.rb
+++ b/Casks/b/bootstrap-studio.rb
@@ -16,7 +16,6 @@ cask "bootstrap-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Bootstrap Studio.app"
 

--- a/Casks/b/boss.rb
+++ b/Casks/b/boss.rb
@@ -9,7 +9,6 @@ cask "boss" do
   homepage "https://www.risalabs.ai/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "BOSS.app"
 

--- a/Casks/b/box-drive.rb
+++ b/Casks/b/box-drive.rb
@@ -17,7 +17,6 @@ cask "box-drive" do
 
   auto_updates true
   conflicts_with cask: "box-sync"
-  depends_on macos: ">= :el_capitan"
 
   pkg "BoxDrive-#{version}.pkg"
 

--- a/Casks/b/box-tools.rb
+++ b/Casks/b/box-tools.rb
@@ -18,8 +18,6 @@ cask "box-tools" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   apps = [
     "Device Trust",
     "Edit",

--- a/Casks/b/boxcryptor.rb
+++ b/Casks/b/boxcryptor.rb
@@ -30,8 +30,6 @@ cask "boxcryptor" do
   desc "Tool to encrypt files and folders in various cloud storage services"
   homepage "https://www.boxcryptor.com/en/"
 
-  depends_on macos: ">= :catalina"
-
   app "Boxcryptor.app"
 
   uninstall delete: [

--- a/Casks/b/boxy-suite.rb
+++ b/Casks/b/boxy-suite.rb
@@ -14,7 +14,6 @@ cask "boxy-suite" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Boxy for Gmail.app"
   app "Boxy for Calendar.app"

--- a/Casks/b/brainfm.rb
+++ b/Casks/b/brainfm.rb
@@ -18,7 +18,6 @@ cask "brainfm" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Brain.fm.app"
 

--- a/Casks/b/brave-browser@dev.rb
+++ b/Casks/b/brave-browser@dev.rb
@@ -15,7 +15,6 @@ cask "brave-browser@dev" do
   disable! date: "2024-12-07", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Brave Browser Dev.app"
 

--- a/Casks/b/breitbandmessung.rb
+++ b/Casks/b/breitbandmessung.rb
@@ -12,8 +12,6 @@ cask "breitbandmessung" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Breitbandmessung.app"
 
   zap trash: "~/Library/Application Support/Breitbandmessung"

--- a/Casks/b/brewlet.rb
+++ b/Casks/b/brewlet.rb
@@ -14,8 +14,6 @@ cask "brewlet" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "Brewlet.app"
 
   zap trash: "~/Library/Preferences/zzada.Brewlet.plist"

--- a/Casks/b/brightness-sync.rb
+++ b/Casks/b/brightness-sync.rb
@@ -7,8 +7,6 @@ cask "brightness-sync" do
   desc "Utility to synchronise the brightness of LG UltraFine display(s)"
   homepage "https://github.com/OCJvanDijk/Brightness-Sync"
 
-  depends_on macos: ">= :catalina"
-
   app "Brightness Sync.app"
 
   # No zap stanza required

--- a/Casks/b/brisync.rb
+++ b/Casks/b/brisync.rb
@@ -9,8 +9,6 @@ cask "brisync" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "Brisync.app"
 
   zap trash: "~/.brisync.json"

--- a/Casks/b/browserosaurus.rb
+++ b/Casks/b/browserosaurus.rb
@@ -13,7 +13,6 @@ cask "browserosaurus" do
   deprecate! date: "2025-08-30", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Browserosaurus.app"
 

--- a/Casks/b/btcpayserver-vault.rb
+++ b/Casks/b/btcpayserver-vault.rb
@@ -13,8 +13,6 @@ cask "btcpayserver-vault" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "BTCPayServer Vault.app"
 
   zap trash: "~/Library/Saved Application State/com.btcpayserver.vault.savedState"

--- a/Casks/b/bubo.rb
+++ b/Casks/b/bubo.rb
@@ -11,7 +11,5 @@ cask "bubo" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "bubo.app"
 end

--- a/Casks/b/buckets.rb
+++ b/Casks/b/buckets.rb
@@ -17,7 +17,6 @@ cask "buckets" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Buckets.app"
 

--- a/Casks/b/buckets@beta.rb
+++ b/Casks/b/buckets@beta.rb
@@ -16,8 +16,6 @@ cask "buckets@beta" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Buckets Beta.app"
 
   zap trash: [

--- a/Casks/b/buildsettingextractor.rb
+++ b/Casks/b/buildsettingextractor.rb
@@ -7,8 +7,6 @@ cask "buildsettingextractor" do
   desc "Xcode build settings extractor"
   homepage "https://github.com/dempseyatgithub/BuildSettingExtractor"
 
-  depends_on macos: ">= :mojave"
-
   app "BuildSettingExtractor.app"
 
   zap trash: [

--- a/Casks/b/burp-suite-professional.rb
+++ b/Casks/b/burp-suite-professional.rb
@@ -29,7 +29,6 @@ cask "burp-suite-professional" do
   end
 
   conflicts_with cask: "burp-suite-professional@early-adopter"
-  depends_on macos: ">= :catalina"
 
   app "Burp Suite Professional.app"
 

--- a/Casks/b/burp-suite-professional@early-adopter.rb
+++ b/Casks/b/burp-suite-professional@early-adopter.rb
@@ -29,7 +29,6 @@ cask "burp-suite-professional@early-adopter" do
   end
 
   conflicts_with cask: "burp-suite-professional"
-  depends_on macos: ">= :catalina"
 
   app "Burp Suite Professional.app"
 

--- a/Casks/b/burp-suite.rb
+++ b/Casks/b/burp-suite.rb
@@ -29,7 +29,6 @@ cask "burp-suite" do
   end
 
   conflicts_with cask: "burp-suite@early-adopter"
-  depends_on macos: ">= :catalina"
 
   app "Burp Suite Community Edition.app"
 

--- a/Casks/b/burp-suite@early-adopter.rb
+++ b/Casks/b/burp-suite@early-adopter.rb
@@ -29,7 +29,6 @@ cask "burp-suite@early-adopter" do
   end
 
   conflicts_with cask: "burp-suite"
-  depends_on macos: ">= :catalina"
 
   app "Burp Suite Community Edition.app"
 

--- a/Casks/b/busycal.rb
+++ b/Casks/b/busycal.rb
@@ -16,7 +16,6 @@ cask "busycal" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "BusyCal Installer.pkg"
 

--- a/Casks/b/butler.rb
+++ b/Casks/b/butler.rb
@@ -13,7 +13,6 @@ cask "butler" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Butler.app"
 

--- a/Casks/b/buttercup.rb
+++ b/Casks/b/buttercup.rb
@@ -12,7 +12,6 @@ cask "buttercup" do
   deprecate! date: "2025-07-17", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Buttercup.app"
 

--- a/Casks/b/bzflag.rb
+++ b/Casks/b/bzflag.rb
@@ -12,8 +12,6 @@ cask "bzflag" do
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "BZFlag-#{version}.app"
 
   zap trash: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.