### PR TITLE
[c]: remove pre-Catalina references

### DIFF
--- a/Casks/c/cables.rb
+++ b/Casks/c/cables.rb
@@ -17,8 +17,6 @@ cask "cables" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "cables-#{version}.app"
 
   zap trash: [

--- a/Casks/c/calcservice.rb
+++ b/Casks/c/calcservice.rb
@@ -12,8 +12,6 @@ cask "calcservice" do
     regex(/calcservice.*?(\d+(?:\.\d+)+).*?app/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "CalcService.app"
 
   zap trash: "~/Library/Preferences/org.grunenberg.CalcService.plist"

--- a/Casks/c/calendar-366.rb
+++ b/Casks/c/calendar-366.rb
@@ -13,8 +13,6 @@ cask "calendar-366" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Calendar 366 II.app"
 
   zap trash: [

--- a/Casks/c/calibre.rb
+++ b/Casks/c/calibre.rb
@@ -1,14 +1,6 @@
 cask "calibre" do
   on_ventura :or_older do
-    on_high_sierra :or_older do
-      version "3.48.0"
-      sha256 "68829cd902b8e0b2b7d5cf7be132df37bcc274a1e5720b4605d2dd95f3a29168"
-    end
-    on_mojave do
-      version "5.44.0"
-      sha256 "89d7772ba1b95d219b34e285353340a174a013e06b4d8ad370433b3b98c94ad4"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "6.11.0"
       sha256 "d7c40f3f35ba9043c13303632526f135b2c4086471a5c09ceb8b397c55c076fa"
     end

--- a/Casks/c/calibrite-profiler.rb
+++ b/Casks/c/calibrite-profiler.rb
@@ -18,7 +18,6 @@ cask "calibrite-profiler" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "calibrite PROFILER.app"
 

--- a/Casks/c/camerabag-photo.rb
+++ b/Casks/c/camerabag-photo.rb
@@ -15,8 +15,6 @@ cask "camerabag-photo" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "CameraBag Photo.app"
 
   zap trash: "~/Library/Saved Application State/com.nevercenter.camerabagphoto.savedState"

--- a/Casks/c/cameracontroller.rb
+++ b/Casks/c/cameracontroller.rb
@@ -13,7 +13,6 @@ cask "cameracontroller" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CameraController.app"
 

--- a/Casks/c/camo-studio.rb
+++ b/Casks/c/camo-studio.rb
@@ -13,7 +13,6 @@ cask "camo-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Camo Studio.app"
 

--- a/Casks/c/canon-ufrii-driver.rb
+++ b/Casks/c/canon-ufrii-driver.rb
@@ -21,8 +21,6 @@ cask "canon-ufrii-driver" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "UFRII_LT_LIPS_LX_Installer.pkg"
 
   uninstall pkgutil: "jp.co.canon.CUPSPrinter.*",

--- a/Casks/c/cantata.rb
+++ b/Casks/c/cantata.rb
@@ -9,7 +9,5 @@ cask "cantata" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Cantata.app"
 end

--- a/Casks/c/canva.rb
+++ b/Casks/c/canva.rb
@@ -13,7 +13,6 @@ cask "canva" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Canva.app"
 

--- a/Casks/c/cap.rb
+++ b/Casks/c/cap.rb
@@ -29,7 +29,6 @@ cask "cap" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Cap.app"
 

--- a/Casks/c/capcut.rb
+++ b/Casks/c/capcut.rb
@@ -22,8 +22,6 @@ cask "capcut" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CapCut.app"
 
   zap trash: [

--- a/Casks/c/caprine.rb
+++ b/Casks/c/caprine.rb
@@ -18,7 +18,6 @@ cask "caprine" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Caprine.app"
 

--- a/Casks/c/capslocknodelay.rb
+++ b/Casks/c/capslocknodelay.rb
@@ -9,8 +9,6 @@ cask "capslocknodelay" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "CapsLockNoDelay.app"
 
   uninstall quit: "gkpln3.CapsLockNoDelay"

--- a/Casks/c/captainplugins.rb
+++ b/Casks/c/captainplugins.rb
@@ -13,8 +13,6 @@ cask "captainplugins" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "CaptainPlugins.pkg"
 
   uninstall pkgutil: "com.mixedinkey.CaptainPlugins.Epic.pkg"

--- a/Casks/c/captin.rb
+++ b/Casks/c/captin.rb
@@ -13,8 +13,6 @@ cask "captin" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Captin.app"
 
   uninstall quit: "com.100hps.captin"

--- a/Casks/c/capto.rb
+++ b/Casks/c/capto.rb
@@ -13,8 +13,6 @@ cask "capto" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Capto.app"
 
   zap trash: [

--- a/Casks/c/carbide-create.rb
+++ b/Casks/c/carbide-create.rb
@@ -15,8 +15,6 @@ cask "carbide-create" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Carbide Create.app"
 
   zap trash: [

--- a/Casks/c/carbon-copy-cloner@6.rb
+++ b/Casks/c/carbon-copy-cloner@6.rb
@@ -18,7 +18,6 @@ cask "carbon-copy-cloner@6" do
     "carbon-copy-cloner",
     "carbon-copy-cloner@5",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Carbon Copy Cloner.app"
 

--- a/Casks/c/cardpresso.rb
+++ b/Casks/c/cardpresso.rb
@@ -13,7 +13,6 @@ cask "cardpresso" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "cardPresso.app"
 

--- a/Casks/c/castr.rb
+++ b/Casks/c/castr.rb
@@ -17,7 +17,6 @@ cask "castr" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Castr.app"
 

--- a/Casks/c/catch.rb
+++ b/Casks/c/catch.rb
@@ -14,7 +14,6 @@ cask "catch" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Catch.app"
 

--- a/Casks/c/catlight.rb
+++ b/Casks/c/catlight.rb
@@ -13,8 +13,6 @@ cask "catlight" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Catlight.app"
 
   zap trash: [

--- a/Casks/c/cave-story.rb
+++ b/Casks/c/cave-story.rb
@@ -1,23 +1,13 @@
 cask "cave-story" do
   language "en", default: true do
-    on_mojave :or_older do
-      version "0.0.9,1"
-      sha256 "a88f053fabe416a4eed5dd98da272ba2ca3fc2caa90f22a58beb85458ef16ff0"
+    version "0.1.0,2"
+    sha256 "30e32c5123b984d0733a1e1e510a1255d511e69b694c4227119c69161ba1dc55"
 
-      livecheck do
-        skip "Legacy version"
-      end
-    end
-    on_catalina :or_newer do
-      version "0.1.0,2"
-      sha256 "30e32c5123b984d0733a1e1e510a1255d511e69b694c4227119c69161ba1dc55"
-
-      livecheck do
-        url "https://www.cavestory.org/downloads/"
-        regex(/href=.*?cavestory[._-]?v?(\d{3})[._-]?r(\d+)\.dmg/i)
-        strategy :page_match do |page, regex|
-          page.scan(regex).map { |match| "#{match[0].chars.join(".")},#{match[1]}" }
-        end
+    livecheck do
+      url "https://www.cavestory.org/downloads/"
+      regex(/href=.*?cavestory[._-]?v?(\d{3})[._-]?r(\d+)\.dmg/i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| "#{match[0].chars.join(".")},#{match[1]}" }
       end
     end
 
@@ -29,24 +19,14 @@ cask "cave-story" do
     "en-US"
   end
   language "ja" do
-    on_mojave :or_older do
-      version "0.0.9"
-      sha256 "cf0f73cbf797f3d24bf2aada970438e82c2e851ae262355286421d3464a18a3a"
+    version "0.2.0"
+    sha256 "fb90f6851e0351c0f8bce52f0cd22f2b26007b9f98543311377c41f6cabb472a"
 
-      livecheck do
-        skip "Legacy version"
-      end
-    end
-    on_catalina :or_newer do
-      version "0.2.0"
-      sha256 "fb90f6851e0351c0f8bce52f0cd22f2b26007b9f98543311377c41f6cabb472a"
-
-      livecheck do
-        url "https://www.nakiwo.com/software.html"
-        regex(/href=.*?doukutsu[._-]?v?(\d+(?:[._]\d+)*)\.dmg/i)
-        strategy :page_match do |page, regex|
-          page.scan(regex).map { |match| match[0].tr("_", ".") }
-        end
+    livecheck do
+      url "https://www.nakiwo.com/software.html"
+      regex(/href=.*?doukutsu[._-]?v?(\d+(?:[._]\d+)*)\.dmg/i)
+      strategy :page_match do |page, regex|
+        page.scan(regex).map { |match| match[0].tr("_", ".") }
       end
     end
 

--- a/Casks/c/ccstudio.rb
+++ b/Casks/c/ccstudio.rb
@@ -10,8 +10,6 @@ cask "ccstudio" do
 
   deprecate! date: "2025-09-09", because: :no_longer_available, replacement_cask: "calibrite-profiler"
 
-  depends_on macos: ">= :catalina"
-
   pkg "ccStudio.pkg"
 
   uninstall launchctl: "com.xrite.device.xrdd (com.xrite.device.xrdd.plist)",

--- a/Casks/c/cctalk.rb
+++ b/Casks/c/cctalk.rb
@@ -15,8 +15,6 @@ cask "cctalk" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "CCtalk.app"
 
   zap trash: [

--- a/Casks/c/cd-to.rb
+++ b/Casks/c/cd-to.rb
@@ -22,8 +22,6 @@ cask "cd-to" do
   desc "Finder Toolbar app to open the current directory in the Terminal"
   homepage "https://github.com/jbtule/cdto"
 
-  depends_on macos: ">= :mojave"
-
   app "cd to.app"
 
   caveats <<~EOS

--- a/Casks/c/celestialteapot-runway.rb
+++ b/Casks/c/celestialteapot-runway.rb
@@ -12,8 +12,6 @@ cask "celestialteapot-runway" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Runway.app"
 
   zap trash: [

--- a/Casks/c/cemu.rb
+++ b/Casks/c/cemu.rb
@@ -1,18 +1,7 @@
 cask "cemu" do
   arch arm: "arm", intel: "intel"
 
-  on_mojave :or_older do
-    version "1.3"
-    sha256 "db28a0497ea944a6118f869b50268d5f8c3730c37367033eeebc7cdec08fd60c"
-
-    url "https://github.com/CE-Programming/CEmu/releases/download/v#{version}/macOS_CEmu.dmg",
-        verified: "github.com/CE-Programming/CEmu/"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "2.0"
     sha256 "11b5ce8fea2c058dc5237756c092342afc618c3010c65694cdcf3b8c0f6b6664"
 
@@ -31,8 +20,6 @@ cask "cemu" do
   name "CEmu"
   desc "TI-84 Plus CE and TI-83 Premium CE calculator emulator"
   homepage "https://ce-programming.github.io/CEmu/"
-
-  depends_on macos: ">= :sierra"
 
   app "CEmu.app"
 

--- a/Casks/c/cerebro.rb
+++ b/Casks/c/cerebro.rb
@@ -10,8 +10,6 @@ cask "cerebro" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Cerebro.app"
 
   uninstall quit: "cerebro"

--- a/Casks/c/chai.rb
+++ b/Casks/c/chai.rb
@@ -9,8 +9,6 @@ cask "chai" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "Chai.app"
 
   zap trash: [

--- a/Casks/c/charmstone.rb
+++ b/Casks/c/charmstone.rb
@@ -13,7 +13,6 @@ cask "charmstone" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Charmstone.app"
 

--- a/Casks/c/chatall.rb
+++ b/Casks/c/chatall.rb
@@ -16,7 +16,6 @@ cask "chatall" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "ChatALL.app"
 

--- a/Casks/c/chatbox.rb
+++ b/Casks/c/chatbox.rb
@@ -16,7 +16,6 @@ cask "chatbox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "chatbox.app"
 

--- a/Casks/c/chatmate-for-whatsapp.rb
+++ b/Casks/c/chatmate-for-whatsapp.rb
@@ -10,8 +10,6 @@ cask "chatmate-for-whatsapp" do
 
   deprecate! date: "2025-03-30", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "ChatMate for WhatsApp.app"
 
   zap trash: [

--- a/Casks/c/chatology.rb
+++ b/Casks/c/chatology.rb
@@ -9,7 +9,5 @@ cask "chatology" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :el_capitan"
-
   app "Chatology.app"
 end

--- a/Casks/c/chatwork.rb
+++ b/Casks/c/chatwork.rb
@@ -17,7 +17,6 @@ cask "chatwork" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "ChatWork.app"
 

--- a/Casks/c/cheatsheet.rb
+++ b/Casks/c/cheatsheet.rb
@@ -10,7 +10,6 @@ cask "cheatsheet" do
   deprecate! date: "2024-11-09", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "CheatSheet.app"
 

--- a/Casks/c/cheetah3d.rb
+++ b/Casks/c/cheetah3d.rb
@@ -12,8 +12,6 @@ cask "cheetah3d" do
     regex(%r{Download\s<br/>Cheetah3D\s(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Cheetah3D.app"
 
   zap trash: [

--- a/Casks/c/chemdoodle.rb
+++ b/Casks/c/chemdoodle.rb
@@ -16,8 +16,6 @@ cask "chemdoodle" do
     regex(%r{href=.*?/ChemDoodle[._-]macos[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   suite "ChemDoodle"
 
   zap trash: "~/Library/Saved Application State/com.iChemLabs.ChemDoodle.savedState"

--- a/Casks/c/chipmunk.rb
+++ b/Casks/c/chipmunk.rb
@@ -16,7 +16,6 @@ cask "chipmunk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "chipmunk.app"
 

--- a/Casks/c/chirp.rb
+++ b/Casks/c/chirp.rb
@@ -11,8 +11,6 @@ cask "chirp" do
 
   disable! date: "2025-08-05", because: "cannot be reliably fetched due to Cloudflare protections"
 
-  depends_on macos: ">= :high_sierra"
-
   app "CHIRP.app"
 
   zap trash: "~/.chirp"

--- a/Casks/c/choice-financial-terminal.rb
+++ b/Casks/c/choice-financial-terminal.rb
@@ -18,7 +18,6 @@ cask "choice-financial-terminal" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Choice金融终端.app"
 

--- a/Casks/c/choosy.rb
+++ b/Casks/c/choosy.rb
@@ -1,30 +1,6 @@
 cask "choosy" do
   on_ventura :or_older do
-    on_el_capitan :or_older do
-      version "1.1"
-      sha256 "c6530d4e0dddbf47c6a8999bda8f3a5ef1857f4481b9325e56cfe00f05b2022c"
-
-      prefpane "Choosy.prefPane"
-    end
-    on_sierra do
-      version "1.3"
-      sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
-
-      prefpane "Choosy.prefPane"
-    end
-    on_high_sierra do
-      version "1.3"
-      sha256 "cb1f40df11ac1b52354f4b81367462d2646a6d023c64bafe5022fcec52f796cd"
-
-      prefpane "Choosy.prefPane"
-    end
-    on_mojave do
-      version "2.1"
-      sha256 "758da621d3a92358885333b767d64b024197a8147a339b1a0d14e938673452f9"
-
-      pkg "Choosy.pkg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "2.2.1"
       sha256 "71fe3c3c592d449063189a575a39b1f00735ee20cf1de94552896f5f8e93bf47"
 

--- a/Casks/c/chordpotion.rb
+++ b/Casks/c/chordpotion.rb
@@ -13,8 +13,6 @@ cask "chordpotion" do
     regex(/href=.*?ChordPotion[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "ChordPotion_#{version}.pkg"
 
   uninstall pkgutil: [

--- a/Casks/c/chronoagent.rb
+++ b/Casks/c/chronoagent.rb
@@ -12,8 +12,6 @@ cask "chronoagent" do
     regex(/>\s*ChronoAgent.*?Version\s+(\d+(?:\.\d+)+)[\s<]+/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Install.pkg"
 
   uninstall launchctl: "com.econtechnologies.ChronoAgentRemote",

--- a/Casks/c/chronosync.rb
+++ b/Casks/c/chronosync.rb
@@ -12,8 +12,6 @@ cask "chronosync" do
     regex(/ChronoSync\s(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "Install.pkg"
 
   uninstall quit:    [

--- a/Casks/c/chrysalis.rb
+++ b/Casks/c/chrysalis.rb
@@ -16,8 +16,6 @@ cask "chrysalis" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Chrysalis.app"
 
   zap trash: [

--- a/Casks/c/cisdem-data-recovery.rb
+++ b/Casks/c/cisdem-data-recovery.rb
@@ -13,8 +13,6 @@ cask "cisdem-data-recovery" do
     regex(/(\d+(?:\.\d+)+)\s+\(\d+(?:-\d+)+\)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Cisdem Data Recovery.app"
 
   zap trash: [

--- a/Casks/c/cisdem-duplicate-finder.rb
+++ b/Casks/c/cisdem-duplicate-finder.rb
@@ -13,8 +13,6 @@ cask "cisdem-duplicate-finder" do
     regex(/(\d+(?:\.\d+)*)\s+\(\d+(?:-\d+)+\)/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Cisdem Duplicate Finder.app"
 
   zap trash: [

--- a/Casks/c/cisdem-pdf-converter-ocr.rb
+++ b/Casks/c/cisdem-pdf-converter-ocr.rb
@@ -13,8 +13,6 @@ cask "cisdem-pdf-converter-ocr" do
     regex(/(\d+(?:\.\d+)*)\s+\(\d+(?:-\d+)+\)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Cisdem PDF Converter OCR.app"
 
   zap trash: [

--- a/Casks/c/citrix-workspace.rb
+++ b/Casks/c/citrix-workspace.rb
@@ -16,7 +16,6 @@ cask "citrix-workspace" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "CitrixWorkspaceAppUniversal#{version}.pkg"
 

--- a/Casks/c/ckb-next.rb
+++ b/Casks/c/ckb-next.rb
@@ -9,8 +9,6 @@ cask "ckb-next" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   pkg "ckb-next.mpkg"
 
   uninstall launchctl: "org.ckb-next.daemon",

--- a/Casks/c/clash-party.rb
+++ b/Casks/c/clash-party.rb
@@ -32,7 +32,6 @@ cask "clash-party" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   uninstall launchctl: "party.mihomo.helper",
             pkgutil:   "party.mihomo.app"

--- a/Casks/c/clash-verge-rev.rb
+++ b/Casks/c/clash-verge-rev.rb
@@ -17,7 +17,6 @@ cask "clash-verge-rev" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Clash Verge.app"
 

--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -19,8 +19,6 @@ cask "claude-code" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   binary "claude"
 
   zap trash: [

--- a/Casks/c/clay.rb
+++ b/Casks/c/clay.rb
@@ -13,7 +13,6 @@ cask "clay" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Clay.app"
 

--- a/Casks/c/clean-me.rb
+++ b/Casks/c/clean-me.rb
@@ -1,12 +1,6 @@
 cask "clean-me" do
-  on_mojave :or_older do
-    version "1.4.1"
-    sha256 "a074546909de68b0b378b58f6804a118f40a03077083a5a61a19c588f0841648"
-  end
-  on_catalina :or_newer do
-    version "1.4.2"
-    sha256 "f58124740e8d9cbf8b4f45ee9a3e30a2aced109381fc34583d1c28d49d54dfe5"
-  end
+  version "1.4.2"
+  sha256 "f58124740e8d9cbf8b4f45ee9a3e30a2aced109381fc34583d1c28d49d54dfe5"
 
   url "https://github.com/Kevin-De-Koninck/Clean-Me/releases/download/v#{version}/Clean.Me.app.zip"
   name "Clean-me"
@@ -14,8 +8,6 @@ cask "clean-me" do
   homepage "https://github.com/Kevin-De-Koninck/Clean-Me"
 
   disable! date: "2024-12-16", because: :discontinued
-
-  depends_on macos: ">= :sierra"
 
   app "Clean Me.app"
 

--- a/Casks/c/cleaneronepro.rb
+++ b/Casks/c/cleaneronepro.rb
@@ -13,7 +13,6 @@ cask "cleaneronepro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "CleanerOnePro.app"
 

--- a/Casks/c/cleanmymac-zh.rb
+++ b/Casks/c/cleanmymac-zh.rb
@@ -15,7 +15,6 @@ cask "cleanmymac-zh" do
 
   auto_updates true
   conflicts_with cask: "cleanmymac"
-  depends_on macos: ">= :high_sierra"
 
   app "CleanMyMac-X.app"
 

--- a/Casks/c/cleanshot.rb
+++ b/Casks/c/cleanshot.rb
@@ -13,7 +13,6 @@ cask "cleanshot" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "CleanShot X.app"
 

--- a/Casks/c/clicker-for-netflix.rb
+++ b/Casks/c/clicker-for-netflix.rb
@@ -13,7 +13,6 @@ cask "clicker-for-netflix" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Clicker for Netflix.app"
 

--- a/Casks/c/clicker-for-youtube.rb
+++ b/Casks/c/clicker-for-youtube.rb
@@ -13,7 +13,6 @@ cask "clicker-for-youtube" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Clicker for YouTube.app"
 

--- a/Casks/c/clion.rb
+++ b/Casks/c/clion.rb
@@ -24,7 +24,6 @@ cask "clion" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CLion.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/c/clion@eap.rb
+++ b/Casks/c/clion@eap.rb
@@ -24,7 +24,6 @@ cask "clion@eap" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CLion #{version.csv.first} EAP.app"
   binary "#{appdir}/CLion #{version.csv.first} EAP.app/Contents/MacOS/clion", target: "clion-eap"

--- a/Casks/c/clipbook.rb
+++ b/Casks/c/clipbook.rb
@@ -16,8 +16,6 @@ cask "clipbook" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "ClipBook.app"
 
   zap trash: [

--- a/Casks/c/clipgrab.rb
+++ b/Casks/c/clipgrab.rb
@@ -12,8 +12,6 @@ cask "clipgrab" do
     regex(/href=.*?ClipGrab[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "ClipGrab.app"
 
   zap trash: "~/Library/Preferences/de.clipgrab.ClipGrab.plist"

--- a/Casks/c/clips-ide.rb
+++ b/Casks/c/clips-ide.rb
@@ -14,8 +14,6 @@ cask "clips-ide" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CLIPS IDE.app"
 
   zap trash: [

--- a/Casks/c/clock-bar.rb
+++ b/Casks/c/clock-bar.rb
@@ -23,8 +23,6 @@ cask "clock-bar" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "Clock Bar.app"
 
   zap trash: [

--- a/Casks/c/clock-signal.rb
+++ b/Casks/c/clock-signal.rb
@@ -8,8 +8,6 @@ cask "clock-signal" do
   desc "Latency-hating emulator of 8- and 16-bit platforms"
   homepage "https://github.com/TomHarte/CLK"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Clock Signal.app"
 
   uninstall quit: "TH.Clock-Signal"

--- a/Casks/c/clocker.rb
+++ b/Casks/c/clocker.rb
@@ -8,8 +8,6 @@ cask "clocker" do
   desc "Menu bar timezone tracker and compact calendar"
   homepage "https://abhishekbanthia.com/clocker"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Clocker.app"
 
   uninstall launchctl: "com.abhishek.ClockerHelper",

--- a/Casks/c/clone-hero.rb
+++ b/Casks/c/clone-hero.rb
@@ -15,8 +15,6 @@ cask "clone-hero" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Clone Hero.app"
 
   zap trash: [

--- a/Casks/c/cloud-pbx.rb
+++ b/Casks/c/cloud-pbx.rb
@@ -16,8 +16,6 @@ cask "cloud-pbx" do
     regex(%r{href=.*?/cloud[._-]pbx[._-]2\.0[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Cloud PBX 2.0.app"
 
   zap trash: [

--- a/Casks/c/cloudash.rb
+++ b/Casks/c/cloudash.rb
@@ -11,8 +11,6 @@ cask "cloudash" do
   desc "Monitoring and troubleshooting for serverless architectures"
   homepage "https://cloudash.dev/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Cloudash.app"
 
   zap trash: [

--- a/Casks/c/cloudcompare.rb
+++ b/Casks/c/cloudcompare.rb
@@ -17,8 +17,6 @@ cask "cloudcompare" do
     regex(/href=.*CloudCompare[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "CloudCompare.app"
 
   zap trash: "~/Library/Preferences/com.cccorp.CloudCompare.plist"

--- a/Casks/c/cloudflare-warp.rb
+++ b/Casks/c/cloudflare-warp.rb
@@ -15,7 +15,6 @@ cask "cloudflare-warp" do
 
   auto_updates true
   conflicts_with cask: "cloudflare-warp@beta"
-  depends_on macos: ">= :catalina"
 
   pkg "Cloudflare_WARP_#{version}.pkg"
 

--- a/Casks/c/cloudflare-warp@beta.rb
+++ b/Casks/c/cloudflare-warp@beta.rb
@@ -15,7 +15,6 @@ cask "cloudflare-warp@beta" do
 
   auto_updates true
   conflicts_with cask: "cloudflare-warp"
-  depends_on macos: ">= :catalina"
 
   pkg "Cloudflare_WARP_#{version}.pkg"
 

--- a/Casks/c/cloudmounter.rb
+++ b/Casks/c/cloudmounter.rb
@@ -14,7 +14,6 @@ cask "cloudmounter" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "CloudMounter.app"
 

--- a/Casks/c/cloudnet.rb
+++ b/Casks/c/cloudnet.rb
@@ -13,7 +13,6 @@ cask "cloudnet" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CloudNet.app"
   installer script: {

--- a/Casks/c/cloudup.rb
+++ b/Casks/c/cloudup.rb
@@ -12,8 +12,6 @@ cask "cloudup" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Cloudup.app"
 
   zap trash: [

--- a/Casks/c/cloudytabs.rb
+++ b/Casks/c/cloudytabs.rb
@@ -10,8 +10,6 @@ cask "cloudytabs" do
   deprecate! date: "2024-06-16", because: :discontinued
   disable! date: "2025-06-16", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "CloudyTabs.app"
 
   caveats do

--- a/Casks/c/cncjs.rb
+++ b/Casks/c/cncjs.rb
@@ -18,8 +18,6 @@ cask "cncjs" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "CNCjs.app"
 
   zap trash: [

--- a/Casks/c/cocktail.rb
+++ b/Casks/c/cocktail.rb
@@ -1,30 +1,6 @@
 cask "cocktail" do
   on_ventura :or_older do
-    on_el_capitan :or_older do
-      version "9.7"
-      sha256 "ca6b4a264ca60a08ff45761f82b0b6161cbe3412bd6cbeedd5dbecebc8d26712"
-
-      url "https://www.maintain.se/downloads/sparkle/elcapitan/Cocktail_#{version}.zip"
-    end
-    on_sierra do
-      version "10.9.1"
-      sha256 "c41bdcff4e0a1bdf3b0b1dfa11e12de71acf64010c7dccfd337ec2f42ca7bd4f"
-
-      url "https://www.maintain.se/downloads/sparkle/sierra/Cocktail_#{version}.zip"
-    end
-    on_high_sierra do
-      version "11.7"
-      sha256 "e1d8b4529963e94b8a5d710ee3dd75f15423701aead815da271d624b2c653278"
-
-      url "https://www.maintain.se/downloads/sparkle/highsierra/Cocktail_#{version}.zip"
-    end
-    on_mojave do
-      version "12.5"
-      sha256 "bdbda2d7c86e598dd9504ba3158dcab71d0b9e2b935b2917c45bb1696fc105cd"
-
-      url "https://www.maintain.se/downloads/sparkle/mojave/Cocktail_#{version}.zip"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "13.3"
       sha256 "8fa2285b84360e9fea73024b9477dbc7ce1bf073fae36a86553c8c95c5fcfcc2"
 

--- a/Casks/c/cocoapacketanalyzer.rb
+++ b/Casks/c/cocoapacketanalyzer.rb
@@ -12,8 +12,6 @@ cask "cocoapacketanalyzer" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CocoaPacketAnalyzer.app"
 
   uninstall delete: [

--- a/Casks/c/cocoarestclient.rb
+++ b/Casks/c/cocoarestclient.rb
@@ -14,7 +14,6 @@ cask "cocoarestclient" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "CocoaRestClient.app"
 

--- a/Casks/c/coda.rb
+++ b/Casks/c/coda.rb
@@ -10,7 +10,6 @@ cask "coda" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Coda #{version.major}.app"
 

--- a/Casks/c/codebolt.rb
+++ b/Casks/c/codebolt.rb
@@ -16,7 +16,6 @@ cask "codebolt" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "CodeBolt.app"
 

--- a/Casks/c/codekit.rb
+++ b/Casks/c/codekit.rb
@@ -13,7 +13,6 @@ cask "codekit" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CodeKit.app"
 

--- a/Casks/c/coderunner.rb
+++ b/Casks/c/coderunner.rb
@@ -13,7 +13,6 @@ cask "coderunner" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CodeRunner.app"
 

--- a/Casks/c/codespace.rb
+++ b/Casks/c/codespace.rb
@@ -12,8 +12,6 @@ cask "codespace" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Codespace.app"
 
   zap trash: [

--- a/Casks/c/cog-app.rb
+++ b/Casks/c/cog-app.rb
@@ -19,7 +19,6 @@ cask "cog-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Cog.app"
 

--- a/Casks/c/coherence-x.rb
+++ b/Casks/c/coherence-x.rb
@@ -14,7 +14,6 @@ cask "coherence-x" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Coherence X.app"
 

--- a/Casks/c/coinomi-wallet.rb
+++ b/Casks/c/coinomi-wallet.rb
@@ -10,8 +10,6 @@ cask "coinomi-wallet" do
 
   deprecate! date: "2025-05-25", because: :moved_to_mas
 
-  depends_on macos: ">= :sierra"
-
   app "Coinomi Wallet.app"
 
   uninstall quit: "com.coinomi.desktop"

--- a/Casks/c/colorpicker-materialdesign.rb
+++ b/Casks/c/colorpicker-materialdesign.rb
@@ -7,8 +7,6 @@ cask "colorpicker-materialdesign" do
   desc "Colour picker"
   homepage "https://github.com/CodeCatalyst/MaterialDesignColorPicker"
 
-  depends_on macos: ">= :el_capitan"
-
   colorpicker "MaterialDesignColorPicker.colorPicker"
 
   # No zap stanza required

--- a/Casks/c/colorsnapper.rb
+++ b/Casks/c/colorsnapper.rb
@@ -18,8 +18,6 @@ cask "colorsnapper" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "ColorSnapper2.app"
 
   uninstall quit: "com.koolesache.ColorSnapper2"

--- a/Casks/c/colour-contrast-analyser.rb
+++ b/Casks/c/colour-contrast-analyser.rb
@@ -13,8 +13,6 @@ cask "colour-contrast-analyser" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Colour Contrast Analyser.app"
 
   zap trash: [

--- a/Casks/c/comfyui.rb
+++ b/Casks/c/comfyui.rb
@@ -23,7 +23,6 @@ cask "comfyui" do
 
   auto_updates true
   depends_on arch: :arm64
-  depends_on macos: ">= :catalina"
 
   app "ComfyUI.app"
 

--- a/Casks/c/command-tab-plus.rb
+++ b/Casks/c/command-tab-plus.rb
@@ -14,7 +14,6 @@ cask "command-tab-plus" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Command-Tab Plus #{version.major}.app"
 

--- a/Casks/c/commander-one.rb
+++ b/Casks/c/commander-one.rb
@@ -14,7 +14,6 @@ cask "commander-one" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Commander One.app"
 

--- a/Casks/c/commandpost.rb
+++ b/Casks/c/commandpost.rb
@@ -1,13 +1,5 @@
 cask "commandpost" do
-  on_mojave :or_older do
-    version "1.2.16"
-    sha256 "a874240a9c37a77da47c7e3c33342f3cc4d415d3bb146bee4b49b0776e8e08a8"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "1.4.13"
     sha256 "dd0ddbf94722174760c82870f537b299ce0b1b6265875aa558d515df4338a816"
 
@@ -27,7 +19,6 @@ cask "commandpost" do
   homepage "https://commandpost.io/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "CommandPost.app"
   binary "#{appdir}/CommandPost.app/Contents/Frameworks/hs/cmdpost"

--- a/Casks/c/commandq.rb
+++ b/Casks/c/commandq.rb
@@ -14,7 +14,6 @@ cask "commandq" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CommandQ.app"
 

--- a/Casks/c/compositor.rb
+++ b/Casks/c/compositor.rb
@@ -13,7 +13,6 @@ cask "compositor" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Compositor.app"
 

--- a/Casks/c/concept2-utility.rb
+++ b/Casks/c/concept2-utility.rb
@@ -1,34 +1,19 @@
 cask "concept2-utility" do
-  on_high_sierra :or_older do
-    version "7.09.02"
-    sha256 "e4ebee8cde57c7ef63c3903285c3fc0ee8f87221e7c5529b9dcf97b3f9ebb57e"
+  version "7.17.00"
+  sha256 "2796b6275e9d1ab08051b94e5c33e89a5b14d31020132324f9948f8aa754cae3"
 
-    url "https://software.concept2.com/utility/Concept2Utility#{version.no_dots}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Concept2 Utility #{version}.pkg"
-  end
-  on_mojave :or_newer do
-    version "7.17.00"
-    sha256 "2796b6275e9d1ab08051b94e5c33e89a5b14d31020132324f9948f8aa754cae3"
-
-    url "https://software.concept2.com/utility/Concept2Utility#{version.no_dots}.pkg"
-
-    # We are using a regional URL as a workaround because checking the main
-    # releases page (https://www.concept2.com/support/software/utility) is
-    # failing in our CI environment.
-    livecheck do
-      url "https://www.concept2.de/service/software/concept2-utility"
-      regex(/Concept2\s+Utility\s+v?(\d+(?:\.\d+)+)/i)
-    end
-  end
-
+  url "https://software.concept2.com/utility/Concept2Utility#{version.no_dots}.pkg"
   name "Concept2 Utility"
   desc "Utilities for the Concept2 Performance Monitor"
   homepage "https://www.concept2.com/support/software/utility"
+
+  # We are using a regional URL as a workaround because checking the main
+  # releases page (https://www.concept2.com/support/software/utility) is
+  # failing in our CI environment.
+  livecheck do
+    url "https://www.concept2.de/service/software/concept2-utility"
+    regex(/Concept2\s+Utility\s+v?(\d+(?:\.\d+)+)/i)
+  end
 
   uninstall pkgutil: "com.concept2.pkg.Concept2Utility"
 

--- a/Casks/c/conductor.rb
+++ b/Casks/c/conductor.rb
@@ -21,7 +21,6 @@ cask "conductor" do
   end
 
   depends_on arch: :arm64
-  depends_on macos: ">= :high_sierra"
 
   app "Conductor.app"
 

--- a/Casks/c/conferences.rb
+++ b/Casks/c/conferences.rb
@@ -17,8 +17,6 @@ cask "conferences" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "Conferences.app"
 
   zap trash: [

--- a/Casks/c/connect-fonts.rb
+++ b/Casks/c/connect-fonts.rb
@@ -13,7 +13,6 @@ cask "connect-fonts" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Connect Fonts.app"
 

--- a/Casks/c/console.rb
+++ b/Casks/c/console.rb
@@ -7,8 +7,6 @@ cask "console" do
   desc "Replacement for console application"
   homepage "https://github.com/macmade/Console"
 
-  depends_on macos: ">= :el_capitan"
-
   app "Console.app"
 
   zap trash: [

--- a/Casks/c/contexts.rb
+++ b/Casks/c/contexts.rb
@@ -1,28 +1,18 @@
 cask "contexts" do
-  on_mojave :or_older do
-    version "3.7.1"
-    sha256 "de5e4a660cc30276155606b539d1ae58684115a3983d69598f1505fcad499a87"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "3.9.0"
-    sha256 "c86a214d5ee7718453d0fb6442b3ef9a7fc02c5c1582b6d28ef0c2e621a6b6aa"
-
-    livecheck do
-      url "https://contexts.co/appcasts/stable.xml"
-      strategy :sparkle do |item|
-        item.version.chars.join(".")
-      end
-    end
-  end
+  version "3.9.0"
+  sha256 "c86a214d5ee7718453d0fb6442b3ef9a7fc02c5c1582b6d28ef0c2e621a6b6aa"
 
   url "https://contexts.co/releases/Contexts-#{version}.dmg"
   name "Contexts"
   desc "Allows switching between application windows"
   homepage "https://contexts.co/"
+
+  livecheck do
+    url "https://contexts.co/appcasts/stable.xml"
+    strategy :sparkle do |item|
+      item.version.chars.join(".")
+    end
+  end
 
   auto_updates true
 

--- a/Casks/c/contraste.rb
+++ b/Casks/c/contraste.rb
@@ -12,8 +12,6 @@ cask "contraste" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Contraste.app"
 
   zap trash: [

--- a/Casks/c/controllermate.rb
+++ b/Casks/c/controllermate.rb
@@ -1,16 +1,6 @@
 cask "controllermate" do
-  on_el_capitan :or_older do
-    version "4.9.10"
-    sha256 "4f24f5763e96b0b0e959197dba5cc064928b59b74d49210bf5a484f4f9766d38"
-  end
-  on_sierra do
-    version "4.10.4"
-    sha256 "fdeb37ca8df145d927b9daef6dfa22ef6d1535f9ad1459c4f4ffcb52fbc19c3b"
-  end
-  on_high_sierra :or_newer do
-    version "4.11.1"
-    sha256 "dd95d0b2abd6c23148092c96593fb303befc374c6a912afad57efb48b0a1e04b"
-  end
+  version "4.11.1"
+  sha256 "dd95d0b2abd6c23148092c96593fb303befc374c6a912afad57efb48b0a1e04b"
 
   url "https://orderedbytes.s3.amazonaws.com/ControllerMate#{version.no_dots}.zip",
       verified: "orderedbytes.s3.amazonaws.com/"

--- a/Casks/c/cool-retro-term.rb
+++ b/Casks/c/cool-retro-term.rb
@@ -9,8 +9,6 @@ cask "cool-retro-term" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "cool-retro-term.app"
 
   zap trash: [

--- a/Casks/c/coolterm.rb
+++ b/Casks/c/coolterm.rb
@@ -14,8 +14,6 @@ cask "coolterm" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "CoolTerm.app"
 
   zap trash: [

--- a/Casks/c/copyclip.rb
+++ b/Casks/c/copyclip.rb
@@ -15,7 +15,6 @@ cask "copyclip" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "CopyClip #{version.major}.app"
 

--- a/Casks/c/copytranslator.rb
+++ b/Casks/c/copytranslator.rb
@@ -16,8 +16,6 @@ cask "copytranslator" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "copytranslator.app"
 
   zap trash: [

--- a/Casks/c/coq-platform.rb
+++ b/Casks/c/coq-platform.rb
@@ -35,8 +35,6 @@ cask "coq-platform" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Coq-Platform~#{version.csv.second.major_minor}~#{version.csv.first.major_minor}.app"
 
   zap trash: [

--- a/Casks/c/core-data-editor.rb
+++ b/Casks/c/core-data-editor.rb
@@ -8,8 +8,6 @@ cask "core-data-editor" do
 
   deprecate! date: "2024-10-10", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "Core Data Editor.app"
 
   caveats do

--- a/Casks/c/cornercal.rb
+++ b/Casks/c/cornercal.rb
@@ -9,8 +9,6 @@ cask "cornercal" do
 
   deprecate! date: "2024-11-01", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "CornerCal.app"
 
   caveats do

--- a/Casks/c/cornerstone.rb
+++ b/Casks/c/cornerstone.rb
@@ -12,8 +12,6 @@ cask "cornerstone" do
     regex(/href=.*?Cornerstone[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Cornerstone.app"
 
   zap trash: [

--- a/Casks/c/corona-tracker.rb
+++ b/Casks/c/corona-tracker.rb
@@ -8,8 +8,6 @@ cask "corona-tracker" do
   desc "Coronavirus tracker app with maps and charts"
   homepage "https://coronatracker.samabox.com/"
 
-  depends_on macos: ">= :catalina"
-
   app "Corona Tracker.app"
 
   zap trash: [

--- a/Casks/c/coteditor.rb
+++ b/Casks/c/coteditor.rb
@@ -1,22 +1,6 @@
 cask "coteditor" do
   on_ventura :or_older do
-    on_el_capitan :or_older do
-      version "3.5.4"
-      sha256 "0b2cbf38cc531268e3691f307445e05ae5da64b48ceaf86c4d16b993c9be3e9f"
-    end
-    on_sierra do
-      version "3.7.8"
-      sha256 "c67a0b5049da7096228074d7b71e7678fcaaf795a5ae45bc593019662f0c6f09"
-    end
-    on_high_sierra do
-      version "3.9.7"
-      sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
-    end
-    on_mojave do
-      version "3.9.7"
-      sha256 "be34d4f800e73cc8363d8b83e1b257a06176dc85d345d680149b108f51686cf2"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "4.0.9"
       sha256 "969e891f4a36146c317150806fee01559d177f956734595c73537affc8897e79"
     end

--- a/Casks/c/couchbase-server-community.rb
+++ b/Casks/c/couchbase-server-community.rb
@@ -16,7 +16,6 @@ cask "couchbase-server-community" do
   end
 
   conflicts_with cask: "couchbase-server-enterprise"
-  depends_on macos: ">= :catalina"
 
   app "Couchbase Server.app"
 

--- a/Casks/c/couchbase-server-enterprise.rb
+++ b/Casks/c/couchbase-server-enterprise.rb
@@ -16,7 +16,6 @@ cask "couchbase-server-enterprise" do
   end
 
   conflicts_with cask: "couchbase-server-community"
-  depends_on macos: ">= :catalina"
 
   app "Couchbase Server.app"
 

--- a/Casks/c/couleurs.rb
+++ b/Casks/c/couleurs.rb
@@ -9,8 +9,6 @@ cask "couleurs" do
 
   deprecate! date: "2025-03-31", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "Couleurs.app"
 
   zap trash: [

--- a/Casks/c/coverload.rb
+++ b/Casks/c/coverload.rb
@@ -13,8 +13,6 @@ cask "coverload" do
     regex(%r{href=.*?/CoverLoad[._-]v?(\d+(?:\.\d+)+-\d+)\.zip}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "CoverLoad.app"
 
   zap trash: [

--- a/Casks/c/creality-print.rb
+++ b/Casks/c/creality-print.rb
@@ -16,8 +16,6 @@ cask "creality-print" do
     regex(/href=.*?Creality[._-]?Print[._-]v?(\d+(?:\.\d+)+)[._-]macx[._-]#{arch}[._-]Release\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Creality Print.app"
 
   zap trash: [

--- a/Casks/c/creative.rb
+++ b/Casks/c/creative.rb
@@ -15,8 +15,6 @@ cask "creative" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Creative.app"
 
   uninstall launchctl: [

--- a/Casks/c/crescendo.rb
+++ b/Casks/c/crescendo.rb
@@ -12,8 +12,6 @@ cask "crescendo" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Crescendo.app"
 
   zap trash: "~/Library/Saved Application State/com.suprhackersteve.crescendo.savedState"

--- a/Casks/c/crossover.rb
+++ b/Casks/c/crossover.rb
@@ -13,7 +13,6 @@ cask "crossover" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CrossOver.app"
 

--- a/Casks/c/crystaldiffract.rb
+++ b/Casks/c/crystaldiffract.rb
@@ -14,8 +14,6 @@ cask "crystaldiffract" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CrystalDiffract.app"
 
   zap trash: [

--- a/Casks/c/crystalmaker.rb
+++ b/Casks/c/crystalmaker.rb
@@ -14,8 +14,6 @@ cask "crystalmaker" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CrystalMaker.app"
 
   zap trash: [

--- a/Casks/c/crystalviewer.rb
+++ b/Casks/c/crystalviewer.rb
@@ -14,8 +14,6 @@ cask "crystalviewer" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CrystalViewer.app"
 
   zap trash: [

--- a/Casks/c/curseforge.rb
+++ b/Casks/c/curseforge.rb
@@ -13,7 +13,6 @@ cask "curseforge" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "CurseForge.app"
 

--- a/Casks/c/cursor.rb
+++ b/Casks/c/cursor.rb
@@ -22,7 +22,6 @@ cask "cursor" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Cursor.app"
   binary "#{appdir}/Cursor.app/Contents/Resources/app/bin/code", target: "cursor"

--- a/Casks/c/cursorsense.rb
+++ b/Casks/c/cursorsense.rb
@@ -12,8 +12,6 @@ cask "cursorsense" do
     regex(%r{href=.*?/CursorSensev?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "CursorSense.app"
 
   zap trash: [

--- a/Casks/c/cursr.rb
+++ b/Casks/c/cursr.rb
@@ -16,8 +16,6 @@ cask "cursr" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Cursr.app"
 
   zap trash: [

--- a/Casks/c/customshortcuts.rb
+++ b/Casks/c/customshortcuts.rb
@@ -13,7 +13,6 @@ cask "customshortcuts" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "CustomShortcuts.app"
 

--- a/Casks/c/cutter.rb
+++ b/Casks/c/cutter.rb
@@ -16,8 +16,6 @@ cask "cutter" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Cutter.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/cutter.wrapper.sh"

--- a/Casks/c/cyberduck.rb
+++ b/Casks/c/cyberduck.rb
@@ -13,7 +13,6 @@ cask "cyberduck" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Cyberduck.app"
 

--- a/Casks/c/cyberghost-vpn.rb
+++ b/Casks/c/cyberghost-vpn.rb
@@ -16,8 +16,6 @@ cask "cyberghost-vpn" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "CyberGhost VPN.app"
 
   zap trash: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.