### PR TITLE
[d]: remove pre-Catalina references

### DIFF
--- a/Casks/d/daedalus-mainnet.rb
+++ b/Casks/d/daedalus-mainnet.rb
@@ -20,7 +20,6 @@ cask "daedalus-mainnet" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   pkg "daedalus-#{version.csv.first}-#{version.csv.second}-mainnet-#{version.csv.third}-x86_64-darwin.pkg"
 

--- a/Casks/d/daisydisk.rb
+++ b/Casks/d/daisydisk.rb
@@ -13,7 +13,6 @@ cask "daisydisk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DaisyDisk.app"
 

--- a/Casks/d/dana-dex.rb
+++ b/Casks/d/dana-dex.rb
@@ -16,8 +16,6 @@ cask "dana-dex" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Dex.app"
 
   zap trash: [

--- a/Casks/d/dante-controller.rb
+++ b/Casks/d/dante-controller.rb
@@ -14,7 +14,6 @@ cask "dante-controller" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "DanteController.pkg"
 

--- a/Casks/d/darkmodebuddy.rb
+++ b/Casks/d/darkmodebuddy.rb
@@ -14,7 +14,6 @@ cask "darkmodebuddy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "DarkModeBuddy.app"
 

--- a/Casks/d/dash.rb
+++ b/Casks/d/dash.rb
@@ -14,7 +14,6 @@ cask "dash" do
 
   auto_updates true
   conflicts_with cask: "dash@6"
-  depends_on macos: ">= :high_sierra"
 
   app "Dash.app"
 

--- a/Casks/d/dash@6.rb
+++ b/Casks/d/dash@6.rb
@@ -14,7 +14,6 @@ cask "dash@6" do
 
   auto_updates true
   conflicts_with cask: "dash"
-  depends_on macos: ">= :high_sierra"
 
   app "Dash.app"
 

--- a/Casks/d/data-rescue.rb
+++ b/Casks/d/data-rescue.rb
@@ -12,8 +12,6 @@ cask "data-rescue" do
     regex(/>\s*Data\s+Rescue(?:\s+\d+)?\s+\(Mac\)\s*<.+?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Data Rescue.app"
 
   uninstall quit:   "com.prosofteng.DataRescue",

--- a/Casks/d/data-science-studio.rb
+++ b/Casks/d/data-science-studio.rb
@@ -12,8 +12,6 @@ cask "data-science-studio" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "DataScienceStudio.app"
 
   zap trash: [

--- a/Casks/d/dataflare.rb
+++ b/Casks/d/dataflare.rb
@@ -18,7 +18,6 @@ cask "dataflare" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Dataflare.app"
 

--- a/Casks/d/datagraph.rb
+++ b/Casks/d/datagraph.rb
@@ -12,8 +12,6 @@ cask "datagraph" do
     regex(/Version\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DataGraph.app"
 
   zap trash: [

--- a/Casks/d/datagrip.rb
+++ b/Casks/d/datagrip.rb
@@ -24,7 +24,6 @@ cask "datagrip" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DataGrip.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/d/datasette-desktop.rb
+++ b/Casks/d/datasette-desktop.rb
@@ -8,8 +8,6 @@ cask "datasette-desktop" do
   desc "Desktop application that wraps Datasette"
   homepage "https://datasette.io/desktop"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Datasette.app"
 
   zap trash: [

--- a/Casks/d/dataspell.rb
+++ b/Casks/d/dataspell.rb
@@ -24,7 +24,6 @@ cask "dataspell" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DataSpell.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/d/db-browser-for-sqlcipher@nightly.rb
+++ b/Casks/d/db-browser-for-sqlcipher@nightly.rb
@@ -13,8 +13,6 @@ cask "db-browser-for-sqlcipher@nightly" do
     regex(/^DB[._-]Browser[._-]for[._-]SQLCipher[._-]universal[._-]v?(\d+(?:\.\d+)*)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DB Browser for SQLCipher Nightly.app"
 
   zap trash: [

--- a/Casks/d/db-browser-for-sqlite.rb
+++ b/Casks/d/db-browser-for-sqlite.rb
@@ -13,8 +13,6 @@ cask "db-browser-for-sqlite" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DB Browser for SQLite.app"
 
   zap trash: [

--- a/Casks/d/db-browser-for-sqlite@nightly.rb
+++ b/Casks/d/db-browser-for-sqlite@nightly.rb
@@ -26,8 +26,6 @@ cask "db-browser-for-sqlite@nightly" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DB Browser for SQLite Nightly.app"
 
   zap trash: [

--- a/Casks/d/dbgate.rb
+++ b/Casks/d/dbgate.rb
@@ -13,8 +13,6 @@ cask "dbgate" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "DbGate.app"
 
   zap trash: [

--- a/Casks/d/dbngin.rb
+++ b/Casks/d/dbngin.rb
@@ -13,7 +13,6 @@ cask "dbngin" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DBngin.app"
 

--- a/Casks/d/dbvisualizer.rb
+++ b/Casks/d/dbvisualizer.rb
@@ -15,8 +15,6 @@ cask "dbvisualizer" do
     regex(/href=.*?dbvis[._-](\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "DbVisualizer.app"
 
   zap trash: [

--- a/Casks/d/dcv-viewer.rb
+++ b/Casks/d/dcv-viewer.rb
@@ -16,8 +16,6 @@ cask "dcv-viewer" do
     regex(%r{href=.*?/nice-dcv-viewer[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DCV Viewer.app"
 
   zap trash: "~/Library/Preferences/com.nicesoftware.dcvviewer.plist"

--- a/Casks/d/deadbeef@nightly.rb
+++ b/Casks/d/deadbeef@nightly.rb
@@ -10,8 +10,6 @@ cask "deadbeef@nightly" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "DeaDBeeF.app"
 
   zap trash: [

--- a/Casks/d/deadbolt.rb
+++ b/Casks/d/deadbolt.rb
@@ -17,8 +17,6 @@ cask "deadbolt" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "Deadbolt.app"
 
   zap trash: [

--- a/Casks/d/debookee.rb
+++ b/Casks/d/debookee.rb
@@ -14,7 +14,6 @@ cask "debookee" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Debookee.app"
 

--- a/Casks/d/deckset.rb
+++ b/Casks/d/deckset.rb
@@ -13,7 +13,6 @@ cask "deckset" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Deckset.app"
 

--- a/Casks/d/decrediton.rb
+++ b/Casks/d/decrediton.rb
@@ -10,8 +10,6 @@ cask "decrediton" do
   desc "GUI for the Decred wallet"
   homepage "https://github.com/decred/decrediton"
 
-  depends_on macos: ">= :high_sierra"
-
   app "decrediton.app"
 
   zap trash: [

--- a/Casks/d/deelay.rb
+++ b/Casks/d/deelay.rb
@@ -9,8 +9,6 @@ cask "deelay" do
 
   disable! date: "2025-06-01", because: :no_longer_meets_criteria
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "Deelay-#{version.csv.first}/Deelay-#{version.csv.first}-Installer-macOS.pkg"
 
   uninstall pkgutil: [

--- a/Casks/d/deeper.rb
+++ b/Casks/d/deeper.rb
@@ -4,27 +4,7 @@ cask "deeper" do
   # NOTE: We use separate `url` values in each of the macOS on_system blocks
   # so that the API data correctly includes URL variants for each.
   on_sonoma :or_older do
-    on_el_capitan :or_older do
-      version "2.1.4"
-
-      url "https://www.titanium-software.fr/download/1011/Deeper.dmg"
-    end
-    on_sierra do
-      version "2.2.3"
-
-      url "https://www.titanium-software.fr/download/1012/Deeper.dmg"
-    end
-    on_high_sierra do
-      version "2.3.3"
-
-      url "https://www.titanium-software.fr/download/1013/Deeper.dmg"
-    end
-    on_mojave do
-      version "2.4.8"
-
-      url "https://www.titanium-software.fr/download/1014/Deeper.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "2.6.0"
 
       url "https://www.titanium-software.fr/download/1015/Deeper.dmg"
@@ -72,10 +52,6 @@ cask "deeper" do
   homepage "https://www.titanium-software.fr/en/deeper.html"
 
   depends_on macos: [
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-    :mojave,
     :catalina,
     :big_sur,
     :monterey,

--- a/Casks/d/deepl.rb
+++ b/Casks/d/deepl.rb
@@ -46,7 +46,6 @@ cask "deepl" do
   homepage "https://www.deepl.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "DeepL.app"
 

--- a/Casks/d/default-folder-x.rb
+++ b/Casks/d/default-folder-x.rb
@@ -13,7 +13,6 @@ cask "default-folder-x" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Default Folder X.app"
 

--- a/Casks/d/dehelper.rb
+++ b/Casks/d/dehelper.rb
@@ -9,8 +9,6 @@ cask "dehelper" do
   desc "Chinese-German dictionary"
   homepage "https://www.eudic.net/v4/de/app/dehelper"
 
-  depends_on macos: ">= :high_sierra"
-
   app "dehelper.app"
 
   uninstall quit: [

--- a/Casks/d/deltachat.rb
+++ b/Casks/d/deltachat.rb
@@ -15,8 +15,6 @@ cask "deltachat" do
     regex(/href=.*?DeltaChat[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "DeltaChat.app"
 
   zap trash: [

--- a/Casks/d/detectx-swift.rb
+++ b/Casks/d/detectx-swift.rb
@@ -14,7 +14,6 @@ cask "detectx-swift" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "DetectX Swift.app"
 

--- a/Casks/d/deveco-studio.rb
+++ b/Casks/d/deveco-studio.rb
@@ -23,7 +23,6 @@ cask "deveco-studio" do
 
   disable! date: "2025-03-17", because: :no_longer_available
 
-  depends_on macos: ">= :catalina"
   container nested: "devecostudio-mac#{arch}-#{version}/deveco-studio-#{version}#{arch_suffix}.dmg"
 
   app "DevEco-Studio.app"

--- a/Casks/d/deviceinfo.rb
+++ b/Casks/d/deviceinfo.rb
@@ -10,8 +10,6 @@ cask "deviceinfo" do
   deprecate! date: "2024-07-10", because: :unmaintained
   disable! date: "2025-07-10", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "DeviceInfo.app"
 
   caveats do

--- a/Casks/d/devilutionx.rb
+++ b/Casks/d/devilutionx.rb
@@ -24,8 +24,6 @@ cask "devilutionx" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "devilutionX.app"
 
   zap trash: [

--- a/Casks/d/devkinsta.rb
+++ b/Casks/d/devkinsta.rb
@@ -16,8 +16,6 @@ cask "devkinsta" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DevKinsta.app"
 
   zap trash: [

--- a/Casks/d/devonagent.rb
+++ b/Casks/d/devonagent.rb
@@ -25,7 +25,6 @@ cask "devonagent" do
   homepage "https://www.devontechnologies.com/apps/devonagent"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "DEVONagent.app"
 

--- a/Casks/d/devonsphere-express.rb
+++ b/Casks/d/devonsphere-express.rb
@@ -23,7 +23,6 @@ cask "devonsphere-express" do
   homepage "https://www.devontechnologies.com/apps/devonsphere"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "DEVONsphere Express.app"
 

--- a/Casks/d/devonthink.rb
+++ b/Casks/d/devonthink.rb
@@ -35,7 +35,6 @@ cask "devonthink" do
   homepage "https://www.devontechnologies.com/apps/devonthink"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   zap trash: [
     "~/Library/Application Scripts/com.devon-technologies.*",

--- a/Casks/d/devpod.rb
+++ b/Casks/d/devpod.rb
@@ -17,7 +17,6 @@ cask "devpod" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DevPod.app"
   binary "#{appdir}/DevPod.app/Contents/MacOS/devpod-cli", target: "devpod"

--- a/Casks/d/devutils.rb
+++ b/Casks/d/devutils.rb
@@ -13,7 +13,6 @@ cask "devutils" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DevUtils.app"
 

--- a/Casks/d/dictionaries.rb
+++ b/Casks/d/dictionaries.rb
@@ -12,8 +12,6 @@ cask "dictionaries" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Dictionaries.app"
 
   zap trash: [

--- a/Casks/d/dingtalk.rb
+++ b/Casks/d/dingtalk.rb
@@ -14,7 +14,6 @@ cask "dingtalk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "DingTalk.app"
 

--- a/Casks/d/dintch.rb
+++ b/Casks/d/dintch.rb
@@ -23,8 +23,6 @@ cask "dintch" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "dintch#{version.csv.first.no_dots}/Dintch.app"
 
   zap trash: [

--- a/Casks/d/direqual.rb
+++ b/Casks/d/direqual.rb
@@ -17,8 +17,6 @@ cask "direqual" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "DirEqual.app"
 
   zap trash: [

--- a/Casks/d/discord.rb
+++ b/Casks/d/discord.rb
@@ -24,7 +24,6 @@ cask "discord" do
   homepage "https://discord.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Discord.app"
 

--- a/Casks/d/discord@canary.rb
+++ b/Casks/d/discord@canary.rb
@@ -14,7 +14,6 @@ cask "discord@canary" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Discord Canary.app"
 

--- a/Casks/d/discord@development.rb
+++ b/Casks/d/discord@development.rb
@@ -14,7 +14,6 @@ cask "discord@development" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Discord Development.app"
 

--- a/Casks/d/discord@ptb.rb
+++ b/Casks/d/discord@ptb.rb
@@ -14,7 +14,6 @@ cask "discord@ptb" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Discord PTB.app"
 

--- a/Casks/d/disk-diet.rb
+++ b/Casks/d/disk-diet.rb
@@ -13,7 +13,6 @@ cask "disk-diet" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Disk Diet.app"
 

--- a/Casks/d/disk-drill.rb
+++ b/Casks/d/disk-drill.rb
@@ -13,7 +13,6 @@ cask "disk-drill" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Disk Drill.app"
 

--- a/Casks/d/disk-expert.rb
+++ b/Casks/d/disk-expert.rb
@@ -13,7 +13,6 @@ cask "disk-expert" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Disk Expert #{version.major}.app"
 

--- a/Casks/d/disk-inventory-x.rb
+++ b/Casks/d/disk-inventory-x.rb
@@ -15,8 +15,6 @@ cask "disk-inventory-x" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Disk Inventory X.app"
 
   zap trash: "~/Library/Preferences/com.derlien.DiskInventoryX.plist"

--- a/Casks/d/diskcatalogmaker.rb
+++ b/Casks/d/diskcatalogmaker.rb
@@ -13,7 +13,6 @@ cask "diskcatalogmaker" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "DiskCatalogMaker.app"
 

--- a/Casks/d/diskspace.rb
+++ b/Casks/d/diskspace.rb
@@ -7,8 +7,6 @@ cask "diskspace" do
   desc "Show available disk space on APFS volumes"
   homepage "https://github.com/scriptingosx/diskspace"
 
-  depends_on macos: ">= :mojave"
-
   pkg "diskspace-#{version}.pkg"
 
   uninstall pkgutil: "com.scriptingosx.diskspace"

--- a/Casks/d/displaylink.rb
+++ b/Casks/d/displaylink.rb
@@ -1,30 +1,6 @@
 cask "displaylink" do
   on_big_sur :or_older do
-    on_sierra :or_older do
-      version "4.3.1,2021-02"
-      sha256 "d5cd6787d6c4ca6a2425984bcbab607e618e9803335455e24196e14e35657b97"
-
-      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20Mac%20OS%20X%20and%20macOS#{version.csv.first}-EXE.dmg"
-
-      pkg "DisplayLink Software Installer.pkg"
-    end
-    on_high_sierra do
-      version "5.1.1,2021-02"
-      sha256 "1ac9093f8113af8c35d6f3ff5b1ae3f119a5aff0d5309d75c7a1742f159184b5"
-
-      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
-
-      pkg "DisplayLink Software Installer.pkg"
-    end
-    on_mojave do
-      version "5.2.6,2021-05"
-      sha256 "9f1854cd5720105d6d45c91172419c503358543e4a23d7113387aedf16a39cbb"
-
-      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20USB%20Graphics%20Software%20for%20macOS#{version.csv.first}-EXE.dmg"
-
-      pkg "DisplayLink Software Installer.pkg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "1.5,2021-09"
       sha256 "d703cc8e9093e4d163c5e612326c0907a02c6d4eec6aaca8d0727503859ef95d"
 

--- a/Casks/d/ditto.rb
+++ b/Casks/d/ditto.rb
@@ -13,7 +13,6 @@ cask "ditto" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ditto.app"
 

--- a/Casks/d/dixa.rb
+++ b/Casks/d/dixa.rb
@@ -13,8 +13,6 @@ cask "dixa" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Dixa.app"
 
   zap trash: [

--- a/Casks/d/djstudio.rb
+++ b/Casks/d/djstudio.rb
@@ -1,36 +1,20 @@
 cask "djstudio" do
-  on_mojave :or_older do
-    version "2.6.28"
-    sha256 "a24739ad73b5fbda7c64aaae320b1486622c669ba3dc414d692def6026d2639d"
+  arch arm: "-arm64"
 
-    url "https://github.com/AppMachine/dj-studio-app-updates/releases/download/v#{version}/DJ.Studio-#{version}.dmg",
-        verified: "github.com/AppMachine/dj-studio-app-updates/"
+  version "3.1.31"
+  sha256 arm:   "c2096c5b03ca1f86bc359b0c3d97404fe53527d5337854599fbeff9915db27e5",
+         intel: "4c35eb09cb8adc87dc3c084ba31cdefae4b75ebdcfd64617a13784cb3b9a13f7"
 
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    arch arm: "-arm64"
-
-    version "3.1.31"
-    sha256 arm:   "c2096c5b03ca1f86bc359b0c3d97404fe53527d5337854599fbeff9915db27e5",
-           intel: "4c35eb09cb8adc87dc3c084ba31cdefae4b75ebdcfd64617a13784cb3b9a13f7"
-
-    url "https://github.com/AppMachine/dj-studio-app-updates/releases/download/v#{version}/DJ.Studio-#{version}#{arch}.dmg",
-        verified: "github.com/AppMachine/dj-studio-app-updates/"
-
-    livecheck do
-      url :url
-      strategy :github_latest
-    end
-  end
-
+  url "https://github.com/AppMachine/dj-studio-app-updates/releases/download/v#{version}/DJ.Studio-#{version}#{arch}.dmg",
+      verified: "github.com/AppMachine/dj-studio-app-updates/"
   name "DJ.Studio"
   desc "DAW for DJs"
   homepage "https://dj.studio/"
 
-  depends_on macos: ">= :high_sierra"
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "DJ.Studio.app"
 

--- a/Casks/d/dmenu-mac.rb
+++ b/Casks/d/dmenu-mac.rb
@@ -14,8 +14,6 @@ cask "dmenu-mac" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "dmenu-mac.app"
   binary "#{appdir}/dmenu-mac.app/Contents/Resources/dmenu-mac"
 

--- a/Casks/d/dmidiplayer.rb
+++ b/Casks/d/dmidiplayer.rb
@@ -16,7 +16,6 @@ cask "dmidiplayer" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on formula: "fluid-synth"
-  depends_on macos: ">= :catalina"
 
   app "dmidiplayer.app"
 

--- a/Casks/d/dnsmonitor.rb
+++ b/Casks/d/dnsmonitor.rb
@@ -8,8 +8,6 @@ cask "dnsmonitor" do
   desc "Monitor DNS activity"
   homepage "https://objective-see.org/products/utilities.html#DNSMonitor"
 
-  depends_on macos: ">= :catalina"
-
   app "DNSMonitor.app"
 
   postflight do

--- a/Casks/d/do-not-disturb.rb
+++ b/Casks/d/do-not-disturb.rb
@@ -10,8 +10,6 @@ cask "do-not-disturb" do
 
   deprecate! date: "2024-11-16", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   installer script: {
     executable: "#{staged_path}/Do Not Disturb Installer.app/Contents/MacOS/Do Not Disturb Installer",
     args:       ["-install"],

--- a/Casks/d/dockey.rb
+++ b/Casks/d/dockey.rb
@@ -12,8 +12,6 @@ cask "dockey" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "dockey.app"
 
   uninstall quit: "com.igorstumberger.dockey"

--- a/Casks/d/dockmate.rb
+++ b/Casks/d/dockmate.rb
@@ -14,7 +14,6 @@ cask "dockmate" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "DockMate.app"
 

--- a/Casks/d/dockstation.rb
+++ b/Casks/d/dockstation.rb
@@ -10,8 +10,6 @@ cask "dockstation" do
   deprecate! date: "2024-07-10", because: :unmaintained
   disable! date: "2025-07-10", because: :unmaintained
 
-  depends_on macos: ">= :el_capitan"
-
   app "DockStation.app"
 
   zap trash: [

--- a/Casks/d/dockview.rb
+++ b/Casks/d/dockview.rb
@@ -14,7 +14,6 @@ cask "dockview" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DockView.app"
 

--- a/Casks/d/dolphin.rb
+++ b/Casks/d/dolphin.rb
@@ -16,7 +16,6 @@ cask "dolphin" do
 
   auto_updates true
   conflicts_with cask: "dolphin@dev"
-  depends_on macos: ">= :catalina"
 
   app "Dolphin.app"
 

--- a/Casks/d/doughnut.rb
+++ b/Casks/d/doughnut.rb
@@ -13,7 +13,6 @@ cask "doughnut" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Doughnut.app"
 

--- a/Casks/d/douyin-chat.rb
+++ b/Casks/d/douyin-chat.rb
@@ -21,7 +21,6 @@ cask "douyin-chat" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "抖音聊天.app"
 

--- a/Casks/d/douyin.rb
+++ b/Casks/d/douyin.rb
@@ -17,7 +17,6 @@ cask "douyin" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "抖音.app"
 

--- a/Casks/d/dozer.rb
+++ b/Casks/d/dozer.rb
@@ -11,7 +11,6 @@ cask "dozer" do
   disable! date: "2024-12-01", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Dozer.app"
 

--- a/Casks/d/drata-agent.rb
+++ b/Casks/d/drata-agent.rb
@@ -13,8 +13,6 @@ cask "drata-agent" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Drata Agent.app"
 
   zap trash: [

--- a/Casks/d/drawpile.rb
+++ b/Casks/d/drawpile.rb
@@ -36,8 +36,6 @@ cask "drawpile" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Drawpile.app"
 
   zap trash: [

--- a/Casks/d/dropbox-capture.rb
+++ b/Casks/d/dropbox-capture.rb
@@ -14,7 +14,6 @@ cask "dropbox-capture" do
   disable! date: "2025-03-24", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Dropbox Capture.app"
 

--- a/Casks/d/dropbox-dash.rb
+++ b/Casks/d/dropbox-dash.rb
@@ -13,8 +13,6 @@ cask "dropbox-dash" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Dropbox Dash.app"
 
   uninstall quit: "io.hypertools.Dropbox-Dash"

--- a/Casks/d/dropbox-passwords.rb
+++ b/Casks/d/dropbox-passwords.rb
@@ -10,8 +10,6 @@ cask "dropbox-passwords" do
 
   deprecate! date: "2024-11-01", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Dropbox Passwords.app"
 
   caveats do

--- a/Casks/d/dropbox.rb
+++ b/Casks/d/dropbox.rb
@@ -20,7 +20,6 @@ cask "dropbox" do
 
   auto_updates true
   conflicts_with cask: "dropbox@beta"
-  depends_on macos: ">= :high_sierra"
 
   app "Dropbox.app"
 

--- a/Casks/d/dropbox@beta.rb
+++ b/Casks/d/dropbox@beta.rb
@@ -18,7 +18,6 @@ cask "dropbox@beta" do
 
   auto_updates true
   conflicts_with cask: "dropbox"
-  depends_on macos: ">= :high_sierra"
 
   app "Dropbox.app"
 

--- a/Casks/d/dropdmg.rb
+++ b/Casks/d/dropdmg.rb
@@ -21,7 +21,6 @@ cask "dropdmg" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "DropDMG.app"
 

--- a/Casks/d/droplr.rb
+++ b/Casks/d/droplr.rb
@@ -13,7 +13,6 @@ cask "droplr" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   pkg "Droplr#{version.csv.first.no_dots}-#{version.csv.second}.pkg"
 

--- a/Casks/d/dropshelf.rb
+++ b/Casks/d/dropshelf.rb
@@ -12,8 +12,6 @@ cask "dropshelf" do
     regex(/href=.*?dropshelf[._-]build[._-](\d+)\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Dropshelf.app"
 
   zap trash: [

--- a/Casks/d/drovio.rb
+++ b/Casks/d/drovio.rb
@@ -15,7 +15,6 @@ cask "drovio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Drovio.app"
 

--- a/Casks/d/duet.rb
+++ b/Casks/d/duet.rb
@@ -28,7 +28,6 @@ cask "duet" do
   homepage "https://www.duetdisplay.com/"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "duet.app"
 

--- a/Casks/d/duplicate-annihilator-for-photos.rb
+++ b/Casks/d/duplicate-annihilator-for-photos.rb
@@ -12,8 +12,6 @@ cask "duplicate-annihilator-for-photos" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Duplicate Annihilator for Photos.app"
 
   uninstall pkgutil: "com.brattoo.pkg.brattoosystemfiles"

--- a/Casks/d/duplicate-file-finder.rb
+++ b/Casks/d/duplicate-file-finder.rb
@@ -13,7 +13,6 @@ cask "duplicate-file-finder" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Duplicate File Finder #{version.major}.app"
 

--- a/Casks/d/dust3d.rb
+++ b/Casks/d/dust3d.rb
@@ -17,8 +17,6 @@ cask "dust3d" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "dust3d-#{version}.app"
 
   zap trash: "~/Library/Saved Application State/com.yourcompany.dust3d.savedState"

--- a/Casks/d/dynamic-dark-mode.rb
+++ b/Casks/d/dynamic-dark-mode.rb
@@ -10,7 +10,6 @@ cask "dynamic-dark-mode" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Dynamic Dark Mode.app"
 

--- a/Casks/d/dynobase.rb
+++ b/Casks/d/dynobase.rb
@@ -24,8 +24,6 @@ cask "dynobase" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Dynobase.app"
 
   zap trash: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.