### PR TITLE
[f]: remove pre-Catalina references

### DIFF
--- a/Casks/f/f-bar.rb
+++ b/Casks/f/f-bar.rb
@@ -1,27 +1,17 @@
 cask "f-bar" do
-  on_el_capitan :or_older do
-    version "3.1.1"
-    sha256 "dd2cbcc8bfb9244cf952d29354f6cd7f442472ca4ed8a11063c006c9f83b07af"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_sierra :or_newer do
-    version "5.1"
-    sha256 "82d6a186209c2b70317b444eea278b570843b09db2373ebefa1c025a73a937e6"
-
-    livecheck do
-      url "https://apps.eastwest.se/fbar/updates/FBarAppcast.xml"
-      strategy :sparkle, &:short_version
-    end
-  end
+  version "5.1"
+  sha256 "82d6a186209c2b70317b444eea278b570843b09db2373ebefa1c025a73a937e6"
 
   url "https://apps.eastwest.se/fbar/updates/F-Bar_#{version}.zip",
       verified: "apps.eastwest.se/fbar/"
   name "F-Bar"
   desc "Manage Laravel Forge servers from the menubar"
   homepage "https://laravel-forge-menubar.com/"
+
+  livecheck do
+    url "https://apps.eastwest.se/fbar/updates/FBarAppcast.xml"
+    strategy :sparkle, &:short_version
+  end
 
   auto_updates true
 

--- a/Casks/f/fabfilter-micro.rb
+++ b/Casks/f/fabfilter-micro.rb
@@ -12,8 +12,6 @@ cask "fabfilter-micro" do
     regex(/FabFilter\s+Micro.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Micro #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Micro.#{version.major}"

--- a/Casks/f/fabfilter-one.rb
+++ b/Casks/f/fabfilter-one.rb
@@ -12,8 +12,6 @@ cask "fabfilter-one" do
     regex(/FabFilter\s+One.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter One #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.One.#{version.major}"

--- a/Casks/f/fabfilter-pro-c.rb
+++ b/Casks/f/fabfilter-pro-c.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-c" do
     regex(/FabFilter\s+Pro-C.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Pro-C #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-C.#{version.major}"

--- a/Casks/f/fabfilter-pro-ds.rb
+++ b/Casks/f/fabfilter-pro-ds.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-ds" do
     regex(/FabFilter\s+Pro-DS.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Pro-DS #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-DS.#{version.major}"

--- a/Casks/f/fabfilter-pro-g.rb
+++ b/Casks/f/fabfilter-pro-g.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-g" do
     regex(/FabFilter\s+Pro-G.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Pro-G #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-G.#{version.major}"

--- a/Casks/f/fabfilter-pro-l.rb
+++ b/Casks/f/fabfilter-pro-l.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-l" do
     regex(/FabFilter\s+Pro-L.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Pro-L #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-L.#{version.major}"

--- a/Casks/f/fabfilter-pro-mb.rb
+++ b/Casks/f/fabfilter-pro-mb.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-mb" do
     regex(/FabFilter\s+Pro-MB.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Pro-MB #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-MB.#{version.major}"

--- a/Casks/f/fabfilter-pro-q.rb
+++ b/Casks/f/fabfilter-pro-q.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-q" do
     regex(/FabFilter\s+Pro-Q.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "FabFilter Pro-Q #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-Q.#{version.major}"

--- a/Casks/f/fabfilter-pro-r.rb
+++ b/Casks/f/fabfilter-pro-r.rb
@@ -12,8 +12,6 @@ cask "fabfilter-pro-r" do
     regex(/FabFilter\s+Pro-R.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Pro-R #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Pro-R.#{version.major}"

--- a/Casks/f/fabfilter-saturn.rb
+++ b/Casks/f/fabfilter-saturn.rb
@@ -12,8 +12,6 @@ cask "fabfilter-saturn" do
     regex(/FabFilter\s+Saturn.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Saturn #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Saturn.#{version.major}"

--- a/Casks/f/fabfilter-simplon.rb
+++ b/Casks/f/fabfilter-simplon.rb
@@ -12,8 +12,6 @@ cask "fabfilter-simplon" do
     regex(/FabFilter\s+Simplon.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Simplon #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Simplon.#{version.major}"

--- a/Casks/f/fabfilter-timeless.rb
+++ b/Casks/f/fabfilter-timeless.rb
@@ -12,8 +12,6 @@ cask "fabfilter-timeless" do
     regex(/FabFilter\s+Timeless.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Timeless #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Timeless.#{version.major}"

--- a/Casks/f/fabfilter-twin.rb
+++ b/Casks/f/fabfilter-twin.rb
@@ -12,8 +12,6 @@ cask "fabfilter-twin" do
     regex(/FabFilter\s+Twin.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Twin #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Twin.#{version.major}"

--- a/Casks/f/fabfilter-volcano.rb
+++ b/Casks/f/fabfilter-volcano.rb
@@ -12,8 +12,6 @@ cask "fabfilter-volcano" do
     regex(/FabFilter\s+Volcano.*?v?(\d+(?:\.\d+)+)/im)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FabFilter Volcano #{version} Installer.pkg"
 
   uninstall pkgutil: "com.fabfilter.Volcano.#{version.major}"

--- a/Casks/f/fanny.rb
+++ b/Casks/f/fanny.rb
@@ -12,8 +12,6 @@ cask "fanny" do
     regex(%r{href=.*?FannyWidget\.zip["' >].*?v?(\d+(?:\.\d+)+).*?</a>}im)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   # The url is unversioned, but the download returns an app directory with a version number
   rename "FannyWidget*", "FannyWidget"
 

--- a/Casks/f/far2l.rb
+++ b/Casks/f/far2l.rb
@@ -2,12 +2,7 @@ cask "far2l" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
   version "2.6.5"
 
-  on_mojave :or_older do
-    sha256 "2bbdcc7531ee0449731a45a07e15739d269ec83cbeca35fa89f15ff9eb9b208c"
-
-    url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.11-x64.dmg"
-  end
-  on_catalina do
+  on_catalina :or_older do
     sha256 "10b1dd4f5302981b0de437c316d8396f75da0abb61c97a67d556e2fa068205f5"
 
     url "https://github.com/elfmz/far2l/releases/download/v_#{version}/far2l-#{version}-beta-MacOS-10.15-x64.dmg"
@@ -27,8 +22,6 @@ cask "far2l" do
     regex(/v?(\d+(?:\.\d+)+(?:\w)*)/i)
     strategy :github_latest
   end
-
-  depends_on macos: ">= :el_capitan"
 
   app "far2l.app"
 

--- a/Casks/f/fastdmg.rb
+++ b/Casks/f/fastdmg.rb
@@ -12,8 +12,6 @@ cask "fastdmg" do
     regex(/href=.*?FastDMG[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "FastDMG.app"
 
   zap trash: "~/Library/Preferences/org.sveinbjorn.FastDMG.plist"

--- a/Casks/f/fastmarks.rb
+++ b/Casks/f/fastmarks.rb
@@ -13,7 +13,6 @@ cask "fastmarks" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Fastmarks.app"
 

--- a/Casks/f/fastrawviewer.rb
+++ b/Casks/f/fastrawviewer.rb
@@ -12,8 +12,6 @@ cask "fastrawviewer" do
     regex(/FastRawViewer[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "FastRawViewer.app"
 
   zap trash: "~/Library/Preferences/com.libraw-llc.FastRawViewer.plist"

--- a/Casks/f/fastscripts.rb
+++ b/Casks/f/fastscripts.rb
@@ -13,7 +13,6 @@ cask "fastscripts" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FastScripts.app"
 

--- a/Casks/f/fathom.rb
+++ b/Casks/f/fathom.rb
@@ -18,8 +18,6 @@ cask "fathom" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Fathom.app"
 
   uninstall quit: [

--- a/Casks/f/favro.rb
+++ b/Casks/f/favro.rb
@@ -14,8 +14,6 @@ cask "favro" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Favro.app"
 
   zap trash: [

--- a/Casks/f/faxbot.rb
+++ b/Casks/f/faxbot.rb
@@ -9,8 +9,6 @@ cask "faxbot" do
 
   disable! date: "2025-08-03", because: :no_longer_available
 
-  depends_on macos: ">= :sierra"
-
   app "Faxbot.app"
 
   zap trash: [

--- a/Casks/f/fedora-media-writer.rb
+++ b/Casks/f/fedora-media-writer.rb
@@ -18,8 +18,6 @@ cask "fedora-media-writer" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "FedoraMediaWriter.app"
 
   zap trash: [

--- a/Casks/f/feed-the-beast.rb
+++ b/Casks/f/feed-the-beast.rb
@@ -23,7 +23,6 @@ cask "feed-the-beast" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FTB Electron App.app"
 

--- a/Casks/f/feishu.rb
+++ b/Casks/f/feishu.rb
@@ -29,7 +29,6 @@ cask "feishu" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "Lark.app", target: "Feishu.app"

--- a/Casks/f/fellow.rb
+++ b/Casks/f/fellow.rb
@@ -13,7 +13,6 @@ cask "fellow" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Fellow.app"
 

--- a/Casks/f/fetch-app.rb
+++ b/Casks/f/fetch-app.rb
@@ -12,8 +12,6 @@ cask "fetch-app" do
     regex(/href=.*Fetch[._-]v?(\d+(?:\.\d+)+)\.zip"/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fetch.app"
 
   zap trash: [

--- a/Casks/f/ff-works.rb
+++ b/Casks/f/ff-works.rb
@@ -13,7 +13,6 @@ cask "ff-works" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "ff·Works.app"
 

--- a/Casks/f/fig.rb
+++ b/Casks/f/fig.rb
@@ -11,7 +11,6 @@ cask "fig" do
   disable! date: "2025-08-03", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Fig.app"
   binary "#{appdir}/Fig.app/Contents/MacOS/fig-darwin-universal", target: "fig"

--- a/Casks/f/fightcade.rb
+++ b/Casks/f/fightcade.rb
@@ -14,8 +14,6 @@ cask "fightcade" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fightcade#{version.major}.app"
 
   zap trash: [

--- a/Casks/f/figma.rb
+++ b/Casks/f/figma.rb
@@ -18,7 +18,6 @@ cask "figma" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Figma.app"
 

--- a/Casks/f/figma@beta.rb
+++ b/Casks/f/figma@beta.rb
@@ -17,8 +17,6 @@ cask "figma@beta" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Figma Beta.app"
 
   zap trash: [

--- a/Casks/f/file-juicer.rb
+++ b/Casks/f/file-juicer.rb
@@ -12,8 +12,6 @@ cask "file-juicer" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "File Juicer.app"
 
   zap trash: [

--- a/Casks/f/filebot.rb
+++ b/Casks/f/filebot.rb
@@ -17,8 +17,6 @@ cask "filebot" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "FileBot.app"
   binary "#{appdir}/FileBot.app/Contents/MacOS/filebot.sh", target: "filebot"
   bash_completion "#{appdir}/FileBot.app/Contents/Resources/bash_completion.d/filebot_completion", target: "filebot"

--- a/Casks/f/filemonitor.rb
+++ b/Casks/f/filemonitor.rb
@@ -13,8 +13,6 @@ cask "filemonitor" do
     regex(/href=.*?FileMonitor[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "FileMonitor.app"
   binary "#{appdir}/FileMonitor.app/Contents/MacOS/FileMonitor", target: "filemonitor"
 

--- a/Casks/f/final-cut-library-manager.rb
+++ b/Casks/f/final-cut-library-manager.rb
@@ -11,8 +11,6 @@ cask "final-cut-library-manager" do
   deprecate! date: "2024-04-03", because: :discontinued
   disable! date: "2025-04-03", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Final Cut Library Manager.app"
 
   zap trash: [

--- a/Casks/f/final-fantasy-xiv-online.rb
+++ b/Casks/f/final-fantasy-xiv-online.rb
@@ -14,7 +14,6 @@ cask "final-fantasy-xiv-online" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "FINAL FANTASY XIV ONLINE.app"
 

--- a/Casks/f/finalshell.rb
+++ b/Casks/f/finalshell.rb
@@ -14,8 +14,6 @@ cask "finalshell" do
     regex(/版本号?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "finalshell_macos_#{arch}.pkg"
 
   uninstall quit:    "finalshellinstall.all",

--- a/Casks/f/find-any-file.rb
+++ b/Casks/f/find-any-file.rb
@@ -14,7 +14,6 @@ cask "find-any-file" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Find Any File.app"
 

--- a/Casks/f/findergo.rb
+++ b/Casks/f/findergo.rb
@@ -9,8 +9,6 @@ cask "findergo" do
 
   deprecate! date: "2025-02-22", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "FinderGo.app"
 
   caveats do

--- a/Casks/f/firebird-emu.rb
+++ b/Casks/f/firebird-emu.rb
@@ -7,8 +7,6 @@ cask "firebird-emu" do
   desc "TI Nspire calculator emulator"
   homepage "https://github.com/nspire-emus/firebird"
 
-  depends_on macos: ">= :high_sierra"
-
   app "firebird-emu.app"
 
   zap trash: "~/Library/Preferences/org.firebird-emus.firebird-emu.plist"

--- a/Casks/f/firefly-iota-desktop.rb
+++ b/Casks/f/firefly-iota-desktop.rb
@@ -13,7 +13,6 @@ cask "firefly-iota-desktop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Firefly.app"
 

--- a/Casks/f/firefly-shimmer.rb
+++ b/Casks/f/firefly-shimmer.rb
@@ -14,7 +14,6 @@ cask "firefly-shimmer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Firefly Shimmer.app"
 

--- a/Casks/f/firefox.rb
+++ b/Casks/f/firefox.rb
@@ -433,7 +433,6 @@ cask "firefox" do
     "firefox@cn",
     "firefox@esr",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Firefox.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/f/firefox@beta.rb
+++ b/Casks/f/firefox@beta.rb
@@ -109,7 +109,6 @@ cask "firefox@beta" do
     "firefox@cn",
     "firefox@esr",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Firefox.app"
 

--- a/Casks/f/firefox@cn.rb
+++ b/Casks/f/firefox@cn.rb
@@ -18,7 +18,6 @@ cask "firefox@cn" do
     "firefox@beta",
     "firefox@esr",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Firefox.app"
 

--- a/Casks/f/firefox@developer-edition.rb
+++ b/Casks/f/firefox@developer-edition.rb
@@ -84,7 +84,6 @@ cask "firefox@developer-edition" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Firefox Developer Edition.app"
 

--- a/Casks/f/firefox@esr.rb
+++ b/Casks/f/firefox@esr.rb
@@ -230,7 +230,6 @@ cask "firefox@esr" do
     "firefox@beta",
     "firefox@cn",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Firefox.app"
 

--- a/Casks/f/firefox@nightly.rb
+++ b/Casks/f/firefox@nightly.rb
@@ -94,7 +94,6 @@ cask "firefox@nightly" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Firefox Nightly.app"
 

--- a/Casks/f/firestorm.rb
+++ b/Casks/f/firestorm.rb
@@ -14,8 +14,6 @@ cask "firestorm" do
     skip "Cannot be fetched due to Cloudflare protections"
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Firestorm-Releasex64.app"
 
   zap trash: [

--- a/Casks/f/fireworks.rb
+++ b/Casks/f/fireworks.rb
@@ -12,8 +12,6 @@ cask "fireworks" do
     regex(/Download\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fireworks.app"
 
   zap trash: [

--- a/Casks/f/fiscript.rb
+++ b/Casks/f/fiscript.rb
@@ -9,8 +9,6 @@ cask "fiscript" do
   deprecate! date: "2024-07-10", because: :unmaintained
   disable! date: "2025-07-10", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "FiScript.app"
 
   zap trash: [

--- a/Casks/f/flameshot.rb
+++ b/Casks/f/flameshot.rb
@@ -18,8 +18,6 @@ cask "flameshot" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "flameshot.app"
 
   uninstall quit: "org.flameshot.flameshot"

--- a/Casks/f/fldigi.rb
+++ b/Casks/f/fldigi.rb
@@ -13,8 +13,6 @@ cask "fldigi" do
     regex(%r{url=.*?/fldigi[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "fldigi-#{version}.app"
 
   zap trash: "~/.fldigi"

--- a/Casks/f/fleet.rb
+++ b/Casks/f/fleet.rb
@@ -18,8 +18,6 @@ cask "fleet" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fleet.app"
   binary "#{appdir}/Fleet.app/Contents/app/bin/fleet"
 

--- a/Casks/f/flexoptix.rb
+++ b/Casks/f/flexoptix.rb
@@ -18,7 +18,6 @@ cask "flexoptix" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FLEXOPTIX App.app"
 

--- a/Casks/f/flic.rb
+++ b/Casks/f/flic.rb
@@ -13,8 +13,6 @@ cask "flic" do
     regex(/Flic\.(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Flic.app"
 
   zap trash: [

--- a/Casks/f/floorp.rb
+++ b/Casks/f/floorp.rb
@@ -14,7 +14,6 @@ cask "floorp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Floorp.app"
 

--- a/Casks/f/flotato.rb
+++ b/Casks/f/flotato.rb
@@ -11,8 +11,6 @@ cask "flotato" do
   deprecate! date: "2024-07-15", because: :unmaintained
   disable! date: "2025-07-15", because: :unmaintained
 
-  depends_on macos: ">= :high_sierra"
-
   app "Flotato.app"
 
   zap trash: [

--- a/Casks/f/flox.rb
+++ b/Casks/f/flox.rb
@@ -16,7 +16,6 @@ cask "flox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "flox-#{version}.#{arch}-darwin.pkg"
 

--- a/Casks/f/flrig.rb
+++ b/Casks/f/flrig.rb
@@ -13,8 +13,6 @@ cask "flrig" do
     regex(%r{url=.*?/flrig[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "flrig-#{version}.app"
 
   zap trash: "~/.flrig"

--- a/Casks/f/fluent-reader.rb
+++ b/Casks/f/fluent-reader.rb
@@ -13,8 +13,6 @@ cask "fluent-reader" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Fluent Reader.app"
 
   zap trash: [

--- a/Casks/f/fluid.rb
+++ b/Casks/f/fluid.rb
@@ -12,8 +12,6 @@ cask "fluid" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Fluid.app"
 
   zap trash: [

--- a/Casks/f/fluor.rb
+++ b/Casks/f/fluor.rb
@@ -23,7 +23,6 @@ cask "fluor" do
   homepage "https://github.com/Pyroh/Fluor"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Fluor.app"
 

--- a/Casks/f/flutterflow.rb
+++ b/Casks/f/flutterflow.rb
@@ -13,8 +13,6 @@ cask "flutterflow" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :catalina"
-
   app "FlutterFlow.app"
 
   zap trash: [

--- a/Casks/f/flycast.rb
+++ b/Casks/f/flycast.rb
@@ -12,8 +12,6 @@ cask "flycast" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Flycast.app"
 
   zap rmdir: [

--- a/Casks/f/flyenv.rb
+++ b/Casks/f/flyenv.rb
@@ -17,7 +17,6 @@ cask "flyenv" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FlyEnv.app"
 

--- a/Casks/f/flykey.rb
+++ b/Casks/f/flykey.rb
@@ -12,8 +12,6 @@ cask "flykey" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :catalina"
-
   app "FlyKey.app"
 
   zap trash: [

--- a/Casks/f/focu.rb
+++ b/Casks/f/focu.rb
@@ -16,7 +16,6 @@ cask "focu" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
   depends_on arch: :arm64
 
   app "Focu.app"

--- a/Casks/f/focus.rb
+++ b/Casks/f/focus.rb
@@ -12,8 +12,6 @@ cask "focus" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Focus.app"
 
   uninstall quit: "BradJasper.focus"

--- a/Casks/f/focusany.rb
+++ b/Casks/f/focusany.rb
@@ -11,8 +11,6 @@ cask "focusany" do
   desc "Open source desktop toolbox"
   homepage "https://focusany.com/"
 
-  depends_on macos: ">= :catalina"
-
   app "FocusAny.app"
 
   zap trash: [

--- a/Casks/f/focused.rb
+++ b/Casks/f/focused.rb
@@ -14,7 +14,6 @@ cask "focused" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Focused.app"
 

--- a/Casks/f/folding-at-home.rb
+++ b/Casks/f/folding-at-home.rb
@@ -13,7 +13,6 @@ cask "folding-at-home" do
   end
 
   conflicts_with cask: "folding-at-home@beta"
-  depends_on macos: ">= :high_sierra"
 
   pkg "fah-client_#{version}_universal.pkg"
 

--- a/Casks/f/folding-at-home@beta.rb
+++ b/Casks/f/folding-at-home@beta.rb
@@ -13,7 +13,6 @@ cask "folding-at-home@beta" do
   end
 
   conflicts_with cask: "folding-at-home"
-  depends_on macos: ">= :high_sierra"
 
   pkg "fah-client_#{version}_universal.pkg"
 

--- a/Casks/f/foldit.rb
+++ b/Casks/f/foldit.rb
@@ -14,7 +14,6 @@ cask "foldit" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Foldit.app"
 

--- a/Casks/f/follow@alpha.rb
+++ b/Casks/f/follow@alpha.rb
@@ -14,7 +14,6 @@ cask "follow@alpha" do
     "follow",
     "follow@nightly",
   ]
-  depends_on macos: ">= :catalina"
 
   app "Follow.app"
 

--- a/Casks/f/folx.rb
+++ b/Casks/f/folx.rb
@@ -14,7 +14,6 @@ cask "folx" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Folx.app"
 

--- a/Casks/f/fontbase.rb
+++ b/Casks/f/fontbase.rb
@@ -13,7 +13,6 @@ cask "fontbase" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FontBase.app"
 

--- a/Casks/f/fontforge-app.rb
+++ b/Casks/f/fontforge-app.rb
@@ -21,8 +21,6 @@ cask "fontforge-app" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "FontForge.app"
 
   zap trash: "~/.cache/fontforge"

--- a/Casks/f/fontlab.rb
+++ b/Casks/f/fontlab.rb
@@ -14,7 +14,6 @@ cask "fontlab" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FontLab #{version.major}.app"
 

--- a/Casks/f/forecast.rb
+++ b/Casks/f/forecast.rb
@@ -13,8 +13,6 @@ cask "forecast" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Forecast.app"
 
   zap trash: [

--- a/Casks/f/fork.rb
+++ b/Casks/f/fork.rb
@@ -19,7 +19,6 @@ cask "fork" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Fork.app"
   binary "#{appdir}/Fork.app/Contents/Resources/fork_cli", target: "fork"

--- a/Casks/f/forkgram-telegram.rb
+++ b/Casks/f/forkgram-telegram.rb
@@ -32,8 +32,6 @@ cask "forkgram-telegram" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   # Renamed to avoid conflict with telegram
   app "Telegram.app", target: "Forkgram.app"
 

--- a/Casks/f/fotokasten.rb
+++ b/Casks/f/fotokasten.rb
@@ -14,7 +14,6 @@ cask "fotokasten" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Fotokasten.app"
 

--- a/Casks/f/foxit-pdf-editor.rb
+++ b/Casks/f/foxit-pdf-editor.rb
@@ -15,8 +15,6 @@ cask "foxit-pdf-editor" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "FoxitPDFEditor#{version.major_minor_patch.no_dots}.L10N.Setup.pkg"
 
   uninstall launchctl: "com.foxit.PDFEditorUpdateService",

--- a/Casks/f/foxmail.rb
+++ b/Casks/f/foxmail.rb
@@ -13,8 +13,6 @@ cask "foxmail" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Foxmail.app"
 
   zap trash: [

--- a/Casks/f/fractal-bot.rb
+++ b/Casks/f/fractal-bot.rb
@@ -12,8 +12,6 @@ cask "fractal-bot" do
     regex(/Version\s*(\d+(?:\.\d+)+).*?\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fractal-Bot.app"
 
   zap trash: "~/Library/Application Support/Fractal Audio/Fractal-Bot"

--- a/Casks/f/framer.rb
+++ b/Casks/f/framer.rb
@@ -16,7 +16,6 @@ cask "framer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Framer.app"
 

--- a/Casks/f/franz.rb
+++ b/Casks/f/franz.rb
@@ -12,7 +12,6 @@ cask "franz" do
   homepage "https://meetfranz.com/"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Franz.app"
 

--- a/Casks/f/frappe-books.rb
+++ b/Casks/f/frappe-books.rb
@@ -16,8 +16,6 @@ cask "frappe-books" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Frappe Books.app"
 
   zap trash: [

--- a/Casks/f/free-download-manager.rb
+++ b/Casks/f/free-download-manager.rb
@@ -13,7 +13,6 @@ cask "free-download-manager" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Free Download Manager.app"
 

--- a/Casks/f/free-gpgmail.rb
+++ b/Casks/f/free-gpgmail.rb
@@ -46,7 +46,6 @@ cask "free-gpgmail" do
   end
 
   depends_on cask: "gpg-suite-no-mail"
-  depends_on macos: ">= :mojave"
 
   artifact "Free-GPGMail_#{version.csv.first.major}.mailbundle", target: "~/Library/Mail/Bundles/Free-GPGMail_#{version.csv.first.major}.mailbundle"
 

--- a/Casks/f/free-podcast-transcription.rb
+++ b/Casks/f/free-podcast-transcription.rb
@@ -20,8 +20,6 @@ cask "free-podcast-transcription" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Free Podcast Transcription.app"
 
   zap trash: [

--- a/Casks/f/free-ruler.rb
+++ b/Casks/f/free-ruler.rb
@@ -8,8 +8,6 @@ cask "free-ruler" do
   desc "Horizontal and vertical rulers"
   homepage "https://www.pascal.com/freeruler"
 
-  depends_on macos: ">= :mojave"
-
   app "Free Ruler.app"
 
   zap trash: "~/Library/Containers/com.pascal.freeruler"

--- a/Casks/f/free42-binary.rb
+++ b/Casks/f/free42-binary.rb
@@ -12,8 +12,6 @@ cask "free42-binary" do
     regex(/:\s*release\s*(\d+(?:\.\d+)+[a-z]?)\s*(?:$|\([^\n)]*MacOS)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Free42 Binary.app"
 
   zap trash: [

--- a/Casks/f/free42-decimal.rb
+++ b/Casks/f/free42-decimal.rb
@@ -12,8 +12,6 @@ cask "free42-decimal" do
     regex(/:\s*release\s*(\d+(?:\.\d+)+[a-z]?)\s*(?:$|\([^\n)]*MacOS)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Free42 Decimal.app"
 
   zap trash: [

--- a/Casks/f/freecad.rb
+++ b/Casks/f/freecad.rb
@@ -19,8 +19,6 @@ cask "freecad" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "FreeCAD.app"
 
   zap trash: [

--- a/Casks/f/freeorion.rb
+++ b/Casks/f/freeorion.rb
@@ -13,8 +13,6 @@ cask "freeorion" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "FreeOrion.app"
 
   zap trash: [

--- a/Casks/f/freeplane.rb
+++ b/Casks/f/freeplane.rb
@@ -16,8 +16,6 @@ cask "freeplane" do
     regex(%r{url=.*?/Freeplane[._-]v?(\d+(?:\.\d+)+)(?:[._-]#{arch})?\.dmg}i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Freeplane.app"
 
   zap trash: "~/Library/Saved Application State/org.freeplane.launcher.savedState"

--- a/Casks/f/freeshow.rb
+++ b/Casks/f/freeshow.rb
@@ -17,7 +17,6 @@ cask "freeshow" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FreeShow.app"
 

--- a/Casks/f/freetube.rb
+++ b/Casks/f/freetube.rb
@@ -32,8 +32,6 @@ cask "freetube" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "FreeTube.app"
 
   uninstall quit: "io.freetubeapp.freetube"

--- a/Casks/f/freeyourmusic.rb
+++ b/Casks/f/freeyourmusic.rb
@@ -17,7 +17,6 @@ cask "freeyourmusic" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "FreeYourMusic.app"
 

--- a/Casks/f/freeze.rb
+++ b/Casks/f/freeze.rb
@@ -12,8 +12,6 @@ cask "freeze" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Freeze.app"
 
   zap trash: [

--- a/Casks/f/fresh.rb
+++ b/Casks/f/fresh.rb
@@ -12,8 +12,6 @@ cask "fresh" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fresh.app"
 
   zap trash: [

--- a/Casks/f/frhelper.rb
+++ b/Casks/f/frhelper.rb
@@ -9,8 +9,6 @@ cask "frhelper" do
   desc "French-Chinese dictionary and learning tool"
   homepage "https://www.eudic.net/v4/fr/app/frhelper"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Frhelper.app"
 
   uninstall quit: [

--- a/Casks/f/fsnotes.rb
+++ b/Casks/f/fsnotes.rb
@@ -13,8 +13,6 @@ cask "fsnotes" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :mojave"
-
   app "FSNotes.app"
 
   zap trash: [

--- a/Casks/f/ftdi-vcp-driver.rb
+++ b/Casks/f/ftdi-vcp-driver.rb
@@ -1,90 +1,51 @@
 cask "ftdi-vcp-driver" do
-  on_mojave :or_older do
-    version "2.4.4"
-    sha256 "f3343fc223f667e1dab0ecf9fd8fade525c261f120a1cd6b29f8806fa6bc4d8b"
+  version "1.5.0,2022,06"
+  sha256 "f535d604d5098c4ecde0f213a80732cd45906339472ae30c0723959336a50b9c"
 
-    url "https://www.ftdichip.com/Drivers/VCP/MacOSX/FTDIUSBSerialDriver_v#{version.dots_to_underscores}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "FTDIUSBSerial.pkg"
-
-    uninstall kext:    "com.FTDI.driver.FTDIUSBSerialDriver",
-              pkgutil: [
-                "com.FTDI.driver.FTDIUSBSerialDriver",
-                "com.FTDI.ftdiusbserialdriverinstaller.*",
-              ],
-              delete:  "/Library/Extensions/FTDIUSBSerialDriver.kext"
-
-    caveats do
-      reboot
-
-      <<~EOS
-        If you don't want to reboot, you can load the driver using the following
-        command:
-          sudo /sbin/kextload -b com.FTDI.driver.FTDIUSBSerialDriver
-
-        Once you've rebooted or loaded the driver, you can (re)connect your FTDI
-        device and it will show up in /dev, usually like this:
-
-          /dev/tty.usbserial-XXXXXXXX
-
-        where XXXXXXXX is a random ID, based on the serial number.
-      EOS
-    end
-  end
-  on_catalina :or_newer do
-    version "1.5.0,2022,06"
-    sha256 "f535d604d5098c4ecde0f213a80732cd45906339472ae30c0723959336a50b9c"
-
-    url "https://ftdichip.com/wp-content/uploads/#{version.csv.second}/#{version.csv.third}/FTDIUSBSerialDextInstaller_#{version.csv.first.dots_to_underscores}.dmg"
-
-    livecheck do
-      url "https://ftdichip.com/drivers/vcp-drivers/"
-      regex(%r{href=.*?/(\d+)/(\d+)/FTDIUSBSerialDextInstaller[._-]v?(\d+(?:[._]\d+)+)\.dmg}i)
-      strategy :page_match do |page, regex|
-        page.scan(regex).map { |match| "#{match[2].tr("_", ".")},#{match[0]},#{match[1]}" }
-      end
-    end
-
-    # App must be installed in `/Applications`.
-    app "FTDIUSBSerialDextInstaller_#{version.csv.first.dots_to_underscores}.app",
-        target: "/Applications/FTDIUSBSerialDextInstaller.app"
-    installer manual: "/Applications/FTDIUSBSerialDextInstaller.app"
-
-    # `systemextensionsctl` currently only works when SIP is disabled and there
-    # doesn't seem to be any other way to uninstall a driver extension.
-    # uninstall script: {
-    #             executable: "systemextensionsctl",
-    #             args:       ["uninstall", "-", "com.ftdi.vcp.dext"],
-    #           }
-
-    uninstall delete: [
-      "~/Library/Application Scripts/com.ftdi.vcp.dext",
-      "~/Library/Containers/com.ftdi.vcp.dext",
-    ]
-
-    caveats do
-      reboot
-
-      <<~EOS
-        Once you've rebooted, you can (re)connect your FTDI
-        device and it will show up in /dev, usually like this:
-
-          /dev/tty.usbserial-XXXXXXXX
-
-        where XXXXXXXX is a random ID, based on the serial number.
-
-        To uninstall the driver, you must use the GUI to move the
-        application from /Applications/FTDIUSBSerialDextInstaller.app to Trash,
-        otherwise the system extension will not be removed.
-      EOS
-    end
-  end
-
+  url "https://ftdichip.com/wp-content/uploads/#{version.csv.second}/#{version.csv.third}/FTDIUSBSerialDextInstaller_#{version.csv.first.dots_to_underscores}.dmg"
   name "FTDI VCP Driver"
   desc "Virtual COM port driver"
   homepage "https://www.ftdichip.com/Drivers/VCP.htm"
+
+  livecheck do
+    url "https://ftdichip.com/drivers/vcp-drivers/"
+    regex(%r{href=.*?/(\d+)/(\d+)/FTDIUSBSerialDextInstaller[._-]v?(\d+(?:[._]\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[2].tr("_", ".")},#{match[0]},#{match[1]}" }
+    end
+  end
+
+  # App must be installed in `/Applications`.
+  app "FTDIUSBSerialDextInstaller_#{version.csv.first.dots_to_underscores}.app",
+      target: "/Applications/FTDIUSBSerialDextInstaller.app"
+  installer manual: "/Applications/FTDIUSBSerialDextInstaller.app"
+
+  # `systemextensionsctl` currently only works when SIP is disabled and there
+  # doesn't seem to be any other way to uninstall a driver extension.
+  # uninstall script: {
+  #             executable: "systemextensionsctl",
+  #             args:       ["uninstall", "-", "com.ftdi.vcp.dext"],
+  #           }
+
+  uninstall delete: [
+    "~/Library/Application Scripts/com.ftdi.vcp.dext",
+    "~/Library/Containers/com.ftdi.vcp.dext",
+  ]
+
+  caveats do
+    reboot
+
+    <<~EOS
+      Once you've rebooted, you can (re)connect your FTDI
+      device and it will show up in /dev, usually like this:
+
+        /dev/tty.usbserial-XXXXXXXX
+
+      where XXXXXXXX is a random ID, based on the serial number.
+
+      To uninstall the driver, you must use the GUI to move the
+      application from /Applications/FTDIUSBSerialDextInstaller.app to Trash,
+      otherwise the system extension will not be removed.
+    EOS
+  end
 end

--- a/Casks/f/fujifilm-tether-app.rb
+++ b/Casks/f/fujifilm-tether-app.rb
@@ -18,8 +18,6 @@ cask "fujifilm-tether-app" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "FUJIFILM_TetherApp_Mac#{version.csv.first.no_dots}.pkg"
 
   uninstall pkgutil: "com.fujifilm.FUJIFILM_TetherApp_Mac"

--- a/Casks/f/fujitsu-scansnap-home.rb
+++ b/Casks/f/fujitsu-scansnap-home.rb
@@ -17,7 +17,6 @@ cask "fujitsu-scansnap-home" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
   container nested: "Download/MacSSHomeInstaller_#{version.dots_to_underscores}.dmg"
 
   pkg "ScanSnap Home.pkg"

--- a/Casks/f/funter.rb
+++ b/Casks/f/funter.rb
@@ -12,8 +12,6 @@ cask "funter" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Funter #{version.major}.app"
 
   # MacCleaner files are part of the cask

--- a/Casks/f/furtherance.rb
+++ b/Casks/f/furtherance.rb
@@ -13,8 +13,6 @@ cask "furtherance" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Furtherance.app"
 
   zap trash: "~/Library/Application Support/io.unobserved.furtherance"

--- a/Casks/f/futubull.rb
+++ b/Casks/f/futubull.rb
@@ -21,8 +21,6 @@ cask "futubull" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "富途牛牛.app", target: "Futubull.app"
 

--- a/Casks/f/futubull@legacy.rb
+++ b/Casks/f/futubull@legacy.rb
@@ -22,7 +22,6 @@ cask "futubull@legacy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "FutuNiuniu.app"
 

--- a/Casks/f/fuwari.rb
+++ b/Casks/f/fuwari.rb
@@ -13,8 +13,6 @@ cask "fuwari" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Fuwari v#{version}/Fuwari.app"
 
   uninstall quit: "com.appknop.Fuwari"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.