### PR TITLE
[g]: remove pre-Catalina references

### DIFF
--- a/Casks/g/gamma-control.rb
+++ b/Casks/g/gamma-control.rb
@@ -12,8 +12,6 @@ cask "gamma-control" do
     regex(/href=.*?gamma[._-]control[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Gamma Control.app"
 
   zap trash: [

--- a/Casks/g/gaphor.rb
+++ b/Casks/g/gaphor.rb
@@ -11,8 +11,6 @@ cask "gaphor" do
   desc "UML/SysML modelling tool"
   homepage "https://gaphor.org/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Gaphor.app"
 
   uninstall quit: "Gaphor-#{version}"

--- a/Casks/g/garagesale.rb
+++ b/Casks/g/garagesale.rb
@@ -12,8 +12,6 @@ cask "garagesale" do
     regex(/href=.*?GarageSale[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "GarageSale.app"
 
   zap trash: [

--- a/Casks/g/garmin-basecamp.rb
+++ b/Casks/g/garmin-basecamp.rb
@@ -12,8 +12,6 @@ cask "garmin-basecamp" do
     regex(/name=["']?software_version["']?\s*content=["']?(\d+(?:\.\d+)+)["' >]/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "Install BaseCamp.pkg"
 
   uninstall quit:    [

--- a/Casks/g/gb-studio.rb
+++ b/Casks/g/gb-studio.rb
@@ -11,8 +11,6 @@ cask "gb-studio" do
   desc "Drag and drop retro game creator"
   homepage "https://www.gbstudio.dev/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "GB Studio.app"
 
   zap trash: [

--- a/Casks/g/gcollazo-mongodb.rb
+++ b/Casks/g/gcollazo-mongodb.rb
@@ -13,8 +13,6 @@ cask "gcollazo-mongodb" do
     regex(/^v?(\d+(?:\.\d+)+(?:-build[._-]?\d+)?)$/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "MongoDB.app"
 
   zap trash: [

--- a/Casks/g/gcs.rb
+++ b/Casks/g/gcs.rb
@@ -11,8 +11,6 @@ cask "gcs" do
   desc "Character sheet editor for the GURPS Fourth Edition roleplaying game"
   homepage "https://gurpscharactersheet.com/"
 
-  depends_on macos: ">= :mojave"
-
   app "GCS.app"
 
   zap trash: [

--- a/Casks/g/geany.rb
+++ b/Casks/g/geany.rb
@@ -15,8 +15,6 @@ cask "geany" do
     regex(/href=.*?geany[._-]v?(\d+(?:\.\d+)+)[._-]osx#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Geany.app"
 
   zap trash: [

--- a/Casks/g/geekbench.rb
+++ b/Casks/g/geekbench.rb
@@ -1,17 +1,5 @@
 cask "geekbench" do
-  on_sierra :or_older do
-    version "4.4.4"
-    sha256 "1fc2b87742cd27deaa184a753a57bfc5a8c81de34524e9fd318d6875be6ac5c9"
-  end
-  on_high_sierra do
-    version "5.5.1"
-    sha256 "04b06cb642e51230a3dfd07ce2d3a4ea696cb349583737622749174dc8747313"
-  end
-  on_mojave do
-    version "5.5.1"
-    sha256 "04b06cb642e51230a3dfd07ce2d3a4ea696cb349583737622749174dc8747313"
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "5.5.1"
     sha256 "04b06cb642e51230a3dfd07ce2d3a4ea696cb349583737622749174dc8747313"
   end

--- a/Casks/g/gemini.rb
+++ b/Casks/g/gemini.rb
@@ -20,7 +20,6 @@ cask "gemini" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Gemini #{version.major}.app"
 

--- a/Casks/g/genesis-plus.rb
+++ b/Casks/g/genesis-plus.rb
@@ -12,8 +12,6 @@ cask "genesis-plus" do
     regex(/<h2>Genesis\s+Plus\s+v?(\d+(?:\.\d+)+)[" <]/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Genesis Plus v#{version}/Genesis Plus.app"
 
   zap trash: [

--- a/Casks/g/geoda.rb
+++ b/Casks/g/geoda.rb
@@ -28,8 +28,6 @@ cask "geoda" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "GeoDa.app"
 
   # No zap stanza required

--- a/Casks/g/geogebra.rb
+++ b/Casks/g/geogebra.rb
@@ -20,8 +20,6 @@ cask "geogebra" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "GeoGebra Classic #{version.major}.app"
 
   uninstall quit:       "org.geogebra.mathapps",

--- a/Casks/g/get-iplayer-automator.rb
+++ b/Casks/g/get-iplayer-automator.rb
@@ -20,8 +20,6 @@ cask "get-iplayer-automator" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Get iPlayer Automator.app"
 
   zap trash: [

--- a/Casks/g/getoutline.rb
+++ b/Casks/g/getoutline.rb
@@ -24,8 +24,6 @@ cask "getoutline" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Outline.app"
 
   zap trash: [

--- a/Casks/g/gg.rb
+++ b/Casks/g/gg.rb
@@ -7,8 +7,6 @@ cask "gg" do
   desc "GUI for Jujutsu"
   homepage "https://github.com/gulbanana/gg"
 
-  depends_on macos: ">= :high_sierra"
-
   app "gg.app"
 
   zap trash: [

--- a/Casks/g/gifox.rb
+++ b/Casks/g/gifox.rb
@@ -23,7 +23,6 @@ cask "gifox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Gifox.app"
 

--- a/Casks/g/gimp.rb
+++ b/Casks/g/gimp.rb
@@ -37,7 +37,6 @@ cask "gimp" do
   homepage "https://www.gimp.org/"
 
   conflicts_with cask: "gimp@dev"
-  depends_on macos: ">= :high_sierra"
 
   app "GIMP.app"
   shimscript = "#{staged_path}/gimp.wrapper.sh"

--- a/Casks/g/gisto.rb
+++ b/Casks/g/gisto.rb
@@ -18,8 +18,6 @@ cask "gisto" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Gisto.app"
 
   zap trash: [

--- a/Casks/g/gitbutler.rb
+++ b/Casks/g/gitbutler.rb
@@ -22,7 +22,6 @@ cask "gitbutler" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "GitButler.app"
   binary "#{appdir}/GitButler.app/Contents/MacOS/but", target: "but"

--- a/Casks/g/gitdock.rb
+++ b/Casks/g/gitdock.rb
@@ -11,8 +11,6 @@ cask "gitdock" do
     url "https://gitlab.com/mvanremmerden/gitdock.git"
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "GitDock.app"
 
   zap trash: [

--- a/Casks/g/gitfiend.rb
+++ b/Casks/g/gitfiend.rb
@@ -19,7 +19,6 @@ cask "gitfiend" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "GitFiend.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/g/gitfinder.rb
+++ b/Casks/g/gitfinder.rb
@@ -13,7 +13,6 @@ cask "gitfinder" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "GitFinder.app"
 

--- a/Casks/g/github.rb
+++ b/Casks/g/github.rb
@@ -2,25 +2,9 @@ cask "github" do
   arch arm: "arm64", intel: "x64"
   platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
 
-  on_mojave :or_older do
-    version "3.3.13-1b0804db"
-    sha256 "df85436557e7b3d709cc702b751f180f48655a3241cce6a864e55cf5161d9a7a"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "3.5.2-14087268"
-    sha256 arm:   "c44c80c8197ae11a3e6029232a28aaa9f3a1f8c1cafde238681fdae97b944c5e",
-           intel: "26ab82296b66aff53aecc7baa71d423364edbcb98d675059a28260e97e55e444"
-
-    livecheck do
-      url "https://central.github.com/deployments/desktop/desktop/latest/#{platform}"
-      regex(%r{(\d+(?:\.\d+)[^/]*)/GitHubDesktop[._-]#{arch}\.zip}i)
-      strategy :header_match
-    end
-  end
+  version "3.5.2-14087268"
+  sha256 arm:   "c44c80c8197ae11a3e6029232a28aaa9f3a1f8c1cafde238681fdae97b944c5e",
+         intel: "26ab82296b66aff53aecc7baa71d423364edbcb98d675059a28260e97e55e444"
 
   url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop-#{arch}.zip",
       verified: "desktop.githubusercontent.com/"
@@ -28,9 +12,14 @@ cask "github" do
   desc "Desktop client for GitHub repositories"
   homepage "https://desktop.github.com/"
 
+  livecheck do
+    url "https://central.github.com/deployments/desktop/desktop/latest/#{platform}"
+    regex(%r{(\d+(?:\.\d+)[^/]*)/GitHubDesktop[._-]#{arch}\.zip}i)
+    strategy :header_match
+  end
+
   auto_updates true
   conflicts_with cask: "github@beta"
-  depends_on macos: ">= :high_sierra"
 
   app "GitHub Desktop.app"
   binary "#{appdir}/GitHub Desktop.app/Contents/Resources/app/static/github.sh", target: "github"

--- a/Casks/g/github@beta.rb
+++ b/Casks/g/github@beta.rb
@@ -20,7 +20,6 @@ cask "github@beta" do
 
   auto_updates true
   conflicts_with cask: "github"
-  depends_on macos: ">= :catalina"
 
   app "GitHub Desktop.app"
   binary "#{appdir}/GitHub Desktop.app/Contents/Resources/app/static/github.sh", target: "github"

--- a/Casks/g/gitkraken-on-premise-serverless.rb
+++ b/Casks/g/gitkraken-on-premise-serverless.rb
@@ -18,7 +18,6 @@ cask "gitkraken-on-premise-serverless" do
 
   auto_updates true
   conflicts_with cask: "gitkraken"
-  depends_on macos: ">= :el_capitan"
 
   app "GitKraken.app"
 

--- a/Casks/g/gitkraken.rb
+++ b/Casks/g/gitkraken.rb
@@ -21,7 +21,6 @@ cask "gitkraken" do
 
   auto_updates true
   conflicts_with cask: "gitkraken-on-premise-serverless"
-  depends_on macos: ">= :el_capitan"
 
   app "GitKraken.app"
 

--- a/Casks/g/gitlight.rb
+++ b/Casks/g/gitlight.rb
@@ -18,8 +18,6 @@ cask "gitlight" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "GitLight.app"
 
   zap trash: [

--- a/Casks/g/gitpigeon.rb
+++ b/Casks/g/gitpigeon.rb
@@ -9,8 +9,6 @@ cask "gitpigeon" do
   deprecate! date: "2024-04-10", because: :unmaintained
   disable! date: "2025-04-22", because: :unmaintained
 
-  depends_on macos: ">= :mojave"
-
   app "GitPigeon.app"
 
   zap trash: [

--- a/Casks/g/gitup-app.rb
+++ b/Casks/g/gitup-app.rb
@@ -14,7 +14,6 @@ cask "gitup-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "GitUp.app"
   binary "#{appdir}/GitUp.app/Contents/SharedSupport/gitup"

--- a/Casks/g/glance.rb
+++ b/Casks/g/glance.rb
@@ -9,8 +9,6 @@ cask "glance" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :catalina"
-
   app "Glance.app"
 
   zap trash: [

--- a/Casks/g/gnucash.rb
+++ b/Casks/g/gnucash.rb
@@ -24,8 +24,6 @@ cask "gnucash" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Gnucash.app"
 
   zap trash: [

--- a/Casks/g/godot-mono.rb
+++ b/Casks/g/godot-mono.rb
@@ -15,7 +15,6 @@ cask "godot-mono" do
   end
 
   depends_on cask: "dotnet-sdk"
-  depends_on macos: ">= :sierra"
 
   app "Godot_mono.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/g/godot.rb
+++ b/Casks/g/godot.rb
@@ -15,7 +15,6 @@ cask "godot" do
   end
 
   conflicts_with cask: "godot@3"
-  depends_on macos: ">= :high_sierra"
 
   app "Godot.app"
   binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"

--- a/Casks/g/godot@3.rb
+++ b/Casks/g/godot@3.rb
@@ -14,7 +14,6 @@ cask "godot@3" do
   end
 
   conflicts_with cask: "godot"
-  depends_on macos: ">= :sierra"
 
   app "Godot.app"
   binary "#{appdir}/Godot.app/Contents/MacOS/Godot", target: "godot"

--- a/Casks/g/gog-galaxy.rb
+++ b/Casks/g/gog-galaxy.rb
@@ -13,7 +13,6 @@ cask "gog-galaxy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "galaxy_client_#{version}.pkg"
 

--- a/Casks/g/goland.rb
+++ b/Casks/g/goland.rb
@@ -24,7 +24,6 @@ cask "goland" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "GoLand.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/g/goldendict.rb
+++ b/Casks/g/goldendict.rb
@@ -10,8 +10,6 @@ cask "goldendict" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "GoldenDict.app"
   binary "#{appdir}/GoldenDict.app/Contents/MacOS/GoldenDict"
 

--- a/Casks/g/gologin.rb
+++ b/Casks/g/gologin.rb
@@ -24,7 +24,6 @@ cask "gologin" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "GoLogin.app"
 

--- a/Casks/g/goodsync.rb
+++ b/Casks/g/goodsync.rb
@@ -12,8 +12,6 @@ cask "goodsync" do
     regex(/Version\sv?\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "GoodSync.app"
 
   zap trash: [

--- a/Casks/g/google-analytics-opt-out.rb
+++ b/Casks/g/google-analytics-opt-out.rb
@@ -11,8 +11,6 @@ cask "google-analytics-opt-out" do
     skip "No version information available"
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Google Analytics Opt Out.app"
 
   caveats do

--- a/Casks/g/google-chat-electron.rb
+++ b/Casks/g/google-chat-electron.rb
@@ -12,8 +12,6 @@ cask "google-chat-electron" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :catalina"
-
   app "google-chat-electron.app"
 
   zap trash: [

--- a/Casks/g/google-drive.rb
+++ b/Casks/g/google-drive.rb
@@ -17,7 +17,6 @@ cask "google-drive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   pkg "GoogleDrive.pkg"
 

--- a/Casks/g/google-web-designer.rb
+++ b/Casks/g/google-web-designer.rb
@@ -12,8 +12,6 @@ cask "google-web-designer" do
     regex(/Shell\s+Build\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Google Web Designer.app"
 
   zap trash: [

--- a/Casks/g/gosign.rb
+++ b/Casks/g/gosign.rb
@@ -12,8 +12,6 @@ cask "gosign" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "GoSign-Desktop.app"
 
   zap trash: [

--- a/Casks/g/goxel.rb
+++ b/Casks/g/goxel.rb
@@ -8,8 +8,6 @@ cask "goxel" do
   desc "Open Source Voxel Editor"
   homepage "https://goxel.xyz/"
 
-  depends_on macos: ">= :mojave"
-
   app "Goxel.app"
 
   zap trash: [

--- a/Casks/g/gpg-suite-no-mail.rb
+++ b/Casks/g/gpg-suite-no-mail.rb
@@ -17,7 +17,6 @@ cask "gpg-suite-no-mail" do
     "gpg-suite-pinentry",
     "gpg-suite@nightly",
   ]
-  depends_on macos: ">= :mojave"
 
   pkg "Install.pkg",
       choices: [

--- a/Casks/g/gpg-suite-pinentry.rb
+++ b/Casks/g/gpg-suite-pinentry.rb
@@ -17,7 +17,6 @@ cask "gpg-suite-pinentry" do
     "gpg-suite-no-mail",
     "gpg-suite@nightly",
   ]
-  depends_on macos: ">= :mojave"
 
   pkg "Install.pkg",
       choices: [

--- a/Casks/g/gpg-suite.rb
+++ b/Casks/g/gpg-suite.rb
@@ -18,7 +18,6 @@ cask "gpg-suite" do
     "gpg-suite-pinentry",
     "gpg-suite@nightly",
   ]
-  depends_on macos: ">= :mojave"
 
   pkg "Install.pkg"
 

--- a/Casks/g/gpg-suite@nightly.rb
+++ b/Casks/g/gpg-suite@nightly.rb
@@ -18,7 +18,6 @@ cask "gpg-suite@nightly" do
     "gpg-suite-no-mail",
     "gpg-suite-pinentry",
   ]
-  depends_on macos: ">= :mojave"
 
   pkg "Install.pkg"
 

--- a/Casks/g/grads.rb
+++ b/Casks/g/grads.rb
@@ -13,8 +13,6 @@ cask "grads" do
     regex(/href=.*?grads[._-]?v?(\d+(?:\.\d+)+)-bin-darwin.*?\.t/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   binary "grads-#{version}/bin/bufrscan"
   binary "grads-#{version}/bin/grads"
   binary "grads-#{version}/bin/grib2scan"

--- a/Casks/g/grammarly-desktop.rb
+++ b/Casks/g/grammarly-desktop.rb
@@ -13,7 +13,6 @@ cask "grammarly-desktop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Grammarly Installer.app", target: "Grammarly Desktop.app"
 

--- a/Casks/g/gramps.rb
+++ b/Casks/g/gramps.rb
@@ -28,8 +28,6 @@ cask "gramps" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Gramps.app"
 
   zap trash: [

--- a/Casks/g/grandperspective.rb
+++ b/Casks/g/grandperspective.rb
@@ -1,17 +1,7 @@
 cask "grandperspective" do
   on_catalina :or_older do
-    on_high_sierra :or_older do
-      version "3.0.1"
-      sha256 "64faab94df5ac39abbeb9e869a6c429d3441c3796ef67f79dab232ba7f0cb222"
-    end
-    on_mojave do
-      version "3.3"
-      sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
-    end
-    on_catalina do
-      version "3.3"
-      sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
-    end
+    version "3.3"
+    sha256 "2e4a0f3b12be447cfdb1496c0292a57631acd7b24f568cb7d7c9d992458e90cf"
 
     livecheck do
       skip "Legacy version"
@@ -26,8 +16,6 @@ cask "grandperspective" do
   name "GrandPerspective"
   desc "Graphically shows disk usage within a file system"
   homepage "https://grandperspectiv.sourceforge.net/"
-
-  depends_on macos: ">= :el_capitan"
 
   app "GrandPerspective.app"
 

--- a/Casks/g/grandtotal.rb
+++ b/Casks/g/grandtotal.rb
@@ -16,7 +16,6 @@ cask "grandtotal" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "GrandTotal.app"
 

--- a/Casks/g/graphicconverter.rb
+++ b/Casks/g/graphicconverter.rb
@@ -18,7 +18,6 @@ cask "graphicconverter" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "GraphicConverter #{version.major}.app"
 

--- a/Casks/g/gray.rb
+++ b/Casks/g/gray.rb
@@ -7,8 +7,6 @@ cask "gray" do
   desc "Tool to set light or dark appearance on a per-app basis"
   homepage "https://github.com/zenangst/Gray"
 
-  depends_on macos: ">= :mojave"
-
   app "Gray.app"
 
   zap trash: [

--- a/Casks/g/greenery.rb
+++ b/Casks/g/greenery.rb
@@ -15,8 +15,6 @@ cask "greenery" do
 
   no_autobump! because: :bumped_by_upstream
 
-  depends_on macos: ">= :catalina"
-
   app "Greenery.app"
 
   zap trash: [

--- a/Casks/g/greenfoot.rb
+++ b/Casks/g/greenfoot.rb
@@ -15,8 +15,6 @@ cask "greenfoot" do
     regex(/Version:\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Greenfoot.app"
 
   zap trash: [

--- a/Casks/g/grids.rb
+++ b/Casks/g/grids.rb
@@ -15,7 +15,6 @@ cask "grids" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Grids.app"
 

--- a/Casks/g/gridtracker2.rb
+++ b/Casks/g/gridtracker2.rb
@@ -12,8 +12,6 @@ cask "gridtracker2" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "GridTracker2.app"
 
   zap trash: [

--- a/Casks/g/grs-bluewallet.rb
+++ b/Casks/g/grs-bluewallet.rb
@@ -8,8 +8,6 @@ cask "grs-bluewallet" do
   desc "Groestlcoin wallet and Lightning wallet"
   homepage "https://www.groestlcoin.org/grs-bluewallet/"
 
-  depends_on macos: ">= :catalina"
-
   app "GRS BlueWallet.app"
 
   zap trash: [

--- a/Casks/g/gswitch.rb
+++ b/Casks/g/gswitch.rb
@@ -8,8 +8,6 @@ cask "gswitch" do
   desc "Set which graphics card to use"
   homepage "https://codyschrank.github.io/gSwitch/"
 
-  depends_on macos: ">= :sierra"
-
   app "gSwitch.app"
 
   zap trash: [

--- a/Casks/g/guilded.rb
+++ b/Casks/g/guilded.rb
@@ -15,7 +15,6 @@ cask "guilded" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Guilded.app"
 

--- a/Casks/g/gyroflow.rb
+++ b/Casks/g/gyroflow.rb
@@ -8,8 +8,6 @@ cask "gyroflow" do
   desc "Video stabilization using gyroscope data"
   homepage "https://gyroflow.xyz/"
 
-  depends_on macos: ">= :mojave"
-
   app "Gyroflow.app"
 
   zap trash: "~/Library/Caches/Gyroflow"

--- a/Casks/g/gzdoom.rb
+++ b/Casks/g/gzdoom.rb
@@ -20,8 +20,6 @@ cask "gzdoom" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "GZDoom.app"
 
   zap trash: "~/Library/Preferences/gzdoom.ini"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.