### PR TITLE
[h]: remove pre-Catalina references

### DIFF
--- a/Casks/h/hackintool.rb
+++ b/Casks/h/hackintool.rb
@@ -8,7 +8,6 @@ cask "hackintool" do
   homepage "https://github.com/headkaze/Hackintool"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Hackintool.app"
 

--- a/Casks/h/hammerspoon.rb
+++ b/Casks/h/hammerspoon.rb
@@ -1,35 +1,19 @@
 cask "hammerspoon" do
-  on_mojave :or_older do
-    version "0.9.93"
-    sha256 "eb4eb4b014d51b32ac15f87050eb11bcc2e77bcdbfbf5ab60a95ecc50e55d2a3"
+  version "1.0.0"
+  sha256 "5db702b55da47dc306e8f5948d91ef85bebd315ddfa29428322a0af7ed7e6a7e"
 
-    url "https://github.com/Hammerspoon/hammerspoon/files/7707382/Hammerspoon-#{version}-for-10.14.zip",
-        verified: "github.com/Hammerspoon/hammerspoon/"
-
-    # Specific build provided for Mojave upstream https://github.com/Hammerspoon/hammerspoon/issues/3023#issuecomment-992980087
-    livecheck do
-      skip "Specific build for Mojave and later"
-    end
-  end
-  on_catalina :or_newer do
-    version "1.0.0"
-    sha256 "5db702b55da47dc306e8f5948d91ef85bebd315ddfa29428322a0af7ed7e6a7e"
-
-    url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip",
-        verified: "github.com/Hammerspoon/hammerspoon/"
-
-    livecheck do
-      url "https://raw.githubusercontent.com/Hammerspoon/hammerspoon/master/appcast.xml"
-      strategy :sparkle, &:short_version
-    end
-  end
-
+  url "https://github.com/Hammerspoon/hammerspoon/releases/download/#{version}/Hammerspoon-#{version}.zip",
+      verified: "github.com/Hammerspoon/hammerspoon/"
   name "Hammerspoon"
   desc "Desktop automation application"
   homepage "https://www.hammerspoon.org/"
 
+  livecheck do
+    url "https://raw.githubusercontent.com/Hammerspoon/hammerspoon/master/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Hammerspoon.app"
   binary "#{appdir}/Hammerspoon.app/Contents/Frameworks/hs/hs"

--- a/Casks/h/hamrs-pro.rb
+++ b/Casks/h/hamrs-pro.rb
@@ -17,7 +17,6 @@ cask "hamrs-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "HAMRS Pro.app"
 

--- a/Casks/h/handbrake-app.rb
+++ b/Casks/h/handbrake-app.rb
@@ -17,7 +17,6 @@ cask "handbrake-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "HandBrake.app"
 

--- a/Casks/h/hapigo.rb
+++ b/Casks/h/hapigo.rb
@@ -15,7 +15,6 @@ cask "hapigo" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "HapiGo.app"
 

--- a/Casks/h/happymac.rb
+++ b/Casks/h/happymac.rb
@@ -13,8 +13,6 @@ cask "happymac" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :sierra"
-
   app "happymac.app"
 
   zap trash: "~/HappyMacApp"

--- a/Casks/h/haptic-touch-bar.rb
+++ b/Casks/h/haptic-touch-bar.rb
@@ -10,8 +10,6 @@ cask "haptic-touch-bar" do
 
   deprecate! date: "2025-03-30", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "Haptic Touch Bar.app"
 
   uninstall quit: [

--- a/Casks/h/haptickey.rb
+++ b/Casks/h/haptickey.rb
@@ -7,8 +7,6 @@ cask "haptickey" do
   desc "Trigger haptic feedback when tapping Touch Bar"
   homepage "https://github.com/niw/HapticKey"
 
-  depends_on macos: ">= :sierra"
-
   app "HapticKey.app"
 
   uninstall quit: "at.niw.HapticKey"

--- a/Casks/h/hazeover.rb
+++ b/Casks/h/hazeover.rb
@@ -13,7 +13,6 @@ cask "hazeover" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "HazeOver.app"
 

--- a/Casks/h/hdfview.rb
+++ b/Casks/h/hdfview.rb
@@ -20,7 +20,6 @@ cask "hdfview" do
     regex(/HDFView[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  depends_on macos: ">= :el_capitan"
   container nested: "HDFView-#{version}.dmg"
 
   app "HDFView.app"

--- a/Casks/h/headlamp.rb
+++ b/Casks/h/headlamp.rb
@@ -28,8 +28,6 @@ cask "headlamp" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "Headlamp.app"
 
   uninstall quit: "com.kinvolk.headlamp"

--- a/Casks/h/height.rb
+++ b/Casks/h/height.rb
@@ -14,7 +14,6 @@ cask "height" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Height.app"
 

--- a/Casks/h/helpwire-operator.rb
+++ b/Casks/h/helpwire-operator.rb
@@ -13,7 +13,6 @@ cask "helpwire-operator" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "HelpWire Operator.app"
 

--- a/Casks/h/heptabase.rb
+++ b/Casks/h/heptabase.rb
@@ -17,7 +17,6 @@ cask "heptabase" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Heptabase.app"
 

--- a/Casks/h/heroic.rb
+++ b/Casks/h/heroic.rb
@@ -16,7 +16,6 @@ cask "heroic" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Heroic.app"
 

--- a/Casks/h/hex-fiend.rb
+++ b/Casks/h/hex-fiend.rb
@@ -14,7 +14,6 @@ cask "hex-fiend" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Hex Fiend.app"
   binary "#{appdir}/Hex Fiend.app/Contents/Resources/hexf"

--- a/Casks/h/hey-desktop.rb
+++ b/Casks/h/hey-desktop.rb
@@ -17,7 +17,6 @@ cask "hey-desktop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "HEY.app"
 

--- a/Casks/h/heynote.rb
+++ b/Casks/h/heynote.rb
@@ -17,7 +17,6 @@ cask "heynote" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Heynote.app"
 

--- a/Casks/h/hhkb.rb
+++ b/Casks/h/hhkb.rb
@@ -13,8 +13,6 @@ cask "hhkb" do
     regex(%r{macOS\s*</td>.*?HHKBkeymapTool[._-]v?\d+(?:\.\d+)*[^.]*?\.dmg.*?>\s*v?(\d+(?:\.\d+)+)\s*<}im)
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "HHKBkeymapTool_#{version.no_dots}ma.pkg"
 
   uninstall quit:    "jp.co.pfu.hhkb-keymap-tool",

--- a/Casks/h/hiarcs-chess-explorer.rb
+++ b/Casks/h/hiarcs-chess-explorer.rb
@@ -1,34 +1,16 @@
 cask "hiarcs-chess-explorer" do
-  on_sierra :or_older do
-    version "1.9.4"
-    sha256 "eaf7627801ca4cc2351fef58bb313353eca2a51d894e28df2b627dd011856a7f"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_high_sierra do
-    version "1.11.1"
-    sha256 "6f188f9c9041ed5667f0398e7b2a9b00d998bd6c77e9391163895bbd746f49ee"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave :or_newer do
-    version "1.13"
-    sha256 "7b34bead03bb9f90ac56f54cb5b728af146025c3271b1a07d07dbcf5ffcbeeb3"
-
-    livecheck do
-      url "https://www.hiarcs.com/mac-chess-explorer-download.html"
-      regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+[a-z]?)\.pkg}i)
-    end
-  end
+  version "1.13"
+  sha256 "7b34bead03bb9f90ac56f54cb5b728af146025c3271b1a07d07dbcf5ffcbeeb3"
 
   url "https://www.hiarcs.com/hce/HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
   name "(Deep) HIARCS Chess Explorer"
   desc "Chess database, analysis and game playing program"
   homepage "https://www.hiarcs.com/mac-chess-explorer.html"
+
+  livecheck do
+    url "https://www.hiarcs.com/mac-chess-explorer-download.html"
+    regex(%r{href=.*?/HIARCS-Chess-Explorer-Installer[._-]v?(\d+(?:\.\d+)+[a-z]?)\.pkg}i)
+  end
 
   pkg "HIARCS-Chess-Explorer-Installer-v#{version}.pkg"
 

--- a/Casks/h/hiddenbar.rb
+++ b/Casks/h/hiddenbar.rb
@@ -12,8 +12,6 @@ cask "hiddenbar" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Hidden Bar.app"
 
   uninstall launchctl: "com.dwarvesv.LauncherApplication",

--- a/Casks/h/hightop.rb
+++ b/Casks/h/hightop.rb
@@ -13,7 +13,6 @@ cask "hightop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "HighTop.app"
 

--- a/Casks/h/historyhound.rb
+++ b/Casks/h/historyhound.rb
@@ -13,7 +13,6 @@ cask "historyhound" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "HistoryHound.app"
 

--- a/Casks/h/holavpn.rb
+++ b/Casks/h/holavpn.rb
@@ -15,8 +15,6 @@ cask "holavpn" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "HolaVPN2E.app"
 
   zap trash: [

--- a/Casks/h/home-inventory.rb
+++ b/Casks/h/home-inventory.rb
@@ -10,7 +10,5 @@ cask "home-inventory" do
   deprecate! date: "2024-07-04", because: :discontinued
   disable! date: "2025-07-04", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Home Inventory.app"
 end

--- a/Casks/h/honto.rb
+++ b/Casks/h/honto.rb
@@ -13,8 +13,6 @@ cask "honto" do
     regex(%r{Mac\s*<br\s*/?>\s*Ver[._-]v?(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "honto.app"
 
   zap trash: [

--- a/Casks/h/hookmark.rb
+++ b/Casks/h/hookmark.rb
@@ -14,7 +14,6 @@ cask "hookmark" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Hookmark.app"
 

--- a/Casks/h/hookshot.rb
+++ b/Casks/h/hookshot.rb
@@ -10,7 +10,6 @@ cask "hookshot" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Hookshot.app"
 

--- a/Casks/h/hopper-disassembler.rb
+++ b/Casks/h/hopper-disassembler.rb
@@ -13,8 +13,6 @@ cask "hopper-disassembler" do
     regex(/<title>\s*Version\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Hopper Disassembler.app"
 
   zap trash: [

--- a/Casks/h/hoppscotch-selfhost.rb
+++ b/Casks/h/hoppscotch-selfhost.rb
@@ -12,7 +12,6 @@ cask "hoppscotch-selfhost" do
   homepage "https://hoppscotch.com/"
 
   conflicts_with cask: "hoppscotch"
-  depends_on macos: ">= :high_sierra"
 
   app "Hoppscotch.app"
 

--- a/Casks/h/hoppscotch.rb
+++ b/Casks/h/hoppscotch.rb
@@ -12,7 +12,6 @@ cask "hoppscotch" do
   homepage "https://hoppscotch.com/"
 
   conflicts_with cask: "hoppscotch-selfhost"
-  depends_on macos: ">= :high_sierra"
 
   app "Hoppscotch.app"
 

--- a/Casks/h/horos.rb
+++ b/Casks/h/horos.rb
@@ -8,14 +8,8 @@ cask "horos" do
     url "https://horosproject.org/horos-content/Horos_#{version}_#{arch}.dmg"
   end
   on_intel do
-    on_el_capitan :or_older do
-      version "2.0.2"
-      sha256 "5cc1d6c71c8ae643b4df4fecee93dbe3cfacbcffef52001a76a7683a2725ac08"
-    end
-    on_sierra :or_newer do
-      version "4.0.0"
-      sha256 "b0ea0ac8793ee1e343c815f5e2bfbeba01ea713181c2c66ad69b73fbed69a902"
-    end
+    version "4.0.0"
+    sha256 "b0ea0ac8793ee1e343c815f5e2bfbeba01ea713181c2c66ad69b73fbed69a902"
 
     url "https://horosproject.org/horos-content/Horos#{version}#{arch}.dmg"
   end

--- a/Casks/h/hostsx.rb
+++ b/Casks/h/hostsx.rb
@@ -13,7 +13,6 @@ cask "hostsx" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "HostsX.app"
 

--- a/Casks/h/hot.rb
+++ b/Casks/h/hot.rb
@@ -8,7 +8,6 @@ cask "hot" do
   homepage "https://github.com/macmade/Hot"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Hot.app"
 

--- a/Casks/h/houdahspot.rb
+++ b/Casks/h/houdahspot.rb
@@ -13,7 +13,6 @@ cask "houdahspot" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "HoudahSpot.app"
 

--- a/Casks/h/hp-easy-admin.rb
+++ b/Casks/h/hp-easy-admin.rb
@@ -12,8 +12,6 @@ cask "hp-easy-admin" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :catalina"
-
   app "HP Easy Admin.app"
 
   zap trash: [

--- a/Casks/h/hp-prime.rb
+++ b/Casks/h/hp-prime.rb
@@ -12,8 +12,6 @@ cask "hp-prime" do
     regex(/<title>.*?\((\d+(?:-\d+)+)\)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "HP Prime.app"
 
   caveats do

--- a/Casks/h/hstracker.rb
+++ b/Casks/h/hstracker.rb
@@ -16,7 +16,6 @@ cask "hstracker" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "HSTracker.app"
 

--- a/Casks/h/http-toolkit.rb
+++ b/Casks/h/http-toolkit.rb
@@ -16,8 +16,6 @@ cask "http-toolkit" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "HTTP Toolkit.app"
 
   zap trash: [

--- a/Casks/h/httpie-desktop.rb
+++ b/Casks/h/httpie-desktop.rb
@@ -16,8 +16,6 @@ cask "httpie-desktop" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "HTTPie.app"
 
   zap trash: [

--- a/Casks/h/hummingbird.rb
+++ b/Casks/h/hummingbird.rb
@@ -16,8 +16,6 @@ cask "hummingbird" do
     regex(/href=.*?hummingbird[._-]macos[._-]#{arch}[._-]notarized[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   binary "hummingbird-macos-#{arch}-#{version}/hummingbird"
 
   postflight do

--- a/Casks/h/hy-rpe2.rb
+++ b/Casks/h/hy-rpe2.rb
@@ -24,8 +24,6 @@ cask "hy-rpe2" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "HY-RPE2.pkg"
 
   uninstall pkgutil: [

--- a/Casks/h/hydrogen.rb
+++ b/Casks/h/hydrogen.rb
@@ -15,8 +15,6 @@ cask "hydrogen" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "Hydrogen.app"
 
   zap trash: "~/Library/Application Support/Hydrogen"

--- a/Casks/h/hyper.rb
+++ b/Casks/h/hyper.rb
@@ -21,7 +21,6 @@ cask "hyper" do
 
   auto_updates true
   conflicts_with cask: "hyper@canary"
-  depends_on macos: ">= :high_sierra"
 
   app "Hyper.app"
   binary "#{appdir}/Hyper.app/Contents/Resources/bin/hyper"

--- a/Casks/h/hyper@canary.rb
+++ b/Casks/h/hyper@canary.rb
@@ -21,7 +21,6 @@ cask "hyper@canary" do
 
   auto_updates true
   conflicts_with cask: "hyper"
-  depends_on macos: ">= :high_sierra"
 
   app "Hyper.app"
   binary "#{appdir}/Hyper.app/Contents/Resources/bin/hyper"

--- a/Casks/h/hyperbackupexplorer.rb
+++ b/Casks/h/hyperbackupexplorer.rb
@@ -14,8 +14,6 @@ cask "hyperbackupexplorer" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "HyperBackupExplorer.app"
 
   zap trash: [

--- a/Casks/h/hyperkey.rb
+++ b/Casks/h/hyperkey.rb
@@ -13,7 +13,6 @@ cask "hyperkey" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Hyperkey.app"
 


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.s