### PR TITLE
[j]: remove pre-Catalina references

### DIFF
--- a/Casks/j/jabra-direct.rb
+++ b/Casks/j/jabra-direct.rb
@@ -16,7 +16,6 @@ cask "jabra-direct" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "JabraDirectSetup.pkg"
 

--- a/Casks/j/jaikoz.rb
+++ b/Casks/j/jaikoz.rb
@@ -14,8 +14,6 @@ cask "jaikoz" do
     regex(/Jaikoz\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Jaikoz.app"
 
   zap trash: [

--- a/Casks/j/jamovi.rb
+++ b/Casks/j/jamovi.rb
@@ -16,7 +16,6 @@ cask "jamovi" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "jamovi.app"
 

--- a/Casks/j/jan.rb
+++ b/Casks/j/jan.rb
@@ -14,7 +14,6 @@ cask "jan" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Jan.app"
 

--- a/Casks/j/jedit-omega.rb
+++ b/Casks/j/jedit-omega.rb
@@ -1,16 +1,6 @@
 cask "jedit-omega" do
-  on_el_capitan :or_older do
-    version "1.32"
-    sha256 "251697fe6b76419b2cef41a89a2cb7d2e3f8caab0bc1ae82aed6c14a366fdad9"
-  end
-  on_sierra do
-    version "2.48"
-    sha256 "fbcebb742f060e4941d901d2e6b9fcd79e575828cafc38f7808ead048a3451ce"
-  end
-  on_high_sierra :or_newer do
-    version "3.11"
-    sha256 "21ea1aec73ac72577b9100cc6be1b3597cd88c88db624fa498b55b66bcb2a7fb"
-  end
+  version "3.11"
+  sha256 "21ea1aec73ac72577b9100cc6be1b3597cd88c88db624fa498b55b66bcb2a7fb"
 
   url "https://artman21.site/JeditOmega#{version.no_dots}.pkg",
       verified: "artman21.site/"

--- a/Casks/j/jet-pilot.rb
+++ b/Casks/j/jet-pilot.rb
@@ -19,7 +19,6 @@ cask "jet-pilot" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "JET Pilot.app"
 

--- a/Casks/j/jetbrains-gateway.rb
+++ b/Casks/j/jetbrains-gateway.rb
@@ -24,7 +24,6 @@ cask "jetbrains-gateway" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "JetBrains Gateway.app"
   binary "#{appdir}/JetBrains Gateway.app/Contents/MacOS/gateway"

--- a/Casks/j/jetbrains-space.rb
+++ b/Casks/j/jetbrains-space.rb
@@ -13,7 +13,6 @@ cask "jetbrains-space" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "JetBrains Space.app"
 

--- a/Casks/j/jetbrains-toolbox.rb
+++ b/Casks/j/jetbrains-toolbox.rb
@@ -24,7 +24,6 @@ cask "jetbrains-toolbox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "JetBrains Toolbox.app"
 

--- a/Casks/j/jetdrive-toolbox.rb
+++ b/Casks/j/jetdrive-toolbox.rb
@@ -15,7 +15,6 @@ cask "jetdrive-toolbox" do
 
   auto_updates true
   depends_on arch: :arm64
-  depends_on macos: ">= :catalina"
 
   pkg "JetDriveToolbox_v#{version}.pkg"
 

--- a/Casks/j/jettison.rb
+++ b/Casks/j/jettison.rb
@@ -14,7 +14,6 @@ cask "jettison" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Jettison.app"
 

--- a/Casks/j/jgrennison-openttd.rb
+++ b/Casks/j/jgrennison-openttd.rb
@@ -9,8 +9,6 @@ cask "jgrennison-openttd" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "OpenTTD.app"
 
   zap trash: [

--- a/Casks/j/jiggler.rb
+++ b/Casks/j/jiggler.rb
@@ -12,8 +12,6 @@ cask "jiggler" do
     regex(/<h1>.+(\d+(?:\.\d+)+)\s/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Jiggler.app"
 
   zap trash: "~/Library/Preferences/com.stick.app.jiggler.plist"

--- a/Casks/j/jitouch.rb
+++ b/Casks/j/jitouch.rb
@@ -8,8 +8,6 @@ cask "jitouch" do
   desc "Multi-touch gestures editor"
   homepage "https://www.jitouch.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "Install-Jitouch.pkg"
 
   uninstall launchctl: "com.jitouch.Jitouch.agent",

--- a/Casks/j/jitsi-meet.rb
+++ b/Casks/j/jitsi-meet.rb
@@ -8,7 +8,6 @@ cask "jitsi-meet" do
   homepage "https://github.com/jitsi/jitsi-meet-electron/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Jitsi Meet.app"
 

--- a/Casks/j/jmc.rb
+++ b/Casks/j/jmc.rb
@@ -9,8 +9,6 @@ cask "jmc" do
 
   deprecate! date: "2024-11-10", because: :unmaintained
 
-  depends_on macos: ">= :catalina"
-
   app "jmc.app"
 
   zap trash: [

--- a/Casks/j/joshjon-nocturnal.rb
+++ b/Casks/j/joshjon-nocturnal.rb
@@ -10,8 +10,6 @@ cask "joshjon-nocturnal" do
   deprecate! date: "2024-08-22", because: :discontinued
   disable! date: "2025-08-22", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "Nocturnal.app"
 
   zap trash: "~/Library/Preferences/com.joshua.jon.Nocturnal.plist"

--- a/Casks/j/jottacloud.rb
+++ b/Casks/j/jottacloud.rb
@@ -20,7 +20,6 @@ cask "jottacloud" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Jottacloud.app"
 

--- a/Casks/j/jpc-qlcolorcode.rb
+++ b/Casks/j/jpc-qlcolorcode.rb
@@ -7,8 +7,6 @@ cask "jpc-qlcolorcode" do
   desc "Quick Look plug-in that renders source code with syntax highlighting"
   homepage "https://github.com/jpc/QLColorCode"
 
-  depends_on macos: ">= :mojave"
-
   qlplugin "QLColorCode.qlgenerator"
 
   zap trash: "~/Library/Preferences/org.n8gray.QLColorCode.plist"

--- a/Casks/j/jquake.rb
+++ b/Casks/j/jquake.rb
@@ -20,8 +20,6 @@ cask "jquake" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "JQuake.app"
 
   zap trash: [

--- a/Casks/j/json-viewer.rb
+++ b/Casks/j/json-viewer.rb
@@ -12,8 +12,6 @@ cask "json-viewer" do
     regex(/JSON[._-]Viewer[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "JSON Viewer.app"
 
   zap trash: [

--- a/Casks/j/jt-bridge.rb
+++ b/Casks/j/jt-bridge.rb
@@ -13,8 +13,6 @@ cask "jt-bridge" do
     regex(/JT[._-]Bridge[._-]app[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "JT-Bridge.app"
 
   zap trash: [

--- a/Casks/j/juice.rb
+++ b/Casks/j/juice.rb
@@ -7,8 +7,6 @@ cask "juice" do
   desc "Make your battery information a bit more interesting"
   homepage "https://github.com/brianmichel/Juice"
 
-  depends_on macos: ">= :sierra"
-
   app "Juice.app"
 
   zap trash: [

--- a/Casks/j/jump-desktop-connect.rb
+++ b/Casks/j/jump-desktop-connect.rb
@@ -1,26 +1,16 @@
 cask "jump-desktop-connect" do
-  on_sierra :or_older do
-    version "6.5.39"
-    sha256 "5ad7235db6cc28a2da7048636e7ea3e4f9f144e85d645d56e3a7b75b5b228b34"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_high_sierra :or_newer do
-    version "7.1.48"
-    sha256 "6e8c0420b4ab36181cc59df74c3184e96e01559dd4ad2470441575f566f2693b"
-
-    livecheck do
-      url "https://mirror.jumpdesktop.com/downloads/connect/connect-mac.xml"
-      strategy :sparkle, &:short_version
-    end
-  end
+  version "7.1.48"
+  sha256 "6e8c0420b4ab36181cc59df74c3184e96e01559dd4ad2470441575f566f2693b"
 
   url "https://mirror.jumpdesktop.com/downloads/connect/JumpDesktopConnect-#{version}.dmg"
   name "Jump Desktop Connect"
   desc "Remote desktop app"
   homepage "https://jumpdesktop.com/connect/"
+
+  livecheck do
+    url "https://mirror.jumpdesktop.com/downloads/connect/connect-mac.xml"
+    strategy :sparkle, &:short_version
+  end
 
   auto_updates true
 

--- a/Casks/j/jump-desktop.rb
+++ b/Casks/j/jump-desktop.rb
@@ -13,8 +13,6 @@ cask "jump-desktop" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Jump Desktop.app"
 
   zap trash: [

--- a/Casks/j/jumpcloud-password-manager.rb
+++ b/Casks/j/jumpcloud-password-manager.rb
@@ -16,7 +16,6 @@ cask "jumpcloud-password-manager" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "JumpCloud Password Manager.app"
 

--- a/Casks/j/jumpcut.rb
+++ b/Casks/j/jumpcut.rb
@@ -8,8 +8,6 @@ cask "jumpcut" do
   desc "Clipboard manager"
   homepage "https://snark.github.io/jumpcut/"
 
-  depends_on macos: ">= :sierra"
-
   app "Jumpcut.app"
 
   zap trash: "~/Library/Preferences/net.sf.Jumpcut.plist"

--- a/Casks/j/jumpshare.rb
+++ b/Casks/j/jumpshare.rb
@@ -13,8 +13,6 @@ cask "jumpshare" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Jumpshare.app"
 
   zap trash: [

--- a/Casks/j/jupyter-notebook-viewer.rb
+++ b/Casks/j/jupyter-notebook-viewer.rb
@@ -7,8 +7,6 @@ cask "jupyter-notebook-viewer" do
   desc "Utility to render Jupyter notebooks"
   homepage "https://github.com/tuxu/nbviewer-app"
 
-  depends_on macos: ">= :catalina"
-
   app "Jupyter Notebook Viewer.app"
 
   zap trash: "~/Library/Saved Application State/com.tinowagner.nbviewer-app.savedState"

--- a/Casks/j/jupyterlab-app.rb
+++ b/Casks/j/jupyterlab-app.rb
@@ -16,8 +16,6 @@ cask "jupyterlab-app" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "JupyterLab.app"
 
   uninstall pkgutil: "com.electron.jupyterlab-desktop",


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.