### PR TITLE
[k]: remove pre-Catalina references

### DIFF
--- a/Casks/k/k6-studio.rb
+++ b/Casks/k/k6-studio.rb
@@ -12,7 +12,6 @@ cask "k6-studio" do
   homepage "https://grafana.com/docs/k6-studio"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "k6 Studio.app"
 

--- a/Casks/k/k8studio.rb
+++ b/Casks/k/k8studio.rb
@@ -16,8 +16,6 @@ cask "k8studio" do
     regex(/href=.*?k8studio[._-]v?(\d+(?:\.\d+)+(?:[._-]beta)?)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "K8Studio.app"
 
   zap trash: [

--- a/Casks/k/kaleidoscope@2.rb
+++ b/Casks/k/kaleidoscope@2.rb
@@ -30,7 +30,6 @@ cask "kaleidoscope@2" do
     kaleidoscope@3
     ksdiff
   ]
-  depends_on macos: ">= :sierra"
 
   app "Kaleidoscope.app"
   binary "#{appdir}/Kaleidoscope.app/Contents/Resources/bin/ksdiff"

--- a/Casks/k/kando.rb
+++ b/Casks/k/kando.rb
@@ -11,8 +11,6 @@ cask "kando" do
   desc "Pie menu"
   homepage "https://kando.menu/"
 
-  depends_on macos: ">= :catalina"
-
   app "Kando.app"
 
   zap trash: [

--- a/Casks/k/kap.rb
+++ b/Casks/k/kap.rb
@@ -12,7 +12,6 @@ cask "kap" do
   homepage "https://getkap.co/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Kap.app"
 

--- a/Casks/k/karabiner-elements.rb
+++ b/Casks/k/karabiner-elements.rb
@@ -1,40 +1,6 @@
 cask "karabiner-elements" do
-  on_mojave :or_older do
-    on_el_capitan :or_older do
-      version "11.6.0"
-      sha256 "c1b06252ecc42cdd8051eb3d606050ee47b04532629293245ffdfa01bbc2430d"
-    end
-    on_sierra :or_newer do
-      version "12.10.0"
-      sha256 "53252f7d07e44f04972afea2a16ac595552c28715aa65ff4a481a1c18c8be2f4"
-    end
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    pkg "Karabiner-Elements.sparkle_guided.pkg"
-
-    uninstall launchctl: [
-                "org.pqrs.karabiner.agent.karabiner_grabber",
-                "org.pqrs.karabiner.agent.karabiner_observer",
-                "org.pqrs.karabiner.karabiner_console_user_server",
-                "org.pqrs.karabiner.karabiner_kextd",
-                "org.pqrs.karabiner.karabiner_session_monitor",
-              ],
-              signal:    [
-                ["TERM", "org.pqrs.Karabiner-Menu"],
-                ["TERM", "org.pqrs.Karabiner-NotificationWindow"],
-              ],
-              script:    {
-                executable: "/Library/Application Support/org.pqrs/Karabiner-Elements/uninstall_core.sh",
-                sudo:       true,
-              },
-              pkgutil:   "org.pqrs.Karabiner-Elements",
-              delete:    "/Library/Application Support/org.pqrs"
-  end
-  on_catalina :or_newer do
-    on_catalina do
+  on_monterey :or_older do
+    on_catalina :or_older do
       version "13.7.0"
       sha256 "9ac5e53a71f3a00d7bdb2f5f5f001f70b6b8b7b2680e10a929e0e4c488c8734b"
 
@@ -58,16 +24,15 @@ cask "karabiner-elements" do
         skip "Legacy version"
       end
     end
-    on_ventura :or_newer do
-      version "15.5.0"
-      sha256 "f7a350c669d4d56fe0d8ed4b97baacb25725173b013e71c327e8663696945170"
+  end
+  on_ventura :or_newer do
+    version "15.5.0"
+    sha256 "f7a350c669d4d56fe0d8ed4b97baacb25725173b013e71c327e8663696945170"
 
-      livecheck do
-        url "https://appcast.pqrs.org/karabiner-elements-appcast.xml"
-        strategy :sparkle
-      end
+    livecheck do
+      url "https://appcast.pqrs.org/karabiner-elements-appcast.xml"
+      strategy :sparkle
     end
-
     pkg "Karabiner-Elements.pkg"
 
     uninstall early_script: {

--- a/Casks/k/kdiff3.rb
+++ b/Casks/k/kdiff3.rb
@@ -16,8 +16,6 @@ cask "kdiff3" do
     regex(/href=["']?kdiff3[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "kdiff3.app"
   shimscript = "#{staged_path}/kdiff3.wrapper.sh"
   binary shimscript, target: "kdiff3"

--- a/Casks/k/kdocs.rb
+++ b/Casks/k/kdocs.rb
@@ -23,8 +23,6 @@ cask "kdocs" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "金山文档.app"
 
   zap trash: [

--- a/Casks/k/kdrive.rb
+++ b/Casks/k/kdrive.rb
@@ -15,7 +15,6 @@ cask "kdrive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "kDrive-#{version}.pkg"
 

--- a/Casks/k/keep-it.rb
+++ b/Casks/k/keep-it.rb
@@ -13,7 +13,6 @@ cask "keep-it" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Keep It.app"
 

--- a/Casks/k/keepassxc@snapshot.rb
+++ b/Casks/k/keepassxc@snapshot.rb
@@ -35,7 +35,6 @@ cask "keepassxc@snapshot" do
     "keepassxc",
     "keepassxc@beta",
   ]
-  depends_on macos: ">= :high_sierra"
 
   app "KeePassXC.app"
   binary "#{appdir}/KeePassXC.app/Contents/MacOS/keepassxc-cli"

--- a/Casks/k/keeper-password-manager.rb
+++ b/Casks/k/keeper-password-manager.rb
@@ -12,8 +12,6 @@ cask "keeper-password-manager" do
     regex(/Release\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Keeper Password Manager.app"
 
   zap trash: [

--- a/Casks/k/keepingyouawake.rb
+++ b/Casks/k/keepingyouawake.rb
@@ -14,7 +14,6 @@ cask "keepingyouawake" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "KeepingYouAwake.app"
 

--- a/Casks/k/keet.rb
+++ b/Casks/k/keet.rb
@@ -16,7 +16,6 @@ cask "keet" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Keet.app"
 

--- a/Casks/k/kext-updater.rb
+++ b/Casks/k/kext-updater.rb
@@ -14,8 +14,6 @@ cask "kext-updater" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Kext Updater.app"
 
   zap trash: [

--- a/Casks/k/keybase.rb
+++ b/Casks/k/keybase.rb
@@ -23,7 +23,6 @@ cask "keybase" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Keybase.app"
 

--- a/Casks/k/keyboard-maestro.rb
+++ b/Casks/k/keyboard-maestro.rb
@@ -20,7 +20,6 @@ cask "keyboard-maestro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Keyboard Maestro.app"
 

--- a/Casks/k/keycastr.rb
+++ b/Casks/k/keycastr.rb
@@ -13,7 +13,6 @@ cask "keycastr" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "KeyCastr.app"
 

--- a/Casks/k/keyguard.rb
+++ b/Casks/k/keyguard.rb
@@ -23,8 +23,6 @@ cask "keyguard" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "keyguard.app"
 
   zap trash: [

--- a/Casks/k/keymapp.rb
+++ b/Casks/k/keymapp.rb
@@ -16,7 +16,6 @@ cask "keymapp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Keymapp.app"
 

--- a/Casks/k/keypad-layout.rb
+++ b/Casks/k/keypad-layout.rb
@@ -7,8 +7,6 @@ cask "keypad-layout" do
   desc "Utility to control window layout using the Ctrl key and the numeric keypad"
   homepage "https://github.com/janten/keypad-layout"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Keypad Layout.app"
 
   zap trash: "~/Library/Preferences/com.jan-gerd.keypad-layout.plist"

--- a/Casks/k/keysmith.rb
+++ b/Casks/k/keysmith.rb
@@ -12,8 +12,6 @@ cask "keysmith" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Keysmith.app"
 
   zap trash: [

--- a/Casks/k/kid3.rb
+++ b/Casks/k/kid3.rb
@@ -1,28 +1,16 @@
 cask "kid3" do
+  arch arm: "arm64", intel: "amd64"
+
   # NOTE: "3" is not a version number, but an intrinsic part of the product name (ID3 tags)
   version "3.9.7"
+  sha256 arm:   "f43e10d44fd2d4b33328f7e4db6d25e33a39716500bc9f1a7a3340e5b564b070",
+         intel: "11d9f03e34c40434972a5073f7e385931a41513345cb032d212c4a1372caf4f8"
 
-  on_high_sierra :or_older do
-    sha256 "ed6bab51f97583a6b967ed9bf9cff7ab3bbce9d3b9e22260f77593cf499b9804"
-
-    url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin-Qt5.dmg",
-        verified: "downloads.sourceforge.net/kid3/"
-  end
-  on_mojave :or_newer do
-    arch arm: "arm64", intel: "amd64"
-
-    sha256 arm:   "f43e10d44fd2d4b33328f7e4db6d25e33a39716500bc9f1a7a3340e5b564b070",
-           intel: "11d9f03e34c40434972a5073f7e385931a41513345cb032d212c4a1372caf4f8"
-
-    url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin-#{arch}.dmg",
-        verified: "downloads.sourceforge.net/kid3/"
-  end
-
+  url "https://downloads.sourceforge.net/kid3/kid3-#{version}-Darwin-#{arch}.dmg",
+      verified: "downloads.sourceforge.net/kid3/"
   name "Kid3"
   desc "Audio tagger focusing on efficiency"
   homepage "https://kid3.kde.org/"
-
-  depends_on macos: ">= :high_sierra"
 
   app "kid3.app"
   binary "#{appdir}/kid3.app/Contents/MacOS/kid3-cli"

--- a/Casks/k/kigb.rb
+++ b/Casks/k/kigb.rb
@@ -12,8 +12,6 @@ cask "kigb" do
     regex(/>\s*?KiGB\s+?v?(\d+(?:\.\d+)+)\s*?</i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "KiGB v#{version}/KiGB.app"
 
   zap trash: [

--- a/Casks/k/kindle-create.rb
+++ b/Casks/k/kindle-create.rb
@@ -14,7 +14,6 @@ cask "kindle-create" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "KindleCreateInstaller.pkg"
 

--- a/Casks/k/kindle-previewer.rb
+++ b/Casks/k/kindle-previewer.rb
@@ -13,8 +13,6 @@ cask "kindle-previewer" do
     regex(/Kindle\sPreviewer\sv?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "KindlePreviewerInstaller.pkg"
 
   uninstall launchctl: "com.amazon.KindlePreviewerUpdater",

--- a/Casks/k/kindle.rb
+++ b/Casks/k/kindle.rb
@@ -11,7 +11,6 @@ cask "kindle" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Kindle.app"
 

--- a/Casks/k/kiro.rb
+++ b/Casks/k/kiro.rb
@@ -24,8 +24,6 @@ cask "kiro" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Kiro.app"
 
   zap trash: [

--- a/Casks/k/kiwi-for-gmail.rb
+++ b/Casks/k/kiwi-for-gmail.rb
@@ -13,7 +13,6 @@ cask "kiwi-for-gmail" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Kiwi for Gmail.app"
 

--- a/Casks/k/klayout.rb
+++ b/Casks/k/klayout.rb
@@ -67,8 +67,6 @@ cask "klayout" do
   desc "IC design layout viewer and editor"
   homepage "https://www.klayout.de/"
 
-  depends_on macos: ">= :catalina"
-
   suite "KLayout"
 
   preflight do

--- a/Casks/k/klokki.rb
+++ b/Casks/k/klokki.rb
@@ -17,8 +17,6 @@ cask "klokki" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Klokki.app"
 
   uninstall launchctl: "com.klokki-launcher",

--- a/Casks/k/kmbmpdc.rb
+++ b/Casks/k/kmbmpdc.rb
@@ -11,7 +11,6 @@ cask "kmbmpdc" do
   disable! date: "2025-07-17", because: :unmaintained
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "kmbmpdc.app"
 

--- a/Casks/k/knime.rb
+++ b/Casks/k/knime.rb
@@ -18,7 +18,6 @@ cask "knime" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "KNIME #{version}.app"
 

--- a/Casks/k/knockknock.rb
+++ b/Casks/k/knockknock.rb
@@ -8,8 +8,6 @@ cask "knockknock" do
   desc "Tool to show what is persistently installed on the computer"
   homepage "https://objective-see.org/products/knockknock.html"
 
-  depends_on macos: ">= :catalina"
-
   app "KnockKnock.app"
 
   zap trash: [

--- a/Casks/k/knuff.rb
+++ b/Casks/k/knuff.rb
@@ -15,7 +15,6 @@ cask "knuff" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Knuff.app"
 

--- a/Casks/k/kodelife.rb
+++ b/Casks/k/kodelife.rb
@@ -13,7 +13,6 @@ cask "kodelife" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "KodeLife.app"
 

--- a/Casks/k/kodi.rb
+++ b/Casks/k/kodi.rb
@@ -19,8 +19,6 @@ cask "kodi" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Kodi.app"
 
   zap trash: [

--- a/Casks/k/komet.rb
+++ b/Casks/k/komet.rb
@@ -13,7 +13,6 @@ cask "komet" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Komet.app"
 

--- a/Casks/k/konica-minolta-bizhub-c750i-driver.rb
+++ b/Casks/k/konica-minolta-bizhub-c750i-driver.rb
@@ -41,8 +41,6 @@ cask "konica-minolta-bizhub-c750i-driver" do
   desc "PostScript printer driver"
   homepage "https://www.konicaminolta.eu/eu-en/support/download-centre"
 
-  depends_on macos: ">= :sierra"
-
   uninstall_preflight do
     set_ownership "/Library/Printers/KONICAMINOLTA/Preferences"
   end

--- a/Casks/k/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
+++ b/Casks/k/konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver.rb
@@ -41,8 +41,6 @@ cask "konica-minolta-bizhub-c759-c658-c368-c287-c3851-driver" do
   desc "Drivers for Konica Monolta Bizhub printers"
   homepage "https://www.konicaminolta.eu/eu-en/support/download-centre"
 
-  depends_on macos: ">= :sierra"
-
   uninstall_preflight do
     set_ownership "/Library/Printers/KONICAMINOLTA/Preferences"
   end

--- a/Casks/k/krisp.rb
+++ b/Casks/k/krisp.rb
@@ -18,7 +18,6 @@ cask "krisp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   pkg "krisp_#{version}_#{arch}.pkg"
 

--- a/Casks/k/krita.rb
+++ b/Casks/k/krita.rb
@@ -13,8 +13,6 @@ cask "krita" do
     regex(/href=.*?krita[._-]v?(\d+(?:\.\d+)+)(?:-signed|-release)?\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "krita.app"
 
   zap trash: [

--- a/Casks/k/kuaitie.rb
+++ b/Casks/k/kuaitie.rb
@@ -14,7 +14,6 @@ cask "kuaitie" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "kuaitie.app"
 

--- a/Casks/k/kui.rb
+++ b/Casks/k/kui.rb
@@ -12,8 +12,6 @@ cask "kui" do
 
   deprecate! date: "2025-08-30", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "Kui-darwin-#{arch}/Kui.app"
   binary "#{appdir}/Kui.app/Contents/Resources/kubectl-kui"
 

--- a/Casks/k/kunkun.rb
+++ b/Casks/k/kunkun.rb
@@ -18,7 +18,6 @@ cask "kunkun" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "kunkun.app"
 

--- a/Casks/k/kvirc.rb
+++ b/Casks/k/kvirc.rb
@@ -27,8 +27,6 @@ cask "kvirc" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "KVIrc.app"
 
   zap trash: [

--- a/Casks/k/kyokan-bob.rb
+++ b/Casks/k/kyokan-bob.rb
@@ -16,8 +16,6 @@ cask "kyokan-bob" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Bob.app"
 
   zap trash: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.