### PR TITLE
[l]: remove pre-Catalina references

### DIFF
--- a/Casks/l/label-live.rb
+++ b/Casks/l/label-live.rb
@@ -12,8 +12,6 @@ cask "label-live" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Label LIVE.app"
 
   zap trash: [

--- a/Casks/l/lagrange.rb
+++ b/Casks/l/lagrange.rb
@@ -17,7 +17,6 @@ cask "lagrange" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Lagrange.app"
 

--- a/Casks/l/landrop.rb
+++ b/Casks/l/landrop.rb
@@ -8,8 +8,6 @@ cask "landrop" do
   desc "Drop any files to any devices on your LAN"
   homepage "https://landrop.app/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "LANDrop.app"
 
   uninstall quit: "app.landrop.landrop"

--- a/Casks/l/langgraph-studio.rb
+++ b/Casks/l/langgraph-studio.rb
@@ -10,8 +10,6 @@ cask "langgraph-studio" do
 
   deprecate! date: "2025-08-30", because: :discontinued
 
-  depends_on macos: ">= :catalina"
-
   app "LangGraph Studio.app"
 
   zap trash: [

--- a/Casks/l/laravel-kit.rb
+++ b/Casks/l/laravel-kit.rb
@@ -13,8 +13,6 @@ cask "laravel-kit" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Laravel Kit.app"
 
   zap trash: [

--- a/Casks/l/lark.rb
+++ b/Casks/l/lark.rb
@@ -29,7 +29,6 @@ cask "lark" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "LarkSuite.app"
 

--- a/Casks/l/last-window-quits.rb
+++ b/Casks/l/last-window-quits.rb
@@ -19,7 +19,6 @@ cask "last-window-quits" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Last Window Quits.app"
 

--- a/Casks/l/lastpass.rb
+++ b/Casks/l/lastpass.rb
@@ -13,7 +13,6 @@ cask "lastpass" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "LastPass.app"
 

--- a/Casks/l/latest.rb
+++ b/Casks/l/latest.rb
@@ -1,12 +1,6 @@
 cask "latest" do
-  on_mojave :or_older do
-    version "0.10.3"
-    sha256 "26e72a8a1555f1f352f4c09189d2feb7c8073f1a4a798fe4beb0e8fa86a7c649"
-  end
-  on_catalina :or_newer do
-    version "0.11"
-    sha256 "b372cde029f1f81c6465b1920a7c5a392a7791243cd30ebf39dab172ec82cbf5"
-  end
+  version "0.11"
+  sha256 "b372cde029f1f81c6465b1920a7c5a392a7791243cd30ebf39dab172ec82cbf5"
 
   url "https://max.codes/latest/#{version}.zip"
   name "Latest"
@@ -23,7 +17,6 @@ cask "latest" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Latest.app"
 

--- a/Casks/l/lazycat.rb
+++ b/Casks/l/lazycat.rb
@@ -17,8 +17,6 @@ cask "lazycat" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "懒猫微服.app"
 
   zap trash: [

--- a/Casks/l/lbry.rb
+++ b/Casks/l/lbry.rb
@@ -14,8 +14,6 @@ cask "lbry" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :mojave"
-
   app "LBRY.app"
   # shim scripts (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shim_lbrynet = "#{staged_path}/lbrynet.wrapper.sh"

--- a/Casks/l/leapp.rb
+++ b/Casks/l/leapp.rb
@@ -17,7 +17,6 @@ cask "leapp" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Leapp.app"
 

--- a/Casks/l/lectrote.rb
+++ b/Casks/l/lectrote.rb
@@ -10,8 +10,6 @@ cask "lectrote" do
   desc "Interactive Fiction interpreter in an Electron shell"
   homepage "https://github.com/erkyrath/lectrote"
 
-  depends_on macos: ">= :catalina"
-
   app "Lectrote.app"
 
   zap trash: [

--- a/Casks/l/ledger-live.rb
+++ b/Casks/l/ledger-live.rb
@@ -13,7 +13,6 @@ cask "ledger-live" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Ledger Live.app"
 

--- a/Casks/l/leech.rb
+++ b/Casks/l/leech.rb
@@ -13,7 +13,6 @@ cask "leech" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Leech.app"
 

--- a/Casks/l/leela.rb
+++ b/Casks/l/leela.rb
@@ -9,8 +9,6 @@ cask "leela" do
 
   deprecate! date: "2025-03-04", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Leela.app"
   app "Leela OpenCL.app"
 

--- a/Casks/l/lens.rb
+++ b/Casks/l/lens.rb
@@ -18,7 +18,6 @@ cask "lens" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Lens.app"
 

--- a/Casks/l/leocad.rb
+++ b/Casks/l/leocad.rb
@@ -9,8 +9,6 @@ cask "leocad" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "LeoCAD.app"
 
   zap trash: [

--- a/Casks/l/lets.rb
+++ b/Casks/l/lets.rb
@@ -14,8 +14,6 @@ cask "lets" do
     regex(/class="c-download__txt"[^>]*?>macOS[^<]*?(\d+(?:\.\d+)+)</i)
   end
 
-  depends_on macos: ">= :mojave"
-
   installer manual: "LETS-Installer.app/Contents/MacOS/LETS-Installer"
 
   uninstall launchctl: "LETS",

--- a/Casks/l/letter-opener.rb
+++ b/Casks/l/letter-opener.rb
@@ -13,8 +13,6 @@ cask "letter-opener" do
     regex(%r{Version:\s*<strong>(\d+(?:\.\d+)+)</strong>}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Install Letter Opener.pkg"
 
   uninstall launchctl: [

--- a/Casks/l/lexicon-dj.rb
+++ b/Casks/l/lexicon-dj.rb
@@ -17,7 +17,6 @@ cask "lexicon-dj" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Lexicon.app"
 

--- a/Casks/l/lg-onscreen-control.rb
+++ b/Casks/l/lg-onscreen-control.rb
@@ -29,8 +29,6 @@ cask "lg-onscreen-control" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "OSC_V#{version.csv.first}_signed.pkg"
 
   postflight do

--- a/Casks/l/libcblite-community.rb
+++ b/Casks/l/libcblite-community.rb
@@ -12,7 +12,6 @@ cask "libcblite-community" do
   end
 
   conflicts_with cask: "libcblite"
-  depends_on macos: ">= :mojave"
 
   artifact "libcblite-#{version}/include/cbl", target: "#{HOMEBREW_PREFIX}/include/cbl"
   artifact "libcblite-#{version}/include/fleece", target: "#{HOMEBREW_PREFIX}/include/fleece"

--- a/Casks/l/libcblite.rb
+++ b/Casks/l/libcblite.rb
@@ -13,7 +13,6 @@ cask "libcblite" do
   end
 
   conflicts_with cask: "libcblite-community"
-  depends_on macos: ">= :mojave"
 
   artifact "libcblite-#{version}/include/cbl", target: "#{HOMEBREW_PREFIX}/include/cbl"
   artifact "libcblite-#{version}/include/fleece", target: "#{HOMEBREW_PREFIX}/include/fleece"

--- a/Casks/l/libreoffice-language-pack.rb
+++ b/Casks/l/libreoffice-language-pack.rb
@@ -506,7 +506,6 @@ cask "libreoffice-language-pack" do
   end
 
   depends_on cask: "libreoffice"
-  depends_on macos: ">= :mojave"
 
   # Start the silent install
   installer script: {

--- a/Casks/l/libreoffice-still-language-pack.rb
+++ b/Casks/l/libreoffice-still-language-pack.rb
@@ -506,7 +506,6 @@ cask "libreoffice-still-language-pack" do
   end
 
   depends_on cask: "libreoffice-still"
-  depends_on macos: ">= :mojave"
 
   # Start the silent install
   installer script: {

--- a/Casks/l/libreoffice-still.rb
+++ b/Casks/l/libreoffice-still.rb
@@ -56,7 +56,6 @@ cask "libreoffice-still" do
   end
 
   conflicts_with cask: "libreoffice"
-  depends_on macos: ">= :catalina"
 
   app "LibreOffice.app"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"

--- a/Casks/l/libreoffice.rb
+++ b/Casks/l/libreoffice.rb
@@ -31,7 +31,6 @@ cask "libreoffice" do
   end
 
   conflicts_with cask: "libreoffice-still"
-  depends_on macos: ">= :catalina"
 
   app "LibreOffice.app"
   binary "#{appdir}/LibreOffice.app/Contents/MacOS/gengal"

--- a/Casks/l/librewolf.rb
+++ b/Casks/l/librewolf.rb
@@ -21,8 +21,6 @@ cask "librewolf" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "LibreWolf.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/librewolf.wrapper.sh"

--- a/Casks/l/licensed-app.rb
+++ b/Casks/l/licensed-app.rb
@@ -12,8 +12,6 @@ cask "licensed-app" do
     regex(%r{>\s*Version\s*v?(\d+(?:\.\d+)+)[^<]*</}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Licensed.app"
 
   zap trash: [

--- a/Casks/l/lidarr.rb
+++ b/Casks/l/lidarr.rb
@@ -21,7 +21,6 @@ cask "lidarr" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Lidarr.app"
 

--- a/Casks/l/lifesize.rb
+++ b/Casks/l/lifesize.rb
@@ -14,7 +14,6 @@ cask "lifesize" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Lifesize.app"
 

--- a/Casks/l/lightform.rb
+++ b/Casks/l/lightform.rb
@@ -10,8 +10,6 @@ cask "lightform" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :mojave"
-
   app "Lightform.app"
 
   zap trash: [

--- a/Casks/l/linear-linear.rb
+++ b/Casks/l/linear-linear.rb
@@ -25,7 +25,6 @@ cask "linear-linear" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Linear.app"
 

--- a/Casks/l/linearmouse.rb
+++ b/Casks/l/linearmouse.rb
@@ -16,7 +16,6 @@ cask "linearmouse" do
 
   auto_updates true
   conflicts_with cask: "linearmouse@beta"
-  depends_on macos: ">= :catalina"
 
   app "LinearMouse.app"
 

--- a/Casks/l/linearmouse@beta.rb
+++ b/Casks/l/linearmouse@beta.rb
@@ -14,7 +14,6 @@ cask "linearmouse@beta" do
 
   auto_updates true
   conflicts_with cask: "linearmouse"
-  depends_on macos: ">= :catalina"
 
   app "LinearMouse.app"
 

--- a/Casks/l/lingon-x.rb
+++ b/Casks/l/lingon-x.rb
@@ -1,13 +1,5 @@
 cask "lingon-x" do
-  on_high_sierra :or_older do
-    version "6.6.5"
-    sha256 "b0231b1a98dcc8f5c4234b419c9f5331407b8cce29b33f0ea2e32b12595adfa8"
-  end
-  on_mojave do
-    version "8.4.9"
-    sha256 "c1c839e8dc13bd295f2080980c5bea22299c33f3333b7c6981161b46d6f021d8"
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "8.4.9"
     sha256 "c1c839e8dc13bd295f2080980c5bea22299c33f3333b7c6981161b46d6f021d8"
   end
@@ -33,7 +25,6 @@ cask "lingon-x" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Lingon X.app"
 

--- a/Casks/l/linkandroid.rb
+++ b/Casks/l/linkandroid.rb
@@ -11,8 +11,6 @@ cask "linkandroid" do
   desc "Open source android assistant"
   homepage "https://linkandroid.com/"
 
-  depends_on macos: ">= :catalina"
-
   app "LinkAndroid.app"
 
   zap trash: [

--- a/Casks/l/linkliar.rb
+++ b/Casks/l/linkliar.rb
@@ -1,12 +1,6 @@
 cask "linkliar" do
-  on_el_capitan :or_older do
-    version "1.1.3"
-    sha256 "34c9baeaf1d6732c8ce9add689b281f9b71fddadd8f56cca614cba4f8c167962"
-  end
-  on_sierra :or_newer do
-    version "3.0.3"
-    sha256 "36e62eab4ef8d2b004c6886182fc49830afdf56f4f14f9be07adfe552d7140d2"
-  end
+  version "3.0.3"
+  sha256 "36e62eab4ef8d2b004c6886182fc49830afdf56f4f14f9be07adfe552d7140d2"
 
   url "https://github.com/halo/LinkLiar/releases/download/#{version}/LinkLiar.app.zip"
   name "LinkLiar"

--- a/Casks/l/linphone.rb
+++ b/Casks/l/linphone.rb
@@ -12,8 +12,6 @@ cask "linphone" do
     regex(/Linphone[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Linphone.app"
 
   zap trash: [

--- a/Casks/l/listen1.rb
+++ b/Casks/l/listen1.rb
@@ -14,8 +14,6 @@ cask "listen1" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :el_capitan"
-
   app "Listen1.app"
 
   zap trash: [

--- a/Casks/l/litecoin.rb
+++ b/Casks/l/litecoin.rb
@@ -12,8 +12,6 @@ cask "litecoin" do
     regex(/href=.*?litecoin[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Litecoin-Qt.app"
 
   preflight do

--- a/Casks/l/liteicon.rb
+++ b/Casks/l/liteicon.rb
@@ -1,16 +1,6 @@
 cask "liteicon" do
-  on_sierra :or_older do
-    version "3.7.1"
-    sha256 "b457521a698a0ef55cd3d9c044c82c28984eeebc20d8baf05a9c21b0fa1df432"
-  end
-  on_high_sierra do
-    version "3.9"
-    sha256 "d185503d1c6cbbc6f770517853bd9ef08dc620f4e7ce3de913251a57e4d450d9"
-  end
-  on_mojave :or_newer do
-    version "4.1"
-    sha256 "545cff53df31b63fe28e794fb7f45e4c891885f5de57422b1483724f6d7ed4e0"
-  end
+  version "4.1"
+  sha256 "545cff53df31b63fe28e794fb7f45e4c891885f5de57422b1483724f6d7ed4e0"
 
   url "https://www.freemacsoft.net/downloads/LiteIcon_#{version}.zip"
   name "LiteIcon"

--- a/Casks/l/liteide.rb
+++ b/Casks/l/liteide.rb
@@ -15,8 +15,6 @@ cask "liteide" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "liteide/LiteIDE.app"
 
   # No zap stanza required

--- a/Casks/l/little-snitch@4.rb
+++ b/Casks/l/little-snitch@4.rb
@@ -1,39 +1,22 @@
 cask "little-snitch@4" do
-  on_mojave :or_older do
-    version "4.5.2"
-    sha256 "52116bb4e5186fed441c7cab835b4dd822243248f402334b486f0c7b20062c13"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "4.6.1"
-    sha256 "bb4c609b0a0c353d42f99f00513cb653acdf6d8c857930f146475ed89a46ff82"
-
-    livecheck do
-      url "https://www.obdev.at/products/littlesnitch/releasenotes#{version.major}.html"
-      regex(/Little\sSnitch\s(\d+(?:\.\d+)+)/i)
-    end
-  end
+  version "4.6.1"
+  sha256 "bb4c609b0a0c353d42f99f00513cb653acdf6d8c857930f146475ed89a46ff82"
 
   url "https://www.obdev.at/downloads/littlesnitch/legacy/LittleSnitch-#{version}.dmg"
   name "Little Snitch"
   desc "Host-based application firewall"
   homepage "https://www.obdev.at/products/littlesnitch/index.html"
 
+  livecheck do
+    url "https://www.obdev.at/products/littlesnitch/releasenotes#{version.major}.html"
+    regex(/Little\sSnitch\s(\d+(?:\.\d+)+)/i)
+  end
+
   auto_updates true
   conflicts_with cask: [
     "little-snitch",
     "little-snitch@5",
     "little-snitch@nightly",
-  ]
-  depends_on macos: [
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-    :mojave,
-    :catalina,
   ]
   container type: :naked
 

--- a/Casks/l/live-home-3d.rb
+++ b/Casks/l/live-home-3d.rb
@@ -13,8 +13,6 @@ cask "live-home-3d" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Live Home 3D.app"
 
   zap trash: [

--- a/Casks/l/lm-studio.rb
+++ b/Casks/l/lm-studio.rb
@@ -20,7 +20,6 @@ cask "lm-studio" do
 
   auto_updates true
   depends_on arch: :arm64
-  depends_on macos: ">= :catalina"
 
   app "LM Studio.app"
 

--- a/Casks/l/lmms.rb
+++ b/Casks/l/lmms.rb
@@ -1,26 +1,14 @@
 cask "lmms" do
-  on_high_sierra :or_older do
-    version "1.2.2"
-    sha256 "e5aa82086dc67817a763f3e54aa0786cdca590f26981584c07f9ff2ff1fb0503"
+  version "1.2.2"
+  sha256 "bcf9d6693cf4000df4a4c705afb8bbaa30a3caf4e146939c983cc31eecb66eb0"
 
-    url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}-mac10.13.dmg",
-        verified: "github.com/LMMS/lmms/"
-  end
-  on_mojave :or_newer do
-    version "1.2.2"
-    sha256 "bcf9d6693cf4000df4a4c705afb8bbaa30a3caf4e146939c983cc31eecb66eb0"
-
-    url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}-mac10.14.dmg",
-        verified: "github.com/LMMS/lmms/"
-  end
-
+  url "https://github.com/LMMS/lmms/releases/download/v#{version}/lmms-#{version}-mac10.14.dmg",
+      verified: "github.com/LMMS/lmms/"
   name "LMMS"
   desc "Music production software"
   homepage "https://lmms.io/"
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
-  depends_on macos: ">= :high_sierra"
 
   app "LMMS.app"
 

--- a/Casks/l/local.rb
+++ b/Casks/l/local.rb
@@ -22,7 +22,6 @@ cask "local" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Local.app"
 

--- a/Casks/l/local@beta.rb
+++ b/Casks/l/local@beta.rb
@@ -21,8 +21,6 @@ cask "local@beta" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Local Beta.app"
 
   zap trash: [

--- a/Casks/l/localizationeditor.rb
+++ b/Casks/l/localizationeditor.rb
@@ -9,8 +9,6 @@ cask "localizationeditor" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "LocalizationEditor.app"
 
   # No zap stanza required

--- a/Casks/l/locationsimulator.rb
+++ b/Casks/l/locationsimulator.rb
@@ -7,8 +7,6 @@ cask "locationsimulator" do
   desc "Application to spoof your iOS, iPadOS or iPhoneSimulator device location"
   homepage "https://github.com/Schlaubischlump/LocationSimulator"
 
-  depends_on macos: ">= :catalina"
-
   app "LocationSimulator.app"
 
   zap trash: [

--- a/Casks/l/lockrattler.rb
+++ b/Casks/l/lockrattler.rb
@@ -23,8 +23,6 @@ cask "lockrattler" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "lockrattler#{version.csv.first.major}#{version.csv.first.minor}/LockRattler.app"
 
   zap trash: [

--- a/Casks/l/lofi.rb
+++ b/Casks/l/lofi.rb
@@ -8,8 +8,6 @@ cask "lofi" do
   desc "Spotify player with WebGL visualisations"
   homepage "https://www.lofi.rocks/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "lofi.app"
 
   zap trash: [

--- a/Casks/l/logi-options+.rb
+++ b/Casks/l/logi-options+.rb
@@ -41,7 +41,6 @@ cask "logi-options+" do
   homepage "https://www.logitech.com/en-us/software/logi-options-plus.html"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   # The installer path can be inconsistent between versions/systems without notice
   rename "Logi Options+ Installer.app", "logioptionsplus_installer.app"

--- a/Casks/l/loginputmac.rb
+++ b/Casks/l/loginputmac.rb
@@ -14,7 +14,6 @@ cask "loginputmac" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "LogInputMac#{version.csv.first.major}.app"
 

--- a/Casks/l/logitech-camera-settings.rb
+++ b/Casks/l/logitech-camera-settings.rb
@@ -20,8 +20,6 @@ cask "logitech-camera-settings" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "LogiCameraSettings_#{version}.pkg"
 
   uninstall signal:     ["TERM", "com.logitech.vc.LogiVCCoreService"],

--- a/Casks/l/logitech-options.rb
+++ b/Casks/l/logitech-options.rb
@@ -1,56 +1,5 @@
 cask "logitech-options" do
-  on_sierra :or_older do
-    version "7.14.77"
-    sha256 "e4df55642e04139fc93d955e949bf736196a404ed067d87f8de7eb9ac9117ece"
-
-    url "https://web.archive.org/web/20220113114711/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
-        verified: "web.archive.org/web/20220113114711/https://download01.logi.com/web/ftp/pub/techsupport/options/"
-
-    livecheck do
-      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.12"
-      regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
-    end
-
-    # The url is unversioned, but the download returns an app with a version number
-    rename "LogiMgr Installer*.app", "LogiMgr Installer.app"
-
-    pkg "LogiMgr Installer.app/Contents/Resources/LogiMgr.mpkg"
-  end
-  on_high_sierra do
-    version "8.30.293"
-    sha256 "db5f2cd94960223bdf74f0db6fc009f82f80928fe2ce849202754bbdb720eb87"
-
-    url "https://web.archive.org/web/20210208002741/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
-        verified: "web.archive.org/web/20210208002741/https://download01.logi.com/web/ftp/pub/techsupport/options/"
-
-    livecheck do
-      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.13"
-      regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
-    end
-
-    # The url is unversioned, but the download returns an app with a version number
-    rename "LogiMgr Installer*.app", "LogiMgr Installer.app"
-
-    pkg "LogiMgr Installer.app/Contents/Resources/LogiMgr.mpkg"
-  end
-  on_mojave do
-    version "8.54.147"
-    sha256 "7b7a8d7a498d868c90b4ffe7dfc50a7a39c25e1f61350702e87d4c771b3d6459"
-
-    url "https://web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/Options_#{version}.zip",
-        verified: "web.archive.org/web/20210811105616/https://download01.logi.com/web/ftp/pub/techsupport/options/"
-
-    livecheck do
-      url "https://support.logi.com/api/v2/help_center/en-us/articles.json?label_names=webcontent=productdownload,webos=mac-macos-x-10.14"
-      regex(%r{/Options[._-]?v?(\d+(?:\.\d+)+)\.zip}i)
-    end
-
-    # The url is unversioned, but the download returns an app with a version number
-    rename "LogiMgr Installer*.app", "LogiMgr Installer.app"
-
-    pkg "LogiMgr Installer.app/Contents/Resources/LogiMgr.pkg"
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "8.54.147"
     sha256 "7b7a8d7a498d868c90b4ffe7dfc50a7a39c25e1f61350702e87d4c771b3d6459"
 
@@ -94,7 +43,6 @@ cask "logitech-options" do
   homepage "https://support.logitech.com/software/options"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   uninstall launchctl: [
               "com.logi.bolt.app",

--- a/Casks/l/logitech-presentation.rb
+++ b/Casks/l/logitech-presentation.rb
@@ -22,7 +22,6 @@ cask "logitech-presentation" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   installer manual: "LogiPresentation Installer.app"
 

--- a/Casks/l/logitune.rb
+++ b/Casks/l/logitune.rb
@@ -21,7 +21,6 @@ cask "logitune" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   installer manual: "LogiTuneInstaller.app"
 

--- a/Casks/l/logmein-client.rb
+++ b/Casks/l/logmein-client.rb
@@ -12,8 +12,6 @@ cask "logmein-client" do
     regex(/Version:\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "LogMeIn Client.app"
 
   zap trash: [

--- a/Casks/l/logseq.rb
+++ b/Casks/l/logseq.rb
@@ -16,7 +16,6 @@ cask "logseq" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Logseq.app"
 

--- a/Casks/l/lookingglassstudio.rb
+++ b/Casks/l/lookingglassstudio.rb
@@ -33,8 +33,6 @@ cask "lookingglassstudio" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   zap trash: [
     "~/Library/Application Support/LookingGlassStudio",
     "~/Library/Preferences/com.lookingglassfactory.studio.plist",

--- a/Casks/l/loom.rb
+++ b/Casks/l/loom.rb
@@ -16,7 +16,6 @@ cask "loom" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Loom.app"
 

--- a/Casks/l/loop-messenger.rb
+++ b/Casks/l/loop-messenger.rb
@@ -16,8 +16,6 @@ cask "loop-messenger" do
     regex(/loop[._-]desktop[._-]v?(\d+(?:\.\d+)+).+?\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "LOOP.app"
 
   zap trash: [

--- a/Casks/l/losslesscut.rb
+++ b/Casks/l/losslesscut.rb
@@ -15,8 +15,6 @@ cask "losslesscut" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "LosslessCut.app"
 
   zap trash: [

--- a/Casks/l/lotus.rb
+++ b/Casks/l/lotus.rb
@@ -15,8 +15,6 @@ cask "lotus" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Lotus.app"
 
   zap trash: [

--- a/Casks/l/loupedeck.rb
+++ b/Casks/l/loupedeck.rb
@@ -12,8 +12,6 @@ cask "loupedeck" do
     regex(/href=.*?LoupedeckInstaller(?:[._\s-]|%20)+v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   # pkg cannot be installed automatically
   installer manual: "LoupedeckInstaller.pkg"
 

--- a/Casks/l/ludwig.rb
+++ b/Casks/l/ludwig.rb
@@ -13,8 +13,6 @@ cask "ludwig" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Ludwig.app"
 
   zap trash: [

--- a/Casks/l/lulu.rb
+++ b/Casks/l/lulu.rb
@@ -13,8 +13,6 @@ cask "lulu" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "LuLu.app"
 
   # Lulu's uninstaller removes all preference files which breaks `brew upgrade`

--- a/Casks/l/luminance-hdr.rb
+++ b/Casks/l/luminance-hdr.rb
@@ -13,8 +13,6 @@ cask "luminance-hdr" do
     regex(%r{url=.*?/Luminance[_-]?HDR[._-]v?(\d+(?:\.\d+)+)[^"' ]*?\.dmg}i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Luminance HDR #{version.major_minor_patch}.app"
 
   zap trash: [

--- a/Casks/l/lunar-client.rb
+++ b/Casks/l/lunar-client.rb
@@ -14,7 +14,6 @@ cask "lunar-client" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Lunar Client.app"
 

--- a/Casks/l/lunasea.rb
+++ b/Casks/l/lunasea.rb
@@ -1,12 +1,6 @@
 cask "lunasea" do
-  on_mojave :or_older do
-    version "10.2.2"
-    sha256 "61ef622b70c31550ec6f700eba1e938c23fb97717344e8876d56e2d856a51be4"
-  end
-  on_catalina :or_newer do
-    version "11.0.0"
-    sha256 "fa4ecb5bdf57d6f1326e356e248232040f1b2d0d409ea93ac96dc560eded980c"
-  end
+  version "11.0.0"
+  sha256 "fa4ecb5bdf57d6f1326e356e248232040f1b2d0d409ea93ac96dc560eded980c"
 
   url "https://github.com/JagandeepBrar/LunaSea/releases/download/v#{version}/lunasea-macos-amd64.zip",
       verified: "github.com/JagandeepBrar/LunaSea/"

--- a/Casks/l/lunatask.rb
+++ b/Casks/l/lunatask.rb
@@ -8,8 +8,6 @@ cask "lunatask" do
   desc "Encrypted to-do list, habit tracker, journaling, life-tracking and notes app"
   homepage "https://lunatask.app/"
 
-  depends_on macos: ">= :catalina"
-
   app "Lunatask.app"
 
   zap trash: [

--- a/Casks/l/lx-music.rb
+++ b/Casks/l/lx-music.rb
@@ -13,8 +13,6 @@ cask "lx-music" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "lx-music-desktop.app"
 
   zap trash: [

--- a/Casks/l/lycheeslicer.rb
+++ b/Casks/l/lycheeslicer.rb
@@ -13,8 +13,6 @@ cask "lycheeslicer" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "LycheeSlicer.app"
 
   zap trash: [

--- a/Casks/l/lyn.rb
+++ b/Casks/l/lyn.rb
@@ -12,8 +12,6 @@ cask "lyn" do
     regex(%r{href=.*?/Lyn[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Lyn.app"
 
   zap trash: [

--- a/Casks/l/lynkeos.rb
+++ b/Casks/l/lynkeos.rb
@@ -15,8 +15,6 @@ cask "lynkeos" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Lynkeos-App-#{version.dots_to_hyphens}/Lynkeos.app"
 
   zap trash: [

--- a/Casks/l/lynx-whiteboard.rb
+++ b/Casks/l/lynx-whiteboard.rb
@@ -13,7 +13,6 @@ cask "lynx-whiteboard" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "lynx-whiteboard.pkg"
 

--- a/Casks/l/lyrics-master.rb
+++ b/Casks/l/lyrics-master.rb
@@ -8,8 +8,6 @@ cask "lyrics-master" do
   desc "Find and download lyrics"
   homepage "https://lyricsmaster.app/desktop/"
 
-  depends_on macos: ">= :mojave"
-
   app "Lyrics Master.app"
 
   zap trash: [

--- a/Casks/l/lyricsfinder.rb
+++ b/Casks/l/lyricsfinder.rb
@@ -12,8 +12,6 @@ cask "lyricsfinder" do
     regex(/"softwareVersion">(\d+(?:\.\d+)+)</i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "LyricsFinder.app"
 
   zap trash: "~/Library/Preferences/com.mediahuman.Lyrics Finder.plist"

--- a/Casks/l/lyx.rb
+++ b/Casks/l/lyx.rb
@@ -15,8 +15,6 @@ cask "lyx" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "LyX.app"
   binary "#{appdir}/LyX.app/Contents/MacOS/inkscape", target: "lyx-inkscape"
   binary "#{appdir}/LyX.app/Contents/MacOS/lyx"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.