### PR TITLE
[n]: remove pre-Catalina references

### DIFF
--- a/Casks/n/nagbar.rb
+++ b/Casks/n/nagbar.rb
@@ -8,8 +8,6 @@ cask "nagbar" do
   desc "Status bar monitor for Nagios, Icinga/2 and Thruk"
   homepage "https://sites.google.com/site/nagbarapp/home"
 
-  depends_on macos: ">= :mojave"
-
   app "NagBar.app"
 
   zap trash: [

--- a/Casks/n/name-mangler.rb
+++ b/Casks/n/name-mangler.rb
@@ -13,7 +13,6 @@ cask "name-mangler" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Name Mangler.app"
 

--- a/Casks/n/namechanger.rb
+++ b/Casks/n/namechanger.rb
@@ -13,7 +13,6 @@ cask "namechanger" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "NameChanger.app"
 

--- a/Casks/n/nano-node.rb
+++ b/Casks/n/nano-node.rb
@@ -13,8 +13,6 @@ cask "nano-node" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Nano.app"
 
   zap trash: [

--- a/Casks/n/nao.rb
+++ b/Casks/n/nao.rb
@@ -24,8 +24,6 @@ cask "nao" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "nao.app"
   binary "#{appdir}/nao.app/Contents/Resources/app/bin/nao"
 

--- a/Casks/n/naps2.rb
+++ b/Casks/n/naps2.rb
@@ -17,8 +17,6 @@ cask "naps2" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "naps2-#{version}-mac-#{arch}.pkg"
 
   uninstall pkgutil: "com.naps2.desktop"

--- a/Casks/n/natron.rb
+++ b/Casks/n/natron.rb
@@ -1,13 +1,7 @@
 cask "natron" do
   version "2.5.0"
 
-  on_mojave :or_older do
-    sha256 "4bf8ce890fe51446c01fc8480e8159cd559cfaac2445eae1699ae1718121fa7a"
-
-    url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-OSX109-x86_64.dmg",
-        verified: "github.com/NatronGitHub/Natron/"
-  end
-  on_catalina do
+  on_catalina :or_older do
     sha256 "1c97a1f373c3adcdbb933f20b02d0ebd4d7737d44e5344a372bd7b9e5211860e"
 
     url "https://github.com/NatronGitHub/Natron/releases/download/v#{version}/Natron-#{version}-macOS1015-x86_64.dmg",

--- a/Casks/n/navicat-data-modeler-essentials.rb
+++ b/Casks/n/navicat-data-modeler-essentials.rb
@@ -11,8 +11,6 @@ cask "navicat-data-modeler-essentials" do
     cask "navicat-data-modeler"
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Navicat Data Modeler Essentials.app"
 
   zap trash: [

--- a/Casks/n/navicat-data-modeler.rb
+++ b/Casks/n/navicat-data-modeler.rb
@@ -12,8 +12,6 @@ cask "navicat-data-modeler" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Navicat Data Modeler.app"
 
   zap trash: [

--- a/Casks/n/navicat-premium-essentials.rb
+++ b/Casks/n/navicat-premium-essentials.rb
@@ -10,8 +10,6 @@ cask "navicat-premium-essentials" do
   deprecate! date: "2024-05-14", because: :discontinued
   disable! date: "2025-05-15", because: :discontinued
 
-  depends_on macos: ">= :mojave"
-
   app "Navicat Premium Essentials.app"
 
   zap trash: [

--- a/Casks/n/navicat-premium@15.rb
+++ b/Casks/n/navicat-premium@15.rb
@@ -13,7 +13,6 @@ cask "navicat-premium@15" do
   end
 
   conflicts_with cask: "navicat-premium"
-  depends_on macos: ">= :mojave"
 
   app "Navicat Premium.app"
 

--- a/Casks/n/navigraph-charts.rb
+++ b/Casks/n/navigraph-charts.rb
@@ -13,7 +13,6 @@ cask "navigraph-charts" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Navigraph Charts.app"
 

--- a/Casks/n/navigraph-simlink.rb
+++ b/Casks/n/navigraph-simlink.rb
@@ -15,7 +15,6 @@ cask "navigraph-simlink" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Navigraph Simlink.app"
 

--- a/Casks/n/ncar-ncl.rb
+++ b/Casks/n/ncar-ncl.rb
@@ -1,19 +1,9 @@
 cask "ncar-ncl" do
   version "6.6.2"
+  sha256 "e2cd644f6b1bb41f55480b8818319e60c450998e31e5e489c69a5e84f3d1f359"
 
-  on_high_sierra :or_older do
-    sha256 "4e937a6de4303a4928f0f42390d991b12a37659726d15b9da7e8072db74e1867"
-
-    url "https://www.earthsystemgrid.org/api/v1/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.13_64bit_gnu710.tar.gz",
-        verified: "earthsystemgrid.org/api/v1/dataset/"
-  end
-  on_mojave :or_newer do
-    sha256 "e2cd644f6b1bb41f55480b8818319e60c450998e31e5e489c69a5e84f3d1f359"
-
-    url "https://www.earthsystemgrid.org/api/v1/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.14_64bit_gnu730.tar.gz",
-        verified: "earthsystemgrid.org/api/v1/dataset/"
-  end
-
+  url "https://www.earthsystemgrid.org/api/v1/dataset/ncl.#{version.no_dots}.dap/file/ncl_ncarg-#{version}-MacOS_10.14_64bit_gnu730.tar.gz",
+      verified: "earthsystemgrid.org/api/v1/dataset/"
   name "NCAR Command Language"
   name "ncl"
   desc "Interpreted language for scientific data analysis and visualization"
@@ -26,7 +16,6 @@ cask "ncar-ncl" do
 
   depends_on cask: "xquartz"
   depends_on formula: "gcc"
-  depends_on macos: ">= :high_sierra"
 
   artifact "include", target: "#{HOMEBREW_PREFIX}/ncl-#{version}/include"
   artifact "bin", target: "#{HOMEBREW_PREFIX}/ncl-#{version}/bin"

--- a/Casks/n/neofinder.rb
+++ b/Casks/n/neofinder.rb
@@ -14,7 +14,6 @@ cask "neofinder" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "NeoFinder.app"
 

--- a/Casks/n/neohtop.rb
+++ b/Casks/n/neohtop.rb
@@ -17,8 +17,6 @@ cask "neohtop" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "NeoHtop.app"
 
   zap trash: [

--- a/Casks/n/nestopia.rb
+++ b/Casks/n/nestopia.rb
@@ -12,8 +12,6 @@ cask "nestopia" do
     regex(/>\s*?Nestopia\s+?v?(\d+(?:\.\d+)+)\s*?</i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Nestopia v#{version}/Nestopia.app"
 
   zap trash: [

--- a/Casks/n/netdownloadhelpercoapp.rb
+++ b/Casks/n/netdownloadhelpercoapp.rb
@@ -2,25 +2,11 @@ cask "netdownloadhelpercoapp" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.0.19"
+  sha256 arm:   "be91d5896db29724389c79bc8ce2b1b257bf7516068755aa2a4027c87c82eb9b",
+         intel: "3e4c513c368aa426d9713c857778996773014bcf1874c909c80cfb6ec96de50e"
 
-  on_mojave :or_older do
-    sha256 "1d826c8456424445309dac74054f0d954dab2eb089c75ef217de0b08c32dd5c5"
-
-    url "https://github.com/aclap-dev/vdhcoapp/releases/download/v#{version}/vdhcoapp-mac13-#{arch}-installer.pkg",
-        verified: "github.com/aclap-dev/vdhcoapp/"
-
-    pkg "vdhcoapp-mac13-#{arch}-installer.pkg"
-  end
-  on_catalina :or_newer do
-    sha256 arm:   "be91d5896db29724389c79bc8ce2b1b257bf7516068755aa2a4027c87c82eb9b",
-           intel: "3e4c513c368aa426d9713c857778996773014bcf1874c909c80cfb6ec96de50e"
-
-    url "https://github.com/aclap-dev/vdhcoapp/releases/download/v#{version}/vdhcoapp-mac-#{arch}-installer.pkg",
-        verified: "github.com/aclap-dev/vdhcoapp/"
-
-    pkg "vdhcoapp-mac-#{arch}-installer.pkg"
-  end
-
+  url "https://github.com/aclap-dev/vdhcoapp/releases/download/v#{version}/vdhcoapp-mac-#{arch}-installer.pkg",
+      verified: "github.com/aclap-dev/vdhcoapp/"
   name "Video DownloadHelper Companion App"
   desc "Allows video downloads from the Web"
   homepage "https://www.downloadhelper.net/w/CoApp-Installation"
@@ -30,6 +16,7 @@ cask "netdownloadhelpercoapp" do
     strategy :github_latest
   end
 
+  pkg "vdhcoapp-mac-#{arch}-installer.pkg"
   pkg "vdhcoapp-mac-#{arch}-installer.pkg"
 
   uninstall pkgutil: "net.downloadhelper.coapp"

--- a/Casks/n/neteasemusic.rb
+++ b/Casks/n/neteasemusic.rb
@@ -24,7 +24,6 @@ cask "neteasemusic" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "NeteaseMusic.app"
 

--- a/Casks/n/nethlink.rb
+++ b/Casks/n/nethlink.rb
@@ -16,7 +16,6 @@ cask "nethlink" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "NethLink.app"
 

--- a/Casks/n/netiquette.rb
+++ b/Casks/n/netiquette.rb
@@ -8,8 +8,6 @@ cask "netiquette" do
   desc "Network monitor"
   homepage "https://objective-see.org/products/netiquette.html"
 
-  depends_on macos: ">= :catalina"
-
   app "Netiquette.app"
 
   zap trash: [

--- a/Casks/n/netnewswire.rb
+++ b/Casks/n/netnewswire.rb
@@ -29,7 +29,6 @@ cask "netnewswire" do
 
   auto_updates true
   conflicts_with cask: "netnewswire@beta"
-  depends_on macos: ">= :catalina"
 
   app "NetNewsWire.app"
 

--- a/Casks/n/nexonplug.rb
+++ b/Casks/n/nexonplug.rb
@@ -7,8 +7,6 @@ cask "nexonplug" do
   desc "Launcher for Nexon games"
   homepage "https://www.nexon.com/"
 
-  depends_on macos: ">= :catalina"
-
   pkg "Install_NexonPlug.pkg"
 
   uninstall pkgutil: "com.nexon.plug.pkg"

--- a/Casks/n/nextcloud.rb
+++ b/Casks/n/nextcloud.rb
@@ -24,7 +24,6 @@ cask "nextcloud" do
 
   auto_updates true
   conflicts_with cask: "nextcloud-vfs"
-  depends_on macos: ">= :mojave"
 
   pkg "Nextcloud-#{version}.pkg"
   binary "/Applications/Nextcloud.app/Contents/MacOS/nextcloudcmd"

--- a/Casks/n/nifty-file-lists.rb
+++ b/Casks/n/nifty-file-lists.rb
@@ -13,7 +13,6 @@ cask "nifty-file-lists" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Nifty File Lists.app"
 

--- a/Casks/n/nifty.rb
+++ b/Casks/n/nifty.rb
@@ -13,8 +13,6 @@ cask "nifty" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Nifty.app"
 
   zap trash: [

--- a/Casks/n/niftyman.rb
+++ b/Casks/n/niftyman.rb
@@ -13,8 +13,6 @@ cask "niftyman" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Niftyman.app"
 
   zap trash: [

--- a/Casks/n/nightfall.rb
+++ b/Casks/n/nightfall.rb
@@ -7,8 +7,6 @@ cask "nightfall" do
   desc "Menu bar utility for toggling dark mode"
   homepage "https://github.com/r-thomson/Nightfall/"
 
-  depends_on macos: ">= :catalina"
-
   app "Nightfall.app"
 
   zap trash: [

--- a/Casks/n/nimble-commander.rb
+++ b/Casks/n/nimble-commander.rb
@@ -13,7 +13,6 @@ cask "nimble-commander" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Nimble Commander.app"
 

--- a/Casks/n/nisus-thesaurus.rb
+++ b/Casks/n/nisus-thesaurus.rb
@@ -12,8 +12,6 @@ cask "nisus-thesaurus" do
     regex(/Version\s*(\d+(?:\.\d+)*)/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Nisus Thesaurus.app"
 
   zap trash: [

--- a/Casks/n/nocturnal.rb
+++ b/Casks/n/nocturnal.rb
@@ -10,8 +10,6 @@ cask "nocturnal" do
   deprecate! date: "2024-07-27", because: :unmaintained
   disable! date: "2025-07-27", because: :unmaintained
 
-  depends_on macos: ">= :mojave"
-
   app "Nocturnal.app"
 
   caveats do

--- a/Casks/n/nodebox.rb
+++ b/Casks/n/nodebox.rb
@@ -13,8 +13,6 @@ cask "nodebox" do
     regex(/href=.*?NodeBox[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "NodeBox.app"
 
   zap trash: [

--- a/Casks/n/noisebuddy.rb
+++ b/Casks/n/noisebuddy.rb
@@ -9,7 +9,5 @@ cask "noisebuddy" do
   deprecate! date: "2024-09-08", because: :unmaintained
   disable! date: "2025-09-09", because: :unmaintained
 
-  depends_on macos: ">= :catalina"
-
   app "NoiseBuddy.app"
 end

--- a/Casks/n/nosql-workbench.rb
+++ b/Casks/n/nosql-workbench.rb
@@ -17,7 +17,6 @@ cask "nosql-workbench" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "NoSQL Workbench.app"
 

--- a/Casks/n/nota.rb
+++ b/Casks/n/nota.rb
@@ -12,7 +12,6 @@ cask "nota" do
   homepage "https://nota.md/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Nota.app"
   binary "#{appdir}/Nota.app/Contents/Resources/app.asar.unpacked/assets/nota.sh", target: "nota"

--- a/Casks/n/notebooks.rb
+++ b/Casks/n/notebooks.rb
@@ -12,8 +12,6 @@ cask "notebooks" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Notebooks.app"
 
   zap trash: [

--- a/Casks/n/notesnook.rb
+++ b/Casks/n/notesnook.rb
@@ -17,7 +17,6 @@ cask "notesnook" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Notesnook.app"
 

--- a/Casks/n/notion-mail.rb
+++ b/Casks/n/notion-mail.rb
@@ -18,7 +18,6 @@ cask "notion-mail" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Notion Mail.app"
 

--- a/Casks/n/noto.rb
+++ b/Casks/n/noto.rb
@@ -12,8 +12,6 @@ cask "noto" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Noto.app"
 
   zap trash: [

--- a/Casks/n/notunes.rb
+++ b/Casks/n/notunes.rb
@@ -7,8 +7,6 @@ cask "notunes" do
   desc "Simple application that will prevent iTunes or Apple Music from launching"
   homepage "https://github.com/tombonez/noTunes"
 
-  depends_on macos: ">= :mojave"
-
   app "noTunes.app"
 
   zap trash: "~/Library/Preferences/digital.twisted.noTunes.plist"

--- a/Casks/n/noun-project.rb
+++ b/Casks/n/noun-project.rb
@@ -15,8 +15,6 @@ cask "noun-project" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Noun Project.app"
 
   zap trash: [

--- a/Casks/n/noxappplayer.rb
+++ b/Casks/n/noxappplayer.rb
@@ -18,7 +18,6 @@ cask "noxappplayer" do
     end
   end
 
-  depends_on macos: ">= :sierra"
   container nested: "NoxAppPlayerInstaller.app/Contents/MacOS/NoxAppPlayer.zip"
 
   app "NoxAppPlayer.app"

--- a/Casks/n/nrf-connect.rb
+++ b/Casks/n/nrf-connect.rb
@@ -17,7 +17,6 @@ cask "nrf-connect" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "nRF Connect for Desktop.app"
 

--- a/Casks/n/ntfstool.rb
+++ b/Casks/n/ntfstool.rb
@@ -8,7 +8,6 @@ cask "ntfstool" do
   homepage "https://github.com/ntfstool/ntfstool"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ntfstool.app"
 

--- a/Casks/n/nucleo.rb
+++ b/Casks/n/nucleo.rb
@@ -16,8 +16,6 @@ cask "nucleo" do
     regex(/href=.*?Nucleo[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Nucleo.app"
 
   zap trash: [

--- a/Casks/n/nuclino.rb
+++ b/Casks/n/nuclino.rb
@@ -13,8 +13,6 @@ cask "nuclino" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Nuclino.app"
 
   zap trash: [

--- a/Casks/n/nulloy.rb
+++ b/Casks/n/nulloy.rb
@@ -13,8 +13,6 @@ cask "nulloy" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Nulloy.app"
 
   zap trash: "~/Library/Saved Application State/com.nulloy.savedState"

--- a/Casks/n/numi.rb
+++ b/Casks/n/numi.rb
@@ -13,7 +13,6 @@ cask "numi" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Numi.app"
 

--- a/Casks/n/nutstore.rb
+++ b/Casks/n/nutstore.rb
@@ -13,7 +13,6 @@ cask "nutstore" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   installer script: {
     executable: "坚果云安装程序.app/Contents/MacOS/NutstoreOnlineInstaller",

--- a/Casks/n/nvidia-geforce-now.rb
+++ b/Casks/n/nvidia-geforce-now.rb
@@ -15,7 +15,6 @@ cask "nvidia-geforce-now" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "GeForceNOW.app"
 

--- a/Casks/n/nvidia-nsight-compute.rb
+++ b/Casks/n/nvidia-nsight-compute.rb
@@ -15,8 +15,6 @@ cask "nvidia-nsight-compute" do
     regex(/nsight[._-]compute[._-]mac[._-]#{arch}[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "NVIDIA Nsight Compute.app"
 
   zap trash: [

--- a/Casks/n/nvidia-nsight-systems.rb
+++ b/Casks/n/nvidia-nsight-systems.rb
@@ -15,8 +15,6 @@ cask "nvidia-nsight-systems" do
     regex(/NsightSystems[._-]macos#{arch}[._-]public[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "NVIDIA Nsight Systems.app"
 
   zap trash: "~/Library/Saved Application State/com.nvidia.devtools.QuadD.savedState"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.