### PR TITLE
[o]: remove pre-Catalina references

### DIFF
--- a/Casks/o/obs-virtualcam.rb
+++ b/Casks/o/obs-virtualcam.rb
@@ -8,8 +8,6 @@ cask "obs-virtualcam" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "obs-mac-virtualcam-#{version.csv.second}-v#{version.csv.first}.pkg"
 
   uninstall pkgutil: "com.johnboiles.obs-mac-virtualcam"

--- a/Casks/o/obsidian.rb
+++ b/Casks/o/obsidian.rb
@@ -16,7 +16,6 @@ cask "obsidian" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Obsidian.app"
 

--- a/Casks/o/ocenaudio.rb
+++ b/Casks/o/ocenaudio.rb
@@ -3,12 +3,7 @@ cask "ocenaudio" do
   sha256 :no_check
 
   on_big_sur :or_older do
-    on_high_sierra :or_older do
-      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_sierra.dmg"
-    end
-    on_mojave :or_newer do
-      url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal_legacy.dmg"
-    end
+    url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal_legacy.dmg"
   end
   on_monterey :or_newer do
     url "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg"
@@ -22,8 +17,6 @@ cask "ocenaudio" do
     url :url
     strategy :header_match
   end
-
-  depends_on macos: ">= :sierra"
 
   app "ocenaudio.app"
 

--- a/Casks/o/octarine.rb
+++ b/Casks/o/octarine.rb
@@ -17,8 +17,6 @@ cask "octarine" do
     regex(/href=.*?octarine[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Octarine.app"
 
   zap trash: [

--- a/Casks/o/october.rb
+++ b/Casks/o/october.rb
@@ -16,8 +16,6 @@ cask "october" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "October.app"
 
   zap trash: "~/Library/Application Support/october"

--- a/Casks/o/ogdesign-eagle.rb
+++ b/Casks/o/ogdesign-eagle.rb
@@ -22,7 +22,6 @@ cask "ogdesign-eagle" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Eagle.app"
 

--- a/Casks/o/oka-unarchiver.rb
+++ b/Casks/o/oka-unarchiver.rb
@@ -16,7 +16,6 @@ cask "oka-unarchiver" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Oka Unarchiver #{version.major} Website.app", target: "Oka Unarchiver.app"
 

--- a/Casks/o/okta-advanced-server-access.rb
+++ b/Casks/o/okta-advanced-server-access.rb
@@ -15,7 +15,6 @@ cask "okta-advanced-server-access" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "ScaleFT-#{version}.pkg"
 

--- a/Casks/o/olive.rb
+++ b/Casks/o/olive.rb
@@ -30,8 +30,6 @@ cask "olive" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Olive.app"
 
   uninstall rmdir: "~/Library/Application Support/olivevideoeditor.org{/Olive,}"

--- a/Casks/o/ollama-app.rb
+++ b/Casks/o/ollama-app.rb
@@ -14,7 +14,6 @@ cask "ollama-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Ollama.app"
   binary "#{appdir}/Ollama.app/Contents/Resources/ollama"

--- a/Casks/o/omnidisksweeper.rb
+++ b/Casks/o/omnidisksweeper.rb
@@ -1,29 +1,9 @@
 cask "omnidisksweeper" do
   on_catalina :or_older do
-    on_sierra do
-      version "1.10"
-      sha256 "0d8f5b7ff075fca4503a41e1ea898a145001f3f602f6b53ffb310e0a465af080"
+    version "1.13"
+    sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
 
-      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniDiskSweeper-#{version}.dmg"
-    end
-    on_high_sierra do
-      version "1.11"
-      sha256 "f06b150239e5c5ee27615b1e8bd6ec2c87c61c4cda575547f124ff84986b6f37"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniDiskSweeper-#{version}(n).dmg"
-    end
-    on_mojave do
-      version "1.13"
-      sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
-    end
-    on_catalina do
-      version "1.13"
-      sha256 "bf572a47079cd4dea44f7ae2f14bb9a75e2548ad6066757d33564c21a0003821"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
-    end
+    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniDiskSweeper-#{version}.dmg"
 
     livecheck do
       skip "Legacy version"
@@ -49,7 +29,6 @@ cask "omnidisksweeper" do
   homepage "https://www.omnigroup.com/more/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "OmniDiskSweeper.app"
 

--- a/Casks/o/omnifocus.rb
+++ b/Casks/o/omnifocus.rb
@@ -1,30 +1,6 @@
 cask "omnifocus" do
   on_ventura :or_older do
-    on_el_capitan :or_older do
-      version "2.10"
-      sha256 "e808a72e60cdff9ff5aa1046d856bf62d6418e4915248816c4640e32e52fd8e8"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniFocus-#{version}.dmg"
-    end
-    on_sierra do
-      version "2.12.4"
-      sha256 "8a2dc53331dba804f6781773fef546a03c181fc4ff0eb7ee4f871c10342621f0"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniFocus-#{version}.dmg"
-    end
-    on_high_sierra do
-      version "3.4.6"
-      sha256 "b770b046c2c59f6e55f54d0ad822d5aa755a18aa201d333341de14ebbbcc6a85"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniFocus-#{version}.dmg"
-    end
-    on_mojave do
-      version "3.11.7"
-      sha256 "21c0a63b6bd8c8ff3e5067f4ccd0ab16c9fd65815a7305e184ed27723bd0aa15"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniFocus-#{version}.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "3.11.7"
       sha256 "21c0a63b6bd8c8ff3e5067f4ccd0ab16c9fd65815a7305e184ed27723bd0aa15"
 

--- a/Casks/o/omnigraffle.rb
+++ b/Casks/o/omnigraffle.rb
@@ -1,30 +1,6 @@
 cask "omnigraffle" do
   on_big_sur :or_older do
-    on_el_capitan :or_older do
-      version "7.5"
-      sha256 "d8d8963a85ee34270d7d0148aaaa7aee75bc7d3fffc1bb89e64626546c943d34"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniGraffle-#{version}.dmg"
-    end
-    on_sierra do
-      version "7.8.2"
-      sha256 "ab463ea6c12d49c4104d3814ac3280d0359072702d4751f5074f644fc79de0c6"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniGraffle-#{version}.dmg"
-    end
-    on_high_sierra do
-      version "7.11.5"
-      sha256 "83ef24af2dbd7977b9922e992f17f23e102562f0589d28bc37d5579b4a4d4938"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniGraffle-#{version}.dmg"
-    end
-    on_mojave do
-      version "7.18.6"
-      sha256 "5dfc4f56f5a243f39abf0baf3d9dc2b1921f981bc6edb876f4eec710379e1fa6"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniGraffle-#{version}.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "7.18.6"
       sha256 "5dfc4f56f5a243f39abf0baf3d9dc2b1921f981bc6edb876f4eec710379e1fa6"
 

--- a/Casks/o/omnioutliner.rb
+++ b/Casks/o/omnioutliner.rb
@@ -1,30 +1,6 @@
 cask "omnioutliner" do
   on_big_sur :or_older do
-    on_el_capitan :or_older do
-      version "5.1.4"
-      sha256 "91817e87a29c6a86f64b22f36e292b354aab89f63a070eeab117f4fbb2704ff0"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniOutliner-#{version}.dmg"
-    end
-    on_sierra do
-      version "5.3.4"
-      sha256 "dd329a070980ae6fe1aa9c55d398a2ab5b6192082455e7eb3526a9fccb3eaf42"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniOutliner-#{version}.dmg"
-    end
-    on_high_sierra do
-      version "5.4.2"
-      sha256 "a9364dcf2ee97a871a881530785fa54d269f5e95298e2e4d2e979c70b6365395"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniOutliner-#{version}(n).dmg"
-    end
-    on_mojave do
-      version "5.8.5"
-      sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniOutliner-#{version}.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "5.8.5"
       sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
 

--- a/Casks/o/omniplan.rb
+++ b/Casks/o/omniplan.rb
@@ -1,30 +1,6 @@
 cask "omniplan" do
   on_big_sur :or_older do
-    on_el_capitan :or_older do
-      version "3.7.3"
-      sha256 "1a3ab3a1ea22bdbdf9c1afda8cafc9a2fdf60cb4414f142b621c8758f81720bd"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPlan-#{version}.dmg"
-    end
-    on_sierra do
-      version "3.10.4"
-      sha256 "a30728e72ae970dbf37b2ef9942a6b54267aa3456288dcc1815f20b44667e9e5"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.12/OmniPlan-#{version}.dmg"
-    end
-    on_high_sierra do
-      version "3.13"
-      sha256 "82e0d7db2626d751f93f97d80dc032e4bc01bba1e05ea52c553e4771c8cfeec5"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPlan-#{version}.dmg"
-    end
-    on_mojave do
-      version "4.2.7"
-      sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
-
-      url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPlan-#{version}.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "4.2.7"
       sha256 "157cbea0055a87b2c078c336ea9f5d9aaa9caa242c92265f410e5d7ac534883f"
 

--- a/Casks/o/omnipresence.rb
+++ b/Casks/o/omnipresence.rb
@@ -1,29 +1,5 @@
 cask "omnipresence" do
-  on_el_capitan :or_older do
-    version "1.5.2"
-    sha256 "82d3c6978e644dc7defafd3706a02d15c500e8254ca22076a5095bdd94b786d1"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.11/OmniPresence-#{version}.dmg"
-  end
-  on_sierra do
-    version "1.6"
-    sha256 "48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPresence-#{version}.dmg"
-  end
-  on_high_sierra do
-    version "1.6"
-    sha256 "48bcc9f4a3b49f120651cb6d8fd3f1744bf91c4c63e7d30c5d1762eaacc3cd0b"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.13/OmniPresence-#{version}.dmg"
-  end
-  on_mojave do
-    version "1.8"
-    sha256 "dfb2d162103b3c23e2225dee2322d006f72be3b99b1283c365f6fdd4d1e047d3"
-
-    url "https://downloads.omnigroup.com/software/MacOSX/10.14/OmniPresence-#{version}.dmg"
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "1.8"
     sha256 "dfb2d162103b3c23e2225dee2322d006f72be3b99b1283c365f6fdd4d1e047d3"
 

--- a/Casks/o/onedrive.rb
+++ b/Casks/o/onedrive.rb
@@ -18,7 +18,6 @@ cask "onedrive" do
     "microsoft-office",
     "microsoft-office-businesspro",
   ]
-  depends_on macos: ">= :mojave"
 
   pkg "OneDrive.pkg"
 

--- a/Casks/o/onekey.rb
+++ b/Casks/o/onekey.rb
@@ -19,7 +19,6 @@ cask "onekey" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "OneKey.app"
 

--- a/Casks/o/onlyoffice.rb
+++ b/Casks/o/onlyoffice.rb
@@ -20,7 +20,6 @@ cask "onlyoffice" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "ONLYOFFICE.app"
 

--- a/Casks/o/ontime.rb
+++ b/Casks/o/ontime.rb
@@ -17,7 +17,6 @@ cask "ontime" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "ontime.app"
 

--- a/Casks/o/onyx.rb
+++ b/Casks/o/onyx.rb
@@ -4,27 +4,7 @@ cask "onyx" do
   # NOTE: We use separate `url` values in each of the macOS on_system blocks
   # so that the API data correctly includes URL variants for each.
   on_sonoma :or_older do
-    on_el_capitan :or_older do
-      version "3.1.9"
-
-      url "https://www.titanium-software.fr/download/1011/OnyX.dmg"
-    end
-    on_sierra do
-      version "3.3.1"
-
-      url "https://www.titanium-software.fr/download/1012/OnyX.dmg"
-    end
-    on_high_sierra do
-      version "3.4.9"
-
-      url "https://www.titanium-software.fr/download/1013/OnyX.dmg"
-    end
-    on_mojave do
-      version "3.6.8"
-
-      url "https://www.titanium-software.fr/download/1014/OnyX.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "3.8.7"
 
       url "https://www.titanium-software.fr/download/1015/OnyX.dmg"
@@ -72,10 +52,6 @@ cask "onyx" do
   homepage "https://www.titanium-software.fr/en/onyx.html"
 
   depends_on macos: [
-    :el_capitan,
-    :sierra,
-    :high_sierra,
-    :mojave,
     :catalina,
     :big_sur,
     :monterey,

--- a/Casks/o/opcode.rb
+++ b/Casks/o/opcode.rb
@@ -17,7 +17,6 @@ cask "opcode" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "opcode.app"
 

--- a/Casks/o/open-data-editor.rb
+++ b/Casks/o/open-data-editor.rb
@@ -13,8 +13,6 @@ cask "open-data-editor" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Open Data Editor.app"
 
   # No zap stanza required

--- a/Casks/o/open-video-downloader.rb
+++ b/Casks/o/open-video-downloader.rb
@@ -15,7 +15,6 @@ cask "open-video-downloader" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Open Video Downloader.app"
 

--- a/Casks/o/openbci.rb
+++ b/Casks/o/openbci.rb
@@ -22,7 +22,6 @@ cask "openbci" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "OpenBCI_GUI.app"
 

--- a/Casks/o/openemu.rb
+++ b/Casks/o/openemu.rb
@@ -1,27 +1,17 @@
 cask "openemu" do
-  on_high_sierra :or_older do
-    version "2.0.9.1"
-    sha256 "c6036374104e8cefee1be12fe941418e893a7f60a1b2ddaae37e477b94873790"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave :or_newer do
-    version "2.4.1"
-    sha256 "521ca1305c012d38f6f907f50399fefbf4e45a9bb8d9d4063157ffca78b217d4"
-
-    livecheck do
-      url "https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast.xml"
-      strategy :sparkle
-    end
-  end
+  version "2.4.1"
+  sha256 "521ca1305c012d38f6f907f50399fefbf4e45a9bb8d9d4063157ffca78b217d4"
 
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}.zip",
       verified: "github.com/OpenEmu/OpenEmu/"
   name "OpenEmu"
   desc "Retro video game emulation"
   homepage "https://openemu.org/"
+
+  livecheck do
+    url "https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast.xml"
+    strategy :sparkle
+  end
 
   auto_updates true
   conflicts_with cask: "openemu@experimental"

--- a/Casks/o/openemu@experimental.rb
+++ b/Casks/o/openemu@experimental.rb
@@ -1,27 +1,17 @@
 cask "openemu@experimental" do
-  on_high_sierra :or_older do
-    version "2.0.9.1"
-    sha256 "62c44e823fef65c583cbf5e6f84faa03618d713f45610f73bc23fb34cbf64762"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave :or_newer do
-    version "2.4.1"
-    sha256 "57b6f2b6005119efecb566e8cf611e12f1d0171dcd1f96797a0e9b4c33d3cdb4"
-
-    livecheck do
-      url "https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast-experimental.xml"
-      strategy :sparkle
-    end
-  end
+  version "2.4.1"
+  sha256 "57b6f2b6005119efecb566e8cf611e12f1d0171dcd1f96797a0e9b4c33d3cdb4"
 
   url "https://github.com/OpenEmu/OpenEmu/releases/download/v#{version}/OpenEmu_#{version}-experimental.zip",
       verified: "github.com/OpenEmu/OpenEmu/"
   name "OpenEmu"
   desc "Retro video game emulation"
   homepage "https://openemu.org/"
+
+  livecheck do
+    url "https://raw.github.com/OpenEmu/OpenEmu-Update/master/appcast-experimental.xml"
+    strategy :sparkle
+  end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 

--- a/Casks/o/openineditor-lite.rb
+++ b/Casks/o/openineditor-lite.rb
@@ -27,8 +27,6 @@ cask "openineditor-lite" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "OpenInEditor-Lite.app"
 
   zap trash: "~/Library/Preferences/wang.jianing.app.OpenInEditor-Lite.plist"

--- a/Casks/o/openinterminal-lite.rb
+++ b/Casks/o/openinterminal-lite.rb
@@ -27,8 +27,6 @@ cask "openinterminal-lite" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "OpenInTerminal-Lite.app"
 
   zap trash: "~/Library/Preferences/wang.jianing.app.OpenInTerminal-Lite.plist"

--- a/Casks/o/openinterminal.rb
+++ b/Casks/o/openinterminal.rb
@@ -7,8 +7,6 @@ cask "openinterminal" do
   desc "Finder Toolbar app to open the current directory in Terminal or Editor"
   homepage "https://github.com/Ji4n1ng/OpenInTerminal"
 
-  depends_on macos: ">= :sierra"
-
   app "OpenInTerminal.app"
 
   zap trash: [

--- a/Casks/o/openlens.rb
+++ b/Casks/o/openlens.rb
@@ -11,7 +11,6 @@ cask "openlens" do
   homepage "https://github.com/MuhammedKalkan/OpenLens/"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "OpenLens.app"
 

--- a/Casks/o/openrct2.rb
+++ b/Casks/o/openrct2.rb
@@ -1,35 +1,11 @@
 cask "openrct2" do
   # NOTE: "2" is not a version number, but an intrinsic part of the product name
-  on_sierra :or_older do
-    version "0.2.6"
-    sha256 "0073933b486da10b181bc8a226a140badc64c7cd93f681d769c17b5715221a85"
 
-    url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86_64.zip",
-        verified: "github.com/OpenRCT2/OpenRCT2/"
+  version "0.4.26"
+  sha256 "159c2005aa93d18fcf8955002f3908bbcbf123b9b3d6b5531d211dcd632fd71c"
 
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_high_sierra do
-    version "0.3.4.1"
-    sha256 "dbe5f13d2ae391160bcf7cfa80d9a8d7fd5937c12f4dd0dea9254f00038e60c7"
-
-    url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-#{version}-macos-x86-64.zip",
-        verified: "github.com/OpenRCT2/OpenRCT2/"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave :or_newer do
-    version "0.4.26"
-    sha256 "159c2005aa93d18fcf8955002f3908bbcbf123b9b3d6b5531d211dcd632fd71c"
-
-    url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-v#{version}-macos-universal.zip",
-        verified: "github.com/OpenRCT2/OpenRCT2/"
-  end
-
+  url "https://github.com/OpenRCT2/OpenRCT2/releases/download/v#{version}/OpenRCT2-v#{version}-macos-universal.zip",
+      verified: "github.com/OpenRCT2/OpenRCT2/"
   name "OpenRCT2"
   desc "Open-source re-implementation of RollerCoaster Tycoon 2"
   homepage "https://openrct2.io/"

--- a/Casks/o/openrgb.rb
+++ b/Casks/o/openrgb.rb
@@ -18,8 +18,6 @@ cask "openrgb" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "OpenRGB.app"
 
   zap trash: [

--- a/Casks/o/openshot-video-editor.rb
+++ b/Casks/o/openshot-video-editor.rb
@@ -14,7 +14,6 @@ cask "openshot-video-editor" do
   end
 
   conflicts_with cask: "openshot-video-editor@daily"
-  depends_on macos: ">= :catalina"
 
   app "OpenShot Video Editor.app"
 

--- a/Casks/o/openshot-video-editor@daily.rb
+++ b/Casks/o/openshot-video-editor@daily.rb
@@ -22,7 +22,6 @@ cask "openshot-video-editor@daily" do
   end
 
   conflicts_with cask: "openshot-video-editor"
-  depends_on macos: ">= :catalina"
 
   app "OpenShot Video Editor.app"
 

--- a/Casks/o/opensoundmeter.rb
+++ b/Casks/o/opensoundmeter.rb
@@ -16,8 +16,6 @@ cask "opensoundmeter" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "OpenSoundMeter.app"
 
   zap trash: [

--- a/Casks/o/openthesaurus-deutsch.rb
+++ b/Casks/o/openthesaurus-deutsch.rb
@@ -13,8 +13,6 @@ cask "openthesaurus-deutsch" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :el_capitan"
-
   dictionary "OpenThesaurus Deutsch.dictionary"
 
   # No zap stanza required

--- a/Casks/o/openttd.rb
+++ b/Casks/o/openttd.rb
@@ -1,41 +1,23 @@
 cask "openttd" do
-  on_high_sierra :or_older do
-    version "1.11.2"
-    sha256 "44f7e08b806124cce8d99c5adc906eb4280ba8057609b8c309080d63fcfb17c2"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_mojave do
-    version "13.4"
-    sha256 "085cdb35867dca1dcfb8a1748417e7ba6431551ebc33df290a4e48b244d8d376"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "14.1"
-    sha256 "68954bbfb941a599c9b2e017d56e12b64794f2494b4d41d308d66167e53fc6c5"
-
-    livecheck do
-      url "https://cdn.openttd.org/openttd-releases/latest.yaml"
-      strategy :yaml do |yaml|
-        yaml["latest"]&.map do |item|
-          next if item["name"] != "stable"
-          next if item["version"].blank?
-
-          item["version"].to_s
-        end
-      end
-    end
-  end
+  version "14.1"
+  sha256 "68954bbfb941a599c9b2e017d56e12b64794f2494b4d41d308d66167e53fc6c5"
 
   url "https://cdn.openttd.org/openttd-releases/#{version}/openttd-#{version}-macos-universal.zip"
   name "OpenTTD"
   desc "Open-source transport simulation game"
   homepage "https://www.openttd.org/"
+
+  livecheck do
+    url "https://cdn.openttd.org/openttd-releases/latest.yaml"
+    strategy :yaml do |yaml|
+      yaml["latest"]&.map do |item|
+        next if item["name"] != "stable"
+        next if item["version"].blank?
+
+        item["version"].to_s
+      end
+    end
+  end
 
   app "OpenTTD.app"
 

--- a/Casks/o/openzfs.rb
+++ b/Casks/o/openzfs.rb
@@ -1,12 +1,7 @@
 cask "openzfs" do
   version "2.3.0"
 
-  on_mojave :or_older do
-    arch intel: "MAVERICKS-10.9"
-
-    sha256 "d45facdaaa80d2b79df309598027f0b48df65c560daf88f0883cebfe9fd9ea6c"
-  end
-  on_catalina do
+  on_catalina :or_older do
     arch intel: "Catalina-10.15"
 
     sha256 "517f8348b7fedc45191c792bb67c6c07dca2ab1aeababa124ddea15b4600d7d7"

--- a/Casks/o/opgg.rb
+++ b/Casks/o/opgg.rb
@@ -13,7 +13,6 @@ cask "opgg" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "OP.GG.app"
 

--- a/Casks/o/optimage.rb
+++ b/Casks/o/optimage.rb
@@ -13,7 +13,6 @@ cask "optimage" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Optimage.app"
   binary "#{appdir}/Optimage.app/Contents/MacOS/cli/optimage"

--- a/Casks/o/optimus-player.rb
+++ b/Casks/o/optimus-player.rb
@@ -13,7 +13,6 @@ cask "optimus-player" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Optimus Player.app"
 

--- a/Casks/o/oracle-jdk.rb
+++ b/Casks/o/oracle-jdk.rb
@@ -17,8 +17,6 @@ cask "oracle-jdk" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "JDK #{version}.pkg"
 
   uninstall pkgutil: "com.oracle.jdk-#{version}"

--- a/Casks/o/oracle-jdk@17.rb
+++ b/Casks/o/oracle-jdk@17.rb
@@ -12,8 +12,6 @@ cask "oracle-jdk@17" do
 
   deprecate! date: "2024-10-28", because: :no_longer_meets_criteria
 
-  depends_on macos: ">= :mojave"
-
   pkg "JDK #{version}.pkg"
 
   uninstall pkgutil: "com.oracle.jdk-#{version}"

--- a/Casks/o/oracle-jdk@21.rb
+++ b/Casks/o/oracle-jdk@21.rb
@@ -17,8 +17,6 @@ cask "oracle-jdk@21" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "JDK #{version}.pkg"
 
   uninstall pkgutil: "com.oracle.jdk-#{version}"

--- a/Casks/o/orcaslicer@nightly.rb
+++ b/Casks/o/orcaslicer@nightly.rb
@@ -10,7 +10,6 @@ cask "orcaslicer@nightly" do
   homepage "https://github.com/SoftFever/OrcaSlicer"
 
   conflicts_with cask: "orcaslicer"
-  depends_on macos: ">= :catalina"
 
   app "OrcaSlicer.app"
 

--- a/Casks/o/origami-studio.rb
+++ b/Casks/o/origami-studio.rb
@@ -15,8 +15,6 @@ cask "origami-studio" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "Origami Studio.app"
 
   zap trash: [

--- a/Casks/o/orion.rb
+++ b/Casks/o/orion.rb
@@ -1,16 +1,5 @@
 cask "orion" do
-  on_mojave :or_older do
-    version "0.99,136"
-    sha256 "bcc91462edcacf071e9a98d8d15960c9295c5622f45d600fafee546a4a87b97f"
-
-    url "https://cdn.kagi.com/updates/10_14/#{version.csv.second}.zip"
-
-    livecheck do
-      url "https://cdn.kagi.com/updates/10_14/appcast.xml"
-      strategy :sparkle
-    end
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "0.99,136"
     sha256 "6f7906497cbac3e9f6356b1b8c451cc5acbaec1b92d8574dd738d3577c1eab20"
 
@@ -93,7 +82,6 @@ cask "orion" do
   homepage "https://browser.kagi.com/"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Orion.app"
 

--- a/Casks/o/oryoki.rb
+++ b/Casks/o/oryoki.rb
@@ -13,8 +13,6 @@ cask "oryoki" do
   deprecate! date: "2024-07-27", because: :unmaintained
   disable! date: "2025-07-27", because: :unmaintained
 
-  depends_on macos: ">= :el_capitan"
-
   app "Oryoki.app"
 
   caveats do

--- a/Casks/o/oscar.rb
+++ b/Casks/o/oscar.rb
@@ -13,8 +13,6 @@ cask "oscar" do
     regex(%r{href=.*?/OSCAR[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "OSCAR.app"
 
   zap trash: [

--- a/Casks/o/ossia-score.rb
+++ b/Casks/o/ossia-score.rb
@@ -28,8 +28,6 @@ cask "ossia-score" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "ossia score.app"
 
   zap trash: [

--- a/Casks/o/osu.rb
+++ b/Casks/o/osu.rb
@@ -18,7 +18,6 @@ cask "osu" do
 
   auto_updates true
   conflicts_with cask: "osu@tachyon"
-  depends_on macos: ">= :sierra"
 
   app "osu!.app"
 

--- a/Casks/o/osu@tachyon.rb
+++ b/Casks/o/osu@tachyon.rb
@@ -17,7 +17,6 @@ cask "osu@tachyon" do
 
   auto_updates true
   conflicts_with cask: "osu"
-  depends_on macos: ">= :sierra"
 
   app "osu!.app"
 

--- a/Casks/o/outerbase-studio.rb
+++ b/Casks/o/outerbase-studio.rb
@@ -13,7 +13,6 @@ cask "outerbase-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Outerbase Studio.app"
 

--- a/Casks/o/outfox.rb
+++ b/Casks/o/outfox.rb
@@ -28,8 +28,6 @@ cask "outfox" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   suite "OutFox"
 
   zap trash: [

--- a/Casks/o/outguess.rb
+++ b/Casks/o/outguess.rb
@@ -12,8 +12,6 @@ cask "outguess" do
     regex(/Version\s+(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Outguess.app"
 
   zap trash: [

--- a/Casks/o/overflow.rb
+++ b/Casks/o/overflow.rb
@@ -13,8 +13,6 @@ cask "overflow" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Overflow #{version.major}.app"
 
   zap trash: [

--- a/Casks/o/overkill.rb
+++ b/Casks/o/overkill.rb
@@ -10,8 +10,6 @@ cask "overkill" do
   deprecate! date: "2024-07-27", because: :unmaintained
   disable! date: "2025-07-27", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "Overkill.app"
 
   zap trash: "~/Library/Preferences/com.krausefx.Overkill.plist"

--- a/Casks/o/overlayed.rb
+++ b/Casks/o/overlayed.rb
@@ -8,8 +8,6 @@ cask "overlayed" do
   desc "Modern, open-source, and free voice chat overlay for Discord"
   homepage "https://overlayed.dev/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Overlayed.app"
 
   zap trash: "~/Library/Application Support/com.hacksore.overlayed"

--- a/Casks/o/overt.rb
+++ b/Casks/o/overt.rb
@@ -16,8 +16,6 @@ cask "overt" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Overt.app"
 
   zap trash: [

--- a/Casks/o/ovice.rb
+++ b/Casks/o/ovice.rb
@@ -18,8 +18,6 @@ cask "ovice" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "ovice.app"
 
   zap trash: [

--- a/Casks/o/ovito-pro.rb
+++ b/Casks/o/ovito-pro.rb
@@ -22,7 +22,6 @@ cask "ovito-pro" do
 
   auto_updates true
   conflicts_with cask: "ovito"
-  depends_on macos: ">= :catalina"
 
   app "Ovito.app"
 

--- a/Casks/o/ovito.rb
+++ b/Casks/o/ovito.rb
@@ -22,7 +22,6 @@ cask "ovito" do
 
   auto_updates true
   conflicts_with cask: "ovito-pro"
-  depends_on macos: ">= :catalina"
 
   app "Ovito.app"
 

--- a/Casks/o/owncloud.rb
+++ b/Casks/o/owncloud.rb
@@ -16,7 +16,6 @@ cask "owncloud" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   pkg "ownCloud-#{version}-#{arch}.pkg"
 

--- a/Casks/o/oxygen-xml-developer.rb
+++ b/Casks/o/oxygen-xml-developer.rb
@@ -27,8 +27,6 @@ cask "oxygen-xml-developer" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   suite "Oxygen XML Developer"
 
   zap trash: "~/Library/Preferences/com.oxygenxml.developer"

--- a/Casks/o/oxygen-xml-editor.rb
+++ b/Casks/o/oxygen-xml-editor.rb
@@ -27,8 +27,6 @@ cask "oxygen-xml-editor" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   suite "Oxygen XML Editor"
 
   zap trash: "~/Library/Preferences/com.oxygenxml"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.