### PR TITLE
[q]: remove pre-Catalina references

### DIFF
--- a/Casks/q/qbittorrent.rb
+++ b/Casks/q/qbittorrent.rb
@@ -1,17 +1,7 @@
 cask "qbittorrent" do
   on_catalina :or_older do
-    on_high_sierra :or_older do
-      version "4.3.2"
-      sha256 "dd38e80710978430694c430276a6b7749ef3533cbd0271075bc9eada484ea36b"
-    end
-    on_mojave do
-      version "4.3.9"
-      sha256 "c43323a625a937383da68e50a99d823d56e6843580dc8550dd4942683467c3ed"
-    end
-    on_catalina do
-      version "4.6.7"
-      sha256 "0b1051af73562fc3f7c0c71abd27c3433ad238fbca0c4612f554db35be3eba6e"
-    end
+    version "4.6.7"
+    sha256 "0b1051af73562fc3f7c0c71abd27c3433ad238fbca0c4612f554db35be3eba6e"
 
     livecheck do
       skip "Legacy version"
@@ -36,7 +26,6 @@ cask "qbittorrent" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   conflicts_with cask: "qbittorrent@lt20"
-  depends_on macos: ">= :high_sierra"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "qbittorrent.app", target: "qBittorrent.app"

--- a/Casks/q/qcad.rb
+++ b/Casks/q/qcad.rb
@@ -30,8 +30,6 @@ cask "qcad" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "QCAD.app"
 
   zap trash: [

--- a/Casks/q/qdirstat.rb
+++ b/Casks/q/qdirstat.rb
@@ -8,7 +8,6 @@ cask "qdirstat" do
   homepage "https://github.com/jesusha123/qdirstat-macos/"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "QDirStat.app"
 

--- a/Casks/q/qdslrdashboard.rb
+++ b/Casks/q/qdslrdashboard.rb
@@ -21,8 +21,6 @@ cask "qdslrdashboard" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "qDslrDashboard.app"
 
   zap trash: [

--- a/Casks/q/qflipper.rb
+++ b/Casks/q/qflipper.rb
@@ -12,8 +12,6 @@ cask "qflipper" do
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "qFlipper.app"
   binary "#{appdir}/qFlipper.app/Contents/MacOS/qFlipper-cli"
 

--- a/Casks/q/qgis.rb
+++ b/Casks/q/qgis.rb
@@ -18,8 +18,6 @@ cask "qgis" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "QGIS.app"
 
   zap trash: [

--- a/Casks/q/qgis@ltr.rb
+++ b/Casks/q/qgis@ltr.rb
@@ -15,8 +15,6 @@ cask "qgis@ltr" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "QGIS-LTR.app"
 
   zap trash: [

--- a/Casks/q/qlcolorcode.rb
+++ b/Casks/q/qlcolorcode.rb
@@ -7,8 +7,6 @@ cask "qlcolorcode" do
   desc "Quick Look plug-in that renders source code with syntax highlighting"
   homepage "https://github.com/anthonygelibert/QLColorCode"
 
-  depends_on macos: ">= :mojave"
-
   qlplugin "QLColorCode.qlgenerator"
 
   zap trash: "~/Library/Preferences/org.n8gray.QLColorCode.plist"

--- a/Casks/q/qlimagesize.rb
+++ b/Casks/q/qlimagesize.rb
@@ -9,8 +9,6 @@ cask "qlimagesize" do
 
   disable! date: "2024-11-11", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   qlplugin "qlImageSize.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlzipinfo.rb
+++ b/Casks/q/qlzipinfo.rb
@@ -7,8 +7,6 @@ cask "qlzipinfo" do
   desc "List out the contents of a zip file in the QuickLook preview"
   homepage "https://github.com/srirangav/qlZipInfo"
 
-  depends_on macos: ">= :high_sierra"
-
   qlplugin "qlZipInfo.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qobuz-downloader.rb
+++ b/Casks/q/qobuz-downloader.rb
@@ -15,8 +15,6 @@ cask "qobuz-downloader" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Qobuz Downloader.app"
 
   zap trash: [

--- a/Casks/q/qq.rb
+++ b/Casks/q/qq.rb
@@ -13,7 +13,6 @@ cask "qq" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "QQ.app"
 

--- a/Casks/q/qqlive.rb
+++ b/Casks/q/qqlive.rb
@@ -15,7 +15,6 @@ cask "qqlive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "QQLive.app"
 

--- a/Casks/q/qr-journal.rb
+++ b/Casks/q/qr-journal.rb
@@ -12,8 +12,6 @@ cask "qr-journal" do
     regex(%r{href=.*?/QRJournal(\d+(?:\.\d+)*)\.dmg}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "QR Journal.app"
 
   zap trash: [

--- a/Casks/q/qspace-pro.rb
+++ b/Casks/q/qspace-pro.rb
@@ -13,7 +13,6 @@ cask "qspace-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "QSpace Pro.app"
 

--- a/Casks/q/qt3dstudio.rb
+++ b/Casks/q/qt3dstudio.rb
@@ -19,8 +19,6 @@ cask "qt3dstudio" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   installer manual: "qt-3dstudio-opensource-mac-x64-#{version}.app"
 
   uninstall delete: "~/Applications/qt3dstudio-#{version}"

--- a/Casks/q/qth.rb
+++ b/Casks/q/qth.rb
@@ -9,8 +9,6 @@ cask "qth" do
 
   deprecate! date: "2025-02-24", because: :moved_to_mas
 
-  depends_on macos: ">= :high_sierra"
-
   app "QTH.app"
 
   zap trash: [

--- a/Casks/q/qtpass.rb
+++ b/Casks/q/qtpass.rb
@@ -10,8 +10,6 @@ cask "qtpass" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "QtPass.app"
 
   zap trash: [

--- a/Casks/q/quarto.rb
+++ b/Casks/q/quarto.rb
@@ -13,8 +13,6 @@ cask "quarto" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "quarto-#{version}-macos.pkg"
 
   uninstall pkgutil: "org.rstudio.quarto"

--- a/Casks/q/quassel-client.rb
+++ b/Casks/q/quassel-client.rb
@@ -15,8 +15,6 @@ cask "quassel-client" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Quassel Client.app"
 
   zap trash: "~/Library/Preferences/org.quassel-irc.client.plist"

--- a/Casks/q/quassel.rb
+++ b/Casks/q/quassel.rb
@@ -15,8 +15,6 @@ cask "quassel" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Quassel.app"
 
   zap trash: [

--- a/Casks/q/quaternion.rb
+++ b/Casks/q/quaternion.rb
@@ -22,8 +22,6 @@ cask "quaternion" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "quaternion.app"
 
   zap trash: [

--- a/Casks/q/quick-app-ide.rb
+++ b/Casks/q/quick-app-ide.rb
@@ -15,8 +15,6 @@ cask "quick-app-ide" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "quickapp-ide-#{version}.pkg"
 
   uninstall quit:    "cn.quickapp.ide",

--- a/Casks/q/quicksilver.rb
+++ b/Casks/q/quicksilver.rb
@@ -14,7 +14,6 @@ cask "quicksilver" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Quicksilver.app"
 

--- a/Casks/q/quiet.rb
+++ b/Casks/q/quiet.rb
@@ -13,8 +13,6 @@ cask "quiet" do
     regex(/href=.*?Quiet[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Quiet.app"
 
   zap trash: "~/Library/Application Support/Quiet*"

--- a/Casks/q/quip.rb
+++ b/Casks/q/quip.rb
@@ -14,7 +14,6 @@ cask "quip" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Quip.app"
 

--- a/Casks/q/quit-all.rb
+++ b/Casks/q/quit-all.rb
@@ -12,8 +12,6 @@ cask "quit-all" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "QuitAll.app"
 
   zap trash: [

--- a/Casks/q/qv2ray.rb
+++ b/Casks/q/qv2ray.rb
@@ -10,7 +10,6 @@ cask "qv2ray" do
   disable! date: "2024-12-16", because: :discontinued
 
   depends_on formula: "v2ray"
-  depends_on macos: ">= :mojave"
 
   app "qv2ray.app"
 

--- a/Casks/q/qwerty-fr.rb
+++ b/Casks/q/qwerty-fr.rb
@@ -8,8 +8,6 @@ cask "qwerty-fr" do
   desc "QWERTY-based layout. Type EU languages, greek, math, currencies, & more!"
   homepage "https://qwerty-fr.org/"
 
-  depends_on macos: ">= :sierra"
-
   keyboard_layout "qwerty-fr.bundle"
 
   # No zap stanza required


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.