### PR TITLE
[r]: remove pre-Catalina references

### DIFF
--- a/Casks/r/r-app.rb
+++ b/Casks/r/r-app.rb
@@ -2,18 +2,10 @@ cask "r-app" do
   arch arm: "arm64", intel: "x86_64"
 
   on_catalina :or_older do
-    on_sierra :or_older do
-      version "3.6.3.nn"
-      sha256 "f2b771e94915af0fe0a6f042bc7a04ebc84fb80cb01aad5b7b0341c4636336dd"
+    version "4.2.3"
+    sha256 "dd96e8dcae20cf3c9cde429dd29f252b87af69028a6a403ec867eb92bb8eb659"
 
-      url "https://cran-archive.r-project.org/bin/macosx/base/R-#{version}.pkg"
-    end
-    on_high_sierra :or_newer do
-      version "4.2.3"
-      sha256 "dd96e8dcae20cf3c9cde429dd29f252b87af69028a6a403ec867eb92bb8eb659"
-
-      url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
-    end
+    url "https://cloud.r-project.org/bin/macosx/base/R-#{version}.pkg"
 
     livecheck do
       skip "Legacy version"
@@ -39,8 +31,6 @@ cask "r-app" do
   name "R"
   desc "Environment for statistical computing and graphics"
   homepage "https://www.r-project.org/"
-
-  depends_on macos: ">= :el_capitan"
 
   uninstall pkgutil: [
               "org.r-project*",

--- a/Casks/r/radar.rb
+++ b/Casks/r/radar.rb
@@ -13,7 +13,6 @@ cask "radar" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Radar.app"
 

--- a/Casks/r/radarr.rb
+++ b/Casks/r/radarr.rb
@@ -21,7 +21,6 @@ cask "radarr" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Radarr.app"
 

--- a/Casks/r/raindropio.rb
+++ b/Casks/r/raindropio.rb
@@ -18,7 +18,6 @@ cask "raindropio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Raindrop.io.app"
 

--- a/Casks/r/rambox.rb
+++ b/Casks/r/rambox.rb
@@ -9,7 +9,6 @@ cask "rambox" do
   homepage "https://rambox.app/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Rambox.app"
 

--- a/Casks/r/rancher.rb
+++ b/Casks/r/rancher.rb
@@ -18,7 +18,6 @@ cask "rancher" do
 
   auto_updates true
   conflicts_with cask: "docker"
-  depends_on macos: ">= :catalina"
 
   app "Rancher Desktop.app"
 

--- a/Casks/r/rapidweaver.rb
+++ b/Casks/r/rapidweaver.rb
@@ -13,8 +13,6 @@ cask "rapidweaver" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "RapidWeaver.app"
 
   zap trash: [

--- a/Casks/r/raze.rb
+++ b/Casks/r/raze.rb
@@ -13,8 +13,6 @@ cask "raze" do
     regex(/href=.*?raze[._-]macos[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Raze.app"
 
   zap trash: [

--- a/Casks/r/razorsql.rb
+++ b/Casks/r/razorsql.rb
@@ -19,8 +19,6 @@ cask "razorsql" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "RazorSQL.app"
 
   zap trash: "~/.razorsql"

--- a/Casks/r/react-native-debugger.rb
+++ b/Casks/r/react-native-debugger.rb
@@ -8,7 +8,6 @@ cask "react-native-debugger" do
   homepage "https://github.com/jhen0409/react-native-debugger"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "React Native Debugger.app"
 

--- a/Casks/r/react-studio.rb
+++ b/Casks/r/react-studio.rb
@@ -10,8 +10,6 @@ cask "react-studio" do
 
   deprecate! date: "2025-07-24", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "React Studio.app"
 
   zap trash: [

--- a/Casks/r/reactotron.rb
+++ b/Casks/r/reactotron.rb
@@ -22,7 +22,6 @@ cask "reactotron" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Reactotron.app"
 

--- a/Casks/r/reader.rb
+++ b/Casks/r/reader.rb
@@ -14,7 +14,6 @@ cask "reader" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Reader.app"
 

--- a/Casks/r/readmoreading.rb
+++ b/Casks/r/readmoreading.rb
@@ -16,8 +16,6 @@ cask "readmoreading" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Readmoo看書.app"
 
   zap trash: [

--- a/Casks/r/readwise-ibooks.rb
+++ b/Casks/r/readwise-ibooks.rb
@@ -12,8 +12,6 @@ cask "readwise-ibooks" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Readwise_iBooks.app"
 
   zap trash: [

--- a/Casks/r/realforce.rb
+++ b/Casks/r/realforce.rb
@@ -15,8 +15,6 @@ cask "realforce" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "REALFORCE CONNECT Software_#{version.dots_to_hyphens}.pkg"
 
   uninstall pkgutil: "com.topre.installpkg.realforce"

--- a/Casks/r/reamp.rb
+++ b/Casks/r/reamp.rb
@@ -12,8 +12,6 @@ cask "reamp" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "reAMP.app"
 
   zap trash: [

--- a/Casks/r/reaper.rb
+++ b/Casks/r/reaper.rb
@@ -1,17 +1,8 @@
 cask "reaper" do
   version "7.45"
+  sha256 "a655cb3897106d995218f80d7633443d2da967d6a59ab98dcf161f84e6465e38"
 
-  on_mojave :or_older do
-    sha256 "92cf0e39079fc69aeba13a45ab67ab1db3c4f667c2179e99314c8e6397431139"
-
-    url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_x86_64.dmg"
-  end
-  on_catalina :or_newer do
-    sha256 "a655cb3897106d995218f80d7633443d2da967d6a59ab98dcf161f84e6465e38"
-
-    url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_universal.dmg"
-  end
-
+  url "https://dlcf.reaper.fm/#{version.major}.x/reaper#{version.major_minor.no_dots}_universal.dmg"
   name "REAPER"
   desc "Digital audio production application"
   homepage "https://www.reaper.fm/"

--- a/Casks/r/receipts.rb
+++ b/Casks/r/receipts.rb
@@ -12,8 +12,6 @@ cask "receipts" do
     regex(/href=.*?Receipts[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Receipts.app"
 
   zap trash: [

--- a/Casks/r/rectangle-pro.rb
+++ b/Casks/r/rectangle-pro.rb
@@ -13,7 +13,6 @@ cask "rectangle-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Rectangle Pro.app"
 

--- a/Casks/r/rectangle.rb
+++ b/Casks/r/rectangle.rb
@@ -14,7 +14,6 @@ cask "rectangle" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Rectangle.app"
 

--- a/Casks/r/recut.rb
+++ b/Casks/r/recut.rb
@@ -13,7 +13,6 @@ cask "recut" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Recut.app"
 

--- a/Casks/r/red-eye.rb
+++ b/Casks/r/red-eye.rb
@@ -11,7 +11,5 @@ cask "red-eye" do
   deprecate! date: "2024-01-21", because: :no_longer_available
   disable! date: "2025-01-22", because: :no_longer_available
 
-  depends_on macos: ">= :mojave"
-
   app "Red Eye.app"
 end

--- a/Casks/r/reflect.rb
+++ b/Casks/r/reflect.rb
@@ -12,7 +12,6 @@ cask "reflect" do
   homepage "https://reflect.app/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Reflect.app"
 

--- a/Casks/r/reflector.rb
+++ b/Casks/r/reflector.rb
@@ -12,8 +12,6 @@ cask "reflector" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Reflector #{version.major}.app"
 
   zap trash: [

--- a/Casks/r/reflex-app.rb
+++ b/Casks/r/reflex-app.rb
@@ -12,8 +12,6 @@ cask "reflex-app" do
     regex(/href=.*?reflex[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Reflex.app"
 
   zap trash: "~/Library/Preferences/com.stuntsoftware.Reflex.plist"

--- a/Casks/r/reikey.rb
+++ b/Casks/r/reikey.rb
@@ -13,8 +13,6 @@ cask "reikey" do
     regex(/href=.*?ReiKey[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   installer script: {
     executable: "#{staged_path}/ReiKey Installer.app/Contents/MacOS/ReiKey Installer",
     args:       ["-install"],

--- a/Casks/r/rekordbox.rb
+++ b/Casks/r/rekordbox.rb
@@ -16,7 +16,6 @@ cask "rekordbox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "Install_rekordbox_#{version.csv.first.dots_to_underscores}.pkg"
 

--- a/Casks/r/remember-the-milk.rb
+++ b/Casks/r/remember-the-milk.rb
@@ -21,8 +21,6 @@ cask "remember-the-milk" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Remember The Milk.app"
 
   zap trash: [

--- a/Casks/r/remnote.rb
+++ b/Casks/r/remnote.rb
@@ -17,7 +17,6 @@ cask "remnote" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "RemNote.app"
 

--- a/Casks/r/remote-buddy.rb
+++ b/Casks/r/remote-buddy.rb
@@ -12,8 +12,6 @@ cask "remote-buddy" do
     regex(/Changes\s+in\s+version\s+(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Remote Buddy.app"
 
   zap trash: [

--- a/Casks/r/remote-desktop-manager-free.rb
+++ b/Casks/r/remote-desktop-manager-free.rb
@@ -10,8 +10,6 @@ cask "remote-desktop-manager-free" do
 
   disable! date: "2024-12-16", because: :discontinued, replacement_cask: "remote-desktop-manager"
 
-  depends_on macos: ">= :sierra"
-
   app "Remote Desktop Manager Free.app"
 
   zap trash: [

--- a/Casks/r/remote-desktop-manager.rb
+++ b/Casks/r/remote-desktop-manager.rb
@@ -14,7 +14,6 @@ cask "remote-desktop-manager" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Remote Desktop Manager.app"
 

--- a/Casks/r/remotehamradio.rb
+++ b/Casks/r/remotehamradio.rb
@@ -13,8 +13,6 @@ cask "remotehamradio" do
     regex(/href=.*?RemoteHamRadio[._-]v?(\d+(?:\.\d+)+)[._-]universal[._-]mac\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "RemoteHamRadio.app"
 
   zap trash: [

--- a/Casks/r/removebg.rb
+++ b/Casks/r/removebg.rb
@@ -15,8 +15,6 @@ cask "removebg" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "remove.bg.app"
 
   zap trash: [

--- a/Casks/r/replay.rb
+++ b/Casks/r/replay.rb
@@ -10,8 +10,6 @@ cask "replay" do
   deprecate! date: "2024-07-24", because: :discontinued
   disable! date: "2025-07-24", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "Replay.app"
 
   zap trash: [

--- a/Casks/r/replaywebpage.rb
+++ b/Casks/r/replaywebpage.rb
@@ -13,8 +13,6 @@ cask "replaywebpage" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "ReplayWeb.page.app"
 
   zap trash: [

--- a/Casks/r/replit.rb
+++ b/Casks/r/replit.rb
@@ -12,7 +12,6 @@ cask "replit" do
   homepage "https://replit.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Replit.app"
 

--- a/Casks/r/reqable.rb
+++ b/Casks/r/reqable.rb
@@ -12,7 +12,6 @@ cask "reqable" do
   homepage "https://reqable.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Reqable.app"
 

--- a/Casks/r/requestly.rb
+++ b/Casks/r/requestly.rb
@@ -16,8 +16,6 @@ cask "requestly" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Requestly.app"
 
   zap trash: [

--- a/Casks/r/resilio-sync.rb
+++ b/Casks/r/resilio-sync.rb
@@ -13,7 +13,6 @@ cask "resilio-sync" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Resilio Sync.app"
 

--- a/Casks/r/resolume-arena.rb
+++ b/Casks/r/resolume-arena.rb
@@ -20,7 +20,6 @@ cask "resolume-arena" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "Resolume Arena Installer.pkg"
 

--- a/Casks/r/responsively.rb
+++ b/Casks/r/responsively.rb
@@ -12,7 +12,6 @@ cask "responsively" do
   homepage "https://responsively.app/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "ResponsivelyApp.app"
 

--- a/Casks/r/restfox.rb
+++ b/Casks/r/restfox.rb
@@ -12,7 +12,6 @@ cask "restfox" do
   homepage "https://restfox.dev/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Restfox.app"
 

--- a/Casks/r/restic-browser.rb
+++ b/Casks/r/restic-browser.rb
@@ -13,7 +13,6 @@ cask "restic-browser" do
   end
 
   depends_on formula: "restic"
-  depends_on macos: ">= :high_sierra"
 
   app "Restic-Browser.app"
 

--- a/Casks/r/retro-virtual-machine.rb
+++ b/Casks/r/retro-virtual-machine.rb
@@ -13,8 +13,6 @@ cask "retro-virtual-machine" do
     regex(/RetroVirtualMachine[._-](\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Retro Virtual Machine #{version.major_minor}.app"
 
   zap trash: [

--- a/Casks/r/retroactive.rb
+++ b/Casks/r/retroactive.rb
@@ -10,8 +10,6 @@ cask "retroactive" do
   deprecate! date: "2024-08-21", because: :discontinued
   disable! date: "2025-08-21", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "Retroactive #{version}/Retroactive.app"
 
   zap delete: "~/Library/Caches/com.retroactive.Retroactive"

--- a/Casks/r/retroarch-metal.rb
+++ b/Casks/r/retroarch-metal.rb
@@ -13,7 +13,6 @@ cask "retroarch-metal" do
   end
 
   conflicts_with cask: "retroarch"
-  depends_on macos: ">= :high_sierra"
 
   app "RetroArch.app"
 

--- a/Casks/r/retroarch-metal@nightly.rb
+++ b/Casks/r/retroarch-metal@nightly.rb
@@ -8,8 +8,6 @@ cask "retroarch-metal@nightly" do
   desc "Frontend for emulators, game engines, and media players (Metal graphics API)"
   homepage "https://www.retroarch.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "RetroArch.app", target: "RetroArch Nightly.app"
 
   zap trash: [

--- a/Casks/r/retroarch.rb
+++ b/Casks/r/retroarch.rb
@@ -14,7 +14,6 @@ cask "retroarch" do
   end
 
   conflicts_with cask: "retroarch-metal"
-  depends_on macos: ">= :high_sierra"
 
   app "RetroArch.app"
 

--- a/Casks/r/reverso.rb
+++ b/Casks/r/reverso.rb
@@ -13,7 +13,6 @@ cask "reverso" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Reverso.app"
 

--- a/Casks/r/revisionist.rb
+++ b/Casks/r/revisionist.rb
@@ -23,8 +23,6 @@ cask "revisionist" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "revisionist#{version.csv.first.no_dots}/Revisionist.app"
 
   zap trash: [

--- a/Casks/r/revolver-office.rb
+++ b/Casks/r/revolver-office.rb
@@ -12,8 +12,6 @@ cask "revolver-office" do
     regex(/>\s*Revolver\s+v?(\d+(?:\.\d+)+)\s*</i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Revolver Office.app"
 
   zap trash: [

--- a/Casks/r/rider.rb
+++ b/Casks/r/rider.rb
@@ -24,7 +24,6 @@ cask "rider" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Rider.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/r/ridibooks.rb
+++ b/Casks/r/ridibooks.rb
@@ -13,8 +13,6 @@ cask "ridibooks" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Ridibooks.app"
 
   zap trash: [

--- a/Casks/r/ringcentral.rb
+++ b/Casks/r/ringcentral.rb
@@ -15,7 +15,6 @@ cask "ringcentral" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   pkg "RingCentral#{arch}.pkg"
 

--- a/Casks/r/rio.rb
+++ b/Casks/r/rio.rb
@@ -12,8 +12,6 @@ cask "rio" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "rio.app"
   binary "#{appdir}/rio.app/Contents/MacOS/rio"
   binary "#{appdir}/rio.app/Contents/Resources/72/rio",

--- a/Casks/r/ripcord.rb
+++ b/Casks/r/ripcord.rb
@@ -12,8 +12,6 @@ cask "ripcord" do
     regex(%r{/Ripcord_Mac_(\d+(?:\.\d+)*)\.zip}i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Ripcord.app"
 
   zap trash: [

--- a/Casks/r/rippling.rb
+++ b/Casks/r/rippling.rb
@@ -12,8 +12,6 @@ cask "rippling" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Rippling.app"
 
   zap trash: [

--- a/Casks/r/ripx.rb
+++ b/Casks/r/ripx.rb
@@ -28,8 +28,6 @@ cask "ripx" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "RipX DAW.pkg"
 
   uninstall pkgutil: [

--- a/Casks/r/rive.rb
+++ b/Casks/r/rive.rb
@@ -13,7 +13,6 @@ cask "rive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Rive.app"
 

--- a/Casks/r/rivet.rb
+++ b/Casks/r/rivet.rb
@@ -23,8 +23,6 @@ cask "rivet" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Rivet.app"
 
   zap trash: [

--- a/Casks/r/rize.rb
+++ b/Casks/r/rize.rb
@@ -17,7 +17,6 @@ cask "rize" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Rize.app"
 

--- a/Casks/r/rnote.rb
+++ b/Casks/r/rnote.rb
@@ -15,8 +15,6 @@ cask "rnote" do
     url "https://gitlab.com/dehesselle/rnote_macos.git"
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Rnote.app"
 
   zap trash: "~/Library/Preferences/net.flxzt.Rnote.plist"

--- a/Casks/r/roam-research.rb
+++ b/Casks/r/roam-research.rb
@@ -16,8 +16,6 @@ cask "roam-research" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Roam Research.app"
 
   zap trash: [

--- a/Casks/r/roam.rb
+++ b/Casks/r/roam.rb
@@ -22,7 +22,6 @@ cask "roam" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Roam.app"
 

--- a/Casks/r/roaringapps.rb
+++ b/Casks/r/roaringapps.rb
@@ -12,8 +12,6 @@ cask "roaringapps" do
     regex(%r{href=.*?/RoaringApps-(\d+(?:\.\d+)*)\.zip}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "RoaringApps.app"
 
   zap trash: [

--- a/Casks/r/roblox.rb
+++ b/Casks/r/roblox.rb
@@ -23,7 +23,6 @@ cask "roblox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   # The default installer installs the application as `Roblox.app` - so do the same for consistency
   app "RobloxPlayer.app", target: "Roblox.app"

--- a/Casks/r/robloxstudio.rb
+++ b/Casks/r/robloxstudio.rb
@@ -23,7 +23,6 @@ cask "robloxstudio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "RobloxStudio.app"
 

--- a/Casks/r/robofont.rb
+++ b/Casks/r/robofont.rb
@@ -16,8 +16,6 @@ cask "robofont" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "RoboFont.app"
 
   zap trash: [

--- a/Casks/r/roboform.rb
+++ b/Casks/r/roboform.rb
@@ -13,7 +13,6 @@ cask "roboform" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "RoboForm.app"
 

--- a/Casks/r/rocket.rb
+++ b/Casks/r/rocket.rb
@@ -13,7 +13,6 @@ cask "rocket" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Rocket.app"
 

--- a/Casks/r/rode-central.rb
+++ b/Casks/r/rode-central.rb
@@ -14,8 +14,6 @@ cask "rode-central" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   rename "RØDE Central*.pkg", "RØDE Central.pkg"
 
   pkg "RØDE Central.pkg"

--- a/Casks/r/rode-virtual-channels.rb
+++ b/Casks/r/rode-virtual-channels.rb
@@ -12,8 +12,6 @@ cask "rode-virtual-channels" do
     regex(/href=.*?RODECASTERDriver[._-]MACOS[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "RODE Virtual Channels-#{version}.pkg"
 
   uninstall quit:    "com.rode.RODEVirtualChannels",

--- a/Casks/r/rodecaster.rb
+++ b/Casks/r/rodecaster.rb
@@ -14,8 +14,6 @@ cask "rodecaster" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "RØDECaster App.pkg"
 
   preflight do

--- a/Casks/r/roku-remote-tool.rb
+++ b/Casks/r/roku-remote-tool.rb
@@ -14,8 +14,6 @@ cask "roku-remote-tool" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "roku_remote_tool.app"
 
   zap trash: [

--- a/Casks/r/roon.rb
+++ b/Casks/r/roon.rb
@@ -19,7 +19,6 @@ cask "roon" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Roon.app"
 

--- a/Casks/r/rouvy.rb
+++ b/Casks/r/rouvy.rb
@@ -15,7 +15,6 @@ cask "rouvy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Rouvy.app"
 

--- a/Casks/r/rowmote-helper.rb
+++ b/Casks/r/rowmote-helper.rb
@@ -13,7 +13,6 @@ cask "rowmote-helper" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Rowmote Helper.app"
 

--- a/Casks/r/rubymine.rb
+++ b/Casks/r/rubymine.rb
@@ -24,7 +24,6 @@ cask "rubymine" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "RubyMine.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/r/runescape.rb
+++ b/Casks/r/runescape.rb
@@ -11,8 +11,6 @@ cask "runescape" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "RuneScape.app"
 
   caveats do

--- a/Casks/r/runjs.rb
+++ b/Casks/r/runjs.rb
@@ -14,7 +14,6 @@ cask "runjs" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "RunJS.app"
 

--- a/Casks/r/rustdesk.rb
+++ b/Casks/r/rustdesk.rb
@@ -17,8 +17,6 @@ cask "rustdesk" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :mojave"
-
   app "RustDesk.app"
 
   uninstall quit: "com.carriez.rustdesk"

--- a/Casks/r/rustrover.rb
+++ b/Casks/r/rustrover.rb
@@ -24,7 +24,6 @@ cask "rustrover" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "RustRover.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.