### PR TITLE
[s]: remove pre-Catalina references

### DIFF
--- a/Casks/s/sabnzbd.rb
+++ b/Casks/s/sabnzbd.rb
@@ -13,8 +13,6 @@ cask "sabnzbd" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SABnzbd.app"
 
   zap trash: "~/Library/Application Support/SABnzbd"

--- a/Casks/s/safe-exam-browser.rb
+++ b/Casks/s/safe-exam-browser.rb
@@ -13,8 +13,6 @@ cask "safe-exam-browser" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Safe Exam Browser.app"
 
   zap trash: "~/Library/Preferences/org.safeexambrowser.SafeExamBrowser.plist"

--- a/Casks/s/safeincloud-password-manager.rb
+++ b/Casks/s/safeincloud-password-manager.rb
@@ -12,8 +12,6 @@ cask "safeincloud-password-manager" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SafeInCloud Password Manager.app"
 
   zap trash: [

--- a/Casks/s/sage.rb
+++ b/Casks/s/sage.rb
@@ -24,8 +24,6 @@ cask "sage" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "SageMath-#{version.csv.first.dots_to_hyphens}.app"
   pkg "Recommended_#{version.csv.first.dots_to_underscores}.pkg"
 

--- a/Casks/s/saleae-logic.rb
+++ b/Casks/s/saleae-logic.rb
@@ -16,8 +16,6 @@ cask "saleae-logic" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Logic#{version.major}.app"
 
   zap trash: [

--- a/Casks/s/salesforce-cli.rb
+++ b/Casks/s/salesforce-cli.rb
@@ -22,8 +22,6 @@ cask "salesforce-cli" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "sf-v#{version.csv.first}-#{version.csv.second}-#{arch}.pkg"
 
   uninstall pkgutil: "com.salesforce.cli",

--- a/Casks/s/sameboy.rb
+++ b/Casks/s/sameboy.rb
@@ -13,8 +13,6 @@ cask "sameboy" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "SameBoy.app"
 
   zap trash: [

--- a/Casks/s/sanctum.rb
+++ b/Casks/s/sanctum.rb
@@ -17,8 +17,6 @@ cask "sanctum" do
     regex(/href=.*?Sanctum[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sanctum.app"
 
   zap trash: [

--- a/Casks/s/satellite-eyes.rb
+++ b/Casks/s/satellite-eyes.rb
@@ -14,7 +14,6 @@ cask "satellite-eyes" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Satellite Eyes.app"
 

--- a/Casks/s/satyrn.rb
+++ b/Casks/s/satyrn.rb
@@ -17,7 +17,6 @@ cask "satyrn" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "satyrn.app"
 

--- a/Casks/s/scap-workbench.rb
+++ b/Casks/s/scap-workbench.rb
@@ -10,8 +10,6 @@ cask "scap-workbench" do
 
   deprecate! date: "2024-10-04", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "scap-workbench.app"
 
   caveats do

--- a/Casks/s/scapple.rb
+++ b/Casks/s/scapple.rb
@@ -13,8 +13,6 @@ cask "scapple" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Scapple.app"
 
   zap trash: [

--- a/Casks/s/scenebuilder.rb
+++ b/Casks/s/scenebuilder.rb
@@ -15,8 +15,6 @@ cask "scenebuilder" do
     regex(%r{href=.*?/SceneBuilder-(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SceneBuilder.app"
 
   zap trash: [

--- a/Casks/s/scenica-player.rb
+++ b/Casks/s/scenica-player.rb
@@ -12,8 +12,6 @@ cask "scenica-player" do
     regex(/href=.*?scenica[._-]player[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Scenica Player.app"
 
   zap trash: "~/Library/Preferences/ByHost/ca.sceni.Player.*.plist"

--- a/Casks/s/scilab.rb
+++ b/Casks/s/scilab.rb
@@ -22,8 +22,6 @@ cask "scilab" do
   desc "Software for numerical computation"
   homepage "https://www.scilab.org/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "scilab-#{version}.app"
   binary "#{appdir}/scilab-#{version}.app/Contents/bin/scilab"
   binary "#{appdir}/scilab-#{version}.app/Contents/bin/scilab-cli"

--- a/Casks/s/scratch.rb
+++ b/Casks/s/scratch.rb
@@ -12,8 +12,6 @@ cask "scratch" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Scratch #{version.major}.app"
 
   zap trash: [

--- a/Casks/s/screenflick.rb
+++ b/Casks/s/screenflick.rb
@@ -18,8 +18,6 @@ cask "screenflick" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Screenflick.app"
 
   zap trash: [

--- a/Casks/s/screenfocus.rb
+++ b/Casks/s/screenfocus.rb
@@ -12,8 +12,6 @@ cask "screenfocus" do
     regex(/href=.*?ScreenFocus[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "ScreenFocus.app"
 
   zap trash: [

--- a/Casks/s/screens-assist.rb
+++ b/Casks/s/screens-assist.rb
@@ -13,7 +13,6 @@ cask "screens-assist" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Screens Assist.app"
 

--- a/Casks/s/script-debugger.rb
+++ b/Casks/s/script-debugger.rb
@@ -13,8 +13,6 @@ cask "script-debugger" do
     regex(/href=.*?ScriptDebugger[._-]?v?(\d+(?:\.\d+)+(?:-\d+A\d+)?)\.dmg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Script Debugger.app"
 
   zap trash: [

--- a/Casks/s/script-kit.rb
+++ b/Casks/s/script-kit.rb
@@ -16,8 +16,6 @@ cask "script-kit" do
     regex(/href=.*?Script[._-]Kit[._-]macOS[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Script Kit.app"
 
   zap trash: [

--- a/Casks/s/scrivener.rb
+++ b/Casks/s/scrivener.rb
@@ -17,7 +17,6 @@ cask "scrivener" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Scrivener.app"
 

--- a/Casks/s/scroll.rb
+++ b/Casks/s/scroll.rb
@@ -13,7 +13,6 @@ cask "scroll" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Scroll.app"
 

--- a/Casks/s/scrub-utility.rb
+++ b/Casks/s/scrub-utility.rb
@@ -17,8 +17,6 @@ cask "scrub-utility" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "scrub#{version.csv.first.no_dots}/Scrub.app"
 
   zap trash: [

--- a/Casks/s/seaglass.rb
+++ b/Casks/s/seaglass.rb
@@ -10,7 +10,6 @@ cask "seaglass" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Seaglass.app"
 end

--- a/Casks/s/secretive.rb
+++ b/Casks/s/secretive.rb
@@ -30,8 +30,6 @@ cask "secretive" do
   desc "Store SSH keys in the Secure Enclave"
   homepage "https://github.com/maxgoedjen/secretive"
 
-  depends_on macos: ">= :catalina"
-
   app "Secretive.app"
 
   zap trash: [

--- a/Casks/s/securesafe.rb
+++ b/Casks/s/securesafe.rb
@@ -12,8 +12,6 @@ cask "securesafe" do
     regex(/securesafe-(\d+(?:\.\d+)+)\.pkg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "securesafe-#{version}.pkg"
 
   uninstall pkgutil: [

--- a/Casks/s/securityspy.rb
+++ b/Casks/s/securityspy.rb
@@ -12,8 +12,6 @@ cask "securityspy" do
     regex(/Version\s+(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SecuritySpy.app"
 
   zap trash: [

--- a/Casks/s/sejda-pdf.rb
+++ b/Casks/s/sejda-pdf.rb
@@ -16,8 +16,6 @@ cask "sejda-pdf" do
     regex(/mac\s*:\s*["']sejda[._-]desktop[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sejda PDF Desktop.app"
 
   zap trash: [

--- a/Casks/s/senadevicemanager.rb
+++ b/Casks/s/senadevicemanager.rb
@@ -12,8 +12,6 @@ cask "senadevicemanager" do
     regex(/SENADeviceManagerForMAC[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "SENADeviceManagerForMAC-v#{version}.pkg"
 
   uninstall quit:    [

--- a/Casks/s/sengi.rb
+++ b/Casks/s/sengi.rb
@@ -14,8 +14,6 @@ cask "sengi" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sengi.app"
 
   zap trash: [

--- a/Casks/s/serial.rb
+++ b/Casks/s/serial.rb
@@ -13,7 +13,6 @@ cask "serial" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Serial.app"
 

--- a/Casks/s/shadow-bot.rb
+++ b/Casks/s/shadow-bot.rb
@@ -13,8 +13,6 @@ cask "shadow-bot" do
 
   disable! date: "2024-12-30", because: "now has the download artifact behind a signed URL"
 
-  depends_on macos: ">= :high_sierra"
-
   app "影刀.app"
 
   zap trash: [

--- a/Casks/s/shadow@beta.rb
+++ b/Casks/s/shadow@beta.rb
@@ -15,8 +15,6 @@ cask "shadow@beta" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Shadow PC Beta.app"
 
   zap trash: [

--- a/Casks/s/shadowsocksx-ng-r.rb
+++ b/Casks/s/shadowsocksx-ng-r.rb
@@ -8,7 +8,6 @@ cask "shadowsocksx-ng-r" do
   homepage "https://github.com/qinyuhang/ShadowsocksX-NG-R/"
 
   conflicts_with cask: "shadowsocksx"
-  depends_on macos: ">= :el_capitan"
 
   app "ShadowsocksX-NG-R8.app"
 

--- a/Casks/s/shadowsocksx-ng.rb
+++ b/Casks/s/shadowsocksx-ng.rb
@@ -8,7 +8,6 @@ cask "shadowsocksx-ng" do
   homepage "https://github.com/shadowsocks/ShadowsocksX-NG/"
 
   conflicts_with cask: "shadowsocksx"
-  depends_on macos: ">= :sierra"
 
   app "ShadowsocksX-NG.app"
 

--- a/Casks/s/shapes.rb
+++ b/Casks/s/shapes.rb
@@ -12,8 +12,6 @@ cask "shapes" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Shapes.app"
 
   zap trash: [

--- a/Casks/s/sharemouse.rb
+++ b/Casks/s/sharemouse.rb
@@ -12,8 +12,6 @@ cask "sharemouse" do
     regex(/Mac\s*Version:.*?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "ShareMouse.app"
 
   zap trash: [

--- a/Casks/s/shield.rb
+++ b/Casks/s/shield.rb
@@ -13,8 +13,6 @@ cask "shield" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Shield.app"
 
   zap trash: "/Library/Application Support/Shield/com.csaba.fitzl.shield.preferences.plist"

--- a/Casks/s/shift.rb
+++ b/Casks/s/shift.rb
@@ -19,8 +19,6 @@ cask "shift" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Shift.app"
 
   zap trash: [

--- a/Casks/s/shifty.rb
+++ b/Casks/s/shifty.rb
@@ -14,7 +14,6 @@ cask "shifty" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Shifty.app"
 

--- a/Casks/s/shimo.rb
+++ b/Casks/s/shimo.rb
@@ -14,7 +14,6 @@ cask "shimo" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Shimo.app"
 

--- a/Casks/s/shop-different.rb
+++ b/Casks/s/shop-different.rb
@@ -12,8 +12,6 @@ cask "shop-different" do
     regex(%r{href=.*?/Shop\+Different\+(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Shop Different.app"
 
   zap trash: [

--- a/Casks/s/shortcutor.rb
+++ b/Casks/s/shortcutor.rb
@@ -12,8 +12,6 @@ cask "shortcutor" do
     regex(%r{href=.*?/Shortcutor[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Shortcutor.app"
 
   uninstall quit: "Shortcutor"

--- a/Casks/s/shortwave.rb
+++ b/Casks/s/shortwave.rb
@@ -16,7 +16,6 @@ cask "shortwave" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Shortwave.app"
 

--- a/Casks/s/shottr.rb
+++ b/Casks/s/shottr.rb
@@ -13,7 +13,6 @@ cask "shottr" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Shottr.app"
 

--- a/Casks/s/sidenotes.rb
+++ b/Casks/s/sidenotes.rb
@@ -13,7 +13,6 @@ cask "sidenotes" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "SideNotes.app"
 

--- a/Casks/s/sidequest.rb
+++ b/Casks/s/sidequest.rb
@@ -11,8 +11,6 @@ cask "sidequest" do
   desc "Virtual reality content platform"
   homepage "https://sidequestvr.com/"
 
-  depends_on macos: ">= :catalina"
-
   app "SideQuest.app"
 
   zap trash: "~/Library/Application Support/SideQuest"

--- a/Casks/s/sigdigger.rb
+++ b/Casks/s/sigdigger.rb
@@ -13,8 +13,6 @@ cask "sigdigger" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SigDigger.app"
 
   zap trash: [

--- a/Casks/s/signet.rb
+++ b/Casks/s/signet.rb
@@ -23,8 +23,6 @@ cask "signet" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "#{token}#{version.csv.first.no_dots}/Signet.app"
 
   zap trash: [

--- a/Casks/s/silentknight.rb
+++ b/Casks/s/silentknight.rb
@@ -1,32 +1,6 @@
 cask "silentknight" do
-  on_mojave :or_older do
-    version "1.21,2022.06"
-    sha256 "c1cbb734f620e073f1c08c473edaa036c2b5ccdca02baa99ca117f86c10ad505"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "2.12,2025.06"
-    sha256 "84eb2feb1e4d0ac26f28f963bf809e6d6206b5d345d9d9c428bdbc583b249f76"
-
-    livecheck do
-      url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
-      regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
-      strategy :xml do |xml, regex|
-        item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='SilentKnight#{version.major}']]"]
-        next unless item
-
-        version = item.elements["key[text()='Version']"]&.next_element&.text
-        url = item.elements["key[text()='URL']"]&.next_element&.text
-        match = url.strip.match(regex) if url
-        next if version.blank? || match.blank?
-
-        "#{version.strip},#{match[1]}.#{match[2]}"
-      end
-    end
-  end
+  version "2.12,2025.06"
+  sha256 "84eb2feb1e4d0ac26f28f963bf809e6d6206b5d345d9d9c428bdbc583b249f76"
 
   # Upstream zero-pads the minor version in the no-dot filename version to two
   # digits (e.g. 2.9 is 209). We only need this workaround while the minor
@@ -40,6 +14,22 @@ cask "silentknight" do
   name "SilentKnight"
   desc "Automatically checks computer's security"
   homepage "https://eclecticlight.co/lockrattler-systhist/"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/hoakleyelc/updates/master/eclecticapps.plist"
+    regex(%r{/(\d+)/(\d+)/[^/]+?$}i)
+    strategy :xml do |xml, regex|
+      item = xml.elements["//dict[key[text()='AppName']/following-sibling::*[1][text()='SilentKnight#{version.major}']]"]
+      next unless item
+
+      version = item.elements["key[text()='Version']"]&.next_element&.text
+      url = item.elements["key[text()='URL']"]&.next_element&.text
+      match = url.strip.match(regex) if url
+      next if version.blank? || match.blank?
+
+      "#{version.strip},#{match[1]}.#{match[2]}"
+    end
+  end
 
   app "silentknight#{no_dot_version}/SilentKnight.app"
 

--- a/Casks/s/silicon-app.rb
+++ b/Casks/s/silicon-app.rb
@@ -8,7 +8,6 @@ cask "silicon-app" do
   homepage "https://github.com/DigiDNA/Silicon"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Silicon.app"
 

--- a/Casks/s/silo.rb
+++ b/Casks/s/silo.rb
@@ -12,8 +12,6 @@ cask "silo" do
     regex(/Silo\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Silo.app"
 
   zap trash: [

--- a/Casks/s/sim-genie.rb
+++ b/Casks/s/sim-genie.rb
@@ -13,8 +13,6 @@ cask "sim-genie" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Sim Genie.app"
 
   zap trash: [

--- a/Casks/s/simpholders.rb
+++ b/Casks/s/simpholders.rb
@@ -16,7 +16,6 @@ cask "simpholders" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "simpholders_#{version.csv.first.dots_to_underscores}.app", target: "SimPholders.app"
 

--- a/Casks/s/simple-comic.rb
+++ b/Casks/s/simple-comic.rb
@@ -7,8 +7,6 @@ cask "simple-comic" do
   desc "Comic viewer/reader"
   homepage "https://github.com/MaddTheSane/Simple-Comic"
 
-  depends_on macos: ">= :mojave"
-
   app "Simple Comic.app"
 
   zap trash: "~/Library/Application Support/Simple Comic"

--- a/Casks/s/simplemind.rb
+++ b/Casks/s/simplemind.rb
@@ -17,7 +17,6 @@ cask "simplemind" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "SimpleMind Pro.app"
 

--- a/Casks/s/simplenote.rb
+++ b/Casks/s/simplenote.rb
@@ -12,8 +12,6 @@ cask "simplenote" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Simplenote.app"
 
   zap trash: [

--- a/Casks/s/simpletex.rb
+++ b/Casks/s/simpletex.rb
@@ -18,7 +18,6 @@ cask "simpletex" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "SimpleTex.app"
 

--- a/Casks/s/simplex.rb
+++ b/Casks/s/simplex.rb
@@ -16,8 +16,6 @@ cask "simplex" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SimpleX.app"
 
   zap trash: "~/Library/Saved Application State/chat.simplex.app.savedState"

--- a/Casks/s/simsim.rb
+++ b/Casks/s/simsim.rb
@@ -7,8 +7,6 @@ cask "simsim" do
   desc "Tool to explore iOS application folders in Terminal or Finder"
   homepage "https://github.com/dsmelov/simsim/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "SimSim.app"
 
   uninstall quit: "com.dsmelov.SimSim"

--- a/Casks/s/singlecrystal.rb
+++ b/Casks/s/singlecrystal.rb
@@ -14,8 +14,6 @@ cask "singlecrystal" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SingleCrystal.app"
 
   zap trash: [

--- a/Casks/s/sioyek.rb
+++ b/Casks/s/sioyek.rb
@@ -13,7 +13,6 @@ cask "sioyek" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
   container nested: "build/sioyek.dmg"
 
   app "sioyek.app"

--- a/Casks/s/sip-app.rb
+++ b/Casks/s/sip-app.rb
@@ -1,18 +1,6 @@
 cask "sip-app" do
   on_monterey :or_older do
-    on_sierra :or_older do
-      version "1.2"
-      sha256 "eb4507ce67c6d19c4e649d3e033542265be8d2aaccabc7f8ee00080842a886c0"
-    end
-    on_high_sierra do
-      version "2.4.1"
-      sha256 "9e8e69b8874891fab4fcc44edfb9b6ff2e510a1f41c87e9faea6060fc3f33073"
-    end
-    on_mojave do
-      version "2.5.5"
-      sha256 "a67550abe2f43981b7b41827ee9ccc0f826383cc1d146e748bde399f3c352d62"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "2.8"
       sha256 "95e2bd14ce3de9743304efee4fb9964f00fc9505401f1e036de8175616ca58dd"
     end
@@ -50,7 +38,6 @@ cask "sip-app" do
   homepage "https://sipapp.io/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Sip.app"
 

--- a/Casks/s/sipgate-softphone.rb
+++ b/Casks/s/sipgate-softphone.rb
@@ -13,8 +13,6 @@ cask "sipgate-softphone" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "sipgate softphone.app"
 
   zap trash: [

--- a/Casks/s/sipgate.rb
+++ b/Casks/s/sipgate.rb
@@ -14,7 +14,6 @@ cask "sipgate" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "sipgate.app"
 

--- a/Casks/s/sirimote.rb
+++ b/Casks/s/sirimote.rb
@@ -12,8 +12,6 @@ cask "sirimote" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "SiriMote.app"
 
   zap trash: "~/Library/Preferences/at.EternalStorms.SiriMote-nonappstore.plist"

--- a/Casks/s/sitesucker-pro.rb
+++ b/Casks/s/sitesucker-pro.rb
@@ -36,7 +36,6 @@ cask "sitesucker-pro" do
   homepage "https://ricks-apps.com/osx/sitesucker/index.html"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "SiteSucker Pro.app"
 

--- a/Casks/s/siyuan.rb
+++ b/Casks/s/siyuan.rb
@@ -10,8 +10,6 @@ cask "siyuan" do
   desc "Local-first personal knowledge management system"
   homepage "https://github.com/siyuan-note/siyuan"
 
-  depends_on macos: ">= :catalina"
-
   app "SiYuan.app"
 
   zap trash: [

--- a/Casks/s/sizzy.rb
+++ b/Casks/s/sizzy.rb
@@ -16,7 +16,6 @@ cask "sizzy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Sizzy.app"
 

--- a/Casks/s/skiff.rb
+++ b/Casks/s/skiff.rb
@@ -11,7 +11,6 @@ cask "skiff" do
   disable! date: "2024-12-16", because: :moved_to_mas
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Skiff Desktop.app"
 

--- a/Casks/s/skim.rb
+++ b/Casks/s/skim.rb
@@ -14,7 +14,6 @@ cask "skim" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Skim.app"
   binary "#{appdir}/Skim.app/Contents/SharedSupport/displayline"

--- a/Casks/s/skype-for-business.rb
+++ b/Casks/s/skype-for-business.rb
@@ -11,7 +11,6 @@ cask "skype-for-business" do
 
   auto_updates true
   depends_on cask: "microsoft-auto-update"
-  depends_on macos: ">= :el_capitan"
 
   pkg "SkypeForBusinessInstaller-#{version}.pkg",
       choices: [

--- a/Casks/s/skype.rb
+++ b/Casks/s/skype.rb
@@ -11,7 +11,6 @@ cask "skype" do
 
   auto_updates true
   conflicts_with cask: "skype@preview"
-  depends_on macos: ">= :high_sierra"
 
   app "Skype.app"
 

--- a/Casks/s/skype@preview.rb
+++ b/Casks/s/skype@preview.rb
@@ -11,7 +11,6 @@ cask "skype@preview" do
 
   auto_updates true
   conflicts_with cask: "skype"
-  depends_on macos: ">= :high_sierra"
 
   app "Skype.app"
 

--- a/Casks/s/slab.rb
+++ b/Casks/s/slab.rb
@@ -12,7 +12,6 @@ cask "slab" do
   homepage "https://slab.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Slab.app"
 

--- a/Casks/s/slack.rb
+++ b/Casks/s/slack.rb
@@ -33,7 +33,6 @@ cask "slack" do
 
   auto_updates true
   conflicts_with cask: "slack@beta"
-  depends_on macos: ">= :catalina"
 
   app "Slack.app"
 

--- a/Casks/s/sleep-aid.rb
+++ b/Casks/s/sleep-aid.rb
@@ -19,7 +19,6 @@ cask "sleep-aid" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   pkg "Sleep_Aid_#{version.dots_to_underscores}_#{arch}.pkg"
 

--- a/Casks/s/slidepilot.rb
+++ b/Casks/s/slidepilot.rb
@@ -19,7 +19,6 @@ cask "slidepilot" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "SlidePilot.app"
 

--- a/Casks/s/slimhud.rb
+++ b/Casks/s/slimhud.rb
@@ -15,7 +15,6 @@ cask "slimhud" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "SlimHUD.app"
 

--- a/Casks/s/slippi-dolphin.rb
+++ b/Casks/s/slippi-dolphin.rb
@@ -13,8 +13,6 @@ cask "slippi-dolphin" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Slippi Dolphin.app"
 
   zap trash: [

--- a/Casks/s/slite.rb
+++ b/Casks/s/slite.rb
@@ -24,8 +24,6 @@ cask "slite" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Slite.app"
 
   zap trash: [

--- a/Casks/s/sloth.rb
+++ b/Casks/s/sloth.rb
@@ -13,7 +13,6 @@ cask "sloth" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Sloth.app"
 

--- a/Casks/s/smart-converter-pro.rb
+++ b/Casks/s/smart-converter-pro.rb
@@ -12,8 +12,6 @@ cask "smart-converter-pro" do
     regex(/href=.*?SmartConverterPro[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Smart Converter Pro #{version.major}.app"
 
   zap trash: [

--- a/Casks/s/smartgit.rb
+++ b/Casks/s/smartgit.rb
@@ -1,26 +1,11 @@
 cask "smartgit" do
   arch arm: "aarch64", intel: "x86_64"
 
-  on_sierra :or_older do
-    version "20.2.6"
-    sha256 "af5fbf8db26edde3d996d99c6e82287332598359fe63ff2cd97c712a1685a2ea"
+  version "24.1.4"
+  sha256 arm:   "330274ba9923d64298cad928026c3db69fe3a899dac5e8cb995ccbe6644c48c0",
+         intel: "b44e5450edc9559fc5e5e7b7874318dbdfc682fdc80e4ae410ff8665dc998487"
 
-    url "https://www.syntevo.com/downloads/smartgit/archive/smartgit-macosx-#{version.dots_to_underscores}.dmg"
-  end
-  on_high_sierra do
-    version "22.1.8"
-    sha256 "d98688ee937bbc02c17e08f7d300c6f3e237cb638b64c46944f46895812ed679"
-
-    url "https://www.syntevo.com/downloads/smartgit/archive/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
-  end
-  on_mojave :or_newer do
-    version "24.1.4"
-    sha256 arm:   "330274ba9923d64298cad928026c3db69fe3a899dac5e8cb995ccbe6644c48c0",
-           intel: "b44e5450edc9559fc5e5e7b7874318dbdfc682fdc80e4ae410ff8665dc998487"
-
-    url "https://www.syntevo.com/downloads/smartgit/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
-  end
-
+  url "https://www.syntevo.com/downloads/smartgit/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
   name "SmartGit"
   desc "Git client"
   homepage "https://www.syntevo.com/smartgit/"

--- a/Casks/s/smartreporter-free.rb
+++ b/Casks/s/smartreporter-free.rb
@@ -12,8 +12,6 @@ cask "smartreporter-free" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SMARTReporter Free.app"
 
   zap trash: [

--- a/Casks/s/smartsvn.rb
+++ b/Casks/s/smartsvn.rb
@@ -18,8 +18,6 @@ cask "smartsvn" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SmartSVN.app"
 
   zap trash: [

--- a/Casks/s/smartsynchronize.rb
+++ b/Casks/s/smartsynchronize.rb
@@ -21,8 +21,6 @@ cask "smartsynchronize" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SmartSynchronize.app"
   binary "#{appdir}/SmartSynchronize.app/Contents/MacOS/SmartSynchronize"
 

--- a/Casks/s/smoothcsv.rb
+++ b/Casks/s/smoothcsv.rb
@@ -8,8 +8,6 @@ cask "smoothcsv" do
   desc "CSV editor"
   homepage "https://smoothcsv.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "SmoothCSV.app"
 
   uninstall quit: "com.smoothcsv.desktop"

--- a/Casks/s/smoothscroll.rb
+++ b/Casks/s/smoothscroll.rb
@@ -12,8 +12,6 @@ cask "smoothscroll" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SmoothScroll.app"
 
   uninstall login_item: "SmoothScroll"

--- a/Casks/s/smooze-pro.rb
+++ b/Casks/s/smooze-pro.rb
@@ -13,7 +13,6 @@ cask "smooze-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Smooze Pro.app"
 

--- a/Casks/s/smooze.rb
+++ b/Casks/s/smooze.rb
@@ -10,7 +10,6 @@ cask "smooze" do
   disable! date: "2024-12-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Smooze.app"
 

--- a/Casks/s/sms-plus.rb
+++ b/Casks/s/sms-plus.rb
@@ -12,8 +12,6 @@ cask "sms-plus" do
     regex(/<h2>SMS\s+Plus\s+v?(\d+(?:\.\d+)+)[" <]/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SMS Plus v#{version}/SMS Plus.app"
 
   zap trash: [

--- a/Casks/s/snapndrag.rb
+++ b/Casks/s/snapndrag.rb
@@ -12,8 +12,6 @@ cask "snapndrag" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SnapNDrag.app"
 
   zap trash: [

--- a/Casks/s/snes9x.rb
+++ b/Casks/s/snes9x.rb
@@ -29,8 +29,6 @@ cask "snes9x" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Snes9x.app"
 
   zap trash: [

--- a/Casks/s/snipaste.rb
+++ b/Casks/s/snipaste.rb
@@ -14,7 +14,6 @@ cask "snipaste" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Snipaste.app"
 

--- a/Casks/s/sococo.rb
+++ b/Casks/s/sococo.rb
@@ -12,8 +12,6 @@ cask "sococo" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Sococo.app"
 
   zap trash: [

--- a/Casks/s/soduto.rb
+++ b/Casks/s/soduto.rb
@@ -12,8 +12,6 @@ cask "soduto" do
     regex(%r{href=.*?/Soduto_v?(\d+(?:\.\d+)*)\.dmg}i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Soduto.app"
 
   zap trash: [

--- a/Casks/s/sofa-server.rb
+++ b/Casks/s/sofa-server.rb
@@ -12,8 +12,6 @@ cask "sofa-server" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sofa Server.app"
 
   zap trash: [

--- a/Casks/s/softraid.rb
+++ b/Casks/s/softraid.rb
@@ -13,8 +13,6 @@ cask "softraid" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SoftRAID.app"
 
   zap trash: [

--- a/Casks/s/sonarr.rb
+++ b/Casks/s/sonarr.rb
@@ -18,7 +18,6 @@ cask "sonarr" do
 
   auto_updates true
   conflicts_with cask: "sonarr@beta"
-  depends_on macos: ">= :catalina"
 
   app "Sonarr.app"
 

--- a/Casks/s/songkong.rb
+++ b/Casks/s/songkong.rb
@@ -14,8 +14,6 @@ cask "songkong" do
     regex(/SongKong\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "SongKong.app"
 
   zap trash: [

--- a/Casks/s/sonic-lineup.rb
+++ b/Casks/s/sonic-lineup.rb
@@ -16,8 +16,6 @@ cask "sonic-lineup" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Sonic Lineup.app"
 
   zap trash: [

--- a/Casks/s/sonic-pi.rb
+++ b/Casks/s/sonic-pi.rb
@@ -2,13 +2,7 @@ cask "sonic-pi" do
   arch arm: "Mac-arm64", intel: "Mac-x64"
 
   on_monterey :or_older do
-    on_mojave :or_older do
-      version "3.3.1"
-      sha256 "0bfd12f930311e8ef1c7306dc9c012cfcc1f8e50710fd26a8c18ba003573a506"
-
-      url "https://sonic-pi.net/files/releases/v#{version}/Sonic-Pi-for-Mac-x64-v#{version.dots_to_hyphens}.dmg"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "4.3.0"
       sha256 "c5646b221d61ba55c8e1025a646718d1244333bd57e2a7bccc8eb71c5a7be585"
 
@@ -50,8 +44,6 @@ cask "sonic-pi" do
   name "Sonic Pi"
   desc "Code-based music creation and performance tool"
   homepage "https://sonic-pi.net/"
-
-  depends_on macos: ">= :high_sierra"
 
   app "Sonic Pi.app"
 

--- a/Casks/s/sonic-visualiser.rb
+++ b/Casks/s/sonic-visualiser.rb
@@ -21,8 +21,6 @@ cask "sonic-visualiser" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Sonic Visualiser.app"
 
   zap trash: [

--- a/Casks/s/sonic3air.rb
+++ b/Casks/s/sonic3air.rb
@@ -13,8 +13,6 @@ cask "sonic3air" do
     regex(/v(\d+(?:\.\d+)*)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sonic 3 AIR.app"
   artifact "Manual.pdf", target: "~/Library/Application Support/sonic3air/Manual.pdf"
   artifact "doc", target: "~/Library/Application Support/sonic3air/doc"

--- a/Casks/s/sonos.rb
+++ b/Casks/s/sonos.rb
@@ -16,7 +16,6 @@ cask "sonos" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Sonos.app"
 

--- a/Casks/s/sony-ps-remote-play.rb
+++ b/Casks/s/sony-ps-remote-play.rb
@@ -14,8 +14,6 @@ cask "sony-ps-remote-play" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "RemotePlayInstaller.pkg"
 
   uninstall pkgutil: "com.playstation.RemotePlay.pkg"

--- a/Casks/s/soothe2.rb
+++ b/Casks/s/soothe2.rb
@@ -14,8 +14,6 @@ cask "soothe2" do
     regex(/<h3>v?(\d+(?:\.\d+)+)[" <]/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "soothe2_v#{version.no_dots}_Mac.pkg"
 
   uninstall pkgutil: [

--- a/Casks/s/soqlxplorer.rb
+++ b/Casks/s/soqlxplorer.rb
@@ -13,7 +13,6 @@ cask "soqlxplorer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "SoqlXplorer.app"
 

--- a/Casks/s/soundtoys.rb
+++ b/Casks/s/soundtoys.rb
@@ -19,8 +19,6 @@ cask "soundtoys" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "Install Soundtoys #{version.major_minor} Bundle.pkg"
 
   # The Soundtoys application bundles the install of the iLok License Manager

--- a/Casks/s/sourcenote.rb
+++ b/Casks/s/sourcenote.rb
@@ -13,7 +13,6 @@ cask "sourcenote" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "SourceNote.app"
 

--- a/Casks/s/sourcetree.rb
+++ b/Casks/s/sourcetree.rb
@@ -1,47 +1,17 @@
 cask "sourcetree" do
-  on_mojave :or_older do
-    on_sierra :or_older do
-      version "2.7.6a"
-      sha256 "d60614e9ab603e0ed158b6473c36e7944b2908d9943e332c505eba03dc1d829e"
+  version "4.2.14,297"
+  sha256 "62d7822019137879911b6fbd6ef36ec3916ac97198fe03de20d4cef105b64dd8"
 
-      url "https://downloads.atlassian.com/software/sourcetree/Sourcetree_#{version}.zip",
-          verified: "downloads.atlassian.com/software/sourcetree/"
-    end
-    on_high_sierra do
-      version "3.2.1,225"
-      sha256 "4bd82affa3402814c3d07ff613fbc8f45da8b0cda294d498ffbb0667bf729c9f"
-
-      url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
-          verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
-    end
-    on_mojave do
-      version "4.2.1,248"
-      sha256 "3dac6ab514c7debe960339e2aee99f018342a41baf743dbb59524728b373561f"
-
-      url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
-          verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
-    end
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "4.2.14,297"
-    sha256 "62d7822019137879911b6fbd6ef36ec3916ac97198fe03de20d4cef105b64dd8"
-
-    url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
-        verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
-
-    livecheck do
-      url "https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcast.xml"
-      strategy :sparkle
-    end
-  end
-
+  url "https://product-downloads.atlassian.com/software/sourcetree/ga/Sourcetree_#{version.csv.first}_#{version.csv.second}.zip",
+      verified: "product-downloads.atlassian.com/software/sourcetree/ga/"
   name "Atlassian SourceTree"
   desc "Graphical client for Git version control"
   homepage "https://www.sourcetreeapp.com/"
+
+  livecheck do
+    url "https://product-downloads.atlassian.com/software/sourcetree/Appcast/SparkleAppcast.xml"
+    strategy :sparkle
+  end
 
   auto_updates true
 

--- a/Casks/s/sourcetree@beta.rb
+++ b/Casks/s/sourcetree@beta.rb
@@ -13,8 +13,6 @@ cask "sourcetree@beta" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Sourcetree-Beta.app"
   binary "#{appdir}/Sourcetree-Beta.app/Contents/Resources/stree", target: "stree-beta"
 

--- a/Casks/s/space-saver.rb
+++ b/Casks/s/space-saver.rb
@@ -12,8 +12,6 @@ cask "space-saver" do
     regex(/Download Space Saver \(ver (\d+(?:\.\d+)*)\)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Space Saver.app"
 
   zap trash: [

--- a/Casks/s/spacedrive.rb
+++ b/Casks/s/spacedrive.rb
@@ -18,7 +18,6 @@ cask "spacedrive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Spacedrive.app"
 

--- a/Casks/s/spaceid.rb
+++ b/Casks/s/spaceid.rb
@@ -7,8 +7,6 @@ cask "spaceid" do
   desc "Menu bar indicator showing the currently selected space"
   homepage "https://github.com/dshnkao/SpaceId/"
 
-  depends_on macos: ">= :sierra"
-
   app "SpaceId.app"
 
   preflight do

--- a/Casks/s/spamsieve.rb
+++ b/Casks/s/spamsieve.rb
@@ -21,7 +21,6 @@ cask "spamsieve" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "SpamSieve.app"
 

--- a/Casks/s/spark-app.rb
+++ b/Casks/s/spark-app.rb
@@ -12,8 +12,6 @@ cask "spark-app" do
     regex(/Version\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Spark.app"
 
   zap trash: "~/Library/Application Support/Spark"

--- a/Casks/s/sparkle.rb
+++ b/Casks/s/sparkle.rb
@@ -13,8 +13,6 @@ cask "sparkle" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sparkle Test App.app"
   binary "sparkle.app/Contents/MacOS/sparkle"
 

--- a/Casks/s/sparkplate.rb
+++ b/Casks/s/sparkplate.rb
@@ -7,8 +7,6 @@ cask "sparkplate" do
   desc "Features a test page for resolving human readable domains to crypto addresses"
   homepage "https://github.com/GreenfireInc/Sparkplate.Vue"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sparkplate.app"
 
   zap trash: [

--- a/Casks/s/spatterlight.rb
+++ b/Casks/s/spatterlight.rb
@@ -13,8 +13,6 @@ cask "spatterlight" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Spatterlight.app"
 
   zap trash: [

--- a/Casks/s/specter.rb
+++ b/Casks/s/specter.rb
@@ -16,8 +16,6 @@ cask "specter" do
     regex(/href=.*?Specter[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Specter.app"
 
   zap trash: [

--- a/Casks/s/spectrolite.rb
+++ b/Casks/s/spectrolite.rb
@@ -16,7 +16,6 @@ cask "spectrolite" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Spectrolite.app"
 

--- a/Casks/s/speedify.rb
+++ b/Casks/s/speedify.rb
@@ -12,8 +12,6 @@ cask "speedify" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Speedify.app"
 
   uninstall launchctl: [

--- a/Casks/s/spike.rb
+++ b/Casks/s/spike.rb
@@ -12,8 +12,6 @@ cask "spike" do
     regex(/SPIKE[._-]APP[._-]\d+[._-]macOS[._-]+v?(\d+(?:\.\d+)+)[._-]Global\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Spike.app"
 
   zap trash: [

--- a/Casks/s/spires.rb
+++ b/Casks/s/spires.rb
@@ -13,7 +13,6 @@ cask "spires" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "spires.app"
 

--- a/Casks/s/splice.rb
+++ b/Casks/s/splice.rb
@@ -17,7 +17,6 @@ cask "splice" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Splice.app"
 

--- a/Casks/s/spline.rb
+++ b/Casks/s/spline.rb
@@ -15,8 +15,6 @@ cask "spline" do
     regex(/Spline[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}[._-]mac\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Spline.app"
 
   zap trash: "~/Library/Preferences/com.design.spline.plist"

--- a/Casks/s/spundle.rb
+++ b/Casks/s/spundle.rb
@@ -23,8 +23,6 @@ cask "spundle" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "spundle#{version.csv.first.no_dots}/Spundle.app"
 
   zap trash: [

--- a/Casks/s/sq-mixpad.rb
+++ b/Casks/s/sq-mixpad.rb
@@ -21,8 +21,6 @@ cask "sq-mixpad" do
 
   disable! date: "2025-09-15", because: :unreachable
 
-  depends_on macos: ">= :sierra"
-
   app "SQ MixPad #{version.csv.first}.app"
 
   zap trash: "~/Library/Preferences/com.allen-heath.SQ-MixPad*.plist"

--- a/Casks/s/sqlitemanager.rb
+++ b/Casks/s/sqlitemanager.rb
@@ -12,8 +12,6 @@ cask "sqlitemanager" do
     regex(/version\s+(\d+(?:\.\d+)*)/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SQLiteManager.app"
 
   zap trash: [

--- a/Casks/s/sqlpro-for-mssql.rb
+++ b/Casks/s/sqlpro-for-mssql.rb
@@ -13,8 +13,6 @@ cask "sqlpro-for-mssql" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SQLPro for MSSQL.app"
 
   zap trash: [

--- a/Casks/s/sqlpro-for-mysql.rb
+++ b/Casks/s/sqlpro-for-mysql.rb
@@ -13,8 +13,6 @@ cask "sqlpro-for-mysql" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SQLPro for MySQL.app"
 
   zap trash: [

--- a/Casks/s/sqlpro-for-postgres.rb
+++ b/Casks/s/sqlpro-for-postgres.rb
@@ -13,8 +13,6 @@ cask "sqlpro-for-postgres" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SQLPro for Postgres.app"
 
   zap trash: [

--- a/Casks/s/sqlpro-studio.rb
+++ b/Casks/s/sqlpro-studio.rb
@@ -13,8 +13,6 @@ cask "sqlpro-studio" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SQLPro Studio.app"
 
   zap trash: [

--- a/Casks/s/ssdreporter-free.rb
+++ b/Casks/s/ssdreporter-free.rb
@@ -12,8 +12,6 @@ cask "ssdreporter-free" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SSDReporter.app"
 
   zap trash: [

--- a/Casks/s/ssokit.rb
+++ b/Casks/s/ssokit.rb
@@ -12,8 +12,6 @@ cask "ssokit" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SSokit.app"
 
   zap trash: "~/Library/Preferences/cn.rangaofei.SSokit.plist"

--- a/Casks/s/stack-stack.rb
+++ b/Casks/s/stack-stack.rb
@@ -19,7 +19,6 @@ cask "stack-stack" do
   disable! date: "2024-09-30", because: :no_longer_available
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Stack.app"
 

--- a/Casks/s/stand.rb
+++ b/Casks/s/stand.rb
@@ -13,8 +13,6 @@ cask "stand" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Stand.app"
 
   uninstall quit: "com.reddavis.Stand"

--- a/Casks/s/standard-notes.rb
+++ b/Casks/s/standard-notes.rb
@@ -25,7 +25,6 @@ cask "standard-notes" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Standard Notes.app"
 

--- a/Casks/s/starcraft.rb
+++ b/Casks/s/starcraft.rb
@@ -10,8 +10,6 @@ cask "starcraft" do
 
   disable! date: "2025-03-06", because: :no_longer_available
 
-  depends_on macos: ">= :el_capitan"
-
   installer manual: "StarCraft-Setup.app"
 
   uninstall delete: "/Applications/StarCraft"

--- a/Casks/s/start.rb
+++ b/Casks/s/start.rb
@@ -25,7 +25,6 @@ cask "start" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "START.app"
 

--- a/Casks/s/staruml.rb
+++ b/Casks/s/staruml.rb
@@ -16,7 +16,6 @@ cask "staruml" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "StarUML.app"
 

--- a/Casks/s/stashpad.rb
+++ b/Casks/s/stashpad.rb
@@ -11,8 +11,6 @@ cask "stashpad" do
   desc "Notes app for collaborative work"
   homepage "https://www.stashpad.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Stashpad.app"
 
   zap trash: [

--- a/Casks/s/stats.rb
+++ b/Casks/s/stats.rb
@@ -1,16 +1,6 @@
 cask "stats" do
-  on_mojave :or_older do
-    version "2.8.26"
-    sha256 "1a4b44ba02520683b0a6c192388f593c36dde4d15c784a22dccf0caefe81e8b7"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_catalina :or_newer do
-    version "2.11.52"
-    sha256 "c3c55fb29c6dff15c95e5cc18425e8740130c35cb5822c09e0e28c48e8918ff2"
-  end
+  version "2.11.52"
+  sha256 "c3c55fb29c6dff15c95e5cc18425e8740130c35cb5822c09e0e28c48e8918ff2"
 
   url "https://github.com/exelban/stats/releases/download/v#{version}/Stats.dmg"
   name "Stats"
@@ -18,7 +8,6 @@ cask "stats" do
   homepage "https://github.com/exelban/stats"
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Stats.app"
 

--- a/Casks/s/stay.rb
+++ b/Casks/s/stay.rb
@@ -12,8 +12,6 @@ cask "stay" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Stay.app"
 
   zap trash: [

--- a/Casks/s/steelseries-engine.rb
+++ b/Casks/s/steelseries-engine.rb
@@ -12,7 +12,6 @@ cask "steelseries-engine" do
 
   auto_updates true
   conflicts_with cask: "steelseries-gg"
-  depends_on macos: ">= :sierra"
 
   pkg "SteelSeriesEngine#{version}.pkg"
 

--- a/Casks/s/steelseries-gg.rb
+++ b/Casks/s/steelseries-gg.rb
@@ -15,7 +15,6 @@ cask "steelseries-gg" do
 
   auto_updates true
   conflicts_with cask: "steelseries-engine"
-  depends_on macos: ">= :sierra"
 
   pkg "SteelSeriesGG#{version}.pkg"
 

--- a/Casks/s/steermouse.rb
+++ b/Casks/s/steermouse.rb
@@ -12,8 +12,6 @@ cask "steermouse" do
     regex(/href=.*?SteerMouse[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SteerMouse.app"
 
   zap trash: [

--- a/Casks/s/steinberg-activation-manager.rb
+++ b/Casks/s/steinberg-activation-manager.rb
@@ -13,8 +13,6 @@ cask "steinberg-activation-manager" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Steinberg Activation Manager.pkg"
 
   uninstall quit:    [

--- a/Casks/s/steinberg-download-assistant.rb
+++ b/Casks/s/steinberg-download-assistant.rb
@@ -19,7 +19,6 @@ cask "steinberg-download-assistant" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   installer manual: "Steinberg Download Assistant Setup.app"
 

--- a/Casks/s/steinberg-library-manager.rb
+++ b/Casks/s/steinberg-library-manager.rb
@@ -18,8 +18,6 @@ cask "steinberg-library-manager" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "Library Manager.pkg"
 
   uninstall launchctl: "com.steinberg.HALionLibraryInstallerHelper",

--- a/Casks/s/stellarium.rb
+++ b/Casks/s/stellarium.rb
@@ -1,40 +1,5 @@
 cask "stellarium" do
-  on_sierra :or_older do
-    version "0.22.2"
-    sha256 "5e8c2ee315f8c00a393e7bd22461f9b48355538cec39e1bb771e92a5795bcfb4"
-
-    url "https://github.com/Stellarium/stellarium/releases/download/v#{version}/Stellarium-#{version}-x86_64.zip",
-        verified: "github.com/Stellarium/stellarium/"
-
-    livecheck do
-      skip "Legacy version"
-    end
-  end
-  on_high_sierra do
-    version "25.2"
-    sha256 "f6d08ed9bc7c7272f237b78dd91eb299aac4ed9ef9c4b25a5e89f65eef2495e0"
-
-    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
-        verified: "github.com/Stellarium/stellarium/"
-
-    livecheck do
-      url :url
-      strategy :github_latest
-    end
-  end
-  on_mojave do
-    version "25.2"
-    sha256 "f6d08ed9bc7c7272f237b78dd91eb299aac4ed9ef9c4b25a5e89f65eef2495e0"
-
-    url "https://github.com/Stellarium/stellarium/releases/download/v#{version.major_minor}/Stellarium-#{version}-qt5-x86_64.zip",
-        verified: "github.com/Stellarium/stellarium/"
-
-    livecheck do
-      url :url
-      strategy :github_latest
-    end
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "25.2"
     sha256 "f6d08ed9bc7c7272f237b78dd91eb299aac4ed9ef9c4b25a5e89f65eef2495e0"
 
@@ -62,8 +27,6 @@ cask "stellarium" do
   name "Stellarium"
   desc "Tool to render realistic skies in real time on the screen"
   homepage "https://stellarium.org/"
-
-  depends_on macos: ">= :sierra"
 
   app "Stellarium.app"
 

--- a/Casks/s/stolendata-mpv.rb
+++ b/Casks/s/stolendata-mpv.rb
@@ -44,8 +44,6 @@ cask "stolendata-mpv" do
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io/"
 
-  depends_on macos: ">= :mojave"
-
   folder = label&.sub("VERSION", version)
 
   app "#{folder}mpv.app"

--- a/Casks/s/stoplight-studio.rb
+++ b/Casks/s/stoplight-studio.rb
@@ -24,8 +24,6 @@ cask "stoplight-studio" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Stoplight Studio.app"
 
   zap trash: [

--- a/Casks/s/streamlabs.rb
+++ b/Casks/s/streamlabs.rb
@@ -16,7 +16,6 @@ cask "streamlabs" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Streamlabs Desktop.app"
 

--- a/Casks/s/streamlink-twitch-gui.rb
+++ b/Casks/s/streamlink-twitch-gui.rb
@@ -8,7 +8,6 @@ cask "streamlink-twitch-gui" do
   homepage "https://github.com/streamlink/streamlink-twitch-gui/"
 
   depends_on formula: "streamlink"
-  depends_on macos: ">= :catalina"
 
   app "Streamlink Twitch GUI.app"
 

--- a/Casks/s/stringz.rb
+++ b/Casks/s/stringz.rb
@@ -13,7 +13,6 @@ cask "stringz" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Stringz.app"
 

--- a/Casks/s/strongvpn.rb
+++ b/Casks/s/strongvpn.rb
@@ -14,7 +14,6 @@ cask "strongvpn" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "StrongVPN.app"
 

--- a/Casks/s/studiolinkstandalone.rb
+++ b/Casks/s/studiolinkstandalone.rb
@@ -1,19 +1,9 @@
 cask "studiolinkstandalone" do
   version "21.07.0"
+  sha256 "13e1e57eb209e451469ec8c973af4ff290306316a7e766a11d8595125abb8608"
 
-  on_mojave :or_older do
-    sha256 "6f8e9770482420936ba0356c986f07822978f91bda37aea1a1bdafd1a36a2144"
-
-    url "https://download.studio.link/releases/v#{version}-stable/macos_x86_64/studio-link-standalone-v#{version}-stable.zip",
-        verified: "download.studio.link/"
-  end
-  on_catalina :or_newer do
-    sha256 "13e1e57eb209e451469ec8c973af4ff290306316a7e766a11d8595125abb8608"
-
-    url "https://download.studio.link/releases/v#{version}-stable/macos_x86_64/signed/studio-link-standalone-v#{version}-stable.zip",
-        verified: "download.studio.link/"
-  end
-
+  url "https://download.studio.link/releases/v#{version}-stable/macos_x86_64/signed/studio-link-standalone-v#{version}-stable.zip",
+      verified: "download.studio.link/"
   name "Studio Link Standalone"
   desc "SIP application to create high quality Audio over IP (AoIP) connections"
   homepage "https://studio-link.de/"

--- a/Casks/s/subethaedit.rb
+++ b/Casks/s/subethaedit.rb
@@ -13,7 +13,6 @@ cask "subethaedit" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "SubEthaEdit.app"
 

--- a/Casks/s/subler.rb
+++ b/Casks/s/subler.rb
@@ -14,7 +14,6 @@ cask "subler" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Subler.app"
 

--- a/Casks/s/sunloginclient.rb
+++ b/Casks/s/sunloginclient.rb
@@ -18,8 +18,6 @@ cask "sunloginclient" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "SunloginClient.pkg"
 
   postflight do

--- a/Casks/s/sunvox.rb
+++ b/Casks/s/sunvox.rb
@@ -14,8 +14,6 @@ cask "sunvox" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "sunvox/sunvox/macos/SunVox.app"
 
   zap trash: [

--- a/Casks/s/supercollider.rb
+++ b/Casks/s/supercollider.rb
@@ -25,8 +25,6 @@ cask "supercollider" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SuperCollider.app"
 
   zap trash: [

--- a/Casks/s/superduper.rb
+++ b/Casks/s/superduper.rb
@@ -20,7 +20,6 @@ cask "superduper" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "SuperDuper!.app"
 

--- a/Casks/s/superlist.rb
+++ b/Casks/s/superlist.rb
@@ -14,7 +14,6 @@ cask "superlist" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Superlist.app"
 

--- a/Casks/s/supermjograph.rb
+++ b/Casks/s/supermjograph.rb
@@ -13,8 +13,6 @@ cask "supermjograph" do
     regex(%r{url=.*?/SuperMjograph[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SuperMjograph.app"
 
   zap trash: [

--- a/Casks/s/supernotes.rb
+++ b/Casks/s/supernotes.rb
@@ -18,7 +18,6 @@ cask "supernotes" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Supernotes.app"
 

--- a/Casks/s/supremo.rb
+++ b/Casks/s/supremo.rb
@@ -14,7 +14,6 @@ cask "supremo" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Supremo.app"
 

--- a/Casks/s/surge@4.rb
+++ b/Casks/s/surge@4.rb
@@ -19,7 +19,6 @@ cask "surge@4" do
 
   auto_updates true
   conflicts_with cask: "surge"
-  depends_on macos: ">= :high_sierra"
 
   app "Surge.app"
 

--- a/Casks/s/suspicious-package.rb
+++ b/Casks/s/suspicious-package.rb
@@ -1,18 +1,6 @@
 cask "suspicious-package" do
   on_big_sur :or_older do
-    on_sierra :or_older do
-      version "3.4.1"
-      sha256 "e4673a0c590e7dcb711789d98fcadd2283c2152d262b7809dfd8c8a1b3e9094b"
-    end
-    on_high_sierra do
-      version "3.5.3"
-      sha256 "fad69db99a60058f8136954653fa2de81667f12cb731957a6d921d36ceaf195d"
-    end
-    on_mojave do
-      version "4.0"
-      sha256 "844708fb75f8aa102f3ede8ddef3c20180f469b7bc8ec65bbc0370ce9f7db33c"
-    end
-    on_catalina do
+    on_catalina :or_older do
       version "4.2.1"
       sha256 "5c05df9bf3d56758a3eefa972597e3138afdea4c3774f91fe2849482b7112823"
     end

--- a/Casks/s/svp.rb
+++ b/Casks/s/svp.rb
@@ -13,8 +13,6 @@ cask "svp" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SVP #{version.major} Mac.app"
 
   zap trash: [

--- a/Casks/s/swift-publisher.rb
+++ b/Casks/s/swift-publisher.rb
@@ -14,7 +14,6 @@ cask "swift-publisher" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Swift Publisher #{version.major}.app"
 

--- a/Casks/s/swiftformat-for-xcode.rb
+++ b/Casks/s/swiftformat-for-xcode.rb
@@ -26,8 +26,6 @@ cask "swiftformat-for-xcode" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SwiftFormat for Xcode.app"
 
   zap trash: [

--- a/Casks/s/swiftplantumlapp.rb
+++ b/Casks/s/swiftplantumlapp.rb
@@ -7,8 +7,6 @@ cask "swiftplantumlapp" do
   desc "Generate and view a class diagram for Swift code in Xcode"
   homepage "https://github.com/MarcoEidinger/SwiftPlantUML-Xcode-Extension"
 
-  depends_on macos: ">= :catalina"
-
   app "SwiftPlantUMLApp.app"
 
   zap trash: [

--- a/Casks/s/swiftpm-catalog.rb
+++ b/Casks/s/swiftpm-catalog.rb
@@ -15,8 +15,6 @@ cask "swiftpm-catalog" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "SwiftPM Catalog.app"
 
   zap trash: [

--- a/Casks/s/swifty.rb
+++ b/Casks/s/swifty.rb
@@ -9,7 +9,6 @@ cask "swifty" do
   homepage "https://getswifty.pro/"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Swifty.app"
 

--- a/Casks/s/swinsian.rb
+++ b/Casks/s/swinsian.rb
@@ -13,7 +13,6 @@ cask "swinsian" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Swinsian.app"
 

--- a/Casks/s/swish.rb
+++ b/Casks/s/swish.rb
@@ -14,7 +14,6 @@ cask "swish" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Swish.app"
 

--- a/Casks/s/switchhosts.rb
+++ b/Casks/s/switchhosts.rb
@@ -24,8 +24,6 @@ cask "switchhosts" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "SwitchHosts.app"
 
   zap trash: [

--- a/Casks/s/synalyze-it-pro.rb
+++ b/Casks/s/synalyze-it-pro.rb
@@ -14,7 +14,6 @@ cask "synalyze-it-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Synalyze It! Pro.app"
 

--- a/Casks/s/sync-my-l2p.rb
+++ b/Casks/s/sync-my-l2p.rb
@@ -8,8 +8,6 @@ cask "sync-my-l2p" do
   desc "Synchronises your documents from the L2P and Moodle of RWTH Aachen"
   homepage "https://www.syncmyl2p.de/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Sync-my-L2P.app"
 
   caveats do

--- a/Casks/s/syncalicious.rb
+++ b/Casks/s/syncalicious.rb
@@ -9,8 +9,6 @@ cask "syncalicious" do
 
   deprecate! date: "2025-04-22", because: :unmaintained
 
-  depends_on macos: ">= :mojave"
-
   app "Syncalicious.app"
 
   uninstall quit: "com.zenangst.Syncalicious"

--- a/Casks/s/syncmate.rb
+++ b/Casks/s/syncmate.rb
@@ -13,8 +13,6 @@ cask "syncmate" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "SyncMate.app"
 
   zap trash: [

--- a/Casks/s/syncplay.rb
+++ b/Casks/s/syncplay.rb
@@ -25,8 +25,6 @@ cask "syncplay" do
     end
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Syncplay.app"
 
   zap trash: [

--- a/Casks/s/syncroom.rb
+++ b/Casks/s/syncroom.rb
@@ -12,8 +12,6 @@ cask "syncroom" do
     regex(%r{href=.*?/SYNCROOM-MULTI-mac-(\d+(?:\.\d+)+)\.zip}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "SYNCROOM.pkg"
 
   uninstall pkgutil: [

--- a/Casks/s/sys-pc-tool.rb
+++ b/Casks/s/sys-pc-tool.rb
@@ -20,7 +20,6 @@ cask "sys-pc-tool" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   pkg "SYS_PC_TOOL_setup_mac-#{version}.pkg"
 

--- a/Casks/s/sysex-librarian.rb
+++ b/Casks/s/sysex-librarian.rb
@@ -12,8 +12,6 @@ cask "sysex-librarian" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "SysEx Librarian.app"
 
   uninstall quit: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.