### PR TITLE
[t]: remove pre-Catalina references

### DIFF
--- a/Casks/t/tableau-prep.rb
+++ b/Casks/t/tableau-prep.rb
@@ -16,8 +16,6 @@ cask "tableau-prep" do
     cask "tableau"
   end
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "Tableau Prep Builder.pkg"
 
   uninstall pkgutil: [

--- a/Casks/t/tableau.rb
+++ b/Casks/t/tableau.rb
@@ -30,8 +30,6 @@ cask "tableau" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Tableau Desktop.pkg"
 
   uninstall pkgutil: [

--- a/Casks/t/tableflip.rb
+++ b/Casks/t/tableflip.rb
@@ -14,7 +14,6 @@ cask "tableflip" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TableFlip.app"
 

--- a/Casks/t/tableplus.rb
+++ b/Casks/t/tableplus.rb
@@ -13,7 +13,6 @@ cask "tableplus" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "TablePlus.app"
 

--- a/Casks/t/taccy.rb
+++ b/Casks/t/taccy.rb
@@ -23,8 +23,6 @@ cask "taccy" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "#{token}#{version.csv.first.no_dots}/Taccy.app"
 
   zap trash: [

--- a/Casks/t/tachidesk-sorayomi.rb
+++ b/Casks/t/tachidesk-sorayomi.rb
@@ -7,8 +7,6 @@ cask "tachidesk-sorayomi" do
   desc "Manga reader"
   homepage "https://github.com/Suwayomi/Tachidesk-Sorayomi/"
 
-  depends_on macos: ">= :catalina"
-
   app "Sorayomi.app"
 
   zap trash: [

--- a/Casks/t/tad.rb
+++ b/Casks/t/tad.rb
@@ -16,8 +16,6 @@ cask "tad" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Tad.app"
   binary "#{appdir}/Tad.app/Contents/Resources/tad.sh", target: "tad"
 

--- a/Casks/t/tageditor.rb
+++ b/Casks/t/tageditor.rb
@@ -12,8 +12,6 @@ cask "tageditor" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   # The url is unversioned, but the download returns an app with a version number
   rename "Tag Editor*.app", "Tag Editor.app"
 

--- a/Casks/t/tal-drum.rb
+++ b/Casks/t/tal-drum.rb
@@ -12,8 +12,6 @@ cask "tal-drum" do
     regex(/Version\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   pkg "TAL-Drum-installer.pkg"
 
   uninstall pkgutil: [

--- a/Casks/t/talon.rb
+++ b/Casks/t/talon.rb
@@ -12,8 +12,6 @@ cask "talon" do
     regex(/<h\d>\s*(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Talon.app"
 
   zap trash: [

--- a/Casks/t/tandem.rb
+++ b/Casks/t/tandem.rb
@@ -25,7 +25,6 @@ cask "tandem" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Tandem.app"
 

--- a/Casks/t/tap-forms.rb
+++ b/Casks/t/tap-forms.rb
@@ -19,8 +19,6 @@ cask "tap-forms" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Tap Forms Mac #{version.major}.app"
 
   zap trash: [

--- a/Casks/t/taskade.rb
+++ b/Casks/t/taskade.rb
@@ -12,8 +12,6 @@ cask "taskade" do
     regex(%r{href=.*?/Taskade[._-]v?(\d+(?:\.\d+)+)[._-]universal\.dmg}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Taskade.app"
 
   zap trash: [

--- a/Casks/t/taskbar.rb
+++ b/Casks/t/taskbar.rb
@@ -19,7 +19,6 @@ cask "taskbar" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Taskbar.app"
 

--- a/Casks/t/taskpaper.rb
+++ b/Casks/t/taskpaper.rb
@@ -13,7 +13,6 @@ cask "taskpaper" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "TaskPaper.app"
 

--- a/Casks/t/teacode.rb
+++ b/Casks/t/teacode.rb
@@ -13,7 +13,6 @@ cask "teacode" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TeaCode.app"
 

--- a/Casks/t/teambition.rb
+++ b/Casks/t/teambition.rb
@@ -12,8 +12,6 @@ cask "teambition" do
     regex(/Teambition[._-](\d+(?:\.\d+)+)[._-]mac\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Teambition.app"
 
   zap trash: [

--- a/Casks/t/teamspeak-client.rb
+++ b/Casks/t/teamspeak-client.rb
@@ -24,7 +24,6 @@ cask "teamspeak-client" do
   homepage "https://www.teamspeak.com/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TeamSpeak #{version.major} Client.app"
 

--- a/Casks/t/teamspeak-client@beta.rb
+++ b/Casks/t/teamspeak-client@beta.rb
@@ -14,7 +14,6 @@ cask "teamspeak-client@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TeamSpeak.app"
 

--- a/Casks/t/teamviewer.rb
+++ b/Casks/t/teamviewer.rb
@@ -1,27 +1,5 @@
 cask "teamviewer" do
-  on_high_sierra :or_older do
-    version "15.2.2756"
-    sha256 "fe7daf80f9aee056f97d11183941470fa1c5823101a0951990340b6264a2651a"
-
-    livecheck do
-      url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.11.1&type=1&channel=1"
-      regex(%r{url=.*update/v?(\d+(?:\.\d+)+)/Teamviewer\.pkg}i)
-    end
-
-    pkg "TeamViewer.pkg"
-  end
-  on_mojave do
-    version "15.42.4"
-    sha256 "3357bc366cd0295dd100b790d6af6216d349d34451ea18ba08692a51eadd6cf7"
-
-    livecheck do
-      url "https://download.teamviewer.com/download/update/macupdates.xml?id=0&lang=en&version=#{version}&os=macos&osversion=10.14.1&type=1&channel=1"
-      strategy :sparkle
-    end
-
-    pkg "TeamViewer.pkg"
-  end
-  on_catalina do
+  on_catalina :or_older do
     version "15.42.4"
     sha256 "3357bc366cd0295dd100b790d6af6216d349d34451ea18ba08692a51eadd6cf7"
 
@@ -71,7 +49,6 @@ cask "teamviewer" do
 
   auto_updates true
   conflicts_with cask: "teamviewer-host"
-  depends_on macos: ">= :el_capitan"
 
   postflight do
     # postinstall launches the app

--- a/Casks/t/techsmith-capture.rb
+++ b/Casks/t/techsmith-capture.rb
@@ -13,7 +13,6 @@ cask "techsmith-capture" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TechSmith Capture.app"
 

--- a/Casks/t/telegram-a.rb
+++ b/Casks/t/telegram-a.rb
@@ -11,8 +11,6 @@ cask "telegram-a" do
   desc "Web client for Telegram messenger"
   homepage "https://web.telegram.org/a/get"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Telegram A.app"
 
   zap trash: [

--- a/Casks/t/telegram-desktop.rb
+++ b/Casks/t/telegram-desktop.rb
@@ -15,7 +15,6 @@ cask "telegram-desktop" do
 
   auto_updates true
   conflicts_with cask: "telegram-desktop@beta"
-  depends_on macos: ">= :high_sierra"
 
   # Renamed to avoid conflict with telegram
   app "Telegram.app", target: "Telegram Desktop.app"

--- a/Casks/t/telegram-desktop@beta.rb
+++ b/Casks/t/telegram-desktop@beta.rb
@@ -10,7 +10,6 @@ cask "telegram-desktop@beta" do
 
   auto_updates true
   conflicts_with cask: "telegram-desktop"
-  depends_on macos: ">= :high_sierra"
 
   # Renamed to avoid conflict with telegram
   app "Telegram.app", target: "Telegram Desktop.app"

--- a/Casks/t/telegram.rb
+++ b/Casks/t/telegram.rb
@@ -17,7 +17,6 @@ cask "telegram" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Telegram.app"
 

--- a/Casks/t/tencent-docs.rb
+++ b/Casks/t/tencent-docs.rb
@@ -31,7 +31,6 @@ cask "tencent-docs" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TencentDocs.app"
 

--- a/Casks/t/tencent-meeting.rb
+++ b/Casks/t/tencent-meeting.rb
@@ -31,7 +31,6 @@ cask "tencent-meeting" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "TencentMeeting.app"
 

--- a/Casks/t/tentacle-sync-studio.rb
+++ b/Casks/t/tentacle-sync-studio.rb
@@ -15,8 +15,6 @@ cask "tentacle-sync-studio" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Tentacle Sync Studio.app"
 
   zap trash: [

--- a/Casks/t/termius.rb
+++ b/Casks/t/termius.rb
@@ -15,7 +15,6 @@ cask "termius" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Termius.app"
 

--- a/Casks/t/termius@beta.rb
+++ b/Casks/t/termius@beta.rb
@@ -14,8 +14,6 @@ cask "termius@beta" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Termius Beta.app"
 
   uninstall delete: [

--- a/Casks/t/termora.rb
+++ b/Casks/t/termora.rb
@@ -11,7 +11,6 @@ cask "termora" do
   homepage "https://github.com/TermoraDev/termora"
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Termora.app"
 

--- a/Casks/t/testfully.rb
+++ b/Casks/t/testfully.rb
@@ -21,8 +21,6 @@ cask "testfully" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Testfully.app"
 
   zap trash: [

--- a/Casks/t/tetrio.rb
+++ b/Casks/t/tetrio.rb
@@ -15,8 +15,6 @@ cask "tetrio" do
     regex(%r{href=.*builds/(\d+)/TETR\.IO[. _-]Setup[. _-]#{arch}\.dmg}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "TETR.IO.app"
 
   zap trash: [

--- a/Casks/t/tev.rb
+++ b/Casks/t/tev.rb
@@ -15,8 +15,6 @@ cask "tev" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "tev.app"
   binary "#{appdir}/tev.app/Contents/MacOS/tev"
 

--- a/Casks/t/texmacs.rb
+++ b/Casks/t/texmacs.rb
@@ -15,8 +15,6 @@ cask "texmacs" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :mojave"
-
   app "TeXmacs.app"
 
   zap trash: [

--- a/Casks/t/texmaker.rb
+++ b/Casks/t/texmaker.rb
@@ -23,8 +23,6 @@ cask "texmaker" do
   desc "LaTeX editor"
   homepage "https://www.xm1math.net/texmaker/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "texmaker.app"
 
   zap trash: [

--- a/Casks/t/texshop.rb
+++ b/Casks/t/texshop.rb
@@ -13,7 +13,6 @@ cask "texshop" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "TeXShop.app"
 

--- a/Casks/t/textmate.rb
+++ b/Casks/t/textmate.rb
@@ -14,7 +14,6 @@ cask "textmate" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TextMate.app"
   binary "#{appdir}/TextMate.app/Contents/MacOS/mate"

--- a/Casks/t/textsniper.rb
+++ b/Casks/t/textsniper.rb
@@ -14,7 +14,6 @@ cask "textsniper" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TextSniper.app"
 

--- a/Casks/t/tg-pro.rb
+++ b/Casks/t/tg-pro.rb
@@ -13,7 +13,6 @@ cask "tg-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "TG Pro.app"
 

--- a/Casks/t/thangs-sync.rb
+++ b/Casks/t/thangs-sync.rb
@@ -13,8 +13,6 @@ cask "thangs-sync" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Thangs Sync.app"
 
   zap trash: [

--- a/Casks/t/the-archive.rb
+++ b/Casks/t/the-archive.rb
@@ -14,7 +14,6 @@ cask "the-archive" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "The Archive.app"
 

--- a/Casks/t/the-battle-for-wesnoth.rb
+++ b/Casks/t/the-battle-for-wesnoth.rb
@@ -13,8 +13,6 @@ cask "the-battle-for-wesnoth" do
     regex(/href=.*?Wesnoth[._-]v?(\d+\.\d*[02468](?:\.\d+)*[a-z]?)\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "The Battle for Wesnoth.app"
 
   zap trash: [

--- a/Casks/t/the-unarchiver.rb
+++ b/Casks/t/the-unarchiver.rb
@@ -20,7 +20,6 @@ cask "the-unarchiver" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "The Unarchiver.app"
 

--- a/Casks/t/thebrain.rb
+++ b/Casks/t/thebrain.rb
@@ -12,8 +12,6 @@ cask "thebrain" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :mojave"
-
   app "TheBrain #{version.major}.app"
 
   zap trash: [

--- a/Casks/t/thedesk.rb
+++ b/Casks/t/thedesk.rb
@@ -13,8 +13,6 @@ cask "thedesk" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "TheDesk.app"
 
   zap trash: [

--- a/Casks/t/theiaide.rb
+++ b/Casks/t/theiaide.rb
@@ -17,7 +17,6 @@ cask "theiaide" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "TheiaIDE.app"
 

--- a/Casks/t/thingsmacsandboxhelper.rb
+++ b/Casks/t/thingsmacsandboxhelper.rb
@@ -12,8 +12,6 @@ cask "thingsmacsandboxhelper" do
     regex(%r{href=.*?/(\d+(?:\.\d+)+)/ThingsHelper\.zip}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "ThingsMacSandboxHelper.app"
 
   # No zap stanza required

--- a/Casks/t/threema-work.rb
+++ b/Casks/t/threema-work.rb
@@ -12,8 +12,6 @@ cask "threema-work" do
     regex(/>\s*Threema\s+Work\s+v?(\d+(?:\.\d+)+)\s+for\s+Desktop\s*</i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Threema Work.app"
 
   zap trash: [

--- a/Casks/t/threema.rb
+++ b/Casks/t/threema.rb
@@ -12,8 +12,6 @@ cask "threema" do
     regex(/Threema\s*(\d+(?:\.\d+)+)\s*for\s*Desktop/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Threema.app"
 
   zap trash: [

--- a/Casks/t/threema@beta.rb
+++ b/Casks/t/threema@beta.rb
@@ -17,8 +17,6 @@ cask "threema@beta" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Threema Beta.app"
 
   zap trash: [

--- a/Casks/t/ths.rb
+++ b/Casks/t/ths.rb
@@ -14,8 +14,6 @@ cask "ths" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "同花顺.app"
 
   zap trash: [

--- a/Casks/t/thumbhost3mf.rb
+++ b/Casks/t/thumbhost3mf.rb
@@ -7,8 +7,6 @@ cask "thumbhost3mf" do
   desc "Finder thumbnail provider for some .gcode, .bgcode and .3mf files"
   homepage "https://github.com/DavidPhillipOster/ThumbHost3mf/"
 
-  depends_on macos: ">= :catalina"
-
   app "ThumbHost3mf.app"
 
   zap trash: "~/Library/Containers/com.turbozen.-mfQuickLook/Data/Library/Preferences/com.turbozen.-mfQuickLook.plist"

--- a/Casks/t/thunderbird.rb
+++ b/Casks/t/thunderbird.rb
@@ -237,7 +237,6 @@ cask "thunderbird" do
 
   auto_updates true
   conflicts_with cask: "thunderbird@esr"
-  depends_on macos: ">= :catalina"
 
   app "Thunderbird.app"
 

--- a/Casks/t/thunderbird@beta.rb
+++ b/Casks/t/thunderbird@beta.rb
@@ -80,7 +80,6 @@ cask "thunderbird@beta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Thunderbird Beta.app"
 

--- a/Casks/t/thunderbird@daily.rb
+++ b/Casks/t/thunderbird@daily.rb
@@ -91,7 +91,6 @@ cask "thunderbird@daily" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Thunderbird Daily.app"
 

--- a/Casks/t/thunderbird@esr.rb
+++ b/Casks/t/thunderbird@esr.rb
@@ -238,7 +238,6 @@ cask "thunderbird@esr" do
 
   auto_updates true
   conflicts_with cask: "thunderbird"
-  depends_on macos: ">= :catalina"
 
   app "Thunderbird.app"
 

--- a/Casks/t/ticktick.rb
+++ b/Casks/t/ticktick.rb
@@ -14,7 +14,6 @@ cask "ticktick" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "TickTick.app"
 

--- a/Casks/t/tidal.rb
+++ b/Casks/t/tidal.rb
@@ -18,7 +18,6 @@ cask "tidal" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TIDAL.app"
 

--- a/Casks/t/tiger-trade.rb
+++ b/Casks/t/tiger-trade.rb
@@ -17,8 +17,6 @@ cask "tiger-trade" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Tiger Trade.app"
 
   zap trash: [

--- a/Casks/t/tikzit.rb
+++ b/Casks/t/tikzit.rb
@@ -8,8 +8,6 @@ cask "tikzit" do
   desc "PGF/TikZ diagram editor"
   homepage "https://tikzit.github.io/"
 
-  depends_on macos: ">= :sierra"
-
   app "TikZiT.app"
 
   zap trash: [

--- a/Casks/t/tiled.rb
+++ b/Casks/t/tiled.rb
@@ -23,8 +23,6 @@ cask "tiled" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Tiled.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/tiled.wrapper.sh"

--- a/Casks/t/tiles.rb
+++ b/Casks/t/tiles.rb
@@ -19,7 +19,6 @@ cask "tiles" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Tiles.app"
 

--- a/Casks/t/time-out.rb
+++ b/Casks/t/time-out.rb
@@ -13,7 +13,6 @@ cask "time-out" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Time Out.app"
 

--- a/Casks/t/timecamp.rb
+++ b/Casks/t/timecamp.rb
@@ -13,8 +13,6 @@ cask "timecamp" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "TimeCamp.app"
 
   zap rmdir: "~/Library/Application Support/TimeCamp"

--- a/Casks/t/timelane.rb
+++ b/Casks/t/timelane.rb
@@ -13,7 +13,6 @@ cask "timelane" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Timelane.app"
 

--- a/Casks/t/timemator.rb
+++ b/Casks/t/timemator.rb
@@ -14,7 +14,6 @@ cask "timemator" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Timemator.app"
 

--- a/Casks/t/timescribe.rb
+++ b/Casks/t/timescribe.rb
@@ -17,7 +17,6 @@ cask "timescribe" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TimeScribe.app"
 

--- a/Casks/t/timing.rb
+++ b/Casks/t/timing.rb
@@ -19,7 +19,6 @@ cask "timing" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Timing.app"
 

--- a/Casks/t/tiny-player.rb
+++ b/Casks/t/tiny-player.rb
@@ -13,7 +13,6 @@ cask "tiny-player" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Tiny Player.app"
 

--- a/Casks/t/tip.rb
+++ b/Casks/t/tip.rb
@@ -9,8 +9,6 @@ cask "tip" do
 
   deprecate! date: "2025-05-25", because: :moved_to_mas
 
-  depends_on macos: ">= :mojave"
-
   app "Tip.app"
 
   zap trash: "~/Library/Application Scripts/tanin.tip"

--- a/Casks/t/tiptoi-manager.rb
+++ b/Casks/t/tiptoi-manager.rb
@@ -13,7 +13,6 @@ cask "tiptoi-manager" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   pkg "tiptoi_Manager_Installer.pkg"
 

--- a/Casks/t/tlv.rb
+++ b/Casks/t/tlv.rb
@@ -9,7 +9,5 @@ cask "tlv" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "tlv.app"
 end

--- a/Casks/t/tm-error-logger.rb
+++ b/Casks/t/tm-error-logger.rb
@@ -12,8 +12,6 @@ cask "tm-error-logger" do
     regex(/<p>v?(\d+(?:\.\d+)+)[ "<]/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "TM Error Logger.app"
 
   zap trash: [

--- a/Casks/t/tng-digital-mini-program-studio.rb
+++ b/Casks/t/tng-digital-mini-program-studio.rb
@@ -20,8 +20,6 @@ cask "tng-digital-mini-program-studio" do
     skip "No reliable automated version detection available"
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "MiniProgramStudio.app"
 
   zap trash: [

--- a/Casks/t/to-audio-converter.rb
+++ b/Casks/t/to-audio-converter.rb
@@ -13,8 +13,6 @@ cask "to-audio-converter" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   # The url is unversioned, but the download returns an app with a version number
   rename "To Audio Converter*.app", "To Audio Converter.app"
 

--- a/Casks/t/todoist-app.rb
+++ b/Casks/t/todoist-app.rb
@@ -16,7 +16,6 @@ cask "todoist-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Todoist.app"
 

--- a/Casks/t/todour.rb
+++ b/Casks/t/todour.rb
@@ -12,8 +12,6 @@ cask "todour" do
     regex(/href=.*?Todour[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Todour.app"
 
   zap trash: "~/Library/Preferences/com.nerdur.Todour.plist"

--- a/Casks/t/tofu.rb
+++ b/Casks/t/tofu.rb
@@ -13,8 +13,6 @@ cask "tofu" do
     skip "Upstream website uses a CAPTCHA"
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Tofu.app"
 
   zap trash: [

--- a/Casks/t/toontown-rewritten.rb
+++ b/Casks/t/toontown-rewritten.rb
@@ -14,7 +14,6 @@ cask "toontown-rewritten" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   # Renamed for consistency: app name is different in the Finder and in a shell.
   # Original discussion: https://github.com/Homebrew/homebrew-cask/pull/8037

--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -13,7 +13,6 @@ cask "topaz-video-ai" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Topaz Video AI.app"
 

--- a/Casks/t/toptracker.rb
+++ b/Casks/t/toptracker.rb
@@ -10,8 +10,6 @@ cask "toptracker" do
 
   deprecate! date: "2025-03-31", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "TopTracker.app"
 
   zap trash: [

--- a/Casks/t/tor-browser.rb
+++ b/Casks/t/tor-browser.rb
@@ -18,7 +18,6 @@ cask "tor-browser" do
 
   auto_updates true
   conflicts_with cask: "tor-browser@alpha"
-  depends_on macos: ">= :catalina"
 
   app "Tor Browser.app"
 

--- a/Casks/t/tor-browser@alpha.rb
+++ b/Casks/t/tor-browser@alpha.rb
@@ -16,7 +16,6 @@ cask "tor-browser@alpha" do
 
   auto_updates true
   conflicts_with cask: "tor-browser"
-  depends_on macos: ">= :catalina"
 
   app "Tor Browser Alpha.app"
 

--- a/Casks/t/torguard.rb
+++ b/Casks/t/torguard.rb
@@ -13,8 +13,6 @@ cask "torguard" do
     regex(/TorGuard[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "Install TorGuard.pkg"
 
   uninstall pkgutil: "net.torguard.TorGuardDesktopQt",

--- a/Casks/t/torrent-file-editor.rb
+++ b/Casks/t/torrent-file-editor.rb
@@ -8,8 +8,6 @@ cask "torrent-file-editor" do
   desc "GUI for editing and creating torrent files"
   homepage "https://torrent-file-editor.github.io/"
 
-  depends_on macos: ">= :sierra"
-
   app "Torrent File Editor.app"
 
   zap trash: [

--- a/Casks/t/touch-bar-simulator.rb
+++ b/Casks/t/touch-bar-simulator.rb
@@ -1,31 +1,14 @@
 cask "touch-bar-simulator" do
-  on_high_sierra :or_older do
-    version "1.2.0"
-    sha256 "4abe55de716ae56a41031cdb1d3b27bf6b1efae18b33b80bb0419669a9a76aa1"
+  version "4.2.0"
+  sha256 "7af139d541a8d2875d76aa46ef4074496d07ef49d2aec27467d8879aac903d43"
 
-    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch-Bar-Simulator-#{version}.dmg"
-  end
-  on_mojave do
-    version "3.2.0"
-    sha256 "bdfaf740392bddb3e9b281a30efab27e03638d3428ba555650dca517153c13c6"
-
-    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
-  end
-  on_catalina :or_newer do
-    version "4.2.0"
-    sha256 "7af139d541a8d2875d76aa46ef4074496d07ef49d2aec27467d8879aac903d43"
-
-    url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
-  end
-
+  url "https://github.com/sindresorhus/touch-bar-simulator/releases/download/v#{version}/Touch.Bar.Simulator.#{version}.dmg"
   name "Touch Bar Simulator"
   desc "Touch Bar as a standalone app"
   homepage "https://github.com/sindresorhus/touch-bar-simulator"
 
   deprecate! date: "2024-05-14", because: :discontinued
   disable! date: "2025-05-15", because: :discontinued
-
-  depends_on macos: ">= :sierra"
 
   app "Touch Bar Simulator.app"
 

--- a/Casks/t/touch-portal.rb
+++ b/Casks/t/touch-portal.rb
@@ -17,8 +17,6 @@ cask "touch-portal" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "TouchPortal.app"
 
   uninstall pkgutil: "org.eclipse.jdt.internal.jarinjarloader"

--- a/Casks/t/touchdesigner.rb
+++ b/Casks/t/touchdesigner.rb
@@ -15,8 +15,6 @@ cask "touchdesigner" do
     regex(/Build\s+(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "TouchDesigner.app"
 
   zap trash: [

--- a/Casks/t/touchosc.rb
+++ b/Casks/t/touchosc.rb
@@ -13,7 +13,6 @@ cask "touchosc" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "TouchOSC.app"
 

--- a/Casks/t/touchswitcher.rb
+++ b/Casks/t/touchswitcher.rb
@@ -13,7 +13,6 @@ cask "touchswitcher" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TouchSwitcher.app"
 

--- a/Casks/t/tourbox-console.rb
+++ b/Casks/t/tourbox-console.rb
@@ -17,8 +17,6 @@ cask "tourbox-console" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "TourBoxInstall#{version}/TourBoxInstall#{version}.pkg"
 
   uninstall quit:    "com.tourbox.ui.launch",

--- a/Casks/t/tpvirtual.rb
+++ b/Casks/t/tpvirtual.rb
@@ -12,8 +12,6 @@ cask "tpvirtual" do
     regex(/href=.*?TPVirtual[._-]Installer[._-]v?(\d+(?:\.\d+)*)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "TPVirtual-Launcher.app"
 
   zap trash: [

--- a/Casks/t/tradingview.rb
+++ b/Casks/t/tradingview.rb
@@ -13,7 +13,6 @@ cask "tradingview" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "TradingView.app"
 

--- a/Casks/t/trae-cn.rb
+++ b/Casks/t/trae-cn.rb
@@ -18,7 +18,6 @@ cask "trae-cn" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Trae CN.app"
 

--- a/Casks/t/trae.rb
+++ b/Casks/t/trae.rb
@@ -18,7 +18,6 @@ cask "trae" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Trae.app"
 

--- a/Casks/t/trainerroad.rb
+++ b/Casks/t/trainerroad.rb
@@ -21,8 +21,6 @@ cask "trainerroad" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "TrainerRoad.app"
 
   zap trash: "~/Library/Application Support/TrainerRoad"

--- a/Casks/t/transfer.rb
+++ b/Casks/t/transfer.rb
@@ -13,7 +13,6 @@ cask "transfer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Transfer.app"
 

--- a/Casks/t/transmission.rb
+++ b/Casks/t/transmission.rb
@@ -15,7 +15,6 @@ cask "transmission" do
 
   auto_updates true
   conflicts_with cask: "transmission@nightly"
-  depends_on macos: ">= :high_sierra"
 
   app "Transmission.app"
 

--- a/Casks/t/transocks.rb
+++ b/Casks/t/transocks.rb
@@ -13,8 +13,6 @@ cask "transocks" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "穿梭Transocks.app"
 
   uninstall trash: [

--- a/Casks/t/treesheets.rb
+++ b/Casks/t/treesheets.rb
@@ -23,8 +23,6 @@ cask "treesheets" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "TreeSheets.app"
 
   uninstall quit: "dot3labs.TreeSheets"

--- a/Casks/t/tresorit.rb
+++ b/Casks/t/tresorit.rb
@@ -15,7 +15,6 @@ cask "tresorit" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Tresorit.app"
 

--- a/Casks/t/trivial.rb
+++ b/Casks/t/trivial.rb
@@ -12,8 +12,6 @@ cask "trivial" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Trivial.app"
 
   uninstall launchctl: "com.decisivetactics.trivial-server",

--- a/Casks/t/trojanx.rb
+++ b/Casks/t/trojanx.rb
@@ -10,8 +10,6 @@ cask "trojanx" do
   deprecate! date: "2024-08-30", because: :unmaintained
   disable! date: "2025-08-30", because: :unmaintained
 
-  depends_on macos: ">= :el_capitan"
-
   app "TrojanX.app"
 
   uninstall delete: "/Library/Application Support/TrojanX"

--- a/Casks/t/tropy.rb
+++ b/Casks/t/tropy.rb
@@ -16,8 +16,6 @@ cask "tropy" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Tropy.app"
 
   zap trash: [

--- a/Casks/t/truetree.rb
+++ b/Casks/t/truetree.rb
@@ -8,8 +8,6 @@ cask "truetree" do
   desc "Command-line tool for pstree-like output"
   homepage "https://themittenmac.com/the-truetree-concept/"
 
-  depends_on macos: ">= :high_sierra"
-
   binary "TrueTree"
 
   # No zap stanza required

--- a/Casks/t/truhu.rb
+++ b/Casks/t/truhu.rb
@@ -22,8 +22,6 @@ cask "truhu" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "TruHu Mac Desktop.app"
 
   zap trash: [

--- a/Casks/t/tunein.rb
+++ b/Casks/t/tunein.rb
@@ -12,8 +12,6 @@ cask "tunein" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "TuneIn.app"
 
   zap trash: [

--- a/Casks/t/tuneinstructor.rb
+++ b/Casks/t/tuneinstructor.rb
@@ -12,8 +12,6 @@ cask "tuneinstructor" do
     regex(/href=.*?TuneInstructor[._-]?v?(\d+(?:[.v]\d+)+)\.zip/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Tune•Instructor.app"
 
   zap trash: [

--- a/Casks/t/tunnelbear.rb
+++ b/Casks/t/tunnelbear.rb
@@ -28,7 +28,6 @@ cask "tunnelbear" do
   homepage "https://www.tunnelbear.com/"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TunnelBear.app"
 

--- a/Casks/t/twake.rb
+++ b/Casks/t/twake.rb
@@ -16,8 +16,6 @@ cask "twake" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Twake Desktop.app"
 
   zap trash: [

--- a/Casks/t/twelite-stage.rb
+++ b/Casks/t/twelite-stage.rb
@@ -12,8 +12,6 @@ cask "twelite-stage" do
     regex(/MWSTAGEv?(\d+(?:[._]\d+)+)/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   # It is an SDK with a shell-based application that
   # includes source code and other user resources.
   # It is neither an "app" nor a "suite".

--- a/Casks/t/twine-app.rb
+++ b/Casks/t/twine-app.rb
@@ -8,8 +8,6 @@ cask "twine-app" do
   desc "Tool for telling interactive, nonlinear stories"
   homepage "https://twinery.org/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Twine.app"
 
   zap trash: [

--- a/Casks/t/twist.rb
+++ b/Casks/t/twist.rb
@@ -12,8 +12,6 @@ cask "twist" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Twist.app"
 
   zap trash: [

--- a/Casks/t/typeface.rb
+++ b/Casks/t/typeface.rb
@@ -13,7 +13,6 @@ cask "typeface" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Typeface.app"
 

--- a/Casks/t/typefully.rb
+++ b/Casks/t/typefully.rb
@@ -17,7 +17,6 @@ cask "typefully" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Typefully.app"
 

--- a/Casks/t/typeit4me.rb
+++ b/Casks/t/typeit4me.rb
@@ -13,7 +13,6 @@ cask "typeit4me" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "TypeIt4Me.app"
 

--- a/Casks/t/typinator.rb
+++ b/Casks/t/typinator.rb
@@ -15,8 +15,6 @@ cask "typinator" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Typinator.app"
 
   zap trash: [

--- a/Casks/t/tysimulator.rb
+++ b/Casks/t/tysimulator.rb
@@ -10,8 +10,6 @@ cask "tysimulator" do
   deprecate! date: "2024-09-08", because: :discontinued
   disable! date: "2025-09-09", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "TySimulator.app"
 
   uninstall quit: "com.tianyiyan.TySimulator"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.