### PR TITLE
[u]: remove pre-Catalina references

### DIFF
--- a/Casks/u/ua-midi-control.rb
+++ b/Casks/u/ua-midi-control.rb
@@ -14,7 +14,6 @@ cask "ua-midi-control" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "UA Midi Control.app"
 

--- a/Casks/u/ubar.rb
+++ b/Casks/u/ubar.rb
@@ -12,8 +12,6 @@ cask "ubar" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "uBar.app"
 
   zap trash: [

--- a/Casks/u/ugg.rb
+++ b/Casks/u/ugg.rb
@@ -14,7 +14,6 @@ cask "ugg" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "U.GG.app"
 

--- a/Casks/u/ui-browser.rb
+++ b/Casks/u/ui-browser.rb
@@ -10,8 +10,6 @@ cask "ui-browser" do
 
   disable! date: "2024-12-16", because: :discontinued
 
-  depends_on macos: ">= :sierra"
-
   app "UI Browser.app"
 
   zap trash: [

--- a/Casks/u/ukelele.rb
+++ b/Casks/u/ukelele.rb
@@ -13,7 +13,6 @@ cask "ukelele" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Ukelele.app"
 

--- a/Casks/u/ultimaker-cura.rb
+++ b/Casks/u/ultimaker-cura.rb
@@ -24,8 +24,6 @@ cask "ultimaker-cura" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "UltiMaker Cura.app"
 
   uninstall quit: "nl.ultimaker.cura.dmg"

--- a/Casks/u/ultracopier.rb
+++ b/Casks/u/ultracopier.rb
@@ -11,8 +11,6 @@ cask "ultracopier" do
   deprecate! date: "2024-08-04", because: :discontinued
   disable! date: "2025-08-04", because: :discontinued
 
-  depends_on macos: ">= :high_sierra"
-
   app "ultracopier.app"
 
   zap trash: [

--- a/Casks/u/unclack.rb
+++ b/Casks/u/unclack.rb
@@ -12,8 +12,6 @@ cask "unclack" do
     regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/Unclack\.dmg}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Unclack.app"
 
   zap trash: [

--- a/Casks/u/unclutter.rb
+++ b/Casks/u/unclutter.rb
@@ -12,8 +12,6 @@ cask "unclutter" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Unclutter.app"
 
   zap trash: [

--- a/Casks/u/unexpectedly.rb
+++ b/Casks/u/unexpectedly.rb
@@ -12,8 +12,6 @@ cask "unexpectedly" do
     regex(%r{Version</b>:</td><td>(\d+(?:\.\d+)*\w)}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Unexpectedly.app"
 
   zap trash: "~/Library/Preferences/fr.whitebox.unexpectedly.plist"

--- a/Casks/u/unified-remote.rb
+++ b/Casks/u/unified-remote.rb
@@ -12,8 +12,6 @@ cask "unified-remote" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Unified Remote.app"
 
   caveats do

--- a/Casks/u/uninstallpkg.rb
+++ b/Casks/u/uninstallpkg.rb
@@ -12,8 +12,6 @@ cask "uninstallpkg" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "UninstallPKG.app"
 
   uninstall launchctl: "com.corecode.UninstallPKGDeleteHelper",

--- a/Casks/u/unipro-ugene.rb
+++ b/Casks/u/unipro-ugene.rb
@@ -8,8 +8,6 @@ cask "unipro-ugene" do
   desc "Free open-source cross-platform bioinformatics software"
   homepage "https://ugene.net/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "Unipro UGENE.app"
 
   zap trash: [

--- a/Casks/u/unity-hub.rb
+++ b/Casks/u/unity-hub.rb
@@ -15,7 +15,6 @@ cask "unity-hub" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Unity Hub.app"
 

--- a/Casks/u/universal-media-server.rb
+++ b/Casks/u/universal-media-server.rb
@@ -16,8 +16,6 @@ cask "universal-media-server" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Universal Media Server.app"
 
   zap trash: "~/Library/Application Support/UMS"

--- a/Casks/u/unlox.rb
+++ b/Casks/u/unlox.rb
@@ -9,8 +9,6 @@ cask "unlox" do
 
   deprecate! date: "2025-03-02", because: :unmaintained
 
-  depends_on macos: ">= :high_sierra"
-
   app "Unlox.app"
 
   caveats do

--- a/Casks/u/unnaturalscrollwheels.rb
+++ b/Casks/u/unnaturalscrollwheels.rb
@@ -7,8 +7,6 @@ cask "unnaturalscrollwheels" do
   desc "Tool to invert scroll direction for physical scroll wheels"
   homepage "https://github.com/ther0n/UnnaturalScrollWheels"
 
-  depends_on macos: ">= :high_sierra"
-
   app "UnnaturalScrollWheels.app"
 
   uninstall quit: "com.theron.UnnaturalScrollWheels"

--- a/Casks/u/unshaky.rb
+++ b/Casks/u/unshaky.rb
@@ -13,7 +13,6 @@ cask "unshaky" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Unshaky.app"
 

--- a/Casks/u/updf.rb
+++ b/Casks/u/updf.rb
@@ -13,7 +13,6 @@ cask "updf" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "UPDF.app"
 

--- a/Casks/u/usage-app.rb
+++ b/Casks/u/usage-app.rb
@@ -15,8 +15,6 @@ cask "usage-app" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Usage.app"
 
   zap trash: [

--- a/Casks/u/usenapp.rb
+++ b/Casks/u/usenapp.rb
@@ -12,8 +12,6 @@ cask "usenapp" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Usenapp.app"
 
   zap trash: [

--- a/Casks/u/usr-sse2-rdm.rb
+++ b/Casks/u/usr-sse2-rdm.rb
@@ -7,8 +7,6 @@ cask "usr-sse2-rdm" do
   desc "Set a Retina display to custom resolutions"
   homepage "https://github.com/usr-sse2/RDM"
 
-  depends_on macos: ">= :sierra"
-
   app "RDM.app"
 
   uninstall quit:    "net.alkalay.RDM",

--- a/Casks/u/utools.rb
+++ b/Casks/u/utools.rb
@@ -15,8 +15,6 @@ cask "utools" do
     regex(/uTools[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "uTools.app"
 
   zap trash: [

--- a/Casks/u/utterly.rb
+++ b/Casks/u/utterly.rb
@@ -14,8 +14,6 @@ cask "utterly" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "Utterly-Elevate.pkg"
 
   uninstall launchctl: "app.utterly.Utterly.XPCHelper",

--- a/Casks/u/uu-booster.rb
+++ b/Casks/u/uu-booster.rb
@@ -13,8 +13,6 @@ cask "uu-booster" do
     regex(%r{pc_link.*?/UU[._-]macOS[._-]v?(\d+(?:\.\d+)+).dmg}i)
   end
 
-  depends_on macos: ">= :sierra"
-
   app "UUBooster.app"
 
   zap trash: [

--- a/Casks/u/uvtools.rb
+++ b/Casks/u/uvtools.rb
@@ -13,7 +13,6 @@ cask "uvtools" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "UVtools.app"
 

--- a/Casks/u/uxprotect.rb
+++ b/Casks/u/uxprotect.rb
@@ -10,7 +10,6 @@ cask "uxprotect" do
   disable! date: "2025-08-30", because: :unmaintained
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "UXProtect.app"
 


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.