### PR TITLE
[v]: remove pre-Catalina references

### DIFF
--- a/Casks/v/v2ray-unofficial.rb
+++ b/Casks/v/v2ray-unofficial.rb
@@ -14,8 +14,6 @@ cask "v2ray-unofficial" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "V2Ray-Desktop.app"
 
   zap trash: [

--- a/Casks/v/valentina-studio.rb
+++ b/Casks/v/valentina-studio.rb
@@ -12,8 +12,6 @@ cask "valentina-studio" do
     regex(%r{href=['"]?/en/all-downloads/vstudio/current['"]?>\s*(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Valentina Studio.app"
 
   zap trash: [

--- a/Casks/v/vallum.rb
+++ b/Casks/v/vallum.rb
@@ -13,8 +13,6 @@ cask "vallum" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Vallum.app"
 
   uninstall launchctl: [

--- a/Casks/v/vcam.rb
+++ b/Casks/v/vcam.rb
@@ -12,8 +12,6 @@ cask "vcam" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "VCam_#{version}.pkg"
 
   postflight do

--- a/Casks/v/vero.rb
+++ b/Casks/v/vero.rb
@@ -12,8 +12,6 @@ cask "vero" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :catalina"
-
   app "VERO.app"
 
   zap trash: [

--- a/Casks/v/versions.rb
+++ b/Casks/v/versions.rb
@@ -12,8 +12,6 @@ cask "versions" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Versions.app"
 
   zap trash: [

--- a/Casks/v/vertcoin-core.rb
+++ b/Casks/v/vertcoin-core.rb
@@ -18,8 +18,6 @@ cask "vertcoin-core" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   # Renamed for consistency: app name is different in the Finder and in a shell.
   app "Vertcoin-Qt.app", target: "Vertcoin Core.app"
 

--- a/Casks/v/vezer.rb
+++ b/Casks/v/vezer.rb
@@ -19,7 +19,6 @@ cask "vezer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Vezér.app"
 

--- a/Casks/v/via.rb
+++ b/Casks/v/via.rb
@@ -8,8 +8,6 @@ cask "via" do
   desc "Keyboard configurator"
   homepage "https://caniusevia.com/"
 
-  depends_on macos: ">= :high_sierra"
-
   app "VIA.app"
 
   zap trash: [

--- a/Casks/v/videoduke.rb
+++ b/Casks/v/videoduke.rb
@@ -13,7 +13,6 @@ cask "videoduke" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "VideoDuke.app"
 

--- a/Casks/v/videofusion.rb
+++ b/Casks/v/videofusion.rb
@@ -26,7 +26,6 @@ cask "videofusion" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "VideoFusion-macOS.app"
 

--- a/Casks/v/vidl.rb
+++ b/Casks/v/vidl.rb
@@ -12,8 +12,6 @@ cask "vidl" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "ViDL.app"
 
   zap trash: [

--- a/Casks/v/vienna-assistant.rb
+++ b/Casks/v/vienna-assistant.rb
@@ -15,8 +15,6 @@ cask "vienna-assistant" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   # The url is unversioned, but the download returns a pkg with a version number
   rename "Vienna Assistant*.pkg", "Vienna Assistant.pkg"
 

--- a/Casks/v/vienna.rb
+++ b/Casks/v/vienna.rb
@@ -17,7 +17,6 @@ cask "vienna" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Vienna.app"
 

--- a/Casks/v/vincelwt-chatgpt.rb
+++ b/Casks/v/vincelwt-chatgpt.rb
@@ -12,8 +12,6 @@ cask "vincelwt-chatgpt" do
 
   deprecate! date: "2025-06-21", because: :unmaintained
 
-  depends_on macos: ">= :high_sierra"
-
   app "Chatgpt.app"
 
   zap trash: [

--- a/Casks/v/vine-server.rb
+++ b/Casks/v/vine-server.rb
@@ -17,8 +17,6 @@ cask "vine-server" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :mojave"
-
   app "Vine Server.app"
   binary "#{appdir}/Vine Server.app/Contents/MacOS/OSXvnc-server"
   binary "#{appdir}/Vine Server.app/Contents/MacOS/storepasswd"

--- a/Casks/v/vip-access.rb
+++ b/Casks/v/vip-access.rb
@@ -13,8 +13,6 @@ cask "vip-access" do
     regex(/VIP\s+Access\s+for\s+Mac\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   pkg "VIP Access.pkg"
 
   uninstall pkgutil: "com.symantec.vippaccess"

--- a/Casks/v/virtualbox.rb
+++ b/Casks/v/virtualbox.rb
@@ -31,7 +31,6 @@ cask "virtualbox" do
     "virtualbox@6",
     "virtualbox@beta",
   ]
-  depends_on macos: ">= :catalina"
 
   pkg "VirtualBox.pkg",
       choices: [

--- a/Casks/v/virtualbox@6.rb
+++ b/Casks/v/virtualbox@6.rb
@@ -13,7 +13,6 @@ cask "virtualbox@6" do
     "virtualbox",
     "virtualbox@beta",
   ]
-  depends_on macos: ">= :high_sierra"
   depends_on arch: :x86_64
 
   pkg "VirtualBox.pkg",

--- a/Casks/v/virtualbox@beta.rb
+++ b/Casks/v/virtualbox@beta.rb
@@ -20,7 +20,6 @@ cask "virtualbox@beta" do
     "virtualbox",
     "virtualbox@6",
   ]
-  depends_on macos: ">= :catalina"
 
   pkg "VirtualBox.pkg",
       choices: [

--- a/Casks/v/virtualhereserver.rb
+++ b/Casks/v/virtualhereserver.rb
@@ -2,17 +2,7 @@ cask "virtualhereserver" do
   version "4.8.2"
   sha256 :no_check
 
-  on_mojave :or_older do
-    url "https://www.virtualhere.com/sites/default/files/usbserver/VirtualHereServer.dmg"
-
-    app "VirtualHereServer.app"
-  end
-  on_catalina :or_newer do
-    url "https://www.virtualhere.com/sites/default/files/usbserver/VirtualHereServerUniversal.dmg"
-
-    app "VirtualHereServerUniversal.app"
-  end
-
+  url "https://www.virtualhere.com/sites/default/files/usbserver/VirtualHereServerUniversal.dmg"
   name "VirtualHereServer"
   desc "Remotely access your connected USB devices over the network"
   homepage "https://www.virtualhere.com/osx_server_software"
@@ -21,6 +11,8 @@ cask "virtualhereserver" do
     url :homepage
     regex(/Version\s*(\d+(?:\.\d*)*)/i)
   end
+
+  app "VirtualHereServerUniversal.app"
 
   zap trash: "~/Library/Preferences/com.virtualhere.vhusbd.plist"
 end

--- a/Casks/v/virtualhostx.rb
+++ b/Casks/v/virtualhostx.rb
@@ -12,8 +12,6 @@ cask "virtualhostx" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :sierra"
-
   app "VirtualHostX.app"
 
   zap trash: [

--- a/Casks/v/visit.rb
+++ b/Casks/v/visit.rb
@@ -34,8 +34,6 @@ cask "visit" do
   desc "Visualisation and data analysis for mesh-based scientific data"
   homepage "https://wci.llnl.gov/simulation/computer-codes/visit"
 
-  depends_on macos: ">= :catalina"
-
   app "VisIt.app"
 
   zap trash: "~/Library/Saved Application State/gov.llnl.visit.gui.savedState"

--- a/Casks/v/visual-studio-code.rb
+++ b/Casks/v/visual-studio-code.rb
@@ -30,7 +30,6 @@ cask "visual-studio-code" do
   homepage "https://code.visualstudio.com/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Visual Studio Code.app"
   binary "#{appdir}/Visual Studio Code.app/Contents/Resources/app/bin/code"

--- a/Casks/v/visual-studio-code@insiders.rb
+++ b/Casks/v/visual-studio-code@insiders.rb
@@ -25,7 +25,6 @@ cask "visual-studio-code@insiders" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Visual Studio Code - Insiders.app"
   binary "#{appdir}/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code", target: "code-insiders"

--- a/Casks/v/visual-studio.rb
+++ b/Casks/v/visual-studio.rb
@@ -19,7 +19,6 @@ cask "visual-studio" do
   disable! date: "2025-09-02", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :catalina"
   depends_on cask: "mono-mdk-for-visual-studio"
 
   app "Visual Studio.app"

--- a/Casks/v/vitals.rb
+++ b/Casks/v/vitals.rb
@@ -9,8 +9,6 @@ cask "vitals" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :catalina"
-
   app "Vitals.app"
 
   zap trash: [

--- a/Casks/v/vitamin-r.rb
+++ b/Casks/v/vitamin-r.rb
@@ -1,12 +1,6 @@
 cask "vitamin-r" do
-  on_high_sierra :or_older do
-    version "3.31"
-    sha256 "6c5ce3926060b7e3616527fc3c1f0d2a5cd8a0be4d9f5496c099a33be993312b"
-  end
-  on_mojave :or_newer do
-    version "4.20"
-    sha256 "b2e40fcc8ae457e1be450d3f0e9bfad1ad979edd75ceea9658a6412d23282d91"
-  end
+  version "4.20"
+  sha256 "b2e40fcc8ae457e1be450d3f0e9bfad1ad979edd75ceea9658a6412d23282d91"
 
   url "https://www.publicspace.net/download/signedVitamin#{version.major}.zip"
   name "Vitamin-R"

--- a/Casks/v/vk-calls.rb
+++ b/Casks/v/vk-calls.rb
@@ -14,7 +14,6 @@ cask "vk-calls" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "VK Calls.app"
 

--- a/Casks/v/vmpk.rb
+++ b/Casks/v/vmpk.rb
@@ -16,7 +16,6 @@ cask "vmpk" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on formula: "fluid-synth"
-  depends_on macos: ">= :sierra"
 
   app "vmpk.app"
 

--- a/Casks/v/voicepeak.rb
+++ b/Casks/v/voicepeak.rb
@@ -13,8 +13,6 @@ cask "voicepeak" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "VOICEPEAK 邪神ちゃん 無料お試し版/Mac/Voicepeak.pkg"
 
   uninstall pkgutil: "com.dreamtonics.voicepeak.editor"

--- a/Casks/v/voiden.rb
+++ b/Casks/v/voiden.rb
@@ -18,8 +18,6 @@ cask "voiden" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Voiden.app"
 
   zap trash: [

--- a/Casks/v/volanta.rb
+++ b/Casks/v/volanta.rb
@@ -20,8 +20,6 @@ cask "volanta" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Volanta.app"
 
   zap trash: [

--- a/Casks/v/volta-app.rb
+++ b/Casks/v/volta-app.rb
@@ -17,7 +17,6 @@ cask "volta-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Volta.app"
 

--- a/Casks/v/voodoopad.rb
+++ b/Casks/v/voodoopad.rb
@@ -13,8 +13,6 @@ cask "voodoopad" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :sierra"
-
   app "VoodooPad.app"
 
   zap trash: [

--- a/Casks/v/voov-meeting.rb
+++ b/Casks/v/voov-meeting.rb
@@ -30,8 +30,6 @@ cask "voov-meeting" do
     end
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "VooV Meeting.app"
 
   zap trash: [

--- a/Casks/v/vorta.rb
+++ b/Casks/v/vorta.rb
@@ -16,7 +16,6 @@ cask "vorta" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Vorta.app"
 

--- a/Casks/v/vox.rb
+++ b/Casks/v/vox.rb
@@ -15,7 +15,6 @@ cask "vox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "VOX.app"
 

--- a/Casks/v/vpn-enabler.rb
+++ b/Casks/v/vpn-enabler.rb
@@ -1,30 +1,13 @@
 cask "vpn-enabler" do
-  on_el_capitan :or_older do
-    version "3.0.6"
-    sha256 "fae22c4e3b05c77d3658b45c92398c3a6f7fa7792bc124e1b463efb662519536"
+  version "5.2"
+  sha256 :no_check
 
-    url "https://cutedgesystems.com/downloads/VPNEnablerForElCapitan.zip"
-  end
-  on_sierra do
-    version "4.0"
-    sha256 "50e22bcc2e341adff7fc625714c251ac0ac889cfb55983e026cff8478ebd3793"
-
-    url "https://cutedgesystems.com/downloads/VPNEnablerForSierra.zip"
-  end
-  on_high_sierra :or_newer do
-    version "5.2"
-    sha256 :no_check
-
-    url "https://cutedgesystems.com/downloads/VPNEnablerForHighSierra.zip"
-  end
-
+  url "https://cutedgesystems.com/downloads/VPNEnablerForHighSierra.zip"
   name "VPN Enabler"
   desc "VPN settings utility"
   homepage "https://cutedgesystems.com/"
 
   disable! date: "2024-12-16", because: :discontinued
-
-  depends_on macos: ">= :el_capitan"
 
   app "VPN Enabler.app"
 

--- a/Casks/v/vpn-tracker-365.rb
+++ b/Casks/v/vpn-tracker-365.rb
@@ -20,8 +20,6 @@ cask "vpn-tracker-365" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "VPN Tracker 365.app"
 
   uninstall delete: [

--- a/Casks/v/vscodium.rb
+++ b/Casks/v/vscodium.rb
@@ -29,7 +29,6 @@ cask "vscodium" do
   homepage "https://github.com/VSCodium/vscodium"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "VSCodium.app"
   binary "#{appdir}/VSCodium.app/Contents/Resources/app/bin/codium"

--- a/Casks/v/vsd-viewer.rb
+++ b/Casks/v/vsd-viewer.rb
@@ -13,7 +13,6 @@ cask "vsd-viewer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "VSD Viewer.app"
 

--- a/Casks/v/vsdx-annotator.rb
+++ b/Casks/v/vsdx-annotator.rb
@@ -13,7 +13,6 @@ cask "vsdx-annotator" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "VSDX Annotator.app"
 

--- a/Casks/v/vsee.rb
+++ b/Casks/v/vsee.rb
@@ -13,8 +13,6 @@ cask "vsee" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :catalina"
-
   app "VSee.app"
 
   uninstall delete: "~/Library/Internet Plug-Ins/VSeeHelper.plugin"

--- a/Casks/v/vu.rb
+++ b/Casks/v/vu.rb
@@ -10,8 +10,6 @@ cask "vu" do
 
   deprecate! date: "2024-11-01", because: :unmaintained
 
-  depends_on macos: ">= :sierra"
-
   app "vu.app"
 
   caveats do

--- a/Casks/v/vv.rb
+++ b/Casks/v/vv.rb
@@ -8,7 +8,6 @@ cask "vv" do
   homepage "https://github.com/vv-vim/vv"
 
   depends_on formula: "neovim"
-  depends_on macos: ">= :catalina"
 
   app "VV.app"
   binary "#{appdir}/VV.app/Contents/Resources/bin/vv"

--- a/Casks/v/vyprvpn.rb
+++ b/Casks/v/vyprvpn.rb
@@ -13,7 +13,6 @@ cask "vyprvpn" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "VyprVPN.app"
 

--- a/Casks/v/vysor.rb
+++ b/Casks/v/vysor.rb
@@ -13,8 +13,6 @@ cask "vysor" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Vysor.app"
 
   zap trash: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.