### PR TITLE
[w]: remove pre-Catalina references

### DIFF
--- a/Casks/w/wakatime.rb
+++ b/Casks/w/wakatime.rb
@@ -8,8 +8,6 @@ cask "wakatime" do
   desc "System tray app for automatic time tracking"
   homepage "https://wakatime.com/mac"
 
-  depends_on macos: ">= :catalina"
-
   app "WakaTime.app"
 
   zap trash: [

--- a/Casks/w/wallpaper-wizard.rb
+++ b/Casks/w/wallpaper-wizard.rb
@@ -13,8 +13,6 @@ cask "wallpaper-wizard" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :sierra"
-
   app "Wallpaper Wizard.app"
 
   uninstall quit: "com.macpaw.WallWiz-site"

--- a/Casks/w/waltr-pro.rb
+++ b/Casks/w/waltr-pro.rb
@@ -13,7 +13,6 @@ cask "waltr-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "WALTR PRO.app"
 

--- a/Casks/w/wannianli.rb
+++ b/Casks/w/wannianli.rb
@@ -9,8 +9,6 @@ cask "wannianli" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :el_capitan"
-
   app "WanNianLi.app"
 
   zap trash: "~/Library/Application Support/com.zfdang.calendar"

--- a/Casks/w/warcraft-logs-uploader.rb
+++ b/Casks/w/warcraft-logs-uploader.rb
@@ -14,7 +14,6 @@ cask "warcraft-logs-uploader" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Warcraft Logs Uploader.app"
 

--- a/Casks/w/warzone-2100.rb
+++ b/Casks/w/warzone-2100.rb
@@ -15,8 +15,6 @@ cask "warzone-2100" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Warzone 2100.app"
 
   zap trash: [

--- a/Casks/w/wasabi-wallet.rb
+++ b/Casks/w/wasabi-wallet.rb
@@ -15,8 +15,6 @@ cask "wasabi-wallet" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Wasabi Wallet.app"
 
   zap trash:  "~/.walletwasabi"

--- a/Casks/w/waterfox.rb
+++ b/Casks/w/waterfox.rb
@@ -13,7 +13,6 @@ cask "waterfox" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Waterfox.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/w/wave.rb
+++ b/Casks/w/wave.rb
@@ -17,7 +17,6 @@ cask "wave" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Wave.app"
 

--- a/Casks/w/waves-central.rb
+++ b/Casks/w/waves-central.rb
@@ -13,7 +13,6 @@ cask "waves-central" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Waves Central.app"
 

--- a/Casks/w/wealthfolio.rb
+++ b/Casks/w/wealthfolio.rb
@@ -19,7 +19,6 @@ cask "wealthfolio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Wealthfolio.app"
 

--- a/Casks/w/weasis.rb
+++ b/Casks/w/weasis.rb
@@ -19,7 +19,6 @@ cask "weasis" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   pkg "Weasis-#{version}-#{arch}.pkg"
 

--- a/Casks/w/webex.rb
+++ b/Casks/w/webex.rb
@@ -15,7 +15,6 @@ cask "webex" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Webex.app"
 

--- a/Casks/w/webkinz.rb
+++ b/Casks/w/webkinz.rb
@@ -12,8 +12,6 @@ cask "webkinz" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "Webkinz.app"
 
   zap trash: [

--- a/Casks/w/webots.rb
+++ b/Casks/w/webots.rb
@@ -18,7 +18,6 @@ cask "webots" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "Webots.app"
 

--- a/Casks/w/webplotdigitizer.rb
+++ b/Casks/w/webplotdigitizer.rb
@@ -22,8 +22,6 @@ cask "webplotdigitizer" do
   deprecate! date: "2024-06-10", because: :discontinued
   disable! date: "2025-06-11", because: :discontinued
 
-  depends_on macos: ">= :catalina"
-
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.electron.webplotdigitizer.sfl*",
     "~/Library/Application Support/WebPlotDigitizer",

--- a/Casks/w/website-audit.rb
+++ b/Casks/w/website-audit.rb
@@ -14,8 +14,6 @@ cask "website-audit" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "website-audit.app"
 
   zap trash: [

--- a/Casks/w/website-watchman.rb
+++ b/Casks/w/website-watchman.rb
@@ -12,8 +12,6 @@ cask "website-watchman" do
     regex(/Version\s+(\d+(?:\.\d+)+)\s*released/i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Website Watchman.app"
 
   zap trash: [

--- a/Casks/w/webstorm.rb
+++ b/Casks/w/webstorm.rb
@@ -24,7 +24,6 @@ cask "webstorm" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "WebStorm.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)

--- a/Casks/w/webull.rb
+++ b/Casks/w/webull.rb
@@ -16,8 +16,6 @@ cask "webull" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Webull Desktop.app"
 
   zap trash: [

--- a/Casks/w/wechatwork.rb
+++ b/Casks/w/wechatwork.rb
@@ -23,7 +23,6 @@ cask "wechatwork" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "企业微信.app"
 

--- a/Casks/w/weektodo.rb
+++ b/Casks/w/weektodo.rb
@@ -15,8 +15,6 @@ cask "weektodo" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "WeekToDo.app"
 
   zap trash: [

--- a/Casks/w/weiyun.rb
+++ b/Casks/w/weiyun.rb
@@ -15,8 +15,6 @@ cask "weiyun" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Weiyun.app"
 
   uninstall quit: "com.tencent.MacWeiyun"

--- a/Casks/w/wetype.rb
+++ b/Casks/w/wetype.rb
@@ -20,7 +20,6 @@ cask "wetype" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   installer manual: "WeTypeInstaller_#{version.csv.first}_#{version.csv.second}.app"
 

--- a/Casks/w/wezterm@nightly.rb
+++ b/Casks/w/wezterm@nightly.rb
@@ -9,7 +9,6 @@ cask "wezterm@nightly" do
   homepage "https://wezterm.org/"
 
   conflicts_with cask: "wezterm"
-  depends_on macos: ">= :sierra"
 
   app "WezTerm.app"
   %w[

--- a/Casks/w/whatroute.rb
+++ b/Casks/w/whatroute.rb
@@ -12,8 +12,6 @@ cask "whatroute" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "WhatRoute.app"
 
   uninstall launchctl: [

--- a/Casks/w/whatsize.rb
+++ b/Casks/w/whatsize.rb
@@ -13,7 +13,6 @@ cask "whatsize" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   pkg "whatsize_#{version}.pkg"
 

--- a/Casks/w/whichspace.rb
+++ b/Casks/w/whichspace.rb
@@ -10,7 +10,6 @@ cask "whichspace" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "WhichSpace.app"
 

--- a/Casks/w/whimsical.rb
+++ b/Casks/w/whimsical.rb
@@ -25,7 +25,6 @@ cask "whimsical" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Whimsical.app"
 

--- a/Casks/w/whoozle-android-file-transfer.rb
+++ b/Casks/w/whoozle-android-file-transfer.rb
@@ -11,7 +11,6 @@ cask "whoozle-android-file-transfer" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   conflicts_with cask: "whoozle-android-file-transfer@nightly"
-  depends_on macos: ">= :sierra"
 
   app "Android File Transfer for Linux.app"
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"

--- a/Casks/w/whoozle-android-file-transfer@nightly.rb
+++ b/Casks/w/whoozle-android-file-transfer@nightly.rb
@@ -11,7 +11,6 @@ cask "whoozle-android-file-transfer@nightly" do
   disable! date: "2024-12-22", because: :unmaintained
 
   conflicts_with cask: "whoozle-android-file-transfer"
-  depends_on macos: ">= :sierra"
 
   app "Android File Transfer for Linux.app"
   binary "#{appdir}/Android File Transfer for Linux.app/Contents/SharedSupport/bin/aft-mtp-cli"

--- a/Casks/w/wifi-explorer-pro.rb
+++ b/Casks/w/wifi-explorer-pro.rb
@@ -13,7 +13,6 @@ cask "wifi-explorer-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   pkg "WiFiExplorerPro_#{version}.pkg"
 

--- a/Casks/w/wifi-explorer.rb
+++ b/Casks/w/wifi-explorer.rb
@@ -13,7 +13,6 @@ cask "wifi-explorer" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "WiFi Explorer.app"
 

--- a/Casks/w/winclone.rb
+++ b/Casks/w/winclone.rb
@@ -13,8 +13,6 @@ cask "winclone" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "Winclone.pkg"
 
   uninstall signal:  ["TERM", "com.twocanoes.Winclone#{version.major}"],

--- a/Casks/w/windsurf.rb
+++ b/Casks/w/windsurf.rb
@@ -23,7 +23,6 @@ cask "windsurf" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Windsurf.app"
   binary "#{appdir}/Windsurf.app/Contents/Resources/app/bin/windsurf"

--- a/Casks/w/windsurf@next.rb
+++ b/Casks/w/windsurf@next.rb
@@ -23,7 +23,6 @@ cask "windsurf@next" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Windsurf - Next.app"
   binary "#{appdir}/Windsurf - Next.app/Contents/Resources/app/bin/windsurf-next"

--- a/Casks/w/windterm.rb
+++ b/Casks/w/windterm.rb
@@ -35,7 +35,6 @@ cask "windterm" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "WindTerm.app"
 

--- a/Casks/w/wine-stable.rb
+++ b/Casks/w/wine-stable.rb
@@ -38,7 +38,6 @@ cask "wine-stable" do
     "wine@staging",
   ]
   depends_on cask: "gstreamer-runtime"
-  depends_on macos: ">= :catalina"
 
   app "Wine Stable.app"
   binary "#{appdir}/Wine Stable.app/Contents/Resources/start/bin/appdb"

--- a/Casks/w/wine@devel.rb
+++ b/Casks/w/wine@devel.rb
@@ -38,7 +38,6 @@ cask "wine@devel" do
     "wine@staging",
   ]
   depends_on cask: "gstreamer-runtime"
-  depends_on macos: ">= :catalina"
 
   app "Wine Devel.app"
   dir_path = "#{appdir}/Wine Devel.app/Contents/Resources"

--- a/Casks/w/wine@staging.rb
+++ b/Casks/w/wine@staging.rb
@@ -38,7 +38,6 @@ cask "wine@staging" do
     "wine@devel",
   ]
   depends_on cask: "gstreamer-runtime"
-  depends_on macos: ">= :catalina"
 
   app "Wine Staging.app"
   dir_path = "#{appdir}/Wine Staging.app/Contents/Resources"

--- a/Casks/w/wing-personal.rb
+++ b/Casks/w/wing-personal.rb
@@ -12,8 +12,6 @@ cask "wing-personal" do
     regex(%r{href=.*?/pub/wing-personal/v?(\d+(?:\.\d+)+)}i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Wing Personal.app"
 
   zap trash: [

--- a/Casks/w/wins.rb
+++ b/Casks/w/wins.rb
@@ -14,7 +14,6 @@ cask "wins" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Wins.app"
 

--- a/Casks/w/winzip.rb
+++ b/Casks/w/winzip.rb
@@ -20,8 +20,6 @@ cask "winzip" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "WinZip.app"
 
   zap trash: [

--- a/Casks/w/wireshark-app.rb
+++ b/Casks/w/wireshark-app.rb
@@ -12,8 +12,7 @@ cask "wireshark-app" do
       strategy :sparkle do |items|
         items.map do |item|
           next unless item.minimum_system_version
-          next if item.minimum_system_version < :high_sierra ||
-                  item.minimum_system_version >= :catalina
+          next if item.minimum_system_version >= :catalina
 
           item.version
         end
@@ -43,7 +42,6 @@ cask "wireshark-app" do
 
   auto_updates true
   conflicts_with cask: "wireshark-chmodbpf"
-  depends_on macos: ">= :mojave"
 
   app "Wireshark.app"
   pkg "Add Wireshark to the system path.pkg"

--- a/Casks/w/wireshark-chmodbpf.rb
+++ b/Casks/w/wireshark-chmodbpf.rb
@@ -15,7 +15,6 @@ cask "wireshark-chmodbpf" do
   end
 
   conflicts_with cask: "wireshark-app"
-  depends_on macos: ">= :sierra"
 
   pkg "Install ChmodBPF.pkg"
 

--- a/Casks/w/wiso-steuer-2020.rb
+++ b/Casks/w/wiso-steuer-2020.rb
@@ -21,7 +21,6 @@ cask "wiso-steuer-2020" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   # Renamed for consistency: app name differs in Finder to shell
   app "SteuerMac 2020.app", target: "WISO Steuer 2020.app"

--- a/Casks/w/wiso-steuer-2021.rb
+++ b/Casks/w/wiso-steuer-2021.rb
@@ -21,7 +21,6 @@ cask "wiso-steuer-2021" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   # Renamed for consistency: app name differs in Finder to shell
   app "SteuerMac 2021.app", target: "WISO Steuer 2021.app"

--- a/Casks/w/wiso-steuer-2022.rb
+++ b/Casks/w/wiso-steuer-2022.rb
@@ -21,7 +21,6 @@ cask "wiso-steuer-2022" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   # Renamed for consistency: app name differs in Finder to shell
   app "SteuerMac 2022.app", target: "WISO Steuer-Mac 2022.app"

--- a/Casks/w/wiso-steuer-2023.rb
+++ b/Casks/w/wiso-steuer-2023.rb
@@ -21,7 +21,6 @@ cask "wiso-steuer-2023" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   # Renamed for consistency: app name differs in Finder to shell
   app "SteuerMac 2023.app", target: "WISO Steuer 2023.app"

--- a/Casks/w/wiso-steuer-2024.rb
+++ b/Casks/w/wiso-steuer-2024.rb
@@ -21,7 +21,6 @@ cask "wiso-steuer-2024" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   # Renamed for consistency: app name differs in Finder to shell
   app "SteuerMac 2024.app", target: "WISO Steuer 2024.app"

--- a/Casks/w/wiso-steuer-2025.rb
+++ b/Casks/w/wiso-steuer-2025.rb
@@ -21,7 +21,6 @@ cask "wiso-steuer-2025" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   # Renamed for consistency: app name differs in Finder to shell
   app "SteuerMac 2025.app", target: "WISO Steuer 2025.app"

--- a/Casks/w/witch.rb
+++ b/Casks/w/witch.rb
@@ -13,7 +13,6 @@ cask "witch" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   prefpane "Witch.prefPane"
 

--- a/Casks/w/witsy.rb
+++ b/Casks/w/witsy.rb
@@ -19,7 +19,6 @@ cask "witsy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Witsy.app"
 

--- a/Casks/w/wiznote.rb
+++ b/Casks/w/wiznote.rb
@@ -17,7 +17,6 @@ cask "wiznote" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "WizNote.app"
 

--- a/Casks/w/wljs-notebook.rb
+++ b/Casks/w/wljs-notebook.rb
@@ -36,7 +36,6 @@ cask "wljs-notebook" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "WLJS Notebook.app"
 

--- a/Casks/w/wolai.rb
+++ b/Casks/w/wolai.rb
@@ -17,7 +17,6 @@ cask "wolai" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "wolai.app"
 

--- a/Casks/w/wondershare-edrawmax.rb
+++ b/Casks/w/wondershare-edrawmax.rb
@@ -25,8 +25,6 @@ cask "wondershare-edrawmax" do
     regex(/ma(?:c|xOS)\s*V?(\d+(?:\.\d+)+)/i)
   end
 
-  depends_on macos: ">= :sierra"
-
   zap trash: [
     "~/Library/Edraw",
     "~/Library/Preferences/com.edrawsoft.edrawmax.plist",

--- a/Casks/w/wondershare-filmora.rb
+++ b/Casks/w/wondershare-filmora.rb
@@ -17,8 +17,6 @@ cask "wondershare-filmora" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Wondershare Filmora Mac.app"
 
   zap trash: [

--- a/Casks/w/wordpresscom-studio.rb
+++ b/Casks/w/wordpresscom-studio.rb
@@ -23,7 +23,6 @@ cask "wordpresscom-studio" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Studio.app"
 

--- a/Casks/w/wordpresscom.rb
+++ b/Casks/w/wordpresscom.rb
@@ -17,7 +17,6 @@ cask "wordpresscom" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "WordPress.com.app"
 

--- a/Casks/w/wordservice.rb
+++ b/Casks/w/wordservice.rb
@@ -12,8 +12,6 @@ cask "wordservice" do
     regex(/wordservice.*?(\d+(?:\.\d+)+).*?app/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "WordService.app"
 
   zap trash: "~/Library/Preferences/org.grunenberg.WordService.plist"

--- a/Casks/w/workbench.rb
+++ b/Casks/w/workbench.rb
@@ -8,7 +8,6 @@ cask "workbench" do
   homepage "https://github.com/mxcl/Workbench"
 
   auto_updates true
-  depends_on macos: ">= :sierra"
 
   app "Workbench.app"
 

--- a/Casks/w/workspace-one-intelligent-hub.rb
+++ b/Casks/w/workspace-one-intelligent-hub.rb
@@ -14,7 +14,6 @@ cask "workspace-one-intelligent-hub" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   pkg "WorkspaceONEIntelligentHub.pkg"
 

--- a/Casks/w/workspaces.rb
+++ b/Casks/w/workspaces.rb
@@ -12,8 +12,6 @@ cask "workspaces" do
     strategy :sparkle, &:short_version
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Workspaces.app"
 
   zap trash: [

--- a/Casks/w/worldpainter.rb
+++ b/Casks/w/worldpainter.rb
@@ -14,8 +14,6 @@ cask "worldpainter" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :el_capitan"
-
   app "WorldPainter.app"
 
   zap trash: "~/Library/Application Support/WorldPainter"

--- a/Casks/w/wowup.rb
+++ b/Casks/w/wowup.rb
@@ -12,7 +12,6 @@ cask "wowup" do
   homepage "https://wowup.io/"
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "WowUp.app"
 

--- a/Casks/w/wpsoffice-cn.rb
+++ b/Casks/w/wpsoffice-cn.rb
@@ -20,7 +20,6 @@ cask "wpsoffice-cn" do
   end
 
   conflicts_with cask: "wpsoffice"
-  depends_on macos: ">= :high_sierra"
 
   app "wpsoffice.app"
 

--- a/Casks/w/wpsoffice.rb
+++ b/Casks/w/wpsoffice.rb
@@ -15,7 +15,6 @@ cask "wpsoffice" do
   end
 
   conflicts_with cask: "wpsoffice-cn"
-  depends_on macos: ">= :sierra"
 
   app "wpsoffice.app"
 

--- a/Casks/w/wrike.rb
+++ b/Casks/w/wrike.rb
@@ -23,8 +23,6 @@ cask "wrike" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Wrike for Mac.app"
 
   zap trash: [

--- a/Casks/w/writemapper.rb
+++ b/Casks/w/writemapper.rb
@@ -13,8 +13,6 @@ cask "writemapper" do
     strategy :electron_builder
   end
 
-  depends_on macos: ">= :catalina"
-
   app "WriteMapper.app"
 
   zap trash: [

--- a/Casks/w/writerside.rb
+++ b/Casks/w/writerside.rb
@@ -14,7 +14,6 @@ cask "writerside" do
   deprecate! date: "2025-08-16", because: :discontinued
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Writerside #{version.before_comma} EAP.app", target: "Writerside.app"
   binary "#{appdir}/Writerside.app/Contents/MacOS/writerside"

--- a/Casks/w/wrkspace.rb
+++ b/Casks/w/wrkspace.rb
@@ -17,8 +17,6 @@ cask "wrkspace" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Wrkspace.app"
 
   zap trash: "~/Library/Application Support/Wrkspace",


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.