### PR TITLE
[y]: remove pre-Catalina references

### DIFF
--- a/Casks/y/yandex-disk.rb
+++ b/Casks/y/yandex-disk.rb
@@ -13,7 +13,6 @@ cask "yandex-disk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "Yandex.Disk.2.app"
 

--- a/Casks/y/yandex-music.rb
+++ b/Casks/y/yandex-music.rb
@@ -14,7 +14,6 @@ cask "yandex-music" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Яндекс Музыка.app"
 

--- a/Casks/y/yate.rb
+++ b/Casks/y/yate.rb
@@ -2,13 +2,7 @@ cask "yate" do
   version "8.3.1"
   sha256 :no_check
 
-  on_sierra :or_older do
-    url "https://2manyrobots.com/Updates/YateOM/Yate.zip"
-  end
-  on_high_sierra :or_newer do
-    url "https://2manyrobots.com/Updates/Yate/Yate.zip"
-  end
-
+  url "https://2manyrobots.com/Updates/Yate/Yate.zip"
   name "Yate"
   desc "Media file tag editor"
   homepage "https://2manyrobots.com/yate/"

--- a/Casks/y/yed.rb
+++ b/Casks/y/yed.rb
@@ -15,8 +15,6 @@ cask "yed" do
     regex(/yEd[._-]v?(\d+(?:\.\d+)+)[._-]with[._-]JRE\d+?[._-]#{arch}\.dmg/i)
   end
 
-  depends_on macos: ">= :el_capitan"
-
   app "yEd.app"
 
   zap trash: [

--- a/Casks/y/yep.rb
+++ b/Casks/y/yep.rb
@@ -13,7 +13,6 @@ cask "yep" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "Yep.app"
 

--- a/Casks/y/yinxiangbiji.rb
+++ b/Casks/y/yinxiangbiji.rb
@@ -15,7 +15,6 @@ cask "yinxiangbiji" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "印象笔记.app"
 

--- a/Casks/y/yippy.rb
+++ b/Casks/y/yippy.rb
@@ -9,8 +9,6 @@ cask "yippy" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :high_sierra"
-
   app "Yippy.app"
 
   zap trash: "~/Library/Application Support/MatthewDavidson.Yippy"

--- a/Casks/y/yojimbo.rb
+++ b/Casks/y/yojimbo.rb
@@ -15,8 +15,6 @@ cask "yojimbo" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Yojimbo.app"
 
   zap trash: [

--- a/Casks/y/youdaodict.rb
+++ b/Casks/y/youdaodict.rb
@@ -13,8 +13,6 @@ cask "youdaodict" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :mojave"
-
   app "网易有道翻译.app"
 
   zap trash: [

--- a/Casks/y/youku.rb
+++ b/Casks/y/youku.rb
@@ -14,8 +14,6 @@ cask "youku" do
     regex(/youkuclient[._-]setup[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
-  depends_on macos: ">= :mojave"
-
   app "优酷.app"
 
   zap trash: [

--- a/Casks/y/yousician.rb
+++ b/Casks/y/yousician.rb
@@ -15,8 +15,6 @@ cask "yousician" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Yousician Launcher.app"
 
   zap trash: [

--- a/Casks/y/youtube-downloader.rb
+++ b/Casks/y/youtube-downloader.rb
@@ -9,8 +9,6 @@ cask "youtube-downloader" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :sierra"
-
   app "Youtube Downloader.app"
 
   zap trash: "~/Library/Preferences/denbeke.Youtube-Downloader.plist"

--- a/Casks/y/youtube-to-mp3.rb
+++ b/Casks/y/youtube-to-mp3.rb
@@ -5,13 +5,7 @@ cask "youtube-to-mp3" do
   version "3.9.16"
   sha256 :no_check
 
-  on_sierra :or_older do
-    url "https://www.mediahuman.net/files/YouTubeToMP3-1012.dmg"
-  end
-  on_high_sierra :or_newer do
-    url "https://www.mediahuman.net/files/YouTubeToMP3#{arch}.dmg"
-  end
-
+  url "https://www.mediahuman.net/files/YouTubeToMP3#{arch}.dmg"
   name "MediaHuman YouTube to MP3 Converter"
   desc "Downloads music from playlists or channels"
   homepage "https://www.mediahuman.net/youtube-to-mp3/"
@@ -20,8 +14,6 @@ cask "youtube-to-mp3" do
     url :homepage
     regex(/>\s*Version:.*?(\d+(?:\.\d+)+)/i)
   end
-
-  depends_on macos: ">= :sierra"
 
   app "YouTube to MP3.app"
 

--- a/Casks/y/youtype.rb
+++ b/Casks/y/youtype.rb
@@ -15,7 +15,6 @@ cask "youtype" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
-  depends_on macos: ">= :el_capitan"
 
   app "YouType.app"
 

--- a/Casks/y/yt-music.rb
+++ b/Casks/y/yt-music.rb
@@ -13,7 +13,6 @@ cask "yt-music" do
   end
 
   auto_updates true
-  depends_on macos: ">= :high_sierra"
 
   app "YT Music.app"
 

--- a/Casks/y/yubico-authenticator.rb
+++ b/Casks/y/yubico-authenticator.rb
@@ -12,8 +12,6 @@ cask "yubico-authenticator" do
     regex(/href=.*?yubico[._-]authenticator[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Yubico Authenticator.app"
 
   zap trash: [

--- a/Casks/y/yubico-yubikey-manager.rb
+++ b/Casks/y/yubico-yubikey-manager.rb
@@ -9,8 +9,6 @@ cask "yubico-yubikey-manager" do
 
   disable! date: "2025-07-27", because: :discontinued, replacement_cask: "yubico-authenticator"
 
-  depends_on macos: ">= :sierra"
-
   pkg "yubikey-manager-qt-#{version}-mac.pkg"
 
   uninstall quit:    "com.yubico.ykman",

--- a/Casks/y/yuque.rb
+++ b/Casks/y/yuque.rb
@@ -19,8 +19,6 @@ cask "yuque" do
     end
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "语雀.app"
 
   zap trash: [


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.