### PR TITLE
[z]: remove pre-Catalina references

### DIFF
--- a/Casks/z/zalo.rb
+++ b/Casks/z/zalo.rb
@@ -13,8 +13,6 @@ cask "zalo" do
     strategy :header_match
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "Zalo.app"
 
   zap trash: [

--- a/Casks/z/zed.rb
+++ b/Casks/z/zed.rb
@@ -18,7 +18,6 @@ cask "zed" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Zed.app"
   binary "#{appdir}/Zed.app/Contents/MacOS/cli", target: "zed"

--- a/Casks/z/zed@preview.rb
+++ b/Casks/z/zed@preview.rb
@@ -18,7 +18,6 @@ cask "zed@preview" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Zed Preview.app"
   binary "#{appdir}/Zed Preview.app/Contents/MacOS/cli", target: "zed-preview"

--- a/Casks/z/zen-privacy.rb
+++ b/Casks/z/zen-privacy.rb
@@ -18,7 +18,6 @@ cask "zen-privacy" do
 
   auto_updates true
   conflicts_with cask: "zen"
-  depends_on macos: ">= :high_sierra"
 
   app "Zen.app"
 

--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -17,7 +17,6 @@ cask "zen" do
 
   auto_updates true
   conflicts_with cask: "zen-privacy"
-  depends_on macos: ">= :catalina"
 
   app "Zen.app"
   binary "#{appdir}/Zen.app/Contents/MacOS/zen"

--- a/Casks/z/zen@twilight.rb
+++ b/Casks/z/zen@twilight.rb
@@ -16,7 +16,6 @@ cask "zen@twilight" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Twilight.app"
 

--- a/Casks/z/zeplin.rb
+++ b/Casks/z/zeplin.rb
@@ -15,7 +15,6 @@ cask "zeplin" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Zeplin.app"
 

--- a/Casks/z/zerotier-one.rb
+++ b/Casks/z/zerotier-one.rb
@@ -12,8 +12,6 @@ cask "zerotier-one" do
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  depends_on macos: ">= :high_sierra"
-
   pkg "ZeroTier One.pkg"
 
   uninstall launchctl: "com.zerotier.one",

--- a/Casks/z/zight.rb
+++ b/Casks/z/zight.rb
@@ -13,7 +13,6 @@ cask "zight" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "Zight.app"
 

--- a/Casks/z/znote.rb
+++ b/Casks/z/znote.rb
@@ -16,8 +16,6 @@ cask "znote" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
-
   app "znote.app"
 
   zap trash: [

--- a/Casks/z/zoho-cliq.rb
+++ b/Casks/z/zoho-cliq.rb
@@ -22,8 +22,6 @@ cask "zoho-cliq" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   pkg "Cliq-#{arch}-#{version}.pkg"
 
   uninstall pkgutil: "com.zoho.cliq"

--- a/Casks/z/zoho-mail.rb
+++ b/Casks/z/zoho-mail.rb
@@ -25,8 +25,6 @@ cask "zoho-mail" do
     end
   end
 
-  depends_on macos: ">= :catalina"
-
   app "Zoho Mail - Desktop.app"
 
   zap trash: [

--- a/Casks/z/zoho-workdrive.rb
+++ b/Casks/z/zoho-workdrive.rb
@@ -13,8 +13,6 @@ cask "zoho-workdrive" do
     strategy :extract_plist
   end
 
-  depends_on macos: ">= :mojave"
-
   app "Zoho WorkDrive.app"
 
   zap trash: [

--- a/Casks/z/zoom-m3-edit-and-play.rb
+++ b/Casks/z/zoom-m3-edit-and-play.rb
@@ -15,7 +15,6 @@ cask "zoom-m3-edit-and-play" do
     end
   end
 
-  depends_on macos: ">= :catalina"
   container nested: "M3_Edit_&_Play_Mac_v#{version.csv.first}_E/ZOOM M3 Edit & Play #{version.csv.first} Installer.dmg"
 
   app "ZOOM M3 Edit & Play.app"

--- a/Casks/z/zotero.rb
+++ b/Casks/z/zotero.rb
@@ -16,7 +16,6 @@ cask "zotero" do
 
   auto_updates true
   conflicts_with cask: "zotero@beta"
-  depends_on macos: ">= :sierra"
 
   app "Zotero.app"
 

--- a/Casks/z/zotero@beta.rb
+++ b/Casks/z/zotero@beta.rb
@@ -16,7 +16,6 @@ cask "zotero@beta" do
 
   auto_updates true
   conflicts_with cask: "zotero"
-  depends_on macos: ">= :sierra"
 
   app "Zotero.app"
 

--- a/Casks/z/zspace.rb
+++ b/Casks/z/zspace.rb
@@ -27,7 +27,6 @@ cask "zspace" do
   end
 
   auto_updates true
-  depends_on macos: ">= :catalina"
 
   app "极空间.app"
 

--- a/Casks/z/zui.rb
+++ b/Casks/z/zui.rb
@@ -11,8 +11,6 @@ cask "zui" do
   desc "Graphical user interface for exploring data in Zed lakes"
   homepage "https://zui.brimdata.io/docs"
 
-  depends_on macos: ">= :catalina"
-
   app "Zui.app"
 
   zap trash: [

--- a/Casks/z/zulu@17.rb
+++ b/Casks/z/zulu@17.rb
@@ -24,8 +24,6 @@ cask "zulu@17" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"

--- a/Casks/z/zulu@8.rb
+++ b/Casks/z/zulu@8.rb
@@ -24,8 +24,6 @@ cask "zulu@8" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"


### PR DESCRIPTION
As of 4.6.11, `brew` no longer runs on Mojave and earlier.