### PR TITLE
zulufx: remove pre-Catalina references

### DIFF
--- a/Casks/z/zulufx.rb
+++ b/Casks/z/zulufx.rb
@@ -24,8 +24,6 @@ cask "zulufx" do
     end
   end
 
-  depends_on macos: ">= :mojave"
-
   pkg "Double-Click to Install Azul Zulu JDK #{version.major}.pkg"
 
   uninstall pkgutil: "com.azulsystems.zulu.#{version.major}"


### PR DESCRIPTION
Somehow missed this one. All pre-Catalina references are removed from Homebrew/cask after this PR is merged.