### PR TITLE
companion@beta: disable

### DIFF
--- a/Casks/c/companion@beta.rb
+++ b/Casks/c/companion@beta.rb
@@ -19,6 +19,8 @@ cask "companion@beta" do
     end
   end
 
+  disable! date: "2025-09-15", because: :unreachable
+
   depends_on macos: ">= :big_sur"
 
   # Companion beta does not share preferences with the stable branch, so can be installed side by side


### PR DESCRIPTION
This routinely hits our 30 minute timeout while trying to download.