### PR TITLE
utm@beta: update checksum for 4.7.4

### DIFF
--- a/Casks/u/utm@beta.rb
+++ b/Casks/u/utm@beta.rb
@@ -1,6 +1,6 @@
 cask "utm@beta" do
   version "4.7.4"
-  sha256 "fdf4b7fbdc9ca6362c5752dac9753e93dd9ac3d4d6d7e6c1ff35b4c2a11cd737"
+  sha256 "e259e81fd142acbdc4596369980118cfe5c2c4f491ed96bf5bc606c405d79ace"
 
   url "https://github.com/utmapp/UTM/releases/download/v#{version}/UTM.dmg",
       verified: "github.com/utmapp/UTM/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

UTM 4.7.4 was re-released, so the checksum for the release dmg file has changed. The checksum for the `utm` cask was updated (https://github.com/Homebrew/homebrew-cask/pull/228175), so this updates the `utm@beta` cask as well.

Fixes #228114
