### PR TITLE
defguard-client 1.5.0 (new cask)

### DIFF
--- a/Casks/d/defguard-client.rb
+++ b/Casks/d/defguard-client.rb
@@ -1,0 +1,25 @@
+cask "defguard-client" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "1.5.0"
+  sha256 arm:   "e957b4fa68dc46b97b1fe2a7fa77f00c774172fb95486e38190cde8a67975950",
+         intel: "b0d49b65dfc70b7b69fc018d400ab5b07461a7a3191de28e09947feaa4a61492"
+
+  url "https://github.com/DefGuard/client/releases/download/v#{version}/defguard-#{arch}-apple-darwin-#{version}.pkg"
+  name "Defguard Client"
+  desc "WireGuard VPN client which supports multi-factor authentication"
+  homepage "https://github.com/defguard/client"
+
+  pkg "defguard-#{arch}-apple-darwin-#{version}.pkg"
+
+  uninstall launchctl: "net.defguard",
+            quit:      "defguard-client",
+            pkgutil:   "net.defguard",
+            delete:    "/Library/LaunchDaemons/net.defguard.plist"
+
+  zap trash: [
+    "~/Library/Application Support/net.defguard",
+    "~/Library/Logs/Defguard",
+    "~/Library/Preferences/net.defguard.plist",
+  ]
+end


### PR DESCRIPTION
Our homepage: https://defguard.net

Repositories:
- **Client**: https://github.com/DefGuard/client (195 stars)
- **Core (the VPN management server)**: https://github.com/DefGuard/defguard (2232 stars)

This application is:
- Actively maintained and regularly updated
- Code-signed and distributed through GitHub Releases  
- Supports both Apple Silicon and Intel architectures
- Tested locally on macOS with proper install/uninstall

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
