### PR TITLE
virtual-desktop-streamer: update cask to the official URL and use latest version

### DIFF
--- a/Casks/v/virtual-desktop-streamer.rb
+++ b/Casks/v/virtual-desktop-streamer.rb
@@ -9,7 +9,11 @@ cask "virtual-desktop-streamer" do
 
   pkg "VirtualDesktop.Streamer.Setup.pkg"
 
-  uninstall quit:    "com.virtualdesktop.streamer",
+  uninstall launchctl: [
+              "com.virtualdesktop.daemon",
+              "com.virtualdesktop.streamer"
+            ],
+            quit:    "com.virtualdesktop.streamer",
             pkgutil: [
               "com.VirtualDesktop.AudioDriver",
               "com.VirtualDesktop.MicDriver",

--- a/Casks/v/virtual-desktop-streamer.rb
+++ b/Casks/v/virtual-desktop-streamer.rb
@@ -1,11 +1,16 @@
 cask "virtual-desktop-streamer" do
-  version :latest
+  version "1.34.8"
   sha256 :no_check
 
   url "https://files.vrdesktop.net/files/VirtualDesktop.Streamer.Setup.pkg"
   name "Virtual Desktop Streamer"
   desc "VR Virtual Desktop Streamer"
   homepage "https://www.vrdesktop.net/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
 
   pkg "VirtualDesktop.Streamer.Setup.pkg"
 

--- a/Casks/v/virtual-desktop-streamer.rb
+++ b/Casks/v/virtual-desktop-streamer.rb
@@ -11,10 +11,10 @@ cask "virtual-desktop-streamer" do
 
   uninstall launchctl: [
               "com.virtualdesktop.daemon",
-              "com.virtualdesktop.streamer"
+              "com.virtualdesktop.streamer",
             ],
-            quit:    "com.virtualdesktop.streamer",
-            pkgutil: [
+            quit:      "com.virtualdesktop.streamer",
+            pkgutil:   [
               "com.VirtualDesktop.AudioDriver",
               "com.VirtualDesktop.MicDriver",
               "com.virtualdesktop.streamer",

--- a/Casks/v/virtual-desktop-streamer.rb
+++ b/Casks/v/virtual-desktop-streamer.rb
@@ -1,58 +1,24 @@
 cask "virtual-desktop-streamer" do
-  version "1.33.4"
-  sha256 "e868c1514d741de0f391e85cc95cd8fc0ae1a407cdde53fd88821c845ce9c6f3"
+  version :latest
+  sha256 :no_check
 
-  url "https://github.com/guygodin/VirtualDesktop/releases/download/v#{version}/VirtualDesktop.Streamer.Setup.dmg",
-      verified: "github.com/guygodin/VirtualDesktop/"
+  url "https://files.vrdesktop.net/files/VirtualDesktop.Streamer.Setup.pkg"
   name "Virtual Desktop Streamer"
   desc "VR Virtual Desktop Streamer"
   homepage "https://www.vrdesktop.net/"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  pkg "VirtualDesktop.Streamer.Setup.pkg"
 
-  pkg "Virtual Desktop.pkg"
-
-  postflight do
-    # postinstall launches the app
-    retries ||= 3
-    ohai "The Virtual Desktop package postinstall script launches the Streamer app" if retries >= 3
-    ohai "Attempting to close the Streamer app to avoid unwanted user intervention" if retries >= 3
-    return unless system_command "/usr/bin/pkill", args: ["-f", "/Applications/Virtual Desktop Streamer.app"]
-  rescue RuntimeError
-    sleep 1
-    retry unless (retries -= 1).zero?
-    opoo "Unable to forcibly close Virtual Desktop Streamer"
-  end
-
-  uninstall launchctl: [
-              "com.VirtualDesktop.autoinstall",
-              "com.VirtualDesktop.launch",
-              "com.VirtualDesktop.uninstall",
-            ],
-            quit:      "com.virtualDesktopInc.Mac.Streamer",
-            pkgutil:   [
+  uninstall quit:    "com.virtualdesktop.streamer",
+            pkgutil: [
               "com.VirtualDesktop.AudioDriver",
-              "com.VirtualDesktop.Libs",
               "com.VirtualDesktop.MicDriver",
-              "com.VirtualDesktop.VirtualDesktop",
-              "com.VirtualDesktop.VirtualDesktopUpdater",
-            ],
-            delete:    [
-              "/Applications/Virtual Desktop Streamer.app",
-              "/Applications/Virtual Desktop Updater.app",
-              "/usr/local/bin/virtualdesktop/",
+              "com.virtualdesktop.streamer",
             ]
 
   zap trash: [
-    "/tmp/.vdready",
-    "/tmp/.vdrequestclean",
-    "/tmp/.vdupdatedetail",
-    "~/Library/Caches/com.virtualDesktopInc.Mac.Streamer",
-    "~/Library/HTTPStorages/com.virtualDesktopInc.Mac.Streamer",
-    "~/Library/Preferences/com.virtualDesktopInc.Mac.Streamer.plist",
-    "~/Library/Saved Application State/com.virtualDesktopInc.Mac.Streamer.savedState",
+    "~/Library/Application Support/VirtualDesktop",
+    "~/Library/Caches/com.virtualdesktop.streamer",
+    "~/Library/Preferences/com.virtualdesktop.streamer.plist",
   ]
 end


### PR DESCRIPTION
- Updated URL to https://files.vrdesktop.net/files/VirtualDesktop.Streamer.Setup.pkg

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
- [X] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [X] `brew uninstall --cask <cask>` worked successfully.
---
