### PR TITLE
pcsx2: update livecheck, add app target

### DIFF
--- a/Casks/p/pcsx2.rb
+++ b/Casks/p/pcsx2.rb
@@ -9,13 +9,20 @@ cask "pcsx2" do
   homepage "https://pcsx2.net/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://api.pcsx2.net/v1/stableReleases?pageSize=1"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json["data"]&.map do |release|
+        next unless release.dig("assets", "MacOS")
+
+        release["version"]&.[](regex, 1)
+      end
+    end
   end
 
   depends_on macos: ">= :big_sur"
 
-  app "PCSX2-v#{version}.app"
+  app "PCSX2-v#{version}.app", target: "PCSX2.app"
 
   zap trash: [
     "~/Library/Application Support/PCSX2",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the `livecheck` block for `pcsx2` to use the same API endpoint that the app uses to check for updates. The `GithubLatest` strategy works but older releases don't include a macOS asset and we try to align checks with the in-app updater when possible.

Besides that, this adds an app `target` value to omit the version from the app name. I can drop this change if it's not something that we want to do (or normally do) but it makes for a nicer app name.

[For what it's worth, I had created a local version of this cask a while back and only just realized that there's now a copy in homebrew/cask, so this is me upstreaming differences.]