### PR TITLE
secretive: restore legacy versions

### DIFF
--- a/Casks/s/secretive.rb
+++ b/Casks/s/secretive.rb
@@ -1,13 +1,36 @@
 cask "secretive" do
-  version "3.0.2"
-  sha256 "03b2b7c81bfc3e061aa0542835f034ebd861d77f8f3298bcc1ac5dbd1ed2d4dd"
+  on_ventura :or_older do
+    on_catalina :or_older do
+      version "1.0.3"
+      sha256 "d8522c153f20cd03513e6815bdb46be98eae0db2b2a45d30f60b25a6609d1657"
+    end
+    on_big_sur do
+      version "2.3.1"
+      sha256 "493a72362898b4480baa70f115d9515b41b2af4a503caf00277e2bc3824b0bbd"
+    end
+    on_monterey :or_newer do
+      version "2.4.1"
+      sha256 "00ddf651f1151f1e3888c51e58ce343f6888480db79771b6de7371db21bde4d8"
+    end
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_sonoma :or_newer do
+    version "3.0.2"
+    sha256 "03b2b7c81bfc3e061aa0542835f034ebd861d77f8f3298bcc1ac5dbd1ed2d4dd"
+  end
 
   url "https://github.com/maxgoedjen/secretive/releases/download/v#{version}/Secretive.zip"
   name "Secretive"
   desc "Store SSH keys in the Secure Enclave"
   homepage "https://github.com/maxgoedjen/secretive"
 
-  depends_on macos: ">= :sonoma"
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "Secretive.app"
 

--- a/Casks/s/secretive.rb
+++ b/Casks/s/secretive.rb
@@ -20,17 +20,17 @@ cask "secretive" do
   on_sonoma :or_newer do
     version "3.0.2"
     sha256 "03b2b7c81bfc3e061aa0542835f034ebd861d77f8f3298bcc1ac5dbd1ed2d4dd"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
   end
 
   url "https://github.com/maxgoedjen/secretive/releases/download/v#{version}/Secretive.zip"
   name "Secretive"
   desc "Store SSH keys in the Secure Enclave"
   homepage "https://github.com/maxgoedjen/secretive"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   app "Secretive.app"
 


### PR DESCRIPTION
I removed these in https://github.com/Homebrew/homebrew-cask/pull/227995. Restoring them and condensing the stanzas.

cc @bevanjkay @singularitti 