### PR TITLE
android-studio-preview@canary 2025.1.4.5: zap user's Library subdirs correctly

### DIFF
--- a/Casks/a/android-studio-preview@canary.rb
+++ b/Casks/a/android-studio-preview@canary.rb
@@ -24,9 +24,9 @@ cask "android-studio-preview@canary" do
   zap trash: [
         "~/.android",
         "~/Library/Android/sdk",
-        "~/Library/Application Support/Google/AndroidStudioPreview#{version.major_minor}",
-        "~/Library/Caches/Google/AndroidStudioPreview#{version.major_minor}",
-        "~/Library/Logs/Google/AndroidStudioPreview#{version.major_minor}",
+        "~/Library/Application Support/Google/AndroidStudio#{version.major_minor_patch}",
+        "~/Library/Caches/Google/AndroidStudio#{version.major_minor_patch}",
+        "~/Library/Logs/Google/AndroidStudio#{version.major_minor_patch}",
         "~/Library/Preferences/com.android.Emulator.plist",
         "~/Library/Preferences/com.google.android.studio-EAP.plist",
         "~/Library/Saved Application State/com.google.android.studio-EAP.savedState",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The current formula of the Canary preview release of Android Studio doesn't remove the Library subdirectories correctly when zapping:

```
~/Library/Application Support/Google/AndroidStudioPreview2025.1
~/Library/Caches/Google/AndroidStudioPreview2025.1
~/Library/Logs/Google/AndroidStudioPreview2025.1

```

With this patch the correct Library subdirectories are wiped out correctly when passing `--zap`:
```
~/Library/Application Support/Google/AndroidStudio2025.1.4
~/Library/Caches/Google/AndroidStudio2025.1.4
~/Library/Logs/Google/AndroidStudio2025.1.4
```
