### PR TITLE
Set minimum macOS for Eclipse RCP applications

### DIFF
--- a/Casks/e/eclipse-cpp.rb
+++ b/Casks/e/eclipse-cpp.rb
@@ -14,6 +14,8 @@ cask "eclipse-cpp" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse CPP.app"
 

--- a/Casks/e/eclipse-dsl.rb
+++ b/Casks/e/eclipse-dsl.rb
@@ -14,6 +14,8 @@ cask "eclipse-dsl" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse DSL.app"
 

--- a/Casks/e/eclipse-ide.rb
+++ b/Casks/e/eclipse-ide.rb
@@ -27,6 +27,8 @@ cask "eclipse-ide" do
     end
   end
 
+  depends_on macos: ">= :ventura"
+
   app "Eclipse.app"
 
   zap trash: "~/Library/Preferences/epp.package.committers.plist"

--- a/Casks/e/eclipse-installer.rb
+++ b/Casks/e/eclipse-installer.rb
@@ -15,6 +15,8 @@ cask "eclipse-installer" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   app "Eclipse Installer.app"
 
   zap trash: [

--- a/Casks/e/eclipse-java.rb
+++ b/Casks/e/eclipse-java.rb
@@ -14,6 +14,8 @@ cask "eclipse-java" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Java.app"
 

--- a/Casks/e/eclipse-jee.rb
+++ b/Casks/e/eclipse-jee.rb
@@ -14,6 +14,8 @@ cask "eclipse-jee" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse JEE.app"
 

--- a/Casks/e/eclipse-modeling.rb
+++ b/Casks/e/eclipse-modeling.rb
@@ -14,6 +14,8 @@ cask "eclipse-modeling" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Modeling.app"
 

--- a/Casks/e/eclipse-php.rb
+++ b/Casks/e/eclipse-php.rb
@@ -14,6 +14,8 @@ cask "eclipse-php" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse PHP.app"
 

--- a/Casks/e/eclipse-platform.rb
+++ b/Casks/e/eclipse-platform.rb
@@ -18,6 +18,8 @@ cask "eclipse-platform" do
     end
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse Platform.app"
 

--- a/Casks/e/eclipse-rcp.rb
+++ b/Casks/e/eclipse-rcp.rb
@@ -14,6 +14,8 @@ cask "eclipse-rcp" do
     cask "eclipse-ide"
   end
 
+  depends_on macos: ">= :ventura"
+
   # Renamed to avoid conflict with other Eclipse.
   app "Eclipse.app", target: "Eclipse RCP.app"
 

--- a/Casks/o/openchrom.rb
+++ b/Casks/o/openchrom.rb
@@ -23,7 +23,7 @@ cask "openchrom" do
 
   no_autobump! because: :bumped_by_upstream
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :ventura"
 
   app "OpenChrom.app"
 


### PR DESCRIPTION
This is a followup for https://github.com/Homebrew/homebrew-cask/pull/228826. Latest @OpenChrom is based on @eclipse-platform 4.37 so the requirements are the same. https://eclipse.dev/eclipse/development/plans/eclipse_project_plan_4_37.xml#target_environments