### PR TITLE
motu-m-series 2.0.0

### DIFF
--- a/Casks/m/motu-m-series.rb
+++ b/Casks/m/motu-m-series.rb
@@ -1,18 +1,21 @@
 cask "motu-m-series" do
-  version "96480"
-  sha256 "c1605afc03b563b2a1b8f4412c2329574bffd8083a0a7f242a2ed1a377cbd76b"
+  version "2.0.0,fb961a2c0"
+  sha256 "cb4f3a9f48d667eca14ea93aeeccca826d3a28d29ece068f54f959228222e1be"
 
-  url "https://cdn-data.motu.com/downloads/audio/mseries/driver/RC/MOTU%20M%20Series%20Installer%20(#{version}).pkg"
+  url "https://cdn-data.motu.com/downloads/audio/mseries/driver/RC/MOTU%20MSeries%20Installer%20(#{version.csv.second}).pkg"
   name "Motu M-Series"
   desc "Audio interface driver for Motu M-Series (M2, M4, M6) audio interfaces"
   homepage "https://motu.com/en-us/download/product/408/"
 
   livecheck do
     url :homepage
-    regex(/<span[^>]*?>Mac\s*v?(\d+(?:\.\d+)*)</i)
+    regex(/>\s*Mac\s*v?(\d+(?:\.\d+)+)\+(\h+)\s*</i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
-  pkg "MOTU M Series Installer (#{version}).pkg"
+  pkg "MOTU MSeries Installer (#{version.csv.second}).pkg"
 
   uninstall launchctl: "com.motu.coreuac.reenumerator",
             pkgutil:   [


### PR DESCRIPTION
Updates the `livecheck` block to correctly handle the versioning scheme used on the homepage.

The previous regex was matching the user-facing version number (e.g., `2024.6`), but the download URL requires a build hash. The new implementation now parses the full version string (e.g., `2.0.0+fb961a2c0`) to extract the required hash.

Also updates the `url` and `pkg` stanzas to align with the latest installer filename.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
