### PR TITLE
helium: adjust disable date to today

### DIFF
--- a/Casks/h/helium.rb
+++ b/Casks/h/helium.rb
@@ -6,7 +6,7 @@ cask "helium" do
   name "Helium"
   homepage "https://github.com/koush/support-wiki/wiki/Helium-Desktop-Installer-and-Android-App"
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  disable! date: "2025-09-22", because: :fails_gatekeeper_check
 
   app "Helium.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR serves as less of a request, and more of a question. I was wondering if the removal of the `helium` cask could be expedited beyond what is its current expiry in two years.

The only official policy I could find regarding this, is *Deprecating, Disabling and Removing Casks* [1], which states that: 
> The most common reasons for disabling a cask are:
> ...
> it cannot be installed on any supported OS versions
> ...
> Unpopular casks (e.g. have fewer than 300 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/cask-install/90d/)) can be disabled immediately for any of the reasons above, e.g. the upstream URL has been removed. They can be manually removed three months after their disable date.

At the time of writing, the `helium` cask has 132 (331) downloads in the past 90 days (year). It is deprecated due to being unsigned, and does not have any ARM version. It has not been materially changed since it was added in 2015, and the mobile application it's supposed to interface with[2], has been gone from the Play Store for at least four years[3].

The motivation behind this request is that I am one of the maintainers of Helium[4, 5], a browser that we are planning on releasing soon. We would prefer to, if possible, use *this* name on Homebrew as a method of downloading it, sooner than in two years' time. 

[1] https://docs.brew.sh/Deprecating-Disabling-and-Removing-Casks#disabling
[2] https://play.google.com/store/apps/details?id=com.koushikdutta.backup
[3] https://web.archive.org/web/20211022113428/https://play.google.com/store/apps/details?id=com.koushikdutta.backup
[4] https://helium.computer
[5] https://github.com/imputnet/helium-chromium
