### PR TITLE
various: deprecate all old-style Quick Look plugins

### DIFF
--- a/Casks/a/avifquicklook.rb
+++ b/Casks/a/avifquicklook.rb
@@ -7,6 +7,8 @@ cask "avifquicklook" do
   desc "Quick Look Plugin for AVIF images"
   homepage "https://github.com/dreampiggy/AVIFQuickLook"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "AVIFQuickLook.qlgenerator"
 
   # No zap stanza required

--- a/Casks/g/gltfquicklook.rb
+++ b/Casks/g/gltfquicklook.rb
@@ -7,6 +7,8 @@ cask "gltfquicklook" do
   desc "Quick Look plugin for glTF files"
   homepage "https://github.com/magicien/GLTFQuickLook"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "GLTFQuickLook.qlgenerator"
 
   # No zap stanza required

--- a/Casks/i/inloop-qlplayground.rb
+++ b/Casks/i/inloop-qlplayground.rb
@@ -7,6 +7,8 @@ cask "inloop-qlplayground" do
   desc "Quick Look generator for Xcode Playgrounds"
   homepage "https://github.com/inloop/qlplayground"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "inloop-qlplayground.qlgenerator"
 
   # No zap stanza required

--- a/Casks/i/ipynb-quicklook.rb
+++ b/Casks/i/ipynb-quicklook.rb
@@ -12,6 +12,8 @@ cask "ipynb-quicklook" do
     strategy :github_latest
   end
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "ipynb-quicklook.qlgenerator"
 
   # No zap stanza required

--- a/Casks/j/jpc-qlcolorcode.rb
+++ b/Casks/j/jpc-qlcolorcode.rb
@@ -7,6 +7,8 @@ cask "jpc-qlcolorcode" do
   desc "Quick Look plug-in that renders source code with syntax highlighting"
   homepage "https://github.com/jpc/QLColorCode"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLColorCode.qlgenerator"
 
   zap trash: "~/Library/Preferences/org.n8gray.QLColorCode.plist"

--- a/Casks/j/jupyter-notebook-ql.rb
+++ b/Casks/j/jupyter-notebook-ql.rb
@@ -7,6 +7,8 @@ cask "jupyter-notebook-ql" do
   desc "Quick Look plugin for Jupyter notebooks"
   homepage "https://github.com/jendas1/jupyter-notebook-quick-look"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "jupyter-notebook-quick-look.qlgenerator"
 
   # No zap stanza required

--- a/Casks/p/provisionql.rb
+++ b/Casks/p/provisionql.rb
@@ -7,6 +7,8 @@ cask "provisionql" do
   desc "Quick Look plugin for mobile apps and provisioning profiles"
   homepage "https://github.com/ealeksandrov/ProvisionQL"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "ProvisionQL.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qladdict.rb
+++ b/Casks/q/qladdict.rb
@@ -7,6 +7,8 @@ cask "qladdict" do
   desc "Quick Look plugin for subtitle (.srt) files"
   homepage "https://github.com/tattali/QLAddict/"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLAddict.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlcolorcode.rb
+++ b/Casks/q/qlcolorcode.rb
@@ -7,6 +7,8 @@ cask "qlcolorcode" do
   desc "Quick Look plug-in that renders source code with syntax highlighting"
   homepage "https://github.com/anthonygelibert/QLColorCode"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLColorCode.qlgenerator"
 
   zap trash: "~/Library/Preferences/org.n8gray.QLColorCode.plist"

--- a/Casks/q/qlcommonmark.rb
+++ b/Casks/q/qlcommonmark.rb
@@ -7,6 +7,8 @@ cask "qlcommonmark" do
   desc "Quick Look plugin for CommonMark and Markdown"
   homepage "https://github.com/digitalmoksha/QLCommonMark/"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLCommonMark.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlfits.rb
+++ b/Casks/q/qlfits.rb
@@ -7,6 +7,8 @@ cask "qlfits" do
   desc "Quick Look plugin to view FITS files"
   homepage "https://github.com/onekiloparsec/QLFits"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLFits#{version.major}.qlgenerator"
 
   zap trash: "~/Library/Preferences/com.softtenebraslux.qlfitsgenerator.plist"

--- a/Casks/q/qlgradle.rb
+++ b/Casks/q/qlgradle.rb
@@ -7,6 +7,8 @@ cask "qlgradle" do
   desc "Quick Look plugin for viewing gradle files"
   homepage "https://github.com/Urucas/QLGradle"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLGradle.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlmobi.rb
+++ b/Casks/q/qlmobi.rb
@@ -7,6 +7,8 @@ cask "qlmobi" do
   desc "Quick Look plugin for Kindle ebook formats"
   homepage "https://github.com/bfabiszewski/QLMobi"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLMobi.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlnetcdf.rb
+++ b/Casks/q/qlnetcdf.rb
@@ -7,6 +7,8 @@ cask "qlnetcdf" do
   desc "Quick Look plugin for viewing NetCDF files"
   homepage "https://github.com/tobeycarman/QLNetcdf/"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLNetcdf.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlplayground.rb
+++ b/Casks/q/qlplayground.rb
@@ -7,6 +7,8 @@ cask "qlplayground" do
   desc "Quick Look plugin for Swift files"
   homepage "https://github.com/norio-nomura/qlplayground"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "qlplayground.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlprettypatch.rb
+++ b/Casks/q/qlprettypatch.rb
@@ -7,6 +7,8 @@ cask "qlprettypatch" do
   desc "Quick Look plugin to view patch files"
   homepage "https://github.com/atnan/QLPrettyPatch"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLPrettyPatch.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlstephen.rb
+++ b/Casks/q/qlstephen.rb
@@ -8,6 +8,8 @@ cask "qlstephen" do
   desc "Quick Look plugin for plaintext files without an extension"
   homepage "https://whomwah.github.io/qlstephen/"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLStephen.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlswift.rb
+++ b/Casks/q/qlswift.rb
@@ -7,6 +7,8 @@ cask "qlswift" do
   desc "Quick Look plugin for Swift files"
   homepage "https://github.com/lexrus/QLSwift"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QLSwift.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/qlzipinfo.rb
+++ b/Casks/q/qlzipinfo.rb
@@ -7,6 +7,8 @@ cask "qlzipinfo" do
   desc "List out the contents of a zip file in the QuickLook preview"
   homepage "https://github.com/srirangav/qlZipInfo"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "qlZipInfo.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/quickgeojson.rb
+++ b/Casks/q/quickgeojson.rb
@@ -7,6 +7,8 @@ cask "quickgeojson" do
   desc "Quick Look plugin for GeoJSON and TopoJSON"
   homepage "https://github.com/irees/quickgeojson"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "quickgeojson.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/quicklook-csv.rb
+++ b/Casks/q/quicklook-csv.rb
@@ -7,6 +7,8 @@ cask "quicklook-csv" do
   desc "Quick Look plugin for CSV files"
   homepage "https://github.com/p2/quicklook-csv"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QuickLookCSV.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/quicklook-json.rb
+++ b/Casks/q/quicklook-json.rb
@@ -12,6 +12,8 @@ cask "quicklook-json" do
     strategy :extract_plist
   end
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QuickLookJSON.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/quicklook-pfm.rb
+++ b/Casks/q/quicklook-pfm.rb
@@ -12,6 +12,8 @@ cask "quicklook-pfm" do
     strategy :github_latest
   end
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "Quicklook-PFM.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/quicklookase.rb
+++ b/Casks/q/quicklookase.rb
@@ -7,6 +7,8 @@ cask "quicklookase" do
   desc "Quick Look generator for Adobe Swatch Exchange files"
   homepage "https://github.com/rsodre/QuickLookASE"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QuickLookASE.qlgenerator"
 
   # No zap stanza required

--- a/Casks/q/quicknfo.rb
+++ b/Casks/q/quicknfo.rb
@@ -7,6 +7,8 @@ cask "quicknfo" do
   desc "Quick Look plugin for viewing NFO files"
   homepage "https://github.com/planbnet/QuickNFO"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "QuickNFO.qlgenerator"
 
   # No zap stanza required

--- a/Casks/r/receiptquicklook.rb
+++ b/Casks/r/receiptquicklook.rb
@@ -7,6 +7,8 @@ cask "receiptquicklook" do
   desc "Quick Look plugin to visualise App Store cryptographic receipts"
   homepage "https://github.com/letiemble/ReceiptQuickLook"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "ReceiptQuickLook.qlgenerator"
 
   # No zap stanza required

--- a/Casks/t/ttscoff-mmd-quicklook.rb
+++ b/Casks/t/ttscoff-mmd-quicklook.rb
@@ -7,6 +7,8 @@ cask "ttscoff-mmd-quicklook" do
   desc "Quick Look plugin for viewing MultiMarkdown"
   homepage "https://github.com/ttscoff/mmd-quicklook"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "MultiMarkdown QuickLook.qlgenerator"
 
   # No zap stanza required

--- a/Casks/v/voxql.rb
+++ b/Casks/v/voxql.rb
@@ -7,6 +7,8 @@ cask "voxql" do
   desc "Quick Look generator for MagicaVoxel files"
   homepage "https://github.com/heptal/VoxQL"
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "VoxQL.qlgenerator"
 
   # No zap stanza required

--- a/Casks/w/webpquicklook.rb
+++ b/Casks/w/webpquicklook.rb
@@ -13,6 +13,8 @@ cask "webpquicklook" do
     strategy :extract_plist
   end
 
+  deprecate! date: "2025-09-22", because: :no_longer_meets_criteria
+
   qlplugin "WebpQuickLook.qlgenerator"
 
   # No zap stanza required


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
See [brew#20732](https://github.com/Homebrew/brew/pull/20732) for background. Basically, these old-style Quick Look plugins (those with a `.qlgenerator` extension) will no longer be supported by macOS versions later than Sequoia. Therefore, it seems like a good time to deprecate them now and disable them at the same time Sequoia will become the minimum supported Tier 1 version of Homebrew, which will likely be next year.