### PR TITLE
font-lxgw-neoxihei: add livecheck

### DIFF
--- a/Casks/font/font-l/font-lxgw-neoxihei.rb
+++ b/Casks/font/font-l/font-lxgw-neoxihei.rb
@@ -7,6 +7,11 @@ cask "font-lxgw-neoxihei" do
   name "霞鹜新晰黑"
   homepage "https://github.com/lxgw/LxgwNeoXiHei"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   font "LXGWNeoXiHei.ttf"
 
   # No zap stanza required


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck uses the `Git` strategy to check for new versions of `font-lxgw-neoxihei` but this is currently returning a version that's marked as pre-release on GitHub. The release uses a tag with the stable version format, so the `Git` strategy isn't able to reliably identify the newest stable version in this situation. This addresses the issue by adding a `livecheck` block using the `GithubLatest` strategy.