### PR TITLE
Topaz Studio apps (and related cleanup)

### DIFF
--- a/Casks/t/topaz-gigapixel-ai.rb
+++ b/Casks/t/topaz-gigapixel-ai.rb
@@ -1,6 +1,6 @@
 cask "topaz-gigapixel-ai" do
-  version "8.4.3"
-  sha256 "afaeeebeb3f418615f878dc5d93b899cd3b1f5eb8764c4409106b1f08446fb71"
+  version "8.4.4"
+  sha256 "9b3acfa9f98bf52fa494043c4f6e9176ce6385fce07273aa559cf9ff86492aed"
 
   url "https://downloads.topazlabs.com/deploy/TopazGigapixelAI/#{version}/TopazGigapixelAI-#{version}.pkg"
   name "Topaz Gigapixel AI"

--- a/Casks/t/topaz-gigapixel-ai.rb
+++ b/Casks/t/topaz-gigapixel-ai.rb
@@ -5,12 +5,14 @@ cask "topaz-gigapixel-ai" do
   url "https://downloads.topazlabs.com/deploy/TopazGigapixelAI/#{version}/TopazGigapixelAI-#{version}.pkg"
   name "Topaz Gigapixel AI"
   desc "AI image upscaler"
-  homepage "https://www.topazlabs.com/gigapixel-ai"
+  homepage "https://docs.topazlabs.com/other-apps/legacy"
 
   livecheck do
     url "https://topazlabs.com/d/gigapixel/latest/mac/full"
     strategy :header_match
   end
+
+  deprecate! date: "2025-09-16", because: :discontinued, replacement_cask: "topaz-gigapixel"
 
   auto_updates true
 

--- a/Casks/t/topaz-gigapixel-ai.rb
+++ b/Casks/t/topaz-gigapixel-ai.rb
@@ -16,9 +16,20 @@ cask "topaz-gigapixel-ai" do
 
   pkg "TopazGigapixelAI-#{version}.pkg"
 
-  uninstall pkgutil: "com.topazlabs.TopazGigapixelAI"
+  uninstall pkgutil: "com.topazlabs.TopazGigapixelAI",
+            delete:  [
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelAI.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelAIApply.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelAIAutomate.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelAIGather.plugin",
+              "~/Library/Application Support/Adobe/Lightroom/External Editor Presets/TopazGigapixelAI.lrtemplate",
+              "~/Library/Application Support/Affinity Photo 2/Plugins/TopazGigapixelAI.plugin",
+              "~/Library/Application Support/Capture One/Plug-ins/TopazGigapixelAI.coplugin",
+              "~/Library/Application Support/Topaz Labs LLC/Topaz Gigapixel AI",
+            ]
 
   zap trash: [
+    "~/Library/Caches/Topaz Labs LLC/Topaz Gigapixel AI",
     "~/Library/Preferences/com.topaz-labs-llc.Topaz Gigapixel AI.plist",
     "~/Library/Preferences/com.topazlabs.Topaz Gigapixel AI.plist",
     "~/Library/Preferences/com.topazlabs.TopazGigapixelAI.plist",

--- a/Casks/t/topaz-gigapixel.rb
+++ b/Casks/t/topaz-gigapixel.rb
@@ -1,0 +1,38 @@
+cask "topaz-gigapixel" do
+  version "1.0.2"
+  sha256 "3e47a066460ed89636ede6d5ac659c3b00fdc92eb315d5044c03f34e1bf60af1"
+
+  url "https://downloads.topazlabs.com/deploy/TopazGigapixel/#{version}/TopazGigapixel-#{version}.pkg"
+  name "Topaz Gigapixel"
+  desc "AI image upscaler"
+  homepage "https://www.topazlabs.com/topaz-gigapixel"
+
+  livecheck do
+    url "https://topazlabs.com/d/gigapixelstudio/latest/mac/full"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on arch:  :arm64,
+             macos: ">= :monterey"
+
+  pkg "TopazGigapixel-#{version}.pkg"
+
+  uninstall pkgutil: "com.topazlabs.TopazGigapixel",
+            delete:  [
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixel.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelApply.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelAutomate.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazGigapixelGather.plugin",
+              "~/Library/Application Support/Adobe/Lightroom/External Editor Presets/TopazGigapixel.lrtemplate",
+              "~/Library/Application Support/Affinity Photo 2/Plugins/TopazGigapixel.plugin",
+              "~/Library/Application Support/Capture One/Plug-ins/TopazGigapixel.coplugin",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/Topaz Labs LLC/Topaz Gigapixel",
+    "~/Library/Cache/Topaz Labs LLC/Topaz Gigapixel",
+    "~/Library/Preferences/com.topazlabs.Topaz Gigapixel.plist",
+    "~/Library/Preferences/com.topazlabs.TopazGigapixel.plist",
+  ]
+end

--- a/Casks/t/topaz-photo-ai.rb
+++ b/Casks/t/topaz-photo-ai.rb
@@ -16,9 +16,24 @@ cask "topaz-photo-ai" do
 
   pkg "TopazPhotoAI-#{version}.pkg"
 
-  uninstall pkgutil: "com.topazlabs.TopazPhotoAI"
+  uninstall pkgutil: "com.topazlabs.TopazPhotoAI",
+            delete:  [
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoAI.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoAIApply.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoAIAutomate.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoAIGather.plugin",
+              "~/Library/Application Support/Adobe/Lightroom/External Editor Presets/TopazPhotoAI.lrtemplate",
+              "~/Library/Application Support/Adobe/Lightroom/Modules/Topaz Photo AI.lrplugin",
+              "~/Library/Application Support/Affinity Photo 2/Plugins/TopazPhotoAI.plugin",
+              "~/Library/Application Support/Capture One/Plug-ins/TopazPhotoAI.coplugin",
+            ]
 
   zap trash: [
+    "~/Library/Application Scripts/com.topazlabs.TopazPhotoAIplugin",
+    "~/Library/Application Support/Topaz Labs LLC/Topaz Photo AI",
+    "~/Library/Caches/com.topazlabs.TopazPhotoAI",
+    "~/Library/Caches/Topaz Labs LLC/Topaz Photo AI",
+    "~/Library/Containers/com.topazlabs.TopazPhotoAIplugin",
     "~/Library/Preferences/com.topaz-labs-llc.Topaz Photo AI.plist",
     "~/Library/Preferences/com.topazlabs.Topaz Photo AI.plist",
     "~/Library/Preferences/com.topazlabs.TopazPhotoAI.plist",

--- a/Casks/t/topaz-photo-ai.rb
+++ b/Casks/t/topaz-photo-ai.rb
@@ -5,12 +5,14 @@ cask "topaz-photo-ai" do
   url "https://downloads.topazlabs.com/deploy/TopazPhotoAI/#{version}/TopazPhotoAI-#{version}.pkg"
   name "Topaz Photo AI"
   desc "AI image enhancer"
-  homepage "https://www.topazlabs.com/photo-ai"
+  homepage "https://docs.topazlabs.com/other-apps/legacy"
 
   livecheck do
     url "https://topazlabs.com/d/photo/latest/mac/full"
     strategy :header_match
   end
+
+  deprecate! date: "2025-09-16", because: :discontinued, replacement_cask: "topaz-photo"
 
   auto_updates true
 

--- a/Casks/t/topaz-photo.rb
+++ b/Casks/t/topaz-photo.rb
@@ -1,0 +1,41 @@
+cask "topaz-photo" do
+  version "1.0.1"
+  sha256 "c69d76e8a3ab45fb8c092813a7c7e88064c7d2979ae64de2affee674857a63d7"
+
+  url "https://downloads.topazlabs.com/deploy/TopazPhoto/#{version}/TopazPhoto-#{version}.pkg"
+  name "Topaz Photo"
+  desc "AI image enhancer"
+  homepage "https://www.topazlabs.com/topaz-photo"
+
+  livecheck do
+    url "https://topazlabs.com/d/photostudio/latest/mac/full"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on arch:  :arm64,
+             macos: ">= :monterey"
+
+  pkg "TopazPhoto-#{version}.pkg"
+
+  uninstall pkgutil: "com.topazlabs.TopazPhoto",
+            delete:  [
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhoto.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoApply.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoAutomate.plugin",
+              "/Library/Application Support/Adobe/Plug-Ins/CC/TopazPhotoGather.plugin",
+              "~/Library/Application Support/Adobe/Lightroom/External Editor Presets/TopazGigapixel.lrtemplate",
+              "~/Library/Application Support/Adobe/Lightroom/Modules/Topaz Photo.lrplugin",
+              "~/Library/Application Support/Affinity Photo 2/Plugins/TopazGigapixel.plugin",
+              "~/Library/Application Support/Capture One/Plug-ins/TopazGigapixel.coplugin",
+            ]
+
+  zap trash: [
+    "~/Library/Application Scripts/com.topazlabs.TopazPhotoplugin",
+    "~/Library/Application Support/Topaz Labs LLC/Topaz Photo",
+    "~/Library/Caches/Topaz Labs LLC/Topaz Photo",
+    "~/Library/Containers/com.topazlabs.TopazPhotoplugin",
+    "~/Library/Preferences/com.topazlabs.Topaz Photo.plist",
+    "~/Library/Preferences/com.topazlabs.TopazPhoto.plist",
+  ]
+end

--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -16,7 +16,32 @@ cask "topaz-video-ai" do
 
   app "Topaz Video AI.app"
 
+  uninstall pkgutil: [
+              "com.topazlabs.aeplugin",
+              "com.topazlabs.ofxplugin",
+              "com.topazlabs.VAIPackage",
+            ],
+            delete:  [
+              "/Applications/Adobe After Effects 2020/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2020/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2021/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2021/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2022/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2022/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2023/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2023/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2024/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2024/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2025/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2025/Plug-ins/Topaz Video AI.plugin",
+              "/Library/OFX/Plugins/Topaz Video AI.ofx.bundle",
+            ]
+
   zap trash: [
+    "~/Library/Application Support/Topaz Labs LLC/Topaz Video AI",
+    "~/Library/Caches/com.topazlabs.Topaz-Video-AI",
+    "~/Library/Caches/Topaz Labs LLC/Topaz Video AI",
+    "~/Library/Preferences/com.topazlabs.Topaz Video AI.plist",
     "~/Library/Preferences/com.topazlabs.Topaz-Video-AI.plist",
     "~/Library/Saved Application State/com.topazlabs.Topaz-Video-AI.savedState",
   ]

--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -5,12 +5,14 @@ cask "topaz-video-ai" do
   url "https://downloads.topazlabs.com/deploy/TopazVideoAI/#{version}/TopazVideoAI-#{version}.pkg"
   name "Topaz Video AI"
   desc "Video upscaler and quality enhancer"
-  homepage "https://www.topazlabs.com/topaz-video-ai"
+  homepage "https://docs.topazlabs.com/other-apps/legacy"
 
   livecheck do
     url "https://topazlabs.com/d/tvai/latest/mac/full"
     strategy :header_match
   end
+
+  deprecate! date: "2025-09-16", because: :discontinued, replacement_cask: "topaz-video"
 
   auto_updates true
 

--- a/Casks/t/topaz-video-ai.rb
+++ b/Casks/t/topaz-video-ai.rb
@@ -1,8 +1,8 @@
 cask "topaz-video-ai" do
   version "7.1.3"
-  sha256 "1f2e97ee89a53e04649e7c8d70596a63aee87a4448db5ab673beab72ff96cd86"
+  sha256 "7d3fd71d8d59066312bd87372362db87aa47646eb775e2a0b1e59d040db65bea"
 
-  url "https://downloads.topazlabs.com/deploy/TopazVideoAI/#{version}/TopazVideoAI-#{version}.dmg"
+  url "https://downloads.topazlabs.com/deploy/TopazVideoAI/#{version}/TopazVideoAI-#{version}.pkg"
   name "Topaz Video AI"
   desc "Video upscaler and quality enhancer"
   homepage "https://www.topazlabs.com/topaz-video-ai"
@@ -14,7 +14,7 @@ cask "topaz-video-ai" do
 
   auto_updates true
 
-  app "Topaz Video AI.app"
+  pkg "TopazVideoAI-#{version}.pkg"
 
   uninstall pkgutil: [
               "com.topazlabs.aeplugin",

--- a/Casks/t/topaz-video.rb
+++ b/Casks/t/topaz-video.rb
@@ -1,0 +1,54 @@
+cask "topaz-video" do
+  version "1.0.1"
+  sha256 "11643bbe1df7aa89a0304157ea6700dcc6db1f233169ad1b068a549c8a82409e"
+
+  url "https://downloads.topazlabs.com/deploy/TopazVideoStudio/#{version}/TopazVideo-#{version}.pkg"
+  name "Topaz Video"
+  desc "Video upscaler and quality enhancer"
+  homepage "https://www.topazlabs.com/topaz-video"
+
+  livecheck do
+    url "https://topazlabs.com/d/videostudio/latest/mac/full"
+    strategy :header_match
+  end
+
+  auto_updates true
+  depends_on arch:  :arm64,
+             macos: ">= :big_sur"
+
+  pkg "TopazVideo-#{version}.pkg"
+
+  # Unlike the previous version of this app (topaz-video-ai), the .pkg installer does not contain
+  # supplementary packages to install the plugins. Additionally, the app does not contain the menu
+  # options for the user to manually install the plugins post-installation. Until this is resolved
+  # by the vendor, trigger the plugin installation scripts here so the end state is a ready-to-use
+  # installation as per the previous version users are likely to be transitioning from.
+  postflight do
+    system "sudo", "bash", "#{appdir}/Topaz Video.app/Contents/Resources/ae_inst.sh"
+    system "sudo", "bash", "#{appdir}/Topaz Video.app/Contents/Resources/ofx_inst.sh"
+  end
+
+  uninstall pkgutil: "com.topazlabs.VStudioPackage",
+            delete:  [
+              "/Applications/Adobe After Effects 2020/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2020/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2021/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2021/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2022/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2022/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2023/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2023/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2024/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2024/Plug-ins/Topaz Video AI.plugin",
+              "/Applications/Adobe After Effects 2025/Plug-ins/Topaz Video AI Frame Interpolation.plugin",
+              "/Applications/Adobe After Effects 2025/Plug-ins/Topaz Video AI.plugin",
+              "/Library/OFX/Plugins/Topaz Video AI.ofx.bundle",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/Topaz Labs LLC/Topaz Video",
+    "~/Library/Caches/Topaz Labs LLC/Topaz Video",
+    "~/Library/Preferences/com.topazlabs.Topaz Video.plist",
+    "~/Library/Preferences/com.topazlabs.Topaz-Video.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Topaz recently repackaged their apps as "Studio", resetting the version numbers and switching to a subscription licensing model. The existing apps are still usable with a persistent license (the previous model), so I didn't just want to replace them. Plus the names dropped the "AI" suffix anyway.

The `livecheck`s in the new casks aren't ideal, but there aren't equivalent download links I can find that would give suitable headers. There _is_ an API endpoint used by the apps to self-update, but it requires authentication using license details (despite being called `/unauth` weirdly).

Additionally, all three apps were missing lots of `uninstall` and `zap` paths; and `topaz-video-ai` has some weirdness around the plugins made available to other apps.