### PR TITLE
espresso 25.10

### DIFF
--- a/Casks/e/espresso.rb
+++ b/Casks/e/espresso.rb
@@ -1,17 +1,18 @@
 cask "espresso" do
-  version "5.9.1"
-  sha256 "1bd6bc510ecb4aea724ced65716f7597c0fe2749ee1fd8f05fccad56336fa61e"
+  version "25.10"
+  sha256 "f9002003d0ae046a42caeaf30681c977eb797d1917cd357517ed456d9312dcb0"
 
-  url "https://downloads.espressoapps.au/Espresso/Espresso_#{version}.zip",
-      verified: "downloads.espressoapps.au/"
+  url "https://get.espressoapp.com/Espresso_#{version}.zip"
   name "Espresso"
   desc "Website editor focusing on flair and efficiency"
   homepage "https://espressoapp.com/"
 
   livecheck do
-    url "https://espressoapp.com/updates/"
-    regex(/data-title="(\d+(?:\.\d+)+)"/i)
+    url "https://espressoapp.com/download/"
+    regex(/data-title=["']?v?(\d+(?:\.\d+)+)["' >]/i)
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "Espresso.app"
 
@@ -21,8 +22,4 @@ cask "espresso" do
     "~/Library/Preferences/com.kanagacode.espresso.plist",
     "~/Library/WebKit/com.kanagacode.espresso",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `espresso` zip URL changed with the 2.9 release, so this updates the cask accordingly. The app is now a universal binary, so the Rosetta caveat is no longer necessary.

Besides that, this updates the `livecheck` block URL to align with the download URL on the homepage (it's basically the same content as the `/updates/` page) and to make the regex a bit more flexible about matching the attribute value.