### PR TITLE
hopper-disassembler 6.0.3

### DIFF
--- a/Casks/h/hopper-disassembler.rb
+++ b/Casks/h/hopper-disassembler.rb
@@ -1,6 +1,6 @@
 cask "hopper-disassembler" do
-  version "6.0.2"
-  sha256 "f0ea4de51d8e7423bb19aacaffae4d093f6e1598acae401ffab60a9cf0c16123"
+  version "6.0.3"
+  sha256 "f48de70810ca658bc1777967ae00af7b9e5cd9274d244fb52996ec24248d1b10"
 
   url "https://www.hopperapp.com/downloader/public/Hopper-#{version}-demo.dmg",
       user_agent: :fake
@@ -12,6 +12,8 @@ cask "hopper-disassembler" do
     url "https://www.hopperapp.com/rss/changelog.xml"
     regex(/<title>\s*Version\s+v?(\d+(?:\.\d+)+)/i)
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Hopper Disassembler.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`hopper-disassembler` is autobumped but the workflow failed to update to version 6.0.3 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds a related `depends_on macos:` call.