### PR TITLE
kontur-talk 3.2.0

### DIFF
--- a/Casks/k/kontur-talk.rb
+++ b/Casks/k/kontur-talk.rb
@@ -1,6 +1,6 @@
 cask "kontur-talk" do
-  version "3.1.1"
-  sha256 "d5b646955000f2ee91d639d6291cdc0db50e8527e41d4829d5db2c736c06d55a"
+  version "3.2.0"
+  sha256 "f3cbea475b6072d5503468e91bb64f890936469d4f3dfefc797c743997d660d2"
 
   url "https://st.ktalk.host/ktalk-app/mac/ktalk.#{version}-mac.dmg",
       verified: "st.ktalk.host/"
@@ -15,7 +15,7 @@ cask "kontur-talk" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Толк.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kontur-talk` is autobumped but the workflow failed to update to 3.2.0 because `brew audit` is failing with an "Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and modifies the `depends_on macos:` value accordingly.