### PR TITLE
zappy 4.9.0

### DIFF
--- a/Casks/z/zappy.rb
+++ b/Casks/z/zappy.rb
@@ -1,8 +1,8 @@
 cask "zappy" do
-  version "4.8.9"
-  sha256 "7927aa6d595b5ed1d9efdbb87130d8ed562ee29a5d0d60a678b70c9135af2959"
+  version "4.9.0"
+  sha256 "568f8dc44ef15f67262afa2bca318afcb2fc8dc88d41eaf01f46dd420f687f42"
 
-  url "https://zappy.zapier.com/releases/zappy_#{version}.dmg"
+  url "https://zappy.zapier.com/releases/zappy-#{version}.dmg"
   name "Zappy"
   desc "Screen capture tool for remote teams"
   homepage "https://zapier.com/zappy"
@@ -13,7 +13,7 @@ cask "zappy" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sequoia"
 
   app "Zappy.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`zappy` is autobumped but the workflow failed to update to 4.9.0 because the delimiter in the file name changed back from an underscore to the usual hyphen (it appears to have been a one-off issue for 4.8.9). Besides that, this also fails `brew audit` with an "Upstream defined :sequoia as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version, `url`, and `depends_on macos:` value accordingly.