### PR TITLE
zipic 1.8.1

### DIFF
--- a/Casks/z/zipic.rb
+++ b/Casks/z/zipic.rb
@@ -1,6 +1,6 @@
 cask "zipic" do
-  version "1.8.0"
-  sha256 "31f7f797ce44bfe654251b4fd0f307361379ae6d944687f3f045f7d5b69bdaf7"
+  version "1.8.1"
+  sha256 "a0ae1c48c4acf336a3b5b2b71a75cf4c99e40bf65432b29d2c3671755ebd561f"
 
   url "https://zipic.5km.tech/Zipic%20#{version}.dmg"
   name "Zipic"
@@ -13,7 +13,7 @@ cask "zipic" do
   end
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :ventura"
 
   app "Zipic.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`zipic` is autobumped but the workflow failed to update to 1.8.1 because `brew audit` failed with an "Upstream defined :ventura as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :monterey" error. This updates the version and modifies the `depends_on macos:` value accordingly.