### PR TITLE
Update espanso to 2.2.5

### DIFF
--- a/Casks/e/espanso.rb
+++ b/Casks/e/espanso.rb
@@ -1,25 +1,16 @@
 cask "espanso" do
-  arch arm: "M1", intel: "Intel"
+  version "2.2.5"
+  sha256 "96906a2987d77d5ce875078a307da7826626088b5c44741de1b99bc988753547"
 
-  version "2.2.1"
-  sha256 arm:   "419687d4d954630c8690e315eb7830b28f03b95521d720fc2bd960e084d49993",
-         intel: "369ad7eb9a30015a3836012970acd15b3b06c6f67349a89ced6bb3ae9c3f2d20"
-
-  url "https://github.com/espanso/espanso/releases/download/v#{version}/Espanso-Mac-#{arch}.zip",
+  url "https://github.com/espanso/espanso/releases/download/v#{version}/Espanso-Mac-Universal.zip",
       verified: "github.com/espanso/espanso/"
   name "Espanso"
   desc "Cross-platform Text Expander written in Rust"
   homepage "https://espanso.org/"
 
-  # Upstream may not mark unstable releases like `1.2.3-beta` as pre-release
-  # on GitHub, so they can end up as the "latest" release. They also tag
-  # versions that may not end up with a release and some releases use a stable
-  # version format but are marked as pre-release, so we can't rely on Git tags.
-  # This checks the first-party website's Installation page, which links to
-  # release files on GitHub.
   livecheck do
-    url "https://espanso.org/install/"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/Espanso-Mac-#{arch}\.zip}i)
+    url :url
+    strategy :github_latest
   end
 
   app "Espanso.app"


### PR DESCRIPTION
Also remove livecheck using espanso website, GitHub latest stable release already match with the upgraded version so we can check against that now

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
