### PR TITLE
agentkube bump release 0.0.6

### DIFF
--- a/Casks/a/agentkube.rb
+++ b/Casks/a/agentkube.rb
@@ -11,6 +11,8 @@ cask "agentkube" do
   desc "AI-powered Kubernetes IDE"
   homepage "https://agentkube.com/"
 
+  # The upstream repository contains an old, one-off tag (1.0.4) that is
+  # higher than current versions, so we check the "latest" release instead.
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/a/agentkube.rb
+++ b/Casks/a/agentkube.rb
@@ -1,15 +1,20 @@
 cask "agentkube" do
   arch arm: "aarch64", intel: "x64"
 
-  version "1.0.4"
-  sha256 arm:   "8afb8b9aa6fa9d13cc7e8018c0ff836600f5b08e57fc50305a592ffc63098373",
-         intel: "8bd840ccfaaf884517bdf6c40b49bfd9263f5025d40787a3e78975607e2a2fd5"
+  version "0.0.6"
+  sha256 arm:   "b26159149837a0236e0951c28bebb1fd38fdd80c7540eea62b7b0401616a5527",
+         intel: "9fec8e8854b9512c9af621f6ccf858ad05da993bb5eac725414be5c7ed958fb8"
 
   url "https://github.com/agentkube/agentkube/releases/download/v#{version}/agentkube_#{version}_#{arch}-apple-darwin.tar.gz",
       verified: "github.com/agentkube/agentkube/"
   name "Agentkube"
   desc "AI-powered Kubernetes IDE"
   homepage "https://agentkube.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   auto_updates true
 


### PR DESCRIPTION
Agentkube udpate release `v0.0.6`

- **Homepage**: https://agentkube.com/
- **Repository**: https://github.com/agentkube/agentkube
- **Platform**: Macos only

---

**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

*In the following questions `<cask>` is the token of the cask you're submitting.*

After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+agentkube&type=pullrequests).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.