### PR TITLE
Remove `auto_updates` block for `mullvad-vpn` cask

### DIFF
--- a/Casks/m/mullvad-vpn.rb
+++ b/Casks/m/mullvad-vpn.rb
@@ -17,7 +17,6 @@ cask "mullvad-vpn" do
     end
   end
 
-  auto_updates true
   conflicts_with cask: "mullvad-vpn@beta"
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
Per [documentation here](https://docs.brew.sh/Cask-Cookbook#page), `auto_updates` should only be `true` if the cask artifact auto-updates without user intervention, not just links to a webpage. This cask does not fit this definition, so we should remove `auto_updates`. 

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

