### PR TITLE
dropdmg: update sha256

### DIFF
--- a/Casks/d/dropdmg.rb
+++ b/Casks/d/dropdmg.rb
@@ -1,6 +1,6 @@
 cask "dropdmg" do
   version "3.7"
-  sha256 "63568b7194334d05052ca1ac94c2d26e9f00d6b51a0d39213f484352a4c6d233"
+  sha256 "73e1fac3314297903a623c34fc9968a902d074eaacdddc3428d3193c1c2e7dbd"
 
   url "https://c-command.com/downloads/DropDMG-#{version}.dmg"
   name "DropDMG"


### PR DESCRIPTION
Update DropDMG 3.7 hash to match the current 3606018.5.5 version as shown at https://c-command.com/downloads/.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
