### PR TITLE
midi-router-client: add livecheck

### DIFF
--- a/Casks/m/midi-router-client.rb
+++ b/Casks/m/midi-router-client.rb
@@ -7,6 +7,11 @@ cask "midi-router-client" do
   desc "Create routes from anywhere to anywhere"
   homepage "https://sourceforge.net/projects/midi-router-client/"
 
+  livecheck do
+    url :url
+    regex(%r{url=.*?/midi-router-client[._-]v?(\d+(?:\.\d+)+)[._-]Darwin\.(?:dmg|zip)}i)
+  end
+
   depends_on macos: ">= :tahoe"
 
   app "midi-router-client.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck uses the `Sourceforge` strategy for `midi-router-client` but it's returning 2.4.0 as newest (from the midi-router-client-2.4.0-Linux.deb file). The only 2.4.0 file at the moment is the aforementioned deb file and the newest version for macOS is 2.3.3. This addresses the issue by adding a `livecheck` block with a regex to restrict matching to only the macOS files.