### PR TITLE
workflows: remove `test-bot` Action inputs

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           core: false
           cask: true
-          test-bot: false
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@main

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - name: Cache Homebrew Gems
         id: cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           core: false
           cask: true
-          test-bot: false
 
       - name: Check out Pull Request
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -88,7 +87,6 @@ jobs:
         with:
           core: true
           cask: true
-          test-bot: true
 
       - name: Enable debug mode
         run: |

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           core: false
           cask: true
-          test-bot: false
 
       - name: Configure Git user
         id: git-user-config

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           core: false
           cask: true
-          test-bot: false
 
       - run: brew install coreutils
 
@@ -73,7 +72,6 @@ jobs:
         with:
           core: false
           cask: true
-          test-bot: false
 
       - name: Check cask source is not archived.
         id: archived


### PR DESCRIPTION
`test-bot` has been merged into Homebrew/brew, so these are no longer necessary and output a warning in CI.