### PR TITLE
quo 4.1.12

### DIFF
--- a/Casks/q/quo.rb
+++ b/Casks/q/quo.rb
@@ -1,18 +1,18 @@
-cask "openphone" do
-  version "4.1.10"
-  sha256 "af3b18d6ab98151c02d67a1066c71d88782dd68c660e256c867e5a51b6e9530e"
+cask "quo" do
+  version "4.1.12"
+  sha256 "c2938c18cd29259121d8cd3d9aa522c609727cd0a17fa627796798cd43fb3211"
 
-  url "https://download.openphone.co/OpenPhone-#{version}-universal.dmg"
-  name "OpenPhone"
+  url "https://download.quo.com/Quo-#{version}-universal.dmg"
+  name "Quo"
   desc "Business phone for professionals, teams, and companies"
-  homepage "https://www.openphone.co/"
+  homepage "https://www.quo.com/"
 
   livecheck do
     url "https://s3-us-west-2.amazonaws.com/download.openphone.co/latest-mac.yml"
     strategy :electron_builder
   end
 
-  app "OpenPhone.app"
+  app "Quo.app"
 
   zap trash: [
     "~/Library/Application Support/OpenPhone",

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -136,6 +136,7 @@
   "ollama": "ollama-app",
   "opal": "opal-composer",
   "openmsx": "openmsx-emulator",
+  "openphone": "quo",
   "openra-playtest": "openra@playtest",
   "opensc": "opensc-app",
   "opera-developer": "opera@developer",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`openphone` is autobumped but the workflow failed to update to 4.1.12 because the app has been renamed to Quo, so the file name changed as well. This updates and renames the cask accordingly. For what it's worth, the appcast URL remains the same in the Quo app (and updating the domain in the path didn't work), so we will have to update it if/when it changes in the future.