### PR TITLE
publii 0.47.0

### DIFF
--- a/Casks/p/publii.rb
+++ b/Casks/p/publii.rb
@@ -1,7 +1,7 @@
 cask "publii" do
-  arch arm: "apple-silicon", intel: "intel"
+  arch arm: "arm64", intel: "intel"
 
-  version "0.46.5,17089"
+  version "0.47.0,17290"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://getpublii.com/download/Publii-#{version.csv.first}-#{arch}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`publii` is autobumped but the workflow failed to update to 0.47.0 because the architecture suffix for the ARM dmg has changed to `-arm64`, so livecheck was mixing the build number for 0.47.0 with the version for 0.46.0 (due to how the regex matches). This updates the version and ARM `arch` value accordingly.