### PR TITLE
nvidia-geforce-now: update zap

### DIFF
--- a/Casks/n/nvidia-geforce-now.rb
+++ b/Casks/n/nvidia-geforce-now.rb
@@ -19,13 +19,15 @@ cask "nvidia-geforce-now" do
   app "GeForceNOW.app"
 
   zap trash: [
-    "~/Library/Application Support/NVIDIA Corporation/MessageBus_GFN_session*.conf",
-    "~/Library/Application Support/NVIDIA/GeForceNOW",
-    "~/Library/Caches/com.apple.nsurlsessiond/Downloads/com.nvidia.gfnpc.mall",
-    "~/Library/Caches/NVIDIA/GeForceNOW",
-    "~/Library/HTTPStorages/com.nvidia.gfnpc.mall",
-    "~/Library/Preferences/com.nvidia.gfnpc.mall.helper.plist",
-    "~/Library/Preferences/com.nvidia.gfnpc.mall.helper.renderer.plist",
-    "~/Library/Saved Application State/com.nvidia.gfnpc.mall.savedState",
-  ]
+        "~/Library/Application Support/NVIDIA Corporation/MessageBus_GFN_session*.conf",
+        "~/Library/Application Support/NVIDIA/GeForceNOW",
+        "~/Library/Caches/com.apple.nsurlsessiond/Downloads/com.nvidia.gfnpc.mall",
+        "~/Library/Caches/com.nvidia.nvcontainer",
+        "~/Library/Caches/NVIDIA/GeForceNOW",
+        "~/Library/HTTPStorages/com.nvidia.gfnpc.mall",
+        "~/Library/Preferences/com.nvidia.gfnpc.mall.helper.plist",
+        "~/Library/Preferences/com.nvidia.gfnpc.mall.helper.renderer.plist",
+        "~/Library/Saved Application State/com.nvidia.gfnpc.mall.savedState",
+      ],
+      rmdir: "~/Movies/NVIDIA"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
I found running the GeForce NOW app creates the directory `~/Movies/NVIDIA/GeForce NOW`, which should ideally get cleaned up during zap