### PR TITLE
silo: update livecheck

### DIFF
--- a/Casks/s/silo.rb
+++ b/Casks/s/silo.rb
@@ -1,15 +1,18 @@
 cask "silo" do
-  version "2025.2"
+  version "2025.2.0"
   sha256 "3751133586904f76840ee40778792d43c954e039ab6f346ce54093a1eca67cdb"
 
-  url "https://nevercenter.com/silo/download/filearchive/Install_Silo_#{version.major}_#{version.minor}_#{version.patch.presence || "0"}_mac.dmg"
+  url "https://nevercenter.com/silo/download/filearchive/Install_Silo_#{version.dots_to_underscores}_mac.dmg"
   name "Silo"
   desc "3D polygonal modeller and UV mapper"
   homepage "https://nevercenter.com/silo/"
 
   livecheck do
-    url "https://nevercenter.com/silo/download/"
-    regex(/Silo\s+v?(\d+(?:\.\d+)+)/i)
+    url "https://nevercenter.com/silo/download/?filetype=silomac"
+    regex(/href=.*?Install[._-]Silo[._-]v?(\d+(?:[._]\d+)+)(?:[._-]mac)?\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
   end
 
   app "Silo.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `silo` checks the download page and matches versions from text like "Silo v2025.2" or "Silo 2025.2.0". However, this regex is loose/open-ended, so it matches both PC and Mac versions and this is currently causing livecheck to surface a higher PC-only version as newest (i.e., the newest version links are "Silo 2025.2.1 [PC]" and "Silo 2025.2.0 [Mac]"). This addresses the issue by updating the `livecheck` block to check the download page for the latest Mac version and match the version from the dmg link on that page (the main download page doesn't contain a dmg link).

In the process, this also addresses the issue where livecheck could surface a version without a `0` patch number (e.g., 2025.2 instead of 2025.2.0). With this new setup, if the version in the file name contains a `0` patch, the livecheck version will follow suit. Importantly, if the file name doesn't contain a patch version, livecheck will respect this as well (the existing logic in the cask `url` would fail to produce an accurate URL in that situation).