### PR TITLE
krita 5.2.13

### DIFF
--- a/Casks/k/krita.rb
+++ b/Casks/k/krita.rb
@@ -1,8 +1,8 @@
 cask "krita" do
-  version "5.2.11"
-  sha256 "c38443656c017e299264473c9d11f4f92aca63b1475bda325a0a0f969973a147"
+  version "5.2.13"
+  sha256 "17ccfbf2b72fcca314ce59c6d6f0b62dda1dc230ece71aa42f56031ef75ea6e8"
 
-  url "https://download.kde.org/stable/krita/#{version}/krita-#{version}.dmg",
+  url "https://download.kde.org/stable/krita/#{version}/krita-#{version}_signed.dmg",
       verified: "download.kde.org/stable/krita/"
   name "Krita"
   desc "Free and open-source painting and sketching program"
@@ -10,7 +10,7 @@ cask "krita" do
 
   livecheck do
     url "https://krita.org/en/download/"
-    regex(/href=.*?krita[._-]v?(\d+(?:\.\d+)+)(?:-signed|-release)?\.dmg/i)
+    regex(/href=.*?krita[._-]v?(\d+(?:\.\d+)+)(?:[._-]signed|[._-]release)?\.dmg/i)
   end
 
   app "krita.app"


### PR DESCRIPTION
[x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
[x] brew audit --cask --online <cask> is error-free.
[x] brew style --fix <cask> reports no offenses.

Update Krita to version 5.2.13.

Release notes: https://krita.org/en/krita-5-2-13-released/