### PR TITLE
opendeck: add 2.6.0 (new cask)

### DIFF
--- a/Casks/o/opendeck.rb
+++ b/Casks/o/opendeck.rb
@@ -1,0 +1,21 @@
+cask "opendeck" do
+  version "2.6.0"
+
+  arch arm: "aarch64", intel: "x64"
+
+  sha256 arm:   "b72353667ba7696557b61c83b20b9c157bdcb300fa71cc7a0448426f032924f5",
+         intel: "efdf914330c3b54bfadd347879fc876cf7fd1c620d93cf723cb848505b978edd"
+
+  url "https://github.com/nekename/OpenDeck/releases/download/v#{version}/OpenDeck_#{version}_#{arch}.dmg"
+  name "OpenDeck"
+  desc "Stream controller utility supporting Elgato Stream Deck plugins"
+  homepage "https://github.com/nekename/OpenDeck"
+
+  app "OpenDeck.app"
+
+  zap trash: [
+    "~/Library/Application Support/opendeck",
+    "~/Library/Logs/opendeck",
+    "~/Library/Preferences/opendeck.plist",
+  ]
+end

--- a/Casks/o/opendeck.rb
+++ b/Casks/o/opendeck.rb
@@ -1,12 +1,10 @@
 cask "opendeck" do
   version "2.6.0"
-
   arch arm: "aarch64", intel: "x64"
-
   sha256 arm:   "b72353667ba7696557b61c83b20b9c157bdcb300fa71cc7a0448426f032924f5",
          intel: "efdf914330c3b54bfadd347879fc876cf7fd1c620d93cf723cb848505b978edd"
-
-  url "https://github.com/nekename/OpenDeck/releases/download/v#{version}/OpenDeck_#{version}_#{arch}.dmg"
+  url "https://github.com/nekename/OpenDeck/releases/download/v#{version}/OpenDeck_#{version}_#{arch}.dmg",
+      verified: "github.com/nekename/OpenDeck/"
   name "OpenDeck"
   desc "Stream controller utility supporting Elgato Stream Deck plugins"
   homepage "https://github.com/nekename/OpenDeck"


### PR DESCRIPTION
_In the following questions `opendeck` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online opendeck` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new opendeck` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask opendeck` worked successfully.
- [x] `brew uninstall --cask opendeck` worked successfully.

---
