### PR TITLE
Add img2jpg optimizer

### DIFF
--- a/Casks/i/img2jpg-optimizer.rb
+++ b/Casks/i/img2jpg-optimizer.rb
@@ -3,7 +3,7 @@ cask "img2jpg-optimizer" do
   sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
 
   url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
-  name "IMG2JPG Optimizer"
+  name "IMG2JPG-Optimizer"
   desc "Optimiseur JPEG/PNG basé sur MozJPEG (progressif, Huffman optimisé)"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 

--- a/Casks/i/img2jpg-optimizer.rb
+++ b/Casks/i/img2jpg-optimizer.rb
@@ -1,0 +1,19 @@
+cask "img2jpg-optimizer" do
+  version "1.0.0"
+  sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
+
+  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
+  name "IMG2JPG Optimizer"
+  desc "Optimiseur JPEG/PNG basé sur MozJPEG (progressif, Huffman optimisé)"
+  homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
+
+  depends_on arch: :arm64
+  depends_on macos: ">= :monterey"
+
+  app "IMG2JPG-Optimizer.app"
+
+  zap trash: [
+    "~/Library/Preferences/org.guy.IMG2JPG-Optimizer.plist",
+    "~/Library/Saved Application State/org.guy.IMG2JPG-Optimizer.savedState",
+  ]
+end

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -2,19 +2,10 @@ cask "img2jpg-optimizer" do
   version "1.0.0"
   sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
 
-  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
+  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v1.0.0/IMG2JPG-Optimizer-final.dmg"
   name "IMG2JPG Optimizer"
-  desc "Optimiseur d’images MozJPEG (progressif + Huffman optimisé)"
+  desc "Optimiseur d’images MozJPEG (JPEG progressif + Huffman) pour macOS Apple Silicon"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 
-  depends_on arch: :arm64
-  depends_on macos: ">= :monterey"
-
   app "IMG2JPG-Optimizer.app"
-
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/IMG2JPG-Optimizer.app"],
-                   sudo: false
-  end
 end

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -4,7 +4,7 @@ cask "img2jpg-optimizer" do
 
   url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
   name "IMG2JPG Optimizer"
-  desc "Optimiseur d’images MozJPEG (JPEG progressif, Huffman optimisé) pour macOS Apple Silicon"
+  desc "Optimiseur d’images MozJPEG (progressif + Huffman optimisé)"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 
   depends_on arch: :arm64

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -5,7 +5,7 @@ cask "img2jpg-optimizer" do
   url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg",
       verified: "github.com/chupchupchup/IMG2JPG-Optimizer/"
   name "IMG2JPG Optimizer"
-  desc "MozJPEG-based JPEG optimizer for macOS (progressive + optimized Huffman)"
+  desc "MozJPEG-based JPEG optimizer (progressive + optimized Huffman)"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 
   depends_on arch: :arm64

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -1,10 +1,11 @@
 cask "img2jpg-optimizer" do
   version "1.0.0"
-  sha256 "0351516d75fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
+  sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
 
-  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
+  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg",
+      verified: "github.com/chupchupchup/IMG2JPG-Optimizer/"
   name "IMG2JPG Optimizer"
-  desc "Optimiseur d’images MozJPEG (progressif, Huffman optimisé) pour macOS Apple Silicon"
+  desc "MozJPEG-based JPEG optimizer for macOS (progressive + optimized Huffman)"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 
   depends_on arch: :arm64
@@ -16,10 +17,4 @@ cask "img2jpg-optimizer" do
     "~/Library/Preferences/org.guy.IMG2JPG-Optimizer.plist",
     "~/Library/Saved Application State/org.guy.IMG2JPG-Optimizer.savedState",
   ]
-
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/IMG2JPG-Optimizer.app"],
-                   sudo: false
-  end
 end

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -1,11 +1,10 @@
 cask "img2jpg-optimizer" do
   version "1.0.0"
-  sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
+  sha256 "REPLACE_WITH_ACTUAL_SHA"
 
-  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg",
-      verified: "github.com/chupchupchup/IMG2JPG-Optimizer/"
-  name "IMG2JPG Optimizer"
-  desc "MozJPEG-based JPEG optimizer (progressive + optimized Huffman)"
+  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
+  name "IMG2JPG-Optimizer"
+  desc "Optimiseur JPEG/PNG basé sur MozJPEG (progressif, Huffman optimisé)"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 
   depends_on arch: :arm64

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -1,0 +1,20 @@
+cask "img2jpg-optimizer" do
+  version "1.0.0"
+  sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
+
+  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
+  name "IMG2JPG Optimizer"
+  desc "Optimiseur d’images MozJPEG (JPEG progressif, Huffman optimisé) pour macOS Apple Silicon"
+  homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
+
+  depends_on arch: :arm64
+  depends_on macos: ">= :monterey"
+
+  app "IMG2JPG-Optimizer.app"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/IMG2JPG-Optimizer.app"],
+                   sudo: false
+  end
+end

--- a/Casks/img2jpg-optimizer.rb
+++ b/Casks/img2jpg-optimizer.rb
@@ -1,11 +1,25 @@
 cask "img2jpg-optimizer" do
   version "1.0.0"
-  sha256 "035151d675fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
+  sha256 "0351516d75fb27b49d6e46ec5df63c3454ed1f09f4637bccb8924af20224d9e5"
 
-  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v1.0.0/IMG2JPG-Optimizer-final.dmg"
+  url "https://github.com/chupchupchup/IMG2JPG-Optimizer/releases/download/v#{version}/IMG2JPG-Optimizer-final.dmg"
   name "IMG2JPG Optimizer"
-  desc "Optimiseur d’images MozJPEG (JPEG progressif + Huffman) pour macOS Apple Silicon"
+  desc "Optimiseur d’images MozJPEG (progressif, Huffman optimisé) pour macOS Apple Silicon"
   homepage "https://github.com/chupchupchup/IMG2JPG-Optimizer"
 
+  depends_on arch: :arm64
+  depends_on macos: ">= :monterey"
+
   app "IMG2JPG-Optimizer.app"
+
+  zap trash: [
+    "~/Library/Preferences/org.guy.IMG2JPG-Optimizer.plist",
+    "~/Library/Saved Application State/org.guy.IMG2JPG-Optimizer.savedState",
+  ]
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/IMG2JPG-Optimizer.app"],
+                   sudo: false
+  end
 end


### PR DESCRIPTION
Add cask for IMG2JPG Optimizer.
- Optimizes JPEG/PNG images using MozJPEG.
- Universal app for Apple Silicon.
- No extra dependencies required.