### PR TITLE
typeface 4.2.1

### DIFF
--- a/Casks/t/typeface.rb
+++ b/Casks/t/typeface.rb
@@ -1,6 +1,6 @@
 cask "typeface" do
-  version "4.2.0,4734"
-  sha256 "e0927f47e3d49b24d23eb9c835f9da37fadeb347025971c18d04a6e7d2de05b3"
+  version "4.2.1,4761"
+  sha256 "53861ccd67bb195deb6a1ea798fa528fc6ec06a654845f9cf61dd610a86a6822"
 
   url "https://dcdn.typefaceapp.com/Typeface-#{version.csv.first}-#{version.csv.second}/Typeface-#{version.csv.first}-#{version.csv.second}.dmg"
   name "Typeface"
@@ -13,6 +13,7 @@ cask "typeface" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Typeface.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`typeface` is autobumped but the workflow failed to update to 4.2.1 because brew audit failed with an "Upstream defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds a `depends_on macos:` value to resolve the audit error.