### PR TITLE
[FIX] Revert "owncloud 6.0.0.17092"

### DIFF
--- a/Casks/o/owncloud.rb
+++ b/Casks/o/owncloud.rb
@@ -1,9 +1,9 @@
 cask "owncloud" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "6.0.0.17092"
-  sha256 arm:   "cf20f91d3569647b30f4c4add58815c7b1de5bcc35852fc7244f784419023151",
-         intel: "d3d4bb4af65f42ac1cdb73a65159c70bdd572d1d5f41d84f7cd9a5242fe173c9"
+  version "5.3.2.15463"
+  sha256 arm:   "83a494e0187e25d6a766057dc22494b2683126ee665c08062520f448012b0569",
+         intel: "8b33726d338091f99ea980ccb02e050e80989058df8ff8b680acc5436fe856fe"
 
   url "https://download.owncloud.com/desktop/ownCloud/stable/#{version}/mac/ownCloud-#{version}-#{arch}.pkg"
   name "ownCloud"


### PR DESCRIPTION
Hi all, I wasn't sure about procedure here - sorry if this is not the proper way.

This PR reverts commit ee36aeec855fef66ff5204b05adf6ef96fe7ce37, which updated the `owncloud` cask to v6.0.0. This version contains a major issue (see https://github.com/owncloud/client/issues/12333), which is most likely the reason they removed it from their download page (https://owncloud.com/desktop-app/). 

To spare others the same fate, I thought you might rollback this version on Homebrew too.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
