### PR TITLE
opera@beta 123.0.5669.3

### DIFF
--- a/Casks/o/opera@beta.rb
+++ b/Casks/o/opera@beta.rb
@@ -1,6 +1,6 @@
 cask "opera@beta" do
-  version "122.0.5643.59"
-  sha256 "4fae80bf76c2f80946d45316d21a7c4b9ab0b5d8d8276540092a5cdf50db9aab"
+  version "123.0.5669.3"
+  sha256 "addda587168ff6dbf392533cedff583cab0698cd0655bd2690d479de839c895c"
 
   url "https://get.geo.opera.com/pub/opera-beta/#{version}/mac/Opera_beta_#{version}_Setup.dmg"
   name "Opera Beta"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
`brew audit --cask --online opera@beta` returned:
```
* Artifact defined :big_sur as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :monterey
```

Opera mistakenly left `LSMinimumSystemVersion` set to `11.0` in their `info.plist`. [Per their blog post](https://blogs.opera.com/desktop/2025/10/opera-123-beta/#:~:text=This%20update%20also%20includes%20an%20upgrade%20to%20Chromium%20139.0.7258.156), this version is based on Chr 139, so it **will not run** on macOS 11; this is a false positive caused by Opera's oversight.