### PR TITLE
tap_migrations: remove stale Hashicorp migrations

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -30,7 +30,6 @@
   "nmap": "homebrew/core",
   "node": "homebrew/core",
   "otto": "homebrew/core",
-  "packer": "homebrew/core",
   "pandoc": "homebrew/core",
   "pgloader": "homebrew/core",
   "pgweb": "homebrew/core",
@@ -47,7 +46,6 @@
   "sslmate": "homebrew/core",
   "swi-prolog": "homebrew/core",
   "terraform": "homebrew/core",
-  "vault": "homebrew/core",
   "vfuse": "homebrew/core",
   "volatility": "homebrew/core"
 }


### PR DESCRIPTION
These formula were removed in https://github.com/Homebrew/homebrew-core/pull/246011.