### PR TITLE
markedit 1.27.0

### DIFF
--- a/Casks/m/markedit.rb
+++ b/Casks/m/markedit.rb
@@ -1,6 +1,6 @@
 cask "markedit" do
-  version "1.26.2"
-  sha256 "4ec499ce2d423dd46c412b222f0515f65fc57b2fdc15096e46155c60a7e25faa"
+  version "1.27.0"
+  sha256 "4c3027d5a2816552e32b4dccf16d100c4ee9ba0665cd3080c6c06ae707b157a7"
 
   url "https://github.com/MarkEdit-app/MarkEdit/releases/download/v#{version}/MarkEdit-#{version}.dmg"
   name "MarkEdit"
@@ -12,7 +12,7 @@ cask "markedit" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: ">= :sequoia"
 
   app "MarkEdit.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`markedit` is autobumped but the workflow failed to update to version 1.27.0 because `brew audit` failed with an "Artifact defined :sequoia as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :sonoma" error. This updates the version and `depends_on macos:` value accordingly.