### PR TITLE
claude-code: docs - fix config caveat

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -36,7 +36,7 @@ cask "claude-code" do
     Claude Code's auto-updater installs updates to `~/.local/bin/claude` and
     not to Homebrew's location. It is recommended to disable the auto-updater
     with either `DISABLE_AUTOUPDATER=1` or
-    `claude config set -g autoUpdates false` and use
+    `claude config set autoUpdates false` and use
     `brew upgrade --cask #{token}`.
   EOS
 end


### PR DESCRIPTION
This is a documentation change to `claude code`.

After making any changes to a cask, existing or new, verify:

- [x] The submission is a documentation fix for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) .
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---

Fixes #230561
