### PR TITLE
atuin-desktop 0.1.3 (new cask)

### DIFF
--- a/Casks/a/atuin-desktop.rb
+++ b/Casks/a/atuin-desktop.rb
@@ -1,0 +1,20 @@
+cask "atuin-desktop" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.1.3"
+  sha256 arm:   "f0af64dfc2a02f3f04956d1325101edc63595943607d3d3011cac68f56d58e32",
+         intel: "c175d57ce5b819f6039ed375b7445d69a95813ab0d08034f64f7cc6b3ad832d6"
+
+  url "https://github.com/atuinsh/desktop/releases/download/v#{version}/Atuin_#{version}_#{arch}.dmg",
+      verified: "github.com/atuinsh/desktop/"
+  name "Atuin Desktop"
+  desc "Runbook editor for terminal workflows"
+  homepage "https://atuin.sh/"
+
+  app "Atuin.app"
+
+  zap trash: [
+    "~/Library/Caches/sh.atuin.app",
+    "~/Library/Preferences/sh.atuin.app.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

`brew audit --cask --new atuin-desktop` fails with `cask token mentions desktop`, but the `-desktop` suffix is to differentiate the cask from the [`atuin`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/a/atuin.rb) cli, similar to [`docker`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/d/docker.rb)/[`docker-desktop`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/d/docker-desktop.rb).