### PR TITLE
meru 3.10.1

### DIFF
--- a/Casks/m/meru.rb
+++ b/Casks/m/meru.rb
@@ -1,9 +1,9 @@
 cask "meru" do
   arch arm: "-arm64"
 
-  version "3.10.0"
-  sha256 arm:   "30d394f6906d0c2aa16e81cd51b550164118193c3e58d1140456463b6683090a",
-         intel: "6ac7794173b5a0160bf90c8a7dab8a11f0a60ffa42b40467e63dc6a8a336484a"
+  version "3.10.1"
+  sha256 arm:   "25deec07b795ef5c5cf2dad1d5d074d0dffe25e31394fc40f10f22fdfe88341e",
+         intel: "3d789aed07ec3f90c94621994f5f1da56254e09b8f85fbb98de2dc8031f95d05"
 
   url "https://github.com/zoidsh/meru/releases/download/v#{version}/Meru-#{version}#{arch}.dmg",
       verified: "github.com/zoidsh/meru/"
@@ -11,7 +11,7 @@ cask "meru" do
   desc "Gmail desktop app"
   homepage "https://meru.so/"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Meru.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`meru` is autobumped but the workflow failed to update to 3.10.1 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and `depends_on macos:` value accordingly.