### PR TITLE
toinane-colorpicker 2.3.0

### DIFF
--- a/Casks/t/toinane-colorpicker.rb
+++ b/Casks/t/toinane-colorpicker.rb
@@ -1,17 +1,19 @@
 cask "toinane-colorpicker" do
-  arch arm: "arm64", intel: "x64"
+  arch arm: "-arm64"
 
-  version "2.2.2"
-  sha256 arm:   "59e0df7270d53902e0971a2f70c7cce6c646a0f58634ac8d7418dcc72a526d82",
-         intel: "dc1af14fe9785a3e5906153aec20f2960266628b0428d9ca98ef4944dc4bef9b"
+  version "2.3.0"
+  sha256 arm:   "98bc5be6e0d1c6193fab7f7b021635d8f35eab32bf5baabd33f599e41b79f3e8",
+         intel: "1ad3018a9006e55fcf90cd90af0c0ec88d593df99ccf5636dee6cf1eea9d7a0a"
 
-  url "https://github.com/toinane/colorpicker/releases/download/#{version}/Colorpicker-#{version}-#{arch}.dmg",
+  url "https://github.com/toinane/colorpicker/releases/download/#{version}/Colorpicker-#{version}#{arch}.dmg",
       verified: "github.com/toinane/colorpicker/"
   name "Colorpicker"
   desc "Get and save colour codes"
   homepage "https://colorpicker.fr/"
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :monterey"
 
   app "Colorpicker.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`toinane-colorpicker` is autobumped but the workflow failed to update to version 2.3.0 because the Intel dmg file name doesn't use an `-x64` suffix in this release. `brew audit` also fails with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the cask accordingly.