### PR TITLE
archiver-app: update livecheck

### DIFF
--- a/Casks/a/archiver-app.rb
+++ b/Casks/a/archiver-app.rb
@@ -9,7 +9,7 @@ cask "archiver-app" do
   homepage "https://archiverapp.com/"
 
   livecheck do
-    url "https://api.incrediblebee.com/appcasts/archiver-#{version.major}.xml"
+    url "https://api.incrediblebee.com/updates?app=Archiver&locale=en-US&mode=sparkle&short_version=#{version}"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `archiver-app` is giving an `Unable to get versions` error, as the URL now returns a 404 (Not Found) response. This updates the `livecheck` block to use the URL that the app is checking, with only the necessary query string parameters to produce the Sparkle output (i.e., omitting `format=php` and `version=43100` parameters).

For what it's worth, the app checks incrediblebee.com/updates.php and that redirects to the API URL. I've opted to use the API URL for now, to align with the existing `livecheck` block URL and avoid the redirection. However, one benefit of minimizing the query string parameters in this case is that we're only using the parameters that exist in both the original and redirected URLs, so we can easily update the `livecheck` block URL to use the original domain instead of the API subdomain if needed in the future.