### PR TITLE
epic 140.0.7339.133

### DIFF
--- a/Casks/e/epic.rb
+++ b/Casks/e/epic.rb
@@ -1,19 +1,34 @@
 cask "epic" do
-  arch arm: "arm"
+  arch arm: "arm", intel: "intel"
 
-  version "138.0.7204.50"
-  sha256 arm:   "8a9f8b892de4b49ff7e3d3b1712b231dbc45ff8b90a645d60213e62942185b3b",
-         intel: "b982ada33880e55010779f5f03dc8c4d0d661448767cc50d093ef5dee09a48fb"
+  on_arm do
+    version "140.0.7339.133,139"
+    sha256 "4eb9346a5509bfba0cb94e6a72747afe98d90852f48d2dc4abb3a1120a09393a"
+  end
+  on_intel do
+    version "138.0.7204.50,139"
+    sha256 "b982ada33880e55010779f5f03dc8c4d0d661448767cc50d093ef5dee09a48fb"
+  end
 
-  url "https://cdn.epicbrowser.com/mac#{version.major}#{arch}/epic_#{version}.dmg"
+  url "https://cdn.epicbrowser.com/mac#{version.csv.second || version.major}#{arch}/epic_#{version.csv.first}.dmg"
   name "Epic Privacy Browser"
   desc "Private, secure web browser"
   homepage "https://epicbrowser.com/"
 
   livecheck do
     url "https://epicbrowser.com/thank-you"
-    regex(%r{href=.*?/mac\d+#{arch}/epic[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    regex(%r{href=.*?/mac(\d+)#{arch}/epic[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        major = match[1].split(".").first
+        next match[1] if major == match[1]
+
+        (match[0] == major) ? match[1] : "#{match[1]},#{match[0]}"
+      end
+    end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "Epic.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`epic` is autobumped but the workflow failed to update to version 140.0.7339.133 because the URL doesn't conform to the expected format. The current URL path uses `mac139arm` and `mac139intel` directories, which doesn't correspond to the major version and also introduces an `intel` suffix for Intel files. Besides that, the Intel version has remained on version 138.0.7204.50.

This addresses these issues by splitting the versions based on arch, updating the `livecheck` block to append the directory version to the `version` when it differs from the major version, and updating the cask `url` to conditionally handle that situation. This also adds a `depends_on macos:` value to address a related `brew audit` error.