### PR TITLE
epson-print-layout: update livecheck

### DIFF
--- a/Casks/e/epson-print-layout.rb
+++ b/Casks/e/epson-print-layout.rb
@@ -13,7 +13,7 @@ cask "epson-print-layout" do
   # up to date, otherwise it could end up persistently returning an older
   # version as newest.
   livecheck do
-    url "https://epson.com/c/Epson-Print-Layout/s/SPT_PRINTLAYOUT?review-filter=macOS+14.x"
+    url "https://epson.com/c/Epson-Print-Layout/s/SPT_PRINTLAYOUT?review-filter=macOS+14.x+%28Sonoma%29"
     regex(/Epson(?:\s|&nbsp;)*Print(?:\s|&nbsp;)*Layout(?:\s|&nbsp;)*v?(\d+(?:\.\d+)+)/im)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

livecheck is returning an `Unable to get versions` error for `epson-print-layout`, as the page doesn't display any download information for the current `livecheck` block URL. The `review-filter` option values have changed, so the `macOS 14.x` value is no longer valid and we need to use `macOS 14.x (Sonoma)` instead.