### PR TITLE
fs-uae-emulator 3.2.35

### DIFF
--- a/Casks/f/fs-uae-emulator.rb
+++ b/Casks/f/fs-uae-emulator.rb
@@ -1,23 +1,24 @@
 cask "fs-uae-emulator" do
   arch arm: "ARM64", intel: "x86-64"
 
-  version "3.1.66"
-  sha256 arm:   "7dc51930740a0634505f18a076b78fdbe97de09eed6888a61c7dc2022e94643d",
-         intel: "c0c83858e80e3e150065e74669d1fefd4e9773c90b00b6bfbe9abd43a5b90840"
+  version "3.2.35"
+  sha256 arm:   "ef8115986c0ddb987dc024f159da59f788b96d20f7b77ca97b465a9f4492eff8",
+         intel: "f291c2c93f575115c4ffbc73be3144bbec88e39e590a1932e443e67eb735128f"
 
-  url "https://fs-uae.net/files/FS-UAE/Stable/#{version}/FS-UAE_#{version}_macOS_#{arch}.tar.xz"
+  url "https://github.com/FrodeSolheim/fs-uae/releases/download/v#{version}/FS-UAE_#{version}_macOS_#{arch}.dmg",
+      verified: "github.com/FrodeSolheim/fs-uae/"
   name "FS-UAE"
   desc "Amiga emulator"
   homepage "https://fs-uae.net/"
 
   livecheck do
-    url "https://fs-uae.net/builds/stable"
-    regex(/href=.*?FS[._-]UAE[._-](\d+(?:\.\d+)+)[._-]macOS[._-]/i)
+    url "https://fs-uae.net/download/macos/"
+    regex(/href=.*?FS[._-]UAE[._-](\d+(?:\.\d+)+)[._-]macOS[._-]#{arch}/i)
   end
 
   depends_on cask: "fs-uae-launcher"
 
-  app "FS-UAE/macOS/#{arch}/FS-UAE.app"
+  app "FS-UAE.app"
 
   zap trash: [
     "~/Library/Preferences/fs-uae",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`fs-uae-emulator` is autobumped but the workflow failed to update to version 3.2.35 because upstream has migrated their releases to GitHub, so the existing `livecheck` block now returns an `Unable to get versions` error. This updates the cask to use the current version (making adjustments as needed) and modifies the `livecheck` block to check the first-party download page (which links to the newest release files on GitHub).