### PR TITLE
fs-uae-launcher 3.2.35

### DIFF
--- a/Casks/f/fs-uae-launcher.rb
+++ b/Casks/f/fs-uae-launcher.rb
@@ -1,21 +1,22 @@
 cask "fs-uae-launcher" do
   arch arm: "ARM64", intel: "x86-64"
 
-  version "3.1.68"
-  sha256 arm:   "d53e40a26c22b86e3e495751144eb5c895da91953a0b84347fc98b31f2f597eb",
-         intel: "8aee4b56adb3faf669ffd59384f06bae2628667f51aed51e839f90189c874a54"
+  version "3.2.35"
+  sha256 arm:   "859a5889e82df6d59b3e23ea6f96313e3ab59ee4bedc9ee0ff9aa86a1113fa71",
+         intel: "d7d23200cdb1f568f97336d6b48f9ef6d3cf58a9e628b7feba5c4ff38cb08d39"
 
-  url "https://fs-uae.net/files/FS-UAE-Launcher/Stable/#{version}/FS-UAE-Launcher_#{version}_macOS_#{arch}.tar.xz"
+  url "https://github.com/FrodeSolheim/fs-uae-launcher/releases/download/v#{version}/FS-UAE-Launcher_#{version}_macOS_#{arch}.dmg",
+      verified: "github.com/FrodeSolheim/fs-uae-launcher/"
   name "FS-UAE Launcher"
   desc "Amiga emulator launcher"
   homepage "https://fs-uae.net/"
 
   livecheck do
-    url "https://fs-uae.net/builds/stable"
-    regex(/href=.*?FS[._-]UAE[._-]Launcher[._-](\d+(?:\.\d+)+)[._-]macOS[._-]/i)
+    url "https://fs-uae.net/download/macos/"
+    regex(/href=.*?FS[._-]UAE[._-]Launcher[._-](\d+(?:\.\d+)+)[._-]macOS[._-]#{arch}/i)
   end
 
-  app "FS-UAE-Launcher/macOS/#{arch}/FS-UAE Launcher.app"
+  app "FS-UAE Launcher.app"
 
   zap trash: [
     "~/Library/Preferences/fs-uae-launcher",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`fs-uae-launcher` is autobumped but the workflow failed to update to version 3.2.35 because upstream has migrated their releases to GitHub, so the existing `livecheck` block now returns an `Unable to get versions` error. This updates the cask to use the current version (making adjustments as needed) and modifies the `livecheck` block to check the first-party download page (which links to the newest release files on GitHub).