### PR TITLE
geoda 1.22.0.21

### DIFF
--- a/Casks/g/geoda.rb
+++ b/Casks/g/geoda.rb
@@ -1,11 +1,18 @@
 cask "geoda" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "1.22.0.20,1.22.0"
-  sha256 arm:   "0db259e253d18ef4fca65fdaa3c9ad3fa66e90f33b57e6ca6accf07c0abb235d",
-         intel: "08bd3333ac410a34f1f7089f669c8994236781579099be01945003e4d2bd3c5b"
+  version "1.22.0.21,1.22.0"
+  sha256 arm:   "bb7858799c66786812cab6002f59f2b107bc2a62d7d2e5d11fb984f3746138e6",
+         intel: "f42c4dca84071cd1141398e60d5651dbfed12f0a78b1238de9adaeb95b16cdce"
 
-  url "https://github.com/GeoDaCenter/geoda/releases/download/v#{version.csv.first}/GeoDa#{version.csv.second || version.csv.first}-#{arch}-Installer.dmg",
+  on_arm do
+    depends_on macos: ">= :sonoma"
+  end
+  on_intel do
+    depends_on macos: ">= :ventura"
+  end
+
+  url "https://github.com/GeoDaCenter/geoda/releases/download/v#{version.csv.first}/GeoDa-#{version.csv.second || version.csv.first}-#{arch}-MacOS.zip",
       verified: "github.com/GeoDaCenter/geoda/"
   name "GeoDa"
   desc "Spatial analysis, statistics, autocorrelation and regression"
@@ -15,7 +22,7 @@ cask "geoda" do
   # the `version` when necessary.
   livecheck do
     url :url
-    regex(%r{/v?(\d+(?:\.\d+)+)/GeoDav?(\d+(?:\.\d+)+)[._-]#{arch}[._-]Installer\.dmg$}i)
+    regex(%r{/v?(\d+(?:\.\d+)+)/GeoDa[._-]?v?(\d+(?:\.\d+)+)[._-]#{arch}[._-](?:Installer|MacOS)\.(?:dmg|zip)$}i)
     strategy :github_latest do |json, regex|
       json["assets"]&.map do |asset|
         match = asset["browser_download_url"]&.match(regex)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`geoda` is autobumped but the workflow failed to update to 1.22.0.21 because livecheck is returning an `Unable to get versions` error. The latest macOS files for the v1.22.0.21 release are now zip files and the file name format has changed, so the existing regex wasn't able to match. This updates the version and adjusts the `livecheck` block regex to handle both the previous and current file name formats.