### PR TITLE
kdenlive 25.08.1

### DIFF
--- a/Casks/k/kdenlive.rb
+++ b/Casks/k/kdenlive.rb
@@ -1,11 +1,11 @@
 cask "kdenlive" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "25.08.0"
-  sha256 arm:   "e10887fef445624757fbe4ca0ebb88da7bbbe0369e7db241aa2076406cec597a",
-         intel: "e26559d88d0a96471d4625fa41d9907fd779dabe5032caabde1ec42693428dea"
+  version "25.08.1,A"
+  sha256 arm:   "c2b8537bc1d44af9bc315182795e88cb240e5c3af56fbabc489fde939238f624",
+         intel: "3c0bf00b889574fecce6ad302e90ceb86f3da165b701e6ae5963fc0f877f63ec"
 
-  url "https://cdn.download.kde.org/stable/kdenlive/#{version.major_minor}/macOS/kdenlive-#{version}-#{arch}.dmg",
+  url "https://cdn.download.kde.org/stable/kdenlive/#{version.csv.first.major_minor}/macOS/kdenlive-#{version.csv.first}-#{arch}#{"_#{version.csv.second}" if version.csv.second}.dmg",
       verified: "cdn.download.kde.org/stable/kdenlive/"
   name "Kdenlive"
   desc "Free and Open Source Video Editor"
@@ -13,7 +13,10 @@ cask "kdenlive" do
 
   livecheck do
     url "https://kdenlive.org/download/"
-    regex(/href=.*?kdenlive[._-]v?(\d+(?:[.-]\d+)+)-#{arch}\.dmg/i)
+    regex(/href=.*?kdenlive[._-]v?(\d+(?:[.-]\d+)+)-#{arch}(?:[._-]([A-Z]?))?\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[1] ? "#{match[0]},#{match[1]}" : match[0] }
+    end
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kdenlive` is autobumped but the workflow failed to update to 25.08.1 because livecheck is returning an `Unable to get versions` error. The files for this release include a `_A` suffix at the end of the file name and the `livecheck` block regex doesn't account for this (as it diverges from the existing file name format). This updates the cask to be able to handle a suffix like this (whether it's a new format or a one-off), so we can update to 25.08.1.