### PR TITLE
msgfiler: downgrade to 4.2.0.41

### DIFF
--- a/Casks/m/msgfiler.rb
+++ b/Casks/m/msgfiler.rb
@@ -1,15 +1,21 @@
 cask "msgfiler" do
-  version "4.3.0.58,20251001,113245"
-  sha256 "800903b5a2b86f734e679e6a55d915abfe2d39ff599b37f0c2355cf87ff7e48c"
+  version "4.2.0.41,20250910,133221"
+  sha256 "edc967f6018212da25694daf45960e55a89f955d46fa06a6d5e47f3757cf5474"
 
   url "https://files.msgfiler.com/MsgFiler_#{version.csv.first}_#{version.csv.second}_#{version.csv.third}.dmg"
   name "MsgFiler"
   desc "Keyboard-based email filing application for Apple Mail"
   homepage "https://msgfiler.com/"
 
+  # The download page may link to an unstable version that uses the same file
+  # name format as the stable version, so we also check the inner text of the
+  # links to try to only match the stable version.
   livecheck do
     url "https://files.msgfiler.com/"
-    regex(/href=.*?MsgFiler[._-]v?(\d+(?:\.\d+)+)[._-](\d+)[._-](\d+)\.dmg/i)
+    regex(/
+      href=.*?MsgFiler[._-]v?(\d+(?:\.\d+)+)[._-](\d+)[._-](\d+)\.dmg[^>]*?>
+      \s*MsgFiler\s+v?\d+(?:\.\d+)+(?:\s+on\s+Gumroad)?\s*<
+    /imx)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The 4.3.0 version of `msgfiler` is listed as beta on the first-party download page but livecheck has been returning those versions as newest because the dmg file name uses the same format as the stable version. This downgrades the cask to the newest stable version and updates the `livecheck` block to only match the stable versions.