### PR TITLE
logmein-hamachi: re-enable

### DIFF
--- a/Casks/l/logmein-hamachi.rb
+++ b/Casks/l/logmein-hamachi.rb
@@ -1,20 +1,32 @@
 cask "logmein-hamachi" do
-  version "2.1.827"
-  sha256 :no_check
+  on_sonoma :or_older do
+    version "23000048"
+    sha256 "f7ef83b188c134194d61f0d8e4d1e6112f8300eb2b3cf19d4cdfdb045d8fa484"
 
-  url "https://secure.logmein.com/LogMeInHamachi.zip",
-      verified: "logmein.com/"
+    livecheck do
+      url :homepage
+      regex(%r{macVersionHighSierra\s*=\s*["'][^"']*?/osx[._-]v?(\d+(?:\.\d+)*)/LogMeInHamachi\.zip}i)
+    end
+  end
+  on_sequoia :or_newer do
+    version "23000049"
+    sha256 "f479ebba6f4a166fe26d78ba47de64fd27f8008d407de2b66cd61e6c64d633e5"
+
+    livecheck do
+      url :homepage
+      regex(%r{macVersionSequoia\s*=\s*["'][^"']*?/osx[._-]v?(\d+(?:\.\d+)*)/LogMeInHamachi\.zip}i)
+    end
+  end
+
+  url "https://vpn.net/installers/osx_#{version}/LogMeInHamachi.zip"
   name "LogMeIn Hamachi"
   desc "Hosted VPN service that lets you securely extend LAN-like networks"
   homepage "https://vpn.net/"
 
-  deprecate! date: "2024-07-07", because: :unmaintained
-  disable! date: "2025-07-07", because: :unmaintained
-
   installer manual: "LogMeInHamachiInstaller.app"
 
   uninstall script: {
-    executable: "/Applications/LogMeIn Hamachi/HamachiUninstaller.app/Contents/Resources/uninstaller.sh",
+    executable: "/Applications/LogMeIn Hamachi Uninstaller.app/Contents/Resources/uninstaller.sh",
     sudo:       true,
   }
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
The app is supported again on recent macOS versions ([source](https://community.logmein.com/discussions/hamachi/new-logmein-hamachi-for-mac-2-3-0-48-and-2-3-0-49/323401)).

Reverts #178811.