### PR TITLE
TG Pro does not require Tahoe

### DIFF
--- a/Casks/t/tg-pro.rb
+++ b/Casks/t/tg-pro.rb
@@ -13,7 +13,7 @@ cask "tg-pro" do
   end
 
   auto_updates true
-  depends_on macos: ">= :tahoe"
+  depends_on macos: ">= :catalina"
 
   app "TG Pro.app"
 


### PR DESCRIPTION
The "TG Pro" cask was updated yesterday and now has macOS Tahoe as a requirement. However, TG Pro doesn't actually require Tahoe, the current version supports all the way back to macOS 10.13 "High Sierra". (https://www.tunabellysoftware.com/tgpro/releasenotes/)

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

---

The `brew audit` fails. It complains that there is no minimum macOS version set (even though I set it properly to "high_sierra", which is on [list of supported values](https://rubydoc.brew.sh/MacOSVersion)). It gives the same complaint if I remove the "depends_on macos" line entirely. If I set it to something newer like "big_sur", it still complains about the macOS required version going backwards. What's the proper way forward here?