### PR TITLE
neo4j-desktop 2.0.5

### DIFF
--- a/Casks/n/neo4j-desktop.rb
+++ b/Casks/n/neo4j-desktop.rb
@@ -1,7 +1,7 @@
 cask "neo4j-desktop" do
   # NOTE: "4" is not a version number, but an intrinsic part of the product name
-  version "2.0.3"
-  sha256 "f32a6a0e6a3927a9e2e9abf70120c2bb4c7bfeaf6a512f172833edbd1f05cae1"
+  version "2.0.5"
+  sha256 "51248dbb193b615f64d8b6defbbada00ac3d458498fb7493ac28c4c864f39f60"
 
   url "https://dist.neo4j.org/neo4j-desktop-#{version.major}/mac/neo4j-desktop-#{version}-universal.dmg",
       verified: "dist.neo4j.org/"
@@ -13,6 +13,8 @@ cask "neo4j-desktop" do
     url "https://neo4j.com/deployment-center/"
     regex(%r{href=.*?/neo4j-desktop/.*?flavour=osx.*?release=(\d+(?:\.\d+)+)}i)
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Neo4j Desktop #{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`neo4j-desktop` is autobumped but the workflow failed to update to version 2.0.5 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the cask and adds a `depends_on macos:` call to address the audit failure.