### PR TITLE
northern-softworks-cache-cleaner 26.0

### DIFF
--- a/Casks/n/northern-softworks-cache-cleaner.rb
+++ b/Casks/n/northern-softworks-cache-cleaner.rb
@@ -1,5 +1,5 @@
 cask "northern-softworks-cache-cleaner" do
-  version "20.6"
+  version "26.0"
   sha256 :no_check
 
   # Homepage, livecheck regex, and app change with major macOS releases
@@ -7,14 +7,14 @@ cask "northern-softworks-cache-cleaner" do
   url "https://www.northernsoftworks.com/downloads/nscc.dmg"
   name "Northern Softworks Cache Cleaner"
   desc "General purpose system maintenance tool"
-  homepage "https://www.northernsoftworks.com/sequoiacachecleaner.html"
+  homepage "https://www.northernsoftworks.com/tahoecachecleaner.html"
 
   livecheck do
     url :homepage
-    regex(/Download\s*Sequoia\s*Cache\s*Cleaner\s*v?(\d+(?:\.\d+)+)/i)
+    regex(/Download\s*Tahoe\s*Cache\s*Cleaner\s*v?(\d+(?:\.\d+)+)/i)
   end
 
-  app "Sequoia Cache Cleaner.app"
+  app "Tahoe Cache Cleaner.app"
 
   zap trash: [
     "~/Library/Application Support/com.northernsw.nswCacheCleaner",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`northern-softworks-cache-cleaner` is autobumped but livecheck returns an `Unable to get versions` error because the software name has been predictably updated to reference the newest macOS version and the regex no longer matches. This updates the cask accordingly, which should get it back on track until the next major macOS release.