### PR TITLE
socialstream 0.3.56 (new cask)

### DIFF
--- a/Casks/s/socialstream.rb
+++ b/Casks/s/socialstream.rb
@@ -1,0 +1,26 @@
+cask "socialstream" do
+  version "0.3.56"
+  sha256 "8a9b86a9229401a6d9656afc9b6bc48fcb9c5b4bbc8b7e6bc664c25d5465c079"
+
+  url "https://github.com/steveseguin/social_stream/releases/download/#{version}/socialstreamninja_mac_v#{version}.dmg",
+      verified: "github.com/steveseguin/social_stream/"
+  name "Social Stream"
+  name "Social Stream Ninja"
+  desc "Consolidate, control, and customise live social messaging streams"
+  homepage "https://socialstream.ninja/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "socialstream.app"
+
+  zap trash: [
+    "~/Library/Application Support/socialstream",
+    "~/Library/Preferences/socialstream.electron.plist",
+    "~/Library/Saved Application State/socialstream.electron.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

### Notes

- Contrary to what SemVer may suggest, v0.x.x are stable releases in this case:

    1. Repository mentions [website for stable releases](https://github.com/steveseguin/social_stream/blob/8bfa9a8bcb0682185056b1840cf52d441b01f13f/beta.html#L113-L117)
    2. [Website](https://socialstream.ninja/docs/download.html) links to [GitHub Releases](https://github.com/steveseguin/social_stream/releases)
    
    Unstable versions are referred by the author as [nightly versions](https://github.com/steveseguin/social_stream/issues/632#issuecomment-3358293866) and listed as [GitHub pre-releases](https://github.com/steveseguin/social_stream/releases/tag/0.0.0).

- The product name is "Social Stream Ninja" which according to the rules should become:

    1. Convert to lowercase: "social stream ninja"
    4. Spaces become hyphens: "social-stream-ninja"
    
    However, the actual app bundle is socialstream.app (one word), and the DMG file is socialstreamninja_mac (one word with no hyphens) so leaving this up to maintainers.