### PR TITLE
postico@1: update livecheck

### DIFF
--- a/Casks/p/postico@1.rb
+++ b/Casks/p/postico@1.rb
@@ -7,22 +7,11 @@ cask "postico@1" do
   desc "GUI client for PostgreSQL databases"
   homepage "https://eggerapps.at/postico/v1.php"
 
-  # The version number is only present on the homepage. The filename ID is
-  # matched from the `location` header of the download URL response.
   livecheck do
-    url :homepage
-    regex(/Version\s+(\d+(?:\.\d+)+)/i)
+    url "https://releases.eggerapps.at/postico2/downloads"
+    regex(/>\s*Postico\s+v?(1(?:\.\d+){2,})\s*<.*?href=["']?[^"' >]*?postico[._-]v?(\d+(?:\.\d+)*)\.zip/im)
     strategy :page_match do |page, regex|
-      v = page[regex, 1]
-      next if v.blank?
-
-      merged_headers = Homebrew::Livecheck::Strategy.page_headers(
-        "https://eggerapps.at/postico/download/",
-      ).reduce(&:merge)
-      match = merged_headers["location"]&.match(/postico[._-]v?(\d+(?:\.\d+)*)\.zip/i)
-      next if match.blank?
-
-      "#{v},#{match[1]}"
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `postico@1` is producing an `Unable to get versions` error, as the download URL on the 1.x homepage redirects to the download page for 2.x, which also links to files for 1.x. This updates the `livecheck` block to check the current download page, updating the regex and `strategy` block for the different content.

For what it's worth, we specifically have to match versions with 3+ parts, as there's also text like "Postico 1.5" that precedes the full version text and the regex will match that instead (leading to an incomplete version). Alternatively, we could match the [full] version text within a `li` element (as the incomplete version text is in a `div`) but that may not hold up as well over time.

The latest Postico 1.x release was 1.5.22 on 2023-03-17 but it's not clear if this is the final 1.x version or if there's a possibility of another version in the future. If there aren't any further versions over time, we can eventually update the `livecheck` block to skip instead.