### PR TITLE
prolific-pl2303 2.2.11

### DIFF
--- a/Casks/p/prolific-pl2303.rb
+++ b/Casks/p/prolific-pl2303.rb
@@ -1,17 +1,26 @@
 cask "prolific-pl2303" do
-  version "2.2.5,20240808"
-  sha256 "cb83f3d4d6102325a4daedb1e34acdda740d0f4798e21654b721202e9d192b36"
+  version "2.2.11,20250314,2025,07,_-1"
+  sha256 "2c4c1ebf8f1eb997cde5c138b881c4389e17069114b6ef3a1aaff53e424465f2"
 
-  url "https://www.prolific.com.tw/UserFiles/files/PL2303HXD_G_Mac%20Driver_v#{version.csv.first.dots_to_underscores}_#{version.csv.second}_pkg.zip"
+  url "https://www.prolific.com.tw/wp-content/uploads/#{version.csv.third}/#{version.csv.fourth}/PL2303HXD_G_Mac-Driver_v#{version.csv.first}_#{version.csv.second}.pkg#{version.csv.fifth}.7z"
   name "Prolific USB to Serial Cable driver"
   desc "PL2303 USB-to-serial driver"
   homepage "https://www.prolific.com.tw/US/"
 
   livecheck do
-    url "https://www.prolific.com.tw/US/ShowProduct.aspx?pcid=41"
-    regex(/href=.*?PL2303HXD_G_Mac\s*Driver[._-]v?(\d+(?:[._]\d+)+)[_-](\d+)[._-]pkg\.zip/i)
+    url "https://www.prolific.com.tw/portfolio-item/pl2303gc/"
+    regex(%r{
+      href=.*?/(\d+)/(\d+)/
+      PL2303HXD[._-]G[._-]Mac[._-]Driver[._-]v?(\d+(?:\.\d+)+)[_-](\d+)[._-]pkg([._-]+\d+)?\.(?:7z|zip)
+    }ix)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0].tr("_", ".")},#{match[1]}" }
+      page.scan(regex).map do |match|
+        if match[4]
+          "#{match[2]},#{match[3]},#{match[0]},#{match[1]},#{match[4]}"
+        else
+          "#{match[2]},#{match[3]},#{match[0]},#{match[1]}"
+        end
+      end
     end
   end
 
@@ -33,4 +42,6 @@ cask "prolific-pl2303" do
               "/var/db/receipts/*PL2303*.*",
               "/var/db/receipts/*ProlificUSbSerial*.*",
             ]
+
+  # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`prolific-pl2303` is autobumepd but the workflow failed to update to 2.2.11 because livecheck is returning an `Unable to get versions` error, as the `livecheck` block URL now returns a 404 (Not Found) response. This updates the `livecheck` block URL to the page that the generic /portfolio-item/pl2303/ URL redirects to and adjusts the regex and `strategy` block to handle the current download file URL format. There are some parts of the file name that may change in the future (e.g., the `_-1` suffix) but this works for now.