### PR TITLE
renamer 7.0.1

### DIFF
--- a/Casks/r/renamer.rb
+++ b/Casks/r/renamer.rb
@@ -1,19 +1,19 @@
 cask "renamer" do
-  version "6.2.0"
-  sha256 "0a3098b7555d0f3f96e2ac16fccabfe2811c722045e6b403f056700314314af6"
+  version "7.0.1"
+  sha256 "c8885c4767de9f32407ab721575eee0a1708cd7887ff4bb44ec988c771b3badb"
 
-  url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer-#{version}.zip",
+  url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer.zip",
       verified: "storage.googleapis.com/incrediblebee/"
   name "Renamer"
   desc "Batch file renamer application"
   homepage "https://renamer.com/"
 
   livecheck do
-    url "https://api.incrediblebee.com/appcasts/renamer-#{version.major}.xml"
-    strategy :sparkle, &:short_version
+    url "https://github.com/incbee/renamer-7-releases/releases/latest/download/latest-mac.yml"
+    strategy :electron_builder
   end
 
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :sequoia"
 
   app "Renamer.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`renamer` is autobumped but the workflow failed to update to 7.0.1 because livecheck is returning an `Unable to get versions` error, as the Renamer 6 appcast now returns a 404 (Not Found) response. The new app checks the `latest-mac.yml` file from the latest GitHub release in the incbee/renamer-7 repository and that doesn't seem to exist (at least not publicly) but there is a renamer-7-releases repository, so this updates the `livecheck` block to check the file from those releases.