### PR TITLE
specter: update livecheck

### DIFF
--- a/Casks/s/specter.rb
+++ b/Casks/s/specter.rb
@@ -9,11 +9,23 @@ cask "specter" do
   homepage "https://specter.solutions/"
 
   # Upstream doesn't reliably mark unstable versions as pre-release on GitHub.
-  # We check the upstream download page, which links to the latest stable files
-  # on GitHub.
+  # The first-party download page uses JavaScript to handle the download links,
+  # so we have to check the related JS file for the URL of the latest stable
+  # file on GitHub.
   livecheck do
     url "https://specter.solutions/downloads/"
-    regex(/href=.*?Specter[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    regex(/Specter[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :page_match do |page, regex|
+      js_file_name = page[%r{src=["']?/assets/(index[._-]\w+\.js)}i, 1]
+      next unless js_file_name
+
+      js_file = Homebrew::Livecheck::Strategy.page_content(
+        "https://specter.solutions/assets/#{js_file_name}",
+      )[:content]
+      next if js_file.blank?
+
+      js_file.scan(regex).map { |match| match[0] }
+    end
   end
 
   app "Specter.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `specter` is producing an `Unable to get versions` error, as the first-party download page now uses JavaScript to handle the download buttons. The URL of the latest stable file is now found in a JS file but the file name contains a variable suffix (e.g. /assets/index-BPqTpli2.js), so this updates the `livecheck` block to find the JS file name in the download page HTML, fetches the file content, and matches within that.