### PR TITLE
starsector: update livecheck, deprecate

### DIFF
--- a/Casks/s/starsector.rb
+++ b/Casks/s/starsector.rb
@@ -15,6 +15,8 @@ cask "starsector" do
     skip "Cannot be fetched due to Cloudflare protections"
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   app "Starsector.app"
 
   # No zap stanza required

--- a/Casks/s/starsector.rb
+++ b/Casks/s/starsector.rb
@@ -8,9 +8,11 @@ cask "starsector" do
   desc "Open-world single-player space combat and trading RPG"
   homepage "https://fractalsoftworks.com/"
 
+  # The upstream preorder page links to the latest dmg file but Cloudflare
+  # protections prevent us from fetching it, so it must be checked manually:
+  # https://fractalsoftworks.com/preorder/
   livecheck do
-    url "https://fractalsoftworks.com/preorder/"
-    regex(/href=.*?starsector_mac[._-]v?(\d+(?:\.\d+)+[\w._-]+)\.zip/i)
+    skip "Cannot be fetched due to Cloudflare protections"
   end
 
   app "Starsector.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `starsector` is producing an `Unable to get versions` error, as the upstream website has Cloudflare protections that prevent anyone from reaching the website unless they go through the interactive verification page first. This updates the `livecheck` block with a `skip` call and a preceding comment to explain the situation, as the Cloudflare verification page appears even in a browser and from a good IP address (i.e., it's not related to a curl user agent or the autobump/CI environment IP address range).

Besides that, the Starsector app is unsigned and fails Gatekeeper checks, so this adds a `disable!` call with the future date that we've been using for this situation.