### PR TITLE
taskade: update livecheck

### DIFF
--- a/Casks/t/taskade.rb
+++ b/Casks/t/taskade.rb
@@ -8,7 +8,7 @@ cask "taskade" do
   homepage "https://www.taskade.com/"
 
   livecheck do
-    url "https://www.taskade.com/downloads"
+    url :homepage
     regex(%r{href=.*?/Taskade[._-]v?(\d+(?:\.\d+)+)[._-]universal\.dmg}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `taskade` is producing an `Unable to get versions` error, presumably because the HTML for the downloads page is a 6.44 MB download (_with_ compression) and curl can time out before the server finishes sending the response body. The download URL for macOS isn't part of the main download page content and is instead found in the footer that's part of every page. This resolves the issue by updating the `livecheck` block to check the homepage, which is ~100 KB compressed and hopefully won't run into the same issue over time.