### PR TITLE
tastytrade: update livecheck

### DIFF
--- a/Casks/t/tastytrade.rb
+++ b/Casks/t/tastytrade.rb
@@ -20,18 +20,7 @@ cask "tastytrade" do
   livecheck do
     url "https://tastytrade.com/page-data/desktop-platform/page-data.json"
     strategy :json do |json|
-      requests = 0
-      version = json["staticQueryHashes"]&.each do |static_hash|
-        requests += 1
-        break if requests > 4
-
-        content = Homebrew::Livecheck::Strategy.page_content("https://tastytrade.com/page-data/sq/d/#{static_hash}.json")
-        next if content[:content].blank?
-
-        hash_json = Homebrew::Livecheck::Strategy::Json.parse_json(content[:content])
-        version = hash_json.dig("data", "contentstackGlobalSettings", "tastyworksSoftware", "desktopVersion")
-        break version if version.present?
-      end
+      json.dig("result", "pageContext", "globalSettings", "tastyworksSoftware", "desktopVersion")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `tastytrade` is producing an `Unable to get versions` error, as the `staticQueryHashes` array in the JSON response is empty. However, the JSON now provides a `desktopVersion` field that easily gives us the current version. This works for now (and is considerably simpler than the existing approach) but hopefully it's accurate with respect to the macOS version (and stays accurate over time). At the very least, I don't think there's an alternative source of version information, so we'll just have to keep an eye out for issues when the version changes in the future.