### PR TITLE
testfully 1.179.0

### DIFF
--- a/Casks/t/testfully.rb
+++ b/Casks/t/testfully.rb
@@ -1,5 +1,5 @@
 cask "testfully" do
-  version "1.178.0,472"
+  version "1.179.0,472"
   sha256 "9aeda8809bbdbc4f3425dae8f736f148511ff5141b90c29ad927c03519ce1120"
 
   url "https://releases.testfully.io/desktop/build-#{version.csv.second}/Testfully.app.zip"
@@ -8,16 +8,17 @@ cask "testfully" do
   homepage "https://docs.testfully.io/"
 
   livecheck do
-    url "https://docs.testfully.io/docs/download/"
-    regex(%r{build[._-](\d+)/Testfully(\.app)?\.zip}i)
-    strategy :page_match do |page, regex|
-      version = page.match(/latest\s*version\s*\((\d+(?:\.\d+)+)\)/i)
+    url "https://releases.testfully.io/desktop/updater-prod.json"
+    regex(%r{build[._-](\d+)/Testfully(\.app)?\.(?:t|zip)}i)
+    strategy :json do |json, regex|
+      # This assumes that macOS ARM and Intel continue to use the same file
+      build = json.dig("platforms", "darwin-aarch64", "url")&.[](regex, 1)
+      next unless build
+
+      version = json["version"]&.[](/v?(\d+(?:\.\d+)+)/i, 1)
       next if version.blank?
 
-      build = page.match(regex)
-      next if build.blank?
-
-      "#{version[1]},#{build[1]}"
+      "#{version},#{build}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `testfully` is producing an `Unable to get versions` error, as the URL doesn't seem to work when fetched in livecheck (and I'm not quite sure why, as it doesn't seem to be a user agent problem). This addresses the issue by updating the `livecheck` block to check the JSON file that the app uses to check for new versions. This is fairly straightforward, except that the macOS file URL is duplicated in the darwin-aarch64 and darwin-x86_64 URLs and it uses a .tar.gz file instead of a .zip file (like on the download page).

One other thing to note is that the download page references the latest version as both 1.178.0 and 1.179.0 but build 472 is for 1.179.0, so this also updates the cask version (though this is still the same file as before).