### PR TITLE
virtualhostx: update livecheck

### DIFF
--- a/Casks/v/virtualhostx.rb
+++ b/Casks/v/virtualhostx.rb
@@ -2,14 +2,18 @@ cask "virtualhostx" do
   version "2021.01.10,1017"
   sha256 "3d86e05f0e4072d1180d06b9126e12c7943ffc6bdce9b754e6a1d417eb18fc0a"
 
-  url "https://download.clickontyler.com/virtualhostx/virtualhostxpro_#{version.csv.second}.zip"
+  url "https://download.clickontyler.com/virtualhostx/virtualhostxpro_#{version.csv.second}.zip",
+      verified: "download.clickontyler.com/virtualhostx/"
   name "VirtualHostX"
   desc "Local server environment"
-  homepage "https://clickontyler.com/virtualhostx/"
+  homepage "https://retina.studio/virtualhostx/"
 
+  # The homepage states that "as of November 24, 2021, ...VirtualHostX is sunset
+  # as an actively developed product". As of writing (2025-10-04), the Sparkle
+  # feed we were checking (https://shine.clickontyler.com/appcast.php?id=45) no
+  # longer works because the `shine` subdomain doesn't resolve.
   livecheck do
-    url "https://shine.clickontyler.com/appcast.php?id=45"
-    strategy :sparkle
+    skip "No longer developed or maintained"
   end
 
   app "VirtualHostX.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `virtualhostx` produces an `Unable to get versions` error because the URL's subdomain no longer resolves. The homepage states that VirtualHostX was sunset on 2021-11-24 but the zip file still works, so I've simply updated the `livecheck` block to skip. Besides that, this updates the homepage, as the existing URL is redirecting with a 301 (Moved Permanently) response.