### PR TITLE
clone-hero 1.0.0.4080 (Unity)

### DIFF
--- a/Casks/c/clone-hero.rb
+++ b/Casks/c/clone-hero.rb
@@ -1,6 +1,6 @@
 cask "clone-hero" do
   version "1.0.0.4080"
-  sha256 "7b7d170b344773ce8355a0c3274e4adc1715e7cd978e210d3c701af22df00d5c"
+  sha256 "ea0cb7d9ac5e55cbbe736ed30b49e9faeb642ce96f8b4b6383aba05387ea9f12"
 
   url "https://github.com/clonehero-game/releases/releases/download/V#{version}/CloneHero-mac.dmg",
       verified: "github.com/clonehero-game/"
@@ -12,8 +12,6 @@ cask "clone-hero" do
     url :url
     strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Clone Hero.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The Clone Hero team have [responded](https://discord.com/channels/296481029303304192/296482562812018690/1423998822824284221) to a [Unity vulnerability disclosure](https://discussions.unity.com/t/cve-2025-59489-patcher-tool/1688032) by releasing a patched version of their game under the _same_ version number (& stored in the same place on Github).

I have altered the SHA256 of this formula to match the new hash of the patched game. (You can see this hash listed [on their releases page](https://github.com/clonehero-game/releases/releases/tag/V1.0.0.4080#:~:text=ea0cb7d9ac5e55cbbe736ed30b49e9faeb642ce96f8b4b6383aba05387ea9f12))

They kindly also [started notarizing their builds](https://discord.com/channels/296481029303304192/352141290101538816/1424138323261132914), so I have removed the `fails_gatekeeper_check` annotation. (Please let me know, or make the change yourselves, if it is inappropriate to do like this — I couldn't find guidance in the contributing notes.)