### PR TITLE
anki: update livecheck

### DIFF
--- a/Casks/a/anki.rb
+++ b/Casks/a/anki.rb
@@ -32,8 +32,8 @@ cask "anki" do
         verified: "github.com/ankitects/anki/"
 
     livecheck do
-      url :url
-      strategy :github_latest
+      url :homepage
+      regex(/href=.*?anki[._-]launcher[._-]v?(\d+(?:\.\d+)+)(?:[._-]mac)?\.dmg/i)
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `anki` uses the `GithubLatest` strategy but the two most recent releases (25.09.1 and 25.09.2) don't provide any release assets. The 25.09.2 release description mentions that users should download the latest launcher from https://apps.ankiweb.net/ and the homepage does link to the newest available dmg file on GitHub (currently for 25.09). This updates the `livecheck` block to check the dmg link on the homepage, which correctly reports 25.09 as the latest version instead of 25.09.2 from the "latest" release on GitHub.