### PR TITLE
baidunetdisk 4.53.7

### DIFF
--- a/Casks/b/baidunetdisk.rb
+++ b/Casks/b/baidunetdisk.rb
@@ -1,20 +1,20 @@
 cask "baidunetdisk" do
-  arch arm: "_arm64"
+  arch arm: "arm64", intel: "x64"
 
-  version "4.52.5"
-  sha256 arm:   "924c7eafce02ba73fec0e822d1090a6a8d5f5f7928c3512b96f77a70d44104fe",
-         intel: "95e4904f044cf73bbb4157c09e11038ede9c1558d359166ff5576b0c4974faff"
+  version "4.53.7"
+  sha256 arm:   "e56ce16b367a9d40b740a2f6323d7950de281f60ae51b6c1d88c0f2b1886e1ff",
+         intel: "b9fa80f09cce13231ed298d551a28783ae29701253988936cbaa3236f9e180ee"
 
-  url "https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}#{arch}.dmg",
+  url "https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}_#{arch}.dmg",
       verified: "issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/"
   name "Baidu NetDisk"
   name "百度网盘"
   desc "Cloud storage service"
-  homepage "https://pan.baidu.com/download"
+  homepage "https://pan.baidu.com/"
 
   livecheck do
     url "https://pan.baidu.com/disk/cmsdata?do=client"
-    regex(/BaiduNetdisk[._-]mac[._-]v?(\d+(?:\.\d+)+)#{arch}\.dmg/i)
+    regex(/BaiduNetdisk(?:[._-]mac)?[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`baidunetdisk` is autobumped but the workflow failed to update to version 4.53.7 because the Intel dmg now uses a `_x64` suffix. This updates the cask accordingly.