### PR TITLE
yesplaymusic: update livecheck

### DIFF
--- a/Casks/y/yesplaymusic.rb
+++ b/Casks/y/yesplaymusic.rb
@@ -1,9 +1,9 @@
 cask "yesplaymusic" do
-  arch arm: "arm64", intel: "universal"
+  arch arm: "arm64", intel: "x64"
 
   version "0.4.8-2"
   sha256 arm:   "15a7ae98d9a43d0623f407b65f0fde294b9ecd1e1b11d9e2f258be35153d8b59",
-         intel: "2f182bbbc6f654d59e0bd77a8b5801ff0502b1c2e43f38bd3b96fa5dc29818c7"
+         intel: "5079c47685d3fef02b4912973e57c3614514303c85da69c3b262448c0096dafa"
 
   url "https://github.com/qier222/YesPlayMusic/releases/download/v#{version}/YesPlayMusic-mac-#{version.hyphens_to_dots.major_minor_patch}-#{arch}.dmg"
   name "YesPlayMusic"
@@ -12,9 +12,22 @@ cask "yesplaymusic" do
 
   livecheck do
     url :url
-    strategy :github_latest
-    regex(/v?(\d+(?:[.-]\d+)+)/i)
+    regex(%r{/v?(\d+(?:[.-]\d+)+)/YesPlayMusic(?:[._-]mac)?[._-]v?\d+(?:[.-]\d+)+[._-]#{arch}\.dmg}i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "YesPlayMusic.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `yesplaymusic` uses the `GithubLatest` strategy and it returns 0.4.9 as the newest version but this release has no assets even almost one year after it was created. Looking at previous releases, 0.4.8 also has no release assets, so unfortunately we can't rely on every release having assets. This updates the `livecheck` block to use the `GithubReleases` strategy along with a `strategy` block that matches versions from releases that provide the expected dmg file(s). Hopefully this isn't a long-term issue and we can eventually return to using `GithubLatest` but this is necessary for now.

Besides that, this also updates the cask to use the `x64` dmg for Intel instead of the `universal` dmg, as upstream provides ARM, Intel, and universal dmg files. Lastly, this adds a `disable!` call with the future date we've been using for apps that fail Gatekeeper checks.