### PR TITLE
teleport-suite@16 16.5.18

### DIFF
--- a/Casks/t/teleport-suite@16.rb
+++ b/Casks/t/teleport-suite@16.rb
@@ -1,6 +1,6 @@
 cask "teleport-suite@16" do
-  version "16.5.17"
-  sha256 "e842ed5221da9e688571c4793a0d1524ed8663a5c5d3563d4e933d64f5b54db9"
+  version "16.5.18"
+  sha256 "e7644697d2a254096ddd6ce11c1c4ddb237fd2e1251055c0fdd23a42a1f5b99d"
 
   url "https://cdn.teleport.dev/teleport-#{version}.pkg",
       verified: "cdn.teleport.dev/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`teleport-suite@16` is disabled as discontinued but upstream has released a 16.5.18 version, so this updates the cask.

Edit: I had a feeling this would fail CI tests because it's technically disabled now. If we can't (or don't want to) update to this newer version, then I can simply rework this to remove the `livecheck` block so it will be automatically skipped as disabled.