### PR TITLE
frame0 1.1.2

### DIFF
--- a/Casks/f/frame0.rb
+++ b/Casks/f/frame0.rb
@@ -2,15 +2,9 @@ cask "frame0" do
   # NOTE: "0" is not a version number, but an intrinsic part of the product name
   arch arm: "arm64", intel: "x64"
 
-  sha256 arm:   "45ad29dbe1eaa5d57cc0ebd97f70917889a1b06151527afbf5c4912cfe662add",
-         intel: "bda5d78133c7b9da7e8737887e5931e1ed056e5662f769a8d396c158ea2680d5"
-
-  on_arm do
-    version "1.1.1"
-  end
-  on_intel do
-    version "1.1.0"
-  end
+  version "1.1.2"
+  sha256 arm:   "c465929a9581e11dd0fc440298719bf39dea680e881b6ca76bb53e43c64bdc1f",
+         intel: "dcec01403b7910941286cc6be4813ad3b19a4b7dbdba7752e80ef8c1db031797"
 
   url "https://files.frame0.app/releases/darwin/#{arch}/Frame0-#{version}-#{arch}.dmg"
   name "Frame0"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The 1.1.2 release of `frame0` provides files for both ARM and Intel, so this removes the temporary architecture-specific `version` setup.