### PR TITLE
hashbackup 3300

### DIFF
--- a/Casks/h/hashbackup.rb
+++ b/Casks/h/hashbackup.rb
@@ -1,5 +1,5 @@
 cask "hashbackup" do
-  version "3296"
+  version "3300"
   sha256 :no_check
 
   url "https://www.hashbackup.com/download/hb-mac-64bit.tar.gz"
@@ -11,6 +11,8 @@ cask "hashbackup" do
     url "http://upgrade.hashbackup.com/release/latest.txt"
     regex(/^(\d+)$/i)
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   binary "hb"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`hashbackup` is autobumped but the workflow failed to update to version 3300 because `brew audit `errors as the app is unsigned an fails Gatekeeper checks. This updates the cask and adds a `disable!` call with the future date that we've been using for this scenario.