### PR TITLE
stash 4.0.0,407

### DIFF
--- a/Casks/s/stash.rb
+++ b/Casks/s/stash.rb
@@ -1,6 +1,6 @@
 cask "stash" do
-  version "4.0.0,405"
-  sha256 "d78d35bbb983c17869106a4a2734e3ad9cd1119694f0c4d27cbe764d59197172"
+  version "4.0.0,407"
+  sha256 "1c2a63bed31c7d8f72640300f1eac7de2a2fc1bc9ae276b9bf982367c6942fcc"
 
   url "https://mac-release-static.stash.ws/Stash-build-#{version.csv.second}.zip"
   name "Stash"
@@ -13,7 +13,7 @@ cask "stash" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Stash.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`stash` is autobumped but the workflow failed to update to version 4.0.0,407 because `brew audit` failed with an "Upstream defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and `depends_on macos:` value accordingly.