### PR TITLE
wetype 1.4.2

### DIFF
--- a/Casks/w/wetype.rb
+++ b/Casks/w/wetype.rb
@@ -1,6 +1,6 @@
 cask "wetype" do
-  version "1.4.1,519"
-  sha256 "da85bafa2c168b03c548f5eeae94484cf9e2fb1ff4e482b354804dc988893c04"
+  version "1.4.2,529"
+  sha256 "53c521f91a4b94517ab770d84960f173123552ba12fd8dc19c44fb13eeb77903"
 
   url "https://download.z.weixin.qq.com/app/mac/#{version.csv.first}/WeTypeInstaller_#{version.csv.first}_#{version.csv.second}.zip"
   name "WeType"
@@ -13,7 +13,11 @@ cask "wetype" do
     regex(/WeTypeInstaller[._-]v?(\d+(?:\.\d+)+)[._-](\d+)\.zip/i)
     strategy :json do |json, regex|
       match = json.dig("data", "mac", "download_link")&.match(regex)
-      next if match.blank?
+
+      # Try to match the version from the `InstallInfo` file name if the
+      # Mac installer file name doesn't include a version
+      match ||= json.dig("data", "mac", "InstallInfo")&.match(/v?(\d+(?:\.\d+)+)[_-](\d+)/i)
+      next unless match
 
       "#{match[1]},#{match[2]}"
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wetype` is autobumped but the existing `livecheck` block is producing an `Unable to get versions` error because the file name in the Mac download link doesn't include version information (it's `WeTypeInstaller_1001.zip` instead of the expected `WeTypeInstaller_1.4.2_529.zip`). Other Mac-related URLs include the version in their file name, so this adds some fallback logic to the `livecheck` block's `strategy` block to try to match the version from the `InstallInfo` URL. The installer download URL works with this version, so this approach works for this particular version/scenario but hopefully upstream simply returns to the usual file name format in future versions. Until then, this will allow us to update to version 1.4.2 and we can always remove this fallback logic if it causes problems in the future.