### PR TITLE
glide-browser: 0.1.51a (new cask)

### DIFF
--- a/Casks/g/glide-browser.rb
+++ b/Casks/g/glide-browser.rb
@@ -1,0 +1,37 @@
+cask "glide-browser" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "0.1.51a"
+  sha256 arm:   "da7a7194a07f935b0ebfab45c151ede6d0ec305464c3f4aea802681d759106eb",
+         intel: "3c30c6abd482f6a555ca2279f0eefa6e9bf79c9f1f03b6e50c1a9006ba603896"
+
+  url "https://github.com/glide-browser/glide/releases/download/#{version}/glide.macos-#{arch}.dmg",
+      verified: "github.com/glide-browser/glide/"
+  name "Glide Browser"
+  desc "Extensible, firefox-based web browser"
+  homepage "https://glide-browser.app/"
+
+  livecheck do
+    url "https://updates.glide-browser.app/versions/latest/browser/Darwin_#{arch}-gcc3/glide/update.xml"
+    strategy :xml do |xml|
+      xml.get_elements("//update").map { |item| item.attributes["appVersion"] }
+    end
+  end
+
+  auto_updates true
+
+  app "Glide.app"
+  binary "#{appdir}/Glide.app/Contents/MacOS/glide"
+
+  zap trash: [
+        "~/Library/Application Support/Glide Browser",
+        "~/Library/Caches/Glide Browser",
+        "~/Library/Caches/Mozilla/updates/Applications/Glide Browser",
+        "~/Library/Caches/Mozilla/updates/Applications/Glide",
+        "~/Library/Preferences/app.glide-browser.glide.plist",
+        "~/Library/Preferences/org.mozilla.com.glide.browser.plist",
+        "~/Library/Saved Application State/app.glide-browser.glide.savedState",
+        "~/Library/Saved Application State/org.mozilla.com.glide.browser.savedState",
+      ],
+      rmdir: "~/Library/Caches/Mozilla"
+end


### PR DESCRIPTION
Adds [Glide Browser](https://glide-browser.app/), a firefox fork of which I'm the maintainer.

Glide is very new, I only publicly [announced](https://blog.craigie.dev/introducing-glide/) it last week - but I have personally been using it for ~6 months. That said, I appreciate if there are any concerns with merging this until it's more mature.

---

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
  - note: I didn't tick this as glide is in an alpha state and the "documented exception" docs link just takes me to the entire page, not an explicit exceptions section? and I couldn't find one myself.
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
  - note: I went with the more explicit `glide-browser` over `glide`, as while `glide` is available in this repo, there is other software with the name "glide", so I'd rather avoid any theoretical clashes.
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---