### PR TITLE
osu@tachyon 2025.912.0-lazer

### DIFF
--- a/Casks/o/osu@tachyon.rb
+++ b/Casks/o/osu@tachyon.rb
@@ -1,18 +1,31 @@
 cask "osu@tachyon" do
   arch arm: "Apple.Silicon", intel: "Intel"
 
-  version "2025.911.0-tachyon"
-  sha256 arm:   "c46b380b2fa2f0661e2b4659ccb7eebcfdf76d38566a378429e5d5c2be8cc64f",
-         intel: "91970ddb2cfa29116ab2325fc3bd1ac62ca2347e71d0f0d4f34ae45da1c64900"
+  version "2025.912.0-lazer"
+  sha256 arm:   "8eda72e694580c819e9972d813a2e5f13882d9060fa18c0632bd3b723456ba98",
+         intel: "e0baa03c1747931a8c39b0013b9987b4f1588e5a87547057d4ee66488ee3ad91"
 
   url "https://github.com/ppy/osu/releases/download/#{version}/osu.app.#{arch}.zip"
   name "osu! (tachyon)"
   desc "Rhythm game"
   homepage "https://github.com/ppy/osu/"
 
+  # There can be a notable gap between tag and release, so it's necessary to
+  # check releases instead of Git tags. Tachyon releases are marked as
+  # "pre-release" on GitHub, so we have to use the `GithubReleases` strategy.
   livecheck do
     url :url
-    regex(/^v?((\d+(?:\.\d+)+)(?:-tachyon)?)$/i)
+    regex(/^v?((\d+(?:\.\d+)+)(?:-\w+)?)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   auto_updates true

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -48,7 +48,7 @@
   "openra@playtest": "all",
   "openshot-video-editor@daily": "all",
   "orcaslicer@nightly": "all",
-  "osu@tachyon": "all",
+  "osu@tachyon": "any",
   "playcover-community@beta": "all",
   "positron": "all",
   "powershell@preview": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `osu@tachyon` uses the `Git` strategy to check for Tachyon version tags using a regex where the `-tachyon` suffix is optional, which is intended to allow it to also match stable versions (though it currently misses Lazer versions). This is causing livecheck to return 2025.1002.0 as newest but there isn't a release for that tag yet.

This addresses the issue by updating the `livecheck` block to use the `GithubReleases` strategy, which is necessary because Tachyon releases are marked as "pre-release" on GitHub. This copies the regex from the `osu` cask, which is loose about suffix-matching and will allow this to match versions like 2025.911.0-tachyon, 2025.912.0-lazer, and 2025.607.1. To be clear, the app will also update to newer Lazer releases when the release stream setting is set to "Tachyon (Unstable)". With that in mind, this updates the cask to the latest version, which is currently 025.912.0-lazer.

Lastly, this updates the value in `github_prerelease_allowlist.json` from `all` to `any`, as the GitHub releases that this cask uses may or may not be marked as "pre-release" (depending on whether it's a Tachyon version, Lazer, etc.).