### PR TITLE
qlc+ 5.0.0

### DIFF
--- a/Casks/q/qlc+.rb
+++ b/Casks/q/qlc+.rb
@@ -1,19 +1,28 @@
 cask "qlc+" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "4.14.3"
-  sha256 arm:   "de6c1196f0ea69d1a344a3cc073aba3e74e31d097dbc9da599c916572bd52ddc",
-         intel: "95c15f73e647e6b90cc11f5ebf24c55cebbbce427c711259405053e88fca29ee"
+  on_arm do
+    version "5.0.0"
+    sha256 "f42b26a1328ce4f6120c160c43e4aabd5a5f950fe662eb8b75f74c321d716288"
+
+    livecheck do
+      url "https://qlcplus.org/download"
+      regex(/href=.*?QLC\+[._-]v?(\d+(?:[.-]\d+)+)[._-]#{arch}\.dmg/i)
+    end
+  end
+  on_intel do
+    version "4.14.3"
+    sha256 "95c15f73e647e6b90cc11f5ebf24c55cebbbce427c711259405053e88fca29ee"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
 
   url "https://qlcplus.org/downloads/#{version.split("-").first}/QLC+_#{version}_#{arch}.dmg"
   name "Q Light Controller+"
   desc "Control DMX or analogue lighting systems"
   homepage "https://qlcplus.org/"
-
-  livecheck do
-    url "https://qlcplus.org/download"
-    regex(/href=.*?QLC\+[._-]v?(\d+(?:[.-]\d+)+)[._-]#{arch}\.dmg/i)
-  end
 
   app "QLC+.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`qlc+` is autobumped but the workflow failed to update to version 5.0.0 because it's only for Apple Silicon (as mentioned in the [upstream release notes](https://www.qlcplus.org/forum/viewtopic.php?t=18679)). This updates the cask accordingly, splitting the versions based on architecture and maintaining the last Intel release as a legacy version for now. It's technically possible to continue checking for new Intel versions on the download page but upstream doesn't appear to create new releases for older major versions after a newer major version is released, so it would likely just be a waste of effort.