### PR TITLE
pushplaylabs-sidekick: disable

### DIFF
--- a/Casks/p/pushplaylabs-sidekick.rb
+++ b/Casks/p/pushplaylabs-sidekick.rb
@@ -1,6 +1,5 @@
 cask "pushplaylabs-sidekick" do
   arch arm: "arm64", intel: "x64"
-  livecheck_folder = on_arch_conditional arm: "macm1", intel: "mac"
 
   on_arm do
     version "124.61.1.50292,e244ab6"
@@ -16,16 +15,7 @@ cask "pushplaylabs-sidekick" do
   desc "Browser designed for modern work"
   homepage "https://www.meetsidekick.com/"
 
-  livecheck do
-    url "https://api.meetsidekick.com/downloads/df/#{livecheck_folder}"
-    regex(/[_-](\d+(?:\.\d+)+)[_-](.+)[._-](?:default|df)\.dmg/i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
+  disable! date: "2025-10-05", because: :discontinued
 
   app "Sidekick.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

From what I'm reading, I guess Perplexity bought Sidekick (for the benefit of their Comet browser), as all meetsidekick.com URLs redirect to www.perplexity.ai/comet. This applies to the dmg URLs, so those no longer work. This disables the cask, as it's no longer usable.