### PR TITLE
tencent-docs: deprecate

### DIFF
--- a/Casks/t/tencent-docs.rb
+++ b/Casks/t/tencent-docs.rb
@@ -11,24 +11,10 @@ cask "tencent-docs" do
   desc "Online editor for Word, Excel and PPT documents"
   homepage "https://docs.qq.com/"
 
-  livecheck do
-    url "https://docs.qq.com/rainbow/config.v2.ConfigService/PullConfigReq", post_json: {
-      pull_item: {
-        app_id:  "e4099bf9-f579-4233-9a15-6625a48bcb56",
-        group:   "Prod.Common.AutoUpdate",
-        envName: "Default",
-      },
-    }
-    strategy :json do |json|
-      json.dig("config", "items")&.map do |item|
-        yaml_string = item["key_values"]&.find { |key_value| key_value["key"] == "app.yaml" }&.dig("value")
-        next if yaml_string.blank?
-
-        yaml = Homebrew::Livecheck::Strategy::Yaml.parse_yaml(yaml_string)
-        yaml.dig("channelMap", "30001")
-      end
-    end
-  end
+  # Newer versions of TencentDocs use a URL that doesn't work in the cask, so
+  # there doesn't appear to be any usable upstream dmg file to continue updating
+  # this cask beyond the current version.
+  deprecate! date: "2025-10-05", because: :unreachable
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tencent-docs` is autobumped but the workflow has been unable to update to versions beyond 3.10.1 for quite some time. We can successfully identify new versions but the newer upstream dmg URLs that I've found are unusable in the cask. I spent an unreasonable amount of time trying various approaches to try to make this work and never found a working solution. That's not to say that there isn't a way but I didn't find it.

With that in mind, this removes the `livecheck` block and deprecates the cask unless/until there's a way that the cask can use newer versions.

-----

I can provide more information on what I tried if anyone is _really_ invested in trying to fix this cask but I can't recommend it. The short version is that the `https://docs.qq.com/api/package/get?channel_id=30001&version_id=latest&package_name=TencentDocs-#{arch}.dmg` URL doesn't end up downloading the dmg file (e.g., when running `brew audit --strict --online tencent-docs`) and no amount of request configuration resolved that when I tried (e.g., setting headers, cookies, etc.).