### PR TITLE
atv-remote 1.4.3

### DIFF
--- a/Casks/a/atv-remote.rb
+++ b/Casks/a/atv-remote.rb
@@ -1,11 +1,11 @@
 cask "atv-remote" do
-  arch arm: "-arm64"
+  arch arm: "arm64", intel: "x64"
 
-  version "1.4.2"
-  sha256 arm:   "dfe04c2739a3d1dcc2837f4d45c306a56bfd7e30e9b5f219f0d926cceb0b4bf9",
-         intel: "97427e9a3d9affb5a423fae643b78147e510bc90bd346b81928d0eaa4b1319ca"
+  version "1.4.3"
+  sha256 arm:   "346c95cdae25f78d4d75d9e1fafc60a6d37e05258dfadfd2a40b010231b1b39f",
+         intel: "80c7b55da85799f23e4e36ede23990a9d9ee22c90d9c23bd5fcd8c55125b48e5"
 
-  url "https://github.com/bsharper/atv-desktop-remote/releases/download/v.#{version}/ATV.Remote-#{version}#{arch}.dmg"
+  url "https://github.com/bsharper/atv-desktop-remote/releases/download/v#{version}/ATV.Remote-#{version}-#{arch}.dmg"
   name "ATV Remote"
   desc "Control Apple TV from your desktop"
   homepage "https://github.com/bsharper/atv-desktop-remote"
@@ -16,6 +16,8 @@ cask "atv-remote" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :monterey"
 
   app "ATV Remote.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`atv-remote` is autobumped but the workflow failed to update to version 1.4.3 because the related GitHub release uses a `v1.4.3` tag format but the previous tag used a `v.1.4.2` format (upstream unpredictably switches between one or the other) and the Intel dmg file name now has an `-x64` suffix. This updates the cask accordingly and adds a `depends_on macos:` value to resolve a `brew audit` error ("Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version").