### PR TITLE
turtl: update livecheck

### DIFF
--- a/Casks/t/turtl.rb
+++ b/Casks/t/turtl.rb
@@ -9,15 +9,46 @@ cask "turtl" do
   homepage "https://turtlapp.com/"
 
   # A tag using the stable version format is sometimes marked as "Pre-release"
-  # on the GitHub releases page, so we have to use the `GithubLatest` strategy.
+  # on the GitHub releases page, so we have to check releases instead of tags.
   # Versions with suffixes like `0.7.2.6-sqlite-fix` are also a problem when
   # using the `Git` strategy, as the suffix is compared alphabetically (so a
-  # newer version may wrongly appear to be older).
+  # newer version may wrongly appear to be older). Newer releases may not
+  # provide a macOS asset, so this uses the `GithubReleases` strategy until
+  # upstream consistently provides macOS files. The regex is currently very
+  # loose and ambiguous because it's not clear what the file name format will
+  # be going forward (after several years without a new version) but we should
+  # tighten it up if/when the format becomes more clear in the future.
   livecheck do
     url :url
-    regex(/^\D*?(\d+(?:\.\d+)+.*)$/i)
-    strategy :github_latest
+    regex(%r{
+      /v?(\d+(?:\.\d+)+[^/]*)/
+      turtl(?:[._-]v?(\d+(?:\.\d+)+.*?))?
+      (?:[._-](?:mac(?:os)?|osx)\.zip|.*?\.(?:dmg|pkg))
+    }ix)
+    strategy :github_releases do |json, regex|
+      version = nil
+      json.each do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.each do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          version = if match[2] && match[1] != match[2]
+            "#{match[2]},#{match[1]}"
+          else
+            match[1]
+          end
+          break
+        end
+        break if version
+      end
+
+      version
+    end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Turtl.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `turtl` uses the `GithubLatest` strategy and it's currently returning 0.7.3 as the newest version but this release doesn't provide a macOS asset (only a Linux tarball). The release was created on 2025-03-26, so `turtl` has been failing as long as it's been autobumped (i.e., for the past two months).

This addresses the issue by updating the `livecheck` block to use the `GithubReleases` strategy to identify the newest release with a macOS asset. I've been putting this off for some time because 0.7.3 was the first release since 0.7.2.6-sqlite-fix on 2019-11-05 and it's not clear what the file name format for the next macOS asset will be. Historically, the macOS file has been something like `turtl-1.2.3-osx.zip`, `turtl-1.2.3-some-fix-osx.zip`, or `turtl-osx.zip` but who knows after 5+ years. With that in mind, I made the regex fairly loose to be able to handle the current formats as well as some other common scenarios, though it may still fail to match something I didn't anticipate. There may be room for improvement but this works for now.

Besides that, the app for the current macOS release that the cask uses (0.7.2.6-sqlite-fix from 2019) isn't signed, so this adds a `disable!` call with the future date we've been using for this scenario.