### PR TITLE
helium-browser 0.5.2.1: add auto_updates

### DIFF
--- a/Casks/h/helium-browser.rb
+++ b/Casks/h/helium-browser.rb
@@ -16,6 +16,7 @@ cask "helium-browser" do
     strategy :github_latest
   end
 
+  auto_updates true
   depends_on macos: ">= :monterey"
 
   app "Helium.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
As per [homepage](https://helium.computer)

> On macOS, Helium installs updates automatically, by default. Helium will let you know when it's time to update.

Also,
<img width="1472" height="426" alt="CleanShot 2025-10-07 at 09 52 01@2x" src="https://github.com/user-attachments/assets/b5c3cb69-7ab0-4fe7-827e-2652a9d256af" />
