### PR TITLE
Fix FreeFileSync SHA-256

### DIFF
--- a/Casks/f/freefilesync.rb
+++ b/Casks/f/freefilesync.rb
@@ -1,6 +1,6 @@
 cask "freefilesync" do
   version "14.5"
-  sha256 "811ead8b4d141d92cab792b9c5e71daa3ce65de8abc814e95865e4fcf9a8e470"
+  sha256 "99b531404a083b25bf323750c5e376fca9aae7af491a2872e3b11d3789f5b273"
 
   url "https://freefilesync.org/download/FreeFileSync_#{version}_macOS.zip"
   name "FreeFileSync"


### PR DESCRIPTION
FreeFileSync 14.5 SHA-256 appears incorrect; the package may have been updated since the last bot check.

```
mac@MacBook-Pro-de-Eduardo ~ % brew upgrade
...
==> Upgrading 1 outdated package:
freefilesync 14.4 -> 14.5
==> Upgrading freefilesync
==> Downloading https://freefilesync.org/download/FreeFileSync_14.5_macOS.zip
==> Downloading from https://freefilesync.org/get_file.static.php?hash=07fff2ec8
######################################################################### 100.0%
==> Purging files for version 14.5 of Cask freefilesync
Error: freefilesync: SHA-256 mismatch
Expected: 811ead8b4d141d92cab792b9c5e71daa3ce65de8abc814e95865e4fcf9a8e470
  Actual: 99b531404a083b25bf323750c5e376fca9aae7af491a2872e3b11d3789f5b273
    File: /Users/mac/Library/Caches/Homebrew/downloads/e1b6b815c8b3a5b30682526a6f29a4c97a566f6eef2c3817d61a1f73df87a458--FreeFileSync_14.5_macOS.zip
mac@MacBook-Pro-de-Eduardo Downloads % wget https://freefilesync.org/download/FreeFileSync_14.5_macOS.zip
--2025-10-07 22:36:41--  https://freefilesync.org/download/FreeFileSync_14.5_macOS.zip
Resolvendo freefilesync.org (freefilesync.org)... 2606:4700:3031::ac43:815f, 2606:4700:3036::6815:2a0, 172.67.129.95, ...
Conectando-se a freefilesync.org (freefilesync.org)|2606:4700:3031::ac43:815f|:443... conectado.
A requisição HTTP foi enviada, aguardando resposta... 307 Temporary Redirect
Localização: https://freefilesync.org/get_file.static.php?hash=07fff2ec8c33b4da47fb7f5c87b78e9c [redirecionando]
--2025-10-07 22:36:41--  https://freefilesync.org/get_file.static.php?hash=07fff2ec8c33b4da47fb7f5c87b78e9c
Reaproveitando a conexão existente para [freefilesync.org]:443.
A requisição HTTP foi enviada, aguardando resposta... 200 OK
Tamanho: 33632068 (32M) [application/octet-stream]
Salvando em: “FreeFileSync_14.5_macOS.zip”

FreeFileSync_14.5_m 100%[===================>]  32,07M  1,72MB/s    em 18s     

2025-10-07 22:36:59 (1,78 MB/s) - “FreeFileSync_14.5_macOS.zip” salvo [33632068/33632068]

mac@MacBook-Pro-de-Eduardo Downloads % sha256 FreeFileSync_14.5_macOS.zip 
SHA256 (FreeFileSync_14.5_macOS.zip) = 99b531404a083b25bf323750c5e376fca9aae7af491a2872e3b11d3789f5b273
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
