### PR TITLE
bluos-controller 4.12.0

### DIFF
--- a/Casks/b/bluos-controller.rb
+++ b/Casks/b/bluos-controller.rb
@@ -1,6 +1,6 @@
 cask "bluos-controller" do
-  version "4.10.0"
-  sha256 "563c025852c24cec684b9962fba83086d4baa25977a7741bd51aea04ee3c5af4"
+  version "4.12.0"
+  sha256 "981ece99093fc9c6c61d44c577b8c2b8e5de8e5bcec3f4fda9cf106f80175b0e"
 
   url "https://content-bluesound-com.s3.amazonaws.com/uploads/BluOS-Controller-#{version}-MacOS.zip",
       verified: "content-bluesound-com.s3.amazonaws.com/uploads/"
@@ -12,6 +12,8 @@ cask "bluos-controller" do
     url "https://www.bluesound.com/downloads/"
     regex(%r{uploads/BluOS[._-]Controller[._-]v?(\d+(?:\.\d+)+)[._-]MacOS\.zip}i)
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "BluOS Controller.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`bluos-controller` is autobumped but the workflow failed to update to version 4.12.0 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the cask and adds an appropriate `depends_on :macos` value.