### PR TITLE
linphone 5.3.1

### DIFF
--- a/Casks/l/linphone.rb
+++ b/Casks/l/linphone.rb
@@ -1,6 +1,6 @@
 cask "linphone" do
-  version "5.3.0"
-  sha256 "cc4f7509755895d118188a7d65f5051d0cb815769beabab9edac74701528dbe4"
+  version "5.3.1"
+  sha256 "9f4f9884ebb8e0ff13c43b0e51ccca6a78c3ee5d73b86463c49d38d213584895"
 
   url "https://download.linphone.org/releases/macosx/app/Linphone-#{version}-mac.dmg"
   name "Linphone"
@@ -11,6 +11,8 @@ cask "linphone" do
     url "https://download.linphone.org/releases/macosx/app/"
     regex(/Linphone[._-]v?(\d+(?:\.\d+)+)[._-]mac\.dmg/i)
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Linphone.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`linphone` is autobumped but the workflow failed to update to version 5.3.1 because `brew audit` failed with an Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.