### PR TITLE
remote-desktop-manager 2025.3.6.7

### DIFF
--- a/Casks/r/remote-desktop-manager.rb
+++ b/Casks/r/remote-desktop-manager.rb
@@ -1,6 +1,6 @@
 cask "remote-desktop-manager" do
-  version "2025.2.12.6"
-  sha256 "84cf99f5f5c6a17f3815f2a40e558bc3a2f443e76cf4d88becce2b75bd72af65"
+  version "2025.3.6.7"
+  sha256 "4b6713f6be027396a43e68b5d33b457ff9f161c1efaab32481eb1705e6f513b8"
 
   url "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.#{version}.dmg",
       verified: "cdn.devolutions.net/download/Mac/"
@@ -14,6 +14,7 @@ cask "remote-desktop-manager" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Remote Desktop Manager.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`remote-desktop-manager` is autobumped but the workflow failed to update to version 2025.3.6.7 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.