### PR TITLE
vitalsource-bookshelf 11.2.1.3625

### DIFF
--- a/Casks/v/vitalsource-bookshelf.rb
+++ b/Casks/v/vitalsource-bookshelf.rb
@@ -1,8 +1,8 @@
 cask "vitalsource-bookshelf" do
-  version "11.2.0.3557"
-  sha256 "cefc5b8abfd77e2f7095c9cf3f5a096ae241c6b38c3bcc1aa2fb7c3d44fac20f"
+  version "11.2.1.3625"
+  sha256 "d3db099651f9e42f74bce0fa27283260e40feedd5f8621f9f96f69c05c2325ea"
 
-  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor}/mac/bookshelf/VitalSource-Bookshelf_#{version}.dmg",
+  url "https://downloads.vitalbook.com/vsti/bookshelf/#{version.major_minor_patch}/mac/bookshelf/VitalSource-Bookshelf_#{version}.dmg",
       verified: "downloads.vitalbook.com/vsti/bookshelf/"
   name "VitalSource Bookshelf"
   desc "Access etextbooks"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vitalsource-bookshelf` is autobumped but the workflow failed to update to version 11.2.1.3625 because the URL path uses the version major/minor/patch instead of only major/minor. This updates the version and URL accordingly.