### PR TITLE
ovice 1.16.3

### DIFF
--- a/Casks/o/ovice.rb
+++ b/Casks/o/ovice.rb
@@ -1,11 +1,11 @@
 cask "ovice" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.16.2"
-  sha256 arm:   "d4d3bef21bab78ec90a5ea1ec42c248f669977f36b5959e43bae87fbe14ead6c",
-         intel: "d0de26ef19fcaf1cbe6a6bd105cc3137a262a0cfc8f4dc970dc35a1c2ec50cc0"
+  version "1.16.3"
+  sha256 arm:   "6e9e34f5381c5ae3b2ef9a6a92f3a1e36e822ff17bd1ac103e29b0295fe33bdc",
+         intel: "747d6f6788bb5f7679164abef82a2206bd80ca010aa108e4718eb0d836cf9131"
 
-  url "https://assets.ovice.io/desktop-apps/staging/darwin/#{arch}/ovice-darwin-#{arch}-#{version}.zip",
+  url "https://assets.ovice.io/desktop-apps/stable/darwin/#{arch}/ovice-darwin-#{arch}-#{version}.zip",
       verified: "assets.ovice.io/desktop-apps/"
   name "ovice"
   desc "Virtual workplace for distributed teams"
@@ -17,6 +17,8 @@ cask "ovice" do
       json["currentRelease"]
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "ovice.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ovice` is autobumped but the workflow failed to update to 1.16.3, as the zip URL now uses "stable" in the path instead of "staging. `brew audit` also fails with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error, which would have also caused this issue. This updates the version and URL and adds an appropriate `depends_on macos:` value.