### PR TITLE
plistedit-pro 1.10.0

### DIFF
--- a/Casks/p/plistedit-pro.rb
+++ b/Casks/p/plistedit-pro.rb
@@ -1,6 +1,6 @@
 cask "plistedit-pro" do
-  version "1.9.7"
-  sha256 "a38b2336dfd4fd65a4243b32b29975419ade9b0b7d161ca49147a00508e9e6ce"
+  version "1.10.0"
+  sha256 "0ad2f7a4066945b5a67db0667e946748cc4f33858f786554779c54f1a6608c4e"
 
   url "https://www.fatcatsoftware.com/plisteditpro/downloads/PlistEditPro_#{version.no_dots}.zip"
   name "PlistEdit Pro"
@@ -12,12 +12,20 @@ cask "plistedit-pro" do
   livecheck do
     url "https://www.fatcatsoftware.com/plisteditpro/downloads/appcast.xml"
     strategy :sparkle do |items|
-      items.find { |item| item.channel.nil? }&.short_version
+      newest_item = items.find { |item| item.channel.nil? }&.short_version
+      match = newest_item&.match(/v?(\d+\.\d+)((?:\.\d+)*)/i)
+      next if match.blank?
+
+      # The dotless version in the file name uses major/minor/patch but the
+      # appcast `shortVersionString` may omit patch for new major/minor
+      # versions (e.g. 1100 and 1.10 respectively). This adds `.0` to versions
+      # without a patch to avoid this mismatch.
+      "#{match[1]}#{match[2].presence || ".0"}"
     end
   end
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :sonoma"
 
   app "PlistEdit Pro.app"
   binary "#{appdir}/PlistEdit Pro.app/Contents/MacOS/pledit"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`plistedit-pro` is autobumped but the workflow failed to update to version 1.10 because the `shortVersionString` in the appcast is 1.10 but the dotless version in the file name is 1100 (i.e., 1.10.0 without dots). This updates the version and modifies the `livecheck` block to append `.0` to any versions without a patch, so it returns 1.10.0 in this instance.