### PR TITLE
powerphotos 3.1.1

### DIFF
--- a/Casks/p/powerphotos.rb
+++ b/Casks/p/powerphotos.rb
@@ -1,8 +1,8 @@
 cask "powerphotos" do
-  on_big_sur :or_older do
+  on_ventura :or_older do
     on_catalina :or_older do
-      version "1.9.12"
-      sha256 "cbb7cb47b20d947bc8bb30dc29e6eba88ba1e39d073bc304962e3f4759c8f0be"
+      version "1.9.14"
+      sha256 "760bfa114e0a6c807613c689c84ac5eceeae2763bcf246b104636d2d862676f1"
 
       url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos_#{version.no_dots}.zip"
     end
@@ -12,13 +12,19 @@ cask "powerphotos" do
 
       url "https://www.fatcatsoftware.com/powerphotos/downloads/PowerPhotos_#{version.no_dots}.zip"
     end
+    on_monterey :or_newer do
+      version "2.7.8"
+      sha256 "3a1e2dca4adda2d976721178f5df5667fa0ada2923a74131f2f7fa5e767d4aae"
+
+      url "https://www.fatcatsoftware.com/powerphotos/downloads/PowerPhotos_#{version.no_dots}.zip"
+    end
 
     livecheck do
       skip "Legacy version"
     end
   end
-  on_monterey :or_newer do
-    version "3.1"
+  on_sonoma :or_newer do
+    version "3.1.1"
     sha256 :no_check
 
     url "https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`powerphotos` is autobumped but the workflow failed to update to version 3.1.1 because it requires macOS 14 Sonoma or later but the cask is incorrectly using the macOS 12 Monterey or later requirement from the 2.x releases. Looking back at archived snapshots of the [upstream download page](https://www.fatcatsoftware.com/powerphotos_downloads/), it seems that the 3.x versions have had the macOS 14 or later requirement from the start and the cask simply wasn't updated to reflect this change.

This updates the current version to 3.1.1 and adjusts the cask to use an `on_sonoma` block for it. This also adds an `on_monterey :or_newer` block for version 2.7.8, which is the legacy version for macOS 12 and later. Lastly, this updates the Catalina version to 1.9.14. These changes bring the cask in line with the versions listed on the upstream download page at the moment.