### PR TITLE
atuin-desktop 0.1.5

### DIFF
--- a/Casks/a/atuin-desktop.rb
+++ b/Casks/a/atuin-desktop.rb
@@ -1,9 +1,9 @@
 cask "atuin-desktop" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.1.4"
-  sha256 arm:   "94abdebc96d462df7c0771c732d86e18a85c2c7de432a2d3e05cfb1fe2e27b5d",
-         intel: "1e921fc68e7565adf438e8b85e10bdd08e6f46ba6bbabfe6543a0bc7375e3b87"
+  version "0.1.5"
+  sha256 arm:   "942e8aa3e8c9c36568e586be40769abab483cde7f73a0078d4804344a98c986f",
+         intel: "785af5e6213e158b292b6304ad7d31e0c810786360ceb62adc22cea6354c145b"
 
   url "https://github.com/atuinsh/desktop/releases/download/v#{version}/Atuin_#{version}_#{arch}.dmg",
       verified: "github.com/atuinsh/desktop/"
@@ -13,7 +13,7 @@ cask "atuin-desktop" do
 
   livecheck do
     url :url
-    regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :github_latest
   end
 
   app "Atuin.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`atuin-desktop` is autobumped but the workflow failed to update to version 0.1.5 because livecheck checked the Git tags but the related release hadn't been created yet (it took ~3 hours after the tag was pushed). This updates the version and modifies the `livecheck` block to use the `GithubLatest` strategy, as there can be a notable gap between tag and release.