### PR TITLE
clay 2.18.20

### DIFF
--- a/Casks/c/clay.rb
+++ b/Casks/c/clay.rb
@@ -1,6 +1,6 @@
 cask "clay" do
-  version "2.18.19"
-  sha256 "7f5b70040f54cb9401140fe627237b9eead5250d1140e627a006a8e7bcbb8c62"
+  version "2.18.20"
+  sha256 "901c0e81176913d8c53d66719f7348c01d59c153261d19baf9910229a7fce2d2"
 
   url "https://assets.clay.earth/desktop/mac/Clay-#{version}-universal.dmg"
   name "Clay"
@@ -13,6 +13,7 @@ cask "clay" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Clay.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`clay` is autobumped but the workflow failed to update to version 2.18.20 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.