### PR TITLE
matterhorn 90000.1.1

### DIFF
--- a/Casks/m/matterhorn.rb
+++ b/Casks/m/matterhorn.rb
@@ -1,14 +1,16 @@
 cask "matterhorn" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "90000.1.0"
-  sha256 arm:   "39c292a945a9b258fc25e5e36354d1001a2d22b8674e7bf6db464a61f8681259",
-         intel: "96920c83c3300ede0ee38f9fb78d79ab4d3b19abb42aefbe21df12513a1e210d"
+  version "90000.1.1"
+  sha256 arm:   "c9305307f95b1496a66a787ef27832f3abcf4be71dd6197d5e1f1d71377d45e5",
+         intel: "d135d5d76956da08aa1b57f8f5d28967b6d827d7cc52dfe6b2938b37761dd02f"
 
   url "https://github.com/matterhorn-chat/matterhorn/releases/download/#{version}/matterhorn-#{version}-Darwin-#{arch}.tar.bz2"
   name "Matterhorn"
   desc "Unix terminal client for Mattermost"
   homepage "https://github.com/matterhorn-chat/matterhorn"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   binary "matterhorn-#{version}-Darwin-#{arch}/matterhorn"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`matterhorn` is autobumped but the workflow failed to update to version 90000.1.1 because the binary fails Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.