### PR TITLE
kimis 1.21.183

### DIFF
--- a/Casks/k/kimis.rb
+++ b/Casks/k/kimis.rb
@@ -1,8 +1,8 @@
 cask "kimis" do
-  version "1.20.180"
-  sha256 "c65971af9978af87864fe30a86d73187d4adee9453577cf5e13652f1fe5badc7"
+  version "1.21.183"
+  sha256 "7146826719ddb2a1142a9106205aaa50c31676db6214f0e90b4f4bfa7c59a512"
 
-  url "https://github.com/Lakr233/Kimis/releases/download/#{version}/Kimis-v#{version}.zip"
+  url "https://github.com/Lakr233/Kimis/releases/download/#{version}/Kimis-#{version}.zip"
   name "Kimis"
   desc "Desktop client for Misskey"
   homepage "https://github.com/Lakr233/Kimis"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kimis` is autobumped but the workflow failed to update to version 1.21.183 because the file name doesn't include a `v` before the version. This updates the version and adjusts the `url` accordingly.