### PR TITLE
sunsama 3.2.0

### DIFF
--- a/Casks/s/sunsama.rb
+++ b/Casks/s/sunsama.rb
@@ -1,9 +1,9 @@
 cask "sunsama" do
   arch arm: "arm64", intel: "x64"
 
-  version "3.1.2,250711rlkq87w2m"
-  sha256 arm:   "e0a72b354b0254871ac2fffc0ca3047975dfe38b365cbdd0455d7805368cc0c6",
-         intel: "5ad36323ba47b2a3b9b514ad89d87399ba7aa2d05619be00b149e404574adfa0"
+  version "3.2.0,251008ae7l1ezsz"
+  sha256 arm:   "68464061b7566d7d480dea231216ea00913c279c388ade74334ec501d21e115e",
+         intel: "a6388236d9477d43e55b908bdbb4d2596aed4e0841041093826e9d7d82cac7cf"
 
   url "https://download.todesktop.com/2003096gmmnl0g1/Sunsama%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}-mac.zip",
       verified: "download.todesktop.com/2003096gmmnl0g1/"
@@ -25,7 +25,7 @@ cask "sunsama" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Sunsama.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`sunsama` is autobumped but the workflow failed to update to version 3.2.0 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and `depends_on macos:` value.