### PR TITLE
pinwheel 1.7.2

### DIFF
--- a/Casks/p/pinwheel.rb
+++ b/Casks/p/pinwheel.rb
@@ -1,16 +1,15 @@
 cask "pinwheel" do
-  version "1.7.1"
-  sha256 "71091465689ffe6ee52765c14987fd60c1f95296e04ab42d76d9e3f770469864"
+  version "1.7.2,98"
+  sha256 "5b986c13a4c6ca454b5ff2a2b4ba16d7fd34ff1aca99e63ccbcf83ab997958f6"
 
-  url "https://cdn.skala.app/pinwheel/versions/Pinwheel_#{version.dots_to_underscores}.zip",
-      verified: "cdn.skala.app/"
+  url "https://cdn2.bjango.com/pinwheel/versions/Pinwheel_#{version.csv.first.dots_to_underscores}-#{version.csv.second}.zip"
   name "Pinwheel"
   desc "Design systems and accessibility testing"
   homepage "https://bjango.com/mac/pinwheel/"
 
   livecheck do
     url "https://updates.skala.app/pinwheel/pinwheel.xml"
-    strategy :sparkle, &:short_version
+    strategy :sparkle
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`pinwheel` is autobumped but the workflow failed to update to version 1.7.2 because the zip file is now served from cdn2.bjango.com instead of cdn.skala.app according to the appcast. The file name also uses a `1_2_3-45` version format now, so we need both the `shortVersionString` and `version` values from the appcast. This updates the version, `url`, and `livecheck` block accordingly.