### PR TITLE
wireshark-app 4.6.0

### DIFF
--- a/Casks/w/wireshark-app.rb
+++ b/Casks/w/wireshark-app.rb
@@ -2,27 +2,26 @@ cask "wireshark-app" do
   arch arm: "Arm", intel: "Intel"
   livecheck_arch = on_arch_conditional arm: "arm", intel: "x86-"
 
-  on_catalina :or_older do
-    version "4.2.13"
-    sha256 arm:   "0ec816487ff31a6477b7da55dc8e95b0dc0251afcbf07923b9828235b5a3dbe7",
-           intel: "b4d109a295d028180627aa529cd71e69cf799a6616456cc4deed074919346956"
+  on_big_sur :or_older do
+    version "4.4.10"
+    sha256 arm:   "cac11db8389b93d9f4eeab956879b961272050b8c1271819624b94647f73ea02",
+           intel: "9c7b9955fa9cc6aa74df197d2de225cacc97761bbf8398c1980be0a10ecea6f9"
 
+    url "https://www.wireshark.org/download/osx/all-versions/Wireshark%20#{version}%20#{arch}%2064.dmg"
+
+    # The 4.4.x "old stable release" uses the same appcast as the current stable
+    # release but that only includes an item for the current stable release, so
+    # we have to check the homepage for the old stable release version.
     livecheck do
-      url "https://www.wireshark.org/update/0/Wireshark/0.0.0/macOS/#{livecheck_arch}64/en-US/development.xml"
-      strategy :sparkle do |items|
-        items.map do |item|
-          next unless item.minimum_system_version
-          next if item.minimum_system_version >= :catalina
-
-          item.version
-        end
-      end
+      url :homepage
+      regex(/Old\s+Stable\s+Release.*?href=["']?[^"' >]*?Wireshark%20v?(\d+(?:\.\d+)+)%20#{arch}%2064\.dmg/im)
     end
   end
-  on_big_sur :or_newer do
-    version "4.4.9"
-    sha256 arm:   "6623f789646c6a64735d2179fd9333a05606f83f7946d897448eea2074e8654b",
-           intel: "f7e742a6cd42f13c81ad63a99764262c7e15bd66c8b48eb9bf879803150d5b7d"
+  on_monterey :or_newer do
+    version "4.6.0"
+    sha256 "79eda54875cb8f9a8e53e876574a9a2fccaba039c21c1a1e38971c398ca1e3f2"
+
+    url "https://www.wireshark.org/download/osx/all-versions/Wireshark%20#{version}.dmg"
 
     # This appcast sometimes uses a newer pubDate for an older version, so we
     # have to ignore the default `Sparkle` strategy sorting (which involves the
@@ -35,13 +34,13 @@ cask "wireshark-app" do
     end
   end
 
-  url "https://2.na.dl.wireshark.org/osx/all-versions/Wireshark%20#{version}%20#{arch}%2064.dmg"
   name "Wireshark"
   desc "Network protocol analyzer"
   homepage "https://www.wireshark.org/"
 
   auto_updates true
   conflicts_with cask: "wireshark-chmodbpf"
+  depends_on macos: ">= :big_sur"
 
   app "Wireshark.app"
   pkg "Add Wireshark to the system path.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wireshark-app` is autobumped but the workflow failed to update to version 4.6.0 because the related app is now a universal binary, so there's only one dmg file for 4.6.x releases. The app still checks an arch-specific appcast, so I've left that as-is.

With the 4.6.0 release, the "old stable version" is now 4.4.10 and the development appcast doesn't include any versions for Catalina or newer, as it only includes an item for 4.6.0. The stable appcast also only includes an item for 4.6.0, so it doesn't provide the "old stable release" version. With that in mind, I had to set the `livecheck` block for the old stable version to check the homepage, which links to the dmg file.

Lastly, this updates the URLs to use www.wireshark.org, as that goes through Cloudflare (and may use a CDN), whereas the existing 2.na.dl.wireshark.org URLs seem to be region-specific. We can always switch back if this causes a problem but this aligns `wireshark-app` with the `wireshark-chmodbpf` cask's `url`.