### PR TITLE
a-better-finder-rename 12.16

### DIFF
--- a/Casks/a/a-better-finder-rename.rb
+++ b/Casks/a/a-better-finder-rename.rb
@@ -1,5 +1,5 @@
 cask "a-better-finder-rename" do
-  version "12.15"
+  version "12.16"
   sha256 :no_check # required as upstream package is updated in-place
 
   url "https://www.publicspace.net/download/ABFRX#{version.major}.dmg"
@@ -13,6 +13,7 @@ cask "a-better-finder-rename" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "A Better Finder Rename #{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`a-better-finder-rename` is autobumped but the workflow failed to update to version 12.16 because `brew audit` failed with an "Upstream defined :ventura as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.