### PR TITLE
block-goose 1.9.2

### DIFF
--- a/Casks/b/block-goose.rb
+++ b/Casks/b/block-goose.rb
@@ -1,9 +1,9 @@
 cask "block-goose" do
   arch intel: "_intel_mac"
 
-  version "1.9.1"
-  sha256 arm:   "c5b043d68a024c47e020b1f008ebfc85bbba399b1a39d80bdf19c8221f0e2def",
-         intel: "61e1f7954699e156fda66dac6dbbe2b23a6b167cd6f165bb40258a2f4a49540d"
+  version "1.9.2"
+  sha256 arm:   "c92a13153dd914cf7b2a4dd15e1feefe60991ad5ac888b7a3cbb5a88df458a97",
+         intel: "ef180e3bb2c20ece00579dfd7b987e3946ee4c0fb021006ebeaf7002cb2b0603"
 
   url "https://github.com/block/goose/releases/download/v#{version}/Goose#{arch}.zip",
       verified: "github.com/block/goose/"
@@ -16,7 +16,7 @@ cask "block-goose" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Goose.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`block-goose` is autobumped but the workflow failed to update to version 1.9.2 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and adds an appropriate `depends_on macos:` value.