### PR TITLE
camo-studio 2.4.0

### DIFF
--- a/Casks/c/camo-studio.rb
+++ b/Casks/c/camo-studio.rb
@@ -1,6 +1,6 @@
 cask "camo-studio" do
-  version "2.3.2,16475"
-  sha256 "51bbd71beabb1463cb35289c860de9a0077667ade02911eb8011fb3b87114202"
+  version "2.4.0,17515"
+  sha256 "800f30295b4a99274d58f1bc92a3a6cbca1e5a351c770d5c28695d79a60a0ed2"
 
   url "https://releases.reincubate.com/camo/camo-macos-#{version.csv.first}.#{version.csv.second}.zip"
   name "Camo Studio"
@@ -13,6 +13,7 @@ cask "camo-studio" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Camo Studio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`camo-studio` is autobumped but the workflow failed to update to version 2.4.0 because `brew audit` failed with an "Upstream defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.