### PR TITLE
ecamm-live 4.4.10

### DIFF
--- a/Casks/e/ecamm-live.rb
+++ b/Casks/e/ecamm-live.rb
@@ -1,5 +1,5 @@
 cask "ecamm-live" do
-  version "4.4.9"
+  version "4.4.10"
   sha256 :no_check
 
   url "https://downloads.ecamm.com/EcammLive.zip"
@@ -13,6 +13,7 @@ cask "ecamm-live" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   # The url is unversioned, but the download returns an app directory with a version number
   rename "Ecamm Live v#{version}", "Ecamm Live"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ecamm-live` is autobumped but the workflow failed to update to version 4.4.10 because `brew audit` failed with an "Upstream defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.