### PR TITLE
understand 7.2.1235

### DIFF
--- a/Casks/u/understand.rb
+++ b/Casks/u/understand.rb
@@ -1,6 +1,6 @@
 cask "understand" do
-  version "7.1.1234"
-  sha256 "8ca69f17c0e774362512136fdf97a1e29a7b0b6bfd6da94902a8cd4ce5e843af"
+  version "7.2.1235"
+  sha256 "9e46579e3751318dfeb7a061ebd796d6e6b8b1efa98726afbd9b603a921aba25"
 
   url "https://latest.scitools.com/Understand/Understand-#{version}-macOS-Universal.dmg"
   name "SciTools Understand"
@@ -11,6 +11,8 @@ cask "understand" do
     url "https://licensing.scitools.com/download/thanks/macOS-Universal.dmg"
     regex(/Understand[._-]v?(\d+(?:\.\d+)+)[._-]macOS[._-]Universal\.dmg/i)
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Understand.app"
   binary "#{appdir}/Understand.app/Contents/MacOS/userver"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`understand` is autobumped but the workflow failed to update to version 7.2.1235 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.