### PR TITLE
wifi-explorer 3.6

### DIFF
--- a/Casks/w/wifi-explorer.rb
+++ b/Casks/w/wifi-explorer.rb
@@ -1,6 +1,6 @@
 cask "wifi-explorer" do
-  version "3.5.6"
-  sha256 "4f5c0d16d139f0ddb168cd48e4610ab2e1d64d0fd5f27c644ba1b574dbcb127c"
+  version "3.6"
+  sha256 "07bef7f6863e271ac2b8111c11258465fff3cbd3e8469ab92721caeb8388f4f0"
 
   url "https://www.intuitibits.com/downloads/WiFiExplorer_#{version}.dmg"
   name "WiFi Explorer"
@@ -13,6 +13,7 @@ cask "wifi-explorer" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "WiFi Explorer.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wifi-explorer` is autobumped but the workflow failed to update to version 3.6 because `brew audit` failed with an "Upstream defined :ventura as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.