### PR TITLE
wifi-explorer-pro 3.8

### DIFF
--- a/Casks/w/wifi-explorer-pro.rb
+++ b/Casks/w/wifi-explorer-pro.rb
@@ -1,6 +1,6 @@
 cask "wifi-explorer-pro" do
-  version "3.7.5"
-  sha256 "2b800d6bc4660e5be4474a06c423239fd0514e8f43ee8ffb2578716dd73d6862"
+  version "3.8"
+  sha256 "7655fab210b48f82413b13affd810b9bb40e015d9aa4c7fb6a42e1e1380b2cb9"
 
   url "https://www.intuitibits.com/downloads/WiFiExplorerPro_#{version}.pkg"
   name "WiFi Explorer Pro"
@@ -13,6 +13,7 @@ cask "wifi-explorer-pro" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   pkg "WiFiExplorerPro_#{version}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wifi-explorer-pro` is autobumped but the workflow failed to update to version 3.8 because `brew audit` failed with an "Upstream defined :ventura as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.