### PR TITLE
coderabbit 0.3.4

### DIFF
--- a/Casks/c/coderabbit.rb
+++ b/Casks/c/coderabbit.rb
@@ -1,9 +1,9 @@
 cask "coderabbit" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.3.3"
-  sha256 arm:   "d862c6eebdf548d641c24f504b528973b1832e235de4c86cb5c0b4a7ceead3db",
-         intel: "595ba747bc2cc4e941a20dbb77330001106981cb956eca52d4e4f36a38427723"
+  version "0.3.4"
+  sha256 arm:   "e83f0b87ebcbc47eaf2bd79b54c81a666ea201348edb755c75743fca27a85c4f",
+         intel: "8afc606d3017e91023be5dbbe5c5a083c72bc029195799228e576d1211f392ac"
 
   url "https://cli.coderabbit.ai/releases/#{version}/coderabbit-darwin-#{arch}.zip"
   name "CodeRabbit"
@@ -14,6 +14,8 @@ cask "coderabbit" do
     url "https://cli.coderabbit.ai/releases/latest/VERSION"
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   binary "coderabbit"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`coderabbit` is autobumped but the workflow failed to update to version 0.3.4 because the binary fails Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.