### PR TITLE
gitfox 4.0.2

### DIFF
--- a/Casks/g/gitfox.rb
+++ b/Casks/g/gitfox.rb
@@ -1,9 +1,8 @@
 cask "gitfox" do
-  version "4.0.1,10423"
-  sha256 "5224b21d5e481e7439371c71ea64852d3ea1c60e669466909ea9df3e0d249d72"
+  version "4.0.2,10616"
+  sha256 "a0d3bc10740d48e6c5a3a0f3def578375825205463c96977cc5df96cf2d59493"
 
-  url "https://storage.googleapis.com/gitfox/builds/retail/#{version.csv.second}/Gitfox.#{version.csv.second}.zip",
-      verified: "storage.googleapis.com/gitfox/"
+  url "https://update.gitfox.app/builds/retail/#{version.csv.second}/Gitfox.#{version.csv.second}.zip"
   name "Gitfox"
   desc "Git client"
   homepage "https://www.gitfox.app/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gitfox` is autobumped but the workflow failed to update to version 4.0.1 because the cask URL format doesn't work for this release. The download links on the ["Older Versions" page](https://www.gitfox.app/support/older-versions) and the URLs in the API response from the `livecheck` block URL both use update.gitfox.app URLs instead of storage.googleapis.com. This updates the version and modifies the `url` accordingly.