### PR TITLE
ollama-app 0.12.5

### DIFF
--- a/Casks/o/ollama-app.rb
+++ b/Casks/o/ollama-app.rb
@@ -1,6 +1,6 @@
 cask "ollama-app" do
-  version "0.12.3"
-  sha256 "f41e422771b64ef38503e2c6973e03108ecb9584e28aa25ae88452dcb5742432"
+  version "0.12.5"
+  sha256 "8a9f993537e24e673e1cfea47da7533ead3f25709a99ab0c4ec3ed15f942bf5a"
 
   url "https://github.com/ollama/ollama/releases/download/v#{version}/Ollama-darwin.zip",
       verified: "github.com/ollama/ollama/"
@@ -14,7 +14,7 @@ cask "ollama-app" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sonoma"
 
   app "Ollama.app"
   binary "#{appdir}/Ollama.app/Contents/Resources/ollama"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ollama-app` is autobumped but the workflow failed to update to version 0.12.5 because `brew audit` failed with an "Artifact defined :sonoma as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and `depends_on macos:` value accordingly.