### PR TITLE
.github/actionlint.yml: remove

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,4 +1,0 @@
-# TODO: remove this file when actionlint is updated
-# actionlint doesn't know about macos-26 yet
-self-hosted-runner:
-  labels: [macos-15-intel, macos-26]


### PR DESCRIPTION
actionlint v1.7.8 supports `macos-15-intel` and `macos-26` [^1] so this is no longer needed after Homebrew/homebrew-core#248932.

See also: https://github.com/Homebrew/brew/pull/20862.

[^1]: https://github.com/rhysd/actionlint/releases/tag/v1.7.8
