### PR TITLE
debookee: disable

### DIFF
--- a/Casks/d/debookee.rb
+++ b/Casks/d/debookee.rb
@@ -8,10 +8,7 @@ cask "debookee" do
   desc "Network traffic analyser"
   homepage "https://debookee.com/"
 
-  livecheck do
-    url "https://www.iwaxx.com/debookee/appcast.php"
-    strategy :sparkle, &:short_version
-  end
+  disable! date: "2025-10-12", because: :no_longer_available
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `debookee` cask uses www.iwaxx.com URLs but the domain now redirects all incoming requests to the LanScan app on the Mac App Store. The debookee.com homepage states that "Debookee is no longer under active development" and there will not be any future updates. However, the aforementioned redirection breaks iwaxx.com URLs and this effectively prevents the cask from being installed, so this is the end of the road for this software. This disables the cask as `:no_longer_available` and removes the `livecheck` block (so it will be automatically skipped).