### PR TITLE
batfi 3.0.1

### DIFF
--- a/Casks/b/batfi.rb
+++ b/Casks/b/batfi.rb
@@ -1,5 +1,5 @@
 cask "batfi" do
-  version "3.0.0"
+  version "3.0.1"
   sha256 :no_check
 
   url "https://files.micropixels.software/batfi/BatFi-latest.zip"
@@ -15,7 +15,7 @@ cask "batfi" do
   end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: ">= :sonoma"
   depends_on arch: :arm64
 
   app "BatFi.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`batfi` is autobumped but the workflow failed to update to version 3.0.1 because `brew audit` failed with an "Artifact defined :sonoma as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :ventura" error. This updates the version and `depends_on macos:` value accordingly.