### PR TITLE
fontforge-app 2025-10-09

### DIFF
--- a/Casks/f/fontforge-app.rb
+++ b/Casks/f/fontforge-app.rb
@@ -1,8 +1,8 @@
 cask "fontforge-app" do
-  version "2023-01-01,a1dad3e"
-  sha256 "b87479dbb8f8f9131ea37983aae63542f016aa182232be5c6a56976350b3ebfd"
+  version "2025-10-09"
+  sha256 "ba9f883389188d822a36cd447e9a9940a2bf4c4254f49f9fa3aa622a69b73110"
 
-  url "https://github.com/fontforge/fontforge/releases/download/#{version.csv.first.no_hyphens}/FontForge-#{version.csv.first}-#{version.csv.second}.app.dmg",
+  url "https://github.com/fontforge/fontforge/releases/download/#{version.csv.first.no_hyphens}/FontForge-#{version.csv.first}-MacOS.app.dmg",
       verified: "github.com/fontforge/fontforge/"
   name "FontForge"
   desc "Font editor and converter for outline and bitmap fonts"
@@ -10,16 +10,20 @@ cask "fontforge-app" do
 
   livecheck do
     url :url
-    regex(/^FontForge[._-]v?(\d+(?:-\d+)+)-(\h+)\.app\.dmg/i)
+    regex(/^FontForge[._-]v?(\d+(?:-\d+)+)(?:[._-]MacOS\.app)?\.dmg/i)
     strategy :github_latest do |json, regex|
       json["assets"]&.map do |asset|
         match = asset["name"]&.match(regex)
         next if match.blank?
 
-        "#{match[1]},#{match[2]}"
+        match[1]
       end
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :ventura"
 
   app "FontForge.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`fontforge-app` is autobumped but the workflow failed to update to version 2025-10-09 because the new file name format omits the previous hash suffix in favor of `-MacOS`. This updates the version and adjusts the cask accordingly.

The app is unsigned and fails Gatekeeper checks, so this also adds a `disable!` call with the future date we've been using for this scenario.