### PR TITLE
dropbox-dash 3.100.8

### DIFF
--- a/Casks/d/dropbox-dash.rb
+++ b/Casks/d/dropbox-dash.rb
@@ -1,6 +1,6 @@
 cask "dropbox-dash" do
-  version "3.99.10"
-  sha256 "553cd01cd8790cc4b6b37f63427e2234c78574dc0a4b3c629c849819180ec405"
+  version "3.100.8"
+  sha256 "91b4c937c7573a4efb75711b16429f2d74a9b4a6f7155425353f6c203f3244bd"
 
   url "https://edge.dropboxstatic.com/dbx-releng/products/dash-tesla/#{version}/mac.x86_64/Dropbox%20Dash-#{version}.dmg",
       verified: "edge.dropboxstatic.com/dbx-releng/products/dash-tesla/"
@@ -14,6 +14,7 @@ cask "dropbox-dash" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Dropbox Dash.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dropbox-dash` is autobumped but the workflow failed to update to version 3.100.8 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.