### PR TITLE
ableton-live-suite@11 11.3.43

### DIFF
--- a/Casks/a/ableton-live-suite@11.rb
+++ b/Casks/a/ableton-live-suite@11.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-suite@11" do
-  version "11.3.42"
-  sha256 "2e0e5dd4e0499c0e9653554743ab6f8afb66fb8d9564b74c99c781365896c244"
+  version "11.3.43"
+  sha256 "7c94a830e169a706a6b3f4a19169f841e5927a54e8ce24e51b7c796be1402cc2"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
   name "Ableton Live Suite"
@@ -13,6 +13,7 @@ cask "ableton-live-suite@11" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "Ableton Live #{version.major} Suite.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ableton-live-suite@11` is autobumped but the workflow failed to update to version 11.3.43 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.