### PR TITLE
bilibili 1.17.3

### DIFF
--- a/Casks/b/bilibili.rb
+++ b/Casks/b/bilibili.rb
@@ -1,5 +1,5 @@
 cask "bilibili" do
-  version "1.17.2"
+  version "1.17.3"
   sha256 :no_check
 
   url "https://dl.hdslb.com/mobile/fixed/pc_electron_mac/bili_mac.dmg",
@@ -15,6 +15,7 @@ cask "bilibili" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "哔哩哔哩.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`bilibili` is autobumped but the workflow failed to update to version 1.17.3 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.