### PR TITLE
block-goose: update livecheck

### DIFF
--- a/Casks/b/block-goose.rb
+++ b/Casks/b/block-goose.rb
@@ -11,9 +11,23 @@ cask "block-goose" do
   desc "Open source, extensible AI agent that goes beyond code suggestions"
   homepage "https://block.github.io/goose/"
 
+  # Some releases don't provide assets for Goose Desktop, so we have to check
+  # multiple releases to identify the newest version for the desktop app.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(%r{/v?(\d+(?:\.\d+)+)/Goose#{arch}\.zip}i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `block-goose` uses the `GithubLatest` strategy and it returns 1.10.1 as newest but there are no release assets for the Goose Desktop app (only CLI files). The newest release for the desktop app is still 1.9.3, so `GithubLatest` isn't sufficient here. Unfortunately, the first-party installation page only links to desktop app files from the `stable` release and there's no way to identify version information from that, as the file names aren't versioned.

This updates the `livecheck` block to use the `GithubReleases` strategy to identify versions from releases that provide assets for the desktop app. Hopefully a better source of version information eventually appears in the future but this works for now.