### PR TITLE
baidunetdisk 4.54.2

### DIFF
--- a/Casks/b/baidunetdisk.rb
+++ b/Casks/b/baidunetdisk.rb
@@ -1,12 +1,11 @@
 cask "baidunetdisk" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.53.7"
-  sha256 arm:   "e56ce16b367a9d40b740a2f6323d7950de281f60ae51b6c1d88c0f2b1886e1ff",
-         intel: "b9fa80f09cce13231ed298d551a28783ae29701253988936cbaa3236f9e180ee"
+  version "4.54.2"
+  sha256 arm:   "953cd8b9f0ff68ade46ef0576165a6e980dd4a9ab64d1cdde3e6f52f8fd66923",
+         intel: "8321fece36cb9c4d3dc25d15a461a60b397c3cfd7bc4ff2760532c2b3189924e"
 
-  url "https://issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}_#{arch}.dmg",
-      verified: "issuepcdn.baidupcs.com/issue/netdisk/MACguanjia/"
+  url "https://pkg-ant.baidu.com/issue/netdisk/MACguanjia/#{version}/BaiduNetdisk_mac_#{version}_#{arch}.dmg"
   name "Baidu NetDisk"
   name "百度网盘"
   desc "Cloud storage service"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`baidunetdisk` is autobumped but the workflow failed to update to version 4.54.2 because the Intel dmg file isn't accessible. I checked the response from the `livecheck` block URL and the URLs for the dmg files have changed. This updates the version and `url` accordingly.

I've created this as a draft for now, as the Intel dmg is also inaccessible at the new URL, so this will predictably fail. This same issue affects the download links on the homepage, as they use the same source for the dmg files. The URL is correct (with respect to the URL in the `livecheck` block response) but the file simply isn't available on the upstream server.