### PR TITLE
gcloud-cli: migrate to python@3.14

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -16,7 +16,7 @@ cask "gcloud-cli" do
   end
 
   auto_updates true
-  depends_on formula: "python@3.12"
+  depends_on formula: "python@3.14"
 
   google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 
@@ -60,7 +60,7 @@ cask "gcloud-cli" do
     end
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "create", "--python-to-use",
-                                "#{HOMEBREW_PREFIX}/opt/python@3.12/libexec/bin/python3"],
+                                "#{HOMEBREW_PREFIX}/opt/python@3.14/libexec/bin/python"],
                     reset_uid: true
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "enable"],


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

The documentation for gcloud-cli says that it supports running on Python 3.14: https://cloud.google.com/sdk/docs/install#supported_python_versions

This cask's current dependency on python@3.12 is the only reason that old Python is hanging around on my system, which is my motivation for creating this PR.

@maythazin5 I noticed that you've previously been active regarding changes to this cask, and said you work at Google Cloud. I'm very interested in your feedback on this, so I'm marking this PR as Draft status for now.
