### PR TITLE
folo 0.7.1

### DIFF
--- a/Casks/f/folo.rb
+++ b/Casks/f/folo.rb
@@ -1,11 +1,11 @@
 cask "folo" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.7.0"
-  sha256 arm:   "34b6e932277444fdca273fab6e5a9f139378de04914684213c61ba45fde53e73",
-         intel: "3e07f44c643010cb16c218d3e64957a9921fe8254f98f53f51f0300ec362773c"
+  version "0.7.1"
+  sha256 arm:   "910ec6b6a93e31f5a0055ad9bc4611b808d3471c26f48ec684ca70c08a5acf65",
+         intel: "6928abf7d0242f65c7cab6909fcf6067717bb1277552afecfa809489eacbb3ef"
 
-  url "https://github.com/RSSNext/Folo/releases/download/v#{version}/Folo-#{version}-macos-#{arch}.dmg",
+  url "https://github.com/RSSNext/Folo/releases/download/desktop%2Fv#{version}/Folo-#{version}-macos-#{arch}.dmg",
       verified: "github.com/RSSNext/Folo/"
   name "Folo"
   desc "Information browser"
@@ -13,7 +13,7 @@ cask "folo" do
 
   livecheck do
     url :url
-    regex(/^v?(\d+(?:\.\d+)+(?:[._-]beta[._-]?\d+)?)$/i)
+    regex(%r{^(?:desktop[/@])?v?(\d+(?:\.\d+)+(?:[._-]beta[._-]?\d+)?)$}i)
     strategy :github_latest
   end
 
@@ -22,7 +22,7 @@ cask "folo" do
     "follow@alpha",
     "folo@nightly",
   ]
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Folo.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`folo` is autobumped but the workflow failed to update to version 0.7.1 because upstream is now using a `desktop/v1.2.3` tag format and livecheck was giving an `Unable to get versions` error due to the regex not matching the new tag format. This updates the version and modifies the `livecheck` block regex to allow for a `desktop` prefix (the newest release uses `desktop/` but there are other tags using `desktop@`, so I've set it to match both).