### PR TITLE
edrawmind 12.4.1

### DIFF
--- a/Casks/e/edrawmind.rb
+++ b/Casks/e/edrawmind.rb
@@ -1,20 +1,17 @@
 cask "edrawmind" do
-  version "12.2.2,5378"
-  sha256 "11f2bfb3f01274077641c577b6d23ffd8d04cc5fceca15d28468903a497f03ef"
+  version "12.4.1"
+  sha256 "cc82d7a1f4373813576957415fa4619a0ccfd47940db989691514247781e7293"
 
-  url "https://download.edrawsoft.com/cbs_down/edrawmind_#{version.csv.first}_full#{version.csv.second}.zip"
+  url "https://download.wondershare.com/cbs_down/edrawmind_#{version}_full5378.zip",
+      verified: "download.wondershare.com/"
   name "EdrawMind"
   desc "Mind mapping software"
   homepage "https://www.edrawsoft.com/edrawmind/"
 
   livecheck do
-    url "https://www.edrawsoft.com/download-edrawmind.html"
-    regex(/for\s+Mac.*?v?(\d+(?:\.\d+)+).*?edrawmind[._-]full(\d+)\./im)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
+    url "https://crm.wondershare.com/api/v1/support/5378/release-versions"
+    strategy :json do |json|
+      json["data"]&.filter_map { |item| item["version_name"] }
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`edrawmind` is autobumped but the `livecheck` block is returning an innacurate, much lower version because the download page no longer provides version information. This updates the cask version to the latest version and modifies the `livecheck` block to check the JSON data that's used on [the support page for downloading products](https://support.wondershare.com/how-tos/wondershare/product-download.html?product=edrawmind) to populate versions in a select box. This also removes `5378` from the `version` because it's a fixed product ID that won't change between versions.

For what it's worth, the app itself does check for new versions (it's triggered by Help > New Features) but it checks a different URL and the server won't respond with the JSON data unless the request has a proper `Authorization` header and the URL has the expected query string parameters. Needless to say, that's not something we can use in the `livecheck` block but thankfully we have the alternative in this PR.