### PR TITLE
dockflow 1.51 (new cask)

### DIFF
--- a/Casks/d/dockflow.rb
+++ b/Casks/d/dockflow.rb
@@ -9,8 +9,8 @@ cask "dockflow" do
   homepage "https://dockflow.appitstudio.com/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://raw.githubusercontent.com/AppitStudio/dock-flow-updates/refs/heads/main/appcast.xml"
+    strategy :sparkle
   end
 
   depends_on macos: ">= :ventura"

--- a/Casks/d/dockflow.rb
+++ b/Casks/d/dockflow.rb
@@ -13,6 +13,7 @@ cask "dockflow" do
     strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: ">= :ventura"
 
   app "DockFlow.app"

--- a/Casks/d/dockflow.rb
+++ b/Casks/d/dockflow.rb
@@ -1,0 +1,27 @@
+cask "dockflow" do
+  version "1.51"
+  sha256 "a8f552b0c36be59660a763a96f7a3aead538f3f8425fe6912039406b8ef9f411"
+
+  url "https://github.com/AppitStudio/dock-flow-updates/releases/download/v#{version}/DockFlow.dmg",
+      verified: "github.com/AppitStudio/"
+  name "DockFlow"
+  desc "Manage Dock presets and switch between them instantly"
+  homepage "https://dockflow.appitstudio.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "DockFlow.app"
+
+  zap trash: [
+    "~/Library/Application Support/DockFlow",
+    "~/Library/Group Containers/com.appit.DockFlowGroup",
+    "~/Library/Preferences/com.appit.DockFlow.plist",
+    "~/Library/Preferences/com.appit.DockFlowHelper.plist",
+    "~/Library/Saved Application State/com.appit.DockFlow.savedState",
+  ]
+end


### PR DESCRIPTION
This pull request adds DockFlow 1.51, a commercial macOS application to manage Dock presets and switch between them instantly.

– URL: uses GitHub release downloads with version interpolation  
– sha256: a8f552b0c36be59660a763a96f7a3aead538f3f8425fe6912039406b8ef9f411  
– verified: github.com/AppitStudio/  
– depends_on: macOS ≥ Ventura  
– zap: cleans up all user data and preferences  

DockFlow is a proprietary, paid app developed by an established indie developer with proven revenue (> €4k). Requesting an exception to the GitHub notability requirement.  

Website: https://dockflow.appitstudio.com/  
GitHub: https://github.com/AppitStudio/dock-flow-updates  


**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.


_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X ] `brew audit --cask --online <cask>` is error-free. - Error: 1 -  GitHub notability - Ask for an exception for this requirement.
- [X ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ X] `brew audit --cask --new <cask>` worked successfully. - GitHub repository not notable enough - asking for an exception
- [X ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ X] `brew uninstall --cask <cask>` worked successfully.

---
