### PR TITLE
Removed rmdir directive for '/Library/Arturia'

### DIFF
--- a/Casks/a/arturia-software-center.rb
+++ b/Casks/a/arturia-software-center.rb
@@ -37,6 +37,5 @@ cask "arturia-software-center" do
         "~/Library/Caches/com.Arturia.ArturiaSoftwareCenter",
         "~/Library/Saved Application State/com.Arturia.ArturiaSoftwareCenter.savedState",
         "~/Library/WebKit/com.Arturia.ArturiaSoftwareCenter",
-      ],
-      rmdir:  "/Library/Arturia"
+      ]
 end


### PR DESCRIPTION
Removed rmdir directive for '/Library/Arturia' as there are dependencies for some Arturia plugins located in that directory. '/Library/Arturia/Arturia Software Center' is already being zapped by the delete function.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
