### PR TITLE
hazeover: update livecheck

### DIFF
--- a/Casks/h/hazeover.rb
+++ b/Casks/h/hazeover.rb
@@ -7,12 +7,19 @@ cask "hazeover" do
   desc "Windows manager and desktop organiser"
   homepage "https://hazeover.com/"
 
+  # Upstream has published unstable versions in the main channel (e.g. "1.9.6
+  # Beta", using a `HazeOverNext.dmg` file), so this matches the first item
+  # where the `shortVersionString` only contains a typical numeric version.
   livecheck do
     url "https://hazeover.com/updates.xml"
-    strategy :sparkle, &:short_version
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :sparkle do |items, regex|
+      items.find { |item| item.short_version&.match(regex) }&.short_version
+    end
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "HazeOver.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `hazeover` checks the upstream appcast using the `Sparkle` strategy but this returns "1.9.6 Beta" as the newest version. Upstream doesn't restrict unstable versions to a separate (e.g., beta) channel, so we have to skip over those versions using a `strategy` block. This updates the `livecheck` block to use a `strategy` block that finds the first `item` where the `shortVersionString` only contains a typical numeric version like 1.9.6 (not "1.9.6 Beta"). Hopefully this holds up over time but we can always revisit this and change how we identify stable versions if we run into problems in the future.

Besides that, this adds `depends_on macos: ">= :big_sur"`, to resolve a related audit error ("Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version").