### PR TITLE
Adding required path to uninstall and zap lists

### DIFF
--- a/Casks/s/spyder.rb
+++ b/Casks/s/spyder.rb
@@ -26,6 +26,7 @@ cask "spyder" do
               "/Applications/REQUIRED.app",
               "/Applications/Spyder #{version.major} Uninstaller.app",
               "/Applications/Spyder #{version.major}.app",
+              "/System/Volumes/Data/Library/spyder-6",
             ]
 
   zap trash: [
@@ -33,5 +34,6 @@ cask "spyder" do
     "~/Library/Application Support/Spyder",
     "~/Library/Caches/Spyder",
     "~/Library/Saved Application State/org.spyder-ide.Spyder.savedState",
+    "/System/Volumes/Data/Library/spyder-6",
   ]
 end


### PR DESCRIPTION
In order to uninstall this application and to be able to reinstall again (ever) the  following folder must be removed

"/System/Volumes/Data/Library/spyder-6"

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
