### PR TITLE
jamovi 2.7.9.0

### DIFF
--- a/Casks/j/jamovi.rb
+++ b/Casks/j/jamovi.rb
@@ -1,9 +1,9 @@
 cask "jamovi" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.7.8.0"
-  sha256 arm:   "a5bc8be4bae1767fb86e91adb7b41600f5290f3c5f1ba408b5ec4c24d0a1ddaf",
-         intel: "6de45e177a74543bdb751781dbbca36f2f7d900abd59f49decb35bfd341d7839"
+  version "2.7.9.0"
+  sha256 arm:   "15594f76d14a5b2c92f898a8e86c6efba40cb5b74af8b1f6a47ca36ce3cf9b69",
+         intel: "d8ceb775b5c39c67267096a58dd75354907d3d37ec61600dd817573ee6d35356"
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos-#{arch}.dmg"
   name "jamovi"
@@ -16,6 +16,7 @@ cask "jamovi" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "jamovi.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`jamovi` is autobumped but the workflow failed to update to version 2.7.9.0 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.