### PR TITLE
ua-midi-control 5.12.0

### DIFF
--- a/Casks/u/ua-midi-control.rb
+++ b/Casks/u/ua-midi-control.rb
@@ -1,9 +1,8 @@
 cask "ua-midi-control" do
-  version "5.11.2"
-  sha256 "49aeaec28a54d363e0d6193c71748daa4ad3edfc0788fc1a5e29e31e80db504c"
+  version "5.12.0"
+  sha256 :no_check
 
-  url "https://s3.us-east-005.dream.io/ua-midi-control/builds/UA%20Midi%20Control%20#{version}.zip",
-      verified: "dream.io/ua-midi-control/"
+  url "https://fonoflow.com/files/ua-midi-control/UA%20Midi%20Control.zip"
   name "UA Midi Control"
   desc "Control-mapping tool for Universal Audio's UAD Console"
   homepage "https://fonoflow.com/products/ua-midi-control"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ua-midi-control` is autobumped but the workflow failed to update to version 5.12.0 because the zip file URL has changed. The appcast item for 5.12.0 links to an unversioned zip file (the same download link on the first-party product page), so this updates the version and sets `sha256` to `:no_check`.