### PR TITLE
wondershare-uniconverter 17.0.0

### DIFF
--- a/Casks/w/wondershare-uniconverter.rb
+++ b/Casks/w/wondershare-uniconverter.rb
@@ -1,11 +1,11 @@
 cask "wondershare-uniconverter" do
-  arch arm: "arm_"
+  arch arm: "_arm"
 
-  version "16.7.1"
-  sha256 arm:   "3ac1f777b76bb75ee72a5f4a1c9a704932f2a0f0099904c6700e742acfeaf233",
-         intel: "7f4cc5e5380589715eed84eadba7c9202a8196ac0c48321a3a3839a688425acb"
+  version "17.0.0"
+  sha256 arm:   "fd229ed31917fde2cb469b8eeeb99ddb16b14428dfe9e87ef43aa67b39c91277",
+         intel: "8fe2949852deaa169d930cbb2f51451478958f9c96edacda1c63be6d0bd5ef28"
 
-  url "https://download.wondershare.com/cbs_down/uniconverter#{version.major}-mac_#{arch}#{version}_full14207.zip"
+  url "https://download.wondershare.com/cbs_down/uniconverter-mac#{arch}_#{version}_full14207.zip"
   name "UniConverter"
   desc "Video editing software"
   homepage "https://videoconverter.wondershare.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wondershare-uniconverter` is autobumped but the workflow failed to update to version 17.0.0, as the file name format has changed in this release. This updates the version and `url` accordingly.

Besides that, I've tweaked the ARM `arch` value to use a prefix, as that seems to be the more common pattern.