### PR TITLE
yuanbao 2.42.0.625

### DIFF
--- a/Casks/y/yuanbao.rb
+++ b/Casks/y/yuanbao.rb
@@ -1,6 +1,6 @@
 cask "yuanbao" do
-  version "2.41.10.627,7c70406e8ccc7c8ca02a4667c4a3669e"
-  sha256 "26622b5eeb345487ed0b44e260475c033714d730427b6797e0cab580e965b64f"
+  version "2.42.0.625,2862ab2de6a3f25fe2e076fa91f92932"
+  sha256 "1f47d6bedf9f07857a22a6fa8a8e5d42d1d3939fbe7ab4521ff348093c5f919d"
 
   url "https://cdn-hybrid-prod.hunyuan.tencent.com/Desktop/official/#{version.csv.second}/yuanbao_#{version.csv.first}_universal.dmg"
   name "Yuanbao"
@@ -17,8 +17,6 @@ cask "yuanbao" do
       "#{match[2]},#{match[1]}"
     end
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`yuanbao` is autobumped but the workflow failed to update to version 2.42.0.625 because `brew audit` failed with aa "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. I've manually confirmed that the app is signed, notarized, and passes Gatekeeper checks, so this updates the version and removes the `disable!` call.