### PR TITLE
base: update livecheck and cask version with auto updates

### DIFF
--- a/Casks/b/base.rb
+++ b/Casks/b/base.rb
@@ -1,6 +1,6 @@
 cask "base" do
-  version "3.0.0"
-  sha256 "a92ecf421cc2422c01a83238e09b6e02ed35542c02000d60e2346ae79199858d"
+  version "3.1.0"
+  sha256 "f110a96e211449f0ef217472e7d444ca32888083e8bb0bca5ecf91f804e581bf"
 
   url "https://files.menial.co.uk/base/Base-#{version}.zip"
   name "Menial Base"
@@ -8,9 +8,12 @@ cask "base" do
   homepage "https://menial.co.uk/base/"
 
   livecheck do
-    url "https://update.menial.co.uk/software/base/"
+    url "https://update.menial.co.uk/software/base3/"
     strategy :sparkle, &:short_version
   end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
 
   app "Base.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Addresses #170994 `base` cask

---

<img width="510" height="495" alt="image" src="https://github.com/user-attachments/assets/95005b00-329a-4359-9491-8de123c862df" />

---

- **Fixed broken livecheck**: Changed from outdated `base/` feed to correct `base3/` feed that the app actually uses
- **Added auto_updates true**: Verified app has automatic update functionality (screenshot attached)
- **Updated version**: 3.0.0 → 3.1.0 to match current release
- **Updated SHA256**: For new version
