### PR TITLE
launchie 1.0.13 (new cask)

### DIFF
--- a/Casks/l/launchie.rb
+++ b/Casks/l/launchie.rb
@@ -1,0 +1,19 @@
+cask "launchie" do
+  version "1.0.13"
+  sha256 "e9a406dd2eae3d2f91ee9df58a1a21dfcfacdb3e09471d11aaec397fc4f6d02c"
+
+  url "https://github.com/nick-friedrich/launchie-launchpad-replacement-mac-os/releases/download/#{version}/Launchie_#{version}.dmg",
+      verified: "github.com/nick-friedrich/launchie-launchpad-replacement-mac-os/"
+  name "Launchie"
+  desc "Launchpad replacement"
+  homepage "https://www.launchie.app/"
+
+  depends_on macos: ">= :tahoe"
+
+  app "Launchie.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/de.nick-friedrich.Launchie",
+    "~/Library/Containers/de.nick-friedrich.Launchie",
+  ]
+end


### PR DESCRIPTION
Adds Cask for Launchie, a MacOS Launchpad replacement.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
