### PR TITLE
elephas 11.3013

### DIFF
--- a/Casks/e/elephas.rb
+++ b/Casks/e/elephas.rb
@@ -1,26 +1,26 @@
 cask "elephas" do
-  version "11.1087,11_1087"
-  sha256 "6f23b3a02f0a605ba86358a55c3e72d13eb2a49b872fa636e3062696c43f6231"
+  version "11.3013"
+  sha256 "50d72e22862bf7a8e73e745299c575ee00a30d2344d332275351683af6745378"
 
-  url "https://assets.elephas.app/Elephas_#{version.csv.second}.dmg"
+  url "https://assets.elephas.app/Elephas%20#{version.csv.second || version.csv.first}.dmg"
   name "Elephas"
   desc "Personal AI Writing Assistant"
   homepage "https://elephas.app/"
 
   livecheck do
     url "https://assets.elephas.app/index.xml"
-    regex(/Elephas[._-]v?(\d+(?:[._]\d+)*)\.dmg/i)
+    regex(/Elephas(?:%20|[._-])v?(\d+(?:[._]\d+)*)\.dmg/i)
     strategy :sparkle do |item, regex|
       match = item.url.match(regex)
       next if match.blank?
 
-      "#{item.short_version},#{match[1]}"
+      (item.short_version == match[1]) ? match[1] : "#{item.short_version},#{match[1]}"
     end
   end
 
   auto_updates true
   conflicts_with cask: "elephas@beta"
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :ventura"
 
   app "Elephas.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`elephas` is autobumped but the workflow failed to update to version 11.3013 because the file name now uses an encoded space as the delimiter between the name and version. This updates the version and modifies the `livecheck` block regex to be able to match `%20` or the typical delimiters. This also updates the `livecheck` block's `strategy` block logic to only use a comma-delimited `version` if the `shortVersionString` and file name version differ (they are currently the same).