### PR TITLE
supertuxkart: undeprecate, use signed binaries

### DIFF
--- a/Casks/s/supertuxkart.rb
+++ b/Casks/s/supertuxkart.rb
@@ -1,8 +1,8 @@
 cask "supertuxkart" do
   version "1.5"
-  sha256 "3eaf9169f1b17e63f626a59d08407fbabb5f054767695ad190d9a083f9e2c98f"
+  sha256 "c266acdb8a63a3fe30f52652d9b749f5beba4abeb9e54382fbb934b00c53b303"
 
-  url "https://github.com/supertuxkart/stk-code/releases/download/#{version}/SuperTuxKart-#{version}-mac.zip",
+  url "https://github.com/supertuxkart/stk-code/releases/download/#{version}/SuperTuxKart-#{version}-mac-signed.zip",
       verified: "github.com/supertuxkart/stk-code/"
   name "SuperTuxKart"
   desc "Kart racing game"
@@ -12,8 +12,6 @@ cask "supertuxkart" do
     url :url
     strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "SuperTuxKart.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
It appears supertuxkart devs have started signing their MacOS binaries, and the name of the zip now ends with `...-mac-signed.zip` instead of `...-mac.zip`. This is technically a version bump also removing the deprecate stanza.