### PR TITLE
chatgpt-atlas 1.2025.288.13

### DIFF
--- a/Casks/c/chatgpt-atlas.rb
+++ b/Casks/c/chatgpt-atlas.rb
@@ -17,7 +17,7 @@ cask "chatgpt-atlas" do
     end
   end
 
-  auto_updates
+  auto_updates true
   depends_on macos: ">= :sonoma"
   depends_on arch: :arm64
 

--- a/Casks/c/chatgpt-atlas.rb
+++ b/Casks/c/chatgpt-atlas.rb
@@ -1,6 +1,6 @@
 cask "chatgpt-atlas" do
-  version "1.2025.288.12,20251021143446000"
-  sha256 "0e91940abcd4d24fa80b7c0cde70f19e58d378934e7105f4ae53e14b248828a8"
+  version "1.2025.288.13,20251021184832000"
+  sha256 "c01cf975b0664567e420c593ee94dcbc9e2b7ee92ed96473be0c728d4a08c3ee"
 
   url "https://persistent.oaistatic.com/atlas/public/ChatGPT_Atlas_Desktop_public_#{version.csv.first}_#{version.csv.second}.dmg",
       verified: "persistent.oaistatic.com/atlas/public/"
@@ -8,9 +8,13 @@ cask "chatgpt-atlas" do
   desc "OpenAI's official browser with ChatGPT built in"
   homepage "https://chatgpt.com/atlas"
 
+  # Some older items in the Sparkle feed have a more recent pubDate, so it's necessary to
+  # work with all of the items in the feed (not just the newest one).
   livecheck do
     url "https://persistent.oaistatic.com/atlas/public/sparkle_public_appcast.xml"
-    strategy :sparkle
+    strategy :sparkle do |items|
+      items.map(&:nice_version)
+    end
   end
 
   auto_updates


### PR DESCRIPTION
Looks like this Sparkle feed behaves the same as the desktop ChatGPT app, so let's adjust accordingly.