### PR TITLE
concept2-utility 7.18.00

### DIFF
--- a/Casks/c/concept2-utility.rb
+++ b/Casks/c/concept2-utility.rb
@@ -1,6 +1,6 @@
 cask "concept2-utility" do
-  version "7.17.00"
-  sha256 "2796b6275e9d1ab08051b94e5c33e89a5b14d31020132324f9948f8aa754cae3"
+  version "7.18.00"
+  sha256 "7cddf14474f156a925026999b28657c0299b58c58221d798d53b266336cd08be"
 
   url "https://software.concept2.com/utility/Concept2Utility#{version.no_dots}.pkg"
   name "Concept2 Utility"
@@ -11,8 +11,13 @@ cask "concept2-utility" do
   # releases page (https://www.concept2.com/support/software/utility) is
   # failing in our CI environment.
   livecheck do
-    url "https://www.concept2.de/service/software/concept2-utility"
+    url "https://www.concept2.de/support/software/utility"
     regex(/Concept2\s+Utility\s+v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        (match[0].count(".") >= 2) ? match[0] : "#{match[0]}.00"
+      end
+    end
   end
 
   uninstall pkgutil: "com.concept2.pkg.Concept2Utility"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`concept2-utility` is autobumped but the workflow failed to update to version 7.18.00 because the page that livecheck is checking presents the version as 7.18. This predictably fails when used as the dotless version in the filename because it needs a `.00` patch to be 71800. This updates the version and modifies `livecheck` block to append `.00` to versions that only include a major and minor. Besides that, this also updates the `livecheck` block URL to resolve a redirection.