### PR TITLE
hotfix opensuperwhisper to 0.0.0

### DIFF
--- a/Casks/o/opensuperwhisper.rb
+++ b/Casks/o/opensuperwhisper.rb
@@ -1,6 +1,6 @@
 cask "opensuperwhisper" do
-  version "0.0.5"
-  sha256 "38d26be84b5e41345eee6676659aedc6783f9f4c18bc0c8b1cd539dcad6abed9"
+  version "0.0.6"
+  sha256 "76f83ee6c425ca406d0e777064606ca76ca1dba3fc1bebb2ed141173c20aa57b"
 
   url "https://github.com/starmel/OpenSuperWhisper/releases/download/#{version}/OpenSuperWhisper.dmg"
   name "OpenSuperWhisper"


### PR DESCRIPTION
Current version 0.0.5 is crashing on start. 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
