### PR TITLE
tinkerwell 5.5.0

### DIFF
--- a/Casks/t/tinkerwell.rb
+++ b/Casks/t/tinkerwell.rb
@@ -1,9 +1,9 @@
 cask "tinkerwell" do
   arch arm: "-arm64"
 
-  version "5.4.1"
-  sha256 arm:   "7226d2e3f52a912cfd7aed1979a24587b9a47aa77ef3a5437405895c1e85818b",
-         intel: "4f6f9cfc6b38af817f719aef1990017555ebb833452b467f29e4959550553475"
+  version "5.5.0"
+  sha256 arm:   "79fd0e9fe3f6949229ba3e63c508ec57184289d5896d665d613239bde106ed9a",
+         intel: "bef79bdc78dac80b79ccb31fce404cde326c7924cd9a1c37df0097e92b83344c"
 
   url "https://download.tinkerwell.app/tinkerwell/Tinkerwell-#{version}#{arch}.dmg"
   name "Tinkerwell"

--- a/Casks/t/tinkerwell.rb
+++ b/Casks/t/tinkerwell.rb
@@ -15,6 +15,8 @@ cask "tinkerwell" do
     strategy :electron_builder
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   auto_updates true
 
   app "Tinkerwell.app"


### PR DESCRIPTION
tinkerwell 5.5.0

```
Scan completed, but failed because the software is not signed by a distributor that meets the system Gatekeeper requirements.

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
tinkerwell
  * line 8, col 2: Signature verification failed:
```