### PR TITLE
flowdown 3.8.433

### DIFF
--- a/Casks/f/flowdown.rb
+++ b/Casks/f/flowdown.rb
@@ -1,8 +1,8 @@
 cask "flowdown" do
-  version "3.5.407,3.5.408"
-  sha256 "98bfce47992ddfa5582ccd4bd06c4a06490633bdaa837ba57c79650f1e14a909"
+  version "3.8.433"
+  sha256 "dffa94ca15dd47973873b6f1ab2f9e3b285edaa5ebcdd0cc786199a8237934ee"
 
-  url "https://github.com/Lakr233/FlowDown/releases/download/#{version.csv.second || version.csv.first}/FlowDown-V#{version.csv.first}.zip",
+  url "https://github.com/Lakr233/FlowDown/releases/download/#{version.csv.second || version.csv.first}/FlowDown-#{version.csv.first}.zip",
       verified: "github.com/Lakr233/FlowDown/"
   name "FlowDown"
   desc "AI agent"
@@ -21,7 +21,7 @@ cask "flowdown" do
     end
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: ">= :sonoma"
 
   app "FlowDown.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`flowdown` is autobumped but the workflow failed to update to version 3.8.433 because the current zip file name doesn't include a `v` before the version (upstream unpredictably includes/omits it). Besides that, `brew audit` also fails with an "Artifact defined :sonoma as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :ventura" error. This updates the version, url, and `depends_on macos:` value accordingly.