### PR TITLE
workflows/autobump: set up Homebrew/core

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main
         with:
-          core: false
+          core: true
           cask: true
 
       - name: Configure Git user


### PR DESCRIPTION
Current state effectively limits us for handling any conflicts with changes between Homebrew/core and Homebrew/cask.

From our latest autobump run:

```
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/4661be403aa910f9733c3ac92d0f333fb5e812f12a4f0cb0d05040187063a8b3--codex-aarch64-apple-darwin.tar.gz
audit for codex: failed
 - cask token conflicts with an existing homebrew/core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/codex.rb
codex
  * cask token conflicts with an existing homebrew/core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/codex.rb
Error: 1 problem in 1 cask detected.
Error: cask token conflicts with an existing homebrew/core formula: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/codex.rb
Error: `brew audit` failed!
```