### PR TITLE
insomnia@alpha 12.0.0-beta.0

### DIFF
--- a/Casks/i/insomnia@alpha.rb
+++ b/Casks/i/insomnia@alpha.rb
@@ -1,6 +1,6 @@
 cask "insomnia@alpha" do
-  version "11.6.2"
-  sha256 "26ad3d7cac3aeeef8cccf1ddeea0af821be0df704776d54323970e7fde33e564"
+  version "12.0.0-beta.0"
+  sha256 "b4466ed6c31c5e6dd21475a223f813780eabced61ca0559b50fc85018237f213"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",
       verified: "github.com/Kong/insomnia/"
@@ -17,7 +17,7 @@ cask "insomnia@alpha" do
 
   auto_updates true
   conflicts_with cask: "insomnia"
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Insomnia.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`insomnia@alpha` is autobumped but the workflow failed to update to version 12.0.0-beta.0 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and `depends_on macos:` value accordingly.

Running this with ci-skip-livecheck because the `livecheck` block will predictably return nothing when the version is up to date.