### PR TITLE
effect-house 5.3.0

### DIFF
--- a/Casks/e/effect-house.rb
+++ b/Casks/e/effect-house.rb
@@ -3,12 +3,12 @@ cask "effect-house" do
   livecheck_arch = on_arch_conditional arm: "arm64", intel: "x86_64"
 
   on_arm do
-    version "5.2.1,8456,09162025,104"
-    sha256 "dfaa5f9bdf742a11d95af265d2b5beb361c184d54a73d44e98d17a333e2ed319"
+    version "5.3.0,2057,102_105_10242025,104"
+    sha256 "b3f1e72efd17208b140e700e91cd2aa66c6151a2833d1ef580e40a71319029e2"
   end
   on_intel do
-    version "5.2.1,8457,09162025,104"
-    sha256 "6b6f8dff6dd48679bf252a04ba162b91f05f37aada152f88202f24d253317d6b"
+    version "5.3.0,2058,102_105_10242025,104"
+    sha256 "1116daf1754c280cb451248c9bd0241cd117e8ac7126d371f6727feb5a936b22"
   end
 
   url "https://sf16-va.tiktokcdn.com/obj/eden-va2/olaa_ajlmml_zlp/ljhwZthlaukjlkulzlp/V#{version.csv.first.no_dots}_External_Release_Builds_#{version.csv.third}/Effect_House_v#{version.csv.first}.#{version.csv.second}_#{arch}_#{version.csv.fourth}.dmg",
@@ -23,7 +23,7 @@ cask "effect-house" do
       arch:       livecheck_arch,
       entryPoint: version.csv.fourth,
     }
-    regex(%r{(\d+)/Effect[._-]House[._-]v?(\d+(?:\.\d+)+)(?:\.(\d+))(?:[._-]#{arch})?[._-](\d+)\.dmg}i)
+    regex(%r{(\d+(?:[._-]\d+)*)/Effect[._-]House[._-]v?(\d+(?:\.\d+)+)(?:\.(\d+))(?:[._-]#{arch})?[._-](\d+)\.dmg}i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)
       next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`effect-house` is autobumped but the workflow failed to update to version 5.3.0 because the URL format has changed. Previously, the `External_Release_Builds` part of the path was followed by a string of numbers (e.g., 09162025) but now it's a string of numbers with underscores (e.g., 102_105_10242025). The `livecheck` block regex only matched the numbers after the last underscore, so it produced an incomplete version string. This updates the version and modifies the `livecheck` block accordingly.