### PR TITLE
xtool-studio 1.1.10

### DIFF
--- a/Casks/x/xtool-studio.rb
+++ b/Casks/x/xtool-studio.rb
@@ -2,16 +2,16 @@ cask "xtool-studio" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.0.17,28,06bd0f17-e880-4435-a5fa-5d59b27a9c2c"
-    sha256 "b3e54ac877117da89d519700a335f71941be90987fdc15786ba79e58cd7dde85"
+    version "1.1.10,121,43bc6fb6-d1c6-4b64-83c8-a06b2c214614"
+    sha256 "6be9c9f22e538a04ce54ddd1cc32e0fe7cc211d29fdfb625014aa9d26825ae75"
   end
   on_intel do
-    version "1.0.17,16,bbc5d7b6-b2fb-4ca2-87bf-64818321b92b"
-    sha256 "b7a31af49eb16dd0ff3eabc69a1972c0f8936fcc82c5d293e1f83e320bac3765"
+    version "1.1.10,110,4f6db9be-6a59-4505-9e95-c09f67dc0694"
+    sha256 "394dbd39296eb57265910f5a22c49652f1fcca57eb50a3f806c6ac19a8d35d1e"
   end
 
-  url "https://storage.atomm.com/efficacy/xcs-package/prod/packages/#{version.csv.second}/#{version.csv.third}/xTool-Studio-#{arch}-#{version.csv.first}.dmg",
-      verified: "storage.atomm.com/efficacy/xcs-package/"
+  url "https://storage.atomm.com/efficacy/atomm-package/prod/packages/#{version.csv.second}/#{version.csv.third}/xTool-Studio-#{arch}-#{version.csv.first}.dmg",
+      verified: "storage.atomm.com/efficacy/atomm-package/"
   name "xTool Studio"
   desc "Design and control software for xTool laser machines"
   homepage "https://www.xtool.com/pages/software"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`xtool-studio` is autobumped but the workflow failed to update to version 1.1.10 because of a slight path change in the upstream URLs. This updates the version and adjusts the `url` accordingly.