### PR TITLE
codelite 18.2.0

### DIFF
--- a/Casks/c/codelite.rb
+++ b/Casks/c/codelite.rb
@@ -20,15 +20,25 @@ cask "codelite" do
         skip "Legacy version"
       end
     end
-    on_sonoma :or_newer do
+    on_sonoma do
       arch arm: "macOS_14.7.2-arm64"
 
       version "18.1.0"
       sha256 "ba61b4a13cadc0eb4a4a220bbece25cbccd23e16c1f29c55337a00d6cadc092a"
 
       livecheck do
+        skip "Legacy version"
+      end
+    end
+    on_sequoia :or_newer do
+      arch arm: "macOS_15.6.1-arm64"
+
+      version "18.2.0"
+      sha256 "49f919ebed4cf42e49275dc89b5df12bc14cbd4b435f07dbcdaeddef4849a9df"
+
+      livecheck do
         url "https://downloads.codelite.org/"
-        regex(/CodeLite\s*(\d+\.\d+)((?:\.\d+)*)\s*-\s*Stable/i)
+        regex(/CodeLite\s*(\d+\.\d+)((?:\.\d+)*)\s*-\s*(?:Latest|Stable)/i)
         strategy :page_match do |page, regex|
           match = page.match(regex)
           next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`codelite` is autobumped but the workflow failed to update to version 18.2.0 because the `livecheck` block gives an `Unable to get versions` error. The upstream download page previously used " - Stable" text after the version but it's currently using " - Latest", so the existing regex doesn't match.

This updates the version and adjusts the `livecheck` block regex accordingly. 18.2.0 requires macOS Sequoia, so I've kept 18.1.0 as a legacy version for Sonoma.