### PR TITLE
arc 1.118.0

### DIFF
--- a/Casks/a/arc.rb
+++ b/Casks/a/arc.rb
@@ -1,6 +1,6 @@
 cask "arc" do
-  version "1.117.0,69739"
-  sha256 "1eafb9beab5612bba678c0de6da07fd118707b7c807313e3899ccf9b5db90498"
+  version "1.118.0,69942"
+  sha256 "bf37d699f15f7b38961e51cb5f334e759c75b3e0eb3047e708f21a9284f25b06"
 
   url "https://releases.arc.net/release/Arc-#{version.csv.first}-#{version.csv.second}.zip"
   name "Arc"
@@ -13,7 +13,7 @@ cask "arc" do
   end
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :ventura"
 
   app "Arc.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`arc` is autobumped but the workflow failed to update to version 1.118.0 because `brew audit` failed with an "Upstream defined :ventura as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :monterey" error. This updates the version and `depends_on macos:` value accordingly.