### PR TITLE
kindle-comic-converter 9.2.1

### DIFF
--- a/Casks/k/kindle-comic-converter.rb
+++ b/Casks/k/kindle-comic-converter.rb
@@ -1,9 +1,16 @@
 cask "kindle-comic-converter" do
   arch arm: "arm", intel: "i386"
 
-  version "9.1.0"
-  sha256 arm:   "1703548dd4bb2450bd4b02b507e6905d8baa7775d9ddbbf1a6d7a1eac6766705",
-         intel: "631f43307cb93c59fab7f6c87d5d2affd4816b31305ec86627bffc3c88091bc0"
+  version "9.2.1"
+  sha256 arm:   "b4c49b0070edcce69f53e6a4631b37679f7cadb3929ecdd3f9c674953464baf9",
+         intel: "f5609d78c177e67c1f7ffa72b95796b69fe58932425e64ededfefaab6e18ea64"
+
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
 
   url "https://github.com/ciromattia/kcc/releases/download/v#{version}/kcc_macos_#{arch}_#{version}.dmg"
   name "Kindle Comic Converter"
@@ -17,8 +24,6 @@ cask "kindle-comic-converter" do
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
-  depends_on macos: ">= :monterey"
 
   app "Kindle Comic Converter.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kindle-comic-converter` is autobumped but the workflow failed to update to version 9.2.1 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :monterey" error. This updates the version and splits the `depends_on macos:` value for ARM and Intel, as the Intel requirement is macOS 10.13 and the ARM requirement is macOS 11.