### PR TITLE
thebrowsercompany-dia 1.2.0

### DIFF
--- a/Casks/t/thebrowsercompany-dia.rb
+++ b/Casks/t/thebrowsercompany-dia.rb
@@ -1,6 +1,6 @@
 cask "thebrowsercompany-dia" do
-  version "1.1.0,69754"
-  sha256 "e56d011695e9b5afb76492d93bb169fc15247cb22d4c97b1450d030239c3f9a9"
+  version "1.2.0,69925"
+  sha256 "37388ca2d4c3711d3cc7e4792cce6b3861bc6a32b4f81f4112be74977a8d026f"
 
   url "https://releases.diabrowser.com/release/Dia-#{version.tr(",", "-")}.zip"
   name "Dia"
@@ -14,7 +14,7 @@ cask "thebrowsercompany-dia" do
 
   auto_updates true
   depends_on arch: :arm64
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :sonoma"
 
   app "Dia.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`thebrowsercompany-dia` is autobumped but the workflow failed to update to 1.2.0 because `brew audit` failed with an "Upstream defined :sonoma as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :monterey" error. This updates the version and `depends_on macos:` value accordingly.