### PR TITLE
Adjust min macOS version for `datadog-agent`

### DIFF
--- a/Casks/d/datadog-agent.rb
+++ b/Casks/d/datadog-agent.rb
@@ -24,6 +24,8 @@ cask "datadog-agent" do
     end
   end
 
+  depends_on macos: ">= :big_sur"
+
   installer manual: "datadog-agent-#{version}.#{arch}.pkg"
 
   uninstall launchctl: "com.datadoghq.agent",


### PR DESCRIPTION
As of today, the [datadog-agent formula](https://formulae.brew.sh/cask/datadog-agent) shows:
```
Current version: 7.71.2-1

Requirements: macOS >= 10.15
```

This is slightly misleading since [macOS 10.x support was dropped after version 7.61.0](https://docs.datadoghq.com/agent/supported_platforms/?tab=macos).

The present change only aims at reflecting it.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
