### PR TITLE
Enhance LlamaBarn cask with auto-updates and verified cleanup paths

### DIFF
--- a/Casks/l/llamabarn.rb
+++ b/Casks/l/llamabarn.rb
@@ -21,11 +21,11 @@ cask "llamabarn" do
   uninstall quit: "app.llamabarn.LlamaBarn"
 
   zap trash: [
+    "~/Library/Application Support/LlamaBarn",
     "~/Library/Caches/app.llamabarn.LlamaBarn",
     "~/Library/HTTPStorages/app.llamabarn.LlamaBarn",
     "~/Library/HTTPStorages/app.llamabarn.LlamaBarn.binarycookies",
     "~/Library/Preferences/app.llamabarn.LlamaBarn.plist",
     "~/Library/WebKit/app.llamabarn.LlamaBarn",
-    "~/Library/Application Support/LlamaBarn",
   ]
 end

--- a/Casks/l/llamabarn.rb
+++ b/Casks/l/llamabarn.rb
@@ -7,9 +7,24 @@ cask "llamabarn" do
   desc "Menu bar app for running local LLMs"
   homepage "https://github.com/ggml-org/LlamaBarn"
 
+  livecheck do
+    url "https://releases.llamabarn.app/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
   depends_on macos: ">= :sequoia"
 
   app "LlamaBarn.app"
 
-  zap trash: "~/Library/Application Support/LlamaBarn"
+  uninstall quit: "app.llamabarn.LlamaBarn"
+
+  zap trash: [
+    "~/Library/Caches/app.llamabarn.LlamaBarn",
+    "~/Library/HTTPStorages/app.llamabarn.LlamaBarn",
+    "~/Library/HTTPStorages/app.llamabarn.LlamaBarn.binarycookies",
+    "~/Library/Preferences/app.llamabarn.LlamaBarn.plist",
+    "~/Library/WebKit/app.llamabarn.LlamaBarn",
+  ]
 end

--- a/Casks/l/llamabarn.rb
+++ b/Casks/l/llamabarn.rb
@@ -26,5 +26,6 @@ cask "llamabarn" do
     "~/Library/HTTPStorages/app.llamabarn.LlamaBarn.binarycookies",
     "~/Library/Preferences/app.llamabarn.LlamaBarn.plist",
     "~/Library/WebKit/app.llamabarn.LlamaBarn",
+    "~/Library/Application Support/LlamaBarn",
   ]
 end

--- a/Casks/l/llamabarn.rb
+++ b/Casks/l/llamabarn.rb
@@ -9,7 +9,7 @@ cask "llamabarn" do
 
   livecheck do
     url "https://releases.llamabarn.app/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true


### PR DESCRIPTION
Added livecheck for Sparkle appcast updates, auto_updates flag, and arch dependency for Apple Silicon. Added uninstall quit for graceful app closure. Expanded zap trash with verified production paths including caches, HTTP storage, preferences, and WebKit data.