### PR TITLE
codex: switch Linux builds to musl for broader compatibility

### DIFF
--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -1,12 +1,12 @@
 cask "codex" do
   arch arm: "aarch64", intel: "x86_64"
-  os macos: "apple-darwin", linux: "unknown-linux-gnu"
+  os macos: "apple-darwin", linux: "unknown-linux-musl"
 
   version "0.53.0"
   sha256 arm:          "97c70e291f8f1ebc2f060216290af97e0b8915400a79805fbadec12287a67cb6",
          intel:        "6515711ca312433a5cb1a5ca83517515558e46aa20f02c30b929964f9d552edb",
-         arm64_linux:  "d17d5778ec787275a6756afc82be7cd946538391328fa715030c81579c717766",
-         x86_64_linux: "fcdb0a728093f473dd952ff0860838547e7be63ec16c1926a479e54d41629ab3"
+         arm64_linux:  "a8a1dbcbda4b9a1f89e7c3efb69197159b4c81d2bbac72ca60449e0d6e715e9f",
+         x86_64_linux: "55160ac3076f8c0cac8015ac4a1725e4368c15cdcab1e9d97d27c13757d4ffa7"
 
   url "https://github.com/openai/codex/releases/download/rust-v#{version}/codex-#{arch}-#{os}.tar.gz"
   name "Codex"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates the Codex cask to use the unknown-linux-musl binaries (x86_64 and aarch64) for all Linux systems.

The musl builds are statically linked and run on all distributions, including those with older glibc (e.g. Ubuntu 22.04) or alternative libc implementations (e.g. Alpine).

The previous cask referenced the `unknown-linux-gnu` tarballs, which require glibc ≥ 2.39 and fail on older systems with errors like:

```
codex: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

These issues were reported in https://github.com/openai/codex/issues/5583. The musl builds avoid these issues. No changes for macOS.