### PR TITLE
ente 1.7.15

### DIFF
--- a/Casks/e/ente.rb
+++ b/Casks/e/ente.rb
@@ -1,6 +1,6 @@
 cask "ente" do
-  version "1.7.14"
-  sha256 "4df8b45114e4e07ad42650443c867e483431938fad457f768934fd125dac6cb2"
+  version "1.7.15"
+  sha256 "b8993e5e2ef3b9dd9a0476b8c5b9e42a30a6f24dbca41b215a6f501a82f34bca"
 
   url "https://github.com/ente-io/photos-desktop/releases/download/v#{version}/ente-#{version}-universal.dmg",
       verified: "github.com/ente-io/photos-desktop/"

--- a/Casks/e/ente.rb
+++ b/Casks/e/ente.rb
@@ -14,7 +14,7 @@ cask "ente" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "ente.app"
 


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online ente` is error-free. 
- [x] `brew style --fix ente` reports no offenses.
---

When attempting to update `ente` photos desktop to the newest version (`1.7.15`) the [autobump job](https://github.com/Homebrew/homebrew-cask/actions/runs/18940881320/job/54079084024) was giving the following output:

```text
==> ente
Current cask version:     1.7.14
Latest livecheck version: 1.7.15
Duplicate pull requests:  none
Maybe duplicate pull requests: ente 1.7.14 (https://github.com/Homebrew/homebrew-cask/pull/218423), ente 1.7.13 (https://github.com/Homebrew/homebrew-cask/pull/214236), ente 1.7.12 (https://github.com/Homebrew/homebrew-cask/pull/210109), ente 1.7.11 (https://github.com/Homebrew/homebrew-cask/pull/206739), ente 1.7.10 (https://github.com/Homebrew/homebrew-cask/pull/203006), ente 1.7.9 (https://github.com/Homebrew/homebrew-cask/pull/201112), ente 1.7.8 (https://github.com/Homebrew/homebrew-cask/pull/198071), ente 1.7.7 (https://github.com/Homebrew/homebrew-cask/pull/193638), ente 1.7.6 (https://github.com/Homebrew/homebrew-cask/pull/190024), ente 1.7.5 (https://github.com/Homebrew/homebrew-cask/pull/186923), ente 1.7.4 (https://github.com/Homebrew/homebrew-cask/pull/184265), ente 1.7.3 (https://github.com/Homebrew/homebrew-cask/pull/183104), ente 1.7.2 (https://github.com/Homebrew/homebrew-cask/pull/1
==> Downloading https://github.com/ente-io/photos-desktop/releases/download/v1.7.15/ente-1.7.15-universal.dmg
==> Downloading from https://release-assets.githubusercontent.com/github-production-release-asset/353965811/eb1bd008-d703-411a-ad90-562ea1d14552?sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-10-30T14%3A01%3A46Z&rscd=attachment%3B+filename%3Dente-1.7.15-universal.dmg&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2025-10-30T13%3A01%3A28Z&ske=2025-10-30T14%3A01%3A46Z&sks=b&skv=2018-11-09&sig=mca%2Fwv0h%2B6nsucsluSZQKl650bO0KpJyFOr3e9Ut2FA%3D&jwt=***
==> Downloading and extracting artifacts
==> Downloading https://github.com/ente-io/photos-desktop/releases/download/v1.7.15/ente-1.7.15-universal.dmg
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/8a1c89cb1802216afa7e6698e683eae61d5e481f5e255dc5f539595430784294--ente-1.7.15-universal.dmg
==> Downloading https://github.com/ente-io/photos-desktop/releases/download/v1.7.15/ente-1.7.15-universal.dmg
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/8a1c89cb1802216afa7e6698e683eae61d5e481f5e255dc5f539595430784294--ente-1.7.15-universal.dmg
audit for ente: failed
 - Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur
ente
  * Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur
Error: 1 problem in 1 cask detected.
Error: Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur
Error: `brew audit` failed!
```

Let's fix this by updating to user MacOS Monterey