### PR TITLE
wine@devel 10.17_2

### DIFF
--- a/Casks/w/wine@devel.rb
+++ b/Casks/w/wine@devel.rb
@@ -1,6 +1,6 @@
 cask "wine@devel" do
-  version "10.17_1"
-  sha256 "45d496f3732d87db65556ef3309da740dbc579baa77a623ee5e3eda7b4ce1bbf"
+  version "10.17_2"
+  sha256 "b5907e0c209d776e2d2510b3e5ff2ebc502596dcb6e62bad0b75160dac3a5df5"
 
   # Current winehq packages are deprecated and these are packages from
   # the new maintainers that will eventually be pushed to Winehq.


### PR DESCRIPTION
Another revision bump that should resolve all the current regressions found in wine-10.17, the other releases where purged due to how broken they where.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.