### PR TITLE
affinity 3.0.0 (new cask)

### DIFF
--- a/Casks/a/affinity.rb
+++ b/Casks/a/affinity.rb
@@ -1,0 +1,33 @@
+cask "affinity" do
+  version "3.0.0,3791"
+  sha256 "903880c822d62962089eef54b94605dde17dc1fef47fd15267caacf6d1853d5f"
+
+  url "https://affinity-update.s3.amazonaws.com/mac2/retail/Affinity%20Affinity%20Store%20#{version.csv.second}.zip",
+      verified: "affinity-update.s3.amazonaws.com/"
+  name "Affinity"
+  desc "Image editing and design software"
+  homepage "https://www.affinity.studio/"
+
+  livecheck do
+    url "https://things.seriflabs.com/affinity-update-mac-retail-studiopro"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Affinity.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/5HD2ARTBFS.com.canva.affinity",
+    "~/Library/Application Scripts/com.canva.affinity.*",
+    "~/Library/Application Support/Affinity",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.canva.affinity.sfl*",
+    "~/Library/Caches/com.canva.affinity",
+    "~/Library/Containers/com.canva.affinity.*",
+    "~/Library/Group Containers/5HD2ARTBFS.com.canva.affinity",
+    "~/Library/HTTPStorages/com.canva.affinity",
+    "~/Library/HTTPStorages/com.canva.affinity.*",
+    "~/Library/Preferences/com.canva.affinity.plist",
+    "~/Library/WebKit/com.canva.affinity",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This adds a cask for the new Affinity app. Some things to note:

* The website requires users to log in with a Canva account to access the download URLs and the dmg link on the website is unversioned (and does not redirect to a versioned file). The app checks a Sparkle appcast, which links to a versioned zip file on S3 and I've opted to use that, as it aligns with the existing `affinity-` casks. The Sparkle URL specifically uses s3-eu-west-1.amazonaws.com/affinity-update/mac2/... but borrowing the generic affinity-update.s3.amazonaws.com/mac2/... part of the `url` in the existing `affinity-` apps works (and presumably isn't tied to a specific region).
* Creating a description is always challenging, so shout if there's any room for improvement here.
* `brew createzap` picked up a lot of files from my existing installations of the Affinity v2 apps but I pared down the file list after uninstalling and cleaning up those files. Testing in a VM, it was the same file list as an installation on a fresh machine. I've used `.*` in some places but the raw list is as follows:

```
zap trash: [
  "~/Library/Application Scripts/5HD2ARTBFS.com.canva.affinity",
  "~/Library/Application Scripts/com.canva.affinity.quicklook",
  "~/Library/Application Scripts/com.canva.affinity.thumbnail",
  "~/Library/Application Support/Affinity",
  "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.canva.affinity.sfl4",
  "~/Library/Caches/com.canva.affinity",
  "~/Library/Containers/com.canva.affinity.quicklook",
  "~/Library/Containers/com.canva.affinity.thumbnail",
  "~/Library/Group Containers/5HD2ARTBFS.com.canva.affinity",
  "~/Library/HTTPStorages/com.canva.affinity",
  "~/Library/HTTPStorages/com.canva.affinity.binarycookies",
  "~/Library/Preferences/com.canva.affinity.plist",
  "~/Library/WebKit/com.canva.affinity",
]
```