### PR TITLE
clipbook 1.29.6

### DIFF
--- a/Casks/c/clipbook.rb
+++ b/Casks/c/clipbook.rb
@@ -1,9 +1,9 @@
 cask "clipbook" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.29.5"
-  sha256 arm:   "26a391736b018fc506245fbfa24510587827c15984a36d1cbd046669ffdcab51",
-         intel: "3678e3bbae6317c692d25cc491996f3a36d14de06ab1ca3258f7f1a4635d0dc5"
+  version "1.29.6"
+  sha256 arm:   "10616a291af731816ee433a10a02461111f71c8eb6beb3748e95abd4e51e0f88",
+         intel: "3af198e777e9e8e9b658cbcc5515bc8ae17a054407c9e3b19632800b65424a2f"
 
   url "https://f005.backblazeb2.com/file/clipbook/ClipBook-#{version}-#{arch}.dmg",
       verified: "f005.backblazeb2.com/file/clipbook/"
@@ -15,6 +15,8 @@ cask "clipbook" do
     url "https://clipbook.app/downloads/mac/#{arch}/appcast.xml"
     strategy :sparkle, &:short_version
   end
+
+  depends_on macos: ">= :monterey"
 
   app "ClipBook.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`clipbook` is autobumped but the workflow failed to update to version 1.29.6 because `brew audit` failed with an "Upstream defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.