### PR TITLE
blood-on-the-clocktower-online 3.47.0

### DIFF
--- a/Casks/b/blood-on-the-clocktower-online.rb
+++ b/Casks/b/blood-on-the-clocktower-online.rb
@@ -1,11 +1,11 @@
 cask "blood-on-the-clocktower-online" do
   arch arm: "aarch64", intel: "x64"
 
-  version "3.46.4"
-  sha256 arm:   "6294e5c9c89e5f1ad3c18147b9149dd5de3d44d66e89dba014aac11f68a6545f",
-         intel: "50ea9629d78c018ad08cece44ed5ec81b5db1877a8e6002bece48818e0ba5aa6"
+  version "3.47.0"
+  sha256 arm:   "27cbeec87df6d8c39e40748b82d603cc886113fd576f1eacbdf5ec131a01a1c4",
+         intel: "8c50159ec702a0c4384e8db95e862fe2e73ebf0eda0b30edb02855056ee88426"
 
-  url "https://github.com/ThePandemoniumInstitute/botc-release/releases/download/v#{version}/Blood.on.the.Clocktower.Online_#{version}_#{arch}.dmg",
+  url "https://github.com/ThePandemoniumInstitute/botc-release/releases/download/v#{version}/Blood.on.the.Clocktower.Online_#{version}_#{arch}_darwin.dmg",
       verified: "github.com/ThePandemoniumInstitute/botc-release/"
   name "Blood on the Clocktower Online"
   desc "Client for the game Blood on the Clocktower"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`blood-on-the-clocktower-online` is autobumped but the workflow failed to update to version 3.47.0 because the dmg file names now include a `_darwin` suffix. This updates the version and `url` accordingly.