### PR TITLE
connect-fonts 28.0.0

### DIFF
--- a/Casks/c/connect-fonts.rb
+++ b/Casks/c/connect-fonts.rb
@@ -1,6 +1,6 @@
 cask "connect-fonts" do
-  version "27.0.5"
-  sha256 "874fa21d8dccdcc43a3d984ee08959a5c2664dd9482165b3657efc0e4d6b27b1"
+  version "28.0.0"
+  sha256 "bae8a1e428d86aaaa45dfe6ff03f14a0200d42bb9b65d5a24cf3397a6e8d9e37"
 
   url "https://bin.extensis.com/ConnectFonts-M-#{version.dots_to_hyphens}.dmg"
   name "Connect Fonts"
@@ -13,6 +13,7 @@ cask "connect-fonts" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "Connect Fonts.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`connect-fonts` is autobumped but the workflow failed to update to version 28.0.0 because `brew audit` failed with an "Artifact defined :ventura as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.