### PR TITLE
cycling74-max 9.1.0

### DIFF
--- a/Casks/c/cycling74-max.rb
+++ b/Casks/c/cycling74-max.rb
@@ -1,6 +1,6 @@
 cask "cycling74-max" do
-  version "9.0.9,250923"
-  sha256 "3efe312695d277972318e7959703ddfe64d213ea029d847aed2e00d178a36cf3"
+  version "9.1.0,251028"
+  sha256 "23b7a9fee8b13211c3712f05dfc841f00e8bbc1430cbcdf5f49f1999cd7f7025"
 
   url "https://downloads.cdn.cycling74.com/max#{version.csv.first.major}/Max#{version.csv.first.no_dots}_#{version.csv.second}.dmg"
   name "Cycling ‘74 Max"
@@ -19,6 +19,8 @@ cask "cycling74-max" do
       "#{id},#{match[1]}#{match[2]}#{match[3]}"
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "Max.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`cycling74-max` is autobumped but the workflow failed to update to version 9.1.0 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.