### PR TITLE
devilutionx 1.5.5

### DIFF
--- a/Casks/d/devilutionx.rb
+++ b/Casks/d/devilutionx.rb
@@ -1,6 +1,6 @@
 cask "devilutionx" do
-  version "1.5.4"
-  sha256 "d95c726023b625af6e918700dd3d19b1d4888eb829cd2640ca97de96e4564cf8"
+  version "1.5.5"
+  sha256 "ba8aba7ffdb528ff31f22073606c3041fe7c9bfc7dd418cbea2e6351ad4ca049"
 
   url "https://github.com/diasurgical/devilutionX/releases/download/#{version}/devilutionx-macos-universal.dmg"
   name "DevilutionX"
@@ -23,6 +23,8 @@ cask "devilutionx" do
       end.flatten
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "devilutionX.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`devilutionx` is autobumped but the workflow failed to update to version 1.5.5 because `brew audit` failed due to the app failing Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.