### PR TITLE
drata-agent 3.9.0

### DIFF
--- a/Casks/d/drata-agent.rb
+++ b/Casks/d/drata-agent.rb
@@ -1,6 +1,6 @@
 cask "drata-agent" do
-  version "3.8.0"
-  sha256 "486a1da234d0059ada0c2947c041e95120f89534e070b1d73ce4503d2adf622d"
+  version "3.9.0"
+  sha256 "1a312c713b2b6bdd94638121345db14c339089a686b208e684b2f5a3d3d2edf8"
 
   url "https://github.com/drata/agent-releases/releases/download/#{version}/Drata-Agent-mac.dmg",
       verified: "github.com/drata/agent-releases/"
@@ -12,6 +12,8 @@ cask "drata-agent" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Drata Agent.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`drata-agent` is autobumped but the workflow failed to update to version 3.9.0 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:" value.