### PR TITLE
epicenter-whispering 7.6.0

### DIFF
--- a/Casks/e/epicenter-whispering.rb
+++ b/Casks/e/epicenter-whispering.rb
@@ -1,11 +1,11 @@
 cask "epicenter-whispering" do
   arch arm: "aarch64", intel: "x64"
 
-  version "7.5.5"
-  sha256 arm:   "b2bb7c93f977c2848c27f19b9dc764dd24e6335260bb445a1aead5e16660ebee",
-         intel: "b194906a19cdd139ae774fe38dd5d68359060020c3e03ebfc59f5f13fca2594d"
+  version "7.6.0"
+  sha256 arm:   "37c28dc2175142fb4607b9fbdc33c79b97e5a83ef90533e1fa6b8ac435da8196",
+         intel: "cf8996d22d8cfa983b35188a2632687d4966ab04cd6fc513106110ef9841ac5c"
 
-  url "https://github.com/epicenter-os/epicenter/releases/download/v#{version}/Whispering_#{version}_#{arch}.dmg",
+  url "https://github.com/epicenter-os/epicenter/releases/download/v#{version}/Whispering_#{version}_#{arch}_darwin.dmg",
       verified: "github.com/epicenter-os/epicenter/"
   name "Epicenter Whispering"
   desc "Audio transcription that works with local and cloud models"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`epicenter-whispering` is autobumped but the workflow failed to update to version 7.6.0 because the dmg file names now include a `_darwin` suffix. This updates the version and `url` accordingly.