### PR TITLE
gcs 5.42.0

### DIFF
--- a/Casks/g/gcs.rb
+++ b/Casks/g/gcs.rb
@@ -1,9 +1,16 @@
 cask "gcs" do
   arch arm: "arm64", intel: "amd64"
 
-  version "5.41.1"
-  sha256 arm:   "29a94a2238e187de7f5ffff3d2af6048a339a6ba1bb973c308ef52e827bfaf93",
-         intel: "a988c88872a39db444de7676b827e1b5e520942abaa1b44d16496974d68143b9"
+  version "5.42.0"
+  sha256 arm:   "5ef43e48382b77d09c2c99fe9d24bc8720a20a866657872c7e1d5cd551acb585",
+         intel: "1d8866f970d5675643931b6523fcc81f3874ed03fafe5ebce83bca3d33307e6d"
+
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
 
   url "https://github.com/richardwilkes/gcs/releases/download/v#{version}/gcs-#{version}-macos-#{arch}.dmg",
       verified: "github.com/richardwilkes/gcs/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gcs` is autobumped but the workflow failed to update to version 5.42.0 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error in reference to the ARM app. The Intel version has a minimum macOS requirement of Catalina (10.15), so it can rely on the implicit macOS dependency but it's necessary to have an explicit declaration as `brew style` will fail if we only have the `on_arm` `depends_on macos:` value. This updates the version and adds appropriate `depends_on macos:` values.