### PR TITLE
hedy 2.11.1

### DIFF
--- a/Casks/h/hedy.rb
+++ b/Casks/h/hedy.rb
@@ -1,6 +1,6 @@
 cask "hedy" do
-  version "2.11.0"
-  sha256 "2fd9b4fa8253eb2ba266751797d8fc8190e463f1d8ddab4b4d81c6360d2555ef"
+  version "2.11.1"
+  sha256 "6e89fd8c0172237ec0af9eb51eded6db2f964a163195e8e0300c6cbba93ad0c3"
 
   url "https://dl.hedy.ai/Hedy-MacOS-#{version}.dmg"
   name "Hedy AI"
@@ -11,8 +11,6 @@ cask "hedy" do
     url "https://macos-update-xml.hedy.bot"
     strategy :sparkle, &:short_version
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   depends_on macos: ">= :sonoma"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`hedy` is autobumped but the workflow failed to update to version 2.11.1 because `brew audit` failed with an "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. I manually confirmed that the app is signed/notarized and passes Gatekeeper checks, so this updates the version and removes the `disable!` call.