### PR TITLE
igv-desktop 2.19.7

### DIFF
--- a/Casks/i/igv-desktop.rb
+++ b/Casks/i/igv-desktop.rb
@@ -1,6 +1,6 @@
 cask "igv-desktop" do
-  version "2.19.6"
-  sha256 "38b563bed6b20253c3c18271c434953ce5a16b643bca2b0eee0158aadfd3e5e2"
+  version "2.19.7"
+  sha256 "4e03824984c846e681fe7eb5a18b77a5ca51a839788f65981365e543c267c1fa"
 
   url "https://data.broadinstitute.org/igv/projects/downloads/#{version.major_minor}/IGV_MacApp_#{version}.zip",
       verified: "data.broadinstitute.org/"
@@ -12,6 +12,8 @@ cask "igv-desktop" do
     url "https://igv.org/doc/desktop/DownloadPage/"
     regex(/href=.*?IGV[._-]MacApp[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "IGV_#{version}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`igv-desktop` is autobumped but the workflow failed to update to version 2.19.7 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.