### PR TITLE
archi 5.7.0 (new cask)

### DIFF
--- a/Casks/a/archi.rb
+++ b/Casks/a/archi.rb
@@ -1,0 +1,32 @@
+cask "archi" do
+  arch arm: "-Silicon"
+
+  version "5.7.0,57"
+  sha256 arm:   "dbfc38f9a29f8df4c62e38e5fe73a8b85b67bfbfe48e67dece4ae649ae1a6e57",
+         intel: "c0896127a5e684be6b31be73c07258c1a982c15d773cae77c22f6e1172206b92"
+
+  url "https://github.com/archimatetool/archi.io/releases/download/#{version.csv.second}/Archi-Mac#{arch}-#{version.csv.first}.dmg",
+      verified: "github.com/archimatetool/archi.io/"
+  name "Archi"
+  desc "Open-source ArchiMate modelling toolkit"
+  homepage "https://www.archimatetool.com/"
+
+  livecheck do
+    url "https://www.archimatetool.com/download/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)*)/Archi[._-]Mac#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Archi.app"
+
+  zap trash: [
+    "~/Library/Application Support/Archi",
+    "~/Library/Logs/Archi",
+    "~/Library/Preferences/com.archimatetool.editor.plist",
+    "~/Library/Saved Application State/com.archimatetool.editor.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

New Cask: Archi 5.7.0

Description:
Archi is a popular open-source modelling tool for the ArchiMate® enterprise architecture language.
Homepage: https://www.archimatetool.com/￼

Reason for notability exception:
	•	Archi is a well-known application in the enterprise-architecture community.
	•	It has an established website with official download links that redirect to GitHub for distribution.
	•	The GitHub repository (archimatetool/archi.io) is used purely for hosting release assets, not for development, hence the lower star/fork counts.
	•	Archi has previously been included in Homebrew-Cask (e.g. version 4.6.0).

This PR follows the “acceptable GitHub-hosted apps with their own website” exception documented in the Homebrew Cask notability guidelines.
The cask has been tested locally on Apple Silicon macOS 26 and installs/runs correctly.
