### PR TITLE
appflowy 0.10.3

### DIFF
--- a/Casks/a/appflowy.rb
+++ b/Casks/a/appflowy.rb
@@ -1,11 +1,11 @@
 cask "appflowy" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "0.10.2"
-  sha256 arm:   "6eadada93493402a0973194e5b0f2353fb414bbd8dc74ecc4b0db94ea315df79",
-         intel: "0107ab9d55bbfa1447edfe3b90efac0e1081df6c1d56a131be0670cbe1149178"
+  version "0.10.3"
+  sha256 arm:   "d3cdb8451c452bfb3fc745239e4a539c10c874c291faae5f08fd487b0238a228",
+         intel: "cd2a179475e7a8c64734988fd835ed098bbf22b79ab89f0dd6c0db11114f66ff"
 
-  url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-#{arch}.zip",
+  url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-#{arch}.dmg",
       verified: "github.com/AppFlowy-IO/AppFlowy/"
   name "AppFlowy"
   desc "Open-source project and knowledge management tool"
@@ -15,6 +15,8 @@ cask "appflowy" do
     url :url
     strategy :github_latest
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "AppFlowy.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`appflowy` is autobumped but the workflow failed to update to version 0.10.3 because the GitHub release asset for the Intel zip file mistakenly uses a 0.10.2 version in the file name. This works around the issue by switching the cask to use the dmg files instead, which doesn't have the same problem for this release.

Besides that, this adds a `depends_on macos:` value to address the related `brew audit` error ("Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version").