### PR TITLE
bitfocus-buttons 1.4.1 (arm only)

### DIFF
--- a/Casks/b/bitfocus-buttons.rb
+++ b/Casks/b/bitfocus-buttons.rb
@@ -2,11 +2,11 @@ cask "bitfocus-buttons" do
   arch arm: "arm", intel: "x64"
   livecheck_arch = on_arch_conditional arm: "arm", intel: "intel"
 
-  sha256 arm:   "b28c02b0ff9830862c2453f517de5ef98d24cd1816c625d3fc454ad7893fb52c",
+  sha256 arm:   "f0d7adf7040c052b1b53599aaac05a7c74c555f7e5ab805823be99161ea4d7fe",
          intel: "c6a628b36e9c7b0cede33dd7c41505510c0d97ed945e52cb309fcc425436fcd6"
 
   on_arm do
-    version "1.4.0,4766,cca8e4e7"
+    version "1.4.1,4769,492c32cc"
   end
   on_intel do
     version "1.2.2,4157,e14e47c7"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`bitfocus-buttons` is autobumped but the workflow failed to update to version 1.4.1 for ARM because there hasn't been an Intel version since 1.2.2 and the workflow sees the previous 1.2.2 PR as a duplicate. This manually updates the ARM version to 1.4.1.