### PR TITLE
lark 7.54.9

### DIFF
--- a/Casks/l/lark.rb
+++ b/Casks/l/lark.rb
@@ -3,12 +3,16 @@ cask "lark" do
   livecheck_arch = on_arch_conditional arm: "_m1"
 
   on_arm do
-    version "7.53.7,032f9ed6"
-    sha256 "506ccc597f68d57201741777101bbd8109aa1481e8d60ddbe52b8fc5e8b913ab"
+    version "7.54.9,5191978f"
+    sha256 "87a65f823ab15cc4fb97292c3294263b27809e33d31977d46635ba70f000742c"
+
+    depends_on macos: ">= :big_sur"
   end
   on_intel do
-    version "7.53.7,28547293"
-    sha256 "c4285351c78941b96e8a89dd8772cea99fc08db3506f93ad3ce71809a09869bb"
+    version "7.54.9,798cfc23"
+    sha256 "4bf6ebebfb88b09160adf7bd1bbda8c2fd35faf30ce2eef716d715f4d65c1117"
+
+    depends_on macos: ">= :catalina"
   end
 
   url "https://sf16-sg.larksuitecdn.com/obj/lark-artifact-storage/#{version.csv.second}/Lark-darwin_#{arch}-#{version.csv.first}-signed.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`lark` is autobumped but the workflow failed to update to version 7.54.9 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error in reference to the ARM app. The Intel app has a minimum macOS requirement of High Sierra (10.13) and it could rely on the implicit macOS requirement but only having the `depends_on macos:` value in the `on_arm` block will fail `brew style` ("Do not use a depends_on macos: stanza inside an on_{system} block. Add it once to specify the oldest macOS supported by any version in the cask."). This updates the version and adds arch-specific `depends_on macos:` values.