### PR TITLE
retrospective: require arm64

### DIFF
--- a/Casks/r/retrospective.rb
+++ b/Casks/r/retrospective.rb
@@ -12,6 +12,7 @@ cask "retrospective" do
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  depends_on arch: :arm64
   depends_on macos: ">= :big_sur"
 
   app "Retrospective.app"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

