### PR TITLE
babeledit 5.5.1

### DIFF
--- a/Casks/b/babeledit.rb
+++ b/Casks/b/babeledit.rb
@@ -1,6 +1,6 @@
 cask "babeledit" do
-  version "5.5.0"
-  sha256 "6c86c5fb7509ba386381bf2e2dba0f566d071baf2719764f11335fec0e88ea2b"
+  version "5.5.1"
+  sha256 "c5a5677633ae010c02965456c529493b5a39b302be82b268fefa894152fc2cd8"
 
   url "https://www.codeandweb.com/download/babeledit/#{version}/BabelEdit-#{version}.dmg"
   name "BabelEdit"
@@ -13,6 +13,7 @@ cask "babeledit" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "BabelEdit.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`babeledit` is autobumped but the workflow failed to update to version 5.5.1 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.