### PR TITLE
gearsystem 3.8.5

### DIFF
--- a/Casks/g/gearsystem.rb
+++ b/Casks/g/gearsystem.rb
@@ -1,9 +1,9 @@
 cask "gearsystem" do
   arch arm: "arm", intel: "intel"
 
-  version "3.8.4"
-  sha256 arm:   "75886881e369c2b1a95782b1957106fff639f8705e27d06627250d3fee1ada04",
-         intel: "bfe62acc85b750956440ef0eac67c817d9f3088820cd22c2fe383917104907ec"
+  version "3.8.5"
+  sha256 arm:   "04f87767f09fcfb43119038a59b84c1416c35ed3329eab326ad70c094b9d12ee",
+         intel: "a1c64a02c155d11e215d71377f8d92a33985f99207b81b267aecd7ac2d3c9846"
 
   url "https://github.com/drhelius/Gearsystem/releases/download/#{version}/Gearsystem-#{version}-macos-#{arch}.zip"
   name "Gearsystem"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gearsystem` is autobumped but the workflow failed to update to version 3.8.5 because the Intel zip file didn't exist at the time. Both zip files are available now, so this manually updates the cask version.