### PR TITLE
lidarr 3.0.1

### DIFF
--- a/Casks/l/lidarr.rb
+++ b/Casks/l/lidarr.rb
@@ -1,9 +1,16 @@
 cask "lidarr" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.14.5.4836"
-  sha256 arm:   "814d670adb7ba425263d9d0ec866552a1ec1a62c4d3f6fc0e7d1a8597a5aa1db",
-         intel: "09e632b99ced28730da1a199b59a4e6d03e4efed3bd94cc1be6d819e84905af9"
+  version "3.0.1.4866"
+  sha256 arm:   "5bc5c3b99e589501225dd006042776304b80fab7f7f50a0f79456f9bea638125",
+         intel: "9a392c255e25e5bff04c9c04f96141a43a7bcc46058032208e141660b07f6aa6"
+
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
 
   url "https://github.com/lidarr/Lidarr/releases/download/v#{version}/Lidarr.master.#{version}.osx-app-core-#{arch}.zip",
       verified: "github.com/lidarr/Lidarr/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`lidarr` is autobumped but the workflow failed to update to version 3.0.1 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error for the ARM app. The Intel app has a macOS dependency of Catalina (10.15) or later and it can rely on the implicit macOS dependency but we have to include an explicit `depends_on macos:` value, as `brew style` will fail if we only have a `depends_on macos:` value in the `on_arm` block. This updates the version and adds appropriate `depends_on macos:` values.