### PR TITLE
obs-advanced-scene-switcher 1.32.2

### DIFF
--- a/Casks/o/obs-advanced-scene-switcher.rb
+++ b/Casks/o/obs-advanced-scene-switcher.rb
@@ -1,6 +1,6 @@
 cask "obs-advanced-scene-switcher" do
-  version "1.31.0"
-  sha256 "a52cad3773c1bc5c3b80f3e756fd61ee40ec5c05eab83b0025d444e0f03a0c23"
+  version "1.32.2"
+  sha256 "b55258f59d482e119dd13d4590b256534221060722413267b2d6a4954f744fab"
 
   url "https://github.com/WarmUpTill/SceneSwitcher/releases/download/#{version}/advanced-scene-switcher-#{version}-macos-universal.pkg",
       verified: "github.com/WarmUpTill/SceneSwitcher/"
@@ -13,7 +13,10 @@ cask "obs-advanced-scene-switcher" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   depends_on cask: "obs"
+  depends_on macos: ">= :big_sur"
 
   pkg "advanced-scene-switcher-#{version}-macos-universal.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`obs-advanced-scene-switcher` is autobumped but the workflow failed to update to version 1.32.2 because `brew audit` failed due to the plugin not passing Gatekeeper checks (it's only ad-hoc signed). This updates the version and adds a `disable!` call with the future date we've been using in this scenario. Besides that, this also adds a `depends_on macos:` value (`brew audit` didn't have anything to say about it but I manually checked the requirement).