### PR TITLE
springtoolsforeclipse 4.32.1

### DIFF
--- a/Casks/s/springtoolsforeclipse.rb
+++ b/Casks/s/springtoolsforeclipse.rb
@@ -1,9 +1,9 @@
 cask "springtoolsforeclipse" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "4.32.0,4.37.0"
-  sha256 arm:   "ee5764e9a30740082a19a426e5e90544e33576d62d915fb4d81d0bdc0f074028",
-         intel: "2703ad27d878f37e7f871c7a47da7ebaec745111c2bc3cda2c6448a7c35c05dd"
+  version "4.32.1,4.37.0"
+  sha256 arm:   "894ee6cb834bc3507ee47603f084754ae369066a3710fefb43137fc4047750a1",
+         intel: "a303f1c3d746f85aea4a07d35f1b62c402aec8061896e63560b9899baa8cf42a"
 
   url "https://cdn.spring.io/spring-tools/release/STS#{version.major}/#{version.csv.first}.RELEASE/dist/e#{version.csv.second.major_minor}/spring-tools-for-eclipse-#{version.csv.first}.RELEASE-e#{version.csv.second}-macosx.cocoa.#{arch}.dmg"
   name "Spring Tools for Eclipse"
@@ -23,6 +23,7 @@ cask "springtoolsforeclipse" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "SpringToolsForEclipse.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`springtoolsforeclipse` is autobumped but the workflow failed to update to version 4.32.1 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.