### PR TITLE
touchdesigner 2025.31550

### DIFF
--- a/Casks/t/touchdesigner.rb
+++ b/Casks/t/touchdesigner.rb
@@ -1,9 +1,9 @@
 cask "touchdesigner" do
   arch arm: "arm64", intel: "intel"
 
-  version "2023.12480"
-  sha256 arm:   "aa86ad2513ada2a5e8fad8cd1496cb802d5a6fe46c859bdc751197972614be92",
-         intel: "e664d362149381939c2722276459fd82970c675c55c27ec1a2f7e9ef34c1acc5"
+  version "2025.31550"
+  sha256 arm:   "cee4192e5dbd3b0448136ef38c11dc7e96aca55f2e11b9a78acae878f153fed4",
+         intel: "4db0b0de31a5fb3dfa95aec194e366091105d8be004ed86cc69f3b4eefa4f0e1"
 
   url "https://download.derivative.ca/TouchDesigner.#{version}.#{arch}.dmg"
   name "Derivative TouchDesigner"
@@ -14,6 +14,8 @@ cask "touchdesigner" do
     url "https://docs.derivative.ca/Release_Notes"
     regex(/Build\s+(\d+(?:\.\d+)+)/i)
   end
+
+  depends_on macos: ">= :ventura"
 
   app "TouchDesigner.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`touchdesigner` is autobumped but the workflow failed to update to version 2025.31550 because `brew audit` failed with an "Artifact defined :ventura as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.