### PR TITLE
vernier-spectral-analysis 5.1.0-2993

### DIFF
--- a/Casks/v/vernier-spectral-analysis.rb
+++ b/Casks/v/vernier-spectral-analysis.rb
@@ -1,6 +1,6 @@
 cask "vernier-spectral-analysis" do
-  version "5.0.0-2559"
-  sha256 "c8359180d931fe36a993448768a4fbce6133d39d11ef9252f1228f526306d3fd"
+  version "5.1.0-2993"
+  sha256 "afd7f5c5b62b4c989b08c0166af2f652c2843592dbd2c48386bef317872da554"
 
   url "https://software-releases.graphicalanalysis.com/sa/mac/release/Vernier-Spectral-Analysis-#{version}.dmg",
       verified: "software-releases.graphicalanalysis.com/"
@@ -14,7 +14,7 @@ cask "vernier-spectral-analysis" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Vernier Spectral Analysis.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vernier-spectral-analysis` is autobumped but the workflow failed to update to version 5.1.0-2993 because `brew audit` failed with an "Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur" error. This updates the version and `depends_on macos:` value accordingly.