### PR TITLE
vitamin-r 4.21

### DIFF
--- a/Casks/v/vitamin-r.rb
+++ b/Casks/v/vitamin-r.rb
@@ -1,6 +1,6 @@
 cask "vitamin-r" do
-  version "4.20"
-  sha256 "b2e40fcc8ae457e1be450d3f0e9bfad1ad979edd75ceea9658a6412d23282d91"
+  version "4.21"
+  sha256 "96904470a41e5fe61c267ea1e4feb9bedad22d836cdd0fdc41e10a78229821ca"
 
   url "https://www.publicspace.net/download/signedVitamin#{version.major}.zip"
   name "Vitamin-R"
@@ -13,6 +13,7 @@ cask "vitamin-r" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "Vitamin-R #{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vitamin-r` is autobumped but the workflow failed to update to version 4.21 because `brew audit` failed with an "Upstream defined :ventura as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.