### PR TITLE
vyprvpn 6.0.3.11354

### DIFF
--- a/Casks/v/vyprvpn.rb
+++ b/Casks/v/vyprvpn.rb
@@ -1,6 +1,6 @@
 cask "vyprvpn" do
-  version "6.0.2.11265"
-  sha256 "aa48f057015c835a38fd6cda21601d790d87f5651fd50fe149fb2207b1780a34"
+  version "6.0.3.11354"
+  sha256 "fd032258369bdc286073a89d92c700e523ab9bb587064a742fb5497b7d483241"
 
   url "https://downloads.vyprvpn.com/downloads/vyprvpn/desktop/mac/production/#{version}/VyprVPN_v#{version}.dmg"
   name "VyprVPN"
@@ -13,6 +13,7 @@ cask "vyprvpn" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "VyprVPN.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vyprvpn` is autobumped but the workflow failed to update to version 6.0.3.11354 because `brew audit` failed with an "Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version and adds an appropriate `depends_on macos:` value.