### PR TITLE
siyuan 3.3.6

### DIFF
--- a/Casks/s/siyuan.rb
+++ b/Casks/s/siyuan.rb
@@ -1,14 +1,16 @@
 cask "siyuan" do
   arch arm: "-arm64"
 
-  version "3.3.5"
-  sha256 arm:   "44f0e2f7ec60f546c60aa81afe7542e6f331ded0d4a3c3331962574bcc047cca",
-         intel: "78b21980e958ce14cf5cb5e3422f940aba856cd520544b3d8e6c25604fc05797"
+  version "3.3.6"
+  sha256 arm:   "68a70a6f5e568ff6404efc3b839166d9c824dc9c23c2b0bd669dafc01f3b3121",
+         intel: "7ac8f72495684ed4ae99e3cd8c94cd8ea12cb136ed0b021e591775c26d48d455"
 
   url "https://github.com/siyuan-note/siyuan/releases/download/v#{version}/siyuan-#{version}-mac#{arch}.dmg"
   name "SiYuan"
   desc "Local-first personal knowledge management system"
   homepage "https://github.com/siyuan-note/siyuan"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`siyuan` is autobumped but the workflow failed to update to version 3.3.6 because `brew audit` failed due to the app failing Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.