### PR TITLE
brilliant: update livecheck

### DIFF
--- a/Casks/b/brilliant.rb
+++ b/Casks/b/brilliant.rb
@@ -6,13 +6,10 @@ cask "brilliant" do
       verified: "s3.eu-north-1.amazonaws.com/brilliant.design/"
   name "Brilliant"
   desc "Design and communication tool"
-  homepage "https://brilliant.design/"
+  homepage "https://try-brilliant.com/"
 
   livecheck do
-    url "https://brilliant.design/api/versions/info"
-    strategy :json do |json|
-      json.dig("latest", "version")
-    end
+    skip "No version information available"
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `brilliant` produces an "Unable to get versions" error, as brilliant.design redirects to try-brilliant.com but the /api/versions/info path no longer resolves. The current website only consists of a homepage with a form to join a waitlist. There doesn't appear to be any available source of version information at this point, so this updates the `livecheck` block to skip.