### PR TITLE
blender 4.5.4

### DIFF
--- a/Casks/b/blender.rb
+++ b/Casks/b/blender.rb
@@ -1,18 +1,41 @@
 cask "blender" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.5.3"
-  sha256 arm:   "73ea841053b55404bb3a71a9a22366f1f8821787fe5c899f8b55a7fff929d01b",
-         intel: "c1fd8f30eef1b37918659ad65c504d30cebd3e5bac74dd54f7df1a311aeebe18"
+  # NOTE: Please manually check for a new `blender@lts` version at
+  # https://www.blender.org/download/lts/ when updating this cask, as we cannot
+  # identify LTS versions using livecheck.
+  version "4.5.4"
+  sha256 arm:   "7d6bd807563f0af65735cf9e21b788f6ac78bc5ceb87b96c424459785a13cd60",
+         intel: "9194d5cd6c8250e7f04591d430ec3f6da7bc57fc1fa5ae155736bf0f3013553e"
 
   url "https://download.blender.org/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg"
   name "Blender"
   desc "3D creation suite"
   homepage "https://www.blender.org/"
 
+  # The upstream download page (https://www.blender.org/download/) cannot be
+  # fetched due to Cloudflare protections, so we have to naively assume a
+  # version is released when the assets are uploaded.
   livecheck do
-    url "https://www.blender.org/download/"
-    regex(%r{href=.*?/blender[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg}i)
+    url "https://download.blender.org/release/"
+    regex(/href=.*?blender[._-]v?(\d+(?:\.\d+)+)(?:[._-]macos)?[._-]#{arch}\.dmg/i)
+    strategy :page_match do |page, regex|
+      # Match major/minor versions from stable directory names
+      major_minor_versions =
+        page.scan(%r{href=["']?[^"' >]*?Blender[._-]?v?(\d+(?:\.\d+)+)/?["' >]}i)
+            .flatten
+            .uniq
+            .sort_by { |v| Version.new(v) }
+      next if major_minor_versions.blank?
+
+      # Check the directory listing page for the highest major/minor version
+      directory_page = Homebrew::Livecheck::Strategy.page_content(
+        URI.join(@url, "Blender#{major_minor_versions.last}/").to_s,
+      )[:content]
+      next if directory_page.blank?
+
+      directory_page.scan(regex).map { |match| match[0] }
+    end
   end
 
   conflicts_with cask: "blender@lts"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`blender` is autobumped but the workflow failed to update to version 4.5.4 because livecheck is returning an "Unable to get versions" error as www.blender.org is behind Cloudflare and is now inaccessible due to protections. The website is only accessible after going through a Cloudflare turnstile check in a browser and the existing check is broken regardless of IP address, user agent, etc.

This updates the version and modifies the `livecheck` block to match versions from the directory listing page where the release assets are found. This could theoretically result in livecheck surfacing a version before the release is announced but hopefully upstream is careful about their release process, as this is one of few available sources of version information left.

For what it's worth, I added a comment before the `version` to remind us to manually check for a new `blender@lts` version when updating the `blender` cask. `blender` will be autobumped but `blender@lts` will have a `skip` `livecheck` block (as we can't identify LTS versions without checking www.blender.org), so I'm hoping that this helps us to keep the LTS cask updated.