### PR TITLE
dynobase 2.5.1

### DIFF
--- a/Casks/d/dynobase.rb
+++ b/Casks/d/dynobase.rb
@@ -1,26 +1,24 @@
 cask "dynobase" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.3.0,230416d1lkzhd17,2.3.0"
-  sha256 arm:   "04e02e4df46e40d5fef4f20fdd9bf67b7eb1cdf173235d79baa302471af44a83",
-         intel: "23da601ad1256ffbb9ec409173fac7b6b720651529e12369ce6ae4ab5ce94158"
+  version "2.5.1,230920qzouyzmgy"
+  sha256 arm:   "369fe11880c25e1b51852b4446ea844ac09a953d9bae3111977143bbed697ec7",
+         intel: "d059b25cb5bd3203c5bd59e787f5470c70265ac8d6d3235aca0a06eacc26b67d"
 
-  url "https://github.com/Dynobase/dynobase/releases/download/v#{version.csv.third}/Dynobase.#{version.csv.first}.-.Build.#{version.csv.second}-#{arch}.dmg",
-      verified: "github.com/Dynobase/dynobase/"
+  url "https://download.todesktop.com/220811zswf4aj4x/Dynobase%20#{version.csv.first}%20-%20Build%20#{version.csv.second}-#{arch}.dmg",
+      verified: "download.todesktop.com/220811zswf4aj4x/"
   name "Dynobase"
   desc "GUI Client for DynamoDB"
   homepage "https://dynobase.dev/"
 
   livecheck do
-    url :url
-    regex(%r{/v?(\d+(?:\.\d+)+)/Dynobase[._-](\d+(?:\.\d+)+)[._-]+Build[._-](\S+)[._-]#{arch}\.dmg$}i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["browser_download_url"]&.match(regex)
-        next if match.blank?
+    url "https://download.todesktop.com/220811zswf4aj4x/td-latest-mac.json"
+    regex(/Dynobase\s+v?(\d+(?:\.\d+)+)\s+.*?Build\s+(\w+)[._-]#{arch}/i)
+    strategy :json do |json, regex|
+      match = json.dig("artifacts", "dmg", arch, "path")&.match(regex)
+      next if match.blank?
 
-        "#{match[2]},#{match[3]},#{match[1]}"
-      end
+      "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dynobase` is autobumped but the workflow failed to update to versions beyond 2.3.0 because the cask uses a GitHub release asset but the GitHub repository has been deleted. Upstream now serves files from download.todesktop.com but they require users to jump through hoops to download the app. Rather than link to the dmg files directly, they provide an installer that checks a JSON file that includes the latest version and dmg file URLs and uses that information to install the app.

The homepage also provides a link to an old version (linked as 2.5.0 Beta, though the server returns a 2.4.0 file for macOS) but this URL is used to serve files for all OSs/archs and the response varies based on the request user agent. One issue with this is that macOS user agents from 10.15 onward include "Intel Mac OS X 10_15_7", so the server will always return the Intel dmg file. The version and build identifier should be the same for both Intel and ARM but the fact that the server returns incorrect/outdated information makes it unusable. [For what it's worth, the response for the installer also varies based on user agent but thankfully we don't have to use it in the cask.]

This updates the version and `url` using the information from the JSON file and updates the `livecheck` block to check this file.