### PR TITLE
elektron-overbridge: update livecheck

### DIFF
--- a/Casks/e/elektron-overbridge.rb
+++ b/Casks/e/elektron-overbridge.rb
@@ -8,12 +8,11 @@ cask "elektron-overbridge" do
   desc "Integrate Elektron hardware into music software"
   homepage "https://www.elektron.se/overbridge"
 
+  # The upstream download page links to the latest dmg file but Cloudflare
+  # protections prevent us from fetching it, so it must be checked manually:
+  # https://www.elektron.se/support-downloads/overbridge
   livecheck do
-    url "https://www.elektron.se/support-downloads/overbridge"
-    regex(%r{/([\h-]+)/Elektron[._-]?Overbridge[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
-    end
+    skip "Cannot be fetched due to Cloudflare protections"
   end
 
   pkg "Elektron Overbridge Installer #{version.csv.first}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`elektron-overbridge` is autobumped but the livecheck block has been consistently producing an "Unable to get versions" error for quite some time. The `livecheck` block fails because the website is behind Cloudflare and the protections prevent us from fetching pages outside of a browser context (i.e., this fails regardless of user agent, IP address, etc.). This updates the `livecheck` block to skip and adds a comment with the URL for manual checking.