### PR TITLE
elektron-transfer: disable

### DIFF
--- a/Casks/e/elektron-transfer.rb
+++ b/Casks/e/elektron-transfer.rb
@@ -7,13 +7,9 @@ cask "elektron-transfer" do
   desc "Transfer samples, presets, sounds, projects and firmware to Elektron devices"
   homepage "https://elektron.se/support-downloads/transfer"
 
-  livecheck do
-    url :homepage
-    regex(%r{uploads/(\d+)/(\d+)/Elektron[._-]Transfer[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[2]},#{match[1]},#{match[0]}" }
-    end
-  end
+  # The upstream website uses Cloudflare protections and the dmg file is
+  # inaccessible outside of a browser, so this cask is effectively unusable.
+  disable! date: "2025-11-01", because: :unreachable
 
   app "Transfer.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`elektron-transfer` is autobumped but the livecheck block has been consistently producing an "Unable to get versions" error for some time. The `livecheck` block fails because the website is behind Cloudflare and the protections prevent us from fetching pages outside of a browser context (i.e., this fails regardless of user agent, IP address, etc.).

Unfortunately, the dmg file is also served from the website and is subject to the same Cloudflare protections, so this cask is effectively unusable. This removes the `livecheck` block and disables the cask.