### PR TITLE
flightgear 2024.1.2

### DIFF
--- a/Casks/f/flightgear.rb
+++ b/Casks/f/flightgear.rb
@@ -1,22 +1,16 @@
 cask "flightgear" do
-  version "2024.1.1,9261456144"
-  sha256 "def74a0db27616a0db193e38ca6d33eea6201453e8114cdf760fbe76d74d8451"
+  version "2024.1.2"
+  sha256 "3d5ee48e2d30be999e4c65e3aaeb7f1e28aef3de842625c170a261cfb830d131"
 
-  url "https://gitlab.com/flightgear/fgmeta/-/jobs/#{version.csv.second}/artifacts/raw/output/FlightGear-#{version.csv.first}.dmg",
-      verified: "gitlab.com/flightgear/"
+  url "https://mirrors.ibiblio.org/flightgear/ftp/release-#{version.major_minor}/flightgear-#{version}-macos-universal.dmg",
+      verified: "mirrors.ibiblio.org/flightgear/"
   name "FlightGear"
   desc "Flight simulator"
   homepage "https://www.flightgear.org/"
 
   livecheck do
     url "https://www.flightgear.org/download/"
-    regex(%r{href=.*?/jobs/(\d+)/artifacts/raw/output/FlightGear[._-]?v?(\d+(?:\.\d+)+)\.dmg}i)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[2]},#{match[1]}"
-    end
+    regex(/href=.*?flightgear[._-]?v?(\d+(?:\.\d+)+)(?:[._-]macos)?(?:[._-]universal)?\.dmg/i)
   end
 
   app "FlightGear.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`flightgear` is autobumped but the workflow failed to update to version 2024.1.2 because the `livecheck` block has been producing an "Unable to get versions" error for several months. The upstream download page hasn't contained a dmg link using the expected path and file name format as there were issues with the macOS release and the page linked to a very old 2020.3.19 version instead. Upstream released a new version for macOS on 2025-09-18 but the URL path and file name format changed, so the `livecheck` block wasn't able to surface this new version and continued to fail.

This updates the cask version and modifies the URL to align with the one on the download page. This also adapts the `livecheck` block to match the current file name format. The dmg URL path contains a `release-2024.1` part and this is currently `version.major_minor` but we may have to modify this setup if this doesn't hold up in subsequent versions. This is the simplest approach for the time being, as it doesn't require a `strategy` block or a multi-part cask `version`.