### PR TITLE
flowdown 3.10.6

### DIFF
--- a/Casks/f/flowdown.rb
+++ b/Casks/f/flowdown.rb
@@ -1,8 +1,8 @@
 cask "flowdown" do
-  version "3.9.440"
-  sha256 "e53adccd2fa13ddae1070bd2f632c0a1ced0fefac64564d30d84bdcd75d6409c"
+  version "3.10.6"
+  sha256 "aa5878964c561ed1b191b4f097b6e739073d9abd06590712546c5b047c664da2"
 
-  url "https://github.com/Lakr233/FlowDown/releases/download/#{version.csv.second || version.csv.first}/FlowDown-#{version.csv.first}.zip",
+  url "https://github.com/Lakr233/FlowDown/releases/download/#{version}/FlowDown.app.zip",
       verified: "github.com/Lakr233/FlowDown/"
   name "FlowDown"
   desc "AI agent"
@@ -10,15 +10,7 @@ cask "flowdown" do
 
   livecheck do
     url :url
-    regex(%r{/v?(\d+(?:\.\d+)+)/FlowDown[._-]V?(\d+(?:\.\d+)+)\.zip}i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["browser_download_url"]&.match(regex)
-        next if match.blank?
-
-        (match[2] == match[1]) ? match[1] : "#{match[2]},#{match[1]}"
-      end
-    end
+    strategy :github_latest
   end
 
   depends_on macos: ">= :sonoma"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`flowdown` is autobumped but the workflow failed to update to recent versions because the newest releases use an unversioned asset file name (i.e., `FlowDown.app.zip`) instead of the previous versioned format (e.g., `FlowDown-3.9.443.zip`). This updates the version and `url` accordingly. This also simplifies the `livecheck` block to use the default `GithubLatest` strategy logic, as this will be sufficient as long as we only need the version from the tag.