### PR TITLE
font-brill: disable

### DIFF
--- a/Casks/font/font-b/font-brill.rb
+++ b/Casks/font/font-b/font-brill.rb
@@ -6,16 +6,9 @@ cask "font-brill" do
   name "Brill"
   homepage "https://brill.com/page/resources_brilltypeface"
 
-  livecheck do
-    url "https://brill.com/page/resources_fontsdownloads"
-    regex(/href=.*?The[._-]Brill[._-]Typeface[._-]Package[._-]v?[._-]?(\d+(?:[._]\d+)+)\.zip/i)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      match[1].tr("_", ".")
-    end
-  end
+  # The upstream website is inaccessible outside of a browser context and this
+  # applies to the zip file, so the cask is effectively unusable.
+  disable! date: "2025-11-01", because: :unreachable
 
   font "Brill-Bold.ttf"
   font "Brill-BoldItalic.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`font-brill` is autobumped but the workflow has been failing to check for new versions because livecheck returns an "Unable to get versions" error. This has been a persistent issue for some time, as the upstream website is inaccessible outside of a browser context regardless of user agent, IP address, etc. Unfortunately, this also applies to the font zip file and the cask if effectively unusable at this point, so this disables the cask accordingly.