### PR TITLE
height: disable

### DIFF
--- a/Casks/h/height.rb
+++ b/Casks/h/height.rb
@@ -8,10 +8,7 @@ cask "height" do
   desc "All-in-one project management tool"
   homepage "https://height.app/"
 
-  livecheck do
-    url "https://storage.googleapis.com/height-statics/_app/latest-mac.yml"
-    strategy :electron_builder
-  end
+  disable! date: "2025-11-01", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`height` is autobumped but the workflow has been failing to check for new versions because the height.app website is no longer available. Looking back at old snapshots of the homepage, upstream announced earlier this year that they were discontinuing operations and the last day of service would be 2025-09-24. I vaguely remember seeing this sometime earlier but I believe I decided to leave the cask alone for as long as it worked.

We've reached the point now where all of the URLs in the cask are unreachable, so this disables the cask as discontinued and removes the `livecheck` block (ensuring it will be automatically skipped). [Disabling `height` is probably great news for acrophobes 😆]