### PR TITLE
insta360-studio 5.8.0

### DIFF
--- a/Casks/i/insta360-studio.rb
+++ b/Casks/i/insta360-studio.rb
@@ -1,8 +1,8 @@
 cask "insta360-studio" do
-  version "5.7.6,release_insta360,RC_build45,_20250930_010756_signed_1759201794711,f7eaccbff9853965662670108f005b91"
-  sha256 "398933be10b52754785bf2e5996ba351680e5cebd240a2a8b47c8d7e8cbba0f6"
+  version "5.8.0,release_insta360,RC_build64,_20251027_150257_signed_1761552612745,662cbed4068f3563ed28ff6c3c251a42"
+  sha256 "30c4bc37b332ebf86b7e4ec4c2a00e28ae2b82aea23da762b71759ed905d5176"
 
-  url "https://file.insta360.com/static/#{version.csv.fifth}/Insta360Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.zip"
+  url "https://file.insta360.com/static/#{version.csv.fifth}/Insta360_Studio_#{version.csv.first}_#{version.csv.second}(#{version.csv.third})#{version.csv.fourth}.zip"
   name "Insta360 Studio"
   desc "Video and photo editor"
   homepage "https://www.insta360.com/"
@@ -15,7 +15,7 @@ cask "insta360-studio" do
   # that may be beta, RC, etc.
   livecheck do
     url "https://openapi.insta360.com/app/appDownload/getGroupApp?group=insta360-go2&X-Language=en-us"
-    regex(%r{/(\h+)/Insta360(?:%20)?Studio(?:[._-]|%20)v?(\d+(?:\.\d+)+)[._-](.+)\.(?:pkg|zip)}i)
+    regex(%r{/(\h+)/Insta360(?:[._-]|%20)?Studio(?:[._-]|%20)v?(\d+(?:\.\d+)+)[._-](.+)\.(?:pkg|zip)}i)
     strategy :json do |json, regex|
       # Find the Insta360 Studio app
       app = json.dig("data", "apps")&.find { |item| item["app_id"] == 38 }
@@ -38,9 +38,9 @@ cask "insta360-studio" do
   end
 
   # The pkg is often inconsistently named comparatively to the url version
-  rename "Insta360Studio*.pkg", "Insta360Studio.pkg"
+  rename "Insta360_Studio*.pkg", "Insta360_Studio.pkg"
 
-  pkg "Insta360Studio.pkg"
+  pkg "Insta360_Studio.pkg"
 
   uninstall quit:    "com.insta360.studio",
             pkgutil: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`insta360-studio` is autobumped but the workflow has been unable to check for new versions as livecheck is returning an "Unable to get versions" error. This is due to the file name for 5.8.0 including an underscore between "Insta360" and "Studio", which the regex wasn't set up to handle. This was an oversight on my part, as I used a `(?:[._-]|%20)` pattern in other parts of the regex and should have done the same in this area.

This updates the version and `url` and adjusts the `livecheck` block regex accordingly. Thankfully it was an easy fix this time.