### PR TITLE
macx-dvd-ripper-pro: update livecheck

### DIFF
--- a/Casks/m/macx-dvd-ripper-pro.rb
+++ b/Casks/m/macx-dvd-ripper-pro.rb
@@ -8,8 +8,18 @@ cask "macx-dvd-ripper-pro" do
   homepage "https://www.macxdvd.com/mac-dvd-ripper-pro/"
 
   livecheck do
-    url :homepage
-    regex(/Version:\s+(\d+(?:\.\d+)*)/i)
+    url "https://www.macxdvd.com/mac-dvd-ripper-pro/upgrade/macx-dvd-ripper-pro"
+    strategy :xml do |xml|
+      # The plist file contains nested "LastestVersion" keys that apply to
+      # language variants, so we specifically match the main key
+      version = xml.elements["/plist/dict/key[text()='LastestVersion']"]&.next_element&.text
+
+      # Retry without the typo if the key isn't found
+      version ||= xml.elements["/plist/dict/key[text()='LatestVersion']"]&.next_element&.text
+      next if version.blank?
+
+      version.strip
+    end
   end
 
   app "MacX DVD Ripper Pro.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `macx-dvd-ripper-pro` produces an "Unable to get versions" error, as the homepage no longer contains any version information. This updates the `livecheck` block to check the URL that the app uses to check for updates. The related plist file provides a `LastestVersion` key that provides the latest version, so I've also included some fallback login in the `strategy` block to check for a `LatestVersion` key if upstream fixes this typo.