### PR TITLE
mysql-shell 9.5.0

### DIFF
--- a/Casks/m/mysql-shell.rb
+++ b/Casks/m/mysql-shell.rb
@@ -28,9 +28,9 @@ cask "mysql-shell" do
     end
   end
   on_ventura :or_newer do
-    version "9.4.0,15"
-    sha256 arm:   "dfa62764f15057c082954252407b1a07379a64fbebdcb90b5cd7ca115dcb1082",
-           intel: "6289abc130bd9830f05cb97d134a1a0a68d01e81a0daa17d09d48306b50b0e30"
+    version "9.5.0,15"
+    sha256 arm:   "73ac233f83353202c645cdc50de265019718445e7b33568d29dc4827ecab855a",
+           intel: "25c7da7e1d314fb7aa6da410018d7b28d004ea8739bb8465f7e902c0726055c5"
 
     url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg",
         user_agent: "curl/8.7.1"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mysql-shell` is autobumped but the upstream website returns a 403 (Forbidden) response unless brew requests uses a "curl/8.7.1" user agent, so the `livecheck` block predictably returns an "Unable to get versions" error until we can set the user agent there (I have this implemented and confirmed it works here but still need to create a brew PR for this work). In the interim time, this manually updates the cask to the newest upstream version.