### PR TITLE
mysqlworkbench 8.0.44

### DIFF
--- a/Casks/m/mysqlworkbench.rb
+++ b/Casks/m/mysqlworkbench.rb
@@ -27,15 +27,15 @@ cask "mysqlworkbench" do
     end
   end
   on_ventura :or_newer do
-    version "8.0.43"
-    sha256 arm:   "bcf35a7c147e6ec2b55ca39e527df8f250f878330abf56488a05adfe0e20b0ea",
-           intel: "38b909950feebb3094663eaf4b6964ff7002901fc6559e0c1d91f49441a41c1e"
+    version "8.0.44"
+    sha256 arm:   "973b9eb96399b05efa2a6bc7d57c2679b6a18df5199faa73b0eede42ae21adce",
+           intel: "34b49d6f72a26e89770c2efaf3f29af403ca92f4f313f1ace2aad21a12129e55"
 
     url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-#{arch}.dmg"
 
     livecheck do
-      url "https://dev.mysql.com/downloads/workbench/"
-      regex(/MySQL\s*Workbench\s*(\d+(?:\.\d+)+)/i)
+      url "https://dev.mysql.com/downloads/workbench/?tpl=platform&os=33"
+      regex(/mysql[._-]workbench[._-]community[._-]v?(\d+(?:\.\d+)+)(?:[._-]macos)?[._-]#{arch}\.dmg/i)
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mysqlworkbench` is autobumped but the workflow failed to update to version 8.0.44 because the `livecheck` block produces an "Unable to get versions" error, as brew requests to dev.mysql.com receive a 403 (Forbidden) response unless they use a "curl/8.7.1" user agent. This feature isn't available in `livecheck` blocks yet but I confirmed it works with my local implementation (I'll create a PR for user agent support sometime in the near future). In the interim time, this manually updates the cask to the newest upstream version.

Besides that, this updates the `livecheck` block to align with the approach used in the `mysql-shell` cask, which uses query string parameters to ensure that the HTML includes information for the macOS artifacts. The page automatically selects the related OS option based on the user agent in the HTTP request but the Mac option won't be selected for a generic "curl/8.7.1" user agent, so this approach is also necessary for this check to work once user agent support is available.