### PR TITLE
mythic 0.5.0

### DIFF
--- a/Casks/m/mythic.rb
+++ b/Casks/m/mythic.rb
@@ -1,16 +1,24 @@
 cask "mythic" do
-  version "0.4.5"
-  sha256 "e232fbf075c8b6558bd857b9133a6a32ee82aa0377bf94bbed68152c9b65e8a0"
+  version "0.5.0,cfbc3111-f5b3-469d-823b-393f0793c550"
+  sha256 "782a07d9d83f686c351a3867661757447480e52fd65904816760a38b7775b30e"
 
-  url "https://dl.getmythic.app/sparkle-temp/Mythic-#{version}.zip"
+  url "https://dl.getmythic.app/updates/#{version.csv.second}/Mythic.zip"
   name "Mythic"
   desc "Game launcher with the ability to run Windows games"
   homepage "https://getmythic.app/"
 
   livecheck do
     url "https://getmythic.app/appcast.xml"
-    strategy :sparkle, &:short_version
+    regex(%r{/(\h+(?:-\h+)*)/Mythic\.zip}i)
+    strategy :sparkle do |item, regex|
+      match = item.url.match(regex)
+      next item.short_version if match.blank?
+
+      "#{item.short_version},#{match[1]}"
+    end
   end
+
+  no_autobump! because: "livecheck fails in CI environment"
 
   depends_on macos: ">= :sonoma"
   depends_on arch: :arm64


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mythic` is autobumped but the workflow failed to update to version 0.5.0 because livecheck failed with an "Unable to get versions" error. This check works locally but seems to consistently fail in the autobump workflow as well as in CI tests. We're not able to autobump this as a result, so this adds a `no_autobump!` call to the cask.

This manually updates the cask to the newest version, adjusting the `url` to use the new file URL format referenced in the appcast. This is the first version using this URL format, so it's not yet clear if the hexadecimal identifier in the path is specific to version 0.5.0 or if it's a constant and this is an unversioned URL. We'll find out with the next version but I've set up the cask for now with the assumption that this identifier will change in the future. If it doesn't change, then we can inline the identifier in the `url`, set the `sha256` to `:no_check`, and revert this `livecheck` block change at that time.