### PR TITLE
nomachine 9.2.18_1

### DIFF
--- a/Casks/n/nomachine.rb
+++ b/Casks/n/nomachine.rb
@@ -1,6 +1,6 @@
 cask "nomachine" do
-  version "8.16.1_2"
-  sha256 "622e12ab5397b74bfcae3c4de5a91c018ed222244d4e09804af0fc03e9e8e04e"
+  version "9.2.18_1"
+  sha256 "1ae4101f188453a9b3d7a082bef404badcae72afd40505096ece36dcb0b3cb77"
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine_#{version}.dmg"
   name "NoMachine"
@@ -8,8 +8,9 @@ cask "nomachine" do
   homepage "https://www.nomachine.com/"
 
   livecheck do
-    url "https://www.nomachine.com/support&destination=downloads&callback=L2Rvd25sb2FkLz9pZD03"
+    url "https://www.nomachine.com/dwl_nm_bann.php"
     regex(/nomachine[._-]v?(\d+(?:\.\d+)+_\d+)\.dmg/i)
+    strategy :header_match
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`nomachine` is autobumped but it hasn't been updated since version 8.16.1_2 because the `livecheck` block is broken. The download page requires a cookie or the server will redirect to a login page instead, which seems to be what's happening with the existing check.

It's possible to check the redirecting download URL from the homepage but it only redirects to the dmg file for macOS if the request user agent references macOS. It's not currently possible to explicitly set the user agent in the `livecheck` block but livecheck contains some fallback logic where it will retry a failing request with the `:browser` user agent, so this check will technically work in the interim time (albeit, less efficiently). This updates the version and `livecheck` block accordingly.