### PR TITLE
nomachine-enterprise-client 9.2.18_1

### DIFF
--- a/Casks/n/nomachine-enterprise-client.rb
+++ b/Casks/n/nomachine-enterprise-client.rb
@@ -1,15 +1,17 @@
 cask "nomachine-enterprise-client" do
-  version "8.16.1_2"
-  sha256 "44afd719f4f130e692e5f48149e10b66f596036efff5e7727683db475b0c5c80"
+  version "9.2.18_1"
+  sha256 "792fe2bd6109db5ab7cbb5cd06d547522f56a4007dcfb9f8178cf7f0c8451e42"
 
   url "https://download.nomachine.com/download/#{version.major_minor}/MacOSX/nomachine-enterprise-client_#{version}.dmg"
   name "NoMachine Enterprise Client"
   desc "Remote desktop software"
   homepage "https://www.nomachine.com/"
 
+  # We couldn't find a checkable source of Enterprise-specific version
+  # information but it seems to generally follow the `nomachine` version, so
+  # aligning the versions is better than nothing.
   livecheck do
-    url "https://www.nomachine.com/support&destination=downloads&callback=L2Rvd25sb2FkLz9pZD0xNi"
-    regex(/nomachine-enterprise-client[._-]v?(\d+(?:\.\d+)*_\d+)\.dmg/i)
+    cask "nomachine"
   end
 
   pkg "NoMachine.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`nomachine-enterprise-client` is autobumped but it hasn't been updated since version 8.16.1_2 because the `livecheck` block is broken. The download page requires a cookie or the server will redirect to a login page instead, which may be what's happening with the existing check. Unlike `nomachine`, I haven't yet found a fix for this yet.

In the interim time, this updates the cask to the newest version after manually checking the upstream download page.

-----

I've created this as a draft for now and will try to dig more into the `livecheck` block issue tomorrow (anyone feel free to beat me to it).