### PR TITLE
tuxguitar 2.0.0

### DIFF
--- a/Casks/t/tuxguitar.rb
+++ b/Casks/t/tuxguitar.rb
@@ -1,6 +1,6 @@
 cask "tuxguitar" do
-  version "1.6.6"
-  sha256 "87304ed1608495652645ec29d86bad56946618545575a25d87299bca39c9bead"
+  version "2.0.0"
+  sha256 "1eb1ae0284be4da5ada59dcb755f29dff8f07cd9eb0b93b1af02fe65ff9a062d"
 
   url "https://github.com/helge17/tuxguitar/releases/download/#{version}/tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app.tar.gz",
       verified: "github.com/helge17/tuxguitar/"
@@ -12,6 +12,8 @@ cask "tuxguitar" do
     url :url
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "tuxguitar-#{version}-macosx-swt-cocoa-x86_64.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tuxguitar` is autobumped but the workflow failed to update to version 2.0.0 because `brew audit` failed due to the app not passing Gatekeeper checks (it's unsigned). This updates the version and adds a `disable!` call with the future date we've been using for this scenario.