### PR TITLE
nordic-nrf-command-line-tools: update livecheck

### DIFF
--- a/Casks/n/nordic-nrf-command-line-tools.rb
+++ b/Casks/n/nordic-nrf-command-line-tools.rb
@@ -8,12 +8,11 @@ cask "nordic-nrf-command-line-tools" do
   desc "Command-line tools for Nordic nRF Semiconductors"
   homepage "https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Command-Line-Tools"
 
+  # The upstream download page links to the latest dmg file but Cloudflare
+  # protections prevent us from fetching it, so it must be checked manually:
+  # https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download
   livecheck do
-    url "https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download"
-    regex(/nRF[._-]Command[._-]Line[._-]Tools[._-]v?(\d+(?:[._]\d+)+)[._-]Darwin\.dmg/i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match[0].tr("_", ".") }
-    end
+    skip "Cannot be fetched due to Cloudflare protections"
   end
 
   depends_on cask: "segger-jlink"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `nordic-nrf-command-line-tools` is producing an "Unable to get versions" error because the upstream website is behind Cloudflare and requires users to go through a turnstile check in a browser to view any pages. This appears to occur regardless of user agent, IP address, etc., so this updates the `livecheck` block to skip and adds a comment with the URL to manually check.