### PR TITLE
orka: update livecheck

### DIFF
--- a/Casks/o/orka.rb
+++ b/Casks/o/orka.rb
@@ -9,15 +9,7 @@ cask "orka" do
   homepage "https://orkadocs.macstadium.com/docs"
 
   livecheck do
-    url "https://orkadocs.macstadium.com/docs/downloads"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map do |match|
-        next unless match[0].start_with?("#{version.major}.")
-
-        match[0]
-      end
-    end
+    skip "Legacy version"
   end
 
   pkg "orka.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `orka` returns an "Unable to get versions" error as the downloads page redirects to the main support page (because the downloads page no longer exists), support.macstadium.com is behind Cloudflare, and the protections prevent us from fetching the page. That said, this would fail anyway because there is no longer a downloads page for Orka CLI versions before 3.x (for which we have the `orka3` cask). This sets the `livecheck` block to skip, as Orka CLI 2.x was deprecated when 3.0 was released.

I've set this to skip the homepage check in CI because the homepage also redirects to the main support page (on support.macstadium.com) and will fail for the same reasons. This will affect the `orka3` cask the next time it's run through CI, as it also uses the same homepage. We will need to update the homepage at that time (as that page no longer exists) but the trouble is that viable replacements are also on support.macstadium.com, so we'll probably just have to skip the homepage check for that cask going forward. Anyway, that's something for the future.