### PR TITLE
sentinel: update livecheck

### DIFF
--- a/Casks/s/sentinel.rb
+++ b/Casks/s/sentinel.rb
@@ -13,9 +13,12 @@ cask "sentinel" do
   desc "Language and framework for policy as code"
   homepage "https://docs.hashicorp.com/sentinel"
 
+  # The upstream download page links to the latest dmg files but the website
+  # has Vercel challenge mode enabled and this prevents us from fetching it,
+  # so it must be checked manually:
+  # https://developer.hashicorp.com/sentinel/install
   livecheck do
-    url "https://developer.hashicorp.com/sentinel/install"
-    regex(%r{href=.*?/sentinel[._-]?v?(\d+(?:\.\d+)+)[._-]#{os}[._-]#{arch}\.zip}i)
+    skip "Cannot be fetched due to Vercel challenge"
   end
 
   binary "sentinel"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `sentinel` is producing an "Unable to get versions" error because the upstream website appears to have Vercel challenge mode enabled, so the response only contains the challenge HTML and it requires JavaScript to work. This page loads fine in a browser (the challenge doesn't involve any interaction) but this effectively prevents us from checking the page using livecheck, so this sets the `livecheck` block to skip and adds a comment with the URL to check manually.