### PR TITLE
skyfonts: deprecate

### DIFF
--- a/Casks/s/skyfonts.rb
+++ b/Casks/s/skyfonts.rb
@@ -7,10 +7,7 @@ cask "skyfonts" do
   desc "Font manager"
   homepage "https://skyfonts.com/"
 
-  livecheck do
-    url "https://api.skyfonts.com/api/SkyFontsAppCast?osid=3"
-    regex(%r{href=.*?/Monotype_SkyFonts_Mac64_(\d+(?:\.\d+)*)\.dmg}i)
-  end
+  deprecate! date: "2025-11-02", because: :discontinued
 
   installer manual: "Install SkyFonts.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `skyfonts` has been producing an "Unable to get versions" error for some time, as the URL either times out or returns an error. The latest version of `skyfonts` is from years ago and it appears to have been discontinued, so this deprecates the cask accordingly.