### PR TITLE
smartgit 25.1.093

### DIFF
--- a/Casks/s/smartgit.rb
+++ b/Casks/s/smartgit.rb
@@ -1,23 +1,24 @@
 cask "smartgit" do
-  arch arm: "aarch64", intel: "x86_64"
+  arch arm: "arm64", intel: "x86_64"
 
-  version "24.1.5"
-  sha256 arm:   "036c1df4939b53ffe8a3f8558bfe9f7484159d018959c3b3fa1592e695a27635",
-         intel: "bc108b9fe01323d8d795545423221e89e72c07414ebc7eca96cb807c4ada5c49"
+  version "25.1.093"
+  sha256 arm:   "cccbdf366febcde9c69a06a1da75499998c5c00ce4efea02c22e31ec4ae5c7c7",
+         intel: "37db7de219e41b254d68e0ec872492d78580eb4c15a28aff0e9f6b12f62382d6"
 
-  url "https://www.syntevo.com/downloads/smartgit/smartgit-#{arch}-#{version.dots_to_underscores}.dmg"
+  url "https://download.smartgit.dev/smartgit/smartgit-#{version.dots_to_underscores}-macos-#{arch}.dmg"
   name "SmartGit"
   desc "Git client"
-  homepage "https://www.syntevo.com/smartgit/"
+  homepage "https://www.smartgit.dev/"
 
   livecheck do
-    url "https://www.syntevo.com/smartgit/download/"
-    regex(/href=.*?smartgit[._-]#{arch}[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
+    url "https://www.smartgit.dev/download/"
+    regex(/href=.*?smartgit[._-]v?(\d+(?:[._]\d+)+)(?:[._-]macos)?[._-]#{arch}\.dmg/i)
     strategy :page_match do |page, regex|
-      page.scan(regex)
-          .map { |match| match[0].tr("_", ".") }
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "SmartGit.app"
   binary "#{appdir}/SmartGit.app/Contents/MacOS/SmartGit"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`smartgit` is autobumped but the workflow failed to update to version 25.1.093 because the file name format has changed and the `livecheck` block regex no longer matches. This updates the version and makes adjustments to align with upstream changes.