### PR TITLE
soundsource@test: update livecheck

### DIFF
--- a/Casks/s/soundsource@test.rb
+++ b/Casks/s/soundsource@test.rb
@@ -13,7 +13,7 @@ cask "soundsource@test" do
     regex(/SoundSource[._-]v?(\h+)[._-](\d+)[._-](\d+)\.zip/i)
     strategy :sparkle do |item, regex|
       match = item.url&.match(regex)
-      next if match.blank?
+      next item.version if match.blank?
 
       "#{item.version.sub("fc", ",")},#{match[2]},#{match[3]},#{match[1]}"
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `soundsource@test` produces an "Unable to get versions" error because the only version in the appcast is the 5.8.9 stable release, so the regex doesn't match `item.url`. This adjusts the `strategy` block to return `item.version` if the regex doesn't match, as this will at least allow us to see and understand what's happening instead of this appearing as a broken check.

Ideally, this cask should probably update to stable versions (as it conflicts with `soundsource`) but that's a bit of a challenge, as the URL is completely different and would need to vary based on the number of parts in the `version`.

I've set this to run as syntax-only, as the livecheck audit will predictably fail due to the version mismatch.