### PR TITLE
adobe-dng-converter 18.0

### DIFF
--- a/Casks/a/adobe-dng-converter.rb
+++ b/Casks/a/adobe-dng-converter.rb
@@ -1,6 +1,6 @@
 cask "adobe-dng-converter" do
-  version "17.5"
-  sha256 "1d8b01cf50de6533213f8bf89faf3ae515a22f62d45343df3c6982d8c9c02ff3"
+  version "18.0"
+  sha256 "b550fa0c5049e6cb13335cfe9cf062a06d3e69ce5e23a94753b3ecb0cc5baf42"
 
   url "https://download.adobe.com/pub/adobe/dng/mac/DNGConverter_#{version.dots_to_underscores}.dmg"
   name "Adobe DNG Converter"

--- a/Casks/a/adobe-dng-converter.rb
+++ b/Casks/a/adobe-dng-converter.rb
@@ -8,8 +8,14 @@ cask "adobe-dng-converter" do
   homepage "https://helpx.adobe.com/camera-raw/using/adobe-dng-converter.html"
 
   livecheck do
-    url "https://helpx.adobe.com/photoshop/kb/uptodate.html"
-    regex(%r{Adobe\s+DNG\s+Converter\s+(?:is\s+)?(?:<[^>]+?>)?v?(\d+(?:\.\d+)+)(?:</[^>]+?>)?}im)
+    url "https://www.adobe.com/go/dng_converter_mac"
+    regex(/DNGConverter[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      match[1].tr("_", ".")
+    end
   end
 
   pkg "DNGConverter_#{version.dots_to_underscores}.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

According to the livecheck, the version appears unchanged, but [the official download link](https://www.adobe.com/go/dng_converter_mac) redirects to a newer version. I think we can skip the livecheck.