### PR TITLE
sunloginclient: update livecheck

### DIFF
--- a/Casks/s/sunloginclient.rb
+++ b/Casks/s/sunloginclient.rb
@@ -1,6 +1,6 @@
 cask "sunloginclient" do
   arch arm: "arm64", intel: "x86_64"
-  livecheck_id = on_arch_conditional arm: "187", intel: "89"
+  livecheck_id = on_arch_conditional arm: "_ARM"
 
   version "16.0.0.22931"
   sha256 arm:   "dcca75965c295137cfb624bb02ca397f0859f3e2de912aadd9f2688441b3f593",
@@ -13,9 +13,10 @@ cask "sunloginclient" do
   homepage "https://sunlogin.oray.com/"
 
   livecheck do
-    url "https://client-api.oray.com/softwares/#{livecheck_id}/download"
-    regex(/SunloginClient[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
-    strategy :header_match
+    url "https://client-webapi.oray.com/softwares/SUNLOGIN_X_MAC#{livecheck_id}?versiontype=stable"
+    strategy :json do |json|
+      json["versionno"]
+    end
   end
 
   pkg "SunloginClient.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `sunloginclient` is producing an "Unable to get versions" error, as the URL returns a 404 (Not Found) response. This updates the `livecheck` block to check the JSON endpoints that the upstream download page uses to identify the latest versions using JavaScript.