### PR TITLE
tableau 2025.2.4

### DIFF
--- a/Casks/t/tableau.rb
+++ b/Casks/t/tableau.rb
@@ -1,9 +1,9 @@
 cask "tableau" do
   arch arm: "-arm64"
 
-  version "2025.2.3"
-  sha256 arm:   "dc8d10f3340ece5eb10f61f51f8af3f70f08673c3c6c550fe3b2ef070c6dbbf9",
-         intel: "745e6f5cd9fea5c8ba2abead97d97d57f3b112c4ae14cc7651d3c34ad93d5592"
+  version "2025.2.4"
+  sha256 arm:   "3135e9f53ac9ce21b2a91f8b2ee35ba3472b11c666151c7c541e4ac6f38d3cde",
+         intel: "6128faef528f82982e40096f3380a406021d99f8354bf8ecb5f578543f54cf40"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauDesktop-#{version.dots_to_hyphens}#{arch}.dmg",
       user_agent: "curl/8.7.1"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tableau` is autobumped but the workflow failed to update to version 2025.2.4 because the `livecheck` block is producing an "Unable to get versions" error, as the website is unreachable unless the request uses a "curl/8.7.1" user agent. We can't set the user agent in a `livecheck` block yet (this is forthcoming) but this manually updates the version in the interim time.