### PR TITLE
tableau-prep 2025.2.4

### DIFF
--- a/Casks/t/tableau-prep.rb
+++ b/Casks/t/tableau-prep.rb
@@ -1,9 +1,9 @@
 cask "tableau-prep" do
   arch arm: "-arm64"
 
-  version "2025.2.3"
-  sha256 arm:   "3a071cb5cf711b9b106d8daf557159b104c2a7091ca297ddde7538c3656ace7c",
-         intel: "cd012970f350a874a7c218df6643b97f56a53b09b3798ec1c4ae1cefe59b92ef"
+  version "2025.2.4"
+  sha256 arm:   "f3ed25612cade7bc9f1c09defcaffd1afec4aacef683d7f828fdd04130c69366",
+         intel: "e1555b7665c17021b40dba3719db2450923c9e03623d7671fcd2e509c625b25f"
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}#{arch}.dmg",
       user_agent: "curl/8.7.1"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tableau-prep` is autobumped but the workflow failed to update to version 2025.2.4 because the `livecheck` block is producing an "Unable to get versions" error, as the website is unreachable unless the request uses a "curl/8.7.1" user agent. We can't set the user agent in a `livecheck` block yet (this is forthcoming) but this manually updates the version in the interim time.