### PR TITLE
tableau-public 2025.2.4

### DIFF
--- a/Casks/t/tableau-public.rb
+++ b/Casks/t/tableau-public.rb
@@ -1,9 +1,9 @@
 cask "tableau-public" do
   arch arm: "-arm64"
 
-  version "2025.2.3"
-  sha256 arm:   "b1f486da4ee3a2f05e2f9dab57586eecaf5d3f2fbc7c8fb724cbcbdbc6f70ae0",
-         intel: "da7e48fb0f4730797146231526fa7942e2177e4dcfad3d08cf9ab41e26b19afb"
+  version "2025.2.4"
+  sha256 arm:   "2387400960468d87e16f5948bef524a48e8c0fadd24ff265ea7998970c904bf3",
+         intel: "b511fe5f0a13ff95f2232169f7893eced06a6ba225b8dff7054492a0b6ed2898"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauPublic-#{version.dots_to_hyphens}#{arch}.pkg",
       user_agent: "curl/8.7.1"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tableau-public` is autobumped but the workflow failed to update to version 2025.2.4 because the `livecheck` block is producing an "Unable to get versions" error, as the website is unreachable unless the request uses a "curl/8.7.1" user agent. We can't set the user agent in a `livecheck` block yet (this is forthcoming) but this manually updates the version in the interim time.