### PR TITLE
tableau-reader 2025.2.4

### DIFF
--- a/Casks/t/tableau-reader.rb
+++ b/Casks/t/tableau-reader.rb
@@ -1,9 +1,9 @@
 cask "tableau-reader" do
   arch arm: "-arm64"
 
-  version "2025.2.3"
-  sha256 arm:   "24f2413a7e8abd32b8975bb2789558a170c4c62404ada04ce02cea331eeeb7b6",
-         intel: "82d4f039868e9635d5de40c622deeeb33c799ab9ef0f8ef4dad50ed137efbc8e"
+  version "2025.2.4"
+  sha256 arm:   "e05706cfc74e36000384a748c9fbe8b528bff940931242f8a793947f58767741",
+         intel: "5d1b48b3bc156509ef9e41bdd76c2f933c30cdd7d27d60bad8cfaa1c84d0a6ca"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauReader-#{version.dots_to_hyphens}#{arch}.pkg",
       user_agent: "curl/8.7.1"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tableau-reader` is autobumped but the workflow failed to update to version 2025.2.4 because the `livecheck` block is producing an "Unable to get versions" error, as the website is unreachable unless the request uses a "curl/8.7.1" user agent. We can't set the user agent in a `livecheck` block yet (this is forthcoming) but this manually updates the version in the interim time.