### PR TITLE
teamspeak-client@beta 6.0.0-beta3.2

### DIFF
--- a/Casks/t/teamspeak-client@beta.rb
+++ b/Casks/t/teamspeak-client@beta.rb
@@ -1,8 +1,11 @@
 cask "teamspeak-client@beta" do
-  version "6.0.0-beta2"
-  sha256 "7fe0109391515076c97f48503aabbae4032cf0877648aa19ddd81688ac6dff0d"
+  arch arm: "arm", intel: "intel"
 
-  url "https://files.teamspeak-services.com/pre_releases/client/#{version}/teamspeak-client.dmg",
+  version "6.0.0-beta3.2"
+  sha256 arm:   "308f342f51580202e566fd3d42729d5cc517071640809e2545ab5464ea9d23a2",
+         intel: "df0d13ef3095e3d2c239b225beeb5addd27fa26206bc1f698982611458268c0b"
+
+  url "https://files.teamspeak-services.com/pre_releases/client/#{version}/teamspeak-client-#{arch}.dmg",
       verified: "files.teamspeak-services.com/"
   name "TeamSpeak Beta"
   desc "Voice communication client"
@@ -10,8 +13,10 @@ cask "teamspeak-client@beta" do
 
   livecheck do
     url "https://teamspeak.com/en/downloads/"
-    regex(%r{href=.*?/(\d+(?:\.\d+)+[^/]*)/teamspeak[._-]client\.dmg}i)
+    regex(%r{href=.*?/(\d+(?:\.\d+)+[^/]*)/teamspeak[._-]client-#{arch}\.dmg}i)
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
 
@@ -22,8 +27,4 @@ cask "teamspeak-client@beta" do
     "~/Library/Preferences/TeamSpeak",
     "~/Library/Saved Application State/com.teamspeak.#{version.major}.client.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`teamspeak-client@beta` is autobumped but the workflow failed to update to version 6.0.0-beta3.2 because the `livecheck` block is producing an "Unable to get versions" error. The existing regex is unable to match the current dmg file names because they include an arch suffix now that there's also a dmg for ARM. This updates the version and adjusts the cask accordingly.

Besides that, the app fails Gatekeeper checks, so this also adds a `disable!` call with the future date we've been using for this scenario.