### PR TITLE
thebrain 14.0.113.0

### DIFF
--- a/Casks/t/thebrain.rb
+++ b/Casks/t/thebrain.rb
@@ -1,6 +1,6 @@
 cask "thebrain" do
-  version "14.0.110.0"
-  sha256 "04a42517a4eedc3da8c3ee833eea223bb903ea2d1592b3d399bf4866f528add1"
+  version "14.0.113.0"
+  sha256 "47e676dbf93d559cf16d9773854ce0d0bb31c038a36bb8186d3c86b2a1228be0"
 
   url "https://updater.thebrain.com/files/TheBrain#{version}.dmg"
   name "TheBrain"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`thebrain` is autobumped but the `livecheck` block can regularly produce an "Unable to get version" error because the upstream server can take longer than the 15 second timeout to respond, so this manually updates the version. I've set this to skip livecheck in CI, so hopefully it won't fail due to this flaky check.