### PR TITLE
unite-phone 2025.10.7

### DIFF
--- a/Casks/u/unite-phone.rb
+++ b/Casks/u/unite-phone.rb
@@ -1,6 +1,6 @@
 cask "unite-phone" do
-  version "2025.9.2"
-  sha256 "b79fc7a2977b72b69c8b238740c4d5c81073d0a94fcd3cb36b26d5d50e794b26"
+  version "2025.10.7"
+  sha256 "09ca6ee8263baf87e137e8129caf79e7e4496904c08c3e550f4ac795c2223b34"
 
   url "https://update.unitephone.nl/updates/unite_phone-#{version}-universal-mac.zip",
       user_agent: :fake
@@ -12,6 +12,8 @@ cask "unite-phone" do
     url "https://update.unitephone.nl/updates/latest-mac.yml"
     strategy :electron_builder
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`unite-phone` is autobumped but the workflow has failed to update to versions beyond 2025.9.2 because the `livecheck` block seems to produce an "Unable to get versions" error in the autobump environment. The check worked fine for me locally but the cask `url` uses `user_agent: :fake`, so the `livecheck` block URL may need the same treatment to work for autobump. We can't set the user agent in a `livecheck` block yet (this is forthcoming), so this manually updates the version in the interim time. Besides that, the app fails Gatekeeper checks, so this adds a `disable!` call with the future date we've been using for this scenario.