### PR TITLE
fixing hash for intune company portal to the latest one

### DIFF
--- a/Casks/i/intune-company-portal.rb
+++ b/Casks/i/intune-company-portal.rb
@@ -1,6 +1,6 @@
 cask "intune-company-portal" do
   version "5.2508.1"
-  sha256 "f02c69315e47b99c20b77d72f1a994dc7cd004f7cadc5e06abda1ff0bd47a5cc"
+  sha256 "ac165e3a3c364b9def29c07a7719ac0c4fd541309dbdb1e3a57485bedb8f526d"
 
   url "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_#{version}-Upgrade.pkg"
   name "Company Portal"


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online intune-company-portal` is error-free.
- [x] `brew style --fix intune-company-portal` reports no offenses.