### PR TITLE
rnote: update livecheck

### DIFF
--- a/Casks/r/rnote.rb
+++ b/Casks/r/rnote.rb
@@ -5,6 +5,13 @@ cask "rnote" do
   sha256 arm:   "c229895f1e844ce8e81e5fd7e34fbc3c9404cefe136cb66b9ca7601b86c098d7",
          intel: "75aa6d6df454e237db79b9f3d97baa923ab016f298141b01bea9468524bf9288"
 
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
+
   url "https://gitlab.com/api/v4/projects/44053427/packages/generic/rnote_macos/#{version}/Rnote-#{version}_#{arch}.dmg",
       verified: "gitlab.com/api/v4/projects/44053427/packages/generic/rnote_macos/"
   name "Rnote"

--- a/Casks/r/rnote.rb
+++ b/Casks/r/rnote.rb
@@ -12,7 +12,11 @@ cask "rnote" do
   homepage "https://rnote.flxzt.net/"
 
   livecheck do
-    url "https://gitlab.com/dehesselle/rnote_macos.git"
+    url "https://gitlab.com/api/v4/projects/44053427/releases"
+    regex(/^v?(\d+(?:\.\d+)+(?:\+\d+)?)$/i)
+    strategy :json do |json, regex|
+      json.filter_map { |item| item["tag_name"]&.[](regex, 1) }
+    end
   end
 
   app "Rnote.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `rnote` checks the Git tags from the upstream repository and it's currently returning 0.13.1+209 as the latest version but there's not a release for this tag after five hours, so there can be a notable gap between tag and release. This addresses the issue by updating the `livecheck` block to check release versions using the GitLab API.