### PR TITLE
Hashicorp casks: update livecheck

### DIFF
--- a/Casks/c/consul.rb
+++ b/Casks/c/consul.rb
@@ -13,7 +13,7 @@ cask "consul" do
 
   livecheck do
     url "https://releases.hashicorp.com/consul/"
-    regex(%r{href=.*?/consul/v?(\d+(?:\.\d+)+)/}i)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/}i)
   end
 
   binary "consul"

--- a/Casks/s/sentinel.rb
+++ b/Casks/s/sentinel.rb
@@ -13,12 +13,9 @@ cask "sentinel" do
   desc "Language and framework for policy as code"
   homepage "https://docs.hashicorp.com/sentinel"
 
-  # The upstream download page links to the latest dmg files but the website
-  # has Vercel challenge mode enabled and this prevents us from fetching it,
-  # so it must be checked manually:
-  # https://developer.hashicorp.com/sentinel/install
   livecheck do
-    skip "Cannot be fetched due to Vercel challenge"
+    url "https://releases.hashicorp.com/sentinel/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/}i)
   end
 
   binary "sentinel"

--- a/Casks/v/vagrant-vmware-utility.rb
+++ b/Casks/v/vagrant-vmware-utility.rb
@@ -9,7 +9,7 @@ cask "vagrant-vmware-utility" do
 
   livecheck do
     url "https://releases.hashicorp.com/vagrant-vmware-utility/"
-    regex(%r{href=["']?/?vagrant-vmware-utility/v?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/}i)
   end
 
   pkg "VagrantVMwareUtility.pkg"

--- a/Casks/v/vagrant.rb
+++ b/Casks/v/vagrant.rb
@@ -11,8 +11,8 @@ cask "vagrant" do
   homepage "https://www.vagrantup.com/"
 
   livecheck do
-    url "https://developer.hashicorp.com/vagrant/install"
-    regex(/href=[^ >]*?vagrant[._-]v?(\d+(?:\.\d+)+)(?:[._-]darwin)?(?:[._-]#{arch})?\.dmg/i)
+    url "https://releases.hashicorp.com/vagrant/"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/}i)
   end
 
   pkg "vagrant.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates various Hashicorp casks to use the same approach (checking releases.hashicorp.com) and to standardize their regexes. I recently modified the `livecheck` block for `sentinel` to skip because developer.hashicorp.com is inaccessible due to the website using Vercel challenge mode but the aforementioned approach allows us to check for new `sentinel` versions again. The same issue affects `vagrant`, so this addresses that failure as well.