### PR TITLE
valentina-studio: disable

### DIFF
--- a/Casks/v/valentina-studio.rb
+++ b/Casks/v/valentina-studio.rb
@@ -7,10 +7,7 @@ cask "valentina-studio" do
   desc "Visual editors for data"
   homepage "https://valentina-db.com/en/valentina-studio-overview"
 
-  livecheck do
-    url "https://valentina-db.com/en/all-downloads/vstudio"
-    regex(%r{href=['"]?/en/all-downloads/vstudio/current['"]?>\s*(\d+(?:\.\d+)+)}i)
-  end
+  disable! date: "2025-11-02", because: :unreachable
 
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

valentina-db.com URLs in the `valentina-studio` cask are now inaccessible, as the website is behind Cloudflare and the protections prevent brew from reaching the site regardless of user agent, IP address, etc. This means that users cannot download the dmg file to install it, so this makes the cask effectively unusable. This removes the `livecheck` block and disables the cask accordingly.