### PR TITLE
gcloud-cli: update default Python version to Python 3.13

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -16,7 +16,7 @@ cask "gcloud-cli" do
   end
 
   auto_updates true
-  depends_on formula: "python@3.12"
+  depends_on formula: "python@3.13"
 
   google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 
@@ -60,7 +60,7 @@ cask "gcloud-cli" do
     end
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "create", "--python-to-use",
-                                "#{HOMEBREW_PREFIX}/opt/python@3.12/libexec/bin/python3"],
+                                "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python3"],
                     reset_uid: true
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "enable"],


### PR DESCRIPTION
Upgraded depends_on Python version to v3.13, aligning with gcloud's upcoming default python upgrade for macOS which will be released on Tuesday (11/04).

----
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
