### PR TITLE
wpsoffice-cn 12.1.23540

### DIFF
--- a/Casks/w/wpsoffice-cn.rb
+++ b/Casks/w/wpsoffice-cn.rb
@@ -1,11 +1,11 @@
 cask "wpsoffice-cn" do
   arch arm: "arm64", intel: "x64"
 
-  version "7.5.1,8994"
-  sha256 arm:   "a266f7f3b1aa5b49717daa1a604f681bf72ada6df7ffa5824876d30d758dc9c6",
-         intel: "0346cf0d1a0e542f3ace2c4ea31fc4f8753d205e2c6171041d814f3eb5916f76"
+  version "12.1.23540"
+  sha256 arm:   "23072bfff2b411aa856457de4c000c0d31664dd4f24d0d21228490208a470465",
+         intel: "d0a11d586a99784ad89035e38842d53ca66b15a7159e08dfda05c5c9e6494d31"
 
-  url "https://package.mac.wpscdn.cn/mac_wps_pkg/#{version.csv.first}/WPS_Office_#{version.csv.first}(#{version.csv.second})_#{arch}.dmg",
+  url "https://package.mac.wpscdn.cn/mac_wps_pkg/#{version}/WPS_Office_#{version}(#{version.patch})_#{arch}.dmg",
       verified: "package.mac.wpscdn.cn/mac_wps_pkg/"
   name "WPS Office"
   desc "All-in-one office service platform in Chinese"
@@ -13,10 +13,7 @@ cask "wpsoffice-cn" do
 
   livecheck do
     url :homepage
-    regex(%r{>\s*v?(\d+(?:\.\d+)+)\s*[_\uff08(](\d+)[_\uff09)]\s*/\s*\d+(?:\.\d+)*\s*<}im)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
-    end
+    regex(%r{v?(\d+(?:\.\d+)+)/v?\d+(?:\.\d+)+}i)
   end
 
   conflicts_with cask: "wpsoffice"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wpsoffice-cn` is autobumped but the workflow failed to update to versions beyond 7.5.1 because the `livecheck` block produces an "Unable to get versions" error as the homepage no longer provides version information in the format that the regex matches. This updates the version and adjusts the `livecheck` block regex to match the current format for the version information on the homepage. In the versions after 7.5.1, the number in parentheses is the same as the third part of the version and this assumes that will remain true (until it doesn't).

For what it's worth, the app has a menu option to check for new versions but I was unable to capture the network request. It's also worth mentioning that the installer from the homepage makes a POST request to an API endpoint when you open it and the JSON response contains version and file information for the current architecture but it requires very specific request data and that may become outdated over time. While it would be much nicer to work with structured data, continuing to scrape the homepage is the simplest approach for now. If it becomes uncheckable in the future, I have a stashed `livecheck` block that checks the API endpoint the installer uses.