### PR TITLE
Rogue Amoeba casks: remove ACE version, add caveats

### DIFF
--- a/Casks/a/airfoil.rb
+++ b/Casks/a/airfoil.rb
@@ -1,35 +1,16 @@
 cask "airfoil" do
+  version "5.12.6"
   sha256 :no_check
 
-  on_ventura :or_older do
-    version "5.11.9"
-
-    url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil-ACE.zip"
-
-    # The ACE release supports macOS 11 to 14.3.1, so we use the highest
-    # supported macOS version in the URL.
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-  end
-  on_sonoma :or_newer do
-    version "5.12.6"
-
-    url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
-
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-
-    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Airfoil+for+Mac
-    caveats "Airfoil #{version} requires macOS 14.4 or higher."
-  end
-
+  url "https://cdn.rogueamoeba.com/airfoil/mac/download/Airfoil.zip"
   name "Airfoil"
   desc "Sends audio from computer to outputs"
   homepage "https://rogueamoeba.com/airfoil/mac/"
+
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.airfoil&platform=osx&version=#{version.no_dots}8000"
+    strategy :sparkle
+  end
 
   auto_updates true
   depends_on macos: ">= :big_sur"
@@ -50,4 +31,10 @@ cask "airfoil" do
     "~/Library/Saved Application State/com.rogueamoeba.Airfoil*",
     "~/Library/WebKit/com.rogueamoeba.Airfoil*",
   ]
+
+  caveats <<~EOS
+    Airfoil #{version} requires macOS 14.4 or higher.
+    Older versions of macOS will download a compatible version after opening the app.
+    See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Airfoil+for+Mac for more details.
+  EOS
 end

--- a/Casks/l/loopback.rb
+++ b/Casks/l/loopback.rb
@@ -1,35 +1,16 @@
 cask "loopback" do
+  version "2.4.7"
   sha256 :no_check
 
-  on_ventura :or_older do
-    version "2.3.5"
-
-    url "https://cdn.rogueamoeba.com/loopback/download/Loopback-ACE.zip"
-
-    # The ACE release supports macOS 11 to 14.4.1, so we use the highest
-    # supported macOS version in the URL.
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-  end
-  on_sonoma :or_newer do
-    version "2.4.7"
-
-    url "https://cdn.rogueamoeba.com/loopback/download/Loopback.zip"
-
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-
-    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Loopback
-    caveats "Loopback #{version} requires macOS 14.5 or newer."
-  end
-
+  url "https://cdn.rogueamoeba.com/loopback/download/Loopback.zip"
   name "Loopback"
   desc "Cable-free audio router"
   homepage "https://rogueamoeba.com/loopback/"
+
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.Loopback&platform=osx&version=#{version.no_dots}8000"
+    strategy :sparkle
+  end
 
   auto_updates true
   depends_on macos: ">= :big_sur"
@@ -50,4 +31,10 @@ cask "loopback" do
     "~/Library/Saved Application State/com.rogueamoeba.Loopback.savedState",
     "~/Library/WebKit/com.rogueamoeba.Loopback",
   ]
+
+  caveats <<~EOS
+    Loopback #{version} requires macOS 14.5 or higher.
+    Older versions of macOS will download a compatible version after opening the app.
+    See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Loopback for more details.
+  EOS
 end

--- a/Casks/p/piezo.rb
+++ b/Casks/p/piezo.rb
@@ -1,35 +1,16 @@
 cask "piezo" do
+  version "1.9.6"
   sha256 :no_check
 
-  on_ventura :or_older do
-    version "1.8.4"
-
-    url "https://cdn.rogueamoeba.com/piezo/download/Piezo-ACE.zip"
-
-    # The ACE release supports macOS 11 to 14.3.1, so we use the highest
-    # supported macOS version in the URL.
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1431&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-  end
-  on_sonoma :or_newer do
-    version "1.9.6"
-
-    url "https://cdn.rogueamoeba.com/piezo/download/Piezo.zip"
-
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-
-    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Piezo
-    caveats "Piezo #{version} requires macOS 14.4 or higher."
-  end
-
+  url "https://cdn.rogueamoeba.com/piezo/download/Piezo.zip"
   name "Piezo"
   desc "Audio recording application"
   homepage "https://rogueamoeba.com/piezo/"
+
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.Piezo&platform=osx&version=#{version.no_dots}8000"
+    strategy :sparkle
+  end
 
   auto_updates true
   depends_on macos: ">= :big_sur"
@@ -44,4 +25,10 @@ cask "piezo" do
     "~/Library/Preferences/com.rogueamoeba.Piezo.plist",
     "~/Library/WebKit/com.rogueamoeba.Piezo",
   ]
+
+  caveats <<~EOS
+    Piezo #{version} requires macOS 14.4 or higher.
+    Older versions of macOS will download a compatible version after opening the app.
+    See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=Piezo for more details.
+  EOS
 end

--- a/Casks/s/soundsource.rb
+++ b/Casks/s/soundsource.rb
@@ -1,35 +1,16 @@
 cask "soundsource" do
+  version "5.8.9"
   sha256 :no_check
 
-  on_ventura :or_older do
-    version "5.6.6"
-
-    url "https://cdn.rogueamoeba.com/soundsource/download/SoundSource-ACE.zip"
-
-    # The ACE release supports macOS 11 to 14.4.1, so we use the highest
-    # supported macOS version in the URL.
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=1441&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-  end
-  on_sonoma :or_newer do
-    version "5.8.9"
-
-    url "https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip"
-
-    livecheck do
-      url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
-      strategy :sparkle
-    end
-
-    # NOTE: See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=SoundSource
-    caveats "SoundSource #{version} requires macOS 14.5 or higher."
-  end
-
+  url "https://cdn.rogueamoeba.com/soundsource/download/SoundSource.zip"
   name "SoundSource"
   desc "Sound and audio controller"
   homepage "https://rogueamoeba.com/soundsource/"
+
+  livecheck do
+    url "https://rogueamoeba.net/ping/versionCheck.cgi?format=sparkle&system=999&bundleid=com.rogueamoeba.soundsource&platform=osx&version=#{version.no_dots}8000"
+    strategy :sparkle
+  end
 
   auto_updates true
   conflicts_with cask: "soundsource@test"
@@ -46,4 +27,10 @@ cask "soundsource" do
     "~/Library/Preferences/com.rogueamoeba.soundsource.plist",
     "~/Library/WebKit/com.rogueamoeba.soundsource",
   ]
+
+  caveats <<~EOS
+    SoundSource #{version} requires macOS 14.5 or higher.
+    Older versions of macOS will download a compatible version after opening the app.
+    See https://www.rogueamoeba.com/support/knowledgebase/?showCategory=SoundSource for more details.
+  EOS
 end


### PR DESCRIPTION
Companion to https://github.com/Homebrew/homebrew-cask/pull/234740.