### PR TITLE
insomnia@alpha 12.0.0

### DIFF
--- a/Casks/i/insomnia@alpha.rb
+++ b/Casks/i/insomnia@alpha.rb
@@ -1,6 +1,6 @@
 cask "insomnia@alpha" do
-  version "12.0.0-beta.0"
-  sha256 "b4466ed6c31c5e6dd21475a223f813780eabced61ca0559b50fc85018237f213"
+  version "12.0.0"
+  sha256 "98fb5e8d83afac7b92967446da5e9623343751afde986b44d3ccbcf4680c0235"
 
   url "https://github.com/Kong/insomnia/releases/download/core%40#{version}/Insomnia.Core-#{version}.dmg",
       verified: "github.com/Kong/insomnia/"
@@ -8,8 +8,13 @@ cask "insomnia@alpha" do
   desc "HTTP and GraphQL Client"
   homepage "https://insomnia.rest/"
 
+  # The upstream server only returns a JSON response if the provided version is
+  # lower than the newest version. This uses a X.0.0 version in the `url` to
+  # work around it but this won't work for a new major version (e.g., 1.0.0)
+  # where the provided version and newest version are equal, so this uses the
+  # previous major for a new major release.
   livecheck do
-    url "https://updates.insomnia.rest/builds/check/mac?v=#{version.major}.0.0#{"-beta.0" if version.split("-")&.second}&app=com.insomnia.app&channel=beta"
+    url "https://updates.insomnia.rest/builds/check/mac?v=#{version.include?(".0.0") ? (version.major.to_i - 1) : version.major}.0.0#{"-beta.0" if version.include?("-")}&app=com.insomnia.app&channel=beta"
     strategy :json do |json|
       json["name"]
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`insomnia@alpha` is autobumped but the workflow failed to update to version 12.0.0 because the livecheck audit failed for this version. The API endpoint that the `livecheck` block checks only returns a JSON response if the provided version in the URL is lower than the newest version. We work around this by using `#{version.major}.0.0` in the `livecheck` block URL and this works for versions that don't end in ".0.0". However, this predictably fails for a new major version like 12.0.0, preventing autobump from being able to create a version bump PR due to the `livecheck` audit failure.

We can't resolve this issue by falling back to the cask `version` in the `strategy` block because `Json.find_versions` contains a guard that will return early if the response body is empty (as `Json.parse` will error if it's given an empty string), so the `strategy` block isn't executed in that scenario. This resolves the issue by using the previous major version in the `livecheck` block URL if the cask version contains ".0.0". This is slightly different behavior than the `livecheck` block for `insomnia`, as the version may have an unstable suffix in this context. This approach works for 12.0.0 and hopefully it will continue to work in the future, so autobump will also handle new major versions.