### PR TITLE
font-amiri: update urls

### DIFF
--- a/Casks/font/font-a/font-amiri.rb
+++ b/Casks/font/font-a/font-amiri.rb
@@ -2,10 +2,10 @@ cask "font-amiri" do
   version "1.003"
   sha256 "81af0aff7d2086d8af24cea7202f7546130997982534691373485cd96744d05e"
 
-  url "https://github.com/alif-type/amiri/releases/download/#{version}/Amiri-#{version}.zip",
-      verified: "github.com/alif-type/amiri/"
+  url "https://github.com/aliftype/amiri/releases/download/#{version}/Amiri-#{version}.zip",
+      verified: "github.com/aliftype/amiri/"
   name "Amiri"
-  homepage "https://www.amirifont.org/"
+  homepage "https://aliftype.com/amiri/"
 
   font "Amiri-#{version}/Amiri-Bold.ttf"
   font "Amiri-#{version}/Amiri-BoldItalic.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The GitHub organization for `font-amiri` has changed from alif-type to aliftype, so the cask `url` is broken and livecheck is returning an "Unable to get versions" error as a result. This updates the GitHub URLs, as the homepage contains GitHub URLs using the same organization. Besides that, this also updates the homepage to resolve the redirection and align with the website link on the related GitHub repository.