### PR TITLE
expandrive 2025.10.31.775

### DIFF
--- a/Casks/e/expandrive.rb
+++ b/Casks/e/expandrive.rb
@@ -1,23 +1,20 @@
 cask "expandrive" do
-  version "7,2025-05-27,2025-05-27_at_14_49_21"
-  sha256 "2912ea060dc278b76c7d1bf74b27fb20a376691db7b02ddc6c1d2d84ff2ec49e"
+  version "2025.10.31.775"
+  sha256 "39e88b5a39c92ab7eb627567f11c8b0bf3a787e4c4699a3c115c88a910ebd9b8"
 
-  url "https://s3.amazonaws.com/expandrive/expandrive#{version.csv.first}/v#{version.csv.second}_published_#{version.csv.third}/ExpanDrive.dmg",
-      verified: "s3.amazonaws.com/expandrive/"
+  url "https://corp.hosted-by-files.com/builds/ExpanDrive/#{version}/mac/ExpanDrive_#{version.major_minor_patch}.dmg",
+      verified: "corp.hosted-by-files.com/builds/ExpanDrive/"
   name "ExpanDrive"
   desc "Network drive and browser for cloud storage"
   homepage "https://www.expandrive.com/apps/expandrive/"
 
   livecheck do
-    url "https://updates.expandrive.com/apps/expandrive#{version.csv.first}/download_latest"
-    regex(%r{expandrive(\d+)/v?(\d+(?:[.-]\d+)+)[._-]published[._-]([^/]+)/ExpanDrive\.dmg}i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]},#{match[3]}"
-    end
+    url "https://www.expandrive.com/api/download/expandrive?platform=macos"
+    regex(%r{/ExpanDrive/v?(\d+(?:\.\d+)+)/}i)
+    strategy :header_match
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "ExpanDrive.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`expandrive` is autobumped but the workflow failed to update to version 2025.10.31.775 because the livecheck block is producing an "Unable to get versions" error as the server returns a 404 (Not Found) response for the URL. This updates the version and `url` and modifies the `livecheck` block to check the redirecting download URL for the Mac file. The app reportedly checks for updates but that doesn't seem to work until after you unlock it using your license information.