### PR TITLE
handy 0.5.5

### DIFF
--- a/Casks/h/handy.rb
+++ b/Casks/h/handy.rb
@@ -1,11 +1,11 @@
 cask "handy" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.5.4"
-  sha256 arm:   "a0f116683cb78d2e64a2c2e9918fd9918fdf3d9e714c9f6f2636637e3d4703b1",
-         intel: "27a0098c966ca89d6a3c69fdb0df6c85ce57da14fbb9515d23f8a7e4a0072ee4"
+  version "0.5.5"
+  sha256 arm:   "ee176380906cf2dec024417c1ca6e4b1f52535b98f41f198170bf363a2a053e3",
+         intel: "db3618321ed6082502d1a7844482bc6059226b14bca91980d54c5cda5f3885ea"
 
-  url "https://github.com/cjpais/Handy/releases/download/v#{version}/Handy_#{version}_#{arch}.dmg",
+  url "https://github.com/cjpais/Handy/releases/download/v#{version}/Handy_#{version}_#{arch}_darwin.dmg",
       verified: "github.com/cjpais/Handy/"
   name "Handy"
   desc "Speech to text application"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`handy` is autobumped but the workflow failed to update to version 0.5.5 because the dmg file names now include a `_darwin` suffix. This updates the version and `url` accordingly.