### PR TITLE
zen 1.17.5b: update sha256

### DIFF
--- a/Casks/z/zen.rb
+++ b/Casks/z/zen.rb
@@ -1,6 +1,6 @@
 cask "zen" do
   version "1.17.5b"
-  sha256 "32ea1d21ff3bcfc284a4c9bde684f4bf27573c34fa0f9c2bb697a85b5018f693"
+  sha256 "a2f0a18b8949461dc687c1bf8b2dd691dd62658cf1ce40817d3d078ff03b2c54"
 
   url "https://github.com/zen-browser/desktop/releases/download/#{version}/zen.macos-universal.dmg",
       verified: "github.com/zen-browser/desktop/"


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

check [here](https://github.com/zen-browser/desktop/releases/tag/1.17.5b).