### PR TITLE
qlc+ 5.0.1

### DIFF
--- a/Casks/q/qlc+.rb
+++ b/Casks/q/qlc+.rb
@@ -2,13 +2,15 @@ cask "qlc+" do
   arch arm: "arm64", intel: "x86_64"
 
   on_arm do
-    version "5.0.0"
-    sha256 "f42b26a1328ce4f6120c160c43e4aabd5a5f950fe662eb8b75f74c321d716288"
+    version "5.0.1"
+    sha256 "00bab5cd80f3140cc981be72f3d0ad092f30436931e223955255d0a36205b254"
 
     livecheck do
-      url "https://qlcplus.org/download"
+      url "https://www.qlcplus.org/download"
       regex(/href=.*?QLC\+[._-]v?(\d+(?:[.-]\d+)+)[._-]#{arch}\.dmg/i)
     end
+
+    depends_on macos: ">= :monterey"
   end
   on_intel do
     version "4.14.3"
@@ -17,12 +19,14 @@ cask "qlc+" do
     livecheck do
       skip "Legacy version"
     end
+
+    depends_on macos: ">= :catalina"
   end
 
-  url "https://qlcplus.org/downloads/#{version.split("-").first}/QLC+_#{version}_#{arch}.dmg"
+  url "https://www.qlcplus.org/downloads/#{version.split("-").first}/QLC+_#{version}_#{arch}.dmg"
   name "Q Light Controller+"
   desc "Control DMX or analogue lighting systems"
-  homepage "https://qlcplus.org/"
+  homepage "https://www.qlcplus.org/"
 
   app "QLC+.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`qlc+` is autobumped but the workflow failed to update to version 5.0.1 because `brew bump` doesn't handle skipped `livecheck` blocks in a reasonable manner when only one arch is skipped (i.e., the "skipped" string is treated as a version and this produces an artifact URL that will predictably fail). This manually updates the version for the time being.

Besides that, this adds a `depends_on macos:` value for ARM. The macOS requirement for Intel is 10.13 or later and it can use the implicit macOS requirement for casks but we have to make it explicit here for `brew style` to pass (as we can't have only an ARM value).

Lastly, this updates the qlcplus.org URLs to use the www subdomain, as the file links on the download page use it. The website works fine with or without it and doesn't redirect to one or the other, so this is just a preemptive change in case it redirects to the www subdomain in the future.