### PR TITLE
ledger-wallet 2.132.0

### DIFF
--- a/Casks/l/ledger-wallet.rb
+++ b/Casks/l/ledger-wallet.rb
@@ -1,11 +1,11 @@
-cask "ledger-live" do
-  version "2.131.1"
-  sha256 "41b8a5d85196a6aee871cf3ab97d49b42d4a4151c760338d85b8164f4b3e9a38"
+cask "ledger-wallet" do
+  version "2.132.0"
+  sha256 "af3442f8bac7a428ca3729508d53256386e0bec065518b42038387ca0a33e911"
 
   url "https://download.live.ledger.com/ledger-live-desktop-#{version}-mac.dmg"
-  name "Ledger Live"
+  name "Ledger Wallet"
   desc "Wallet desktop application to maintain multiple cryptocurrencies"
-  homepage "https://www.ledger.com/ledger-live"
+  homepage "https://shop.ledger.com/pages/ledger-wallet"
 
   livecheck do
     url "https://download.live.ledger.com/latest-mac.yml"
@@ -15,7 +15,7 @@ cask "ledger-live" do
   auto_updates true
   depends_on macos: ">= :monterey"
 
-  app "Ledger Live.app"
+  app "Ledger Wallet.app"
 
   uninstall quit: [
     "com.ledger.live",
@@ -23,7 +23,7 @@ cask "ledger-live" do
   ]
 
   zap trash: [
-    "~/Library/Application Support/Ledger Live",
+    "~/Library/Application Support/Ledger Wallet",
     "~/Library/Preferences/com.ledger.live.plist",
     "~/Library/Saved Application State/com.ledger.live.savedState",
   ]

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -104,6 +104,7 @@
   "lab": "lab-app",
   "languagetool": "languagetool-desktop",
   "lasso": "lasso-app",
+  "ledger-live": "ledger-wallet",
   "licensed": "licensed-app",
   "logi-options-plus": "logi-options+",
   "lynx": "lynx-whiteboard",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ledger-live` is autobumped but the workflow failed to update to version 2.132.0 because the app is now "Ledger Wallet.app". This updates the version and adjusts the cask to use the new name (renaming it in the process). I confirmed that the artifact and `livecheck` block URLs still use download.live.ledger.com in the newest app version, the file name still uses "ledger-live", and the app is still using a com.ledger.live identifier for now.