### PR TITLE
smlnj 110.99.9

### DIFF
--- a/Casks/s/smlnj.rb
+++ b/Casks/s/smlnj.rb
@@ -1,6 +1,6 @@
 cask "smlnj" do
-  version "110.99.8"
-  sha256 "3c8244ae96dde9b4089faa9073c6dd3f1f1cb50b73143d6e20a711ecda286e79"
+  version "110.99.9"
+  sha256 "41f011e2950935efb7336d4157acb76efa886cec6c14fb28df82ec0a5b4ac993"
 
   url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-amd64-#{version}.pkg",
       verified: "smlnj.cs.uchicago.edu/"
@@ -12,6 +12,8 @@ cask "smlnj" do
     url :homepage
     regex(%r{href=.*?/smlnj-amd64-(\d+(?:\.\d+)*)\.pkg}i)
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   pkg "smlnj-amd64-#{version}.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`smlnj` is autobumped but the workflow failed to update to version 110.99.9 because the pkg file fails Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.