### PR TITLE
sonarr 2.18.29

### DIFF
--- a/Casks/s/sonarr.rb
+++ b/Casks/s/sonarr.rb
@@ -1,9 +1,16 @@
 cask "sonarr" do
   arch arm: "arm64", intel: "x64"
 
-  version "4.0.15.2941"
-  sha256 arm:   "71814960634881a75a98cb349fdc4088b56889e670d06b3e292f8d58f180fc1d",
-         intel: "4e200e11cdca94a782bce820c1baee16c27af96dab48596362385aaf6b7f06f6"
+  version "4.0.16.2944"
+  sha256 arm:   "88f3fed9de4e5bce11ce735bc7d34d6f7f14504108c0fed86ab12bc9558a731d",
+         intel: "b17b90e163e89bb438c1ffd896ead16ffce96b6fb27c05dc96acef80bc84e06f"
+
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
 
   url "https://github.com/Sonarr/Sonarr/releases/download/v#{version}/Sonarr.main.#{version}.osx-#{arch}-app.zip",
       verified: "github.com/Sonarr/Sonarr/"
@@ -15,6 +22,8 @@ cask "sonarr" do
     url :url
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   conflicts_with cask: "sonarr@beta"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`sonarr` is autobumped but the workflow failed to update to version 2.18.29 because the app fails Gatekeeper checks (due to being unsigned). This updates the app and adds a `disable!` call with the future date we've been using for this scenario. This also adds a `depends_on macos:` value for ARM to resolve the related `brew audit` error. The Intel app has a macOS requirement of 10.14 or later, so it can use the implicit macOS requirement but we have to add an explicit dependency to pass `brew style` (as we can't have only an ARM value).