### PR TITLE
unison-app 2.53.8

### DIFF
--- a/Casks/u/unison-app.rb
+++ b/Casks/u/unison-app.rb
@@ -1,9 +1,9 @@
 cask "unison-app" do
-  arch arm: "arm64", intel: "x86_64"
+  arch arm: "arm64", intel: "x86-64"
 
-  version "2.53.7"
-  sha256 arm:   "3dbb8257209ede50989a4442e863ad7b801a9a1ae04903dbb64c2d9b4a7be9e0",
-         intel: "a64996878c94c8432cf1ef898cae389b8f75c3846834af95cb21dd399854a654"
+  version "2.53.8"
+  sha256 arm:   "9ffaa166aff2bf7357d365a67dbd941a71534d5a7e65493920ebb1a804f38c89",
+         intel: "4f3d8d5c2098df220b3e45bd84c9842ebf7139a595243c9533ab953cff0e95d7"
 
   url "https://github.com/bcpierce00/unison/releases/download/v#{version}/Unison-#{version}-macos-#{arch}.app.tar.gz"
   name "Unison"
@@ -22,6 +22,8 @@ cask "unison-app" do
       end
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Unison.app"
   binary "#{appdir}/Unison.app/Contents/MacOS/cltool", target: "unison"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`unison-app` is autobumped but the workflow failed to update to version 2.53.8 because the arch suffix for Intel is `x86-64` for this release instead of the previous `x86_64`. This updates the version and adjusts the related `arch` value accordingly. Besides that, the app fails Gatekeeper checks, so this adds a `disable!` call with the future date we've been using for this scenario.