### PR TITLE
virtualbox@beta 7.1.15-171121 (arm), 7.1.15-171109 (intel)

### DIFF
--- a/Casks/v/virtualbox@beta.rb
+++ b/Casks/v/virtualbox@beta.rb
@@ -2,9 +2,14 @@ cask "virtualbox@beta" do
   arch arm: "macOSArm64", intel: "OSX"
   desc_arch = on_arch_conditional arm: "arm64", intel: "x86"
 
-  version "7.1.13-170872"
-  sha256 arm:   "8b67c3d0dd0e28b62d731d8be64fcd1e06de3c27f91657f82daadad5e6cb9869",
-         intel: "30c72d678dbca4e8f0940893a5c4960d1c7a4ae4a288b64c8c1b956275f1fc59"
+  on_arm do
+    version "7.1.15-171121"
+    sha256 "80685f4b1ecfb25d711dea70b3f58bfda03e04009ca648193d059315946f6b56"
+  end
+  on_intel do
+    version "7.1.15-171109"
+    sha256 "6b2a388ee58a36d618687e7df1d7795891a7337d4fc7cf68e32583b708f51afe"
+  end
 
   url "https://www.virtualbox.org/download/testcase/VirtualBox-#{version}-#{arch}.dmg"
   name "Oracle VirtualBox"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`virtualbox@beta` is autobumped but the workflow failed to update to version 7.1.15-171121 (for ARM) and 7.1.15-171109 (for Intel) because replacing the `inreplace` call to update the version in the cask failed, presumably due to the ARM and Intel versions varying. This manually updates the versions, splitting them based on arch.