### PR TITLE
yaak 2025.8.1

### DIFF
--- a/Casks/y/yaak.rb
+++ b/Casks/y/yaak.rb
@@ -1,11 +1,11 @@
 cask "yaak" do
   arch arm: "aarch64", intel: "x64"
 
-  version "2025.7.3"
-  sha256 arm:   "eac242180a7dce3b685911ab21fcb83d689d89a8d98cdd7c9c8da5eddf29e862",
-         intel: "4646de6bee160c8c245cdcef40666c67221c3fc416a8ebde7c19334a14eb2f27"
+  version "2025.8.1"
+  sha256 arm:   "41a8f8389d79a5dc228577b88c59f6574722d49010d01060754ec2b572bc4e8c",
+         intel: "fd476125a96001cd5d7d83fca9a19283b005ea2f36801444f54116d116534be8"
 
-  url "https://github.com/mountain-loop/yaak/releases/download/v#{version}/Yaak_#{version}_#{arch}.dmg",
+  url "https://github.com/mountain-loop/yaak/releases/download/v#{version}/Yaak_#{version}_#{arch}_darwin.dmg",
       verified: "github.com/mountain-loop/yaak/"
   name "Yaak"
   desc "REST, GraphQL and gRPC client"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`yaak` is autobumped but the workflow failed to update to version 2025.8.1 because the dmg file names now include a `_darwin` suffix. This updates the version and `url` accordingly.