### PR TITLE
Deprecate Affinity V2

### DIFF
--- a/Casks/a/affinity-designer.rb
+++ b/Casks/a/affinity-designer.rb
@@ -8,10 +8,7 @@ cask "affinity-designer" do
   desc "Professional graphic design software"
   homepage "https://affinity.serif.com/en-us/designer/"
 
-  livecheck do
-    url "https://go.seriflabs.com/affinity-update-mac-retail-designer#{version.csv.first.major}"
-    strategy :sparkle
-  end
+  deprecate! date: "2025-10-30", because: :discontinued
 
   auto_updates true
 

--- a/Casks/a/affinity-designer@1.rb
+++ b/Casks/a/affinity-designer@1.rb
@@ -8,10 +8,7 @@ cask "affinity-designer@1" do
   desc "Professional graphic design software"
   homepage "https://affinity.serif.com/en-us/designer/"
 
-  livecheck do
-    url "https://go.seriflabs.com/affinity-update-mac-retail-designer"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-10-30", because: :discontinued
 
   auto_updates true
 

--- a/Casks/a/affinity-photo.rb
+++ b/Casks/a/affinity-photo.rb
@@ -8,10 +8,7 @@ cask "affinity-photo" do
   desc "Professional image editing software"
   homepage "https://affinity.serif.com/en-us/photo/"
 
-  livecheck do
-    url "https://go.seriflabs.com/affinity-update-mac-retail-photo#{version.csv.first.major}"
-    strategy :sparkle
-  end
+  deprecate! date: "2025-10-30", because: :discontinued
 
   auto_updates true
 

--- a/Casks/a/affinity-photo@1.rb
+++ b/Casks/a/affinity-photo@1.rb
@@ -8,10 +8,7 @@ cask "affinity-photo@1" do
   desc "Professional image editing software"
   homepage "https://affinity.serif.com/en-us/photo/"
 
-  livecheck do
-    url "https://go.seriflabs.com/affinity-update-mac-retail-photo"
-    strategy :sparkle, &:version
-  end
+  deprecate! date: "2025-10-30", because: :discontinued
 
   auto_updates true
 

--- a/Casks/a/affinity-publisher.rb
+++ b/Casks/a/affinity-publisher.rb
@@ -8,10 +8,7 @@ cask "affinity-publisher" do
   desc "Professional desktop publishing software"
   homepage "https://affinity.serif.com/en-us/publisher/"
 
-  livecheck do
-    url "https://go.seriflabs.com/affinity-update-mac-retail-publisher#{version.csv.first.major}"
-    strategy :sparkle
-  end
+  deprecate! date: "2025-10-30", because: :discontinued
 
   auto_updates true
 

--- a/Casks/a/affinity-publisher@1.rb
+++ b/Casks/a/affinity-publisher@1.rb
@@ -8,10 +8,7 @@ cask "affinity-publisher@1" do
   desc "Professional desktop publishing software"
   homepage "https://affinity.serif.com/en-us/publisher/"
 
-  livecheck do
-    url "https://go.seriflabs.com/affinity-update-mac-retail-publisher"
-    strategy :sparkle, &:version
-  end
+  deprecate! date: "2025-10-30", because: :discontinued
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

On October 30, the Affinity V2 suite was announced to be discontinued in favor of the new Affinity by Canva app. From the FAQ for existing users (found at https://affinity.serif.com/en-us/v2/):

> **What if I prefer to use the Affinity V2 suite? Will it get updates?**
>
> That’s totally fine. Your Affinity V2 license (via Serif) remains valid and Serif will continue to keep activation servers online. But please note that these apps won’t receive future updates.
>
> For the best experience, we recommend using the new Affinity by Canva app.