### PR TITLE
Remove microsoft-autoupdate dependencies from Microsoft casks.

### DIFF
--- a/Casks/i/intune-company-portal.rb
+++ b/Casks/i/intune-company-portal.rb
@@ -20,7 +20,6 @@ cask "intune-company-portal" do
   end
 
   auto_updates true
-  depends_on cask: "microsoft-auto-update"
 
   pkg "CompanyPortal_#{version}-Upgrade.pkg",
       choices: [

--- a/Casks/m/microsoft-excel.rb
+++ b/Casks/m/microsoft-excel.rb
@@ -37,7 +37,6 @@ cask "microsoft-excel" do
     "microsoft-office",
     "microsoft-office-businesspro",
   ]
-  depends_on cask: "microsoft-auto-update"
 
   pkg "Microsoft_Excel_#{version}_Installer.pkg",
       choices: [

--- a/Casks/m/microsoft-office-businesspro.rb
+++ b/Casks/m/microsoft-office-businesspro.rb
@@ -25,7 +25,6 @@ cask "microsoft-office-businesspro" do
     microsoft-word
     onedrive
   ]
-  depends_on cask: "microsoft-auto-update"
   depends_on macos: ">= :monterey"
 
   pkg "Microsoft_365_and_Office_#{version}_BusinessPro_Installer.pkg",

--- a/Casks/m/microsoft-office.rb
+++ b/Casks/m/microsoft-office.rb
@@ -23,7 +23,6 @@ cask "microsoft-office" do
     microsoft-word
     onedrive
   ]
-  depends_on cask: "microsoft-auto-update"
   depends_on macos: ">= :ventura"
 
   pkg "Microsoft_365_and_Office_#{version}_Installer.pkg",

--- a/Casks/m/microsoft-outlook.rb
+++ b/Casks/m/microsoft-outlook.rb
@@ -39,7 +39,6 @@ cask "microsoft-outlook" do
     "microsoft-office",
     "microsoft-office-businesspro",
   ]
-  depends_on cask: "microsoft-auto-update"
 
   pkg "Microsoft_Outlook_#{version}_Installer.pkg",
       choices: [

--- a/Casks/m/microsoft-powerpoint.rb
+++ b/Casks/m/microsoft-powerpoint.rb
@@ -37,7 +37,6 @@ cask "microsoft-powerpoint" do
     "microsoft-office",
     "microsoft-office-businesspro",
   ]
-  depends_on cask: "microsoft-auto-update"
 
   pkg "Microsoft_PowerPoint_#{version}_Installer.pkg",
       choices: [

--- a/Casks/m/microsoft-teams.rb
+++ b/Casks/m/microsoft-teams.rb
@@ -27,7 +27,6 @@ cask "microsoft-teams" do
 
   auto_updates true
   conflicts_with cask: "microsoft-office-businesspro"
-  depends_on cask: "microsoft-auto-update"
   depends_on macos: ">= :big_sur"
 
   pkg "MicrosoftTeams.pkg",

--- a/Casks/m/microsoft-word.rb
+++ b/Casks/m/microsoft-word.rb
@@ -37,7 +37,6 @@ cask "microsoft-word" do
     "microsoft-office",
     "microsoft-office-businesspro",
   ]
-  depends_on cask: "microsoft-auto-update"
 
   pkg "Microsoft_Word_#{version}_Installer.pkg",
       choices: [

--- a/Casks/s/skype-for-business.rb
+++ b/Casks/s/skype-for-business.rb
@@ -10,7 +10,6 @@ cask "skype-for-business" do
   deprecate! date: "2025-05-05", because: :discontinued
 
   auto_updates true
-  depends_on cask: "microsoft-auto-update"
 
   pkg "SkypeForBusinessInstaller-#{version}.pkg",
       choices: [


### PR DESCRIPTION
Removed the depends_on cask: "microsoft-auto-update" stanza across the Microsoft casks so MAU is no longer installed

Made the same dependency removal for the suite/companion installers

Refs: https://github.com/orgs/Homebrew/discussions/5481

- [x] The submission is for a stable version
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.