### PR TITLE
spline 0.12.11

### DIFF
--- a/Casks/s/spline.rb
+++ b/Casks/s/spline.rb
@@ -1,9 +1,9 @@
 cask "spline" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.12.5"
-  sha256 arm:   "85ebe3f7f7255fd0c5451ea453aade703cbe55b41efa096c55062175cb50c57f",
-         intel: "bbf43f7b34bff38396e1144a662329edf69713798ed890d151b49d3618623a35"
+  version "0.12.11"
+  sha256 arm:   "e07ca72432a1c53366e2fbe4a06566ebd3f314454a86e4fa1edc6e854974a87a",
+         intel: "9417fa964681c5b74ea7d05d21e5f27e19b455f6d986a04d02c944bb170bd942"
 
   url "https://cdn.spline.design/_assets/Spline-#{version}-#{arch}.mac.zip"
   name "Spline"
@@ -11,9 +11,11 @@ cask "spline" do
   homepage "https://spline.design/"
 
   livecheck do
-    url :homepage
-    regex(/Spline[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}[._-]mac\.zip/i)
+    url "https://s3.amazonaws.com/updater.spline.design/latest-mac.yml"
+    strategy :electron_builder
   end
+
+  depends_on macos: ">= :monterey"
 
   app "Spline.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`spline` is autobumped but the workflow failed to update to version 0.12.11 because the `livecheck` block is producing an "Unable to get versions" error, as the homepage now uses JavaScript to render the download links in the browser and the URLs are buried in a random JS file [with a file name that varies between website builds]. This updates the version and modifies the `livecheck` block to check the YAML file that the app uses to check for new versions. Besides that, this adds an appropriate `depends_on macos:` value to resolve the related `brew audit` error.