### PR TITLE
browseros 0.29.0

### DIFF
--- a/Casks/b/browseros.rb
+++ b/Casks/b/browseros.rb
@@ -1,11 +1,11 @@
 cask "browseros" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.28.1"
-  sha256 arm:   "298cbb10f6f12e2398f73b14fe41515c0a9d4e2e0c9b49e4056f6e1aa4230afd",
-         intel: "f21eceb19941df4baa204d8c6b8804d9bc31ce47b7bc0e3eb143fb81329e970f"
+  version "0.29.0"
+  sha256 arm:   "c4015f1b584f5a939d54079060243a5a4a0efcba87ac2769ebecd9fb80ca1aaa",
+         intel: "2bdaa7ab9f7f93068bf8e8f0de6cc1fba9ace02a0f127e9180c700bc7550c815"
 
-  url "https://github.com/browseros-ai/BrowserOS/releases/download/v#{version}/BrowserOS_v#{version}_#{arch}.dmg",
+  url "https://github.com/browseros-ai/BrowserOS/releases/download/#{version}/BrowserOS_v#{version}_#{arch}.dmg",
       verified: "github.com/browseros-ai/BrowserOS/"
   name "BrowserOS"
   desc "Open-source agentic browser"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`browseros` is autobumped but the workflow failed to update to version 0.29.0 because the upstream tag is "0.29.0" but all the previous tags include a "v" at the start. This updates the version and modifies the `url` accordingly.