### PR TITLE
xtool-studio: update livecheck

### DIFF
--- a/Casks/x/xtool-studio.rb
+++ b/Casks/x/xtool-studio.rb
@@ -18,7 +18,7 @@ cask "xtool-studio" do
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/([^/]+)/([^/]+)/xTool[._-]Studio(?:[._-]#{arch})?[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    regex(%r{/([^/\\]+)\\?/([^/\\]+)\\?/xTool[._-]Studio(?:[._-]#{arch})?[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block checks the homepage for version information but it's producing an "Unable to get versions" error, as the dmg URL is now found in some JavaScript code (in the HTML) rather than an `href` attribute. This removes the leading `href=.*?` to allow the regex to match the URL outside of that specific context. The string in the JS escapes the forward slash characters, so we also have to account for those to ensure they're omitted from the capture groups. In my testing, this approach should work for the previous setup (link in an `href` attribute) as well as the current setup (URL in JS code).