### PR TITLE
epic-games 19.0.0

### DIFF
--- a/Casks/e/epic-games.rb
+++ b/Casks/e/epic-games.rb
@@ -2,10 +2,6 @@ cask "epic-games" do
   version "19.0.0"
   sha256 "78e782ff73b3ddaa267b3d536af748b460200398133527cd199562955c1f184c"
 
-  on_intel do
-    disable! date: "2026-09-01", because: :fails_gatekeeper_check
-  end
-
   url "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Mac/EpicInstaller-#{version}.dmg",
       verified: "epicgames-download1.akamaized.net/"
   name "Epic Games Launcher"

--- a/Casks/e/epic-games.rb
+++ b/Casks/e/epic-games.rb
@@ -1,6 +1,10 @@
 cask "epic-games" do
-  version "18.10.0"
-  sha256 "258cc270fdbe6243ad277381bd58d13f27de3670ef702007e7bf9249b76b3e3d"
+  version "19.0.0"
+  sha256 "78e782ff73b3ddaa267b3d536af748b460200398133527cd199562955c1f184c"
+
+  on_intel do
+    disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  end
 
   url "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Mac/EpicInstaller-#{version}.dmg",
       verified: "epicgames-download1.akamaized.net/"
@@ -14,6 +18,7 @@ cask "epic-games" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "Epic Games Launcher.app"
 
@@ -26,8 +31,4 @@ cask "epic-games" do
     "~/Library/Logs/Unreal Engine/EpicGamesLauncher",
     "~/Library/Preferences/Unreal Engine/EpicGamesLauncher",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -1,4 +1,5 @@
 {
   "ai-studio": "all",
+  "epic-games": "intel",
   "shotcut": "intel"
 }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`epic-games` is autobumped but the workflow failed to update to version 19.0.0 because `brew audit` failed with a "No artifacts require Rosetta 2 but the caveats say otherwise!" error. I've confirmed that this release is a universal app, so this updates the version and removes the Rosetta caveat. This also adds an appropriate `depends_on macos:` value to resolve a related `brew audit` error ("Artifact defined :ventura as the minimum macOS version but the cask declared no minimum macOS version").