### PR TITLE
lunatask 2.1.15

### DIFF
--- a/Casks/l/lunatask.rb
+++ b/Casks/l/lunatask.rb
@@ -1,12 +1,17 @@
 cask "lunatask" do
-  version "2.1.13"
-  sha256 "5ce230145c1d266d52cf02789ce89d6ec06bc5fe5bfddc4eba5ff3aee2a0efc9"
+  version "2.1.15"
+  sha256 "e0c2d496ab49382bc939cd2eadef1926dd6e57fcd171a2609d4d36d3d1b8dcf3"
 
   url "https://github.com/lunatask/lunatask/releases/download/v#{version}/Lunatask-#{version}-universal.dmg",
       verified: "github.com/lunatask/lunatask/"
   name "Lunatask"
   desc "Encrypted to-do list, habit tracker, journaling, life-tracking and notes app"
   homepage "https://lunatask.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`lunatask` is autobumped but the workflow failed to update to version 2.1.14 because it was apparently a pre-release on GitHub. At time of writing, there is a 2.1.14 tag but no corresponding release, so upstream my have deleted it in the interim time. There's now a 2.1.15 release, so this updates the version. This also adds a `livecheck` block that uses the `GithubLatest` strategy, which should avoid the aforementioned situations going forward.