### PR TITLE
replicator 8.4.1

### DIFF
--- a/Casks/r/replicator.rb
+++ b/Casks/r/replicator.rb
@@ -1,6 +1,6 @@
 cask "replicator" do
-  version "8.4.0"
-  sha256 "37124593b3dd29c9385a6bedb111dc0ccb49e3a56c00504ede547c5530d48271"
+  version "8.4.1"
+  sha256 "51a665b26aa695cd49077b7c75d34916e9514e9804dd01a198c0951e9c110072"
 
   url "https://github.com/jamf/Replicator/releases/download/v#{version}/Replicator.zip"
   name "Replicator"
@@ -11,8 +11,6 @@ cask "replicator" do
     url :url
     strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`replicator` is autobumped but the workflow failed to update to version 8.4.1 because `brew audit` failed with a "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. I've manually confirmed that the 8.4.1 app passes Gatekeeper checks, so this updates the version and removes the `disable!` call.