### PR TITLE
Remove claude-code caveat

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -31,12 +31,4 @@ cask "claude-code" do
     "~/.local/state/claude",
     "~/Library/Caches/claude-cli-nodejs",
   ]
-
-  caveats <<~EOS
-    Claude Code's auto-updater installs updates to `~/.local/bin/claude` and
-    not to Homebrew's location. It is recommended to disable the auto-updater
-    with either `DISABLE_AUTOUPDATER=1` or
-    `claude config set autoUpdates false` and use
-    `brew upgrade --cask #{token}`.
-  EOS
 end


### PR DESCRIPTION
Claude Code’s auto-updater no longer triggers for Homebrew Cask installations. An update *notification* will be shown instead which can still be disabled with `DISABLE_AUTOUPDATER`. This also means we should continue to have `auto_updates` set to `false` (#222937).

Just to document some other things from my conversation with Anthropic:
- The update notification is based on the version in the NPM registry
- `DISABLE_AUTOUPDATER` doesn’t actually currently disable the update check or notification but it’s intended to and will be fixed
- There are no plans to add an auto-updater for Homebrew Cask installs (anything beyond an update notification)
- Homebrew installs are detected based on the install path
- The original warning about `~/.local/bin/claude` will no longer trigger with Homebrew installs
	- If you set `installMethod` based on https://github.com/Homebrew/homebrew-cask/pull/219994#issuecomment-3092273898, `unknown` is the expected value for Homebrew installs, but it may make little difference
- `claude config` was removed in v2.0.0 and `DISABLE_AUTOUPDATER` is the only expected way to disable the update check