### PR TITLE
bison-wallet 1.0.4

### DIFF
--- a/Casks/b/bison-wallet.rb
+++ b/Casks/b/bison-wallet.rb
@@ -1,14 +1,16 @@
 cask "bison-wallet" do
   arch arm: "arm64", intel: "amd64"
 
-  version "1.0.3"
-  sha256 arm:   "0dcafd9509b435a5e762aeb11cbc63baa084dc71c58d017072707bc292c72bbc",
-         intel: "c0433ab203a5b9c631bb4c6bc21edaa27b90d6266203ef1c16c6c6a7a6a53c74"
+  version "1.0.4"
+  sha256 arm:   "31e5945adc602840aeb3e853909a8003b185a95e31fbc5c8a7db4a23f7c29c2d",
+         intel: "889d54f752c96e6a079db29b66d14d8b8e4a5577c91d1b3d499c4e781f75554e"
 
   url "https://github.com/decred/dcrdex/releases/download/v#{version}/bisonw-desktop-darwin-#{arch}-v#{version}.dmg"
   name "Bison Wallet"
   desc "Multi-coin wallet with feeless DEX, atomic swaps, and arbitrage tools"
   homepage "https://github.com/decred/dcrdex"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Bison Wallet.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`bison-wallet` is autobumped but the workflow failed to update to versin 1.0.4 because the app fails Gatekeeper checks. This updates the version and adds a `disable!` call with the date we've been using for this scenario.