### PR TITLE
longplay 1.1.4

### DIFF
--- a/Casks/l/longplay.rb
+++ b/Casks/l/longplay.rb
@@ -1,8 +1,8 @@
 cask "longplay" do
-  version "1.1.3,500"
-  sha256 "0d165e78842d410e727e73085fb27e0fa2cbea982f43cba36159bea7b1726ebb"
+  version "1.1.4"
+  sha256 "a6d6e1e673b93559a89993fa7d34548b5ed8be978a4b89ab13b8bcbb0d1272b8"
 
-  url "https://download.longplay.app/mac/longplay-#{version.csv.first}-#{version.csv.second}.dmg",
+  url "https://download.longplay.app/mac/longplay-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}.dmg",
       verified: "download.longplay.app/"
   name "Longplay"
   desc "Album-focused music player"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`longplay` is autobumped but the workflow failed to update to version 1.1.4 because the file name does not have a numeric suffix (i.e., `longplay-1.1.4.dmg` instead of `longplay-1.1.3-500.dmg`) but the cask `url` treats it as a required part of the file name. This updates the version and makes the second `version` part optional in the `url`, which should work for either file name format.