### PR TITLE
openmw 2.18.29

### DIFF
--- a/Casks/o/openmw.rb
+++ b/Casks/o/openmw.rb
@@ -1,9 +1,9 @@
 cask "openmw" do
   arch arm: "arm64", intel: "amd64"
 
-  version "0.49.0"
-  sha256 arm:   "7fb223cebd53d2dbbae57dcd5a0d71ffcfd45281ae58da3a74e4f21d3b3d1454",
-         intel: "46ec036e40bcc6dbdd0c3bd1fefc9ed096e6cd2f68d1622c160d2fe79f63bd67"
+  version "0.50.0"
+  sha256 arm:   "f1787384b54ae6b76444ca0899c553c491800d28185e7ee8bf052a30656160ed",
+         intel: "8ba6c83933d999f5f1f6f9d1bb35b948c1d01972fc35e6bfe2c302735ca2db8e"
 
   url "https://github.com/OpenMW/openmw/releases/download/openmw-#{version}/OpenMW-#{version}-macos-#{arch}.dmg",
       verified: "github.com/OpenMW/openmw/"
@@ -16,6 +16,10 @@ cask "openmw" do
     regex(/openmw[._-]v?(\d+(?:\.\d+)+)/i)
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :ventura"
 
   app "OpenMW.app"
   app "OpenMW-CS.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`openmw` is autobumped but the workflow failed to update to version 2.18.29 because `brew audit` failed due to the app failing Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario. This also adds an appropriate `depends_on macos:` value to resolve another `brew audit` error.