### PR TITLE
archi: update livecheck

### DIFF
--- a/Casks/a/archi.rb
+++ b/Casks/a/archi.rb
@@ -1,7 +1,7 @@
 cask "archi" do
   arch arm: "-Silicon"
 
-  version "5.7.0,57"
+  version "5.7.0,5-7"
   sha256 arm:   "dbfc38f9a29f8df4c62e38e5fe73a8b85b67bfbfe48e67dece4ae649ae1a6e57",
          intel: "c0896127a5e684be6b31be73c07258c1a982c15d773cae77c22f6e1172206b92"
 
@@ -13,7 +13,7 @@ cask "archi" do
 
   livecheck do
     url "https://www.archimatetool.com/download/"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)*)/Archi[._-]Mac#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    regex(%r{href=.*?/v?(\d+(?:[.-]\d+)*)/Archi[._-]Mac#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `archi` is producing an "Unable to get versions" error, as the dmg file URLs now reference a `5-7` release tag on GitHub but the regex doesn't expect this format and can't match it. This updates the `livecheck` block regex to be able to match this part of the URL path and adjusts the cask `version` accordingly (as the dmg files were unreachable).