### PR TITLE
muteme 0.25.7

### DIFF
--- a/Casks/m/muteme.rb
+++ b/Casks/m/muteme.rb
@@ -1,9 +1,10 @@
 cask "muteme" do
   arch arm: "arm64", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "_arm64", intel: "_64"
 
-  version "0.24.8"
-  sha256 arm:   "31288e7f8c1b49e2cedd3ed63a3a7ee2c7f7e648f151edc195a08fb4fb6efdb0",
-         intel: "c0b038cf3da93e17019c9969c5a72e2a45525076b5abd537d120e677a9402f90"
+  version "0.25.7"
+  sha256 arm:   "c36b6ca0db49047d41a22866a996a033a3874bb03d5722c3e9fc4198f542969d",
+         intel: "9d2985762f03ceed84164ef454e601993762c5b5deef924cc4316af8de18737d"
 
   url "https://mutemedownloads.s3.us-east-2.amazonaws.com/main/#{version}/MuteMe-Client-#{version}-#{arch}.dmg",
       verified: "mutemedownloads.s3.us-east-2.amazonaws.com/"
@@ -12,11 +13,13 @@ cask "muteme" do
   homepage "https://muteme.com/"
 
   livecheck do
-    url "https://muteme.com/pages/downloads"
-    regex(/href=.*?MuteMe[._-]Client[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
+    url "https://downloads.muteme.com/download/latest/osx#{livecheck_arch}"
+    regex(/v?(\d+(?:\.\d+)+)/i)
+    strategy :header_match
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "MuteMe-Client.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `muteme` produces an "Unable to get versions" error because the upstream download page now contains redirecting links to the dmg files instead of the current dmg URLs. This updates the version and modifies the `livecheck` block to check the redirecting URLs, which provide the file name in the `Content-Disposition` header. This also adds a `depends_on macos:` value to address a `brew audit` error ("Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version").

For what it's worth, I included the `_` delimiter in the `livecheck_arch` strings because the `livecheck` block URL without any `livecheck_arch` value still technically works and I figured that may be better than nothing on some level if/when `brew` is run on a different arch in the future. Not really something we should optimize for but it was a small tweak, so why not.