### PR TITLE
djstudio@next 4.0.7-beta.0 (new cask)

### DIFF
--- a/Casks/d/djstudio@next.rb
+++ b/Casks/d/djstudio@next.rb
@@ -1,0 +1,39 @@
+cask "djstudio@next" do
+  arch arm: "-arm64", intel: ""
+  livecheck_arch = on_arch_conditional arm: "-apple", intel: ""
+
+  version "4.0.7-beta.0"
+  sha256 arm:   "75e0f62d6719b6a4835a6f9c31f24f4c1aa6ea0d2e23e3922a238a277e5f355f",
+         intel: "9d9be5b671bf3bb2ec23fb4029b418d3e270ea4d8b192de933f53ee6b8600ec9"
+
+  url "https://download.next.dj.studio/DJ.Studio%20Next-#{version}#{arch}.dmg"
+  name "DJ.Studio Next"
+  desc "DAW for DJs (beta channel)"
+  homepage "https://dj.studio/"
+
+  livecheck do
+    url "https://downloads.dj.studio/djstudio/download/latest/mac#{livecheck_arch}?next=true"
+    strategy :header_match
+    regex(/DJ\.Studio[ _-]Next[._-](\d+(?:\.\d+)+-beta\.\d+)(?:#{arch})?\.dmg/i)
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "DJ.Studio Next.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/dj.studio.app.sfl*",
+    "~/Library/Application Support/DJ.Studio",
+    "~/Library/Application Support/dj.studio.app",
+    "~/Library/Preferences/dj.studio.app.plist",
+    "~/Library/Saved Application State/dj.studio.app.savedState",
+    "~/Music/DJ.Studio",
+  ]
+
+  caveats <<~EOS
+    DJ.Studio Next uses the same default project and audio directory as the stable version:
+      ~/Music/DJ.Studio
+
+    This folder is intentionally not removed during `brew zap` to avoid data loss.
+  EOS
+end

--- a/Casks/d/djstudio@next.rb
+++ b/Casks/d/djstudio@next.rb
@@ -27,6 +27,5 @@ cask "djstudio@next" do
     "~/Library/Application Support/dj.studio.app",
     "~/Library/Preferences/dj.studio.app.plist",
     "~/Library/Saved Application State/dj.studio.app.savedState",
-    "~/Music/DJ.Studio",
   ]
 end

--- a/Casks/d/djstudio@next.rb
+++ b/Casks/d/djstudio@next.rb
@@ -1,6 +1,6 @@
 cask "djstudio@next" do
-  arch arm: "-arm64", intel: ""
-  livecheck_arch = on_arch_conditional arm: "-apple", intel: ""
+  arch arm: "-arm64"
+  livecheck_arch = on_arch_conditional arm: "-apple"
 
   version "4.0.7-beta.0"
   sha256 arm:   "75e0f62d6719b6a4835a6f9c31f24f4c1aa6ea0d2e23e3922a238a277e5f355f",
@@ -8,7 +8,7 @@ cask "djstudio@next" do
 
   url "https://download.next.dj.studio/DJ.Studio%20Next-#{version}#{arch}.dmg"
   name "DJ.Studio Next"
-  desc "DAW for DJs (beta channel)"
+  desc "DAW for DJs"
   homepage "https://dj.studio/"
 
   livecheck do

--- a/Casks/d/djstudio@next.rb
+++ b/Casks/d/djstudio@next.rb
@@ -29,11 +29,4 @@ cask "djstudio@next" do
     "~/Library/Saved Application State/dj.studio.app.savedState",
     "~/Music/DJ.Studio",
   ]
-
-  caveats <<~EOS
-    DJ.Studio Next uses the same default project and audio directory as the stable version:
-      ~/Music/DJ.Studio
-
-    This folder is intentionally not removed during `brew zap` to avoid data loss.
-  EOS
 end


### PR DESCRIPTION
DAW for DJs (beta channel)

https://dj.studio/next

```
    DJ.Studio Next uses the same default project and audio directory as the stable version:
      ~/Music/DJ.Studio

    This folder is intentionally not removed during `brew zap` to avoid data loss.
```

Location can be changed in `Settings -> Folder -> Database location`

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
