### PR TITLE
Set auto_updates true for Affinity

### DIFF
--- a/Casks/a/affinity.rb
+++ b/Casks/a/affinity.rb
@@ -13,6 +13,7 @@ cask "affinity" do
     strategy :sparkle
   end
 
+  auto_updates true
   depends_on macos: ">= :catalina"
 
   app "Affinity.app"


### PR DESCRIPTION
This PR adds `auto_updates true` to the Affinity cask.

Affinity 3 includes a built-in update mechanism that notifies users when a new version is available. Once confirmed, the app handles the update process internally. Setting `auto_updates true` informs Homebrew that Affinity manages its own updates, so `brew upgrade` will not attempt to reinstall it unnecessarily when the version changes.

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online affinity` is error-free.
- [x] `brew style --fix affinity` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
