### PR TITLE
wootility 5.1.2 (new cask)

### DIFF
--- a/Casks/w/wootility.rb
+++ b/Casks/w/wootility.rb
@@ -1,0 +1,27 @@
+cask "wootility" do
+  arch arm: "-arm64"
+
+  version "5.1.2"
+  sha256 arm:   "5c63dc1417241a7d129e5554ddf2a26ef70661738a431df3646266ae5b26c904",
+         intel: "96022a94cb7b84acb934f28c1b404d5c3e355414b4e262f87941216e12186f3e"
+
+  url "https://wootility-updates.ams3.cdn.digitaloceanspaces.com/wootility-mac/Wootility-#{version}#{arch}.dmg",
+      verified: "wootility-updates.ams3.cdn.digitaloceanspaces.com/wootility-mac/"
+  name "Wootility"
+  desc "Configuration software for Wooting keyboards"
+  homepage "https://wooting.io/wootility"
+
+  livecheck do
+    url "https://wootility-updates.ams3.digitaloceanspaces.com/wootility-mac/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  app "Wootility.app"
+
+  zap trash: [
+    "~/Library/Application Support/wootility",
+    "~/Library/Logs/wootility",
+    "~/Library/Preferences/com.wooting.wootility.plist",
+    "~/Library/Saved Application State/com.wooting.wootility.savedState",
+  ]
+end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
