### PR TITLE
obs-backgroundremoval: disable

### DIFF
--- a/Casks/o/obs-backgroundremoval.rb
+++ b/Casks/o/obs-backgroundremoval.rb
@@ -8,10 +8,8 @@ cask "obs-backgroundremoval" do
   desc "Virtual Green-screen and Low-Light Enhancement OBS Plugin"
   homepage "https://obsproject.com/forum/resources/background-removal-virtual-green-screen-low-light-enhance.1260"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  # Reference: https://github.com/Homebrew/homebrew-cask/pull/235792
+  disable! date: "2026-11-13", because: "the package is not compatible with Homebrew's installation parameters"
 
   auto_updates true
 


### PR DESCRIPTION
… bump to 1.3.0

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

obs-backgroundremoval 1.3.0 is released but autobump didn't not work maybe due to upstream changes.
This PR fixes the Cask to conform with 1.3.0

- The official repository was moved so that reflecting it on URLs
- This plugin don't have self-contained update mechanisms so that set auto_updates to be false
- OBS plugins must be installed under user's home directory and it never works when installed under /Library. To get it worked, I changed the pkg stanza to installer stanza with /usr/sbin/installer and give it the `-target CurrentUserHomeDirectory`.
- pkg identifier was fixed to the uninstall stanza to work