### PR TITLE
WhatsApp: fix version string; improve zap stanza

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,18 +1,15 @@
 cask "whatsapp" do
-  version "2.25.34.11"
+  version "25.34.11"
   sha256 "cc6e2ffe164a0e0e0ad49f45fbbb24e80dc3c0765a6a4cbe16e147e182283093"
 
-  url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&configuration=Release&branch=master&is_buck=true"
+  url "https://web.whatsapp.com/desktop/mac_native/release/?version=2.#{version}&extension=zip&configuration=Release&branch=master&is_buck=true"
   name "WhatsApp"
   desc "Native desktop client for WhatsApp"
   homepage "https://www.whatsapp.com/"
 
   livecheck do
     url "https://web.whatsapp.com/desktop/mac_native/updates/?branch=master&configuration=Release"
-    regex(/version=v?(\d+(?:\.\d+)+)/i)
-    strategy :sparkle do |item, regex|
-      item.url.scan(regex).map(&:first)
-    end
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -22,6 +22,7 @@ cask "whatsapp" do
   app "WhatsApp.app"
 
   zap trash: [
+    "~/Library/Application Scripts/group.com.facebook.family",
     "~/Library/Application Scripts/net.whatsapp.WhatsApp*",
     "~/Library/Caches/net.whatsapp.WhatsApp",
     "~/Library/Containers/net.whatsapp.WhatsApp*",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Currently, Homebrew shows a 4 component version string for WhatsApp, e.g. `2.25.34.11`. The leading component `2` appears to be private to WhatsApp's internal usage, and only required in the download url.

Sparkle: [`<sparkle:shortVersionString>25.34.11</sparkle:shortVersionString>`](https://web.whatsapp.com/desktop/mac_native/updates/?branch=master&configuration=Release)

App Store:

<img width="396" height="278" alt="Screenshot 2025-11-09 at 10 43 27 PM" src="https://github.com/user-attachments/assets/2a1c73a0-7d44-4cb1-bd86-29a7d5e3e44a" />

<img width="1287" height="782" alt="Screenshot 2025-11-09 at 10 44 34 PM" src="https://github.com/user-attachments/assets/eb50000b-4624-4b84-a58e-ca08f062df30" />
