### PR TITLE
allen-and-heath-midi-control: disable livecheck

### DIFF
--- a/Casks/a/allen-and-heath-midi-control.rb
+++ b/Casks/a/allen-and-heath-midi-control.rb
@@ -9,11 +9,7 @@ cask "allen-and-heath-midi-control" do
   homepage "https://www.allen-heath.com/midi-control/"
 
   livecheck do
-    url "https://www.allen-heath.com/hardware/controllers/midi-control/resources/"
-    regex(%r{href=.*?/([^/]+)/([^/]+)/Allen-and-Heath-MIDI-Control[._-]v?(\d+(?:\.\d+)+)(?:-Mac)?\.zip}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match.third},#{match.first},#{match.second}" }
-    end
+    skip "No version information available"
   end
 
   disable! date: "2025-09-15", because: :unreachable

--- a/Casks/a/allen-and-heath-midi-control.rb
+++ b/Casks/a/allen-and-heath-midi-control.rb
@@ -8,10 +8,6 @@ cask "allen-and-heath-midi-control" do
   desc "Midi control software for Allen & Heath audio consoles"
   homepage "https://www.allen-heath.com/midi-control/"
 
-  livecheck do
-    skip "No version information available"
-  end
-
   disable! date: "2025-09-15", because: :unreachable
 
   container nested: "Allen and Heath MIDI Control #{version.csv.first}.dmg"


### PR DESCRIPTION
Currently, when running brew livecheck --eval-all, this cask is marked as "unable to be checked". Since it was removed for the inability to check its version or to download it, this is probably the best option to remove this error message

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free. N/A
- [x] `brew style --fix <cask>` reports no offenses. 
---
