### PR TITLE
sq-mixpad: disable livecheck

### DIFF
--- a/Casks/s/sq-mixpad.rb
+++ b/Casks/s/sq-mixpad.rb
@@ -8,10 +8,6 @@ cask "sq-mixpad" do
   desc "Remote control for Allen & Heath SQ audio consoles"
   homepage "https://www.allen-heath.com/hardware/sq/sq-mixpad/"
 
-  livecheck do
-    skip "No version information available"
-  end
-
   disable! date: "2025-09-15", because: :unreachable
 
   app "SQ MixPad #{version.csv.first}.app"

--- a/Casks/s/sq-mixpad.rb
+++ b/Casks/s/sq-mixpad.rb
@@ -9,14 +9,7 @@ cask "sq-mixpad" do
   homepage "https://www.allen-heath.com/hardware/sq/sq-mixpad/"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/(\d+)/(\d+)/SQ[._-]MixPad[._-]v?(\d+(?:\.\d+)+)[._-]Mac[^>]+SQ\s*MixPad\s*v?(\d+(?:\.\d+)+)}i)
-    strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[4]},#{match[3]},#{match[1]},#{match[2]}"
-    end
+    skip "No version information available"
   end
 
   disable! date: "2025-09-15", because: :unreachable


### PR DESCRIPTION
Currently, when running brew livecheck --eval-all, this cask is marked as "unable to be checked". Since it was removed for the inability to check its version or to download it, this is probably the best option to remove this error message

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free. N/A
- [x] `brew style --fix <cask>` reports no offenses.
---
