### PR TITLE
companion@beta: remove livecheck

### DIFF
--- a/Casks/c/companion@beta.rb
+++ b/Casks/c/companion@beta.rb
@@ -1,6 +1,5 @@
 cask "companion@beta" do
   arch arm: "arm64", intel: "x64"
-  livecheck_arch = on_arch_conditional arm: "arm", intel: "intel"
 
   version "4.1.0+8404-main-624ad91b22"
   sha256 arm:   "94ad832fb7e16319d35cb41ce17eb5bb955c183932f66bf1f6f15052d7e00ff7",
@@ -10,14 +9,6 @@ cask "companion@beta" do
   name "Bitfocus Companion"
   desc "Streamdeck extension and emulation software"
   homepage "https://bitfocus.io/companion"
-
-  livecheck do
-    url "https://api.bitfocus.io/v1/product/companion/packages?branch=beta&limit=150"
-    strategy :json do |json|
-      json["packages"]&.select { |c| c["target"] == "mac-#{livecheck_arch}" }
-                      &.map { |c| c["version"] }
-    end
-  end
 
   disable! date: "2025-09-15", because: :unreachable
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `companion@beta` works locally but the cask was disabled because it routinely hits the 30-minute timeout in CI (https://github.com/Homebrew/homebrew-cask/pull/228198), so there isn't any value in surfacing new versions in this scenario. This removes the `livecheck` block, so it will be automatically skipped as disabled.