### PR TITLE
Revert nordvpn 9.8.0

### DIFF
--- a/Casks/n/nordvpn.rb
+++ b/Casks/n/nordvpn.rb
@@ -1,6 +1,6 @@
 cask "nordvpn" do
-  version "9.8.0"
-  sha256 "9d969276894d5e19b74b98f0583ab3af749cde5e0fca60cdee4d48fc6ecae423"
+  version "9.7.0"
+  sha256 "4e3908734d6f2f1bd186eddccd8cbaf4a3aaa0ef76c89df9ebd76e887977d87d"
 
   url "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/#{version}/NordVPN.pkg",
       verified: "downloads.nordcdn.com/apps/macos/generic/"


### PR DESCRIPTION
This reverts commit 3aa4b74a34882cf63d1d54170a872187b86a78e3.  The previous release appears to have disappeared upstream.  Reverting back to the previous version.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
