### PR TITLE
flowdown 4.0.2-rev-1

### DIFF
--- a/Casks/f/flowdown.rb
+++ b/Casks/f/flowdown.rb
@@ -1,6 +1,6 @@
 cask "flowdown" do
-  version "3.12.0"
-  sha256 "800dca8fda55790e270cce21a5a6d29378f9bf27e433571dbab290b635a24528"
+  version "4.0.2-rev-1"
+  sha256 "3bc30b56c4e43cfc0076fd0ce781605fe18702ca38ccf4f5ca8a07b445100330"
 
   url "https://github.com/Lakr233/FlowDown/releases/download/#{version}/FlowDown.app.zip",
       verified: "github.com/Lakr233/FlowDown/"
@@ -10,6 +10,7 @@ cask "flowdown" do
 
   livecheck do
     url :url
+    regex(/^v?(\d+(?:\.\d+)+(?:[._-](?:patch|rev)[._-]\d+)?)$/i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`flowdown` is autobumped but the workflow failed to update to version 4.0.2-rev-1 because the default regex for the `GithubLatest` strategy matches the 4.0.2 part of the tag but omits the suffix. This updates the version and adds a regex to the `livecheck` block that captures the full version.