### PR TITLE
tinkerwell 5.6.0

### DIFF
--- a/Casks/t/tinkerwell.rb
+++ b/Casks/t/tinkerwell.rb
@@ -1,9 +1,9 @@
 cask "tinkerwell" do
   arch arm: "-arm64"
 
-  version "5.5.0"
-  sha256 arm:   "79fd0e9fe3f6949229ba3e63c508ec57184289d5896d665d613239bde106ed9a",
-         intel: "bef79bdc78dac80b79ccb31fce404cde326c7924cd9a1c37df0097e92b83344c"
+  version "5.6.0"
+  sha256 arm:   "ea1872eef0252d9749f3ae6140cb1209a183e620d88cf859f8758952f6eb4b38",
+         intel: "cd61c65ec6af7032d9eaea6ed1806ea7088b5bcdbe1809e4882985ced960a494"
 
   url "https://download.tinkerwell.app/tinkerwell/Tinkerwell-#{version}#{arch}.dmg"
   name "Tinkerwell"
@@ -14,8 +14,6 @@ cask "tinkerwell" do
     url "https://download.tinkerwell.app/tinkerwell/latest-mac.yml"
     strategy :electron_builder
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tinkerwell` is autobumped but the workflow failed to update to version 5.6.0 because `brew audit` failed with a "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. I manually verified that the app passes Gatekeeper checks, so this updates the version and removes the `disable!` call.