### PR TITLE
dotnet casks: conflicts with `dotnet-sdk@9`

### DIFF
--- a/Casks/d/dotnet-runtime.rb
+++ b/Casks/d/dotnet-runtime.rb
@@ -30,6 +30,7 @@ cask "dotnet-runtime" do
     "dotnet-runtime@preview",
     "dotnet-sdk",
     "dotnet-sdk@8",
+    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-runtime@preview.rb
+++ b/Casks/d/dotnet-runtime@preview.rb
@@ -23,6 +23,7 @@ cask "dotnet-runtime@preview" do
     "dotnet-runtime",
     "dotnet-sdk",
     "dotnet-sdk@8",
+    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-sdk.rb
+++ b/Casks/d/dotnet-sdk.rb
@@ -30,6 +30,7 @@ cask "dotnet-sdk" do
     "dotnet-runtime",
     "dotnet-runtime@preview",
     "dotnet-sdk@8",
+    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-sdk@8.rb
+++ b/Casks/d/dotnet-sdk@8.rb
@@ -30,6 +30,7 @@ cask "dotnet-sdk@8" do
     "dotnet-runtime",
     "dotnet-runtime@preview",
     "dotnet-sdk",
+    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-sdk@preview.rb
+++ b/Casks/d/dotnet-sdk@preview.rb
@@ -24,6 +24,7 @@ cask "dotnet-sdk@preview" do
     "dotnet-runtime@preview",
     "dotnet-sdk",
     "dotnet-sdk@8",
+    "dotnet-sdk@9",
   ]
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
