### PR TITLE
lobehub: revert to 1.142.8

### DIFF
--- a/Casks/l/lobehub.rb
+++ b/Casks/l/lobehub.rb
@@ -1,9 +1,9 @@
 cask "lobehub" do
   arch arm: "-arm64"
 
-  version "1.142.9"
-  sha256 arm:   "10691c93327e1695d8f329f0cec954e75f78a89b2910d24e1293f739b865078c",
-         intel: "066ba044d843d56829a732341e2a240107770dbc5e8a64ddce7ddde3c2020053"
+  version "1.142.8"
+  sha256 arm:   "46316e7481ce9fae27fb72e476dd5eae893fc701332a52398b7a64b56c6f13f0",
+         intel: "e9dec0f847831138e709583e784d4fc5fc08bb80bd7d3fab2dab67960629de5c"
 
   url "https://github.com/lobehub/lobe-chat/releases/download/v#{version}/LobeHub-Beta-#{version}#{arch}-mac.zip"
   name "LobeHub"


### PR DESCRIPTION
This reverts commit 38673253bfc7658830270842a4c6edb7e32e98c4.

## Reason for Revert
Version 1.142.9 was released in error by the LobeHub team and has been removed from GitHub releases. This PR reverts the cask to the last stable version 1.142.8.

## Verification
- The release v1.142.9 is no longer available on https://github.com/lobehub/lobe-chat/releases
- Version 1.142.8 is the current latest stable release

- fix https://github.com/lobehub/lobe-chat/issues/10144

---
Requested by @arvinxx (LobeHub author)