### PR TITLE
JMC depends on Java 21 and later

### DIFF
--- a/Casks/j/jdk-mission-control.rb
+++ b/Casks/j/jdk-mission-control.rb
@@ -28,6 +28,6 @@ cask "jdk-mission-control" do
   ]
 
   caveats do
-    depends_on_java "17"
+    depends_on_java "21"
   end
 end


### PR DESCRIPTION
JMC depends on Java 21 and later

Details from https://www.oracle.com/java/technologies/javase/jmc9-release-notes.html
```
JMC Launch Pre-requisites

JMC 9.1 requires JDK 21 and later to run. This version continues to support connecting to, and parsing
JFR recordings from OpenJDK 8u272+ and Oracle JDK 7u40+, and can open and visualize flight recordings
from JDK 7 and 8. 
```

Current behavior hints wrong Java version
```
==> jdk-mission-control
jdk-mission-control requires Java 17. You can install it with:
  brew install --cask temurin@17
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
