### PR TITLE
ableton-live-suite 12.2.7

### DIFF
--- a/Casks/a/ableton-live-suite.rb
+++ b/Casks/a/ableton-live-suite.rb
@@ -1,6 +1,6 @@
 cask "ableton-live-suite" do
-  version "12.2.6"
-  sha256 "ce5d73909071fa01214cf19cc512140ec4a92ca5bdf31b78fee8c5dbbf8285ec"
+  version "12.2.7"
+  sha256 "3a2ecfe610bc899dc58f91fe35d54654ba1c67c2c7274286e3f4acf308e7ba49"
 
   url "https://cdn-downloads.ableton.com/channels/#{version}/ableton_live_suite_#{version}_universal.dmg"
   name "Ableton Live Suite"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ableton-live-suite` is autobumped but the workflow failed to update to version 12.2.7 due to an audit error. This audited and installed fine locally, so this manually updates the version.