### PR TITLE
cloud-pbx 45.10.0

### DIFF
--- a/Casks/c/cloud-pbx.rb
+++ b/Casks/c/cloud-pbx.rb
@@ -1,9 +1,9 @@
 cask "cloud-pbx" do
   arch arm: "arm", intel: "intel"
 
-  version "45.8.0"
-  sha256 arm:   "ea2ba14fc4e2ce2202290168136112f975b4d1090ca910eaec2341e76aaed770",
-         intel: "02bbcb9da02291ee0b2221e4541d9dc4298a6b2086e97777b1bebbf7b78e3ecd"
+  version "45.10.0"
+  sha256 arm:   "54ce825d81f9484e5fe7b178e77c9be004bd6dfa04eb7df4e236320b02a88abd",
+         intel: "6e5447258d9c689998cd2f19a6e8c775d7dffa0124615c6bd146ea8abff18c19"
 
   url "https://cpbx-hilfe.deutschland-lan.de/de/direkthilfe/hilfe-downloads/desktop-clients/cloud-pbx-2.0-#{arch}_v#{version}",
       verified: "cpbx-hilfe.deutschland-lan.de/de/direkthilfe/hilfe-downloads/desktop-clients/"
@@ -28,8 +28,4 @@ cask "cloud-pbx" do
     "~/Library/Saved Application State/Cisco-Systems.Spark.savedState",
     "~/Library/Saved Application State/com.broadsoft.communicator.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`cloud-pbx` is autobumped but the workflow failed to update to version 45.10.0 because `brew audit` failed with a "No artifacts require Rosetta 2 but the caveats say otherwise!" error. This updates the version and removes the Rosetta caveat, as the cask uses separate ARM and Intel apps.