### PR TITLE
dash-dash 23.0.0

### DIFF
--- a/Casks/d/dash-dash.rb
+++ b/Casks/d/dash-dash.rb
@@ -1,9 +1,9 @@
 cask "dash-dash" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "22.1.3"
-  sha256 arm:   "c7b7842cce5d2dbef5fe339b5e96730dd2483716169db81e6045acc1cabed271",
-         intel: "f7e84707a6fce85176c5d613b391ec269657d9a3feed32f910da538c2251da3d"
+  version "23.0.0"
+  sha256 arm:   "dc9de512c2ce8c9aacd0288a17b8accc5dae37862254d8f29bd7dd24e962d4e4",
+         intel: "7d65a8ab83110e9bcb2626d26858096931a7b9d56a0302197f6749ec40465c89"
 
   url "https://github.com/dashpay/dash/releases/download/v#{version}/dashcore-#{version}-#{arch}-apple-darwin.zip",
       verified: "github.com/dashpay/dash/"
@@ -15,6 +15,8 @@ cask "dash-dash" do
     url :url
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dash-dash` is autobumped but the workflow failed to update to version 23.0.0 because `brew audit` failed due to the app failing Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.