### PR TITLE
mouseless@preview 0.5.0-preview.1

### DIFF
--- a/Casks/m/mouseless@preview.rb
+++ b/Casks/m/mouseless@preview.rb
@@ -1,6 +1,6 @@
 cask "mouseless@preview" do
-  version "0.4.3"
-  sha256 "732aaff73f167971678f5fc7a752c7e7ae8ac1b45012a5dec0932af84ce5c149"
+  version "0.5.0-preview.1"
+  sha256 "ed201883194b41b8e9d78111f6852e0c7d94d6df55520d6f2a5a85c050ffd8c5"
 
   url "https://github.com/croian/mouseless/releases/download/v#{version}/mouseless-installer_v#{version}.dmg",
       verified: "github.com/croian/mouseless/"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -39,6 +39,7 @@
   "magicavoxel": "all",
   "messenger-native": "all",
   "mongotron": "all",
+  "mouseless@preview": "any",
   "mullvad-vpn@beta": "any",
   "my-budget": "all",
   "netnewswire@beta": "any",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mouseless@preview` is autobumped but the workflow failed to update to version 0.5.0-preview.1 because it is marked as pre-release on GitHub. This updates the version and adds the cask to `github_prerelease_allowlist.json` using an `any` value, as the cask will also update to [stable] releases that aren't marked as pre-release.