### PR TITLE
alex313031-thorium: rename app to avoid conflict with thorium

### DIFF
--- a/Casks/a/alex313031-thorium.rb
+++ b/Casks/a/alex313031-thorium.rb
@@ -2,13 +2,13 @@ cask "alex313031-thorium" do
   arch arm: "ARM", intel: "X64"
 
   version "M130.0.6723.174"
-  sha256 arm:   "ba1c45a52962c5f7d9b293757b1ca7456171e240927c30dcdaf7fd48d2dc8c04",
-         intel: "1c92f610b56bc893b4bb11d7513366b1f991e60918d8e5feba927b5f1da66cff"
+  sha256  arm:   "ba1c45a52962c5f7d9b293757b1ca7456171e240927c30dcdaf7fd48d2dc8c04",
+          intel: "1c92f610b56bc893b4bb11d7513366b1f991e60918d8e5feba927b5f1da66cff"
 
   url "https://github.com/Alex313031/Thorium-MacOS/releases/download/#{version}/Thorium_MacOS_#{arch}.dmg",
       verified: "github.com/Alex313031/Thorium-MacOS/"
   name "Thorium"
-  desc "Web browser"
+  desc "Fastest, privacy-focused Chromium-based browser"
   homepage "https://thorium.rocks/"
 
   livecheck do
@@ -19,10 +19,9 @@ cask "alex313031-thorium" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  conflicts_with cask: "thorium"
   depends_on macos: ">= :big_sur"
 
-  app "Thorium.app"
+  app "Thorium.app", target: "Thorium Browser.app"
   # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
   shimscript = "#{staged_path}/thorium.wrapper.sh"
   binary shimscript, target: "thorium"
@@ -30,7 +29,7 @@ cask "alex313031-thorium" do
   preflight do
     File.write shimscript, <<~EOS
       #!/bin/bash
-      exec '#{appdir}/Thorium.app/Contents/MacOS/Thorium' "$@"
+      exec '#{appdir}/Thorium Browser.app/Contents/MacOS/Thorium' "$@"
     EOS
   end
 

--- a/Casks/a/alex313031-thorium.rb
+++ b/Casks/a/alex313031-thorium.rb
@@ -8,7 +8,7 @@ cask "alex313031-thorium" do
   url "https://github.com/Alex313031/Thorium-MacOS/releases/download/#{version}/Thorium_MacOS_#{arch}.dmg",
       verified: "github.com/Alex313031/Thorium-MacOS/"
   name "Thorium"
-  desc "Fastest, privacy-focused Chromium-based browser"
+  desc "Chromium-based web browser"
   homepage "https://thorium.rocks/"
 
   livecheck do


### PR DESCRIPTION
Renames the installed app from 'Thorium.app' to 'Thorium Browser.app' to prevent conflicts with the thorium cask (Thorium Reader).

Fixes: https://github.com/Alex313031/thorium/issues/732

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
