### PR TITLE
epicenter-whispering 7.7.2

### DIFF
--- a/Casks/e/epicenter-whispering.rb
+++ b/Casks/e/epicenter-whispering.rb
@@ -1,11 +1,11 @@
 cask "epicenter-whispering" do
   arch arm: "aarch64", intel: "x64"
 
-  version "7.7.1"
-  sha256 arm:   "1eba037de1476a3f981cb125ca1337ec503962d7a99813fc6ba980542b846fba",
-         intel: "8dd54b5fca5093d38c2600ba2447db8c6dc4200dd1dd4d8150fdafb42059c984"
+  version "7.7.2"
+  sha256 arm:   "9b848ddd3153d99f51c6ec5455a7958829a9ee696b71f7133f03be62f09caaa3",
+         intel: "b5d427601ca2dc377632e43e508dedef8afa7b6413197e5ccee7c90da355a87c"
 
-  url "https://github.com/epicenter-os/epicenter/releases/download/v#{version}/Whispering_#{version}_#{arch}_darwin.dmg",
+  url "https://github.com/epicenter-os/epicenter/releases/download/v#{version}/Whispering_#{version}_#{arch}.dmg",
       verified: "github.com/epicenter-os/epicenter/"
   name "Epicenter Whispering"
   desc "Audio transcription that works with local and cloud models"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`epicenter-whispering` is autobumped but the workflow failed to update to version 7.7.2 because the dmg file names omit the `_darwin` suffix added in 7.6.0. This updates the version and `url` accordingly.