### PR TITLE
quo 4.2.1

### DIFF
--- a/Casks/q/quo.rb
+++ b/Casks/q/quo.rb
@@ -1,8 +1,8 @@
 cask "quo" do
-  version "4.1.12"
-  sha256 "c2938c18cd29259121d8cd3d9aa522c609727cd0a17fa627796798cd43fb3211"
+  version "4.2.1"
+  sha256 "829cf77049aa782dc11cfc321c0cfd44c44a27bc68c91860a127ce773b5dc43e"
 
-  url "https://download.quo.com/Quo-#{version}-universal.dmg"
+  url "https://download.quo.com/Quo%20(formerly%20OpenPhone)-#{version}-universal.dmg"
   name "Quo"
   desc "Business phone for professionals, teams, and companies"
   homepage "https://www.quo.com/"
@@ -12,7 +12,7 @@ cask "quo" do
     strategy :electron_builder
   end
 
-  app "Quo.app"
+  app "Quo (formerly OpenPhone).app"
 
   zap trash: [
     "~/Library/Application Support/OpenPhone",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`quo` is autobumped but the workflow failed to update to version 4.2.1 because the dmg file name now uses "Quo (formerly OpenPhone)" as the software name before the version. This is also used as the app name itself. This updates the version and adjusts the cask accordingly.