### PR TITLE
fix sha256 for voiceink 1.61

### DIFF
--- a/Casks/v/voiceink.rb
+++ b/Casks/v/voiceink.rb
@@ -1,6 +1,6 @@
 cask "voiceink" do
   version "1.61"
-  sha256 "7e3e790e68edfd13d074080f2ed755c4d5baa5d9be3019d69c77c6f2b9f57164"
+  sha256 "88e08a97e06ea7997830e8afdbaea2eac205a1fba444a4ff7f886c5a75c21e63"
 
   url "https://github.com/Beingpax/VoiceInk/releases/download/v#{version}/VoiceInk.dmg",
       verified: "github.com/Beingpax/VoiceInk/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
