### PR TITLE
kiro 0.5.35

### DIFF
--- a/Casks/k/kiro.rb
+++ b/Casks/k/kiro.rb
@@ -1,25 +1,20 @@
 cask "kiro" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.5.9,202511032205"
-  sha256  arm:   "76d73f59fb3c1b354f1e7cb9f0c0d1152afd806d21c1d642e6acf9b88261e8de",
-          intel: "a09e57affc094085f747970b9c10afd64a542cbcb79635b9dcb1aac38cd86397"
+  version "0.5.35"
+  sha256  arm:   "f69e5388a330716d0c84376cbc5b340a1701a984c0e0946f7a109de098e38d89",
+          intel: "a92e0b689e0a24e3abfd30fb316d889b52807654cfc9433c110b809af2dd1efe"
 
-  url "https://prod.download.desktop.kiro.dev/releases/#{version.csv.second}-Kiro-dmg-darwin-#{arch}.dmg"
+  url "https://prod.download.desktop.kiro.dev/releases/stable/darwin-#{arch}/signed/#{version}/kiro-ide-#{version}-stable-darwin-#{arch}.dmg"
   name "kiro"
   desc "Agent-centric IDE with spec-driven development"
   homepage "https://kiro.dev/"
 
   livecheck do
     url "https://prod.download.desktop.kiro.dev/stable/metadata-dmg-darwin-#{arch}-stable.json"
-    regex(/(\d+)[._-]Kiro/i)
-    strategy :json do |json, regex|
+    strategy :json do |json|
       json["releases"]&.map do |release|
-        version = release.dig("updateTo", "version")
-        match = release.dig("updateTo", "url")&.match(regex)
-        next if version.blank? || match.blank?
-
-        "#{version},#{match[1]}"
+        release.dig("updateTo", "version")
       end
     end
   end


### PR DESCRIPTION
Updated kiro to version 0.5.35

This PR updates the kiro cask to version 0.5.35 and updates the URL structure to match the new release format.

### Changes:
- Updated version from 0.5.9 to 0.5.35
- Updated SHA256 checksums for both ARM64 and Intel architectures
- Updated URL pattern to match new release structure (no longer uses timestamps)
- Simplified livecheck block to work with new JSON structure

### Verification:
- ✓ Both download URLs are accessible (HTTP 200)
- ✓ SHA256 checksums verified
- ✓ brew style check passed with no offenses