### PR TITLE
Revert "whatsapp 2.25.35.11"

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,6 +1,6 @@
 cask "whatsapp" do
-  version "2.25.35.11"
-  sha256 "1ae750568b02b785719a4eabc0d332842dd299e135fbb047dfe5fab2b7c48bf9"
+  version "2.25.34.17"
+  sha256 "ad87596ed8b4b28ae924569c89d04b701026724dbbd9c5ab01add6050929acff"
 
   url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&configuration=Release&branch=master&is_buck=true"
   name "WhatsApp"


### PR DESCRIPTION
This reverts commit 2b6b8a7dc3f810e77d9e383bc2ac35ada155a36a.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This version seems to be cancelled.
