### PR TITLE
dotnet-sdk*: allow to install multiple SDKs at once

### DIFF
--- a/Casks/d/dotnet-runtime.rb
+++ b/Casks/d/dotnet-runtime.rb
@@ -29,8 +29,6 @@ cask "dotnet-runtime" do
   conflicts_with cask: [
     "dotnet-runtime@preview",
     "dotnet-sdk",
-    "dotnet-sdk@8",
-    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-runtime@preview.rb
+++ b/Casks/d/dotnet-runtime@preview.rb
@@ -22,8 +22,6 @@ cask "dotnet-runtime@preview" do
   conflicts_with cask: [
     "dotnet-runtime",
     "dotnet-sdk",
-    "dotnet-sdk@8",
-    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-sdk.rb
+++ b/Casks/d/dotnet-sdk.rb
@@ -29,8 +29,6 @@ cask "dotnet-sdk" do
   conflicts_with cask: [
     "dotnet-runtime",
     "dotnet-runtime@preview",
-    "dotnet-sdk@8",
-    "dotnet-sdk@9",
     "dotnet-sdk@preview",
   ]
   depends_on macos: ">= :ventura"

--- a/Casks/d/dotnet-sdk@8.rb
+++ b/Casks/d/dotnet-sdk@8.rb
@@ -26,31 +26,11 @@ cask "dotnet-sdk@8" do
     end
   end
 
-  conflicts_with cask: [
-    "dotnet-runtime",
-    "dotnet-runtime@preview",
-    "dotnet-sdk",
-    "dotnet-sdk@9",
-    "dotnet-sdk@preview",
-  ]
-  depends_on macos: ">= :ventura"
+  depends_on cask: "dotnet-sdk"
 
   pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
-  binary "/usr/local/share/dotnet/dotnet"
 
-  uninstall pkgutil: [
-    "com.microsoft.dotnet.*#{version.major_minor}*#{arch}",
-    "com.microsoft.dotnet.sharedhost*#{arch}",
-    "com.microsoft.netstandard.pack.targeting.*",
-  ]
+  uninstall pkgutil: "com.microsoft.dotnet.*#{version.major_minor}*#{arch}"
 
-  zap pkgutil: "com.microsoft.dotnet.*",
-      delete:  [
-        "/etc/paths.d/dotnet",
-        "/etc/paths.d/dotnet-cli-tools",
-      ],
-      trash:   [
-        "~/.dotnet",
-        "~/.nuget",
-      ]
+  # No zap stanza required
 end

--- a/Casks/d/dotnet-sdk@9.rb
+++ b/Casks/d/dotnet-sdk@9.rb
@@ -26,31 +26,11 @@ cask "dotnet-sdk@9" do
     end
   end
 
-  conflicts_with cask: [
-    "dotnet-runtime",
-    "dotnet-runtime@preview",
-    "dotnet-sdk",
-    "dotnet-sdk@8",
-    "dotnet-sdk@preview",
-  ]
-  depends_on macos: ">= :ventura"
+  depends_on cask: "dotnet-sdk"
 
   pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"
-  binary "/usr/local/share/dotnet/dotnet"
 
-  uninstall pkgutil: [
-    "com.microsoft.dotnet.*#{version.major_minor}*#{arch}",
-    "com.microsoft.dotnet.sharedhost*#{arch}",
-    "com.microsoft.netstandard.pack.targeting.*",
-  ]
+  uninstall pkgutil: "com.microsoft.dotnet.*#{version.major_minor}*#{arch}"
 
-  zap pkgutil: "com.microsoft.dotnet.*",
-      delete:  [
-        "/etc/paths.d/dotnet",
-        "/etc/paths.d/dotnet-cli-tools",
-      ],
-      trash:   [
-        "~/.dotnet",
-        "~/.nuget",
-      ]
+  # No zap stanza required
 end

--- a/Casks/d/dotnet-sdk@preview.rb
+++ b/Casks/d/dotnet-sdk@preview.rb
@@ -23,8 +23,6 @@ cask "dotnet-sdk@preview" do
     "dotnet-runtime",
     "dotnet-runtime@preview",
     "dotnet-sdk",
-    "dotnet-sdk@8",
-    "dotnet-sdk@9",
   ]
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
There might be a problem with uninstallation as cask uninstaller doesn't check cask dependents, see the issue https://github.com/Homebrew/brew/issues/21067

Everything else works just fine, `dotnet-sdk@*` (un)installation (un)installs only the SDK and nothing else. Keeping `dotnet-runtime@preview` separate from other casks as it might install the same SDK as `dotnet-sdk`

Any feedback is appreciated

Closes #236254