### PR TITLE
osaurus: update binary path

### DIFF
--- a/Casks/o/osaurus.rb
+++ b/Casks/o/osaurus.rb
@@ -11,16 +11,18 @@ cask "osaurus" do
   depends_on macos: ">= :sequoia"
   depends_on arch: :arm64
 
-  app "osaurus.app"
-  binary "#{appdir}/osaurus.app/Contents/MacOS/osaurus"
+  app "Osaurus.app"
+  binary "#{appdir}/Osaurus.app/Contents/MacOS/Contents/Helpers/osaurus"
+
+  uninstall quit: "com.dinoki.osaurus"
 
   zap trash: [
     "~/Library/Application Support/com.dinoki.osaurus",
     "~/Library/Application Support/Osaurus",
     "~/Library/Caches/com.dinoki.osaurus",
     "~/Library/HTTPStorages/com.dinoki.osaurus",
-    "~/Library/Preferences/ai.dinoki.osaurus.plist",
-    "~/Library/Saved Application State/ai.dinoki.osaurus.savedState",
+    "~/Library/Preferences/com.dinoki.osaurus.plist",
+    "~/Library/Saved Application State/com.dinoki.osaurus.savedState",
     "~/MLXModels",
   ]
 end


### PR DESCRIPTION
currently, the binary path is linking to the UI, not the CLI. related to https://github.com/dinoki-ai/osaurus/issues/120, https://github.com/Homebrew/homebrew-cask/pull/231419

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
