### PR TITLE
telegram-desktop@beta 6.3.0

### DIFF
--- a/Casks/t/telegram-desktop@beta.rb
+++ b/Casks/t/telegram-desktop@beta.rb
@@ -1,12 +1,32 @@
 cask "telegram-desktop@beta" do
-  version "6.2.6"
-  sha256 "772413b84a42bc1b071b4de83dbb7e78fc9fd31778cc6c507ef97a0dfa1d2b21"
+  version "6.3.0"
+  sha256 "1cc9229bdb9674cf35c989088f402ce5b7a1098cb945d84ab978c109c80c3ea3"
 
-  url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.beta.dmg",
+  url "https://github.com/telegramdesktop/tdesktop/releases/download/v#{version}/tsetup.#{version}.dmg",
       verified: "github.com/telegramdesktop/tdesktop/"
   name "Telegram Desktop"
   desc "Desktop client for Telegram messenger"
   homepage "https://desktop.telegram.org/"
+
+  # This will fall back to a version in a tag name if the regex fails to match,
+  # otherwise this could get into a state where it returns versions but is
+  # omitting the newest release(s) due to a file name format change.
+  livecheck do
+    url :url
+    regex(/tsetup[._-]v?(\d+(?:\.\d+)+(?:[._-]beta)?)/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        release["assets"]&.filter_map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end.presence || release["tag_name"]&.[](/v?(\d+(?:\.\d+)+)/i, 1)
+      end.flatten
+    end
+  end
 
   auto_updates true
   conflicts_with cask: "telegram-desktop"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`telegram-desktop@beta` is autobumped but the workflow failed to update to version 6.3.0 because the cask `url` includes a `.beta` suffix in the file name but this is a stable version. With this setup, the cask `url` has to be manually updated when it switches between stable and unstable versions. This addresses the issue by adding a `livecheck` block that includes the optional `.beta` suffix in the version, so the cask can be bumped regardless of whether a release is stable or beta.

I've set up the `strategy` block to fall back to a version in the tag name if no assets match for a given release, which is intended to ensure that livecheck will still surface a new version. This isn't appropriate for all `GithubReleases` checks but it should be fine here and would allow us to identify when the cask needs to be modified to handle an upstream change in the file name, etc.