### PR TITLE
handy 0.6.1

### DIFF
--- a/Casks/h/handy.rb
+++ b/Casks/h/handy.rb
@@ -1,11 +1,11 @@
 cask "handy" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.6.0"
-  sha256 arm:   "31488bfe2e91b4abcbdd5ad77180827b08660c5c005a297891983f1123df153c",
-         intel: "59636951f5811ea562197b65b260390caaaed194d695bafdab401d8608a3e458"
+  version "0.6.1"
+  sha256 arm:   "00e23cb7404ccc9f29e0c54da27e70c320938a06c312acf1d49083f9f89c20f2",
+         intel: "7467bf6b9523279ca04b1d1fe37276c4ee7cef4cc2e5bec142c8906d5b8f3c25"
 
-  url "https://github.com/cjpais/Handy/releases/download/v#{version}/Handy_#{version}_#{arch}_darwin.dmg",
+  url "https://github.com/cjpais/Handy/releases/download/v#{version}/Handy_#{version}_#{arch}.dmg",
       verified: "github.com/cjpais/Handy/"
   name "Handy"
   desc "Speech to text application"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`handy` is autobumped but the workflow failed to update to version 0.6.1 because the dmg file name now omits the `_darwin` suffix that was recently added. This updates the version and `url` accordingly.