### PR TITLE
dcp-o-matic 2.18.31

### DIFF
--- a/Casks/d/dcp-o-matic.rb
+++ b/Casks/d/dcp-o-matic.rb
@@ -1,13 +1,18 @@
 cask "dcp-o-matic" do
-  version "2.18.21"
-  sha256 "2fb593b6dbd47fec63f7df6eef65c03eed7a495b1ed15156d58026297d3a3f03"
+  version "2.18.31"
+  sha256 "13bbcbeb335da648082acad7c6b4b808b9fb0c96d7aeebaef205900da07c76b9"
 
   url "https://dcpomatic.com/dl.php?id=osx-10.10-main&version=#{version}"
   name "DCP-o-matic"
   desc "Convert video, audio and subtitles into DCP (Digital Cinema Package)"
   homepage "https://dcpomatic.com/"
 
-  disable! date: "2025-07-28", because: "cannot be reliably fetched due to Cloudflare protections"
+  livecheck do
+    url "https://dcpomatic.com/download"
+    regex(/Stable\s+release:\s*v?(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on macos: ">= :big_sur"
 
   app "DCP-o-matic #{version.major}.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I disabled `dcp-o-matic` on 2025-07-28 because the Cloudflare protections on the website prevented brew from being able to fetch the dmg file (or check for new versions), so the cask was effectively unusable. The website is now accessible and has remained that way during the two weeks I've been testing it, so this re-enables the cask and updates it to 2.18.31.

This has worked fine for me locally (whereas it failed locally back in July) but I'm testing this individually on CI before updating the other casks.