### PR TITLE
Update gcloud cask caveats to specify the reason needed for additional components installed

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -78,7 +78,9 @@ cask "gcloud-cli" do
     google_cloud_sdk_root,
   ]
 
-  caveats do
-    path_environment_variable "#{google_cloud_sdk_root}/bin"
-  end
+  caveats <<~EOS
+    To use additional binary components installed via gcloud, add the "#{google_cloud_sdk_root}/bin"
+    directory to your PATH environment variable, e.g., (for Bash shell):
+       export PATH=#{google_cloud_sdk_root}/bin:"$PATH"
+  EOS
 end


### PR DESCRIPTION
As per [request](https://github.com/orgs/Homebrew/discussions/6548), updated caveats to clarify the reason why users need to add gcloud root path to their bash 

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
