### PR TITLE
beid-token: update livecheck

### DIFF
--- a/Casks/b/beid-token.rb
+++ b/Casks/b/beid-token.rb
@@ -8,17 +8,8 @@ cask "beid-token" do
   homepage "https://eid.belgium.be/"
 
   livecheck do
-    url "https://eid.belgium.be/en"
+    url "https://eid.belgium.be/en/download/16/license"
     regex(/href=.*?eID(?:(?:%20|\s)+|[._-])?Quickinstaller[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
-    strategy :page_match do |page, regex|
-      # The first download button on the site is expected to correspond to the
-      # eID-Quickinstaller dmg used in this cask.
-      download_id = page[%r{element_os-mac-os.*?/download/(\d+)/license}im, 1]
-      next if download_id.blank?
-
-      version_page = Homebrew::Livecheck::Strategy.page_content("https://eid.belgium.be/en/download/#{download_id}/license")
-      version_page[:content]&.scan(regex)&.map { |match| match[0] }
-    end
   end
 
   pkg "eID-Quickinstaller-signed.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `beid-token` is producing an `Unable to get versions` error, as livecheck receives HTML that only contains some minified JavaScript. Presumably this is some sort of intermediate verification page but, regardless, livecheck is unable to access this actual page to be able to identify the license URL and fetch that HTML. This addresses the issue by directly checking the license page for this software, as the number in the URL has seemingly remained stable for years. The previous setup may have been more robust to changes but this works and should be fine for now (granted, it will require a manual update if the number in the URL ever changes).