### PR TITLE
Rename eid-viewer to beid-viewer

### DIFF
--- a/Casks/b/beid-viewer.rb
+++ b/Casks/b/beid-viewer.rb
@@ -1,9 +1,9 @@
-cask "eid-viewer" do
+cask "beid-viewer" do
   version "5.1.22"
   sha256 "925bf141569f0f27c28b54f25f2cfe61c5733a5bc5be4d1a2e827cdf3da21a80"
 
   url "https://eid.belgium.be/sites/default/files/software/eID%20Viewer-#{version}.dmg"
-  name "Belgian EID Viewer"
+  name "Belgian eID Viewer"
   desc "Belgian ID card reader"
   homepage "https://eid.belgium.be/"
 

--- a/Casks/b/beid-viewer.rb
+++ b/Casks/b/beid-viewer.rb
@@ -8,15 +8,8 @@ cask "beid-viewer" do
   homepage "https://eid.belgium.be/"
 
   livecheck do
-    url "https://eid.belgium.be/en"
+    url "https://eid.belgium.be/en/download/22/license"
     regex(/href=.*?eID(?:(?:%20|\s)+|[._-])?Viewer[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
-    strategy :page_match do |page, regex|
-      download_id = page[%r{element_os-mac-os.*/en/download/(\d+)/license.*?download\s+eID\s+viewer}im, 1]
-      next if download_id.blank?
-
-      version_page = Homebrew::Livecheck::Strategy.page_content("https://eid.belgium.be/en/download/#{download_id}/license")
-      version_page[:content]&.scan(regex)&.map { |match| match[0] }
-    end
   end
 
   depends_on cask: "beid-token"

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -43,6 +43,7 @@
   "doxygen": "doxygen-app",
   "dymo-label": "dymo-connect",
   "easy-move-plus-resize": "easy-move+resize",
+  "eid-viewer": "beid-viewer",
   "eloston-chromium": "ungoogled-chromium",
   "emacs": "emacs-app",
   "emacs@nightly": "emacs-app@nightly",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`eid-viewer` was merged before `beid-token` but these are related and should use the same naming convention. We decided on the `beid-` prefix in the `beid-token` PR and I suggested that `eid-viewer` should be renamed and updated to reflect feedback from that PR but this did not happen. This renames `eid-viewer` to `beid-viewer` to align it with `beid-token`.

The existing `livecheck` block for `beid-viewer` is also producing an `Unable to get versions` error, as livecheck receives HTML that only contains some minified JavaScript. Presumably this is some sort of intermediate verification page but, regardless, livecheck is unable to access the actual page to be able to identify the license URL and fetch that HTML. This addresses the issue by directly checking the license page for this software, as the number in the URL has seemingly remained stable for years. The previous setup may have been more robust to changes but this works and should be fine for now (granted, it will require a manual update if the number in the URL ever changes).