### PR TITLE
canon-eos-utility 3.20.10.1

### DIFF
--- a/Casks/c/canon-eos-utility.rb
+++ b/Casks/c/canon-eos-utility.rb
@@ -1,8 +1,8 @@
 cask "canon-eos-utility" do
-  version "3.19.0.12,0200007310,0"
-  sha256 "c13cf1f3de7fd85ed506cd41e67b57a680c07b944d310c82b8e0b17d97e16f92"
+  version "3.20.10.1,0200007518,8"
+  sha256 "d69c250fcbf21c07533f249ec98f032d28ea0b9b88e745486fa383d1f941ca1a"
 
-  url "https://gdlp01.c-wss.com/gds/#{version.csv.third}/#{version.csv.second}/01/EU-Installset-M#{version.csv.first}.dmg.zip",
+  url "https://gdlp01.c-wss.com/gds/#{version.csv.third}/#{version.csv.second}/01/EU#{version.csv.first.major}Installer-M#{version.csv.first}.dmg.zip",
       verified: "gdlp01.c-wss.com/"
   name "Canon EOS Utility"
   desc "Communication with Canon EOS cameras"
@@ -13,7 +13,7 @@ cask "canon-eos-utility" do
   # parts from the file URL in the `location` header of the response.
   livecheck do
     url "https://gdlp01.c-wss.com/rmds/ic/autoupdate/common/tls_eu_updater_url.xml"
-    regex(%r{/(\d+)/(\d+)/\d+/EU[._-]Installset[._-]v?M?(\d+(?:\.\d+)+)\.dmg\.zip}i)
+    regex(%r{/(\d+)/(\d+)/\d+/EU\d*[._-]?Install(?:er|set)[._-]v?M?(\d+(?:\.\d+)+)\.dmg\.zip}i)
     strategy :xml do |xml, regex|
       # NOTE: The macOS identifier will need to be manually updated when
       # releases become available for newer macOS versions.


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`canon-eos-utility` is autobumped but the workflow failed to update to version 3.20.10.1 because the `livecheck` block is producing an "Unable to get versions" error, as the file name format has changed and the regex does not match it. This updates the version, adjusts the `url`, and tweaks the `livecheck` block regex accordingly.