### PR TITLE
dvdstyler: update livecheck

### DIFF
--- a/Casks/d/dvdstyler.rb
+++ b/Casks/d/dvdstyler.rb
@@ -9,8 +9,8 @@ cask "dvdstyler" do
   homepage "https://www.dvdstyler.org/"
 
   livecheck do
-    url "https://www.dvdstyler.org/en/downloads"
-    regex(/DVDStyler[._-]?(\d+(?:[._]\d+)+)[._-]?MacOSX\.dmg/i)
+    url "https://sourceforge.net/projects/dvdstyler/rss?path=/dvdstyler"
+    regex(%r{url=.*?/DVDStyler[._-]?v?(\d+(?:[._]\d+)+)(?:[._-]?MacOSX?)?\.dmg}i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `dvdstyler` checks the first-party download page but this no longer contains a link to the dmg file (only a generic link to a dAppCDN page). The cask uses a file from SourceForge and the download page links to the SourceForge project as the source for all releases, so this updates the `livecheck` block to use the `Sourceforge` strategy to check for new versions, restricting the check to the stable `dvdstyler` directory (omitting the sibling `dvdstyler-devel` and `OldFiles` directories).