### PR TITLE
linqpad 9.3.20.2334623

### DIFF
--- a/Casks/l/linqpad.rb
+++ b/Casks/l/linqpad.rb
@@ -1,8 +1,8 @@
 cask "linqpad" do
-  version "8.107.1.7130434"
-  sha256 "6e738291bf2abbc460fdf8f9e8e14cf8dd7063ae324a9d216dd149d180096c10"
+  version "9.3.20.2334623"
+  sha256 "ee7f5c6d2fb47adafda01896721e79de7c58e19ef7c8e6085dd7e55024bb0182"
 
-  url "https://linqpad.azureedge.net/preview/LINQPad#{version.major}-Beta.dmg?cache=#{version}",
+  url "https://linqpad.azureedge.net/public/LINQPad#{version.major}.dmg?cache=#{version}",
       verified: "linqpad.azureedge.net/"
   name "LINQPad"
   desc ".NET LINQ database query tool and code scratchpad"
@@ -12,11 +12,11 @@ cask "linqpad" do
     url "https://www.linqpad.net/Download.aspx"
     regex(/v?(\d+(?:\.\d+)+)/i)
     strategy :page_match do |page, regex|
-      beta_file_url = page[/href=["']([^"' >]*?LINQPad[._-]?v?\d+[._-]Beta\.dmg)/i, 1]
-      next unless beta_file_url
+      file_url = page[/href=["']([^"' >]*?LINQPad[._-]?v?\d+(?:[._-]Beta)?\.dmg)/i, 1]
+      next unless file_url
 
       merged_headers = Homebrew::Livecheck::Strategy.page_headers(
-        URI.join("https://www.linqpad.net/", beta_file_url).to_s,
+        URI.join("https://www.linqpad.net/", file_url).to_s,
       ).reduce(&:merge)
 
       match = merged_headers["location"]&.match(regex)
@@ -30,7 +30,7 @@ cask "linqpad" do
   depends_on arch: :arm64
   depends_on macos: ">= :big_sur"
 
-  app "LINQPad #{version.major} beta.app"
+  app "LINQPad #{version.major}.app"
 
   zap trash: [
     "~/Library/Application Support/.LINQPad",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`linqpad` is autobumped but the workflow failed to update to version 9.3.20.2334623 because the `livecheck` block is producing an "Unable to get versions" error, as the redirecting dmg URL on the download page no longer contains a "-Beta" suffix. This updates the version and adjusts the cask to reflect this change.

I've created this as a draft for the moment because the upstream situation around versions 8 and 9 are a bit confusing. 9 is listed as a "Release Candidate" on the [download page](https://www.linqpad.net/Download.aspx) but if you check the [download page for version 8](https://www.linqpad.net/LINQPad8Mac.aspx) it states "LINQPad 8 is approaching end-of-life. The replacement product is [LINQPad 9](https://www.linqpad.net/LINQPad9.aspx)." and 8 is noted as "End-of-life" next to the download button. However, version 8 is not [yet] listed in the "End-of-Life Products" section on the main download page. It seems like 8 may not have reached EOL yet but also 9 is RC, soooo 🤷

I would say I guess it makes sense to update the cask to 9 but it also requires users to upgrade their license, so I'm a little more wary of throwing them on a [potentially?] unstable version. What do we think about this?