### PR TITLE
mobirise: update livecheck

### DIFF
--- a/Casks/m/mobirise.rb
+++ b/Casks/m/mobirise.rb
@@ -10,7 +10,7 @@ cask "mobirise" do
   homepage "https://mobirise.com/"
 
   livecheck do
-    url "https://mobirise.com/history.html"
+    url "https://history.mobirisesite.com"
     regex(/>\s*Mobirise\s+v?(\d+(?:\.\d+)+)/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `mobirise` is returning an "Unable to get versions" error because the server returns a 404 (Not Found) response. This URL had been redirecting to history.mobirisesite.com for a few months but it seems that this redirection has been removed. This addresses the issue by updating the `livecheck` block URL.