### PR TITLE
amazon-q 1.19.7

### DIFF
--- a/Casks/a/amazon-q.rb
+++ b/Casks/a/amazon-q.rb
@@ -1,6 +1,6 @@
 cask "amazon-q" do
-  version "1.19.6"
-  sha256 "71698848d63f43e6f748e00bbd828e9d4647c6f58b8adcaa25210fb3297f97f9"
+  version "1.19.7"
+  sha256 "e506d851874a6e563ad0749c28831aa752b0e93ad94d16eeac04d44167c7476d"
 
   url "https://desktop-release.q.us-east-1.amazonaws.com/#{version}/Amazon%20Q.dmg",
       verified: "desktop-release.q.us-east-1.amazonaws.com/"
@@ -11,7 +11,13 @@ cask "amazon-q" do
   livecheck do
     url "https://desktop-release.q.us-east-1.amazonaws.com/index.json"
     strategy :json do |json|
-      json["versions"]&.map { |item| item["version"] }
+      json["versions"]&.map do |item|
+        # The JSON data contains versions of other software, so we have to
+        # specifically target Q versions
+        next unless item["packages"]&.find { |pkg| pkg["download"]&.match?(%r{/[^/]*?Q\.dmg$}i) }
+
+        item["version"]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`amazon-q` is autobumped but the workflow tried to update to a 1.20.0 version instead of 1.19.7. The JSON data that the `livecheck` block is checking contains versions for other software (i.e., 1.20.0 is a kirocli version), so we have to specifically target Q versions. This updates the cask and introduces some logic in the `livecheck` block's `strategy` block to only surface versions providing a Q dmg package. This could silently break in the future if the file name format changes (e.g., adding a suffix, different extension, etc.) but this works for now.