### PR TITLE
opensesame 4.1.5

### DIFF
--- a/Casks/o/opensesame.rb
+++ b/Casks/o/opensesame.rb
@@ -1,27 +1,32 @@
 cask "opensesame" do
-  version "4.1.0"
-  sha256 "6bccd27ea150144f67e46cd39ef720435de99faf559a55b94371739e4e45fdd5"
+  version "4.1.5,py313"
+  sha256 "7072758229d54fc6fbcb647ff64dc92574c5aa9a27021085cf2568501a415ff0"
 
-  url "https://github.com/open-cogsci/OpenSesame/releases/download/release%2F#{version}/opensesame_#{version}-py311-macos-x64-1.dmg",
+  url "https://github.com/open-cogsci/OpenSesame/releases/download/release%2F#{version.csv.first}/opensesame_#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-macos-x64-1.dmg",
       verified: "github.com/open-cogsci/OpenSesame/"
   name "OpenSesame"
   desc "Graphical experiment builder for the social sciences"
   homepage "https://osdoc.cogsci.nl/"
 
+  # Upstream sometimes creates releases without any assets, so we check the
+  # homepage, which links to the newest dmg file for the Python version that
+  # upstream uses for development and testing. This saves us from having to
+  # check multiple GitHub releases to find the newest version with a dmg file
+  # and also ensures that we're using the file for the Python version that
+  # upstream targets. GitHub releases can provide multiple dmg files targeting
+  # different Python versions and the dmg file for the targeted Python version
+  # seems to be uploaded first. However, if we checked GitHub releases it may be
+  # technically possible for us to update to something like `1.2.3,py311` only
+  # for livecheck to later surface `1.2.3,py313` as a new version. Hopefully
+  # checking the homepage will continue to avoid these issues but they're worth
+  # noting if/when we update this check in the future.
   livecheck do
-    url :url
-    regex(/opensesame[._-]v?(\d+(?:\.\d+)+)[._-].*\.dmg/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        release["assets"]&.map do |asset|
-          match = asset["name"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end.flatten
+    url :homepage
+    regex(/href=.*?opensesame[._-]v?(\d+(?:\.\d+)+)(?:[._-](py\d+(?:\.\d+)*))?[^"' >]*?\.dmg/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match[1] ? "#{match[0]},#{match[1]}" : match[0]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`opensesame` is autobumped but the workflow failed to update to version 4.1.5 because the related GitHub release only provides a dmg file for Python 3.13. This is the Python version that upstream uses for development and testing and it seems that the dmg files for the older Python versions are added after a delay. The cask was initially created using version 4.0.1 and that release only provided a dmg file for Python 3.11, so that part of that was hardcoded into the cask `url` and it has continued using those versions even after upstream started targeting later Python versions.

This addresses the issue by switching the `livecheck` block to check the homepage, which links to the newest dmg file that uses the Python version that upstream uses for development and testing. This saves us from having to check multiple GitHub releases, which was necessary because upstream creates GitHub releases using the stable version format but no release assets (these are described upstream as "unpackaged"). I've set this up to include the Python suffix in the cask `version` (making it optional), so this approach can also ensure that we use the dmg file for the Python version that upstream targets (rather than getting stuck on a hardcoded Python version). This works for now and hopefully it will continue to do so in the future but I've added an explanatory comment before the `livecheck` block to document the situation (which should have been done when switching to the `GithubReleases` strategy, to explain why it was necessary).