### PR TITLE
readest 0.9.92

### DIFF
--- a/Casks/r/readest.rb
+++ b/Casks/r/readest.rb
@@ -1,8 +1,8 @@
 cask "readest" do
-  version "0.9.91"
-  sha256 "bf3240a7ab7a85f3b6ff0fca47eca49d82441592a54f5604bc599909d8e85efb"
+  version "0.9.92"
+  sha256 "d8bd6a49e6fcf8d488c418a0fb9dc619e6c7db8c2da3a7849e99102e042441ba"
 
-  url "https://github.com/readest/readest/releases/download/v#{version}/Readest_#{version}_universal_darwin.dmg",
+  url "https://github.com/readest/readest/releases/download/v#{version}/Readest_#{version}_universal.dmg",
       verified: "github.com/readest/readest/"
   name "Readest"
   desc "Ebook reader"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`readest` is autobumped but the workflow failed to update to version 0.9.92 because the dmg file name was modified in a previous version to include a `_darwin` suffix but it has been removed in this version. This updates the version and `url` accordingly.