### PR TITLE
soundanchor 1.3.3

### DIFF
--- a/Casks/s/soundanchor.rb
+++ b/Casks/s/soundanchor.rb
@@ -1,8 +1,9 @@
 cask "soundanchor" do
-  version "1.3.2"
-  sha256 "c7a5c4274a21f74e629fab7e3a2e3d44ffbaacc4689db7b2b83e22a0fde5cec5"
+  version "1.3.3"
+  sha256 "dc1f8694bfeabdcac1017b154206cbfcef9148db1ec3bfbd7e05ad3476a2d8ab"
 
-  url "https://apps.kopiro.me/soundanchor/builds/SoundAnchor-#{version}.dmg"
+  url "https://kopiro.s3.eu-west-1.amazonaws.com/soundanchor/SoundAnchor-#{version}.dmg",
+      verified: "kopiro.s3.eu-west-1.amazonaws.com/soundanchor/"
   name "SoundAnchor"
   desc "Audio device utility"
   homepage "https://apps.kopiro.me/soundanchor/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`soundanchor` is autobumped but the workflow failed to update to version 1.3.3 because upstream now hosts dmg files on S3 (this is the download URL on the homepage and in the appcast). This updates the version and `url` accordingly.