### PR TITLE
notepadexe 1.4.1437 (new cask)

### DIFF
--- a/Casks/n/notepadexe.rb
+++ b/Casks/n/notepadexe.rb
@@ -1,0 +1,29 @@
+cask "notepadexe" do
+  version "1.4.1437"
+  sha256 "6ca96bbb26291f43549f70a8ddb1a51596972332daa1bfdd5191de47d2856828"
+
+  url "https://github.com/notepadhq/notepadexe-public/releases/download/#{version}/Notepad.zip",
+      verified: "github.com/notepadhq/notepadexe-public/releases/download/"
+  name "Notepad.exe"
+  desc "Lightweight code editor"
+  homepage "https://notepadexe.com/"
+
+  livecheck do
+    url "https://softwareupdate-notepadexe.swift.best/notepadexe-appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "Notepad.exe.app"
+
+  zap trash: [
+    "~/Library/Application Support/Notepad.exe",
+    "~/Library/Autosave Information/Notepad.exe",
+    "~/Library/Caches/Notepad.exe",
+    "~/Library/HTTPStorages/best.swift.Notepad",
+    "~/Library/Notepad.exe",
+    "~/Library/Preferences/best.swift.Notepad.plist",
+  ]
+end


### PR DESCRIPTION
**if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

the app uses GitHub for downloads only and I believe it classifies to the notability exception https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold