### PR TITLE
firefox@cn: disable

### DIFF
--- a/Casks/f/firefox@cn.rb
+++ b/Casks/f/firefox@cn.rb
@@ -7,10 +7,7 @@ cask "firefox@cn" do
   desc "Chinese version of Firefox"
   homepage "https://www.firefox.com.cn/"
 
-  livecheck do
-    url "https://download-redirect.firefox.com.cn/?product=firefox-latest-ssl&os=osx"
-    strategy :header_match
-  end
+  disable! date: "2025-11-20", because: :no_longer_available, replacement_cask: "firefox"
 
   auto_updates true
   conflicts_with cask: [


### PR DESCRIPTION
Firefox with Chinese service has been discontinued and the website is already shut down. The download is unreachable.

The announcement was made on July 27 and downloads were disabled since that day. The service was shut down on September 29.

References:
- https://zh.wikipedia.org/wiki/火狐中国版#歷史
- https://www.ithome.com/0/871/110.htm