### PR TITLE
biscuit 1.2.31

### DIFF
--- a/Casks/b/biscuit.rb
+++ b/Casks/b/biscuit.rb
@@ -1,17 +1,18 @@
 cask "biscuit" do
   arch arm: "-arm64"
 
-  version "1.2.30"
-  sha256 arm:   "0545a92dce24a2a5758250ddd3b8e58a26b1219ca61fd316872adbc154eb27bf",
-         intel: "c3ab3a00589046167bce909eb7fc9d080c6a2205e312890b36ba568f0358881d"
+  version "1.2.31"
+  sha256 arm:   "8d427d13789e3505836611586fdaf77f8091d66ba07ec0f4140e344993fcfed2",
+         intel: "cd7ea5bbf4d4847aa072b752e745b3f8fb18ded401d635b5ff93879ce438adcf"
 
-  url "https://github.com/agata/dl.biscuit/releases/download/v#{version}/Biscuit-#{version}#{arch}.dmg",
+  url "https://github.com/agata/dl.biscuit/releases/download/#{version}/Biscuit-#{version}#{arch}.dmg",
       verified: "github.com/agata/dl.biscuit/"
   name "Biscuit"
   desc "Browser to organise apps"
   homepage "https://eatbiscuit.com/"
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Biscuit.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`biscuit` is autobumped but the workflow failed to update to version 1.2.31 because the release tag omits the leading "v" that has been present in previous releases. This updates the version and `url` accordingly. This also adds an appropriate `depends_on macos:` value to address a `brew audit` error ("Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version").