### PR TITLE
chronycontrol 1.6.2

### DIFF
--- a/Casks/c/chronycontrol.rb
+++ b/Casks/c/chronycontrol.rb
@@ -1,6 +1,6 @@
 cask "chronycontrol" do
-  version "1.6.1"
-  sha256 "dae3db713650c6e87b323dafc74994d60609c74502604b7c7aad1b0c61abac3e"
+  version "1.6.2"
+  sha256 "d7438f52247b2c9a64d12f9597f94fa0ba5b0a7b7830e0e7b3a9ef67a9f65a6b"
 
   url "https://www.whatroute.net/software/chronycontrol-#{version}.zip"
   name "ChronyControl"
@@ -31,8 +31,4 @@ cask "chronycontrol" do
     "/etc/chrony.d",
     "/var/log/chrony",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`chronycontrol` is autobumped but the workflow failed to update to version 1.6.2 because `brew audit` failed with a "No artifacts require Rosetta 2 but the caveats say otherwise!" error. It's now a universal app, so this updates the version and removes the Rosetta caveat.