### PR TITLE
porting-kit 6.7.0

### DIFF
--- a/Casks/p/porting-kit.rb
+++ b/Casks/p/porting-kit.rb
@@ -1,8 +1,11 @@
 cask "porting-kit" do
-  version "6.5.0"
-  sha256 "e3c7fc05e865669671d2d99c4da932ffafad4b7a1835130a3bdb753647259e5d"
+  arch arm: "-arm64"
 
-  url "https://github.com/vitor251093/porting-kit-releases/releases/download/v#{version}/Porting-Kit-#{version}.dmg",
+  version "6.7.0"
+  sha256 arm:   "7e33b70e326c7e5a99c531b65b678b605c44aaa107f51688777ad5dd9e5fbf5a",
+         intel: "2f19f92a26d464815e10c41e2a4bda5a506ad612415bf0f0c824e5fcec36b0ab"
+
+  url "https://github.com/vitor251093/porting-kit-releases/releases/download/v#{version}/Porting.Kit-#{version}#{arch}.dmg",
       verified: "github.com/vitor251093/porting-kit-releases/"
   name "Porting Kit"
   desc "Install games and apps compiled for Microsoft Windows"
@@ -18,8 +21,4 @@ cask "porting-kit" do
     "~/Library/Preferences/com.paulthetall.portingkit.plist",
     "~/Library/Saved Application State/com.paulthetall.portingkit.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`porting-kit` is autobumped but the workflow failed to update to version 6.7.0 because the dmg file name replaced the hyphen in the "Porting-Kit" name with a dot. However, this release is also the first to provide an ARM dmg, so this updates the version and adjusts the cask accordingly.