### PR TITLE
rustdesk: checksum update

### DIFF
--- a/Casks/r/rustdesk.rb
+++ b/Casks/r/rustdesk.rb
@@ -2,7 +2,7 @@ cask "rustdesk" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.4.4"
-  sha256 arm:   "73fe42fb38235ec4d76d227bdc560192b4b68471562db366fb89c708cfb2799d",
+  sha256 arm:   "a6eb044c22e28612135116c0789d3968fe6c543d6644b49e88dda67dbea984c4",
          intel: "d55ad47e41a7081dea8fdbf5a27c6375107adab57b977e44f388b281e75e37e3"
 
   url "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-#{arch}.dmg",

--- a/Casks/r/rustdesk.rb
+++ b/Casks/r/rustdesk.rb
@@ -3,7 +3,7 @@ cask "rustdesk" do
 
   version "1.4.4"
   sha256 arm:   "a6eb044c22e28612135116c0789d3968fe6c543d6644b49e88dda67dbea984c4",
-         intel: "d55ad47e41a7081dea8fdbf5a27c6375107adab57b977e44f388b281e75e37e3"
+         intel: "795b660cdfc42dfa31f302cd2071d102459e65ec81a15e17da2ea7699d5d207f"
 
   url "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-#{arch}.dmg",
       verified: "github.com/rustdesk/rustdesk/"


### PR DESCRIPTION
## Issue

Upgrade fails due SHA256 mismatch,
```
==> Fetching downloads for: rustdesk
✘ Cask rustdesk (1.4.4)                                                                                                                                                              [Verifying    25.5MB/ 25.5MB]
Error: Cask reports different checksum:     73fe42fb38235ec4d76d227bdc560192b4b68471562db366fb89c708cfb2799d
       SHA-256 checksum of downloaded file: a6eb044c22e28612135116c0789d3968fe6c543d6644b49e88dda67dbea984c4
==> Upgrading 1 outdated package:
rustdesk 1.4.3 -> 1.4.4
==> Upgrading rustdesk
==> Purging files for version 1.4.4 of Cask rustdesk
Error: rustdesk: SHA-256 mismatch
Expected: 73fe42fb38235ec4d76d227bdc560192b4b68471562db366fb89c708cfb2799d
  Actual: a6eb044c22e28612135116c0789d3968fe6c543d6644b49e88dda67dbea984c4
    File: /Users/prayagmatic/Library/Caches/Homebrew/downloads/7ef62ba3f143a12f145ce834a917fb02f5b0e2a4e82896b60235d4b3adf76df0--rustdesk-1.4.4-aarch64.dmg
To retry an incomplete download, remove the file above.
```

## Verification of SHA256

Copied from the GitHub releases UI for file `rustdesk-1.4.4-aarch64.dmg`,
```
sha256:a6eb044c22e28612135116c0789d3968fe6c543d6644b49e88dda67dbea984c4
```

```sh
❯ wget --quiet https://github.com/rustdesk/rustdesk/releases/download/1.4.4/rustdesk-1.4.4-aarch64.dmg
❯ sha256sum ./rustdesk-1.4.4-aarch64.dmg
a6eb044c22e28612135116c0789d3968fe6c543d6644b49e88dda67dbea984c4  ./rustdesk-1.4.4-aarch64.dmg
```

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
