### PR TITLE
cc-mate 0.3.4 (new cask)

### DIFF
--- a/Casks/c/cc-mate.rb
+++ b/Casks/c/cc-mate.rb
@@ -1,0 +1,17 @@
+cask "cc-mate" do
+  version "0.3.4"
+  sha256 "aa4472709c66d8521ed179c8c569baae07704e14e4559155b134e32b450d16fe"
+
+  url "https://github.com/djyde/ccmate-release/releases/download/app-v#{version}/CC.Mate_#{version}_universal.dmg"
+  name "CC Mate"
+  desc "Application for managing Claude Code configuration files"
+  homepage "https://github.com/djyde/ccmate-release"
+
+  livecheck do
+    url "https://github.com/djyde/ccmate-release/releases.atom"
+    regex(/^app[._-]v?(\d+(?:\.\d+)+)$/i)
+    strategy :atom
+  end
+
+  app "CC Mate.app"
+end

--- a/Casks/c/cc-mate.rb
+++ b/Casks/c/cc-mate.rb
@@ -5,7 +5,7 @@ cask "cc-mate" do
   url "https://github.com/djyde/ccmate-release/releases/download/app-v#{version}/CC.Mate_#{version}_universal.dmg"
   name "CC Mate"
   desc "Application for managing Claude Code configuration files"
-  homepage "https://github.com/djyde/ccmate-release"
+  homepage "https://randynamic.org/ccmate"
 
   livecheck do
     url "https://github.com/djyde/ccmate-release/releases.atom"


### PR DESCRIPTION
## Summary

Application for managing Claude Code configuration files.

## Application Details

- **Name**: CC Mate
- **Version**: 0.3.4
- **Description**: Application for managing Claude Code configuration files
- **Homepage**: https://randynamic.org/ccmate
- **Download**: Universal DMG for macOS

## Testing

- ✅ Audit passed with `brew audit --strict --online cc-mate`
- ✅ Style check passed with `brew style --fix cc-mate`
- ✅ SHA256 verified for version 0.3.4
- ✅ Livecheck configured using GitHub releases atom feed

## Test Plan

- [x] Cask installs correctly
- [x] Application launches successfully
- [x] Livecheck detects new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)