### PR TITLE
mountmate 4.4 (new cask)

### DIFF
--- a/Casks/m/mountmate.rb
+++ b/Casks/m/mountmate.rb
@@ -1,0 +1,22 @@
+cask "mountmate" do
+  version "4.4"
+  sha256 "a9b62afc15911bf3e72ac86a1df0ba8f6df5df835cf59a91d1b193476643dd06"
+
+  url "https://github.com/homielab/mountmate/releases/download/v#{version}/MountMate_#{version}.dmg",
+      verified: "github.com/homielab/mountmate/"
+  name "MountMate"
+  desc "Menubar app to easily manage external drives"
+  homepage "https://homielab.com/page/mountmate"
+
+  livecheck do
+    url "https://homielab.github.io/mountmate/appcast.xml"
+    strategy :sparkle, &:title
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "MountMate.app"
+
+  zap trash: "~/Library/Preferences/com.homielab.mountmate.plist"
+end


### PR DESCRIPTION
MountMate is a lightweight macOS menu bar utility that lets you mount and unmount external drives with a single click – no Terminal, no Disk Utility, no hassle.

Source: https://github.com/homielab/mountmate

**Important:** _Do not tick a checkbox if you haven’t performed its action._ Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

* [x]  The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
* [x]  `brew audit --cask --online <cask>` is error-free.
* [x]  `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

* [x]  Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
* [x]  Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
* [x]  `brew audit --cask --new <cask>` worked successfully.
* [x]  `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
* [x]  `brew uninstall --cask <cask>` worked successfully.

