### PR TITLE
antigravity: add binary

### DIFF
--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -27,6 +27,7 @@ cask "antigravity" do
   depends_on macos: ">= :big_sur"
 
   app "Antigravity.app"
+  binary "#{appdir}/Antigravity.app/Contents/Resources/app/bin/antigravity", target: "agy"
 
   zap trash: [
     "~/.antigravity/",


### PR DESCRIPTION
During Antigravity setup, it asks me if I would like to add `agy` to path, much like `code` or `cursor`. But for `code` and `cursor`, brew already set it up for me. I would like to have brew to set up `agy` for me.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online antigravity` is error-free. This returns:

```
Error: These casks are not in any locally installed taps!

  antigravity

You may need to run `brew tap` to install additional taps.
```

- [ ] `brew style --fix antigravity` reports no offenses. This returns:

```
0 files inspected, no offenses detected` for me.
```

References:
- https://github.com/Homebrew/homebrew-cask/blob/4baa79ace9e2659ca1cdc927e3e3364937b36868/Casks/v/visual-studio-code.rb#L35- https://github.com/Homebrew/homebrew-cask/blob/4baa79ace9e2659ca1cdc927e3e3364937b36868/Casks/c/cursor.rb#L28C66-L28C82
