### PR TITLE
audius 1.5.161 (arm only)

### DIFF
--- a/Casks/a/audius.rb
+++ b/Casks/a/audius.rb
@@ -2,13 +2,15 @@ cask "audius" do
   arch arm: "-arm64"
 
   on_arm do
-    version "1.5.133"
-    sha256 "5143dfdcf08324104a8b08e7e5f3e3fc514e1eba7e0a3de9879e27ddc151dc3c"
+    version "1.5.161"
+    sha256 "5ced8f562a65dfa8f5ce7310788792c943d61c326a3b1fae8fbcacd47f62d2e0"
 
     livecheck do
       url "https://download.audius.co/latest-mac.yml"
       strategy :electron_builder
     end
+
+    depends_on macos: ">= :monterey"
   end
   on_intel do
     version "1.5.66"
@@ -17,6 +19,8 @@ cask "audius" do
     livecheck do
       skip "Legacy version"
     end
+
+    depends_on macos: ">= :catalina"
   end
 
   url "https://download.audius.co/Audius-#{version}#{arch}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`audius` is autobumped but the workflow failed to update to version 1.5.161 for ARM because livecheck is skipped for Intel and `brew bump` doesn't handle this situation correctly (it handles skips and errors in a weird way and the "skipped" text for Intel is incorrectly treated as a new version). I have a forthcoming brew PR that will modify `bump` to account for this situation (the work's done and I just need to test it more) but this manually updates the version in the interim time, as we also have to address a `brew audit` error for ARM in the process ("Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version").