### PR TITLE
fontra-pak 2025.11.3 (new cask)

### DIFF
--- a/Casks/f/fontra-pak.rb
+++ b/Casks/f/fontra-pak.rb
@@ -1,0 +1,21 @@
+cask "fontra-pak" do
+  version "2025.11.3"
+  sha256 "fbdf7e44103c1b400e8d3567bfe3bf42a64c8301efb047eebb0b50512b36c43e"
+
+  url "https://github.com/fontra/fontra-pak/releases/download/#{version}/FontraPak-macOS.dmg",
+      verified: "github.com/fontra/fontra-pak/"
+  name "Fontra Pak"
+  desc "Browser-based font editor"
+  homepage "https://fontra.xyz/"
+
+  depends_on macos: ">= :big_sur"
+
+  app "Fontra Pak.app"
+
+  uninstall quit: "xyz.fontra.fontra-pak"
+
+  zap trash: [
+    "~/Library/Preferences/com.xyz-fontra.FontraPak.plist",
+    "~/Library/Preferences/xyz.fontra.fontra-pak.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

The repository for application bundles (https://github.com/fontra/fontra-pak) is not sufficiently notable, but I believe the main repository (https://github.com/fontra/fontra) meets the criteria for notability. Additionally, while registration was previously refused due to the lack of versioning (#168452), this issue has now been resolved.