### PR TITLE
Remove "conflicts_with" stanza from android-commandlinetools.rb

### DIFF
--- a/Casks/a/android-commandlinetools.rb
+++ b/Casks/a/android-commandlinetools.rb
@@ -22,8 +22,6 @@ cask "android-commandlinetools" do
     regex(%r{href=.*?/commandlinetools[._-]#{os}[._-](\d+)[._-]latest\.zip}i)
   end
 
-  conflicts_with cask: "android-sdk"
-
   android_sdk_root = "#{HOMEBREW_PREFIX}/share/android-commandlinetools"
   android_clt_dir = "#{android_sdk_root}/cmdline-tools/latest"
 


### PR DESCRIPTION
This PR removes the now-invalid "conflicts_with" stanza from `android-commandlinetools.rb`. It appears this removal was attempted in the omnibus purge of the stanza in https://github.com/Homebrew/homebrew-cask/pull/224407/files#diff-228f709838ff996124fc80b3028f30b85302f3ae35a6277acb5960c4349abf2a, but it was not completely eliminated.

The presence of this stanza is now causing installation errors for dependent packages with Homebrew 5:

```
Error: Calling conflicts_with formula: is disabled! There is no replacement.
Error: Cask 'android-commandlinetools' definition is invalid: 'conflicts_with' stanza failed with: Calling conflicts_with formula: is disabled! There is no replacement.
Error: Process completed with exit code 1.
```



**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
