### PR TITLE
dexed 0.9.9

### DIFF
--- a/Casks/d/dexed.rb
+++ b/Casks/d/dexed.rb
@@ -1,8 +1,8 @@
 cask "dexed" do
-  version "0.9.8"
-  sha256 "3be32f98e56b40d9555a4069368c7307b8bae3368459bb087cf6195ae7538704"
+  version "0.9.9"
+  sha256 "d747015bcd6d8e0714e87ca8a679ff4861a4c27c73339051ecfa52d1928e8ff8"
 
-  url "https://github.com/asb2m10/dexed/releases/download/v#{version}/dexed-#{version}-macos.zip",
+  url "https://github.com/asb2m10/dexed/releases/download/v#{version}/Dexed-#{version}-macOS.dmg",
       verified: "github.com/asb2m10/dexed/"
   name "Dexed"
   desc "DX7 FM synthesiser"
@@ -13,7 +13,7 @@ cask "dexed" do
     strategy :github_latest
   end
 
-  pkg "dexed-macOS-#{version}.pkg"
+  pkg "Dexed-#{version}-macOS.pkg"
 
   uninstall pkgutil: [
               "com.digitalsuburban.dexed.app.pkg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dexed` is autobumped but the workflow failed to update to version 0.9.9 because upstream is now providing a dmg file (with a different file name) rather than a zip. This updates the version and adjusts the cask accordingly.