### PR TITLE
apifox 2.7.51

### DIFF
--- a/Casks/a/apifox.rb
+++ b/Casks/a/apifox.rb
@@ -2,14 +2,15 @@ cask "apifox" do
   arch arm: "-macOS-arm64"
   livecheck_arch = on_arch_conditional arm: "-arm64"
 
-  version "2.7.50"
-  sha256 arm:   "08546c8bedcb0d02129a359155a6a36a444993ecd7e0dea5da28557bcf97bfa4",
-         intel: "4344deb671567106fe50155939eac6f8957053cf4c61f6c14cef65a08d32c9bf"
+  version "2.7.51"
+  sha256 arm:   "83f73041d3b8c49c83a96013dad03ed4e6e76d579225fe8f6e0afd02858f2e6f",
+         intel: "2c28a99c9a3ffcf82a2d545539004ec850a9141cd26f8df1ae87e10e21cfcea2"
 
-  url "https://file-assets.apifox.com/download/#{version}/Apifox#{arch}-#{version}.dmg"
+  url "https://file-assets.apifox.com/download/#{version}/Apifox#{arch}-#{version}.dmg",
+      verified: "file-assets.apifox.com/download/"
   name "Apifox"
   desc "Platform for API documentation, debugging, and testing"
-  homepage "https://www.apifox.com/"
+  homepage "https://github.com/apifox/apifox"
 
   livecheck do
     url "https://api.apifox.com/api/v1/configs/client-updates/#{version}/mac#{livecheck_arch}/latest-mac.yml?noCache=#{Time.new.to_i * 2}"


### PR DESCRIPTION
apifox: update homepage

---

```
> curl -I https://www.apifox.com/
HTTP/2 301
date: Mon, 24 Nov 2025 03:01:35 GMT
content-type: text/html
content-length: 176
location: https://apifox.com/
set-cookie: acw_tc=0a03834117639532953556406e5fe8df2ef07de904646a7b383b5799e12204;path=/;HttpOnly;Max-Age=1800
via: HTTP/2.0 SLB.128
```