### PR TITLE
kodi: update livecheck

### DIFF
--- a/Casks/k/kodi.rb
+++ b/Casks/k/kodi.rb
@@ -10,9 +10,12 @@ cask "kodi" do
   desc "Free and open-source media player"
   homepage "https://kodi.tv/"
 
+  # The upstream website is protected by Cloudflare, which prevents us from
+  # fetching the download page (https://kodi.tv/download/macos/), so we check
+  # the directory listing page where the dmg files are found.
   livecheck do
-    url "https://mirrors.kodi.tv/releases/osx/arm64/"
-    regex(/kodi[._-]v?(\d+(?:\.\d+[.-]\w+)+)[._-]arm64\.dmg/i)
+    url "https://mirrors.kodi.tv/releases/osx/#{arch}/"
+    regex(/href=.*?kodi[._-]v?(\d+(?:\.\d+)+[._-][^_-]+?)[._-]#{arch}\.dmg/i)
   end
 
   app "Kodi.app"

--- a/Casks/k/kodi.rb
+++ b/Casks/k/kodi.rb
@@ -10,13 +10,9 @@ cask "kodi" do
   desc "Free and open-source media player"
   homepage "https://kodi.tv/"
 
-  # The upstream website is protected by Cloudflare, which prevents us from
-  # fetching the download page. The GitHub releases link to Kodi releases, so
-  # we check the latest GitHub release as a workaround.
   livecheck do
-    url "https://github.com/xbmc/xbmc/"
-    regex(/^v?(\d+(?:\.\d+)+(?:-\w+))$/i)
-    strategy :github_latest
+    url "https://mirrors.kodi.tv/releases/osx/arm64/"
+    regex(/kodi[._-]v?(\d+(?:\.\d+[.-]\w+)+)[._-]arm64\.dmg/i)
   end
 
   app "Kodi.app"


### PR DESCRIPTION
Update to read directly from the official mirror directory, which reliably reflects available macOS builds.

---

- https://github.com/xbmc/xbmc/issues/27418