### PR TITLE
safe-exam-browser: update livecheck

### DIFF
--- a/Casks/s/safe-exam-browser.rb
+++ b/Casks/s/safe-exam-browser.rb
@@ -9,8 +9,8 @@ cask "safe-exam-browser" do
   homepage "https://safeexambrowser.org/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    url "https://safeexambrowser.org/download_en.html"
+    regex(/href=.*?SafeExamBrowser[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   app "Safe Exam Browser.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `safe-exam-browser` uses the `GithubLatest` strategy to check for new versions and returns 3.6.1 as newest. This is the latest release but the tag is `3.6.1b` and the release title clearly describes it as "3.6.1 Beta". Upstream has not marked this release as "pre-release" and it's ambiguous whether this was intentional or not.

However, the first-party download page still links to 3.6 as the newest version, so this works around the issue by updating the `livecheck` block to check the download page instead, making the version from the dmg file link. This could just be due to a delay between when releases are created on GitHub and when the download page is updated but this may be deliberate, signaling that the 3.6.1 beta release is an unstable version. Until the situation becomes clear, this will ensure that livecheck doesn't surface the beta version.