### PR TITLE
shell360 0.1.14

### DIFF
--- a/Casks/s/shell360.rb
+++ b/Casks/s/shell360.rb
@@ -1,9 +1,9 @@
 cask "shell360" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.1.13"
-  sha256 arm:   "EF21F976BE57858705E8EE80F5A1C6D6306F798652FF447FB85B8422D7BCCBDE",
-         intel: "67C505A18553EB34C57D51EF3F521A0631BBCF3CF301F260B4BFE4821636D0CE"
+  version "0.1.14"
+  sha256 arm:   "a02e0e6818893e0b44997a39827e813b18403088d85d246d7635bc1cc7a04fc0",
+         intel: "4b06ab66762be40fe4d0224c0ad597f6c29ac647b89517fdab056dc614f63622"
 
   url "https://github.com/nashaofu/shell360/releases/download/v#{version}/Shell360_#{version}_#{arch}.dmg"
   name "Shell360"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`shell360` is autobumped but the workflow failed to update to version 0.1.14 because an `inreplace` call to modify the cask unexpectedly failed. This manually updates the cask to get it back on track.