### PR TITLE
keepassxc 2.7.11-1

### DIFF
--- a/Casks/k/keepassxc.rb
+++ b/Casks/k/keepassxc.rb
@@ -2,10 +2,10 @@ cask "keepassxc" do
   arch arm: "arm64", intel: "x86_64"
 
   version "2.7.11"
-  sha256 arm:   "eac316a1dce12c0b1f3bfec957ca58d828fa1cd2b1eebfcd4ff9361926675b37",
-         intel: "ee4cf677246d696e9ad80fd21e65f137e38512cdc39720c10ed165c82fa95250"
+  sha256 arm:   "11c514ed9fcc33b82d2a8e113bfc989b5834335dafd7a5dadd8942410cfbd025",
+         intel: "fc04dfbba1f5208ea547af68617f7a6022a73fb841f307ff5f7b2c537320e2c9"
 
-  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-#{arch}.dmg",
+  url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-1-#{arch}.dmg",
       verified: "github.com/keepassxreboot/keepassxc/"
   name "KeePassXC"
   desc "Password manager app"


### PR DESCRIPTION
KeePassXC has been re-released due to a build issue as below:

> Note: The 2.7.11 macOS DMG and AppImage downloads have issues. Please download the 2.7.11-1 builds instead (also below).

---

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
