### PR TITLE
keepassxc: update macOS 2.7.11 DMG to 2.7.11-1

### DIFF
--- a/Casks/k/keepassxc.rb
+++ b/Casks/k/keepassxc.rb
@@ -1,9 +1,9 @@
 cask "keepassxc" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "2.7.11"
-  sha256 arm:   "eac316a1dce12c0b1f3bfec957ca58d828fa1cd2b1eebfcd4ff9361926675b37",
-         intel: "ee4cf677246d696e9ad80fd21e65f137e38512cdc39720c10ed165c82fa95250"
+  version "2.7.11-1"
+  sha256 arm:   "11c514ed9fcc33b82d2a8e113bfc989b5834335dafd7a5dadd8942410cfbd025",
+         intel: "fc04dfbba1f5208ea547af68617f7a6022a73fb841f307ff5f7b2c537320e2c9"
 
   url "https://github.com/keepassxreboot/keepassxc/releases/download/#{version}/KeePassXC-#{version}-#{arch}.dmg",
       verified: "github.com/keepassxreboot/keepassxc/"
@@ -12,8 +12,7 @@ cask "keepassxc" do
   homepage "https://keepassxc.org/"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    skip "Upstream uses the same tag for re-releases; latest corrected build is 2.7.11-1."
   end
 
   conflicts_with cask: [


### PR DESCRIPTION
Upstream has re-released the macOS 2.7.11 build as 2.7.11-1 due to issues in the original DMG.
This PR updates the cask to use the corrected DMG and updates the corresponding sha256 values.

Official upstream note:
“The 2.7.11 macOS DMG and AppImage downloads have issues. Please download the 2.7.11-1 builds instead.”