### PR TITLE
raspberry-pi-imager 2.0.0

### DIFF
--- a/Casks/r/raspberry-pi-imager.rb
+++ b/Casks/r/raspberry-pi-imager.rb
@@ -1,23 +1,25 @@
 cask "raspberry-pi-imager" do
-  version "1.9.6"
-  sha256 "951e0443cddf3553219d53408ac4ec2d205911c9dfed5e5496862a0fd3296a2f"
+  version "2.0.0"
+  sha256 "5c6ce78c0aba09aad1284f7990b11d8059140788f4c0f5a3ccbe1b3d9163e6d0"
 
-  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/rpi-imager-#{version}.dmg",
+  url "https://github.com/raspberrypi/rpi-imager/releases/download/v#{version}/rpi-imager-v#{version}.dmg",
       verified: "github.com/raspberrypi/rpi-imager/"
   name "Raspberry Pi Imager"
   desc "Imaging utility to install operating systems to a microSD card"
-  homepage "https://www.raspberrypi.org/downloads/"
+  homepage "https://www.raspberrypi.com/software/"
 
   livecheck do
     url :url
     strategy :github_latest
   end
 
+  depends_on macos: ">= :monterey"
+
   app "Raspberry Pi Imager.app"
 
   zap trash: [
     "~/Library/Caches/Raspberry Pi",
-    "~/Library/Preferences/org.raspberrypi.Imager.plist",
-    "~/Library/Saved Application State/org.raspberrypi.imagingutility.savedState",
+    "~/Library/Preferences/com.raspberrypi.Raspberry Pi Imager.plist",
+    "~/Library/Saved Application State/com.raspberrypi.imagingutility.savedState",
   ]
 end


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Update the URL to reflect the new release asset naming convention,
update the homepage URL to the official website, and update the zap
stanza to the correct com.raspberrypi prefix.
