### PR TITLE
langflow 1.6.1

### DIFF
--- a/Casks/l/langflow.rb
+++ b/Casks/l/langflow.rb
@@ -1,9 +1,9 @@
 cask "langflow" do
-  arch arm: "aarch64", intel: "x64"
+  arch arm: "aarch64", intel: "universal"
 
-  version "1.6.0"
-  sha256 arm:   "09a31e36a7eea095a154c5e0eb32be8e8c871c35e126e6e8480973e778b49cd8",
-         intel: "efe1db45fce4ce56e87b28fcec58664f414d60a7b13342be78f263a3ac5eaed8"
+  version "1.6.1,1.6.8"
+  sha256 arm:   "ef5ead899d7d3a9831b1834c3eef7cf801d928ecaf239ecb4fc07eec3745a064",
+         intel: "9d8c7b623bb056fe482d6d2332b69c2414482120183f81784fbe4627fa6c8d20"
 
   url "https://github.com/langflow-ai/langflow/releases/download/#{version.csv.second || version}/Langflow_#{version.csv.first}_#{arch}.dmg",
       verified: "github.com/langflow-ai/langflow/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`langflow` is autobumped but the workflow failed to update to version 1.6.1 because upstream publishes only ARM and universal dmg variants, so there isn't an Intel-only dmg anymore. This updates the version and switches the Intel `arch` value to `universal`.