### PR TITLE
julia-app@lts: update livecheck

### DIFF
--- a/Casks/j/julia-app@lts.rb
+++ b/Casks/j/julia-app@lts.rb
@@ -8,7 +8,7 @@ cask "julia-app@lts" do
   homepage "https://julialang.org/"
 
   livecheck do
-    url "https://julialang.org/downloads/"
+    url "https://julialang.org/downloads/manual-downloads/"
     regex(/\(LTS\)\s+release:\s+v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/j/julia-app@lts.rb
+++ b/Casks/j/julia-app@lts.rb
@@ -12,6 +12,8 @@ cask "julia-app@lts" do
     regex(/\(LTS\)\s+release:\s+v?(\d+(?:\.\d+)+)/i)
   end
 
+  depends_on macos: ">= :sequoia"
+
   app "Julia-#{version.major_minor}.app"
   binary "#{appdir}/Julia-#{version.major_minor}.app/Contents/Resources/julia/bin/julia", target: "julia-lts"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `julia-app@lts` checks the upstream download page but this no longer contains any version information. Instead, this page links to the Manual Downloads page as the place to download specific Julia versions. That page contains the information that the Downloads page used to provide, so this updates the `livecheck` block to check that page instead.