### PR TITLE
elecom-mouse-util 6.1.4

### DIFF
--- a/Casks/e/elecom-mouse-util.rb
+++ b/Casks/e/elecom-mouse-util.rb
@@ -1,6 +1,6 @@
 cask "elecom-mouse-util" do
-  version "6.1.3"
-  sha256 "cc35c22afe696938387762cb8f7bc385a330f6cc9c95a5898e17efbf76538cad"
+  version "6.1.4"
+  sha256 "0863a25fc7edb4fce58734ef4717347dd96b834c837462b67967ea01b179b04b"
 
   url "https://dl.elecom.co.jp/support/download/peripheral/mouse/assistant/mac/ELECOM_MA_Setup_#{version}.zip"
   name "ELECOM Mouse Assistant"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

*Manual bump: livecheck works but autobump hasn't updated*

This cask is marked for autobump, but it hasn't been updated by BrewTestBot since September 2024 despite a new version (6.1.4) being available.

Livecheck correctly detects the new version:
```console
❯ brew livecheck --cask elecom-mouse-util --debug --autobump

Cask:             elecom-mouse-util
livecheck block?: Yes

URL (homepage):   https://www.elecom.co.jp/global/download-list/utility/mouse_assistant/mac/
Strategy:         PageMatch
Regex:            /ELECOM[._-]MA[._-]Setup[._-]v?(\d+(?:\.\d+)+)\.zip/i

Matched Versions:
6.1.4

elecom-mouse-util: 6.1.3 ==> 6.1.4
```

This suggests there may be an issue with the autobump workflow for this cask.