### PR TITLE
Rename epicenter-whispering to whispering

### DIFF
--- a/Casks/w/whispering.rb
+++ b/Casks/w/whispering.rb
@@ -1,4 +1,4 @@
-cask "epicenter-whispering" do
+cask "whispering" do
   arch arm: "aarch64", intel: "x64"
 
   version "7.7.2"
@@ -7,7 +7,7 @@ cask "epicenter-whispering" do
 
   url "https://github.com/epicenter-os/epicenter/releases/download/v#{version}/Whispering_#{version}_#{arch}.dmg",
       verified: "github.com/epicenter-os/epicenter/"
-  name "Epicenter Whispering"
+  name "Whispering"
   desc "Audio transcription that works with local and cloud models"
   homepage "https://whispering.epicenter.so/"
 

--- a/Casks/w/whispering.rb
+++ b/Casks/w/whispering.rb
@@ -8,6 +8,7 @@ cask "whispering" do
   url "https://github.com/epicenter-os/epicenter/releases/download/v#{version}/Whispering_#{version}_#{arch}.dmg",
       verified: "github.com/epicenter-os/epicenter/"
   name "Whispering"
+  name "Epicenter Whispering"
   desc "Audio transcription that works with local and cloud models"
   homepage "https://whispering.epicenter.so/"
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -52,6 +52,7 @@
   "emby-server": "embyserver",
   "enigma": "enigma-game",
   "epilogue-operator": "epilogue-playback",
+  "epicenter-whispering": "whispering",
   "eset-cyber-security-pro": "eset-cyber-security",
   "fetch": "fetch-app",
   "figmadaemon": "figma-agent",


### PR DESCRIPTION
Hi! I'm the maintainer of Whispering.

The product is called "Whispering" (and installs as Whispering.app), so I'd like to rename the cask to match. The epicenter- prefix came from the parent organization (Epicenter) but isn't how users know or search for the app. This also resolves the current inconsistency where users install `epicenter-whispering` but get `Whispering.app`.

The rename mapping ensures existing users can upgrade without issues.