### PR TITLE
Update Valhalla Supermassive to version 5.0.0

### DIFF
--- a/Casks/v/valhalla-supermassive.rb
+++ b/Casks/v/valhalla-supermassive.rb
@@ -1,8 +1,8 @@
 cask "valhalla-supermassive" do
-  version "4.0.0"
-  sha256 "6f64b1401cc788877bc19ad07b1d52039196b268702fdd1f458388b2f9954377"
+  version "5.0.0"
+  sha256 "eaac6d0a24ffed0a02afd1dd06124d12f94716d32a8ac376606aa2d701a70c3e"
 
-  url "https://valhallaproduction.s3.us-west-2.amazonaws.com/supermassive/ValhallaSupermassiveOSX_#{version.dots_to_underscores}v#{version.major}.dmg",
+  url "https://valhallaproduction.s3.us-west-2.amazonaws.com/supermassive/ValhallaSupermassiveOSX_#{version.dots_to_underscores}.dmg",
       verified: "valhallaproduction.s3.us-west-2.amazonaws.com"
   name "Valhalla Supermassive"
   desc "Delay/reverb plugin"
@@ -10,7 +10,7 @@ cask "valhalla-supermassive" do
 
   livecheck do
     url "https://valhalladsp.com/demos-downloads/"
-    regex(/ValhallaSupermassiveOSX[._-]v?(\d+(?:[._]\d+)+)v?\d+\.dmg/i)
+    regex(/ValhallaSupermassiveOSX[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match&.first&.tr("_", ".") }
     end


### PR DESCRIPTION
Note that the v{major} suffix is gone. The current URL is simply:

https://valhallaproduction.s3.us-west-2.amazonaws.com/supermassive/ValhallaSupermassiveOSX_5_0_0.dmg

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
