### PR TITLE
assinador-serpro: update livecheck

### DIFF
--- a/Casks/a/assinador-serpro.rb
+++ b/Casks/a/assinador-serpro.rb
@@ -9,7 +9,7 @@ cask "assinador-serpro" do
 
   livecheck do
     url :homepage
-    regex(/Assinador\sSerpro\s(\d+(?:\.\d+)+)/i)
+    regex(/instalação\s+Mac\s+v?(\d+(?:\.\d+)+)/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `assinador-serpro` checks the homepage but the regex unfortunately matches the version for Windows, so it's reporting 4.3.3 as newest but 4.3.2 is the newest version for macOS. There isn't a 4.3.3 Mac version yet, so autobump is predictably producing an error. This updates the `livecheck` block regex to specifically match the Mac version.

It's also worth mentioning that the page doesn't link to a file for macOS. Instead, it provides a shell command to execute an install script but that runs `brew install` to install this cask. So, we're relying on upstream for new version information but they're relying on the cask to be up to date, which creates a weird loop. I suppose we'll just have to wait and see if this causes issues in the future.