### PR TITLE
Update coherence-x to major version 5

### DIFF
--- a/Casks/c/coherence-x.rb
+++ b/Casks/c/coherence-x.rb
@@ -1,6 +1,6 @@
 cask "coherence-x" do
-  version "4.8"
-  sha256 "a81093b088046713c7faf643543d4bfe5664dd82d1ea7c4ccd85bace7be8eab6"
+  version "5.1.1"
+  sha256 "92b538b69f99563407ddbd375454aa130b3a5ee7d87da839f00ac36a74132ee6"
 
   url "https://bzgdownloads.s3.amazonaws.com/Coherence/Coherence+X+#{version}.zip",
       verified: "bzgdownloads.s3.amazonaws.com/Coherence/"
@@ -14,6 +14,7 @@ cask "coherence-x" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "Coherence X.app"
 


### PR DESCRIPTION
The `livecheck` URL is specific per major version, so it isn't noticing the existence of 5.X versions specified here: https://bzgdownloads.s3.amazonaws.com/Coherence/App+Cast/appcast5.xml

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

```
kerrick@laptop-kerrick-primary homebrew-cask % git log -n1 -p                        
commit e737dd408949b2b1447e446022ba1df5402be2e5 (HEAD -> patch-1, kerrick/patch-1)
Author: Kerrick Long <me@kerricklong.com>
Date:   Fri Nov 28 22:24:06 2025 -0600

    Update coherence-x to major version 5
    
    The `livecheck` URL is specific per major version, so it isn't noticing the existence of 5.X versions specified here: https://bzgdownloads.s3.amazonaws.com/Coherence/App+Cast/appcast5.xml

diff --git a/Casks/c/coherence-x.rb b/Casks/c/coherence-x.rb
index 5c1def54372..db48a909569 100644
--- a/Casks/c/coherence-x.rb
+++ b/Casks/c/coherence-x.rb
@@ -1,6 +1,6 @@
 cask "coherence-x" do
-  version "4.8"
-  sha256 "a81093b088046713c7faf643543d4bfe5664dd82d1ea7c4ccd85bace7be8eab6"
+  version "5.1.1"
+  sha256 "92b538b69f99563407ddbd375454aa130b3a5ee7d87da839f00ac36a74132ee6"
 
   url "https://bzgdownloads.s3.amazonaws.com/Coherence/Coherence+X+#{version}.zip",
       verified: "bzgdownloads.s3.amazonaws.com/Coherence/"
@@ -14,6 +14,7 @@ cask "coherence-x" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "Coherence X.app"
 
kerrick@laptop-kerrick-primary homebrew-cask % brew audit --cask --online coherence-x
==> Downloading and extracting artifacts
==> Downloading https://bzgdownloads.s3.amazonaws.com/Coherence/Coherence+X+5.1.1.zip
Already downloaded: /Users/kerrick/Library/Caches/Homebrew/downloads/266d8a88b5378c28074ff7532f9d267dc4207fb123f24ff530ce57b743f97eca--Coherence+X+5.1.1.zip
==> Downloading https://bzgdownloads.s3.amazonaws.com/Coherence/Coherence+X+5.1.1.zip
Already downloaded: /Users/kerrick/Library/Caches/Homebrew/downloads/266d8a88b5378c28074ff7532f9d267dc4207fb123f24ff530ce57b743f97eca--Coherence+X+5.1.1.zip
kerrick@laptop-kerrick-primary homebrew-cask % brew style --fix coherence-x          

1 file inspected, no offenses detected
```