### PR TITLE
betterandbetter 2.7.3

### DIFF
--- a/Casks/b/betterandbetter.rb
+++ b/Casks/b/betterandbetter.rb
@@ -1,16 +1,23 @@
 cask "betterandbetter" do
-  version "2.7.2,2025112601"
-  sha256 "0252182bf1b222a982500064da02c9e329c4c1e9b12dde6d910ad19df6cbbe5d"
+  version "2.7.3,20251112801"
+  sha256 "5217d3d09b5a682effe712ff1a6cdf14dc224267fd568d7cf4aa2e4e281a5721"
 
   url "https://cdn.better365.cn/BetterAndBetter/#{version.csv.second[0, 4]}/BetterAndBetter_#{version.csv.first}_#{version.csv.second}.zip"
   name "Better And Better"
   desc "Keyboard, mouse and touchpad motion gestures"
   homepage "https://www.better365.cn/bab2.html"
 
+  # The Sparkle item version doesn't always strictly correspond to the number
+  # the file name (i.e. there can be typos), so this matches the version parts
+  # from the file name instead.
   livecheck do
     url "https://www.better365.cn/BetterAndBetterUpdate.xml"
-    strategy :sparkle do |item|
-      "#{item.short_version.strip},#{item.version.strip}"
+    regex(/BetterAndBetter[._-]v?(\d+(?:[._]\d+)+)/i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next unless match
+
+      match[1].tr("_", ",")
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`betterandbetter` is autobumped but the workflow failed to update to version 2.7.3 because the number in the Sparkle item's `version` differs from the number in the file name (i.e., 2025112801 instead of 20251112801). The number are mostly the same with only one extra (or missing) digit in one, so that seems to suggest that this may be a typo and we can't strictly rely on the item `version`. This updates the version and modifies the `livecheck` block to match the version parts from the file name instead, as those are the values that matter when it comes to downloading the zip file.