### PR TITLE
mcloud 4.1.2

### DIFF
--- a/Casks/m/mcloud.rb
+++ b/Casks/m/mcloud.rb
@@ -1,6 +1,6 @@
 cask "mcloud" do
-  version "4.1.1,000"
-  sha256 "3640839b679f5bc8ecb46ba16dc6bfcc64bbed6241f3e0f55cff64c1960be78a"
+  version "4.1.2,000"
+  sha256 "8264af1af868c71310fd58f0a8c2618a69f5ff72b412fd3910e2e567e55362d7"
 
   url "https://yun.mcloud.139.com/mCloudPc/macV#{version.csv.first.no_dots}/mCloud-#{version.csv.first}-#{version.csv.second}.dmg"
   name "mcloud"
@@ -31,4 +31,8 @@ cask "mcloud" do
     "~/Library/Application Support/mCloud",
     "~/Library/Preferences/com.cmic.mcloudForMacOSV2.plist",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mcloud` is autobumped but the workflow failed to update to version 4.1.2 because `brew audit` failed with an "At least one artifact requires Rosetta 2 but this is not indicated by the caveats!" error. The app is Intel-only, so this updates the version and adds a Rosetta caveat.