### PR TITLE
pixel-shift-combiner 1.7.0

### DIFF
--- a/Casks/p/pixel-shift-combiner.rb
+++ b/Casks/p/pixel-shift-combiner.rb
@@ -1,8 +1,8 @@
 cask "pixel-shift-combiner" do
-  version "1.6.0,1060,bbh12c19"
-  sha256 "8095e878942602162d8834b3053a5b75074ba4a41a0d2fd48c28a574460c00af"
+  version "1.7.0,1070,f1127ehf"
+  sha256 "65fe50e8929a0efdf13f599cdce7fb7421d9f59ed54e08a26c2feceab2ca7a15"
 
-  url "https://dl.fujifilm-x.com/support/software/pixel-shift-combiner-mac#{version.csv.second}-#{version.csv.third}/FUJIFILM_PixelShiftCombiner#{version.csv.second}.dmg"
+  url "https://dl.fujifilm-x.com/support/software/pixel-shift-combiner-mac#{version.csv.second}-#{version.csv.third}/FUJIFILM_PixelShiftCombiner#{version.csv.second}.pkg"
   name "Fujifilm Pixel Shift Combiner"
   desc "Tool to tether and combine photos for Fujifilm cameras with IBIS function"
   homepage "https://www.fujifilm-x.com/en-us/support/download/software/pixel-shift-combiner/"
@@ -18,7 +18,10 @@ cask "pixel-shift-combiner" do
     end
   end
 
-  app "Pixel Shift Combiner.app"
+  pkg "FUJIFILM_PixelShiftCombiner#{version.csv.second}.pkg"
+
+  uninstall pkgutil: "com.fujifilm.denji.PIXEL-SHIFT-COMBINER",
+            delete:  "/Applications/Pixel Shift Combiner.app"
 
   zap trash: [
     "~/Library/Application Support/com.fujifilm.denji/*Pixel Shift Combiner",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`pixel-shift-combiner` is autobumped but the workflow failed to update to version 1.7.0 because upstream is now using a pkg file instead of a dmg. This updates the version and adjusts the cask accordingly.