### PR TITLE
sodamusic 2.8.9

### DIFF
--- a/Casks/s/sodamusic.rb
+++ b/Casks/s/sodamusic.rb
@@ -1,8 +1,8 @@
 cask "sodamusic" do
-  version "2.8.8"
-  sha256 "27b518d711d9030fb31938ba02d997a79dbc9e28eeea11b56f4cee8c343b2614"
+  version "2.8.9,262114518"
+  sha256 "7d3bfe970cb9e5801431c4f3c8fb262ec05a24c07e06a019bd207c945a927050"
 
-  url "https://lf-luna-release.qishui.com/obj/luna-release/#{version}/243782093/SodaMusic-v#{version}-official-darwin_universal.dmg",
+  url "https://lf-luna-release.qishui.com/obj/luna-release/#{version.csv.first}/#{version.csv.second}/SodaMusic-v#{version.csv.first}-official-darwin_universal.dmg",
       verified: "lf-luna-release.qishui.com/obj/luna-release/"
   name "SodaMusic"
   name "汽水音乐"
@@ -11,8 +11,12 @@ cask "sodamusic" do
 
   livecheck do
     url "https://is.snssdk.com/service/settings/v3/?caller_name=luna_home_page"
-    strategy :json do |json|
-      json.dig("data", "settings", "pc_download", "version")
+    regex(%r{/v?(\d+(?:\.\d+)*)/SodaMusic[._-]v?(\d+(?:\.\d+)+)}i)
+    strategy :json do |json, regex|
+      match = json.dig("data", "settings", "pc_download", "darwin", "universal", "url")&.match(regex)
+      next unless match
+
+      "#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`sodamusic` is autobumped but the workflow failed to update to version 2.8.9 because the secondary number in the URL changes between versions and the hardcoded number doesn't work. This updates the version and adjusts the `livecheck` block to capture the numbers from the universal dmg file URL, so they are both included in the cask version.