### PR TITLE
youdaonote 8.2.10

### DIFF
--- a/Casks/y/youdaonote.rb
+++ b/Casks/y/youdaonote.rb
@@ -1,9 +1,9 @@
 cask "youdaonote" do
   arch arm: "-arm64"
 
-  version "8.2.2"
-  sha256 arm:   "a906fdf951c4aab22be31eff6d209599bffb2f3c846b6a0f5e5874b3b5e286b5",
-         intel: "0e982186d055b43847018110c92975d096b6df549deda69bf6115bfdc7dee2eb"
+  version "8.2.10"
+  sha256 arm:   "4d36cb5775fe486f1ab0ae907ba4a43babcc007a9fd75c42c87a78063c4a0603",
+         intel: "77347a3a1b2f1a80ee6300e814e050147d761d77c393cdff0cf8989e9653f5fa"
 
   url "https://artifact.lx.netease.com/download/ynote-electron/%E6%9C%89%E9%81%93%E4%BA%91%E7%AC%94%E8%AE%B0-#{version}#{arch}.dmg",
       user_agent: :fake,
@@ -17,8 +17,6 @@ cask "youdaonote" do
     url "https://artifact.lx.netease.com/download/ynote-electron/latest-mac.yml"
     strategy :electron_builder
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "有道云笔记.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`youdaonote` is autobumped but the workflow failed to update to version 8.2.10 because `brew audit` failed with a "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error for both ARM and Intel. I manually verified that the apps pass Gatekeeper now, so this updates the version and removes the `disable!` call.