### PR TITLE
corona-tracker: deprecate

### DIFF
--- a/Casks/c/corona-tracker.rb
+++ b/Casks/c/corona-tracker.rb
@@ -8,6 +8,9 @@ cask "corona-tracker" do
   desc "Coronavirus tracker app with maps and charts"
   homepage "https://coronatracker.samabox.com/"
 
+  deprecate! date: "2025-11-30", because: :discontinued
+  disable! date: "2026-11-30", because: :discontinued
+
   app "Corona Tracker.app"
 
   zap trash: [


### PR DESCRIPTION
corona-tracker: deprecate

<img width="1584" height="479" alt="image" src="https://github.com/user-attachments/assets/7ca1bc53-7400-4ef3-b082-edb6370398db" />
