### PR TITLE
protonvpn 6.1.1

### DIFF
--- a/Casks/p/protonvpn.rb
+++ b/Casks/p/protonvpn.rb
@@ -1,6 +1,6 @@
 cask "protonvpn" do
-  version "6.1.0"
-  sha256 "bbf277d9e220a5092f17cee3e0b73720a4f46242474f1e096ae2fa4ec5e0fe5b"
+  version "6.1.1"
+  sha256 "819228af78dcb7406e20531820e5934fbcf8783ded8ab23e146dd94ae54b1e82"
 
   url "https://vpn.protondownload.com/download/macos/#{version}/ProtonVPN_mac_v#{version}.dmg",
       verified: "vpn.protondownload.com/"
@@ -11,7 +11,7 @@ cask "protonvpn" do
   # The Sparkle feed can contain items on the "beta" channel, so we restrict
   # matching to the default channel.
   livecheck do
-    url "https://protonvpn.com/download/macos/updates/v4/sparkle.xml"
+    url "https://protonvpn.com/download/macos/updates/v5/sparkle.xml"
     strategy :sparkle do |items|
       items.find { |item| item.channel.nil? }&.short_version
     end


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Bump protonvpn to 6.1.1.

Also update livecheck URL.
