### PR TITLE
mjolnir: deprecate

### DIFF
--- a/Casks/m/mjolnir.rb
+++ b/Casks/m/mjolnir.rb
@@ -2,11 +2,13 @@ cask "mjolnir" do
   version "1.0.2"
   sha256 "eb39b9ff76258c3aa7970f70465a7c858290ce798e5b8e411cb5b7d300de16d1"
 
-  url "https://github.com/mjolnirapp/mjolnir/releases/download/#{version}/Mjolnir.app.zip",
-      verified: "github.com/mjolnirapp/mjolnir/"
+  url "https://github.com/mjolnirapp/mjolnir/releases/download/#{version}/Mjolnir.app.zip"
   name "Mjolnir"
   desc "Lightweight automation and productivity app"
-  homepage "https://mjolnir.rocks/"
+  homepage "https://github.com/mjolnirapp/mjolnir"
+
+  deprecate! date: "2025-11-30", because: :unmaintained
+  disable! date: "2026-11-30", because: :unmaintained
 
   app "Mjolnir.app"
 


### PR DESCRIPTION
mjolnir: deprecate

----

- `https://mjolnir.rocks/` is no longer accessible 
- last commit march 14 2021
- last release may 2019