### PR TITLE
pencil: disable

### DIFF
--- a/Casks/p/pencil.rb
+++ b/Casks/p/pencil.rb
@@ -13,7 +13,7 @@ cask "pencil" do
     regex(/href=.*?Pencil[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg/i)
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  disable! date: "2025-11-30", because: :discontinued
 
   app "Pencil.app"
 


### PR DESCRIPTION
cannot download anymore

```
Error: Download failed on Cask 'pencil' with message: Download failed: https://pencil.evolus.vn/dl/V3.1.1.ga/Pencil-3.1.1.ga-universal.dmg
```