### PR TITLE
anydesk: update livecheck

### DIFF
--- a/Casks/a/anydesk.rb
+++ b/Casks/a/anydesk.rb
@@ -7,9 +7,11 @@ cask "anydesk" do
   desc "Allows connection to a computer remotely"
   homepage "https://anydesk.com/"
 
+  # The upstream download page links to the unversioned dmg file but Cloudflare
+  # protections prevent us from fetching it, so it must be checked manually:
+  # https://anydesk.com/en/downloads/mac-os
   livecheck do
-    url "https://anydesk.com/en/downloads/mac-os"
-    regex(/>v(\d+(?:\.\d+)+)[\s<]/i)
+    skip "Cannot be fetched due to Cloudflare protections"
   end
 
   app "AnyDesk.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` block for `anydesk` produces an "Unable to get versions" error because the Cloudflare protections for anydesk.com now prevent us from fetching the page, regardless of user agent or IP address. This sets the `livecheck` block to skip and adds an explanatory comment.

To be clear, I haven't disabled this cask because the dmg file is still accessible (i.e., download.anydesk.com doesn't have the same issue).