### PR TITLE
Update URL for GCC ARM Embedded package

### DIFF
--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -25,7 +25,7 @@ cask "gcc-arm-embedded" do
     end
   end
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
+  url "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"


### PR DESCRIPTION
This is a URL fix for https://github.com/Homebrew/homebrew-cask/issues/238908
**needs to be tested** (I can't test it).
