### PR TITLE
arm-performance-libraries, gcc-aarch64-embedded: update url

### DIFF
--- a/Casks/a/arm-performance-libraries.rb
+++ b/Casks/a/arm-performance-libraries.rb
@@ -3,7 +3,8 @@ cask "arm-performance-libraries" do
   install_suffix="#{version}_flang-20"
   sha256 "f6f69249933e78153bbe31ef9649c8c7cd003a1f4823c252634209f74f62a28c"
 
-  url "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_#{version}/arm-performance-libraries_#{version}_macOS.tgz"
+  url "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_#{version}/arm-performance-libraries_#{version}_macOS.tgz",
+      user_agent: "curl/8.7.1"
   name "Arm Performance Libraries"
   desc "Optimized standard core math libraries for Arm processors"
   homepage "https://developer.arm.com/downloads/-/arm-performance-libraries"

--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -25,7 +25,8 @@ cask "gcc-aarch64-embedded" do
     end
   end
 
-  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg"
+  url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg",
+      user_agent: "curl/8.7.1"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 64-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

developer.arm.com URLs return an HTML challenge page outside of a browser (even if the URL isn't for an HTML page), so related URLs are broken in the `arm-performance-libraries` and `gcc-aarch64-embedded` casks (`gcc-arm-embedded` is being handled in https://github.com/Homebrew/homebrew-cask/pull/238913). This adds a `user_agent` argument to the main cask `url` that uses a generic curl user agent string, as this is the only user agent that works (the default user agent and `:browser`/`:fake` don't work).

The `livecheck` block is also failing but we're not yet able to set the user agent in that context (I have a forthcoming PR for that). I will update related `livecheck` blocks if/when that feature becomes available in the future. For now, I've set this to skip livecheck on CI, so we can merge these changes.