### PR TITLE
kando 2.1.2

### DIFF
--- a/Casks/k/kando.rb
+++ b/Casks/k/kando.rb
@@ -1,15 +1,20 @@
 cask "kando" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.1.1"
-  sha256 arm:   "80ff7a8175f9810f5dfd50803774bcf5723372c7750b803e8c89646e47cc9529",
-         intel: "d97b0bd75373f1c86100fe61be998ff40fe8abaabe3e7dcda2aede5e0b4a8ba4"
+  version "2.1.2"
+  sha256 arm:   "c34f77882badb15e4ed833734e3932473309ec5a2d8a0d9262629352dfe60410",
+         intel: "54cdb6026662466223e85e4b7426cee971a2db2ec10ab295390e70d99a5727b3"
 
   url "https://github.com/kando-menu/kando/releases/download/v#{version}/Kando-#{version}-#{arch}.dmg",
       verified: "github.com/kando-menu/kando/"
   name "Kando"
   desc "Pie menu"
   homepage "https://kando.menu/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kando` is autobumped but the workflow failed to update to version 2.1.2 because there wasn't a related release during the last run. The release exists now but it was created 1.5 hours after the tag was pushed. This updates the cask and adds a `livecheck` block that uses the `GithubLatest` strategy, as there can be a notable gap between tag and release.