### PR TITLE
languagetool-desktop 2.9.3

### DIFF
--- a/Casks/l/languagetool-desktop.rb
+++ b/Casks/l/languagetool-desktop.rb
@@ -1,23 +1,27 @@
 cask "languagetool-desktop" do
-  version "2.9.1"
-  sha256 "026f8c040f8107883b61a964b48743f66486a02977ab94574b326f4627b98b50"
+  version "2.9.3,rc3"
+  sha256 "23fe674714c57f234a02290caea91512a927a2bcb4bd7d9d9a3b014ff6756ee9"
 
-  url "https://languagetool.org/download/mac-app/LanguageToolDesktop-#{version}.dmg"
+  url "https://languagetool.org/download/mac-app/LanguageToolDesktop-#{version.csv.first}#{version.csv.second if version.csv.second}.dmg"
   name "LanguageTool for Desktop"
   desc "Grammar, spelling and style suggestions in all the writing apps"
   homepage "https://languagetool.org/"
 
   # Older items in the Sparkle feed may have a newer pubDate, so it's necessary
-  # to work with all of the items in the feed (not just the newest one).
+  # to work with all of the items (not just the newest one).
   livecheck do
     url "https://languagetool.org/download/mac-app/appcast.xml"
-    regex(/(\d+(?:\.\d+)+)/i)
+    regex(/LanguageToolDesktop[._-]v?(\d+(?:\.\d+)+)(.*)?\.dmg/i)
     strategy :sparkle do |items, regex|
-      # The Sparkle versioning scheme is inconsistent. We check the short
-      # version directly since the versions are not listed chronologically.
-      # The livecheck may need to be reverted to extracting the version from
-      # the url. See: https://github.com/Homebrew/homebrew-cask/pull/156995
-      items.map { |item| item.short_version[regex, 1] }
+      items.filter_map do |item|
+        # Skip items in unstable channels (e.g. `beta`)
+        next unless item.channel.nil?
+
+        match = item.url&.match(regex)
+        next unless match
+
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`languagetool-desktop` is autobumped but the workflow failed to update to version 2.9.3 because the versioned file name uses 2.9.3rc3 as the version. The download page links to the unversioned "latest" dmg and this is the same file as the versioned dmg. The appcast presents the versioned dmg as a 2.9.3 version without any rc3 suffix and this item is in the main Sparkle channel. It seems like this is being presented as a stable version (e.g., maybe upstream didn't feel like creating a copy of the rc3 dmg file just to change the file name).

This updates the version and adjusts the cask to be able to handle this version format in a way that it will be seen as a stable 2.9.3 version. This also modifies the `livecheck` block to handle this by checking the version from the URL, as the `shortVersion` isn't guaranteed to match the version in the file name.