### PR TITLE
oxygen-xml-editor 28.0,2025112606

### DIFF
--- a/Casks/o/oxygen-xml-editor.rb
+++ b/Casks/o/oxygen-xml-editor.rb
@@ -1,8 +1,8 @@
 cask "oxygen-xml-editor" do
-  version "28.0,2025032106"
+  version "28.0,2025112606"
   sha256 :no_check # required as upstream package is updated in-place
 
-  url "https://archives.oxygenxml.com/Oxygen/Editor/InstData#{version.csv.first}/MacOSX/VM/oxygen-openjdk.dmg"
+  url "https://www.oxygenxml.com/InstData/Editor/MacOSX/VM/oxygen-openjdk.dmg"
   name "oXygen XML Editor"
   desc "Tools for XML editing, including Oxygen XML Developer and Author"
   homepage "https://www.oxygenxml.com/xml_editor.html"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`oxygen-xml-editor` is autobumped but the workflow failed to update to version 28.0,2025112606 because the archives.oxygenxml.com server isn't responding. This updates the version and switches to the unversioned dmg file URL that's used on the download page. The download page references the same version in the RSS feed that the `livecheck` block checks and links to the feed, so that seems to imply that this unversioned dmg file and the version in the RSS feed are connected. The RSS feed doesn't link to any files but I think this is probably okay for now.

Related to https://github.com/Homebrew/homebrew-cask/pull/239144.