### PR TITLE
spectrolite 1.1.4

### DIFF
--- a/Casks/s/spectrolite.rb
+++ b/Casks/s/spectrolite.rb
@@ -1,11 +1,11 @@
 cask "spectrolite" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.1.3"
-  sha256 arm:   "5cd5979c31f67c319dc4b056e3f55354c43b87cf54a2a9a3dcca1d25349ffa37",
-         intel: "167d2a2349541deca7c2298430e9c65c7073a37ac7fa56e567305e5b91c43288"
+  version "1.1.4"
+  sha256 arm:   "9ecdc681244fad04acbaca8b8f5d4186643bbf228619a8d1b2588978204ee79f",
+         intel: "402e9c62b574118913bc14f145bac30053585394c505aaa8a0a3c0e9ef66adc9"
 
-  url "https://spectrolite.app/downloads/Spectrolite-#{version}-#{arch}.dmg"
+  url "https://spectrolite.app/downloads/Spectrolite-#{version}-#{arch}.zip"
   name "Spectrolite"
   desc "App for making risograph prints"
   homepage "https://spectrolite.app/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`spectrolite` is autobumped but the workflow failed to update to version 1.1.4 because the dmg file URLs don't resolve for this version. The `latest-mac.yml` file that the `livecheck` block checks instead references zip files, so upstream may not have published versioned dmg files for this version (the upstream download page still links to unversioned dmg files, though). This updates the version and switches the `url` to use a zip file for now (we can always switch back if/when upstream provides versioned dmg files again).