### PR TITLE
visual-paradigm-ce 17.3,20251201

### DIFF
--- a/Casks/v/visual-paradigm-ce.rb
+++ b/Casks/v/visual-paradigm-ce.rb
@@ -1,9 +1,9 @@
 cask "visual-paradigm-ce" do
   arch arm: "AArch64", intel: "WithJRE"
 
-  version "17.3,20251166"
-  sha256 arm:   "4a1a533e2c9fdb92f77a04d45555ede9e6c8f562c114cca560094c7b41465cba",
-         intel: "604df83c88c756d6895ae1fdeb41a6ebe4778ccfaed726eb9ff69d82930ef24b"
+  version "17.3,20251201"
+  sha256 arm:   "aa54a2ef84fbf8064cd98d864119bbf307ce9f78c452288122eec0fe158f1deb",
+         intel: "ae4951c2cc20ec61fdd00ce090bf8330d2158fa354c8756390a2c5f05f049051"
 
   url "https://www.visual-paradigm.com/downloads/vpce/Visual_Paradigm_CE_#{version.csv.first.dots_to_underscores}_#{version.csv.second}_OSX_#{arch}.dmg"
   name "Visual Paradigm Community Edition"
@@ -20,6 +20,8 @@ cask "visual-paradigm-ce" do
       "#{match[1]},#{match[2]}"
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   # Renamed to avoid conflict with visual-paradigm.
   app "Visual Paradigm.app", target: "Visual Paradigm CE.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`visual-paradigm-ce` is autobumped but the workflow failed to update to version 17.3,20251201 because the app is failing Gatekeeper checks again. This updates the version and adds a `disable!` call (again) with the future date we've been using for this scenario.