### PR TITLE
witch 4.7.0

### DIFF
--- a/Casks/w/witch.rb
+++ b/Casks/w/witch.rb
@@ -1,15 +1,25 @@
 cask "witch" do
-  version "4.6.2"
-  sha256 "cb9d946400e00221c72706487ac7ba3760e75a8e0f0e46b26bf9a5da79784b25"
+  version "4.7.0"
+  sha256 "aad6812460df8c670999691e244b111bfad19c2544180093ecf2019ca45cb7fe"
 
   url "https://manytricks.com/download/_do_not_hotlink_/witch#{version.no_dots}.dmg"
   name "Witch"
   desc "Switch apps, windows, or tabs"
   homepage "https://manytricks.com/witch/"
 
+  # The dotless version in the file name uses major/minor/patch but the appcast
+  # `shortVersionString` may omit patch for new major/minor versions (e.g.
+  # 470 and 4.7 respectively). This adds `.0` to versions without a patch to
+  # avoid this mismatch.
   livecheck do
     url "https://manytricks.com/witch/appcast/"
-    strategy :sparkle, &:short_version
+    regex(/^v?(\d+\.\d+)(\.\d+)*$/i)
+    strategy :sparkle do |item, regex|
+      match = item.short_version&.match(regex)
+      next unless match
+
+      "#{match[1]}#{match[2].presence || ".0"}"
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`witch` is autobumped but the workflow failed to update to version 4.7.0 because the dotless version in the file name uses major/minor/patch (470) but the appcast `shortVersionString` only uses major/minor (4.7). This updates the version and modifies the `livecheck` block to add `.0` to the end of the version string if it only includes major/minor (as we do in some other casks in the same situation).