### PR TITLE
Disable auto_updates for OpenCloud

### DIFF
--- a/Casks/o/opencloud.rb
+++ b/Casks/o/opencloud.rb
@@ -15,7 +15,6 @@ cask "opencloud" do
     strategy :github_latest
   end
 
-  auto_updates true
   depends_on macos: ">= :monterey"
 
   pkg "OpenCloud_Desktop-v#{version}-macos-clang-#{arch}.pkg"


### PR DESCRIPTION
OpenCloud Desktop does not have a macOS auto update mechanism (confirmed via Matrix), so removing this attribute in order to allow Homebrew to keep installed versions up to date

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
