### PR TITLE
tinypng4mac 2.2.0

### DIFF
--- a/Casks/t/tinypng4mac.rb
+++ b/Casks/t/tinypng4mac.rb
@@ -12,10 +12,10 @@ cask "tinypng4mac" do
     app "TinyPNG4Mac.app"
   end
   on_ventura :or_newer do
-    version "2.1.0"
-    sha256 "8857dc6cbd6962d52eb2dd61696bcb13bfa397c6077c12def820bc9618c95857"
+    version "2.2.0"
+    sha256 "6284d5678df78ab01d7a9b21cee76acd3753f95a1a2f7ecc999ad1ab0fa3a400"
 
-    url "https://github.com/kyleduo/TinyPNG4Mac/releases/download/v#{version}/Tiny-Image-Installer-#{version.major}0#{version.minor}#{version.patch}0.dmg"
+    url "https://github.com/kyleduo/TinyPNG4Mac/releases/download/v#{version}/Tiny-Image-Installer.dmg"
 
     app "Tiny Image.app"
   end
@@ -23,6 +23,8 @@ cask "tinypng4mac" do
   name "TinyPNG4Mac"
   desc "TinyPNG client"
   homepage "https://github.com/kyleduo/TinyPNG4Mac"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   zap trash: "~/Library/Preferences/com.kyleduo.tinypngmac.plist"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tinypng4mac` is autobumped but the workflow failed to update to version 2.2.0 because the file name for this version is simply `Tiny-Image-Installer.dmg`. This updates the version and `url` accordingly.

Besides that, the app fails `brew audit` due to failing Gatekeeper checks, so this adds a `disable!` call using the future date we've been using for this scenario.