### PR TITLE
athas: add livecheck

### DIFF
--- a/Casks/a/athas.rb
+++ b/Casks/a/athas.rb
@@ -11,6 +11,11 @@ cask "athas" do
   desc "Lightweight code editor"
   homepage "https://athas.dev/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   app "Athas.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `athas` and it is returning 0.2.6 as newest but there is not a corresponding release on GitHub after seven hours. This adds a `livecheck` block that uses the `GithubLatest` strategy, as there can be a notable gap between tag and release.