### PR TITLE
Removed conflicts_with stanza for emacs-app cask (incl. beta / pretest)

### DIFF
--- a/Casks/e/emacs-app.rb
+++ b/Casks/e/emacs-app.rb
@@ -14,11 +14,6 @@ cask "emacs-app" do
     regex(%r{href=.*?/Emacs[._-]v?(\d+(?:\.\d+)*(?:-\d+)?)[._-]universal\.dmg}i)
   end
 
-  conflicts_with cask: [
-    "emacs-app@nightly",
-    "emacs-app@pretest",
-  ]
-
   app "Emacs.app"
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: "emacs"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin-#{arch}/ctags"

--- a/Casks/e/emacs-app@nightly.rb
+++ b/Casks/e/emacs-app@nightly.rb
@@ -20,10 +20,6 @@ cask "emacs-app@nightly" do
     end
   end
 
-  conflicts_with cask: [
-    "emacs-app",
-    "emacs-app@pretest",
-  ]
   depends_on macos: ">= :big_sur"
 
   app "Emacs.app"

--- a/Casks/e/emacs-app@pretest.rb
+++ b/Casks/e/emacs-app@pretest.rb
@@ -14,11 +14,6 @@ cask "emacs-app@pretest" do
     regex(/Emacs[._-]pretest[._-]v?(\d+(?:\.\d+)+)[._-]universal\.dmg/i)
   end
 
-  conflicts_with cask: [
-    "emacs-app",
-    "emacs-app@nightly",
-  ]
-
   app "Emacs.app"
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs", target: "emacs"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin-#{arch}/ctags"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

This RP removes the `conflicts_with`-stanzas from `emacs-app`, `emacs-app@nightly` and `emacs-app@pretest` casks. 
