### PR TITLE
athas 0.2.6

### DIFF
--- a/Casks/a/athas.rb
+++ b/Casks/a/athas.rb
@@ -1,11 +1,11 @@
 cask "athas" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.2.4"
-  sha256 arm:   "d5ef703a008827a5ff2b67bc660b75b65305748b52f312dd9b884c4c18031762",
-         intel: "bdc4a4a797b8293657f9e5138ddb13f6a94b183fe26f4f8ccebf23bbf16cf470"
+  version "0.2.6"
+  sha256 arm:   "7ee67b13f8e6a2656e30d4435e1b9afeb592d25f587a0297f3c21cead7703d05",
+         intel: "909e40c5990b90f98d9feb160d989168e59bedb35ecf94a6d2e14fadf61c181c"
 
-  url "https://github.com/athasdev/athas/releases/download/v#{version}/Athas_#{version}_#{arch}_darwin.dmg",
+  url "https://github.com/athasdev/athas/releases/download/v#{version}/Athas_#{version}_#{arch}.dmg",
       verified: "github.com/athasdev/athas/"
   name "Athas"
   desc "Lightweight code editor"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`athas` is autobumped but the workflow failed to update to version 0.2.6 because the dmg files no longer contain the `_darwin` suffix. This updates the version and adjusts the `url` accordingly.