### PR TITLE
hyperwhisper 2.12.0

### DIFF
--- a/Casks/h/hyperwhisper.rb
+++ b/Casks/h/hyperwhisper.rb
@@ -1,15 +1,21 @@
 cask "hyperwhisper" do
-  version "2.11.0"
-  sha256 "5281f94c01d7366e1eee50cb7ef0157a4e97ff5237c8d5d246358115fe94116f"
+  version "2.12.0"
+  sha256 "a0cb70758f8a2ed310fd2833eb916844aa6ea3ac2ae41a8ed44beb564a4c6341"
 
   url "https://builds.hyperwhisper.com/hyperwhisper-#{version}.dmg"
   name "HyperWhisper"
   desc "AI-powered speech-to-text transcription"
   homepage "https://hyperwhisper.com/"
 
+  # The Sparkle `shortVersionString` may not include the full version used in
+  # the filename (e.g. 2.12 instead of 2.12.0), so we match the version from the
+  # file name instead.
   livecheck do
     url "https://hyperwhisper.com/appcast.xml"
-    strategy :sparkle, &:short_version
+    regex(/hyperwhisper[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :sparkle do |item, regex|
+      item.url[regex, 1]
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`hyperwhisper` is autobumped but the workflow failed to update to version 2.12.0 because the appcast only uses 2.12 as the `shortVersionString` but the filename uses 2.12.0. This updates the version and modifies the `livecheck` block to match the version from the `url` instead.