### PR TITLE
tinypng4mac 2.2.1

### DIFF
--- a/Casks/t/tinypng4mac.rb
+++ b/Casks/t/tinypng4mac.rb
@@ -12,10 +12,23 @@ cask "tinypng4mac" do
     app "TinyPNG4Mac.app"
   end
   on_ventura :or_newer do
-    version "2.2.0"
-    sha256 "6284d5678df78ab01d7a9b21cee76acd3753f95a1a2f7ecc999ad1ab0fa3a400"
+    version "2.2.1,20201"
+    sha256 "d1ce60d76bf178221f0ab81051886b8adcb0856e654a2335a514b8b68a0c5b9c"
 
-    url "https://github.com/kyleduo/TinyPNG4Mac/releases/download/v#{version}/Tiny-Image-Installer.dmg"
+    url "https://github.com/kyleduo/TinyPNG4Mac/releases/download/v#{version.csv.first}/Tiny-Image-Installer#{"-#{version.csv.second}" if version.csv.second}.dmg"
+
+    livecheck do
+      url :url
+      regex(%r{/v?(\d+(?:\.\d+)+)/Tiny-Image-Installer(?:[._-](v?(\d+(?:[._]\d+)*)))?\.dmg}i)
+      strategy :github_latest do |json, regex|
+        json["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+        end
+      end
+    end
 
     app "Tiny Image.app"
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tinypng4mac` is autobumped but the workflow failed to update to version 2.2.1 because upstream has been switching back and forth between including a numeric suffix in the file name (e.g., `Tiny-Image-Installer-20100.dmg`) and omitting it (e.g., `Tiny-Image-Installer.dmg`). This updates the version, adjusts the `url` to handle either scenario, and adds a `livecheck` block that will match the numeric suffix in the file name (if any).

The downside of this approach is that the second part of the version could end up appearing redundant if they switch back to a format like `1_2_3` but I'm not sure if we can reasonably handle both scenarios (i.e., the presence/absence of the suffix and a suffix matching/differing from the tag version). I'm just going to take the simple route for now until that happens.