### PR TITLE
[figma] Remove auto_updates from Figma

### DIFF
--- a/Casks/f/figma.rb
+++ b/Casks/f/figma.rb
@@ -17,8 +17,6 @@ cask "figma" do
     end
   end
 
-  auto_updates true
-
   app "Figma.app"
 
   zap trash: [


### PR DESCRIPTION
Removed auto_updates setting for Figma. 

It seems that Figma.app no longer is doing auto updates? At least on 125.5.x I only had a warning that I need to download a new version.

This might have been a local fluke as well, please check me if possible.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online figma` is error-free.
- [x] `brew style --fix figma` reports no offenses.

---
