### PR TITLE
creality-print 6.3.1.3548

### DIFF
--- a/Casks/c/creality-print.rb
+++ b/Casks/c/creality-print.rb
@@ -1,9 +1,9 @@
 cask "creality-print" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "6.3.0.3420"
-  sha256 arm:   "62cc49b9ad41aa9426f1b8c04cca9b3a04eb8eeb2f420f6ad26762d348fd9bb9",
-         intel: "34e029e963353b3ef453a03b86f4d9719d404b06664a1e3e187be90855e26edd"
+  version "6.3.1.3548"
+  sha256 arm:   "9fc341c3efe3c953a0a6719d5760b5c171119eccaf6a092edfaa602add85c7c0",
+         intel: "e40afe14e2db5ebe8c6d1f22fbe0a1b01547b60f6cfa466f012438f0beed72f4"
 
   url "https://github.com/CrealityOfficial/CrealityPrint/releases/download/v#{version.major_minor_patch}/CrealityPrint-#{version}-macx-#{arch}-Release.dmg",
       verified: "github.com/CrealityOfficial/CrealityPrint/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

For whatever reason, Creality labeled this version as 'pre-release', but it appears to be production ready. Also, there are no comments about it in release notes. So, when we run `brew audit --cask --online <cask>` we get the error `Version '6.3.1.3548' differs from '6.3.0.3420' retrieved by livecheck.` and it fails. 