### PR TITLE
beaver-notes 4.2.0

### DIFF
--- a/Casks/b/beaver-notes.rb
+++ b/Casks/b/beaver-notes.rb
@@ -1,6 +1,6 @@
 cask "beaver-notes" do
-  version "4.1.0"
-  sha256 "b8198b4185c1854acb09cae8e7e29f2a9925a9ee1d1aa6a0b8281d7664b15e94"
+  version "4.2.0"
+  sha256 "adb9fc45a464fd055c90d4fdc87fa1b01a1db0f8ad87a8d28828e0509ed8d093"
 
   url "https://github.com/Beaver-Notes/Beaver-Notes/releases/download/#{version}/Beaver-notes-#{version}-universal.dmg",
       verified: "github.com/Beaver-Notes/Beaver-Notes/"
@@ -8,9 +8,9 @@ cask "beaver-notes" do
   desc "Privacy-focused note-taking app"
   homepage "https://beavernotes.com/"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
-  app "Beaver-notes.app"
+  app "Beaver Notes.app"
 
   zap trash: [
     "~/Library/Caches/com.danielerolli.beaver-notes",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`beaver-notes` is autobumped but the workflow failed to update to version 4.2.0 because the app file name has changed to `Beaver Notes.app`. This updates the version and app name and also adjusts the `depends_on macos:` value to address a related `brew audit` error ("Artifact defined :monterey as the minimum macOS version but the cask declared a depends_on stanza with a minimum macOS version of :big_sur").