### PR TITLE
whichspace 0.5.2

### DIFF
--- a/Casks/w/whichspace.rb
+++ b/Casks/w/whichspace.rb
@@ -1,6 +1,6 @@
 cask "whichspace" do
-  version "0.3.2"
-  sha256 "8a59e12862af491de4c42413c839426c28dcb2f29138bfa2f45529c079119ce8"
+  version "0.5.2"
+  sha256 "c90c7b06b9ad8d5ab0ca667bb0b4e5bfc3f62fa9201f0ef7605a614a9ed0c1c9"
 
   url "https://github.com/gechr/WhichSpace/releases/download/v#{version}/WhichSpace.zip"
   name "WhichSpace"
@@ -10,6 +10,7 @@ cask "whichspace" do
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "WhichSpace.app"
 
@@ -21,8 +22,4 @@ cask "whichspace" do
     "~/Library/Preferences/io.gechr.WhichSpace.plist",
     "~/Library/Saved Application State/io.gechr.WhichSpace.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`whichspace` is autobumped but the workflow failed to update to version 0.5.2 because it's now a universal app and the Rosetta caveat is no longer needed. This updates the version, removes the Rosetta caveat, and also adds a `depends_on macos:` value to address a related `brew audit` error ("Artifact defined :ventura as the minimum macOS version but the cask declared no minimum macOS version").