### PR TITLE
font-jetbrains-maple-mono-nf 1.2304.79

### DIFF
--- a/Casks/font/font-j/font-jetbrains-maple-mono-nf.rb
+++ b/Casks/font/font-j/font-jetbrains-maple-mono-nf.rb
@@ -1,8 +1,8 @@
 cask "font-jetbrains-maple-mono-nf" do
-  version "1.2304.77"
-  sha256 "6448c222b40bcee2ea2240e76c1016deb89e975adf1859ed915eb5964329b3a5"
+  version "1.2304.79"
+  sha256 "58e45ecac4d12c46e7a19747272284ca867b3e44695fa0f2fe186f4f2d031768"
 
-  url "https://github.com/SpaceTimee/Fusion-JetBrainsMapleMono/releases/download/#{version}/JetBrainsMapleMono-NF-XX-XX.zip"
+  url "https://github.com/SpaceTimee/Fusion-JetBrainsMapleMono/releases/download/#{version}/JetBrainsMapleMono-NF-XX-XX-XX.zip"
   name "JetBrains Maple Mono NF"
   homepage "https://github.com/SpaceTimee/Fusion-JetBrainsMapleMono"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`font-jetbrains-maple-mono-nf` is autobumped but the workflow failed to update to 1.2304.79 because upstream uses the file name format to indicate presence/absence of features, so all of the file names change whenever a feature is added/removed.