### PR TITLE
font-jetbrains-maple-mono: update sha256

### DIFF
--- a/Casks/font/font-j/font-jetbrains-maple-mono.rb
+++ b/Casks/font/font-j/font-jetbrains-maple-mono.rb
@@ -1,6 +1,6 @@
 cask "font-jetbrains-maple-mono" do
   version "1.2304.79"
-  sha256 "9443ffc36c835db5587ee9510798a4b7ec5bc27bf7e2c755f731fa25a2d52724"
+  sha256 "c781e9cfad69fd7be1ccc92f3f444b59110b03dba88e0d889fb91c15d029610e"
 
   url "https://github.com/SpaceTimee/Fusion-JetBrainsMapleMono/releases/download/#{version}/JetBrainsMapleMono-XX-XX-XX-XX.zip"
   name "JetBrains Maple Mono"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

While testing an update for `font-jetbrains-maple-mono-nf`, I noticed that the GitHub release assets had a newer publish date than when I updated `font-jetbrains-maple-mono`. This updates the `sha256` for the latter, as the file changed between when I updated that cask to 1.2304.79 and now.