### PR TITLE
sqlitestudio 3.4.18

### DIFF
--- a/Casks/s/sqlitestudio.rb
+++ b/Casks/s/sqlitestudio.rb
@@ -1,12 +1,14 @@
 cask "sqlitestudio" do
-  version "3.4.17"
-  sha256 "72dd8f8cd6f564fbdb07488d977afed5a125e08ea8d649a9756789ee21367ea4"
+  version "3.4.18"
+  sha256 "ff827dd7fbc54e52de53893a9185f3abcb130205a498342f2cdf683c48e67b57"
 
   url "https://github.com/pawelsalawa/sqlitestudio/releases/download/#{version}/sqlitestudio-#{version}-macos-x64.dmg",
       verified: "github.com/pawelsalawa/sqlitestudio/releases/download/"
   name "SQLiteStudio"
   desc "Create, edit, browse SQLite databases"
   homepage "https://sqlitestudio.pl/"
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "SQLiteStudio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`sqlitestudio` is autobumped but the workflow failed to update to version 3.4.18 because `brew audit` failed due to the app failing Gatekeeper checks. This updates the version and adds a `disable!` call with the future date we've been using for this scenario.