### PR TITLE
renamer 7.1.4

### DIFF
--- a/Casks/r/renamer.rb
+++ b/Casks/r/renamer.rb
@@ -8,9 +8,16 @@ cask "renamer" do
   desc "Batch file renamer application"
   homepage "https://renamer.com/"
 
+  # The app checks a `latest-mac.yml` file that was previously published as
+  # part of GitHub releases but the related repository has been removed. The
+  # first-party website doesn't provide any up to date version information (only
+  # older versions), so there doesn't appear to be any available version
+  # information unless/until upstream modifies the app to check a new location.
   livecheck do
-    url "https://github.com/incbee/renamer-7-releases/releases/latest/download/latest-mac.yml"
-    strategy :electron_builder
+    url :url
+    strategy :extract_plist do |items|
+      items["com.incrediblebee.Renamer"]&.short_version
+    end
   end
 
   depends_on macos: ">= :sequoia"

--- a/Casks/r/renamer.rb
+++ b/Casks/r/renamer.rb
@@ -1,9 +1,9 @@
 cask "renamer" do
-  version "7.0.1"
-  sha256 "c8885c4767de9f32407ab721575eee0a1708cd7887ff4bb44ec988c771b3badb"
+  version "7.1.4"
+  sha256 "26dd7262aa5db8e42cb002a65f0d0ae8f359c51a7d95d96caa490e9062b7a722"
 
-  url "https://storage.googleapis.com/incrediblebee/apps/Renamer-#{version.major}/Renamer.zip",
-      verified: "storage.googleapis.com/incrediblebee/"
+  url "https://incredible-bee-honeycomb.fra1.digitaloceanspaces.com/apps/Renamer-#{version.major}/Renamer.zip",
+      verified: "incredible-bee-honeycomb.fra1.digitaloceanspaces.com/"
   name "Renamer"
   desc "Batch file renamer application"
   homepage "https://renamer.com/"


### PR DESCRIPTION
## Summary

- Update version from 7.0.1 to 7.1.4
- Update download URL from Google Cloud Storage to DigitalOcean Spaces

The vendor (Incredible Bee) has moved their download hosting. The old URL returns 404:
- **Old:** `https://storage.googleapis.com/incrediblebee/apps/Renamer-7/Renamer.zip` (404)
- **New:** `https://incredible-bee-honeycomb.fra1.digitaloceanspaces.com/apps/Renamer-7/Renamer.zip` (working)

The new URL is linked from the official download page at https://renamer.com (via redirect from `https://incrediblebee.com/download/renamer-7`).

**Note:** The livecheck URL (`github.com/incbee/renamer-7-releases`) also returns 404. The vendor appears to have removed their GitHub releases repo. This may need a separate fix to find an alternative livecheck source.