### PR TITLE
flowdown 4.1.3

### DIFF
--- a/Casks/f/flowdown.rb
+++ b/Casks/f/flowdown.rb
@@ -1,8 +1,8 @@
 cask "flowdown" do
-  version "4.0.14"
-  sha256 "239f8aeca76f743f5d0efac4fdd26ca5a415a26ebfb938cc4d505f01dd6dc89d"
+  version "4.1.3"
+  sha256 "a56fa3aefcd73c0171ebbd12af3d5c78f2369615110a104ab76a307729121ec0"
 
-  url "https://github.com/Lakr233/FlowDown/releases/download/#{version}/FlowDown.app.zip",
+  url "https://github.com/Lakr233/FlowDown/releases/download/#{version}/FlowDown-#{version}.zip",
       verified: "github.com/Lakr233/FlowDown/"
   name "FlowDown"
   desc "AI agent"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`flowdown` is autobumped but the workflow failed to update to 4.1.3 because the release asset file name is now `FlowDown-4.1.3.zip` (i.e., returning to a versioned file name). Prior to these releases, I opened an [upstream issue](https://github.com/Lakr233/FlowDown/issues/199) to discuss the various release inconsistencies that have been causing problems for us and they introduced an automated release process, so hopefully that will help to keep this consistent going forward.