### PR TITLE
gittyup: update livecheck

### DIFF
--- a/Casks/g/gittyup.rb
+++ b/Casks/g/gittyup.rb
@@ -8,16 +8,24 @@ cask "gittyup" do
   desc "Graphical Git client"
   homepage "https://murmele.github.io/Gittyup/"
 
+  # Upstream macOS builds are broken and the developer doesn't have a macOS
+  # system to fix the issues. This checks multiple releases to identify the
+  # newest version with a dmg asset, either until the upstream situation changes
+  # or there are enough releases without a dmg file to break this check.
   livecheck do
     url :url
     regex(/^Gittyup[._-]v?(\d+(?:\.\d+)+)\.dmg$/i)
-    strategy :github_latest do |json, regex|
-      json["assets"]&.map do |asset|
-        match = asset["name"]&.match(regex)
-        next if match.blank?
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
 
-        match[1]
-      end
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
     end
   end
 

--- a/Casks/g/gittyup.rb
+++ b/Casks/g/gittyup.rb
@@ -29,7 +29,10 @@ cask "gittyup" do
     end
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Gittyup.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `gittyup` uses the `GithubLatest` strategy but it has been producing an `Unable to get versions` error for recent versions because there is no dmg file in the release assets. Upstream has acknowledged that macOS builds are broken but this may not change because they don't have a macOS system to fix the issues.

This addresses the issue by modifying the `livecheck` block to use the `GithubReleases` strategy and match versions with a dmg file. We can reevaluate this when upstream fixes macOS builds or there are enough releases without a dmg file to prevent `GithubReleases` from returning version information (i.e., 30 releases after 1.4.0).