### PR TITLE
leader-key: update urls

### DIFF
--- a/Casks/l/leader-key.rb
+++ b/Casks/l/leader-key.rb
@@ -2,13 +2,13 @@ cask "leader-key" do
   version "1.17.3"
   sha256 "07fabeef4a0704b7568f323389b509d3ff5f79df6f8b59f27abec1174886346f"
 
-  url "https://github.com/mikker/LeaderKey.app/releases/download/v#{version}/Leader.Key.app.zip"
+  url "https://github.com/mikker/LeaderKey/releases/download/v#{version}/Leader.Key.app.zip"
   name "Leader Key"
   desc "Application launcher"
-  homepage "https://github.com/mikker/LeaderKey.app"
+  homepage "https://github.com/mikker/LeaderKey"
 
   livecheck do
-    url "https://mikker.github.io/LeaderKey.app/appcast.xml"
+    url "https://mikker.github.io/LeaderKey/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The GitHub repository for `leader-key` has changed from LeaderKey.app to simply LeaderKey. The homepage and artifact URL redirect but the `livecheck` block produces an "Unable to get versions" error. This updates all of the URLs accordingly which resolves the redirections and fixes the `livecheck` block.