### PR TITLE
moves: update urls

### DIFF
--- a/Casks/m/moves.rb
+++ b/Casks/m/moves.rb
@@ -2,14 +2,14 @@ cask "moves" do
   version "1.8.0"
   sha256 "c1476ffc9835468ed7b4a214521fa046a1be3b7724eaab6085c49f7d6589d376"
 
-  url "https://github.com/mikker/Moves.app/releases/download/v#{version}/Moves.app.zip",
-      verified: "github.com/mikker/Moves.app/"
+  url "https://github.com/mikker/Moves/releases/download/v#{version}/Moves.app.zip",
+      verified: "github.com/mikker/Moves/"
   name "Moves"
   desc "Window manager"
   homepage "https://mikkelmalmberg.com/moves"
 
   livecheck do
-    url "https://mikker.github.io/Moves.app/appcast.xml"
+    url "https://mikker.github.io/Moves/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The GitHub repository for `moves` has changed from Moves.app to simply Moves. The artifact URL redirects but the `livecheck` block produces an "Unable to get versions" error. This updates the `url` to resolve the redirection and updates the `livecheck` block URL to fix the check.