### PR TITLE
gitbutler: re-add binary for CLI tool

### DIFF
--- a/Casks/g/gitbutler.rb
+++ b/Casks/g/gitbutler.rb
@@ -24,6 +24,7 @@ cask "gitbutler" do
   auto_updates true
 
   app "GitButler.app"
+  binary "#{appdir}/GitButler.app/Contents/MacOS/gitbutler-tauri", target: "but"
 
   zap trash: [
     "~/Library/Application Support/com.gitbutler.app",


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

We had this auto-linking before, but then modified the binary name. This is the new binary name to autolink to.