### PR TITLE
qqlive 2.147.0.55363

### DIFF
--- a/Casks/q/qqlive.rb
+++ b/Casks/q/qqlive.rb
@@ -1,6 +1,6 @@
 cask "qqlive" do
-  version "2.144.0.55317"
-  sha256 "0aa986051f7a6225d4a3e9ef18ff442a66d0cbb8b28d597d751881038bf45be1"
+  version "2.147.0.55363"
+  sha256 "4a46585a4cf9ad632920156e16ebb7b533c78dd553486ac76ca7746d926b3ae7"
 
   url "https://dldir1.qq.com/qqtv/mac/TencentVideo#{version}.dmg"
   name "QQLive"
@@ -10,8 +10,13 @@ cask "qqlive" do
   homepage "https://v.qq.com/download.html#mac"
 
   livecheck do
-    url :homepage
-    regex(%r{href=.*/TencentVideo(\d+(?:\.\d+)+)\.dmg}i)
+    url "https://cache.wuji.qq.com/x/api/wuji_cache/object?appid=vqqcom&schemaid=downloadpage_config&schemakey=5dbbd3491a7342ad9bd2ed9bc098484a&filter=isShow%3Dtrue"
+    regex(/TencentVideo[._-]?v?(\d+(?:\.\d+)+)\.dmg/i)
+    strategy :json do |json, regex|
+      json["data"]&.filter_map do |item|
+        item["downloadLink"]&.[](regex, 1)
+      end
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`qqlive` is autobumped but the workflow failed to update to version 2.147.0.55363 because the `livecheck` block produces an "Unable to get versions" error due to the homepage no longer containing version information in the HTML. This updates the version and modifies the `livecheck` block to check the JSON endpoint that the homepage uses to fetch the version information and download URLs. The `schemakey` has remained the same for the past two versions, so hopefully this is a persistent value.