### PR TITLE
second-life-viewer 7.2.3.19375695301

### DIFF
--- a/Casks/s/second-life-viewer.rb
+++ b/Casks/s/second-life-viewer.rb
@@ -1,15 +1,15 @@
 cask "second-life-viewer" do
-  version "7.2.2.18475198968"
-  sha256 "29e649f42cbe15ff5e91a2dff27cac5aebf63e13f1f991ba3de45f46a70b7507"
+  version "7.2.3.19375695301"
+  sha256 "23d34f4747bea9a88432b68572424fc6dc933f37fcc668c3495c641d20113871"
 
-  url "https://viewer-download.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_x86_64.dmg"
+  url "https://viewer-download.secondlife.com/Viewer_#{version.major}/Second_Life_#{version.dots_to_underscores}_universal.dmg"
   name "Linden Lab Second Life Viewer"
   desc "3D browsing software for Second Life online virtual world"
   homepage "https://secondlife.com/"
 
   livecheck do
     url "https://secondlife.com/downloads"
-    regex(/href=.*?Second[._-]Life[._-]v?(\d+(?:[._]\d+)+)(?:[._-]x86_64)?\.dmg/i)
+    regex(/Second[._-]Life[._-]v?(\d+(?:[._]\d+)+)(?:[._-](?:universal|x86_64))?\.dmg/i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
       next if match.blank?


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`second-life-viewer` is autobumped but the workflow failed to update to version  7.2.3.19375695301 because the `livecheck` block is producing an "Unable to get versions" error due to the dmg file name now being found in JavaScript and the file name suffix changing to `_universal`. This updates the version, `url`, and `livecheck` block regex accordingly.