### PR TITLE
thorium: update livecheck

### DIFF
--- a/Casks/t/thorium.rb
+++ b/Casks/t/thorium.rb
@@ -12,19 +12,13 @@ cask "thorium" do
   homepage "https://www.edrlab.org/software/thorium-reader/"
 
   livecheck do
-    url :url
+    url "https://thorium.edrlab.org/en/"
     regex(%r{/v?(\d+(?:\.\d+)+)/Thorium[._-]v?(\d+(?:[.-]\d+)+)#{arch}\.dmg}i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next unless match
 
-        release["assets"]&.map do |asset|
-          match = asset["browser_download_url"]&.match(regex)
-          next if match.blank?
-
-          (match[2] == match[1]) ? match[1] : "#{match[1]},#{match[2]}"
-        end
-      end.flatten
+      (match[2] == match[1]) ? match[1] : "#{match[1]},#{match[2]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `thorium` uses the `GithubReleases` strategy to check for versions but the GitHub API response only contains a few pre-release versions. This may be a temporary bug, as the release pagination on the GitHub website isn't working as expected. That said, the homepage links to a dedicated landing page for Throium and that links to the newest stable dmg files, so we can check that instead (this is preferable over `GithubReleases` anyway).