### PR TITLE
vnc-server: update livecheck

### DIFF
--- a/Casks/v/vnc-server.rb
+++ b/Casks/v/vnc-server.rb
@@ -7,9 +7,11 @@ cask "vnc-server" do
   desc "Remote desktop server application"
   homepage "https://www.realvnc.com/"
 
+  # The upstream download page links to the latest pkg file but Cloudflare
+  # protections prevent us from fetching it, so it must be checked manually:
+  # https://www.realvnc.com/en/connect/download/vnc/macos/
   livecheck do
-    url "https://www.realvnc.com/en/connect/download/vnc/macos/"
-    regex(%r{href=.*?/VNC[._-]Server[._-]v?(\d+(?:\.\d+)*)[._-]MacOSX[._-]universal\.pkg}i)
+    skip "Cannot be fetched due to Cloudflare protections"
   end
 
   pkg "VNC-Server-#{version}-MacOSX-universal.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `vnc-server` is producing an "Unable to get versions" error as the Cloudflare protections now prevent us from fetching the upstream download page. This happens regardless of the user agent or IP address, so this updates the `livecheck` block to skip.