### PR TITLE
warcraft-logs-uploader 8.17.122

### DIFF
--- a/Casks/w/warcraft-logs-uploader.rb
+++ b/Casks/w/warcraft-logs-uploader.rb
@@ -1,6 +1,6 @@
 cask "warcraft-logs-uploader" do
-  version "8.17.115"
-  sha256 "624f1672cda011880dc08283031bbc726d64b2d279f25d2c563b52922a5a1a5b"
+  version "8.17.122"
+  sha256 "04d6e44c96a7e16fc9c82bc2fcca204351a6a93fe536ccd81d88008a1a6933c1"
 
   url "https://github.com/RPGLogs/Uploaders-warcraftlogs/releases/download/v#{version}/warcraftlogs-v#{version}.dmg",
       verified: "github.com/RPGLogs/Uploaders-warcraftlogs/"
@@ -8,9 +8,12 @@ cask "warcraft-logs-uploader" do
   desc "Client to upload warcraft logs"
   homepage "https://classic.warcraftlogs.com/"
 
+  # The download page (https://classic.warcraftlogs.com/client/download) is
+  # inaccessible due to Cloudflare protections, so we check GitHub releases
+  # directly.
   livecheck do
-    url "https://classic.warcraftlogs.com/client/download"
-    regex(%r{.*?/warcraftlogs[._-]v?(\d+(?:\.\d+)+)\.dmg}i)
+    url :url
+    strategy :github_latest
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`warcraft-logs-uploader` is autobumped but the workflow failed to update to version 8.17.122 because the `livecheck` block produces an "Unable to get versions" error. This is because the page is now inaccessible due to Cloudflare protections, regardless of user agent or IP address. This updates the version and modifies the `livecheck` block to use the `GithubLatest` strategy, as the dmg file is a GitHub release asset.