### PR TITLE
wordpresscom-studio 1.6.5

### DIFF
--- a/Casks/w/wordpresscom-studio.rb
+++ b/Casks/w/wordpresscom-studio.rb
@@ -1,24 +1,24 @@
 cask "wordpresscom-studio" do
   arch arm: "arm64", intel: "x64"
+  folder_arch = on_arch_conditional arm: "silicon", intel: "intel"
 
-  version "1.6.3"
-  sha256 arm:   "f151209431e79cb8912714b0598a516be57a2ba3cdbbd7a163c0acf2e6c29f64",
-         intel: "b0fdbdb9aee71ff5b949dd12cb9d5eaaca5ad946cdfb364094523fa4833b1dfe"
+  version "1.6.5,9289"
+  sha256 arm:   "ce788d92802a7c65bbe50cd72ab8b1195d04954b943e35c25931fae64b4314ed",
+         intel: "730bab3ba81e5b2a5a78e7eac329bc067a36432f42bfae9e2ace0a6685d919d6"
 
-  url "https://cdn.a8c-ci.services/studio/studio-darwin-#{arch}-v#{version}.app.zip",
-      verified: "cdn.a8c-ci.services/studio/"
+  url "https://appscdn.wordpress.com/downloads/wordpress-com-studio/mac-#{folder_arch}/v#{version.csv.first}/#{version.csv.second}/update/studio-#{arch}-v#{version.csv.first}.zip"
   name "Wordpress Studio"
   desc "WordPress local development environment"
   homepage "https://developer.wordpress.com/studio/"
 
   livecheck do
     url "https://public-api.wordpress.com/wpcom/v2/studio-app/updates?platform=darwin&arch=#{arch}&version=0.0.0"
-    regex(/studio[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.app\.zip/i)
+    regex(%r{/(\d+(?:\.\d+)*)/update/studio(?:[._-]darwin)?[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)(?:\.app)?\.zip}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)
-      next if match.blank?
+      next unless match
 
-      match[1]
+      "#{match[2]},#{match[1]}"
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wordpresscom-studio` is autobumped but the workflow failed to update to version 1.6.5 because the `livecheck` block produces an "Unable to get versions" error due to the regex not matching the URL in the JSON response. The file name format has changed and the URL path now includes a number that we need to capture in the cask `version`, so this updates the version, `url`, and `livecheck` block accordingly.