### PR TITLE
visual-paradigm-ce 17.3,20251211

### DIFF
--- a/Casks/v/visual-paradigm-ce.rb
+++ b/Casks/v/visual-paradigm-ce.rb
@@ -1,9 +1,9 @@
 cask "visual-paradigm-ce" do
   arch arm: "AArch64", intel: "WithJRE"
 
-  version "17.3,20251203"
-  sha256 arm:   "8ec22d3f24c9145d28ad3c0563bf8f888d8e099823562c3e3fe18463ba462b46",
-         intel: "7822a58f29e2a9fe76c8461b1212dd7099b0bdc5fcb2ef3364acfc67b8c34d11"
+  version "17.3,20251211"
+  sha256 arm:   "3923b1884beb10a5961e27da0a13cf3f2eec322a6b3ea7b75458af3d03b7e901",
+         intel: "da9c71e1dab450fe03bae816d8c6f51689b362b2616757267ae8bf2c26febf61"
 
   url "https://www.visual-paradigm.com/downloads/vpce/Visual_Paradigm_CE_#{version.csv.first.dots_to_underscores}_#{version.csv.second}_OSX_#{arch}.dmg"
   name "Visual Paradigm Community Edition"
@@ -20,6 +20,8 @@ cask "visual-paradigm-ce" do
       "#{match[1]},#{match[2]}"
     end
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   # Renamed to avoid conflict with visual-paradigm.
   app "Visual Paradigm.app", target: "Visual Paradigm CE.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`visual-paradigm-ce` is autobumped but the workflow failed to update to version 17.3,20251211 because the app is failing Gatekeeper checks again. This updates the version and adds a `disable!` call (again) with the future date we've been using for this scenario.