### PR TITLE
claude-code 2.0.62

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -2,11 +2,11 @@ cask "claude-code" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.0.61"
-  sha256 arm:          "b3ed440d3c188d26fbad5a9edf8db2682eff114a22732fa9d3281433a6c9c3eb",
-         x86_64:       "77aea692e7fa2ba49786db6aa8a5bd04297f9781c4ceb81e3495617c9089f2be",
-         x86_64_linux: "5c5686e99180eb0bd0498564e1fa991aa05c4199a08222a15c1563626332e8fc",
-         arm64_linux:  "eb5414c3c73bb4a2d7c99a2e9005f3e0930887e06661c0d70bf3be9ab877f68e"
+  version "2.0.62"
+  sha256 arm:          "0c577a0dad0616ca584ab5f4b6b2004c8921ddb3258ab69ea77ffc1a3ebf56aa",
+         x86_64:       "feefa4aee1b8dd8541cf89915c61eb9873c1e0f7ad71117b6e812eca84a026a3",
+         x86_64_linux: "a95117e1a3d8375c97a74e48ef067f44a926e30e6296b975a0e7fac6b9e999ac",
+         arm64_linux:  "7f297b5208e9c8717be4e28904782f7f8fa113475cfb00266beb3cd0f80ec2a1"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
---
