### PR TITLE
copilot-cli: downgrade to 0.0.367

### DIFF
--- a/Casks/c/copilot-cli.rb
+++ b/Casks/c/copilot-cli.rb
@@ -13,7 +13,6 @@ cask "copilot-cli" do
   desc "Brings the power of Copilot coding agent directly to your terminal"
   homepage "https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli"
 
-  # Use GitHub "latest release" when checking for new versions so prereleases are ignored.
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/c/copilot-cli.rb
+++ b/Casks/c/copilot-cli.rb
@@ -13,6 +13,12 @@ cask "copilot-cli" do
   desc "Brings the power of Copilot coding agent directly to your terminal"
   homepage "https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli"
 
+  # Use GitHub "latest release" when checking for new versions so prereleases are ignored.
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :ventura"
 
   binary "copilot"

--- a/Casks/c/copilot-cli.rb
+++ b/Casks/c/copilot-cli.rb
@@ -2,11 +2,11 @@ cask "copilot-cli" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "0.0.368-1"
-  sha256 arm:          "1ed2eb7b56471c8fb5770b367510e529068e3a6e13efbe8788869bcc0244611a",
-         intel:        "57ab3e1178d8722eeee4b98db704628b729b1b8d7ac2d383f53ee4baf2cc710c",
-         arm64_linux:  "c2a8058cfb9ec8f6d6c83ff702729f32423f904e0027691db9d37587844cfd44",
-         x86_64_linux: "87158e6ae8902d4ed6139f7635751900929b7d3aa6d153ac5aadd1aa6c2bbba7"
+  version "0.0.367"
+  sha256 arm:          "7f40e54c24b96b7e43a82c9b37c01613f643a345b5a137a9e7e05863236a298a",
+         intel:        "7d80f323aa5d247c9a3348f43961d0a849cccf89b3c9a21145f4b8597bf55c28",
+         arm64_linux:  "a9d2642990ab8fc63653b12538e66e03964f46c0de86f390f242a4140b1cf941",
+         x86_64_linux: "5cde2b3a9aea6811ce1e3faf2ce92c0868fd3d6df2e8f94cb7ad54c5a331aaf8"
 
   url "https://github.com/github/copilot-cli/releases/download/v#{version}/copilot-#{os}-#{arch}.tar.gz"
   name "GitHub Copilot CLI"

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -8,7 +8,6 @@
   "chime@alpha": "all",
   "cleartext": "all",
   "comma-chameleon": "all",
-  "copilot-cli": "all",
   "creality-print": "any",
   "crypter": "all",
   "db-browser-for-sqlcipher@nightly": "any",


### PR DESCRIPTION
Currently, pre-release versions of CLI are also pushed to Homebrew, which doesn't look like the right configuration for the general public
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
