### PR TITLE
dockflow 1.58

### DIFF
--- a/Casks/d/dockflow.rb
+++ b/Casks/d/dockflow.rb
@@ -1,8 +1,8 @@
 cask "dockflow" do
-  version "1.57"
-  sha256 "929c38b5e6f52b1596991045a69529d5ecda00f2433049795cd46f1d584668cf"
+  version "1.58"
+  sha256 "11a498f8c3ad9c8f01f8e9c60c25fc9081d0a13299ae10eda9ff31a25a01515f"
 
-  url "https://github.com/AppitStudio/dock-flow-updates/releases/download/V#{version}/DockFlow.dmg",
+  url "https://github.com/AppitStudio/dock-flow-updates/releases/download/v#{version}/DockFlow.dmg",
       verified: "github.com/AppitStudio/"
   name "DockFlow"
   desc "Manage Dock presets and switch between them instantly"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`dockflow` is autobumped but the workflow failed to update to version 1.58 because the tag uses a lowercase "v" for this version. This updates the version and `url` accordingly.

If upstream doesn't stick with a lowercase "v" going forward, I'm just going to make it part of the cask `version` because they've been going back and forth for a few versions now.