### PR TITLE
Lm-studio: add lms CLI binary

### DIFF
--- a/Casks/l/lm-studio.rb
+++ b/Casks/l/lm-studio.rb
@@ -22,6 +22,7 @@ cask "lm-studio" do
   depends_on arch: :arm64
 
   app "LM Studio.app"
+  binary "#{appdir}/LM Studio.app/Contents/Resources/app/.webpack/lms"
 
   uninstall quit: [
     "ai.elementlabs.lmstudio",


### PR DESCRIPTION
Symlink the bundled `lms` CLI tool to PATH.

This allows users to use the LM Studio CLI directly after installing the cask.

See: https://lmstudio.ai/docs/cli
