### PR TITLE
aqua-voice  0.10.11

### DIFF
--- a/Casks/a/aqua-voice.rb
+++ b/Casks/a/aqua-voice.rb
@@ -1,14 +1,9 @@
 cask "aqua-voice" do
   arch arm: "arm64", intel: "x64"
 
-  on_arm do
-    version "0.10.11"
-    sha256 "e2c222c5a6a37d84a0c3e68dbc1845342ff8915b6e68cca0dc2d72511ce2ab15"
-  end
-  on_intel do
-    version "0.10.11"
-    sha256 "a9d53deb4f53ab59f97b264e858215681369765ac199582e8b4d9403ec649445"
-  end
+  version "0.10.11"
+  sha256 arm:   "e2c222c5a6a37d84a0c3e68dbc1845342ff8915b6e68cca0dc2d72511ce2ab15",
+         intel: "a9d53deb4f53ab59f97b264e858215681369765ac199582e8b4d9403ec649445"
 
   url "https://d1a1dx1sgvjqrz.cloudfront.net/aqua-voice-updates/darwin/#{arch}/Aqua+Voice-#{version}-#{arch}.dmg",
       verified: "d1a1dx1sgvjqrz.cloudfront.net/"

--- a/Casks/a/aqua-voice.rb
+++ b/Casks/a/aqua-voice.rb
@@ -2,12 +2,12 @@ cask "aqua-voice" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "0.10.10"
-    sha256 "309fa3d613a2753283701eebe818e2a8469e2adef64105f62c892ee98df7bb67"
+    version "0.10.11"
+    sha256 "e2c222c5a6a37d84a0c3e68dbc1845342ff8915b6e68cca0dc2d72511ce2ab15"
   end
   on_intel do
-    version "0.10.9"
-    sha256 "c86160114b38c2b6a76ba43df9df14df6b17032a1caa1d27b5144f5281bec8c9"
+    version "0.10.11"
+    sha256 "a9d53deb4f53ab59f97b264e858215681369765ac199582e8b4d9403ec649445"
   end
 
   url "https://d1a1dx1sgvjqrz.cloudfront.net/aqua-voice-updates/darwin/#{arch}/Aqua+Voice-#{version}-#{arch}.dmg",


### PR DESCRIPTION
Update aqua-voice cask to version 0.10.11 for both ARM and Intel architectures.