### PR TITLE
Update sha256 checksum for AlDente cask

### DIFF
--- a/Casks/a/aldente.rb
+++ b/Casks/a/aldente.rb
@@ -1,6 +1,6 @@
 cask "aldente" do
   version "1.36.2"
-  sha256 "55e34438d3bbc1a7211a00850f26c7e2d19acf9f319531b5d12febbe6fd2fd37"
+  sha256 "9e909894c23c0d7926412d4742788f7875e4877d4dcbcb039cba0a7b8725cb54"
 
   url "https://apphousekitchen.com/aldente/AlDente#{version}.dmg"
   name "AlDente"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

Dear all,

it seems that the automatic update, picked-up a wrong sha256 hash for the AlDente cask. I have verified, that the sha256 for the file downloaded is 

```bash
curl https://apphousekitchen.com/aldente/AlDente1.36.2.dmg | sha256
9e909894c23c0d7926412d4742788f7875e4877d4dcbcb039cba0a7b8725cb54
```

or 

```bash
brew audit --cask --online AlDente                                                                                                                                           main
==> Downloading and extracting artifacts
==> Downloading https://apphousekitchen.com/aldente/AlDente1.36.2.dmg
Already downloaded: /Users/.../Library/Caches/Homebrew/downloads/d7d334b42cbc2bd0fc4b6bb3e25c4540b37026c916a34659b242977cbc34d173--AlDente1.36.2.dmg
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
audit for aldente: failed
 - exception while auditing aldente: SHA-256 mismatch
Expected: 55e34438d3bbc1a7211a00850f26c7e2d19acf9f319531b5d12febbe6fd2fd37
  Actual: 9e909894c23c0d7926412d4742788f7875e4877d4dcbcb039cba0a7b8725cb54
    File: /Users/.../Library/Caches/Homebrew/downloads/d7d334b42cbc2bd0fc4b6bb3e25c4540b37026c916a34659b242977cbc34d173--AlDente1.36.2.dmg
To retry an incomplete download, remove the file above.
aldente
  * exception while auditing aldente: SHA-256 mismatch
    Expected: 55e34438d3bbc1a7211a00850f26c7e2d19acf9f319531b5d12febbe6fd2fd37
      Actual: 9e909894c23c0d7926412d4742788f7875e4877d4dcbcb039cba0a7b8725cb54
        File: /Users/.../Library/Caches/Homebrew/downloads/d7d334b42cbc2bd0fc4b6bb3e25c4540b37026c916a34659b242977cbc34d173--AlDente1.36.2.dmg
    To retry an incomplete download, remove the file above.
Error: 1 problem in 1 cask detected.
```

How can I manually run that check against my changed version?

Thanks and best regards,
Manuel