### PR TITLE
logitech-options: deprecate, replaced by logi-options+

### DIFF
--- a/Casks/l/logitech-options.rb
+++ b/Casks/l/logitech-options.rb
@@ -42,6 +42,8 @@ cask "logitech-options" do
   desc "Software for Logitech devices"
   homepage "https://support.logitech.com/software/options"
 
+  deprecate! date: "2025-12-12", because: :discontinued, replacement_cask: "logi-options+"
+
   auto_updates true
 
   uninstall launchctl: [


### PR DESCRIPTION
Logitech Options is deprecated - see note at https://support.logi.com/hc/en-us/articles/360025297893-Logitech-Options .  Marking as deprecated.

> Important Notice: Logitech Options has reached end of support and is no longer maintained. For the best experience with your supported Logitech devices, we recommend switching to [Logi Options+](https://www.logitech.com/software/logi-options-plus.html), our next-generation customization software. Our team is here to help you during this transition.

Replacement is available in cask `logi-options+`.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
