### PR TITLE
8bitdo-ultimate-software-v2 1.0.11 (new cask)

### DIFF
--- a/Casks/8/8bitdo-ultimate-software-v2.rb
+++ b/Casks/8/8bitdo-ultimate-software-v2.rb
@@ -8,8 +8,8 @@ cask "8bitdo-ultimate-software-v2" do
   homepage "https://app.8bitdo.com/Ultimate-Software-V2/"
 
   livecheck do
-    url :url
-    regex(/^macOS[._-]V?(\d+(?:\.\d+)+)$/i)
+    url :homepage
+    regex(/href=.*?8BitDo[._-]Ultimate[._-]Software[._-]V2[._-]macOS[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   depends_on macos: ">= :monterey"

--- a/Casks/8/8bitdo-ultimate-software-v2.rb
+++ b/Casks/8/8bitdo-ultimate-software-v2.rb
@@ -3,7 +3,7 @@ cask "8bitdo-ultimate-software-v2" do
   sha256 "a06ed63f5d5917f884e72c41aefbacd829b1fb16646bdcbf448539bf2c185342"
 
   url "https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V#{version}.zip"
-  name "8bitdo-ultimate-software-v2"
+  name "8BitDo Ultimate Software V2"
   desc "Control every piece of your controller"
   homepage "https://app.8bitdo.com/Ultimate-Software-V2/"
 

--- a/Casks/8/8bitdo-ultimate-software-v2.rb
+++ b/Casks/8/8bitdo-ultimate-software-v2.rb
@@ -1,0 +1,23 @@
+cask "8bitdo-ultimate-software-v2" do
+  version "1.0.11"
+  sha256 "a06ed63f5d5917f884e72c41aefbacd829b1fb16646bdcbf448539bf2c185342"
+
+  url "https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V#{version}.zip"
+  name "8bitdo-ultimate-software-v2"
+  desc "Control every piece of your controller"
+  homepage "https://app.8bitdo.com/Ultimate-Software-V2/"
+
+  livecheck do
+    url :url
+    regex(/^macOS[._-]V?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "8BitDo Ultimate Software V2.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.8BitDo.UltimateV2",
+    "~/Library/Caches/com.8BitDo.UltimateV2",
+  ]
+end


### PR DESCRIPTION
Introduces a new Homebrew Cask for 8BitDo Ultimate Software V2 (version 1.0.11)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [X] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
Audit runs into timeout. Need a tip since I don't know how to proceed since this is my first try with creating casks.
```
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.7/bin/bundle 
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromNameLoader): loading 8bitdo-ultimate-software-v2
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromNameLoader): loading 8bitdo-ultimate-software-v2
/usr/bin/env /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.7/bin/ruby -W1 --disable=gems,rubyopt -- /opt/homebrew/Library/Homebrew/utils/rubocop.rb --format json --force-exclusion --extra-details --except FormulaAuditStrict --config /opt/homebrew/Library/.rubocop.yml --cache false /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/8/8bitdo-ultimate-software-v2.rb
==> Auditing Cask 8bitdo-ultimate-software-v2 on os tahoe and arch arm
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromPathLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/8/8bitdo-ultimate-software-v2.rb
==> Auditing minimum macOS version
==> Downloading and extracting artifacts
==> Downloading https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/5.0.5-41-gb14042b\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 26.1\)\ curl/8.7.1 --header Accept-Language:\ en --retry 3 -V
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/5.0.5-41-gb14042b\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 26.1\)\ curl/8.7.1 --header Accept-Language:\ en --retry 3 --fail --location --silent --head https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/5.0.5-41-gb14042b\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 26.1\)\ curl/8.7.1 --header Accept-Language:\ en --retry 3 --fail --location --silent --head --request GET --http1.1 https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
Already downloaded: /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
==> Checking quarantine support
/usr/bin/env /usr/bin/xattr -h
/usr/bin/env /Library/Developer/CommandLineTools/usr/bin/swift -target arm64-apple-macosx26 /opt/homebrew/Library/Homebrew/cask/utils/quarantine.swift
==> Quarantine is available.
==> Verifying Gatekeeper status of /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
/usr/bin/env /usr/bin/xattr -p com.apple.quarantine /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
==> /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip is quarantined
==> Verifying checksum for '3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip'
/usr/bin/env hdiutil imageinfo -format /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
/usr/bin/env zipinfo -1 /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
/usr/bin/env zipinfo -1 /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
==> in unpack_strategy, zip, extract_to_dir, verbose: false
/usr/bin/env plutil -convert xml1 -o - /private/tmp/cask-audit20251212-51985-qtb4m0/8BitDo\ Ultimate\ Software\ V2.app/Contents/Info.plist
==> Detected minimum macOS: monterey (from artifact: monterey)
==> Declared minimum macOS: monterey (from depends_on stanza: monterey)
==> Downloading https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
Already downloaded: /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
==> Verifying Gatekeeper status of /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
/usr/bin/env /usr/bin/xattr -p com.apple.quarantine /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
==> /Users/sascha/Library/Caches/Homebrew/downloads/3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip is quarantined
==> Verifying checksum for '3bb3dfc300762ef57e34cf72a47cbd5788e73c31b65f33080bf6be8d6c455157--8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip'
==> Auditing GitHub prerelease
==> Auditing Forgejo prerelease
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Mozilla/5.0\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10_15_7\)\ AppleWebKit/605.1.15\ \(KHTML,\ like\ Gecko\)\ Version/17.0\ Safari/605.1.15 --header Accept-Language:\ en --connect-timeout 15 --max-time 25 --retry 3 --retry-max-time 25 --dump-header - --output /private/tmp/20251212-51985-b7idwr --location https://app.8bitdo.com/Ultimate-Software-V2/
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/5.0.5-41-gb14042b\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 26.1\)\ curl/8.7.1 --header Accept-Language:\ en --connect-timeout 15 --max-time 25 --retry 3 --retry-max-time 25 --dump-header - --output /private/tmp/20251212-51985-a37quz --location https://download.8bitdo.com/Ultimate-Software/8BitDo_Ultimate_Software_V2_macOS_V1.0.11.zip
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 is not a known invalid value
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/5.0.5-41-gb14042b\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 26.1\)\ curl/8.7.1 --header Accept-Language:\ en --retry 3 -V
==> curl: (28) Operation timed out after 15004 milliseconds with 14749277 out of 44583616 bytes received
/opt/homebrew/Library/Homebrew/utils/curl.rb:186:in 'Utils::Curl#curl_with_workarounds'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:179:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:179:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:121:in 'block in Utils::Curl#create_validator_slow_skip_block_type'
/opt/homebrew/Library/Homebrew/utils/curl.rb:269:in 'Utils::Curl#curl_output'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:179:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:179:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:121:in 'block in Utils::Curl#create_validator_slow_skip_block_type'
/opt/homebrew/Library/Homebrew/livecheck/strategy.rb:258:in 'block in Homebrew::Livecheck::Strategy.page_content'
/opt/homebrew/Library/Homebrew/livecheck/strategy.rb:257:in 'Array#each'
/opt/homebrew/Library/Homebrew/livecheck/strategy.rb:257:in 'Homebrew::Livecheck::Strategy.page_content'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew::Livecheck::Strategy._on_method_added'
/opt/homebrew/Library/Homebrew/livecheck/strategy/page_match.rb:107:in 'Homebrew::Livecheck::Strategy::PageMatch.find_versions'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:179:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:179:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:121:in 'block in Homebrew::Livecheck::Strategy::PageMatch.create_validator_slow_skip_block_type'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:732:in 'block in Homebrew::Livecheck.latest_version'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:662:in 'Array#each'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:662:in 'Enumerable#each_with_index'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:662:in 'Homebrew::Livecheck.latest_version'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew::Livecheck._on_method_added'
/opt/homebrew/Library/Homebrew/cask/audit.rb:763:in 'Cask::Audit#audit_livecheck_version'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Cask::Audit#_on_method_added'
/opt/homebrew/Library/Homebrew/cask/audit.rb:327:in 'Cask::Audit#audit_hosting_with_livecheck'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Cask::Audit#_on_method_added'
/opt/homebrew/Library/Homebrew/cask/audit.rb:94:in 'block in Cask::Audit#run!'
/opt/homebrew/Library/Homebrew/cask/audit.rb:89:in 'Array#each'
/opt/homebrew/Library/Homebrew/cask/audit.rb:89:in 'Cask::Audit#run!'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Cask::Audit#_on_method_added'
/opt/homebrew/Library/Homebrew/cask/auditor.rb:140:in 'Cask::Auditor#audit_cask_instance'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Cask::Auditor#_on_method_added'
/opt/homebrew/Library/Homebrew/cask/auditor.rb:97:in 'Cask::Auditor#audit'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Cask::Auditor#_on_method_added'
/opt/homebrew/Library/Homebrew/cask/auditor.rb:29:in 'Cask::Auditor.audit'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Cask::Auditor._on_method_added'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:273:in 'block (3 levels) in Homebrew::DevCmd::Audit#run'
/opt/homebrew/Library/Homebrew/simulate_system.rb:39:in 'Homebrew::SimulateSystem.with'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew::SimulateSystem._on_method_added'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:270:in 'block (2 levels) in Homebrew::DevCmd::Audit#run'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:267:in 'Array#each'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:267:in 'Enumerable#flat_map'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:267:in 'block in Homebrew::DevCmd::Audit#run'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:264:in 'Array#each'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:264:in 'Enumerable#each_with_object'
/opt/homebrew/Library/Homebrew/dev-cmd/audit.rb:264:in 'Homebrew::DevCmd::Audit#run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12806/lib/types/private/methods/_methods.rb:259:in 'block in Homebrew::DevCmd::Audit#_on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:101:in '<main>'
audit for 8bitdo-ultimate-software-v2: failed
 - exception while auditing 8bitdo-ultimate-software-v2: curl: (28) Operation timed out after 15004 milliseconds with 14749277 out of 44583616 bytes received
8bitdo-ultimate-software-v2
  * exception while auditing 8bitdo-ultimate-software-v2: curl: (28) Operation timed out after 15004 milliseconds with 14749277 out of 44583616 bytes received
Error: 1 problem in 1 cask detected.
```