### PR TITLE
brave-browser@beta: 1.86.113.0 (arm), 1.86.111.0 (intel)

### DIFF
--- a/Casks/b/brave-browser@beta.rb
+++ b/Casks/b/brave-browser@beta.rb
@@ -2,9 +2,14 @@ cask "brave-browser@beta" do
   arch arm: "arm64", intel: "x64"
   folder = on_arch_conditional arm: "beta-arm64", intel: "beta"
 
-  version "1.86.108.0"
-  sha256 arm:   "40f4347d8fab87c8860fd1279b66bbb19b91472cfc3cfc2bf87523fbe4048f5b",
-         intel: "d82bf4935dbe8daa8a0030da5478cc079e829ec7bb6b587c7879381bfc0683f0"
+  on_arm do
+    version "1.86.113.0"
+    sha256 "713f6c87a1a06183e97efcb69f98192fb1f0aba192e1eecfd452880e98f36401"
+  end
+  on_intel do
+    version "1.86.111.0"
+    sha256 "49077b1a1e9afe5db2bce3871343f10891c94bb516e1329aafe0d410c971b284"
+  end
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Browser-Beta-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`brave-browser@beta` is autobumped but the workflow failed to update to version 1.86.113.0 for ARM or 1.86.111.0 for Intel because the versions are now out of sync between archs. This splits the versions by arch, hopefully allowing it to automatically update (until the versions align again).