### PR TITLE
copilot-cli@prerelease 0.0.370-0 (new cask)

### DIFF
--- a/Casks/c/copilot-cli@prerelease.rb
+++ b/Casks/c/copilot-cli@prerelease.rb
@@ -1,0 +1,37 @@
+cask "copilot-cli@prerelease" do
+  arch arm: "arm64", intel: "x64"
+  os macos: "darwin", linux: "linux"
+
+  version "0.0.370-0"
+  sha256 arm:          "c8d6eabdd211fdfd3e71695a95554f2c48311beb2e3929c636ace2a23a63c6de",
+         intel:        "5ed24afd6650b0d32fb422c98decd6a5eb28b4d9f067b9c9392f47003b8706d3",
+         arm64_linux:  "f2149f5d5519bc5b8c4978f6a3e2695937a12aaa5ca27c4bb1b156bc3eae8f19",
+         x86_64_linux: "6ca3a0b553dbb762f150059a65c84e96d30a9d232614d2d13f46655e17a4ba18"
+
+  url "https://github.com/github/copilot-cli/releases/download/v#{version}/copilot-#{os}-#{arch}.tar.gz"
+  name "GitHub Copilot CLI"
+  desc "Brings the power of Copilot coding agent directly to your terminal"
+  homepage "https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  conflicts_with cask: "copilot-cli"
+  depends_on macos: ">= :ventura"
+
+  binary "copilot"
+
+  zap trash: "~/.copilot"
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -8,6 +8,7 @@
   "chime@alpha": "all",
   "cleartext": "all",
   "comma-chameleon": "all",
+  "copilot-cli@prerelease": "any",
   "creality-print": "any",
   "crypter": "all",
   "db-browser-for-sqlcipher@nightly": "any",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This adds a new cask for `copilot-cli` prerelease versions, as [requested by a member of the team working on it](https://github.com/Homebrew/homebrew-cask/pull/240053#issuecomment-3633149767). This allows the pre-release versions to be installed from Homebrew, similar to the existing npm and WinGet methods. After discussion, this shouldn't be a notable burden based on their release schedule (one unstable release per day, one stable release per week) but they're fine with us throttling the cask to keep it manageable if that ever changes.

This cask will update to both pre-release and stable versions, in case there are any changes between the last pre-release and stable release. Those releases sometimes reference the same commit but that's not an indicator that they're the same, as the repository doesn't contain any source code.

This cask will conflict with `copilot-cli` but, if I'm remembering correctly, we will need to add that conflict in a separate PR if/when this is merged.