### PR TITLE
kvirc 5.2.10

### DIFF
--- a/Casks/k/kvirc.rb
+++ b/Casks/k/kvirc.rb
@@ -1,6 +1,6 @@
 cask "kvirc" do
-  version "5.2.8,Quasar"
-  sha256 "649292862994dbba4637b047c4701034b0412b6a919caf483f739eb0c2b4179b"
+  version "5.2.10,Quasar"
+  sha256 "c439697be84fb8dc41b9541f64182bb6ee561ecfd3e5070f1f4be64ca0fe156c"
 
   url "https://github.com/kvirc/KVIrc/releases/download/#{version.csv.first}/KVIrc-#{version.csv.first}-#{version.csv.second}.dmg",
       verified: "github.com/kvirc/KVIrc/"
@@ -27,6 +27,9 @@ cask "kvirc" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
+  depends_on arch: :arm64
+  depends_on macos: ">= :sonoma"
+
   app "KVIrc.app"
 
   zap trash: [
@@ -34,8 +37,4 @@ cask "kvirc" do
     "~/Library/Preferences/com.kvirc.kvirc.plist",
     "~/Library/Saved Application State/com.kvirc.kvirc.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kvirc` is autobumped but the workflow failed to update to version 5.2.10 because `brew audit` failed with a "No artifacts require Rosetta 2 but the caveats say otherwise!" error. It also fails with an "Artifact defined :sonoma as the minimum macOS version but the cask declared no minimum macOS version" error. This updates the version, removes the Rosetta caveat, and adds an appropriate `depends_on macos:` value. Looking at the app, it's only built for Apple Silicon, so this also adds an ARM dependency (though `brew audit` doesn't seem to surface any related issues one way or the other).