### PR TITLE
copilot-cli: add conflict with prerelease cask

### DIFF
--- a/Casks/c/copilot-cli.rb
+++ b/Casks/c/copilot-cli.rb
@@ -18,6 +18,7 @@ cask "copilot-cli" do
     strategy :github_latest
   end
 
+  conflicts_with cask: "copilot-cli@prerelease"
   depends_on macos: ">= :ventura"
 
   binary "copilot"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `copilot-cli@prerelease` cask has been merged (https://github.com/Homebrew/homebrew-cask/pull/240674), so this adds a `conflicts_with cask:` value to align with the conflict in the prerelease cask.