### PR TITLE
claude-code 2.0.69

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -2,11 +2,11 @@ cask "claude-code" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.0.67"
-  sha256 arm:          "4b5709f0b799650445da3df46025f600f6ddcc65f2c9857d2c83eb986c343ff0",
-         x86_64:       "58b5110ebd0a4496f07350829c05b17c7bd0d99c54482db68e6c8ee5b79a840e",
-         x86_64_linux: "b2a12279d5df3814f59000682a571edb771b73e89b4bd894101f01e3726726f3",
-         arm64_linux:  "7ae2baadcb6db64b26d4edb277aafb02a42be82f0da4a193289271852c9a96c8"
+  version "2.0.69"
+  sha256 arm:          "08c35a12f0f29118f42240a19b5836cd39cf3db054c57cd540a9e2d43077bb4e",
+         x86_64:       "c69f584c56eb5c280468d6eb1948b40f21809064b3f6bcd1bf20c5bc142da411",
+         x86_64_linux: "dd9857b0e2c9c0a7a966fb9a92af1c3494e12cf08aaddc441132c41a78902510",
+         arm64_linux:  "ae14d975dca38fb84e6872df622cf1f9f2b7edd2472be11d4e1103a6333eea24"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
same as https://github.com/Homebrew/homebrew-cask/pull/240554, livecheck is broken

upstream report
- https://github.com/anthropics/claude-code/issues/13888