### PR TITLE
digiexam 25.3.67 (new cask)

### DIFF
--- a/Casks/d/digiexam.rb
+++ b/Casks/d/digiexam.rb
@@ -1,0 +1,31 @@
+cask "digiexam" do
+  version "25.3.67"
+  sha256 :no_check
+
+  url "https://www.digiexam.com/hubfs/client/Digiexam_Mac_universal.dmg"
+  name "digiexam"
+  desc "Academic testing platform with device lockdown"
+  homepage "https://www.digiexam.com/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Digiexam.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.digiexam.student",
+    "~/Library/Application Support/Digiexam",
+    "~/Library/Caches/com.digiexam.student",
+    "~/Library/Caches/se.digiexam.DigiExam",
+    "~/Library/Caches/se.digiexam.DigiExam.ShipIt",
+    "~/Library/HTTPStorages/se.digiexam.DigiExam",
+    "~/Library/Logs/com.digiexam.student",
+    "~/Library/Preferences/se.digiexam.DigiExam.plist",
+    "~/Library/WebKit/com.digiexam.student",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This is my first cask, so if I did anything wrong, I'm sorry, and please let me know!
The app does receive updates ~2x per week and sometimes more frequently, is this often enough to warrant using the `:latest` version? I did it without but wanted to ask.
Also, I used `extract_plist` as the livecheck strategy since the app doesn't have any version indicators on the website. The app is also only ~80mb in size as well, so I think it's small enough.