### PR TITLE
Add Comet cask for AI-powered web browser

### DIFF
--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -15,9 +15,12 @@ cask "comet" do
 
   livecheck do
     url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64"
-    strategy :header_match do |headers|
-      match = headers["location"]&.match(%r{/(\d+(?:\.\d+)+)/comet_latest\.dmg}i)
-      match&.captures&.first
+    regex(%r{/(\d+(?:\.\d+)+)/comet_latest\.dmg}i)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next if match.blank?
+
+      match[1]
     end
   end
 

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -3,12 +3,10 @@ cask "comet" do
   sha256 :no_check
 
   on_arm do
-    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64",
-        verified: "perplexity.ai/"
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64"
   end
   on_intel do
-    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_x64",
-        verified: "perplexity.ai/"
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_x64"
   end
 
   name "Comet"
@@ -24,6 +22,7 @@ cask "comet" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Comet.app"
 

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -14,13 +14,9 @@ cask "comet" do
   homepage "https://www.perplexity.ai/comet"
 
   livecheck do
-    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64"
-    regex(%r{/(\d+(?:\.\d+)+)/comet_latest\.dmg}i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
-
-      match[1]
+    url :url
+    strategy :extract_plist do |versions|
+      versions.values.filter_map(&:short_version).first
     end
   end
 

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -1,19 +1,29 @@
 cask "comet" do
-  version :latest
+  version "143.0.7499.33687"
   sha256 :no_check
 
-  url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64",
-      verified: "perplexity.ai/"
+  on_arm do
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64",
+        verified: "perplexity.ai/"
+  end
+  on_intel do
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_x64",
+        verified: "perplexity.ai/"
+  end
+
   name "Comet"
   desc "Web browser with integrated AI assistant"
   homepage "https://www.perplexity.ai/comet"
 
   livecheck do
-    skip "Upstream provides no versioned download artifact"
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64"
+    strategy :header_match do |headers|
+      match = headers["location"]&.match(%r{/(\d+(?:\.\d+)+)/comet_latest\.dmg}i)
+      match&.captures&.first
+    end
   end
 
   auto_updates true
-  depends_on arch: :arm64
 
   app "Comet.app"
 

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -1,0 +1,27 @@
+cask "comet" do
+  version :latest
+  sha256 :no_check
+
+  url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64",
+      verified: "perplexity.ai/"
+  name "Comet"
+  desc "Web browser with integrated AI assistant"
+  homepage "https://www.perplexity.ai/comet"
+
+  livecheck do
+    skip "Upstream provides no versioned download artifact"
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+
+  app "Comet.app"
+
+  zap trash: [
+    "~/Library/Application Support/ai.perplexity.comet",
+    "~/Library/Caches/ai.perplexity.comet",
+    "~/Library/Preferences/ai.perplexity.comet.plist",
+    "~/Library/Saved Application State/ai.perplexity.comet.savedState",
+    "~/Library/WebKit/ai.perplexity.comet",
+  ]
+end


### PR DESCRIPTION
Introduces a new Homebrew cask for Comet, a web browser with integrated AI assistant. The cask supports auto-updates, is limited to arm64 architecture, and includes zap instructions for thorough uninstallation.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
