### PR TITLE
comet 143.0.7499.33687 (new cask)

### DIFF
--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -1,0 +1,35 @@
+cask "comet" do
+  version "143.0.7499.33687"
+  sha256 :no_check
+
+  on_arm do
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64"
+  end
+  on_intel do
+    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_x64"
+  end
+
+  name "Comet"
+  desc "Web browser with integrated AI assistant"
+  homepage "https://www.perplexity.ai/comet"
+
+  livecheck do
+    url :url
+    strategy :extract_plist do |versions|
+      versions.values.filter_map(&:short_version).first
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Comet.app"
+
+  zap trash: [
+    "~/Library/Application Support/ai.perplexity.comet",
+    "~/Library/Caches/ai.perplexity.comet",
+    "~/Library/Preferences/ai.perplexity.comet.plist",
+    "~/Library/Saved Application State/ai.perplexity.comet.savedState",
+    "~/Library/WebKit/ai.perplexity.comet",
+  ]
+end

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -1,11 +1,10 @@
 cask "comet" do
+  arch arm: "arm64", intel: "x64"
+
   version "143.0.7499.33687"
   sha256 :no_check
 
-  arch arm: "arm64", intel: "x64"
-
   url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_#{arch}"
-
   name "Comet"
   desc "Web browser with integrated AI assistant"
   homepage "https://www.perplexity.ai/comet"

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -10,8 +10,10 @@ cask "comet" do
   desc "Web browser with integrated AI assistant"
   homepage "https://www.perplexity.ai/comet"
 
+  livecheck_browser = version.sub(/(\d+)$/) { |match| (match.to_i - 1).to_s }
+
   livecheck do
-    url "https://www.perplexity.ai/rest/browser/update?browser=143.0.7499.33686&channel=stable&platform=mac_#{arch}&machine=0000000000000000000000000000000000000000000000000000000000000000"
+    url "https://www.perplexity.ai/rest/browser/update?browser=#{livecheck_browser}&channel=stable&platform=mac_#{arch}&machine=0000000000000000000000000000000000000000000000000000000000000000"
     strategy :json do |json|
       json.dig("body", "browser_version")
     end

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -2,21 +2,18 @@ cask "comet" do
   version "143.0.7499.33687"
   sha256 :no_check
 
-  on_arm do
-    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64"
-  end
-  on_intel do
-    url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_x64"
-  end
+  arch arm: "arm64", intel: "x64"
+
+  url "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_#{arch}"
 
   name "Comet"
   desc "Web browser with integrated AI assistant"
   homepage "https://www.perplexity.ai/comet"
 
   livecheck do
-    url :url
-    strategy :extract_plist do |versions|
-      versions.values.filter_map(&:short_version).first
+    url "https://www.perplexity.ai/rest/browser/update?browser=143.0.7499.33686&channel=stable&platform=mac_#{arch}&machine=0000000000000000000000000000000000000000000000000000000000000000"
+    strategy :json do |json|
+      json.dig("body", "browser_version")
     end
   end
 

--- a/Casks/c/comet.rb
+++ b/Casks/c/comet.rb
@@ -9,10 +9,8 @@ cask "comet" do
   desc "Web browser with integrated AI assistant"
   homepage "https://www.perplexity.ai/comet"
 
-  livecheck_browser = version.sub(/(\d+)$/) { |match| (match.to_i - 1).to_s }
-
   livecheck do
-    url "https://www.perplexity.ai/rest/browser/update?browser=#{livecheck_browser}&channel=stable&platform=mac_#{arch}&machine=0000000000000000000000000000000000000000000000000000000000000000"
+    url "https://www.perplexity.ai/rest/browser/update?browser=1.1.1.1&channel=stable&platform=mac_#{arch}&machine=0"
     strategy :json do |json|
       json.dig("body", "browser_version")
     end


### PR DESCRIPTION
Introduces a new Homebrew Cask for the Comet web browser with integrated AI assistant, supporting both Apple Silicon and Intel Macs. Includes livecheck, auto-updates, and zap instructions for cleanup.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
