### PR TITLE
glkvm 1.3.0 (new cask)

### DIFF
--- a/Casks/g/glkvm.rb
+++ b/Casks/g/glkvm.rb
@@ -5,10 +5,10 @@ cask "glkvm" do
   url "https://static.gl-inet.com/edge-app/kvm-mac/#{version}-release1/1765244166600/gl-kvm-#{version}.dmg"
   name "GLKVM"
   desc "App for controlling GL.iNet KVM devices"
-  homepage "https://www.gl-inet.com/"
+  homepage "https://www.gl-inet.com/app-rm/"
 
   livecheck do
-    url "https://www.gl-inet.com/app-rm/"
+    url :homepage
     regex(%r{href=.*?/kvm-mac/v?(\d+(?:\.\d+)+)-release\d+/.*?\.dmg}i)
   end
 

--- a/Casks/g/glkvm.rb
+++ b/Casks/g/glkvm.rb
@@ -1,0 +1,25 @@
+cask "glkvm" do
+  version "1.3.0"
+  sha256 "0af45164cda49a10aea78556fd7b5c5655ec84b4d51e72eb177b6169600c877c"
+
+  url "https://static.gl-inet.com/edge-app/kvm-mac/#{version}-release1/1765244166600/gl-kvm-#{version}.dmg"
+  name "glkvm"
+  desc "App for controlling GL.iNet KVM devices"
+  homepage "https://www.gl-inet.com/"
+
+  livecheck do
+    url "https://www.gl-inet.com/app-rm/"
+    regex(%r{href=.*?/kvm-mac/v?(\d+(?:\.\d+)+)-release\d+/.*?\.dmg}i)
+  end
+
+  app "GLKVM.app"
+
+  zap trash: [
+    "~/Library/Application Support/gl-kvm",
+    "~/Library/Logs/gl-kvm",
+  ]
+
+  caveats do
+    requires_rosetta
+  end
+end

--- a/Casks/g/glkvm.rb
+++ b/Casks/g/glkvm.rb
@@ -3,7 +3,7 @@ cask "glkvm" do
   sha256 "0af45164cda49a10aea78556fd7b5c5655ec84b4d51e72eb177b6169600c877c"
 
   url "https://static.gl-inet.com/edge-app/kvm-mac/#{version}-release1/1765244166600/gl-kvm-#{version}.dmg"
-  name "glkvm"
+  name "GLKVM"
   desc "App for controlling GL.iNet KVM devices"
   homepage "https://www.gl-inet.com/"
 

--- a/Casks/g/glkvm.rb
+++ b/Casks/g/glkvm.rb
@@ -1,15 +1,20 @@
 cask "glkvm" do
-  version "1.3.0"
+  version "1.3.0,1765244166600,release1"
   sha256 "0af45164cda49a10aea78556fd7b5c5655ec84b4d51e72eb177b6169600c877c"
 
-  url "https://static.gl-inet.com/edge-app/kvm-mac/#{version}-release1/1765244166600/gl-kvm-#{version}.dmg"
+  url "https://static.gl-inet.com/edge-app/kvm-mac/#{version.csv.first}#{"-#{version.csv.third}" if version.csv.third}/#{version.csv.second}/gl-kvm-#{version.csv.first}.dmg"
   name "GLKVM"
   desc "App for controlling GL.iNet KVM devices"
   homepage "https://www.gl-inet.com/app-rm/"
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/kvm-mac/v?(\d+(?:\.\d+)+)-release\d+/.*?\.dmg}i)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)(?:[._-](release\d*))?/(\d+(?:\.\d+)*)/gl-kvm[^"' >]*\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match[1] ? "#{match[0]},#{match[2]},#{match[1]}" : "#{match[0]},#{match[2]}"
+      end
+    end
   end
 
   app "GLKVM.app"


### PR DESCRIPTION
Adding the GL.iNet KVM app for remote controlling the Comet (GL-RM1 / 2)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
