### PR TITLE
kiro: add auto_updates true and binary

### DIFF
--- a/Casks/k/kiro.rb
+++ b/Casks/k/kiro.rb
@@ -19,9 +19,11 @@ cask "kiro" do
     end
   end
 
+  auto_updates true
   depends_on macos: ">= :big_sur"
 
   app "Kiro.app"
+  binary "#{appdir}/Kiro.app/Contents/Resources/app/bin/code", target: "kiro"
 
   zap trash: [
     "~/Library/Application Support/Kiro",


### PR DESCRIPTION
### Changes
- **Added `auto_updates true`**: Kiro has built-in auto-update functionality. Without this flag, users may experience duplicate updates (once from the app itself and once from `brew upgrade`).
- **Added `binary` stanza**: Kiro installs a `kiro` CLI tool that should be accessible from PATH.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
