### PR TITLE
save-hollywood: add livecheck, undeprecate

### DIFF
--- a/Casks/s/save-hollywood.rb
+++ b/Casks/s/save-hollywood.rb
@@ -7,8 +7,10 @@ cask "save-hollywood" do
   desc "Screen saver for custom video files"
   homepage "http://s.sudre.free.fr/Software/SaveHollywood/about.html"
 
-  deprecate! date: "2024-11-03", because: :unmaintained
-  disable! date: "2025-11-03", because: :unmaintained
+  livecheck do
+    url :homepage
+    regex(/>Version.+(\d+(?:\.\d+)+)[ "<]/i)
+  end
 
   screen_saver "SaveHollywood.saver"
 end

--- a/Casks/s/save-hollywood.rb
+++ b/Casks/s/save-hollywood.rb
@@ -13,4 +13,6 @@ cask "save-hollywood" do
   end
 
   screen_saver "SaveHollywood.saver"
+
+  # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

According to a user report the application is still perfectly functional on the latest software, https://github.com/Homebrew/homebrew-cask/pull/190876#issuecomment-3652323207, and the reason for the original deprecation was not fully accurate. It is also reasonably popular with 1k+ downloads in the last year.
