### PR TITLE
profit 1.0.42

### DIFF
--- a/Casks/p/profit.rb
+++ b/Casks/p/profit.rb
@@ -1,7 +1,7 @@
 cask "profit" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.0.35"
+  version "1.0.42"
   sha256 :no_check
 
   url "https://downloadserver-cdn.nelogica.com.br/content/mac/stable/#{arch}/profit.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`profit` is autobumped but the workflow failed to update to version 1.0.42 because the `livecheck` block URL is arch-specific and the Intel version hadn't been updated when autobump ran. This manually updates the version instead.