### PR TITLE
sfm: add livecheck

### DIFF
--- a/Casks/s/sfm.rb
+++ b/Casks/s/sfm.rb
@@ -8,6 +8,27 @@ cask "sfm" do
   desc "Standalone client for sing-box, the universal proxy platform"
   homepage "https://sing-box.sagernet.org/"
 
+  # Upstream is unable to publish the standalone version of the macOS client, so
+  # we have to temporarily check all releases to find the newest version with an
+  # SFM dmg. TODO: Remove this `livecheck` block or switch to `GithubLatest`
+  # once this is resolved.
+  livecheck do
+    url :url
+    regex(/SFM[._-]v?(\d+(?:\.\d+)+)(?:[._-]universal)?\.dmg/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
+  end
+
   depends_on macos: ">= :ventura"
 
   app "SFM.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The description for the [1.12.13 release](https://github.com/SagerNet/sing-box/releases/tag/v1.12.13) of `sfm` on GitHub mention that upstream is unable to notarize the standalone version of the macOS client and that's required to use system extensions, so they had to temporarily halt its release. The autobump workflow is failing for `sfm` because it's trying to update to 1.12.13 but there isn't a dmg file in the release assets, so this adds a temporary `livecheck` block that uses the `GithubReleases` strategy to identify releases with the dmg file the cask uses. We should remove this (or switch to a simple `GithubLatest` check) if/when this issue is resolved in the future.