### PR TITLE
opencode-desktop 1.0.158

### DIFF
--- a/Casks/o/opencode-desktop.rb
+++ b/Casks/o/opencode-desktop.rb
@@ -1,0 +1,34 @@
+cask "opencode-desktop" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "1.0.158"
+  sha256 arm:   "20b9ebabd73e51fd01b4f44b725acfad243b335e4f3447f470a784fba4fd4701",
+         intel: "69cfbdb2dc2ba771fbc65e7386e8b38c7e1f3164a782d4681f53a92235f5d434"
+
+  url "https://github.com/sst/opencode/releases/download/v#{version}/opencode-desktop-darwin-#{arch}.dmg",
+      verified: "github.com/sst/opencode/"
+  name "OpenCode"
+  desc "AI coding agent desktop client"
+  homepage "https://opencode.ai/"
+
+  livecheck do
+    url "https://github.com/sst/opencode/releases/latest/download/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+
+  app "OpenCode.app"
+
+  zap trash: [
+    "~/Library/Application Support/ai.opencode.desktop",
+    "~/Library/Caches/ai.opencode.desktop",
+    "~/Library/HTTPStorages/ai.opencode.desktop",
+    "~/Library/Logs/ai.opencode.desktop",
+    "~/Library/Preferences/ai.opencode.desktop.plist",
+    "~/Library/Saved Application State/ai.opencode.desktop.savedState",
+    "~/Library/WebKit/ai.opencode.desktop",
+  ]
+end


### PR DESCRIPTION
Add OpenCode Desktop https://opencode.ai/download

👋 Please feel free to edit this if you want, also happy to update it given any feedback

### Token discussion

I'm happy with whatever, doesn't seem to be an obvious good option
  - [`opencode` is already a `homebrew/core` formula](https://github.com/Homebrew/homebrew-core/blob/main/Formula/o/opencode.rb) for the terminal version, so the cask cannot use `opencode` without a conflict, maybe we can have an exception?
  - `opencode-desktop` violates the `brew audit` cask token mentions desktop, maybe we can have an exception?
  - `opencode-app` maybe we could go with this?

### Beta discussion

The desktop software is in public beta but is released alongside the stable versions of OpenCode Terminal.
Perhaps we should put `@beta` I don't really mind.

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online opencode-desktop` is error-free.
- [x] `brew style --fix opencode-desktop` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+opencode-desktop&type=pullrequests).
- [ ] `brew audit --cask --new opencode-desktop` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask opencode-desktop` worked successfully.
- [x] `brew uninstall --cask opencode-desktop` worked successfully.

---

### Command logs

<details>
<summary><code>brew style --fix opencode-desktop</code></summary>

```console
1 file inspected, no offenses detected
```

</details>

<details>
<summary><code>brew audit --cask --online opencode-desktop</code></summary>

```console
==> Downloading and extracting artifacts
==> Downloading https://github.com/sst/opencode/releases/download/v1.0.158/opencode-desktop-darwin-aarch64.dmg
Already downloaded: /Users/connorads/Library/Caches/Homebrew/downloads/8f99415af7c6c26f0a32b7c2d630b879373ab06a1603485f8e41cc3eef8278f9--opencode-desktop-darwin-aarch64.dmg
==> Downloading https://github.com/sst/opencode/releases/download/v1.0.158/opencode-desktop-darwin-aarch64.dmg
Already downloaded: /Users/connorads/Library/Caches/Homebrew/downloads/8f99415af7c6c26f0a32b7c2d630b879373ab06a1603485f8e41cc3eef8278f9--opencode-desktop-darwin-aarch64.dmg
```

</details>

<details>
<summary><code>brew audit --cask --new --online opencode-desktop</code> (fails)</summary>

```console
==> Downloading and extracting artifacts
==> Downloading https://github.com/sst/opencode/releases/download/v1.0.158/opencode-desktop-darwin-aarch64.dmg
Already downloaded: /Users/connorads/Library/Caches/Homebrew/downloads/8f99415af7c6c26f0a32b7c2d630b879373ab06a1603485f8e41cc3eef8278f9--opencode-desktop-darwin-aarch64.dmg
==> Downloading https://github.com/sst/opencode/releases/download/v1.0.158/opencode-desktop-darwin-aarch64.dmg
Already downloaded: /Users/connorads/Library/Caches/Homebrew/downloads/8f99415af7c6c26f0a32b7c2d630b879373ab06a1603485f8e41cc3eef8278f9--opencode-desktop-darwin-aarch64.dmg
Error: 1 problem in 1 cask detected.
audit for opencode-desktop: failed
 - cask token mentions desktop
opencode-desktop
  * cask token mentions desktop
```

</details>

<details>
<summary><code>HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask opencode-desktop</code></summary>

```console
==> Downloading https://github.com/sst/opencode/releases/download/v1.0.158/opencode-desktop-darwin-aarch64.dmg
Already downloaded: /Users/connorads/Library/Caches/Homebrew/downloads/8f99415af7c6c26f0a32b7c2d630b879373ab06a1603485f8e41cc3eef8278f9--opencode-desktop-darwin-aarch64.dmg
==> Installing Cask opencode-desktop
==> Moving App 'OpenCode.app' to '/Applications/OpenCode.app'
🍺  opencode-desktop was successfully installed!
```

</details>

<details>
<summary><code>brew uninstall --cask opencode-desktop</code></summary>

```console
==> Uninstalling Cask opencode-desktop
==> Backing App 'OpenCode.app' up to '/opt/homebrew/Caskroom/opencode-desktop/1.0.158/OpenCode.app'
==> Removing App '/Applications/OpenCode.app'
==> Purging files for version 1.0.158 of Cask opencode-desktop
```

</details>