### PR TITLE
font-noto-(sans|sans-mono|serif)-cjk*: cancel deprecation status since repo becomes active

### DIFF
--- a/Casks/font/font-n/font-noto-sans-cjk-hk.rb
+++ b/Casks/font/font-n/font-noto-sans-cjk-hk.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-cjk-hk" do
   name "Noto Sans CJK HK"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-hk"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-hk"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansCJKhk-Black.otf"
   font "NotoSansCJKhk-Bold.otf"

--- a/Casks/font/font-n/font-noto-sans-cjk-jp.rb
+++ b/Casks/font/font-n/font-noto-sans-cjk-jp.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-cjk-jp" do
   name "Noto Sans CJK JP"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-jp"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-jp"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansCJKjp-Black.otf"
   font "NotoSansCJKjp-Bold.otf"

--- a/Casks/font/font-n/font-noto-sans-cjk-kr.rb
+++ b/Casks/font/font-n/font-noto-sans-cjk-kr.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-cjk-kr" do
   name "Noto Sans CJK KR"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-kr"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-kr"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansCJKkr-Black.otf"
   font "NotoSansCJKkr-Bold.otf"

--- a/Casks/font/font-n/font-noto-sans-cjk-sc.rb
+++ b/Casks/font/font-n/font-noto-sans-cjk-sc.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-cjk-sc" do
   name "Noto Sans CJK SC"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-sc"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-sc"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansCJKsc-Black.otf"
   font "NotoSansCJKsc-Bold.otf"

--- a/Casks/font/font-n/font-noto-sans-cjk-tc.rb
+++ b/Casks/font/font-n/font-noto-sans-cjk-tc.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-cjk-tc" do
   name "Noto Sans CJK TC"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-tc"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-tc"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansCJKtc-Black.otf"
   font "NotoSansCJKtc-Bold.otf"

--- a/Casks/font/font-n/font-noto-sans-cjk.rb
+++ b/Casks/font/font-n/font-noto-sans-cjk.rb
@@ -6,8 +6,11 @@ cask "font-noto-sans-cjk" do
   name "Noto Sans CJK"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued
-  disable! date: "2026-11-22", because: :discontinued
+  livecheck do
+    url :url
+    regex(/^(?:Noto)?Sans[._-]?v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
+  end
 
   font "NotoSansCJK.ttc"
 

--- a/Casks/font/font-n/font-noto-sans-mono-cjk-hk.rb
+++ b/Casks/font/font-n/font-noto-sans-mono-cjk-hk.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-mono-cjk-hk" do
   name "Noto Sans Mono CJK HK"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-hk"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-hk"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansMonoCJKhk-Bold.otf"
   font "NotoSansMonoCJKhk-Regular.otf"

--- a/Casks/font/font-n/font-noto-sans-mono-cjk-jp.rb
+++ b/Casks/font/font-n/font-noto-sans-mono-cjk-jp.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-mono-cjk-jp" do
   name "Noto Sans Mono CJK JP"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-jp"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-jp"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansMonoCJKjp-Bold.otf"
   font "NotoSansMonoCJKjp-Regular.otf"

--- a/Casks/font/font-n/font-noto-sans-mono-cjk-kr.rb
+++ b/Casks/font/font-n/font-noto-sans-mono-cjk-kr.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-mono-cjk-kr" do
   name "Noto Sans Mono CJK KR"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-kr"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-kr"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansMonoCJKkr-Bold.otf"
   font "NotoSansMonoCJKkr-Regular.otf"

--- a/Casks/font/font-n/font-noto-sans-mono-cjk-sc.rb
+++ b/Casks/font/font-n/font-noto-sans-mono-cjk-sc.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-mono-cjk-sc" do
   name "Noto Sans Mono CJK SC"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-sc"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-sc"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansMonoCJKsc-Bold.otf"
   font "NotoSansMonoCJKsc-Regular.otf"

--- a/Casks/font/font-n/font-noto-sans-mono-cjk-tc.rb
+++ b/Casks/font/font-n/font-noto-sans-mono-cjk-tc.rb
@@ -6,8 +6,9 @@ cask "font-noto-sans-mono-cjk-tc" do
   name "Noto Sans Mono CJK TC"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Sans"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-tc"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-tc"
+  livecheck do
+    cask "font-noto-sans-cjk"
+  end
 
   font "NotoSansMonoCJKtc-Bold.otf"
   font "NotoSansMonoCJKtc-Regular.otf"

--- a/Casks/font/font-n/font-noto-serif-cjk-hk.rb
+++ b/Casks/font/font-n/font-noto-serif-cjk-hk.rb
@@ -6,8 +6,9 @@ cask "font-noto-serif-cjk-hk" do
   name "Noto Serif CJK HK"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-hk"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-hk"
+  livecheck do
+    cask "font-noto-serif-cjk"
+  end
 
   font "OTF/TraditionalChineseHK/NotoSerifCJKhk-Bold.otf"
   font "OTF/TraditionalChineseHK/NotoSerifCJKhk-Black.otf"

--- a/Casks/font/font-n/font-noto-serif-cjk-jp.rb
+++ b/Casks/font/font-n/font-noto-serif-cjk-jp.rb
@@ -6,8 +6,9 @@ cask "font-noto-serif-cjk-jp" do
   name "Noto Serif CJK JP"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-jp"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-jp"
+  livecheck do
+    cask "font-noto-serif-cjk"
+  end
 
   font "OTF/Japanese/NotoSerifCJKjp-Black.otf"
   font "OTF/Japanese/NotoSerifCJKjp-Bold.otf"

--- a/Casks/font/font-n/font-noto-serif-cjk-kr.rb
+++ b/Casks/font/font-n/font-noto-serif-cjk-kr.rb
@@ -6,8 +6,9 @@ cask "font-noto-serif-cjk-kr" do
   name "Noto Serif CJK KR"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-kr"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-kr"
+  livecheck do
+    cask "font-noto-serif-cjk"
+  end
 
   font "OTF/Korean/NotoSerifCJKkr-Black.otf"
   font "OTF/Korean/NotoSerifCJKkr-Bold.otf"

--- a/Casks/font/font-n/font-noto-serif-cjk-sc.rb
+++ b/Casks/font/font-n/font-noto-serif-cjk-sc.rb
@@ -6,8 +6,9 @@ cask "font-noto-serif-cjk-sc" do
   name "Noto Serif CJK SC"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-sc"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-sc"
+  livecheck do
+    cask "font-noto-serif-cjk"
+  end
 
   font "OTF/SimplifiedChinese/NotoSerifCJKsc-Black.otf"
   font "OTF/SimplifiedChinese/NotoSerifCJKsc-Bold.otf"

--- a/Casks/font/font-n/font-noto-serif-cjk-tc.rb
+++ b/Casks/font/font-n/font-noto-serif-cjk-tc.rb
@@ -6,8 +6,9 @@ cask "font-noto-serif-cjk-tc" do
   name "Noto Serif CJK TC"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
-  deprecate! date: "2025-11-22", because: :discontinued, replacement_cask: "font-noto-sans-tc"
-  disable! date: "2026-11-22", because: :discontinued, replacement_cask: "font-noto-sans-tc"
+  livecheck do
+    cask "font-noto-serif-cjk"
+  end
 
   font "OTF/TraditionalChinese/NotoSerifCJKtc-Black.otf"
   font "OTF/TraditionalChinese/NotoSerifCJKtc-Bold.otf"

--- a/Casks/font/font-n/font-noto-serif-cjk.rb
+++ b/Casks/font/font-n/font-noto-serif-cjk.rb
@@ -6,8 +6,11 @@ cask "font-noto-serif-cjk" do
   name "Noto Serif CJK"
   homepage "https://github.com/notofonts/noto-cjk/tree/main/Serif"
 
-  deprecate! date: "2025-11-22", because: :discontinued
-  disable! date: "2026-11-22", because: :discontinued
+  livecheck do
+    url :url
+    regex(/^Serif[._-]?v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
+  end
 
   font "NotoSerifCJK.ttc"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The relevant casks were deprecated in https://github.com/Homebrew/homebrew-cask/pull/237834 since the repo (https://github.com/notofonts/noto-cjk) was archived. However this repo became active again recently, so we canceled the deprecation status.
