### PR TITLE
fix: Updating sqlcl Cask so we have a latest link to add to the PATH.

### DIFF
--- a/Casks/s/sqlcl.rb
+++ b/Casks/s/sqlcl.rb
@@ -12,7 +12,10 @@ cask "sqlcl" do
     regex(/href=.*?sqlcl[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  # Runs after the staging of the zip file
+  depends_on formula: "openjdk@11"
+
+  stage_only true
+
   postflight do
     cask_dir   = Pathname("#{HOMEBREW_PREFIX}/Caskroom/sqlcl")
     version_dir = cask_dir/version
@@ -23,12 +26,12 @@ cask "sqlcl" do
     latest_dir.make_symlink(version_dir)
   end
 
-  stage_only true
-
   zap trash: "~/.sqlcl"
 
-  caveats do
-    depends_on_java "11+"
-    path_environment_variable "#{staged_path}/sqlcl/bin"
-  end
+  caveats <<~EOS
+    sqlcl requires Java 11+. The OpenJDK dependency will be installed automatically.
+    
+    To use sqlcl, add the following to your PATH:
+      #{staged_path}/sqlcl/bin
+  EOS
 end

--- a/Casks/s/sqlcl.rb
+++ b/Casks/s/sqlcl.rb
@@ -12,6 +12,17 @@ cask "sqlcl" do
     regex(/href=.*?sqlcl[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
+  # Runs after the staging of the zip file
+  postflight do
+    cask_dir   = Pathname("#{HOMEBREW_PREFIX}/Caskroom/sqlcl")
+    version_dir = cask_dir/version
+    latest_dir  = cask_dir/"latest"
+
+    latest_dir.delete if latest_dir.symlink?
+
+    latest_dir.make_symlink(version_dir)
+  end
+
   stage_only true
 
   zap trash: "~/.sqlcl"


### PR DESCRIPTION
this way, once the path is set, all updates via brew will refresh the link and point to the proper release. @elhanafimohammedamine put this change together for us

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X ] `brew audit --cask --online <cask>` is error-free.
- [X ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
