### PR TITLE
defguard-client: deprecate

### DIFF
--- a/Casks/d/defguard-client.rb
+++ b/Casks/d/defguard-client.rb
@@ -10,10 +10,7 @@ cask "defguard-client" do
   desc "WireGuard VPN client which supports multi-factor authentication"
   homepage "https://github.com/defguard/client"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
+  deprecate! date: "2025-12-16", because: :moved_to_mas
 
   pkg "defguard-#{arch}-apple-darwin-#{version}.pkg"
 


### PR DESCRIPTION
This PR removes the defguard-client cask from Homebrew.

Historically, we distributed the macOS version of defguard-client via a signed .pkg installer. We have since changed our distribution strategy and are now shipping the application through the Apple App Store, which is our current and preferred distribution channel for macOS.

While we are not permanently dropping support for .pkg installers, maintaining and updating the existing .pkg artifact is no longer a priority for the project. As a result, we are currently unable to reliably update the package referenced by this cask.

Keeping an outdated or unmaintained cask in Homebrew is undesirable, as it may lead to broken installs or confusion for users. For this reason, we believe removing the cask is the correct and responsible choice at this time.

We may revisit standalone .pkg distribution in the future, and if so, we will reintroduce Homebrew support once we can properly maintain and update the installer again.


