### PR TITLE
Revert "Use :curl user agent instead of string"

### DIFF
--- a/Casks/a/arm-performance-libraries.rb
+++ b/Casks/a/arm-performance-libraries.rb
@@ -4,7 +4,7 @@ cask "arm-performance-libraries" do
   sha256 "f6f69249933e78153bbe31ef9649c8c7cd003a1f4823c252634209f74f62a28c"
 
   url "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_#{version}/arm-performance-libraries_#{version}_macOS.tgz",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "Arm Performance Libraries"
   desc "Optimized standard core math libraries for Arm processors"
   homepage "https://developer.arm.com/downloads/-/arm-performance-libraries"

--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -26,7 +26,7 @@ cask "gcc-aarch64-embedded" do
   end
 
   url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-aarch64-none-elf.pkg",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 64-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"

--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -26,7 +26,7 @@ cask "gcc-arm-embedded" do
   end
 
   url "https://developer.arm.com/-/media/Files/downloads/gnu/#{version}/binrel/arm-gnu-toolchain-#{version}-darwin-#{arch}-arm-none-eabi.pkg",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "GCC ARM Embedded"
   desc "Pre-built GNU bare-metal toolchain for 32-bit Arm processors"
   homepage "https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain"

--- a/Casks/m/mysql-shell.rb
+++ b/Casks/m/mysql-shell.rb
@@ -33,7 +33,7 @@ cask "mysql-shell" do
            intel: "25c7da7e1d314fb7aa6da410018d7b28d004ea8739bb8465f7e902c0726055c5"
 
     url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg",
-        user_agent: :curl
+        user_agent: "curl/8.7.1"
 
     livecheck do
       url "https://dev.mysql.com/downloads/shell/?tpl=platform&os=33"

--- a/Casks/t/tableau-prep.rb
+++ b/Casks/t/tableau-prep.rb
@@ -6,7 +6,7 @@ cask "tableau-prep" do
          intel: "fefe56d3a56732ca8920bdf81dceaac672b1071683bd9a6780c46b74b2b5447b"
 
   url "https://downloads.tableau.com/esdalt/tableau_prep/#{version}/TableauPrep-#{version.dots_to_hyphens}#{arch}.dmg",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "Tableau Prep"
   name "Tableau Prep Builder"
   desc "Combine, shape, and clean your data for analysis"

--- a/Casks/t/tableau-public.rb
+++ b/Casks/t/tableau-public.rb
@@ -6,7 +6,7 @@ cask "tableau-public" do
          intel: "28d05ddde1d46c70684cecc85dfd7ff3d09bfb63b53b0e4e4b8088d646c716bb"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauPublic-#{version.dots_to_hyphens}#{arch}.pkg",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "Tableau Public"
   desc "Explore, create and publicly share data visualisations online"
   homepage "https://public.tableau.com/s/"

--- a/Casks/t/tableau-reader.rb
+++ b/Casks/t/tableau-reader.rb
@@ -6,7 +6,7 @@ cask "tableau-reader" do
          intel: "d7a64c8dfa1d4cec474509b933ea99b33a90fbf0010bc616ce89dde8f4900201"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauReader-#{version.dots_to_hyphens}#{arch}.pkg",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "Tableau Reader"
   desc "Open and interact with data visualisations built in Tableau Desktop"
   homepage "https://www.tableau.com/products/reader"

--- a/Casks/t/tableau.rb
+++ b/Casks/t/tableau.rb
@@ -6,7 +6,7 @@ cask "tableau" do
          intel: "0e8be0b546ad246348956d7bc698c56d59eabd069e8bd7ecae648323bad69095"
 
   url "https://downloads.tableau.com/esdalt/#{version}/TableauDesktop-#{version.dots_to_hyphens}#{arch}.dmg",
-      user_agent: :curl
+      user_agent: "curl/8.7.1"
   name "Tableau Desktop"
   desc "Data visualization software"
   homepage "https://www.tableau.com/products/desktop"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I didn't think that we would have to wait for the next brew release before [updating curl `user_agent` strings to `:curl`](https://github.com/Homebrew/homebrew-cask/pull/241189) but that appears to be the case (https://github.com/Homebrew/homebrew-cask/issues/241342). The existing code in `curl_args` to enforce correct arguments doesn't support `:curl`, so it predictably raises an error. This reverts the changes for now and I will resubmit them after the next brew release.

I'm running this as syntax-only for the sake of being gentle on CI, as we already know that this works with/without these changes.

Fixes #241342.