### PR TITLE
active-trader-pro: deprecate

### DIFF
--- a/Casks/a/active-trader-pro.rb
+++ b/Casks/a/active-trader-pro.rb
@@ -7,16 +7,17 @@ cask "active-trader-pro" do
   desc "Trading platform"
   homepage "https://www.fidelity.com/trading/advanced-trading-tools/active-trader-pro/overview"
 
-  livecheck do
-    url "https://www.fidelity.com/webcontent/CodeweaverUpgradeInfo/activetrader-mac.xml"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-12-17", because: :discontinued
+  disable! date: "2026-12-17", because: :discontinued
+
+  auto_updates true
 
   app "Active Trader Pro.app"
 
   uninstall quit: "com.fmr.activetrader"
 
   zap trash: [
+    "~/Documents/ATP-*.log",
     "~/Library/Application Support/Active Trader Pro",
     "~/Library/HTTPStorages/com.fmr.activetrader",
     "~/Library/HTTPStorages/com.fmr.activetrader.binarycookies",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Deprecates the `active-trader-pro` cask, as it has been superceded by a new app and is unmaintained. The app also fails the macOS gatekeeper check, as mentioned in a comment in the file.
Also updates `zap` and `auto_updates` stanzas to further maintain the cask, addressing issue #170994.