### PR TITLE
various: update livecheck to fix offenses

### DIFF
--- a/Casks/c/cursor-cli.rb
+++ b/Casks/c/cursor-cli.rb
@@ -12,7 +12,7 @@ cask "cursor-cli" do
 
   livecheck do
     url "https://cursor.com/install"
-    regex(%r{downloads\.cursor\.com/lab/v?(\d+(?:\.\d+)+(?:[._-]\h+)?)/})
+    regex(%r{downloads\.cursor\.com/lab/v?(\d+(?:\.\d+)+(?:[._-]\h+)?)/}i)
   end
 
   binary "#{staged_path}/dist-package/cursor-agent", target: "cursor-agent"

--- a/Casks/m/mozregression-gui.rb
+++ b/Casks/m/mozregression-gui.rb
@@ -9,6 +9,7 @@ cask "mozregression-gui" do
   homepage "https://mozilla.github.io/mozregression/"
 
   livecheck do
+    url :url
     strategy :github_latest
   end
 

--- a/Casks/w/wechatwebdevtools.rb
+++ b/Casks/w/wechatwebdevtools.rb
@@ -12,8 +12,8 @@ cask "wechatwebdevtools" do
   homepage "https://developers.weixin.qq.com/miniprogram/dev/devtools/download.html"
 
   livecheck do
-    url "https://developers.weixin.qq.com/miniprogram/dev/devtools/download.html"
-    regex(%r{Stable\s*Build\s*</a>\s*\(v?(\d+(?:\.\d+)+)[) ]}i)
+    url :homepage
+    regex(%r{Stable\s*Build\s*</a>\s*\(v?(\d+(?:\.\d+)+)[)\s]}i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This addresses various `livecheck` block offenses that would be normally be caught by `brew audit` except that the related audits only apply to formulae for now (I have some in-progress work to extend it to casks but it needs just a little bit more to cross the finish line). Namely:

* `cursor-cli`: Regexes should be case-insensitive unless sensitivity is explicitly required for proper matching.
* `mozregression-gui`: A `url` should be provided when `regex` or `strategy` are used.
* `wechatwebdevtools`: Use `url :homepage`

`qianwen` also has some issues but I'll be handling that separately, as my changes are a little more involved.