### PR TITLE
bitrix24: add auto_updates, fix depends_on and zap

### DIFF
--- a/Casks/b/bitrix24.rb
+++ b/Casks/b/bitrix24.rb
@@ -1,13 +1,13 @@
 cask "bitrix24" do
   # NOTE: "24" is not a version number, but an intrinsic part of the product name
-  arch arm: "macos_arm", intel: "desktop"
+  arch arm: "desktop_arm", intel: "desktop"
 
   version "19.0.23.89"
   sha256 :no_check
 
   url "https://dl.bitrix24.com/b24/bitrix24_#{arch}.dmg"
   name "Bitrix24"
-  desc "Online workspace for your business"
+  desc "Business management platform"
   homepage "https://www.bitrix24.com/apps/mobile-and-desktop-apps.php#desktop_app"
 
   livecheck do
@@ -15,7 +15,8 @@ cask "bitrix24" do
     strategy :sparkle
   end
 
-  depends_on macos: ">= :big_sur"
+  auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "Bitrix24.app"
 
@@ -26,6 +27,6 @@ cask "bitrix24" do
     "~/Library/Containers/com.bitrixsoft.bitrix24desktop.finder-ext",
     "~/Library/Group Containers/com.bitrixsoft.bitrix24desktop",
     "~/Library/HTTPStorages/com.bitrixsoft.bitrix24desktop",
-    "~/Library/Preferences/com.bitrixsoft.bitrix24desktop.plist",
+    "~/Library/Preferences/com.bitrixsoft.bitrix24desktop*",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Minor updates to the cask along with the `auto_updates` stanza. Fixes the cask in issue #170994 (sparkle livecheck with no `auto_updates`).

<img width="241" height="249" alt="Screenshot 2025-12-17 at 9 13 36 PM" src="https://github.com/user-attachments/assets/91a65f45-39bb-4dc2-a0c0-9f24e43d299f" />
