### PR TITLE
m32-edit 4.4.1 (new cask)

### DIFF
--- a/Casks/m/m32-edit.rb
+++ b/Casks/m/m32-edit.rb
@@ -1,0 +1,35 @@
+cask "m32-edit" do
+  version "4.4.1,-9wjMPE6KUuoA04LKN3i5Q,0kmo3C_Pjk-L7if9X24-xw"
+  sha256 "6c508f2160d4a34f9d124e503e66263d726f3258b492c590c2beb69aa4fc5f22"
+
+  url "https://cdn.mediavalet.com/aunsw/musictribe/#{version.csv.second}/#{version.csv.third}/Original/M32-Edit_MAC_#{version.csv.first}.zip",
+      verified: "mediavalet.com/aunsw/musictribe/"
+  name "M32 Edit"
+  desc "Remote control for Midas M32 audio consoles"
+  homepage "https://www.midasconsoles.com/product.html?modelCode=0603-AEO"
+
+  livecheck do
+    url "https://www.midasconsoles.com/.rest/musictribe/v1/products/media-library?brandName=midas&modelCode=0603-AEO"
+    regex(%r{([^/]+)/([^/]+)/Original/M32[._-]Edit[._-]MAC[._-]v?(\d+(?:\.\d+)+)\.zip}i)
+    strategy :json do |json, regex|
+      json.filter_map do |category|
+        next if category["title"] != "Software"
+
+        category["list"]&.map do |item|
+          next unless item["title"]&.match?(/M32[._\s-]Edit[._\s-]Mac/i)
+
+          match = item["url"]&.match(regex)
+          next if match.blank?
+
+          "#{match[3]},#{match[1]},#{match[2]}"
+        end
+      end.flatten
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "M32-Edit.app"
+
+  zap trash: "~/Library/.M32-Edit"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
Although `x32-edit` exists, `m32-edit` is a separate application specifically for the Midas M32 console. They serve different devices, so including m32-edit provides Homebrew users official tooling for the M32 without duplication.