### PR TITLE
santa: require ventura

### DIFF
--- a/Casks/s/santa.rb
+++ b/Casks/s/santa.rb
@@ -7,6 +7,8 @@ cask "santa" do
   desc "Binary authorization system"
   homepage "https://github.com/northpolesec/santa"
 
+  depends_on macos: ">= :ventura"
+
   pkg "santa-#{version}.pkg"
 
   uninstall early_script: {


### PR DESCRIPTION

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

