### PR TITLE
bridge: deprecate

### DIFF
--- a/Casks/b/bridge.rb
+++ b/Casks/b/bridge.rb
@@ -1,17 +1,17 @@
 cask "bridge" do
   version "2025.0.0"
-  sha256 :no_check
+  sha256 "3e74ba32f28d29a9f951f1f7cc98b2207049ce618c269ee15cfcd1652bfa1249"
 
-  url "https://d2shgxa8i058x8.cloudfront.net/bridge/mac/Bridge.dmg",
-      verified: "d2shgxa8i058x8.cloudfront.net/bridge/mac/"
+  url "https://d2shgxa8i058x8.cloudfront.net/bridge/mac/Bridge-#{version}.dmg",
+      verified: "d2shgxa8i058x8.cloudfront.net/bridge/"
   name "Quixel Bridge"
-  desc "Your gateway to Megascans and Metahumans"
-  homepage "https://quixel.com/bridge/"
+  desc "3D asset manager"
+  homepage "https://quixel.com/"
 
-  livecheck do
-    url "https://quixel-apps.s3.amazonaws.com/bridge/mac/latest-mac.yml"
-    strategy :electron_builder
-  end
+  deprecate! date: "2025-12-18", because: :discontinued, replacement_cask: "epic-games"
+  disable! date: "2026-12-18", because: :discontinued, replacement_cask: "epic-games"
+
+  auto_updates true
 
   app "Bridge.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Deprecate `bridge` cask as it has been discontinued and replaced by Fab in the Epic Games Launcher (`epic-games`), as well as a few other maintenance fixes.
I put a disable date 1 year in the future, but if this isn't appropriate since the cask is still available online and only in the process of being phased out please let me know!
<img width="691" height="59" alt="Screenshot 2025-12-18 at 11 36 00 AM" src="https://github.com/user-attachments/assets/02061f6f-1acc-4079-b8b0-7e766f065509" />
<img width="692" height="213" alt="Screenshot 2025-12-18 at 11 36 13 AM" src="https://github.com/user-attachments/assets/f4f12c5b-c825-44e6-994a-d2a05cb61315" />
Proof of auto-update feature for #170994:
<img width="261" height="140" alt="Screenshot 2025-12-18 at 11 38 02 AM" src="https://github.com/user-attachments/assets/7e061183-e4e1-49ec-b09d-8c0aba20b8a7" />
