### PR TITLE
qianwen 1.2.3

### DIFF
--- a/Casks/q/qianwen.rb
+++ b/Casks/q/qianwen.rb
@@ -1,19 +1,22 @@
 cask "qianwen" do
-  version "1.2.2,2512042113"
-  sha256 "ec4d592ec55283a3955547ebf1a65c9320a1a7421cca87a326928b75ce58f2e1"
+  version "1.2.3,2512151438"
+  sha256 "70569e8c828eb677c0a1bedc114c48d505d0cd6807137d480c3b40c0ba204784"
 
-  url "https://qianwen-portal-cdn.tongyi.com/native/app/#{version.csv.first}/darwin/universal/qwenclient_setup_#{version.csv.first}.#{version.csv.second}.dmg"
+  url "https://qianwen-portal-cdn.tongyi.com/native/app/#{version.csv.first}/darwin/universal/qwenclient_setup_#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.dmg",
+      verified: "qianwen-portal-cdn.tongyi.com/native/app/"
   name "qianwen"
   name "千问"
   desc "AI assistant and chatbot powered by Alibaba's Qwen model"
-  homepage "https://www.tongyi.com/qianwen"
+  homepage "https://www.qianwen.com/qianwen"
 
   livecheck do
-    url "https://www.tongyi.com/qianwen"
-    regex(%r{"mac":"https://qianwen-portal-cdn\.tongyi\.com/native/app/([\d.]+)/darwin/universal/qwenclient_setup_[\d.]+\.(\d+)\.dmg"})
+    url :homepage
+    regex(%r{/v?(\d+(?:\.\d+)+)/darwin/universal/qwenclient[._-]setup[._-]\1(?:\.(\d+))?\.dmg}i)
     strategy :page_match do |page, regex|
       match = page.match(regex)
-      "#{match[1]},#{match[2]}" if match
+      next unless match
+
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `qianwen` to the latest version, 1.2.3. Besides that, this updates the `livecheck` block to address some stylistic issues and updates the homepage to resolve a redirection.

The existing `livecheck` block for `qianwen` uses a case-sensitive regex when it should be case insensitive and duplicates the homepage URL when it should use `url :homepage`. This addresses these issues and reduces the regex to only what's necessary to match the version parts.

One notable change in the regex is using `\1` to match the first capture group (i.e., the version like 1.2.2) in the file name, as a way of isolating the secondary part of the version (i.e., "2512151438" in "1.2.3.2512151438"). This approach ensures that we only match an extra version part (if any), whereas the existing approach could parse something like "1.2.3" and erroneously return "3" as the secondary version part.