### PR TITLE
aspire-cli 13.1.0 (new cask)

### DIFF
--- a/Casks/a/aspire-cli.rb
+++ b/Casks/a/aspire-cli.rb
@@ -1,0 +1,21 @@
+cask "aspire-cli" do
+  arch arm: "arm64", intel: "x64"
+
+  version "13.1.0"
+  sha256 arm:   "7d7bdf26822f0744efccfdea47e6a2b9bcd762f2144289b7a75171b8b18fd024",
+         intel: "a17c61b57a83806c4bd212dbf927686a6f0c9f700535c6d8e9599925aa110c49"
+
+  url "https://ci.dot.net/public/aspire/#{version}-preview.1.25616.3/aspire-cli-osx-#{arch}-#{version}.tar.gz",
+      verified: "ci.dot.net/public/aspire/"
+  name "Aspire CLI"
+  desc "Command-line interface for .NET Aspire cloud-native development"
+  homepage "https://aspire.dev/"
+
+  livecheck do
+    skip "Version is not auto-updatable from ci.dot.net"
+  end
+
+  binary "aspire"
+
+  zap trash: "~/.aspire"
+end


### PR DESCRIPTION
Adds a new cask for Aspire CLI version 13.1.0 with appropriate architecture support, URL and checksum configuration.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
 Screenshots:
 
Audit:
<img width="852" height="132" alt="Screenshot 2025-12-19 at 10 15 33" src="https://github.com/user-attachments/assets/aabdf0c5-5019-4c2d-8751-43d7e3ad52ba" />
Remove:
<img width="400" height="101" alt="Screenshot 2025-12-19 at 10 15 11" src="https://github.com/user-attachments/assets/a5cfa165-83d5-4765-85ef-7556a0c0be49" />
Install:
<img width="852" height="153" alt="Screenshot 2025-12-19 at 10 14 57" src="https://github.com/user-attachments/assets/3f7bd529-2f52-41ba-96b8-d4ee85775600" />
