### PR TITLE
tor-browser: use official download url

### DIFF
--- a/Casks/t/tor-browser.rb
+++ b/Casks/t/tor-browser.rb
@@ -2,7 +2,7 @@ cask "tor-browser" do
   version "15.0.3"
   sha256 "4abacbf7db22c6d826a63eead72784541aba9a8609bf9bd04621b652f7b7287f"
 
-  url "https://archive.torproject.org/tor-package-archive/torbrowser/#{version}/tor-browser-macos-#{version}.dmg"
+  url "https://www.torproject.org/dist/torbrowser/#{version}/tor-browser-macos-#{version}.dmg"
   name "Tor Browser"
   desc "Web browser focusing on security"
   homepage "https://www.torproject.org/"


### PR DESCRIPTION
Closes #241427

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

As suggested by https://www.torproject.org/download/
