### PR TITLE
tudu 1.0.3 (new cask)

### DIFF
--- a/Casks/t/tudu.rb
+++ b/Casks/t/tudu.rb
@@ -1,0 +1,22 @@
+cask "tudu" do
+  version "1.0.3"
+  sha256 "5773fce9d5058ce64f870782b9fb2fba2d496a57d255b75171d54fa61e9bc851"
+
+  url "https://github.com/AslamSDM/tudu/releases/download/v#{version}/Tudu-#{version}.zip"
+  name "Tudu"
+  desc "Beautiful todo app with widget support"
+  homepage "https://github.com/AslamSDM/tudu"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Tudu.app"
+
+  zap trash: [
+    "~/Library/Application Support/Tudu",
+    "~/Library/Caches/com.Tudu",
+    "~/Library/Preferences/com.Tudu.plist",
+  ]
+end


### PR DESCRIPTION
**Description:**
Tudu is a beautiful todo app with widget support for macOS.

**Release notes URL:**
https://github.com/AslamSDM/tudu/releases/tag/v1.0.3

**Homebrew/homebrew-cask checklist:**
- [x] Named the cask according to the token reference
- [x] Verified the cask is available from macOS 11+
- [x] Cask builds successfully on macOS 11+
- [x] Livecheck strategy is present
- [x] Cask passes `brew style`
- [x] The app is signed and notarized