### PR TITLE
browserstacklocal: add auto_updates, update zap

### DIFF
--- a/Casks/b/browserstacklocal.rb
+++ b/Casks/b/browserstacklocal.rb
@@ -12,13 +12,19 @@ cask "browserstacklocal" do
     strategy :sparkle
   end
 
+  auto_updates true
+
   app "BrowserStackLocal.app"
 
-  uninstall launchctl: "com.browserstack.local"
+  uninstall launchctl: "com.browserstack.local",
+            delete:    "~/Library/LaunchAgents/BrowserStackLocal.plist"
 
   zap trash: [
-    "~/.bstack",
+    "~/.browserstack",
     "~/Library/Caches/com.browserstack.Local",
+    "~/Library/HTTPStorages/com.browserstack.local",
+    "~/Library/HTTPStorages/com.browserstack.local.binarycookies",
+    "~/Library/Preferences/com.browserstack.local.plist",
   ]
 
   caveats do


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This adds `auto_updates true` to the cask, as, according to the screenshot below, the app includes that functionality (part of #170994). It also updates the `zap` stanza to remove additional app files, as there were a bunch not already in the cask file.
There was nothing I could add to the `uninstall` stanza that would fully quit and remove the app from the menu bar upon uninstallation—I tried `quit` and `signal`, and neither worked, unfortunately—the app stayed in the menu bar until I quit it manually.

<img width="242" height="219" alt="Screenshot 2025-12-19 at 3 06 23 PM" src="https://github.com/user-attachments/assets/d18577d3-9d26-45e5-8ac6-85ce3da3c7f5" />