### PR TITLE
celestialteapot-runway: deprecate

### DIFF
--- a/Casks/c/celestialteapot-runway.rb
+++ b/Casks/c/celestialteapot-runway.rb
@@ -7,10 +7,8 @@ cask "celestialteapot-runway" do
   desc "UML (Unified Modelling Language) design app"
   homepage "https://celestialteapot.com/runway/"
 
-  livecheck do
-    url "https://celestialteapot.com/runway/appcast/runway2.rss"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-12-20", because: :no_longer_meets_criteria
+  disable! date: "2026-12-20", because: :no_longer_meets_criteria
 
   app "Runway.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The cask shows 0 downloads in the past 90 days on brew.sh, and I saw on the docs this is reason for deprecation. If this doesn't fit I apologize!