### PR TITLE
workflows/google-fonts: remove reference to Homebrew/cask-fonts

### DIFF
--- a/.github/workflows/google-fonts.yml
+++ b/.github/workflows/google-fonts.yml
@@ -26,11 +26,6 @@ jobs:
           - noun: deletion
             mode: delete
     steps:
-      - name: Checkout homebrew/cask-fonts
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-
       - name: Checkout google/fonts
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
This step no longer does anything since the deprecation of Homebrew/cask-fonts.