### PR TITLE
persepolis-download-manager: deprecate, url change

### DIFF
--- a/Casks/p/persepolis-download-manager.rb
+++ b/Casks/p/persepolis-download-manager.rb
@@ -1,11 +1,8 @@
 cask "persepolis-download-manager" do
-  arch arm: "arm64", intel: "x64"
-
   version "5.2.0"
-  sha256 arm:   "092f7975e97ac73aff29d3b0fb084ba6ab4cb5529d6a7a6c8385676ec3468669",
-         intel: "ce91acdba96448d00c7e712960a2670c0e9173a6fc9c382dbeca9ac258f9e319"
+  sha256 "548b4b07904f8ec57d7f5d746459bf32a1bd0e0ae710e58108a37e3f17043895"
 
-  url "https://github.com/persepolisdm/persepolis/releases/download/#{version}/persepolis_#{version}_macos_#{arch}.dmg",
+  url "https://github.com/persepolisdm/persepolis/releases/download/#{version}/persepolis_#{version}_macos.dmg",
       verified: "github.com/persepolisdm/persepolis/"
   name "Persepolis"
   desc "Download manager"

--- a/Casks/p/persepolis-download-manager.rb
+++ b/Casks/p/persepolis-download-manager.rb
@@ -13,6 +13,8 @@ cask "persepolis-download-manager" do
     strategy :github_latest
   end
 
+  deprecate! date: "2025-12-20", because: :fails_gatekeeper_check
+
   app "Persepolis Download Manager.app"
 
   zap trash: [

--- a/Casks/p/persepolis-download-manager.rb
+++ b/Casks/p/persepolis-download-manager.rb
@@ -19,4 +19,8 @@ cask "persepolis-download-manager" do
     "~/.persepolis",
     "~/Library/Application Support/persepolis_download_manager",
   ]
+
+  caveats do
+    requires_rosetta
+  end
 end

--- a/Casks/p/persepolis-download-manager.rb
+++ b/Casks/p/persepolis-download-manager.rb
@@ -13,7 +13,7 @@ cask "persepolis-download-manager" do
     strategy :github_latest
   end
 
-  deprecate! date: "2025-12-20", because: :fails_gatekeeper_check
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Persepolis Download Manager.app"
 


### PR DESCRIPTION
Persepolis-download-manager no longer uses separate arm and x86 buids as of 5.2.0, this commit closes persepolisdm/persepolis#1101

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---