### PR TITLE
Add :browser user_agent to livecheck blocks

### DIFF
--- a/Casks/a/adobe-connect.rb
+++ b/Casks/a/adobe-connect.rb
@@ -10,7 +10,8 @@ cask "adobe-connect" do
   homepage "https://www.adobe.com/products/adobeconnect.html"
 
   livecheck do
-    url "https://helpx.adobe.com/adobe-connect/connect-downloads-updates.html"
+    url "https://helpx.adobe.com/adobe-connect/connect-downloads-updates.html",
+        user_agent: :browser
     regex(/macOS.*?v?(\d+(?:\.\d+)+)[< "]/im)
     strategy :page_match do |page, regex|
       version = page.scan(regex)&.flatten&.first
@@ -20,8 +21,6 @@ cask "adobe-connect" do
       "#{version},#{directory}"
     end
   end
-
-  no_autobump! because: "livecheck fails during CI workflow"
 
   auto_updates true
 

--- a/Casks/a/adobe-digital-editions.rb
+++ b/Casks/a/adobe-digital-editions.rb
@@ -8,7 +8,8 @@ cask "adobe-digital-editions" do
   homepage "https://www.adobe.com/solutions/ebook/digital-editions.html"
 
   livecheck do
-    url "https://www.adobe.com/solutions/ebook/digital-editions/download.html"
+    url "https://www.adobe.com/solutions/ebook/digital-editions/download.html",
+        user_agent: :browser
     regex(/Adobe\s*Digital\s*Editions\s*(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/b/boosteroid.rb
+++ b/Casks/b/boosteroid.rb
@@ -6,13 +6,14 @@ cask "boosteroid" do
   sha256 :no_check
 
   url "https://boosteroid.com/macos#{folder}/installer/boosteroid-install-#{arch}.dmg",
-      user_agent: :fake
+      user_agent: :browser
   name "Boosteroid"
   desc "Cloud gaming service"
   homepage "https://boosteroid.com/"
 
   livecheck do
-    url "https://boosteroid.com/macos#{folder}/client/changelog.md"
+    url "https://boosteroid.com/macos#{folder}/client/changelog.md",
+        user_agent: :browser
     regex(/\[\s*\v?(\d+(?:\.\d+)+)\s*\]/i)
   end
 

--- a/Casks/c/canon-ufrii-driver.rb
+++ b/Casks/c/canon-ufrii-driver.rb
@@ -9,7 +9,8 @@ cask "canon-ufrii-driver" do
   homepage "https://oip.manual.canon/USRMA-3844-zz-DR-enUV/"
 
   livecheck do
-    url "https://www.usa.canon.com/bin/canon/support/getsoftwarediver.ds.MACOS_14.39319.All.English.json"
+    url "https://www.usa.canon.com/bin/canon/support/getsoftwarediver.ds.MACOS_14.39319.All.English.json",
+        user_agent: :browser
     regex(/UFRII[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i)
     strategy :json do |json, regex|
       json.map do |item|

--- a/Casks/c/cisco-jabber.rb
+++ b/Casks/c/cisco-jabber.rb
@@ -8,7 +8,7 @@ cask "cisco-jabber" do
   homepage "https://www.webex.com/downloads/jabber.html"
 
   livecheck do
-    url :homepage
+    url :homepage, user_agent: :browser
     regex(%r{jabberAppUrl =.*?(\d+)/Install[._-]Cisco[._-]Jabber[._-]Mac\.pkg}i)
   end
 

--- a/Casks/c/couchbase-server-community.rb
+++ b/Casks/c/couchbase-server-community.rb
@@ -11,7 +11,8 @@ cask "couchbase-server-community" do
   homepage "https://www.couchbase.com/"
 
   livecheck do
-    url "https://www.couchbase.com/downloads/"
+    url "https://www.couchbase.com/downloads/",
+        user_agent: :browser
     regex(/couchbase[._-]server[._-]community[._-]v?(\d+(:?\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 

--- a/Casks/c/couchbase-server-enterprise.rb
+++ b/Casks/c/couchbase-server-enterprise.rb
@@ -11,7 +11,8 @@ cask "couchbase-server-enterprise" do
   homepage "https://www.couchbase.com/"
 
   livecheck do
-    url "https://www.couchbase.com/downloads/"
+    url "https://www.couchbase.com/downloads/",
+        user_agent: :browser
     regex(/couchbase[._-]server[._-]enterprise[._-]v?(\d+(:?\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 

--- a/Casks/h/hookmark.rb
+++ b/Casks/h/hookmark.rb
@@ -3,13 +3,14 @@ cask "hookmark" do
   sha256 "f60e5e31b397add7e00067ed2118b3492cad14145b89c0f8fa4cb1aa7aa1fe97"
 
   url "https://updates.hookproductivity.com/downloads/Hookmark-app-#{version}.dmg",
-      user_agent: :fake
+      user_agent: :browser
   name "Hook"
   desc "Link and retrieve key information"
   homepage "https://hookproductivity.com/"
 
   livecheck do
-    url "https://updates.hookproductivity.com/updates/a77a1a87-7d69-435d-90ea-7365b2f7bddb"
+    url "https://updates.hookproductivity.com/updates/a77a1a87-7d69-435d-90ea-7365b2f7bddb",
+        user_agent: :browser
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/h/hopper-disassembler.rb
+++ b/Casks/h/hopper-disassembler.rb
@@ -3,13 +3,14 @@ cask "hopper-disassembler" do
   sha256 "a7c57f9c6f63bef87dd90584a202db04aa7cd1f482a2323e31f299404095b8d2"
 
   url "https://www.hopperapp.com/downloader/public/Hopper-#{version}-demo.dmg",
-      user_agent: :fake
+      user_agent: :browser
   name "Hopper Disassembler"
   desc "Reverse engineering tool that lets you disassemble, decompile and debug your app"
   homepage "https://www.hopperapp.com/"
 
   livecheck do
-    url "https://www.hopperapp.com/rss/changelog.xml"
+    url "https://www.hopperapp.com/rss/changelog.xml",
+        user_agent: :browser
     regex(/<title>\s*Version\s+v?(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/i/izip.rb
+++ b/Casks/i/izip.rb
@@ -9,7 +9,8 @@ cask "izip" do
   homepage "https://www.izip.com/"
 
   livecheck do
-    url "https://www.izip.com/updates"
+    url "https://www.izip.com/updates",
+        user_agent: :browser
     strategy :sparkle, &:short_version
   end
 

--- a/Casks/j/jetdrive-toolbox.rb
+++ b/Casks/j/jetdrive-toolbox.rb
@@ -3,13 +3,14 @@ cask "jetdrive-toolbox" do
   sha256 "2a52a2d24d22a120c737e5d9a13eceadd7be59751185a0821ef84fdf6f5605f8"
 
   url "https://cdn.transcend-info.com/files/special/JetDriveToolbox_v#{version}.zip",
-      user_agent: :fake
+      user_agent: :browser
   name "JetDrive Toolbox"
   desc "Helper for Transcend SSDs and expansion cards"
   homepage "https://www.transcend-info.com/Support/Software-181/"
 
   livecheck do
-    url "https://www.transcend-info.com/Software/1151/"
+    url "https://www.transcend-info.com/Software/1151/",
+        user_agent: :browser
     strategy :header_match
   end
 

--- a/Casks/j/jt-bridge.rb
+++ b/Casks/j/jt-bridge.rb
@@ -3,13 +3,14 @@ cask "jt-bridge" do
   sha256 "bce72da1bd44175b86f5eceec4716e212ad8eacbd2da999198112ab995b8d02f"
 
   url "https://jt-bridge.eller.nu/download/JT-Bridge.app-#{version}.zip",
-      user_agent: :fake
+      user_agent: :browser
   name "JT-Bridge"
   desc "Acts as a bridge between WSJT-X and ham radio logging application"
   homepage "https://jt-bridge.eller.nu/"
 
   livecheck do
-    url "https://jt-bridge.eller.nu/downloads/"
+    url "https://jt-bridge.eller.nu/downloads/",
+        user_agent: :browser
     regex(/JT[._-]Bridge[._-]app[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 

--- a/Casks/l/ltspice.rb
+++ b/Casks/l/ltspice.rb
@@ -8,7 +8,7 @@ cask "ltspice" do
   homepage "https://www.analog.com/en/resources/design-tools-and-calculators/ltspice-simulator.html"
 
   livecheck do
-    url :homepage
+    url :homepage, user_agent: :browser
     regex(/for\s+MacOS.*?Version\s+v?(\d+(?:\.\d+)+)/im)
   end
 

--- a/Casks/l/ludwig.rb
+++ b/Casks/l/ludwig.rb
@@ -3,13 +3,13 @@ cask "ludwig" do
   sha256 :no_check
 
   url "https://desktop.ludwig.guru/download/latest",
-      user_agent: :fake
+      user_agent: :browser
   name "ludwig"
   desc "Sentence search engine app that helps you write better English"
   homepage "https://ludwig.guru/"
 
   livecheck do
-    url :url
+    url :url, user_agent: :browser
     strategy :header_match
   end
 

--- a/Casks/m/mega.rb
+++ b/Casks/m/mega.rb
@@ -9,7 +9,8 @@ cask "mega" do
   homepage "https://megasoftware.net/"
 
   livecheck do
-    url "https://www.megasoftware.net/current_release/"
+    url "https://www.megasoftware.net/current_release/",
+        user_agent: :browser
     strategy :json do |json|
       json.map do |item|
         next if item["operating_system"] != "mac" ||

--- a/Casks/p/pages-data-merge.rb
+++ b/Casks/p/pages-data-merge.rb
@@ -3,13 +3,13 @@ cask "pages-data-merge" do
   sha256 "21458a889452ea20915bbb61b3a0522b880475b91e1080966d120a3a4341d9c9"
 
   url "https://iworkautomation.com/pages/data-merge-#{version.dots_to_hyphens}.zip",
-      user_agent: :fake
+      user_agent: :browser
   name "Pages Data Merge"
   desc "Mail merge for Pages"
   homepage "https://iworkautomation.com/pages/script-tags-data-merge.html"
 
   livecheck do
-    url :homepage
+    url :homepage, user_agent: :browser
     regex(/href=.*?data[._-]merge[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match[0].tr("-", ".") }

--- a/Casks/s/silhouette-studio.rb
+++ b/Casks/s/silhouette-studio.rb
@@ -9,7 +9,7 @@ cask "silhouette-studio" do
   homepage "https://www.silhouetteamerica.com/silhouette-studio"
 
   livecheck do
-    url :homepage
+    url :homepage, user_agent: :browser
     regex(/SS[._-]V?((?:\d+(?:\.\d+)+)[._-]M6R(?:[._-]\d+)?)\.dmg/i)
   end
 

--- a/Casks/s/smart-converter-pro.rb
+++ b/Casks/s/smart-converter-pro.rb
@@ -8,7 +8,8 @@ cask "smart-converter-pro" do
   homepage "https://shedworx.com/smart-converter-pro"
 
   livecheck do
-    url "https://shedworx.com/download/?product=scp3"
+    url "https://shedworx.com/download/?product=scp3",
+        user_agent: :browser
     regex(/href=.*?SmartConverterPro[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/t/tableau.rb
+++ b/Casks/t/tableau.rb
@@ -17,7 +17,8 @@ cask "tableau" do
   # should return to checking the XML file if/when it starts being reliably
   # updated to include the newest releases again.
   livecheck do
-    url "https://www.tableau.com/support/releases"
+    url "https://www.tableau.com/support/releases",
+        user_agent: :browser
     regex(%r{href=.*?desktop/v?(\d+(?:\.\d+)+)[^"' >]*["' >]}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|

--- a/Casks/t/teleport-connect.rb
+++ b/Casks/t/teleport-connect.rb
@@ -9,7 +9,8 @@ cask "teleport-connect" do
   homepage "https://goteleport.com/"
 
   livecheck do
-    url "https://goteleport.com/download/"
+    url "https://goteleport.com/download/",
+        user_agent: :browser
     regex(/href=.*?Teleport%20Connect[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/t/teleport-suite.rb
+++ b/Casks/t/teleport-suite.rb
@@ -9,7 +9,8 @@ cask "teleport-suite" do
   homepage "https://goteleport.com/"
 
   livecheck do
-    url "https://goteleport.com/download/"
+    url "https://goteleport.com/download/",
+        user_agent: :browser
     regex(/teleport[._-]v?(\d+(?:\.\d+)+)\.pkg/i)
   end
 

--- a/Casks/t/teleport-suite@17.rb
+++ b/Casks/t/teleport-suite@17.rb
@@ -9,7 +9,8 @@ cask "teleport-suite@17" do
   homepage "https://goteleport.com/"
 
   livecheck do
-    url "https://goteleport.com/download/"
+    url "https://goteleport.com/download/",
+        user_agent: :browser
     regex(/teleport[._-]v?(17(?:\.\d+)+)\.pkg/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This adds `user_agent: :browser` to `livecheck` blocks that work but fall back to the `:browser` user agent. This uses livecheck's built-in user agent fallback logic (i.e., retrying with a `:browser` user agent if `:default` fails) but it was only intended as a temporary measure until we can explicitly set the user agent in a `livecheck` block. That feature is now available in a brew release, so this adds an explicit user agent to allow us to remove the temporary fallback logic in livecheck.