### PR TITLE
qgis 3.44.6, qgis@ltr: update livecheck

### DIFF
--- a/Casks/q/qgis.rb
+++ b/Casks/q/qgis.rb
@@ -1,22 +1,24 @@
 cask "qgis" do
-  version "3.42.1,20250324_153321"
-  sha256 "6cf5292f1149613d8c413d181aacd513ca1ee1ae2b882ba038e07301b15aeaac"
+  version "3.44.6"
+  sha256 "aeb21c1b1659403e92c7efbc4c48b1a0c4f97f025bf62044d492e6b5931512c0"
 
-  url "https://download.qgis.org/downloads/macos/pr/qgis_pr_final-#{version.csv.first.dots_to_underscores}_#{version.csv.second}.dmg"
+  url "https://download.qgis.org/downloads/macos/pr/qgis_pr_final-#{version.dots_to_underscores.csv.join("_")}.dmg"
   name "QGIS"
   desc "Geographic Information System"
   homepage "https://www.qgis.org/"
 
   livecheck do
-    url "https://download.qgis.org/downloads/macos/qgis-macos-pr.sha256sum"
-    regex(/qgis_pr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
+    url "https://www.qgis.org/downloads-list/#macos/pr"
+    regex(/qgis[._-]pr[._-]final[._-]v?(\d+(?:[._]\d+)+?)(?:[._-](\d{6,8}(?:[._-]\d+)?))?\.dmg/i)
     strategy :page_match do |page, regex|
-      match = page.match(regex)
-      next if match.blank?
-
-      "#{match[1].tr("_", ".")},#{match[2]}"
+      page.scan(regex).map do |match|
+        match[0] = match[0].tr("_", ".")
+        match.compact.join(",")
+      end
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "QGIS.app"
 
@@ -25,8 +27,4 @@ cask "qgis" do
     "~/Library/Caches/QGIS",
     "~/Library/Saved Application State/org.qgis.qgis*.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/q/qgis@ltr.rb
+++ b/Casks/q/qgis@ltr.rb
@@ -2,16 +2,19 @@ cask "qgis@ltr" do
   version "3.40.5,20250321_160709"
   sha256 "e25964bff62a884aab696c86f698172b0aa7b26a5fbb8279c0e17c97287c75e8"
 
-  url "https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-#{version.csv.first.dots_to_underscores}_#{version.csv.second}.dmg"
+  url "https://download.qgis.org/downloads/macos/ltr/qgis_ltr_final-#{version.dots_to_underscores.csv.join("_")}.dmg"
   name "QGIS LTR"
   desc "Geographic Information System"
   homepage "https://www.qgis.org/"
 
   livecheck do
-    url "https://download.qgis.org/downloads/macos/qgis-macos-ltr.sha256sum"
-    regex(/qgis_ltr_final[._-]v?(\d+(?:_\d+)+)[._-](\d+_\d+)\.dmg/i)
+    url "https://www.qgis.org/downloads-list/#macos/ltr"
+    regex(/qgis[._-]ltr[._-]final[._-]v?(\d+(?:[._]\d+)+?)(?:[._-](\d{6,8}(?:[._-]\d+)?))?\.dmg/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0].tr("_", ".")},#{match[1]}" }
+      page.scan(regex).map do |match|
+        match[0] = match[0].tr("_", ".")
+        match.compact.join(",")
+      end
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

It looks like the livecheck for `qgis` and `qgis@ltr` have been broken for a while (since at least June, as that's when 3.44 was released). This PR updates `qgis` to 3.44.6 and changes the livecheck to an `extract_plist` (I would have tried to pull it from the website, but they've released 3.44.6 without updating any of the version numbers on their website). I've also removed the Rosetta caveat as all Mach-O binaries in the app are universal (though I haven't tested on a machine without Rosetta).

It is worth noting that the naming scheme for the downloads have changed twice over the last two releases, so no guarantees it won't change again next release.

<img width="2068" height="1068" src="https://github.com/user-attachments/assets/74a2f161-1189-484b-aa5f-b3beaf4ee230" />

`brew audit` does fail with `Artifact defined :big_sur as the minimum macOS version but the cask declared no minimum macOS version`, though I assume this is a Homebrew bug as no minimum version is defined in the cask.

For `qgis@ltr`, I've removed the livecheck as the download link for it still uses the naming convention with the build date (which `extract_plist` doesn't retrieve). However, the QGIS site does note:

> Note: There are no QGIS 3.40 LTR builds available on macOS. QGIS 3.44 is stable and has been designated as the future Long Term Release (LTR); therefore 3.44 is the recommended version for macOS users.

