### PR TITLE
typeless 0.8.1 (new cask)

### DIFF
--- a/Casks/t/typeless.rb
+++ b/Casks/t/typeless.rb
@@ -1,0 +1,30 @@
+cask "typeless" do
+  arch arm: "arm64", intel: "x64"
+  livecheck_arch = on_arch_conditional arm: "arm64", intel: "latest"
+
+  version "0.8.1"
+  sha256 arm:   "c7603e47f4d446dac220255ab61f0d4fb95a4aad10c98aead09d4273af58d951",
+         intel: "a25279072c3455ebfd9de292ee489e3a39ec92416b589b48fd3f750d03305c95"
+
+  url "https://typeless-static.com/desktop-release/Typeless-#{version}-#{arch}.dmg",
+      verified: "typeless-static.com/"
+  name "Typeless"
+  desc "AI voice dictation that turns speech into polished text"
+  homepage "https://typeless.com/"
+
+  livecheck do
+    url "https://typeless-static.com/desktop-release/#{livecheck_arch}-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Typeless.app"
+
+  zap trash: [
+    "~/Library/Application Support/typeless",
+    "~/Library/Caches/typeless",
+    "~/Library/Preferences/com.typeless.plist",
+  ]
+end


### PR DESCRIPTION
Adds the Typeless macOS app.

- App installs cleanly via `brew install --cask typeless`
- `brew audit --cask --online --strict typeless` passes
- Livecheck uses the macOS release notes page:
  https://www.typeless.com/help/release-notes/macos