### PR TITLE
adobe-dng-converter: update livecheck

### DIFF
--- a/Casks/a/adobe-dng-converter.rb
+++ b/Casks/a/adobe-dng-converter.rb
@@ -8,7 +8,8 @@ cask "adobe-dng-converter" do
   homepage "https://helpx.adobe.com/camera-raw/using/adobe-dng-converter.html"
 
   livecheck do
-    url "https://www.adobe.com/go/dng_converter_mac"
+    url "https://www.adobe.com/go/dng_converter_mac",
+        user_agent: :curl
     regex(/DNGConverter[._-]v?(\d+(?:[._]\d+)+)\.dmg/i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `adobe-dng-converter` fails in the autobump/CI environment without a different user agent. There was a brief period recently where it worked using the `:browser` fallback but now it's back to failing like before. This addresses the issue by setting the `livecheck` block to use the `:curl` user agent, which seems to work.