### PR TITLE
arm-performance-libraries: update livecheck

### DIFF
--- a/Casks/a/arm-performance-libraries.rb
+++ b/Casks/a/arm-performance-libraries.rb
@@ -10,7 +10,8 @@ cask "arm-performance-libraries" do
   homepage "https://developer.arm.com/downloads/-/arm-performance-libraries"
 
   livecheck do
-    url :homepage
+    url :homepage,
+        user_agent: :curl
     regex(/Version[._-]v?(\d+(?:\.\d+)+)/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`arm-performance-libraries` uses a curl user agent for the artifact URL, as requests to developer.arm.com will fail without it. The same issue affects the `livecheck` block URL, so the check has been broken for some time. This addresses this issue by adding `user_agent: :curl` to the `livecheck` block URL now that it's supported.