### PR TITLE
gcc-aarch64-embedded 15.2.rel1

### DIFF
--- a/Casks/g/gcc-aarch64-embedded.rb
+++ b/Casks/g/gcc-aarch64-embedded.rb
@@ -6,20 +6,25 @@ cask "gcc-aarch64-embedded" do
   pkg_version = nil
   gcc_version = nil
   on_arm do
-    version "14.3.rel1"
-    sha256 "82a4987c670f589d3c5b97bc579561365116670ff3c1c67a07fc29fa23aef3b2"
-    pkg_version = "14.3.rel1"
-    gcc_version = "14.3.1"
+    version "15.2.rel1"
+    pkg_version = "15.2.rel1"
+    gcc_version = "15.2.1"
+    sha256 "a616eb0a32738cbddc7b8653a20abbddc487712714d57ac993b8987a7451dbce"
+
     livecheck do
-      url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
+      url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads",
+          user_agent: :curl
       regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-aarch64-none-elf\.pkg/i)
     end
+
+    binary "/Applications/ArmGNUToolchain/#{pkg_version}/aarch64-none-elf/bin/aarch64-none-elf-gstack"
   end
   on_intel do
     version "14.2.rel1"
-    sha256 "4e0da7bc82d316deb7f385d249bf7f87ce06d31b9d6f8b63f9b981a2203cf2ce"
     pkg_version = "14.2.rel1"
     gcc_version = "14.2.1"
+    sha256 "4e0da7bc82d316deb7f385d249bf7f87ce06d31b9d6f8b63f9b981a2203cf2ce"
+
     livecheck do
       skip "Legacy version"
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `gcc-aarch64-embedded` to the latest version, 15.2.rel1. I added a `binary` call for `aarch64-none-elf-gstack` and scoped it to the ARM version, as the older Intel version doesn't have this file.

`gcc-aarch64-embedded` uses a curl user agent for the artifact URL, as requests to developer.arm.com will fail without it. The same issue affects the `livecheck` block URL, so the check has been broken for some time. This addresses the issue by adding `user_agent: :curl` to the `livecheck` block URL now that it's supported.