### PR TITLE
gcc-arm-embedded 15.2.rel1

### DIFF
--- a/Casks/g/gcc-arm-embedded.rb
+++ b/Casks/g/gcc-arm-embedded.rb
@@ -6,20 +6,25 @@ cask "gcc-arm-embedded" do
   pkg_version = nil
   gcc_version = nil
   on_arm do
-    version "14.3.rel1"
-    sha256 "b93712026cec9f98a5d98dfec84e8096d32be3759642381e1982c4a5d2aa020b"
-    pkg_version = "14.3.rel1"
-    gcc_version = "14.3.1"
+    version "15.2.rel1"
+    pkg_version = "15.2.rel1"
+    gcc_version = "15.2.1"
+    sha256 "396aacf7bb81126fed0de66f17e2d0009de373b667abbcc7855afab43628224f"
+
     livecheck do
-      url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
+      url "https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads",
+          user_agent: :curl
       regex(/href=.*?arm-gnu-toolchain-(\d+\.\d+\.\w+)-darwin-(?:\w+)-arm-none-eabi\.pkg/i)
     end
+
+    binary "/Applications/ArmGNUToolchain/#{pkg_version}/arm-none-eabi/bin/arm-none-eabi-gstack"
   end
   on_intel do
     version "14.2.rel1"
-    sha256 "5d2e9ee4e73350bda79accc69fcd5ee59ccb902804a3f81a01d4c543b1ad7de7"
     pkg_version = "14.2.rel1"
     gcc_version = "14.2.1"
+    sha256 "5d2e9ee4e73350bda79accc69fcd5ee59ccb902804a3f81a01d4c543b1ad7de7"
+
     livecheck do
       skip "Legacy version"
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This updates `gcc-arm-embedded` to the latest version, 15.2.rel1. I added a `binary` call for `aarch64-none-elf-gstack` and scoped it to the ARM version, as the older Intel version doesn't have this file.

`gcc-arm-embedded` uses a curl user agent for the artifact URL, as requests to developer.arm.com will fail without it. The same issue affects the `livecheck` block URL, so the check has been broken for some time. This addresses this issue by adding `user_agent: :curl` to the `livecheck` block URL now that it's supported.