### PR TITLE
izotope-product-portal: update livecheck

### DIFF
--- a/Casks/i/izotope-product-portal.rb
+++ b/Casks/i/izotope-product-portal.rb
@@ -9,7 +9,8 @@ cask "izotope-product-portal" do
   homepage "https://www.izotope.com/en/products/downloads.html"
 
   livecheck do
-    url "https://www.izotope.com/in-app/pp/download/mac"
+    url "https://www.izotope.com/in-app/pp/download/mac",
+        user_agent: :curl
     regex(/iZotope[._-]Product[._-]Portal[._-]v?(\d+(?:[._-]\d+)+\w?)\.dmg/i)
     strategy :header_match do |headers, regex|
       match = headers["location"]&.match(regex)


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` block for `izotope-product-portal` consistently fails using the `:default` and `:browser` user agents and this has been visible in the autobump/CI environment for some time. A curl user agent works, so this updates the `livecheck` block accordingly.