### PR TITLE
azookey: remove livecheck

### DIFF
--- a/Casks/a/azookey.rb
+++ b/Casks/a/azookey.rb
@@ -7,12 +7,6 @@ cask "azookey" do
   desc "Japanese input method"
   homepage "https://github.com/azooKey/azooKey-Desktop"
 
-  livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+(?:[._-]alpha[._-]?\d+)?)$/i)
-    strategy :github_latest
-  end
-
   depends_on macos: ">= :ventura"
 
   pkg "azooKey-release-signed.pkg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

When this cask was newly added, it was in alpha version, so a livecheck block was configured. However, it has now out of alpha and the livecheck is therefore no longer required.