### PR TITLE
mysql-shell: update livecheck

### DIFF
--- a/Casks/m/mysql-shell.rb
+++ b/Casks/m/mysql-shell.rb
@@ -6,21 +6,24 @@ cask "mysql-shell" do
       version "8.0.27,11-x86-64bit"
       sha256 "3214e9d35b4950cd326b0bef3b9c582cf01957fbf64cebce4b7bb85b7e38add9"
 
-      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}.dmg",
+          user_agent: :curl
     end
     on_big_sur do
       version "8.0.29,12"
       sha256 arm:   "7095eaa8c67a8952101e0e6173645ac4377b1c06df5e8f87ceddea418d79b5a6",
              intel: "971e88d93f477437b7b6507408c0c31183f36af7922b7c2f6570ec314779ad20"
 
-      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg",
+          user_agent: :curl
     end
     on_monterey do
       version "8.0.34,13"
       sha256 arm:   "c67890eff6829afbc234260b3f54d34cb65b699e53ae59520b94feee8e337d71",
              intel: "6fd9e3855e70028b88a05ba6be76e9101a601f1416fd6c0eb2078169dbe8937d"
 
-      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg"
+      url "https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell-#{version.csv.first}-macos#{version.csv.second}-#{arch}.dmg",
+          user_agent: :curl
     end
 
     livecheck do
@@ -36,7 +39,8 @@ cask "mysql-shell" do
         user_agent: :curl
 
     livecheck do
-      url "https://dev.mysql.com/downloads/shell/?tpl=platform&os=33"
+      url "https://dev.mysql.com/downloads/shell/?tpl=platform&os=33",
+          user_agent: :curl
       regex(/mysql[._-]shell[._-]v?(\d+(?:\.\d+)+)[._-]macos(\d+)[._-]#{arch}\.dmg/i)
       strategy :page_match do |page, regex|
         page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mysql-shell` uses a curl user agent for the newest artifact URL, as requests to dev.mysql.com will fail without it. The same issue affects the `livecheck` block URL, so the check has been broken for some time. This addresses this issue by adding `user_agent: :curl` to the `livecheck` block URL now that it's supported.

Besides that, this also adds `user_agent :curl` to the URLs for the older versions, as they fail in the same way but weren't updated like the `url` for the newest version.