### PR TITLE
mysqlworkbench: update livecheck

### DIFF
--- a/Casks/m/mysqlworkbench.rb
+++ b/Casks/m/mysqlworkbench.rb
@@ -6,20 +6,33 @@ cask "mysqlworkbench" do
       version "8.0.23"
       sha256 "4c8664f5686a449a9760bda9b85d7e8c6beb1367d35f668048ffe534652da7b3"
 
-      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg",
+          user_agent: :curl
+
+      disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+      caveats do
+        requires_rosetta
+      end
     end
     on_big_sur do
       version "8.0.31"
       sha256 "6807ac1138c424c57d7e912c08301a838a90935dd0fc7a5658d3ded23f98a865"
 
-      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-x86_64.dmg",
+          user_agent: :curl
+
+      caveats do
+        requires_rosetta
+      end
     end
     on_monterey do
       version "8.0.34"
       sha256 arm:   "aea67c39354d76c38f2e9aca4390dbe4f75ecc3f12110ff598bf2fc46f48bf8c",
              intel: "9fba65a06db4c67e353014b49c41d7cd0e915dd6584df43d6cb099f38cf841e2"
 
-      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-#{arch}.dmg"
+      url "https://downloads.mysql.com/archives/get/p/#{version.major}/file/mysql-workbench-community-#{version}-macos-#{arch}.dmg",
+          user_agent: :curl
     end
 
     livecheck do
@@ -34,7 +47,8 @@ cask "mysqlworkbench" do
     url "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-#{version}-macos-#{arch}.dmg"
 
     livecheck do
-      url "https://dev.mysql.com/downloads/workbench/?tpl=platform&os=33"
+      url "https://dev.mysql.com/downloads/workbench/?tpl=platform&os=33",
+          user_agent: :curl
       regex(/mysql[._-]workbench[._-]community[._-]v?(\d+(?:\.\d+)+)(?:[._-]macos)?[._-]#{arch}\.dmg/i)
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `mysqlworkbench` fails because requests to dev.mysql.com do not work with a `:default` or `:browser` user agent. The check works with a curl user agent, so this updates the `livecheck` block accordingly now that it's possible to set the user agent.

This also adds `user_agent :curl` to the URLs for the older versions, as requests to downloads.mysql.com fail in the same way. Besides that, this addresses audit failures in the older versions.