### PR TITLE
unite-phone: disable

### DIFF
--- a/Casks/u/unite-phone.rb
+++ b/Casks/u/unite-phone.rb
@@ -3,17 +3,13 @@ cask "unite-phone" do
   sha256 "09ca6ee8263baf87e137e8129caf79e7e4496904c08c3e550f4ac795c2223b34"
 
   url "https://update.unitephone.nl/updates/unite_phone-#{version}-universal-mac.zip",
-      user_agent: :fake
+      user_agent: :browser
   name "Unite Phone"
   desc "Video and voice calling application"
   homepage "https://unitephone.nl/"
 
-  livecheck do
-    url "https://update.unitephone.nl/updates/latest-mac.yml"
-    strategy :electron_builder
-  end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  # Artifact URL is consistently unreachable in the homebrew/cask CI environment
+  disable! date: "2025-12-31", because: :unreachable
 
   depends_on macos: ">= :big_sur"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `unite-phone` works locally but it frequently fails in the autobump environment. The artifact URL uses a browser user agent, so this does the same for the `livecheck` block. This check works locally with the default user agent but hopefully this change will address the autobump failure (if it doesn't, we can try the curl user agent).