### PR TITLE
assinador-serpro 4.3.3

### DIFF
--- a/Casks/a/assinador-serpro.rb
+++ b/Casks/a/assinador-serpro.rb
@@ -1,20 +1,20 @@
 cask "assinador-serpro" do
-  version "4.3.2"
-  sha256 "6ca57788e88cefc6b098a4fd7f7088c27c3dfa226368da43689a7261ee81c2b2"
+  version "4.3.3"
+  sha256 "d577d143e7fd7305e505da856e48cf1eb089b4f94c0af23012b7358cf50b42eb"
 
-  url "https://assinadorserpro.estaleiro.serpro.gov.br/downloads/#{version}/AssinadorSerpro-#{version}.mpkg.zip"
+  url "https://assinadorserpro.estaleiro.serpro.gov.br/downloads/#{version}/AssinadorSerpro-#{version}.pkg"
   name "Assinador Serpro"
   desc "Validate and sign documents using digital certificates"
   homepage "https://www.serpro.gov.br/links-fixos-superiores/assinador-digital/assinador-serpro"
 
   livecheck do
     url :homepage
-    regex(/instalação\s+Mac\s+v?(\d+(?:\.\d+)+)/i)
+    regex(/href=.*?AssinadorSerpro[._-]v?(\d+(?:\.\d+)+)\.m?pkg/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  pkg "AssinadorSerpro-#{version}.mpkg/Contents/Packages/AssinadorSerpro.pkg"
+  pkg "AssinadorSerpro-#{version}.pkg"
 
   uninstall pkgutil: "br.gov.serpro.desktop.assinador"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`assinador-serpro` is autobumped but the workflow failed to update to version 4.3.3 because the `livecheck` block produces an "Unable to get versions" error. This updates the `livecheck` block to match the version from the pkg URL on the page instead of loose text that can (and did) change over time.

Upstream switched to a pkg file with this version, so this updates the cask accordingly. `brew audit` reported that all of the artifacts pass Gatekeeper checks, so this also removes the future `disable!` call.