### PR TITLE
avast-security: update livecheck

### DIFF
--- a/Casks/a/avast-security.rb
+++ b/Casks/a/avast-security.rb
@@ -9,7 +9,7 @@ cask "avast-security" do
   homepage "https://www.avast.com/"
 
   livecheck do
-    url "http://mac-av.u.avcdn.net/mac-av/10_11/AAFM/changelog.html"
+    url "https://mac-av.u.avcdn.net/mac-av/10_11/AAFM/changelog.html"
     regex(%r{<h2>(\d+(?:\.\d+)+).*</h2>}i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block URL for `avast-security` uses HTTP but can use HTTPS, so this updates it accordingly.