### PR TITLE
hashbackup: update livecheck

### DIFF
--- a/Casks/h/hashbackup.rb
+++ b/Casks/h/hashbackup.rb
@@ -5,11 +5,11 @@ cask "hashbackup" do
   url "https://www.hashbackup.com/download/hb-mac-64bit.tar.gz"
   name "HashBackup"
   desc "Command-line backup program"
-  homepage "https://www.hashbackup.com/hashbackup/index.html"
+  homepage "https://www.hashbackup.com/hashbackup/"
 
   livecheck do
-    url "http://upgrade.hashbackup.com/release/latest.txt"
-    regex(/^(\d+)$/i)
+    url "https://www.hashbackup.com/hashbackup/releases.html"
+    regex(/id=["']?_?(\d+)/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `hashbackup` uses HTTP and the upgrade.hashbackup.com server doesn't support HTTPS, so this updates the `livecheck` block to check the Releases page on the main website.