### PR TITLE
font-luculent: update urls

### DIFF
--- a/Casks/font/font-l/font-luculent.rb
+++ b/Casks/font/font-l/font-luculent.rb
@@ -2,9 +2,9 @@ cask "font-luculent" do
   version :latest
   sha256 :no_check
 
-  url "http://eastfarthing.com/luculent/luculent.tar.xz"
+  url "https://fontlibrary.org/assets/downloads/luculent/2de871ff7494289a7c7ff160552158eb/luculent.zip"
   name "Luculent"
-  homepage "http://eastfarthing.com/luculent/"
+  homepage "https://fontlibrary.org/en/font/luculent"
 
   font "luculent/luculent.ttf"
   font "luculent/luculentb.ttf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing artifact URL and homepage for `font-luculent` use HTTP and eastfarthing.com doesn't support HTTPS. We have decided to disable casks that use an HTTP artifact URL and `sha256 :no_check` (for security reasons), so this updates the cask to use fontlibrary.org (like a few other casks) as an alternative to disabling it.