### PR TITLE
unexpectedly: disable

### DIFF
--- a/Casks/u/unexpectedly.rb
+++ b/Casks/u/unexpectedly.rb
@@ -7,10 +7,8 @@ cask "unexpectedly" do
   desc "Browse and visualise the reports from crashes"
   homepage "http://s.sudre.free.fr/Software/Unexpectedly/about.html"
 
-  livecheck do
-    url :homepage
-    regex(%r{Version</b>:</td><td>(\d+(?:\.\d+)*\w)}i)
-  end
+  # Artifact not available over HTTPS
+  disable! date: "2025-12-23", because: :no_longer_meets_criteria
 
   app "Unexpectedly.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The artifact URL for `unexpectedly` is only available over HTTP and I could not find any alternative sources. We have decided to disable casks that use an HTTP artifact URL and `sha256 :no_check` (for security reasons), so this updates the cask accordingly.

For what it's worth, `brew audit` hangs while auditing this cask but this would fail in CI anyway due to it being disabled, so I'm running this as syntax-only.