### PR TITLE
mimecast: update livecheck

### DIFF
--- a/Casks/m/mimecast.rb
+++ b/Casks/m/mimecast.rb
@@ -2,13 +2,14 @@ cask "mimecast" do
   version "2.11"
   sha256 :no_check
 
-  url "https://us-api.mimecast.com/update/bin/msm/eNptjMtuwjAURP_F6xb5mdjsoBWL8lBVhKqyiRzfa7CKkxYnoaTqv9fsWY00c-b8koSuP2MAMiVvzUn4xerA5gv_8RKfr5fd97haDj-7i9ovj-YwcjsPfP36rrd-vTzqbR2LYTOmzQJmcF2RB-JOAZuu_wLb4cSHE04aGzG71yGis6mbQDzc5SKojIG3SjrNlRGqMKIUvHRgwDHuCi50cbv2qWsjnl0LN_HTbjtjM2nuSlMYbwyjrDSS6swMeE6hbciU3eO79hPzRuqqT5RVSlUDKPUoKk45pSpXkjOBhlFEB-C8LrUsTAFSuZLpmqI33tKS5dRWc5_7GmovbQ1WGecY-fsHKkl1eg"
+  url "https://us-api.mimecast.com/update/bin/msm/eNptjMtuwjAURP_F6xb5mdjsoBWL8lBVhKqyiRzfa7CKkxYnoaTqv9fsWY00c-b8koSuP2MAMiVvzUn4xerA5gv_8RKfr5fd97haDj-7i9ovj-YwcjsPfP36rrd-vTzqbR2LYTOmzQJmcF2RB-JOAZuu_wLb4cSHE04aGzG71yGis6mbQDzc5SKojIG3SjrNlRGqMKIUvHRgwDHuCi50cbv2qWsjnl0LN_HTbjtjM2nuSlMYbwyjrDSS6swMeE6hbciU3eO79hPzRuqqT5RVSlUDKPUoKk45pSpXkjOBhlFEB-C8LrUsTAFSuZLpmqI33tKS5dRWc5_7GmovbQ1WGecY-fsHKkl1eg",
+      verified: "us-api.mimecast.com/update/bin/msm/"
   name "Mimecast for Mac"
   desc "Access to the Mime Cast email archive"
-  homepage "https://community.mimecast.com/community/knowledge-base/mimecast-for-mac"
+  homepage "https://mimecastsupport.zendesk.com/hc/en-us/articles/34000775267731-Mimecast-for-Mac-Overview"
 
   livecheck do
-    url "http://updates-us.mimecast.com/update/descriptors/msm/latest"
+    url "https://updates-us.mimecast.com/update/descriptor/msm/latest"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block URL for `mimecast` uses an HTTP URL but the server returns a 405 (Method Not Allowed) response if the URL is updated to HTTPS. The app uses a similar HTTPS URL but the path uses `descriptor` instead of `descriptors`. That URL works, so this updates the `livecheck` block accordingly.

This also updates the homepage, as the existing URL returns a 404 (Not Found) response. The best alternative I found was the "Mimecast for Mac - Overview" section of the knowledge hub.