### PR TITLE
textbar: update urls

### DIFF
--- a/Casks/t/textbar.rb
+++ b/Casks/t/textbar.rb
@@ -2,13 +2,14 @@ cask "textbar" do
   version "3.5.6"
   sha256 "61fba4cdab18070c1ba21176072556df42a9c92fc280a51363028d86731a298e"
 
-  url "http://richsomerfield.com/apps/textbar/TextBar.app-#{version}.zip"
+  url "https://raw.githubusercontent.com/richie5um/richie5um.github.io/master/apps/textbar/TextBar.app-#{version}.zip",
+      verified: "raw.githubusercontent.com/richie5um/richie5um.github.io/master/apps/textbar/"
   name "TextBar"
   desc "Add any text to menu bar"
   homepage "http://richsomerfield.com/apps/textbar/"
 
   livecheck do
-    url "http://richsomerfield.com/apps/textbar/sparkle_textbar.xml"
+    url "https://raw.githubusercontent.com/richie5um/richie5um.github.io/master/apps/textbar/sparkle_textbar.xml"
     strategy :sparkle
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The richsomerfield.com URLs in the `textbar` cask use HTTP and HTTPS doesn't work. It's a GitHub Pages site using a custom domain but maybe there's something off about their DNS records or the GitHub Pages configuration.

The Sparkle appcast links to raw.githubusercontent.com zip files in the website repository, so we can use the same URLs to upgrade the artifact and `livecheck` block URLs to HTTPS. This is something that upstream should probably sort out but I'll save that for after the holidays.

For what it's worth, I didn't update the homepage URL because the github.io URL for the site redirects to the custom domain, so that's not a solution.