### PR TITLE
aurora-hdr: update livecheck

### DIFF
--- a/Casks/a/aurora-hdr.rb
+++ b/Casks/a/aurora-hdr.rb
@@ -8,7 +8,7 @@ cask "aurora-hdr" do
   homepage "https://skylum.com/aurorahdr"
 
   livecheck do
-    url "http://aurorahdr2019mac.update.skylum.com/"
+    url "https://aurorahdrmac.skylum.com"
     strategy :sparkle
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `aurora-hdr` works but it uses HTTP and cannot be upgraded to HTTPS. This updates the `livecheck` block to use the redirecting URL that the installer uses, which supports HTTPS and points to the same appcast file as the existing URL.