### PR TITLE
various: disable due to not being available over HTTPS

### DIFF
--- a/Casks/a/apptivate.rb
+++ b/Casks/a/apptivate.rb
@@ -7,10 +7,8 @@ cask "apptivate" do
   desc "Create global hotkeys for your files and applications"
   homepage "http://www.apptivateapp.com/"
 
-  livecheck do
-    url "http://www.apptivateapp.com/changelog.txt"
-    regex(/Apptivate\s*v?(\d+(?:\.\d+)+)/i)
-  end
+  # Artifact not available over HTTPS
+  disable! date: "2025-12-23", because: :no_longer_meets_criteria
 
   app "Apptivate.app"
 

--- a/Casks/font/font-h/font-humor-sans.rb
+++ b/Casks/font/font-h/font-humor-sans.rb
@@ -7,10 +7,8 @@ cask "font-humor-sans" do
   name "Humor Sans"
   homepage "https://xkcdsucks.blogspot.com.au/2009/03/xkcdsucks-is-proud-to-present-humor.html"
 
-  livecheck do
-    url "http://antiyawn.com/uploads/humorsans.html"
-    regex(/href=.*Humor[._-]Sans[._-]v?(\d+(?:\.\d+)+)\.ttf/i)
-  end
+  # Artifact not available over HTTPS
+  disable! date: "2025-12-23", because: :no_longer_meets_criteria
 
   font "Humor-Sans-#{version}.ttf"
 

--- a/Casks/i/id3-editor.rb
+++ b/Casks/i/id3-editor.rb
@@ -7,10 +7,8 @@ cask "id3-editor" do
   desc "MP3 and AIFF ID3 tag editor"
   homepage "http://www.pa-software.com/id3editor/"
 
-  livecheck do
-    url "http://www.pa-software.com/id3editor/history/"
-    regex(/Version\s*v?(\d+(?:\.\d+)+)/i)
-  end
+  # Artifact not available over HTTPS
+  disable! date: "2025-12-23", because: :no_longer_meets_criteria
 
   depends_on macos: ">= :big_sur"
 

--- a/Casks/x/xact.rb
+++ b/Casks/x/xact.rb
@@ -7,10 +7,8 @@ cask "xact" do
   desc "X Audio Compression Toolkit"
   homepage "http://xact.scottcbrown.org/"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?xACTv?(\d+(?:\.\d+)+)\.zip/i)
-  end
+  # Artifact not available over HTTPS
+  disable! date: "2025-12-23", because: :no_longer_meets_criteria
 
   app "xACT#{version}/xACT.app"
 


### PR DESCRIPTION
These are the remaining casks still using insecure links for their artifacts.