### PR TITLE
redis-insight: update url

### DIFF
--- a/Casks/r/redis-insight.rb
+++ b/Casks/r/redis-insight.rb
@@ -5,14 +5,14 @@ cask "redis-insight" do
   sha256 arm:   "2ef847845b5cc725050d4ab78992afb9afccd01ee8e84f49a77bfb6e1f9fcb34",
          intel: "c33dede2ae81cfaeba66cdf6d27084647fcc9f0fb8ea84a11b393420695dd0ba"
 
-  url "https://download.redisinsight.redis.com/releases/#{version}/Redis-Insight-mac-#{arch}.dmg",
-      verified: "download.redisinsight.redis.com/"
+  url "https://s3.amazonaws.com/redisinsight.download/public/releases/#{version}/Redis-Insight-mac-#{arch}.dmg",
+      verified: "s3.amazonaws.com/redisinsight.download/"
   name "Redis Insight"
   desc "GUI for streamlined Redis application development"
   homepage "https://redis.io/insight/"
 
   livecheck do
-    url "https://download.redisinsight.redis.com/latest/latest-mac.yml"
+    url "https://s3.amazonaws.com/redisinsight.download/public/latest/latest-mac.yml"
     strategy :electron_builder
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The SSL certificate for `download.redisinsight.redis.com` has expired, so reverting to the previous S3 URL.