### PR TITLE
sourcegit 2025.40 (new cask)

### DIFF
--- a/Casks/s/sourcegit.rb
+++ b/Casks/s/sourcegit.rb
@@ -3,14 +3,12 @@ cask "sourcegit" do
 
   on_arm do
     sha256 "49a868c212162a3f7e59dabece3bce21d763787ab419e3bd725348c29ece1d45"
-    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-arm64-signed.dmg",
-        verified: "github.com/ybeapps/homebrew-sourcegit/"
+    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-arm64-signed.dmg"
   end
 
   on_intel do
     sha256 "e1e5379b64189f4a24e07f75f247ab47a433fa4ddfd9e6ff9f530ebd6d2603a3"
-    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-x64-signed.dmg",
-        verified: "github.com/ybeapps/homebrew-sourcegit/"
+    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-x64-signed.dmg"
   end
 
   name "SourceGit"

--- a/Casks/s/sourcegit.rb
+++ b/Casks/s/sourcegit.rb
@@ -1,16 +1,11 @@
 cask "sourcegit" do
+  arch arm: "arm64", intel: "x64"
+
   version "2025.40"
+  sha256 arm:   "49a868c212162a3f7e59dabece3bce21d763787ab419e3bd725348c29ece1d45",
+         intel: "e1e5379b64189f4a24e07f75f247ab47a433fa4ddfd9e6ff9f530ebd6d2603a3"
 
-  on_arm do
-    sha256 "49a868c212162a3f7e59dabece3bce21d763787ab419e3bd725348c29ece1d45"
-    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-arm64-signed.dmg"
-  end
-
-  on_intel do
-    sha256 "e1e5379b64189f4a24e07f75f247ab47a433fa4ddfd9e6ff9f530ebd6d2603a3"
-    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-x64-signed.dmg"
-  end
-
+  url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-#{arch}-signed.dmg"
   name "SourceGit"
   desc "Git GUI client"
   homepage "https://github.com/sourcegit-scm/sourcegit"

--- a/Casks/s/sourcegit.rb
+++ b/Casks/s/sourcegit.rb
@@ -1,0 +1,33 @@
+cask "sourcegit" do
+  version "2025.40"
+
+  on_arm do
+    sha256 "49a868c212162a3f7e59dabece3bce21d763787ab419e3bd725348c29ece1d45"
+    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-arm64-signed.dmg",
+        verified: "github.com/ybeapps/homebrew-sourcegit/"
+  end
+
+  on_intel do
+    sha256 "e1e5379b64189f4a24e07f75f247ab47a433fa4ddfd9e6ff9f530ebd6d2603a3"
+    url "https://github.com/ybeapps/homebrew-sourcegit/releases/download/v#{version}-signed/SourceGit-v#{version}-x64-signed.dmg",
+        verified: "github.com/ybeapps/homebrew-sourcegit/"
+  end
+
+  name "SourceGit"
+  desc "Git GUI client"
+  homepage "https://github.com/sourcegit-scm/sourcegit"
+
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "SourceGit.app"
+
+  zap trash: [
+    "~/Library/Application Support/SourceGit",
+    "~/Library/Saved Application State/com.sourcegit.app.savedState",
+  ]
+end


### PR DESCRIPTION
Sorry - PR created with Claude - and he skipped the template - adding it now:
--

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---


Add SourceGit, a Git GUI client.

**About SourceGit:**
SourceGit is an open source, cross-platform Git GUI client that provides a clean and intuitive interface for managing Git repositories.

**Download Source:**
The cask downloads from `ybeapps/homebrew-sourcegit` which provides properly signed and notarized versions of the macOS app. The upstream SourceGit project officially recommends this tap in their README:
https://github.com/sourcegit-scm/sourcegit#macos

**Key Details:**
- Upstream project: https://github.com/sourcegit-scm/sourcegit
- All DMG files are properly code-signed and notarized for macOS
- Supports both Apple Silicon (ARM64) and Intel (x64) architectures
- Requires macOS Big Sur or later

**Testing:**
- [x] `brew audit --new --cask sourcegit` completed
- [x] `brew style --fix sourcegit` completed
- [x] Cask follows Homebrew style guidelines