### PR TITLE
Add fluidvoice cask

### DIFF
--- a/Casks/f/fluidvoice.rb
+++ b/Casks/f/fluidvoice.rb
@@ -1,0 +1,25 @@
+cask "fluidvoice" do
+  version "1.5.1"
+  sha256 "aac9037c05f36a22814c1fc5ab696e66f490e70c7eac35ec97f4c3edec028e45"
+
+  url "https://github.com/altic-dev/FluidVoice/releases/download/v#{version}/Fluid-oss-#{version}.zip",
+      verified: "github.com/altic-dev/FluidVoice/"
+  name "FluidVoice"
+  desc "Open source voice-to-text dictation app with AI enhancement"
+  homepage "https://altic.dev/fluid"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "FluidVoice.app"
+
+  zap trash: [
+    "~/Library/Application Support/FluidVoice",
+    "~/Library/Caches/com.FluidApp.app",
+    "~/Library/Preferences/com.FluidApp.app.plist",
+  ]
+end


### PR DESCRIPTION
## Description

This PR adds a new cask for **FluidVoice**, an open source voice-to-text dictation app for macOS with AI enhancement.

- **Name**: FluidVoice
- **Homepage**: https://altic.dev/fluid
- **Repository**: https://github.com/altic-dev/FluidVoice
- **Version**: 1.5.1

### Features
- Real-time speech transcription using multiple models (Parakeet TDT v3/v2, Apple Speech, or Whisper)
- Live preview overlays
- Direct text input into any macOS application
- Global hotkey activation
- AI enhancement via OpenAI or Groq APIs

Note: The cask is named `fluidvoice` rather than `fluid` because the `fluid` cask already exists (for a different app - website-to-desktop converter).