### PR TITLE
displaylink 15.0

### DIFF
--- a/Casks/d/displaylink.rb
+++ b/Casks/d/displaylink.rb
@@ -1,5 +1,5 @@
 cask "displaylink" do
-  on_big_sur :or_older do
+  on_ventura :or_older do
     on_catalina :or_older do
       version "1.5,2021-09"
       sha256 "d703cc8e9093e4d163c5e612326c0907a02c6d4eec6aaca8d0727503859ef95d"
@@ -16,16 +16,34 @@ cask "displaylink" do
 
       pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
     end
+    on_monterey do
+      version "1.11,2024-10"
+      sha256 "e154588f340aefe887d10e3566703ac381592eefc0175b7f1a53569fcc315a3f"
+
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
+
+      pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
+    end
+    on_ventura do
+      version "14.2,2025-11"
+      sha256 "2a08be4e7fba2c11dbfaf5ea78f60c66e1683a14212c60ff36e24ba469822b1c"
+
+      url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.zip"
+
+      rename "DisplayLinkManager-#{version.csv.first}*pkg", "DisplayLinkManager-#{version.csv.first}.pkg"
+
+      pkg "DisplayLinkManager-#{version.csv.first}.pkg"
+    end
 
     livecheck do
       skip "Legacy version"
     end
   end
-  on_monterey :or_newer do
-    version "14.2,2025-11"
-    sha256 "2a08be4e7fba2c11dbfaf5ea78f60c66e1683a14212c60ff36e24ba469822b1c"
+  on_sonoma :or_newer do
+    version "15.0,2025-12"
+    sha256 "4cedae42b642c3662b3eea0e81989226e5ae510a404bcf1fbbbb90262a71e014"
 
-    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.zip"
+    url "https://www.synaptics.com/sites/default/files/exe_files/#{version.csv.second}/DisplayLink%20Manager%20Graphics%20Connectivity#{version.csv.first}-EXE.pkg"
 
     livecheck do
       url "https://www.synaptics.com/products/displaylink-graphics/downloads/macos"
@@ -35,9 +53,7 @@ cask "displaylink" do
       end
     end
 
-    rename "DisplayLinkManager-#{version.csv.first}*pkg", "DisplayLinkManager-#{version.csv.first}.pkg"
-
-    pkg "DisplayLinkManager-#{version.csv.first}.pkg"
+    pkg "DisplayLink Manager Graphics Connectivity#{version.csv.first}-EXE.pkg"
   end
 
   name "DisplayLink USB Graphics Software"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`displaylink` is autobumped but the workflow failed to update to version 15.0 because the artifact is back to being a pkg file (not a zip). This updates the version, `url`, and adjusts the newest on_os block to use the minimum requirement for this version. The on_os value for the newest version was incorrect, as 1.11 was the last version to support Monterey 12, so this updates the legacy blocks accordingly. I haven't tested installation but hopefully the `pkg` values are correct.