### PR TITLE
messenger: disable

### DIFF
--- a/Casks/m/messenger.rb
+++ b/Casks/m/messenger.rb
@@ -7,10 +7,8 @@ cask "messenger" do
   desc "Native desktop app for Messenger (formerly Facebook Messenger)"
   homepage "https://www.messenger.com/desktop"
 
-  livecheck do
-    url "https://www.facebook.com/messenger/desktop/zeratul/update.xml?target=zeratul&platform=mac"
-    strategy :sparkle, &:short_version
-  end
+  deprecate! date: "2025-12-25", because: :discontinued
+  disable! date: "2025-12-25", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
Facebook Messenger has been deprecated by Meta. See https://www.facebook.com/help/messenger-app/1789649698300122 for more details. It can be installed, but upon opening, it looks like this:

<img width="940" height="831" alt="image" src="https://github.com/user-attachments/assets/9b9bdbda-6aa9-495c-887a-4f18b6ac71b3" />

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
