### PR TITLE
vimcal 1.0.41 (arm only)

### DIFF
--- a/Casks/v/vimcal.rb
+++ b/Casks/v/vimcal.rb
@@ -2,9 +2,14 @@ cask "vimcal" do
   arch arm: "-arm64"
   host_suffix = on_arch_conditional arm: "m1", intel: "production"
 
-  version "1.0.40"
-  sha256 arm:   "016e364a763a25808ac74d16b878451005220a0b27389124d6f7deb24d3a55e8",
-         intel: "c3d12755f990b7aa6bedf55c94f2105138e9aa07ab01cb91e673d633f737083b"
+  on_arm do
+    version "1.0.41"
+    sha256 "dd7e588498e0376ab23054c0a8c7c5aa9a0bbf2e292c2f93527dd2c484afe1e2"
+  end
+  on_intel do
+    version "1.0.40"
+    sha256 "c3d12755f990b7aa6bedf55c94f2105138e9aa07ab01cb91e673d633f737083b"
+  end
 
   url "https://vimcal-#{host_suffix}.s3.amazonaws.com/Vimcal-#{version}#{arch}.dmg",
       verified: "vimcal-#{host_suffix}.s3.amazonaws.com/"


### PR DESCRIPTION
vimcal 1.0.41 (arm only)

---

autobump failed, https://github.com/Homebrew/homebrew-cask/actions/runs/20507290447/job/58923669914#step:5:17444