### PR TITLE
bison-wallet 1.0.5 (arm only)

### DIFF
--- a/Casks/b/bison-wallet.rb
+++ b/Casks/b/bison-wallet.rb
@@ -1,21 +1,32 @@
 cask "bison-wallet" do
   arch arm: "arm64", intel: "amd64"
 
-  version "1.0.4"
-  sha256 arm:   "31e5945adc602840aeb3e853909a8003b185a95e31fbc5c8a7db4a23f7c29c2d",
-         intel: "889d54f752c96e6a079db29b66d14d8b8e4a5577c91d1b3d499c4e781f75554e"
+  on_arm do
+    version "1.0.5"
+    sha256 "be34568944052e1c0e32a94d21d120c7b7af3725eb3eaaee243b204313c606f6"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
+  on_intel do
+    version "1.0.4"
+    sha256 "889d54f752c96e6a079db29b66d14d8b8e4a5577c91d1b3d499c4e781f75554e"
+
+    livecheck do
+      skip "No Intel releases available after 1.0.4"
+    end
+  end
 
   url "https://github.com/decred/dcrdex/releases/download/v#{version}/bisonw-desktop-darwin-#{arch}-v#{version}.dmg"
   name "Bison Wallet"
   desc "Multi-coin wallet with feeless DEX, atomic swaps, and arbitrage tools"
   homepage "https://github.com/decred/dcrdex"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :big_sur"
 
   app "Bison Wallet.app"
 


### PR DESCRIPTION
bison-wallet 1.0.5 (arm only)

- darwin/amd64 build got dropped in https://github.com/decred/dcrdex/pull/3366