### PR TITLE
Update gcloud-cli depends_on version for python

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -16,7 +16,7 @@ cask "gcloud-cli" do
   end
 
   auto_updates true
-  depends_on formula: "python@3.13"
+  depends_on formula: "python@3.14"
 
   google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 


### PR DESCRIPTION
Update to use the latest release of python that is supported by gcloud-cli.

"The Google Cloud CLI requires Python 3.9 to 3.14."
Source: https://docs.cloud.google.com/sdk/docs/install-sdk

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

As a side note, the above `brew audit` command is not working for me.