### PR TITLE
macdown3000 3000.0.1 (new cask)

### DIFF
--- a/Casks/m/macdown-3000.rb
+++ b/Casks/m/macdown-3000.rb
@@ -1,8 +1,9 @@
-cask "macdown3000" do
+cask "macdown-3000" do
   version "3000.0.1"
   sha256 "82965a72eed6d212a7cffebd711733178657cebae6b580ef6ef732acbd5b1f3a"
 
-  url "https://github.com/schuyler/macdown3000/releases/download/v#{version}/MacDown-#{version}.dmg"
+  url "https://github.com/schuyler/macdown3000/releases/download/v#{version}/MacDown-#{version}.dmg",
+      verified: "github.com/schuyler/macdown3000/"
   name "MacDown 3000"
   desc "Markdown editor with live preview and syntax highlighting"
   homepage "https://macdown.app/"

--- a/Casks/m/macdown3000.rb
+++ b/Casks/m/macdown3000.rb
@@ -1,0 +1,19 @@
+cask "macdown3000" do
+  version "3000.0.1"
+  sha256 "82965a72eed6d212a7cffebd711733178657cebae6b580ef6ef732acbd5b1f3a"
+
+  url "https://github.com/schuyler/macdown3000/releases/download/v#{version}/MacDown-#{version}.dmg"
+  name "MacDown 3000"
+  desc "Markdown editor with live preview and syntax highlighting"
+  homepage "https://macdown.app/"
+
+  depends_on macos: ">= :big_sur"
+
+  app "MacDown 3000.app"
+
+  zap trash: [
+    "~/Library/Application Support/MacDown 3000",
+    "~/Library/Caches/app.macdown.macdown3000",
+    "~/Library/Preferences/app.macdown.macdown3000.plist",
+  ]
+end


### PR DESCRIPTION
MacDown 3000 is an open-source Markdown editor for macOS with live preview and syntax highlighting.

**Release:** https://github.com/schuyler/macdown3000/releases/tag/v3000.0.1

The DMG is signed with a Developer ID Application certificate and notarized by Apple.