### PR TITLE
astah-professional 11.0.0

### DIFF
--- a/Casks/a/astah-professional.rb
+++ b/Casks/a/astah-professional.rb
@@ -1,25 +1,41 @@
 cask "astah-professional" do
-  version "10.1.0,9ceee1"
-  sha256 "4d9c28800d6ccf6c7ff10488e1cc6e856392347a7191feeda7ccf0e305aeb0e0"
+  on_arm do
+    version "11.0.0,ba221e"
+    sha256 "220f7057cef479f7fb28841bb22ae7552771ab3c5295e471719c1ac9912590d2"
 
-  url "https://cdn.change-vision.com/files/astah-professional-#{version.csv.first.dots_to_underscores}-#{version.csv.second}-MacOs.dmg",
-      verified: "cdn.change-vision.com/files/"
+    url "https://cdn.change-vision.com/files/astah-professional-#{version.csv.first.dots_to_underscores}-#{version.csv.second}-MacOs-aarch64.dmg",
+        verified: "cdn.change-vision.com/files/"
+
+    livecheck do
+      url "https://members.change-vision.com/download/files/astah_professional/latest/mac_pkg"
+      regex(/astah[._-]professional[._-]v?(\d+(?:[._]\d+)+)[._-](\h+)[._-]MacOs.*?\.dmg/i)
+      strategy :header_match do |headers, regex|
+        match = headers["location"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1].tr("_", ".")},#{match[2]}"
+      end
+    end
+
+    pkg "astah professional aarch64 ver #{version.csv.first.dots_to_underscores}.pkg"
+  end
+  on_intel do
+    version "10.1.0,9ceee1"
+    sha256 "4d9c28800d6ccf6c7ff10488e1cc6e856392347a7191feeda7ccf0e305aeb0e0"
+
+    url "https://cdn.change-vision.com/files/astah-professional-#{version.csv.first.dots_to_underscores}-#{version.csv.second}-MacOs.dmg",
+        verified: "cdn.change-vision.com/files/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    pkg "astah professional ver #{version.csv.first.dots_to_underscores}.pkg"
+  end
+
   name "Change Vision Astah Professional"
   desc "Software modelling tool"
   homepage "https://astah.net/editions/professional"
-
-  livecheck do
-    url "https://members.change-vision.com/download/files/astah_professional/latest/mac_pkg"
-    regex(/astah[._-]professional[._-]v?(\d+(?:[._]\d+)+)[._-](\h+)[._-]MacOs\.dmg/i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1].tr("_", ".")},#{match[2]}"
-    end
-  end
-
-  pkg "astah professional ver #{version.csv.first.dots_to_underscores}.pkg"
 
   uninstall pkgutil: "com.change-vision.astah.professional"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`astah-professional` is autobumped but the workflow failed to update to version 11.0.0 because the `livecheck` block produces an "Unable to get versions" error due to the regex not matching the current file name. This updates the cask for 11.0.0 and adjusts the `livecheck` block regex accordingly. It's worth noting that upstream seems to only offer an ARM version for macOS.