### PR TITLE
recut 4.3.4

### DIFF
--- a/Casks/r/recut.rb
+++ b/Casks/r/recut.rb
@@ -1,24 +1,23 @@
 cask "recut" do
-  version "2.1.7"
-  sha256 "786c03f4a6396e04e4ee4f3e258ba420f78776114cacffa753ea67f518a7c7e7"
+  version "4.3.4"
+  sha256 "db979442ba85ac4eb9fe34fac1c7dbcadb579cf8c24bb4387287f3fce8496f0b"
 
-  url "https://updates.getrecut.com/Recut-#{version}.dmg"
+  url "https://updates.getrecut.com/universal/Recut_#{version}_universal.dmg"
   name "Recut"
   desc "Remove silence from videos and automatically generate a cut list"
   homepage "https://getrecut.com/"
 
   livecheck do
-    url "https://updates.getrecut.com/appcast.xml"
-    strategy :sparkle, &:short_version
+    url "https://updates.getrecut.com/latest-mac"
+    strategy :header_match
   end
-
-  auto_updates true
 
   app "Recut.app"
 
   zap trash: [
-    "~/Library/Caches/co.tinywins.recut",
-    "~/Library/Preferences/co.tinywins.recut.plist",
-    "~/Library/Saved Application State/co.tinywins.recut.savedState",
+    "~/Library/Application Support/Recut",
+    "~/Library/Caches/com.tinywins.recut",
+    "~/Library/Preferences/com.tinywins.recut.plist",
+    "~/Library/Saved Application State/com.tinywins.recut.savedState",
   ]
 end


### PR DESCRIPTION
The automated BrewTestBot is stuck at 2.1.7 because the download URL structure changed. This PR updates to 4.3.4 using the latest redirect URL and fixes the livecheck.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
