### PR TITLE
taphouse 1.0.0 (new cask)

### DIFF
--- a/Casks/t/taphouse.rb
+++ b/Casks/t/taphouse.rb
@@ -1,0 +1,25 @@
+cask "taphouse" do
+  version "1.0.0"
+  sha256 "94e92577a26d636c67972acce8888c65c6bb9facf27e5dfdd366870bb674eb5a"
+
+  url "https://taphouse.multimodalsolutions.gr/downloads/Taphouse-#{version}.dmg"
+  name "Taphouse"
+  desc "Native GUI for Homebrew package management"
+  homepage "https://taphouse.multimodalsolutions.gr/"
+
+  livecheck do
+    url "https://taphouse.multimodalsolutions.gr/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Taphouse.app"
+
+  zap trash: [
+    "~/Library/Application Support/Taphouse",
+    "~/Library/Caches/Taphouse",
+    "~/Library/Preferences/com.multimodalsolutions.taphouse.plist",
+  ]
+end


### PR DESCRIPTION
### Description
  Taphouse is a native macOS GUI for Homebrew package management.

  ### Homepage
  https://taphouse.multimodalsolutions.gr/

  ### Checklist
  - [x] The submission is for a stable version of the software
  - [x] The app is not already in the Homebrew Cask repository
  - [x] The download URL is permanent and versioned
  - [x] I have tested the cask locally

  ### Additional information
  - Notarized and signed with Developer ID
  - Auto-updates via Sparkle
  - macOS 14.0+ (Sonoma) required