### PR TITLE
macdown: deprecate as unmaintained, suggest macdown-3000

### DIFF
--- a/Casks/m/macdown.rb
+++ b/Casks/m/macdown.rb
@@ -19,7 +19,7 @@ cask "macdown" do
     end
   end
 
-  deprecate! date: "2025-12-27", because: :unmaintained, replacement: "macdown-3000"
+  deprecate! date: "2025-12-27", because: :unmaintained, replacement_cask: "macdown-3000"
 
   auto_updates true
 

--- a/Casks/m/macdown.rb
+++ b/Casks/m/macdown.rb
@@ -19,6 +19,8 @@ cask "macdown" do
     end
   end
 
+  deprecate! date: "2025-12-27", because: :unmaintained, replacement: "macdown-3000"
+
   auto_updates true
 
   app "MacDown.app"


### PR DESCRIPTION


MacDown has not been maintained since 2021 (last release: 0.7.2 on 2021-07-03). The project has no Apple Silicon support and requires Rosetta.

[MacDown 3000](https://macdown.app/) is an actively maintained fork that:
- Supports Apple Silicon natively (universal binary)
- Is compatible with macOS 11.0+ (Big Sur and later)
- Continues development with updated dependencies

`macdown-3000` was added to homebrew-cask in #242416.

This PR deprecates `macdown` and suggests `macdown-3000` as the replacement.

---

  - [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
  - [x] `brew audit --cask --online <cask>` is error-free.
  - [x] `brew style --fix <cask>` reports no offenses.