### PR TITLE
Add ocrmypdf-gui

### DIFF
--- a/Casks/o/ocrmypdf-gui.rb
+++ b/Casks/o/ocrmypdf-gui.rb
@@ -7,6 +7,7 @@ cask "ocrmypdf-gui" do
   desc "Modern GUI application for OCRMyPDF with drag-and-drop support"
   homepage "https://github.com/nexusparadise/ocrmypdf-gui"
 
+  depends_on macos: ">= :ventura"
   depends_on formula: [
     "ocrmypdf",
     "tesseract-lang",

--- a/Casks/ocrmypdf-gui.rb
+++ b/Casks/ocrmypdf-gui.rb
@@ -1,0 +1,21 @@
+cask "ocrmypdf-gui" do
+  version "0.8"
+  sha256 "a19b7e3f6729172f0f9df8e9b999ac574c1b7105eeda4744ccc8c12ddd837771"
+
+  url "https://github.com/nexusparadise/ocrmypdf-gui/releases/download/v#{version}/ocrmypdf-gui-v#{version}.zip"
+  name "OCRMyPDF GUI"
+  desc "Modern GUI application for OCRMyPDF with drag-and-drop support"
+  homepage "https://github.com/nexusparadise/ocrmypdf-gui"
+
+  depends_on formula: [
+    "ocrmypdf",
+    "tesseract-lang",
+  ]
+
+  app "ocrmypdf-gui.app"
+
+  zap trash: [
+    "~/Library/Application Support/ocrmypdf-gui",
+    "~/Library/Preferences/de.ralf-eisenreich.ocrmypdf-gui.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *This is a new cask. Please note that verifying a new cask submission may take 10-15 minutes.*

- [x] `brew audit --cask ocrmypdf-gui` passes
- [x] `brew style --fix Casks/ocrmypdf-gui.rb` passes
- [x] The submission is for a stable version (v0.8)
- [x] `sha256` sum matches the release: `de18fc892966776fa3581c9c15eb44aefe70c7b75d167c937d437cf37debf335`
- [x] The cask includes `depends_on` for required dependencies (`ocrmypdf` and `tesseract-lang`)

A modern GUI application for OCRMyPDF with drag-and-drop support and batch processing.

**Homepage:** https://github.com/nexusparadise/ocrmypdf-gui
**GitHub Releases:** https://github.com/nexusparadise/ocrmypdf-gui/releases