### PR TITLE
astah-uml: add legacy version for intel

### DIFF
--- a/Casks/a/astah-uml.rb
+++ b/Casks/a/astah-uml.rb
@@ -1,27 +1,41 @@
 cask "astah-uml" do
-  version "11.0.0,ba221e"
-  sha256 "dc545402dd56ccfd94eb5a837233eb0b185bd7b5b7041b4bc11492cf6683d393"
+  on_arm do
+    version "11.0.0,ba221e"
+    sha256 "dc545402dd56ccfd94eb5a837233eb0b185bd7b5b7041b4bc11492cf6683d393"
 
-  url "https://cdn.change-vision.com/files/astah-uml-#{version.csv.first.dots_to_underscores}-#{version.csv.second}-MacOs-aarch64.dmg",
-      verified: "cdn.change-vision.com/files/"
+    url "https://cdn.change-vision.com/files/astah-uml-#{version.csv.first.dots_to_underscores}-#{version.csv.second}-MacOs-aarch64.dmg",
+        verified: "cdn.change-vision.com/files/"
+
+    livecheck do
+      url "https://members.change-vision.com/download/files/astah_UML/latest/mac_pkg"
+      regex(/astah[._-]uml[._-]v?(\d+(?:[._]\d+)+)[._-](\h+)[._-]MacOs.*?\.dmg/i)
+      strategy :header_match do |headers, regex|
+        match = headers["location"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1].tr("_", ".")},#{match[2]}"
+      end
+    end
+
+    pkg "astah uml aarch64 ver #{version.csv.first.dots_to_underscores}.pkg"
+  end
+  on_intel do
+    version "10.1.0,9ceee1"
+    sha256 "919592fdecfc26d1e2ebd798960f9e1bacd013145036552f703aeec2c4b27fdf"
+
+    url "https://cdn.change-vision.com/files/astah-uml-#{version.csv.first.dots_to_underscores}-#{version.csv.second}-MacOs.dmg",
+        verified: "cdn.change-vision.com/files/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    pkg "astah uml ver #{version.csv.first.dots_to_underscores}.pkg"
+  end
+
   name "Change Vision Astah UML"
   desc "UML diagramming tool with mind mapping"
   homepage "https://astah.net/products/astah-uml/"
-
-  livecheck do
-    url "https://members.change-vision.com/download/files/astah_UML/latest/mac_pkg"
-    regex(/astah[._-]uml[._-]v?(\d+(?:[._]\d+)+)[._-](\h+)[._-]MacOs.*?\.dmg/i)
-    strategy :header_match do |headers, regex|
-      match = headers["location"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1].tr("_", ".")},#{match[2]}"
-    end
-  end
-
-  depends_on arch: :arm64
-
-  pkg "astah uml aarch64 ver #{version.csv.first.dots_to_underscores}.pkg"
 
   uninstall pkgutil: "com.change-vision.astah.uml"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

We recently updated `astah-uml` to 11.0.0, which was only released for ARM. This adds the previous 10.1.0 version back for Intel and treats it as a legacy version, as that's potentially better than dropping Intel entirely.