### PR TITLE
boss: update 8.14.0

### DIFF
--- a/Casks/b/boss.rb
+++ b/Casks/b/boss.rb
@@ -1,6 +1,6 @@
 cask "boss" do
-  version "8.13.36"
-  sha256 "5ea576c56987f97749db505ac01ba8b430a9407ea8679ff9a2bca78f7aaffdc3"
+  version "8.14.0"
+  sha256 "a3c98461efda915df3258b11cbd4c58cea1fddf6b4c258ab64058b58e4c4062b"
 
   url "https://github.com/risa-labs-inc/BOSS-Releases/releases/download/v#{version}/BOSS-#{version}-Universal.dmg",
       verified: "github.com/risa-labs-inc/BOSS-Releases/"


### PR DESCRIPTION
Updates boss cask to version 8.14.0

  **Release Information:**
  - Version: 8.14.0  
  - SHA256: `a3c98461efda915df3258b11cbd4c58cea1fddf6b4c258ab64058b58e4c4062b`
  - Release URL: https://github.com/risa-labs-inc/BOSS-Releases/releases/tag/v8.14.0

  **Changes:**
  - Updated version from previous to 8.14.0
  - Updated SHA256 hash for new release asset

  BOSS is an AI-powered workspace for complex business operations.