### PR TITLE
Enhance uninstall process for eqMac

### DIFF
--- a/Casks/e/eqmac.rb
+++ b/Casks/e/eqmac.rb
@@ -17,7 +17,11 @@ cask "eqmac" do
 
   app "eqMac.app"
 
-  uninstall delete: "/Library/Audio/Plug-Ins/HAL/eqMac.driver"
+  uninstall delete: [
+    "/Library/Audio/Plug-Ins/HAL/eqMac.driver",
+    "/Library/PrivilegedHelperTools/com.bitgapp.eqmac.helper",
+    "/Library/LaunchDaemons/com.bitgapp.eqmac.helper.plist",
+  ]
 
   zap trash: [
     "~/Library/Caches/com.bitgapp.eqmac",

--- a/Casks/e/eqmac.rb
+++ b/Casks/e/eqmac.rb
@@ -19,8 +19,8 @@ cask "eqmac" do
 
   uninstall delete: [
     "/Library/Audio/Plug-Ins/HAL/eqMac.driver",
-    "/Library/PrivilegedHelperTools/com.bitgapp.eqmac.helper",
     "/Library/LaunchDaemons/com.bitgapp.eqmac.helper.plist",
+    "/Library/PrivilegedHelperTools/com.bitgapp.eqmac.helper",
   ]
 
   zap trash: [


### PR DESCRIPTION
This PR updates an existing cask (`eqmac`) to fix incomplete uninstall. No new cask is being added, and no local testing has been performed. Only the uninstall stanza paths were modified.

Adds removal of privileged helper tool and LaunchDaemon plist that currently persist after uninstall.
New paths that are removed during normal `brew uninstall eqmac` are:
- `/Library/PrivilegedHelperTools/com.bitgapp.eqmac.helper`
- `/Library/LaunchDaemons/com.bitgapp.eqmac.helper.plist`

No changes were made to `zap`.
For reference, look at the Uninstall FAQ for eqMac [here](https://help.eqmac.app/en/article/how-to-uninstall-eqmac-1syrpgj/#:~:text=Step%205:%20Remove%20Helper,rf%20/Library/LaunchDaemons/com.bitgapp.eqmac.helper.plist).

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
