### PR TITLE
taphouse: use static download URL

### DIFF
--- a/Casks/t/taphouse.rb
+++ b/Casks/t/taphouse.rb
@@ -1,8 +1,8 @@
 cask "taphouse" do
-  version "1.0.0"
-  sha256 "94e92577a26d636c67972acce8888c65c6bb9facf27e5dfdd366870bb674eb5a"
+  version "1.1.0"
+  sha256 :no_check
 
-  url "https://taphouse.multimodalsolutions.gr/downloads/Taphouse-#{version}.dmg"
+  url "https://taphouse.multimodalsolutions.gr/downloads/Taphouse.dmg"
   name "Taphouse"
   desc "Native GUI for Homebrew package management"
   homepage "https://taphouse.multimodalsolutions.gr/"


### PR DESCRIPTION
Changes the download URL from versioned (`Taphouse-X.Y.Z.dmg`) to static (`Taphouse.dmg`) to simplify the release workflow.

**Why:**
- The app uses Sparkle for auto-updates with frequent builds
- Having a static URL allows in-app updates without uploading versioned DMGs each time
- Reduces maintenance overhead for the developer

**Changes:**
- URL: `Taphouse-#{version}.dmg` → `Taphouse.dmg`
- sha256: switched to `:no_check` (required for unversioned URLs)
- Version: 1.0.0 → 1.1.0

The livecheck still uses the Sparkle appcast, so version detection continues to work.