### PR TITLE
gcloud-cli: fix python path for virtualenv creation

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -16,7 +16,7 @@ cask "gcloud-cli" do
   end
 
   auto_updates true
-  depends_on formula: "python@3.13"
+  depends_on formula: "python@3"
 
   google_cloud_sdk_root = "#{HOMEBREW_PREFIX}/share/google-cloud-sdk"
 
@@ -60,7 +60,7 @@ cask "gcloud-cli" do
     end
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "create", "--python-to-use",
-                                "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python3"],
+                                "#{HOMEBREW_PREFIX}/bin/python3"],
                     reset_uid: true
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "enable"],


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

## Description

Fixes #241514

The cask was attempting to use python3 from `libexec/bin`, which only contains unversioned symlinks (`python`, `pip`, etc.) for non-default Python versions. The `python3` symlink exists in `bin/`, not `libexec/bin/`.

### Changes
- Use standard `HOMEBREW_PREFIX/bin/python3` instead of version-specific `libexec/bin` path
- Depend on `python@3` instead of `python@3.13` for better compatibility with Homebrew's default Python version

### Testing
- `brew audit --cask --online gcloud-cli` passes (exit code 0)
- `brew style --fix gcloud-cli` passes with no offenses
- This fix aligns with Homebrew's current Python formula structure where versioned Python packages only provide unversioned symlinks in `libexec/bin/`

### References
- https://github.com/orgs/Homebrew/discussions/6361