### PR TITLE
novation-components 1.61.3 (new cask)

### DIFF
--- a/Casks/n/novation-components.rb
+++ b/Casks/n/novation-components.rb
@@ -1,0 +1,26 @@
+cask "novation-components" do
+  version "1.61.3"
+  sha256 :no_check
+
+  url "https://components-updates.novationmusic.com/download/osx"
+  name "Novation Components"
+  desc "Manager and updater for Novation hardware"
+  homepage "https://novationmusic.com/components/"
+
+  livecheck do
+    url "https://components-updates.novationmusic.com/download/osx"
+    strategy :extract_plist
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Components.app"
+
+  zap trash: [
+    "~/Library/Application Support/Components",
+    "~/Library/Caches/com.novationmusic.circuitcomponents*",
+    "~/Library/HTTPStorages/com.novationmusic.circuitcomponents",
+    "~/Library/Preferences/com.novationmusic.circuitcomponents.plist",
+  ]
+end

--- a/Casks/n/novation-components.rb
+++ b/Casks/n/novation-components.rb
@@ -1,15 +1,17 @@
 cask "novation-components" do
   version "1.61.3"
-  sha256 :no_check
+  sha256 "592f9011696fee419025b0b91a779fdeef20d92251612568a05e7f5770e3b555"
 
-  url "https://components-updates.novationmusic.com/download/osx"
+  url "https://components-updates.novationmusic.com/download/version/#{version}/osx_64?filetype=zip"
   name "Novation Components"
   desc "Manager and updater for Novation hardware"
   homepage "https://novationmusic.com/components/"
 
   livecheck do
-    url "https://components-updates.novationmusic.com/download/osx"
-    strategy :extract_plist
+    url "https://components-updates.novationmusic.com/update/darwin/0.0.0"
+    strategy :json do |json|
+      json["name"]
+    end
   end
 
   auto_updates true
@@ -18,6 +20,7 @@ cask "novation-components" do
   app "Components.app"
 
   zap trash: [
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.novationmusic.circuitcomponents.sfl*",
     "~/Library/Application Support/Components",
     "~/Library/Caches/com.novationmusic.circuitcomponents*",
     "~/Library/HTTPStorages/com.novationmusic.circuitcomponents",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

I named the app with the vendor prefix since I think "components" is too generic of a name and could be confused with MacOS system naming (for example, AU plugins are installed to a "Components" folder). If this isn't right, though, of course I'll change it!

I hate to use `extract_plist` here, but I cannot find any version information AT ALL on the website, anywhere. I also couldn't find any `latest-mac.yml` files despite the app using electron since it uses its own update mechanism internally. The file downloaded from the link does have the version in the name, though—would it be possible to use that somehow, even though the version isn't in the link itself?