### PR TITLE
gcloud-cli: fix python path for virtualenv creation

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -60,7 +60,7 @@ cask "gcloud-cli" do
     end
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "create", "--python-to-use",
-                                "#{HOMEBREW_PREFIX}/opt/python@3.13/bin/python3"],
+                                "#{HOMEBREW_PREFIX}/opt/python@3.13/bin/python3.13"],
                     reset_uid: true
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "enable"],

--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -60,7 +60,7 @@ cask "gcloud-cli" do
     end
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "create", "--python-to-use",
-                                "#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python3"],
+                                "#{HOMEBREW_PREFIX}/opt/python@3.13/bin/python3"],
                     reset_uid: true
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["config", "virtualenv", "enable"],


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

## Description

Fixes #241514

The cask was using an incorrect path that doesn't exist:
```ruby
#{HOMEBREW_PREFIX}/opt/python@3.13/libexec/bin/python3
```

The `python3` binary exists in `bin/`, not `libexec/bin/`:
```ruby
#{HOMEBREW_PREFIX}/opt/python@3.13/bin/python3.13
```

The `libexec/bin` directory only contains unversioned symlinks (`python`, `pip`, etc.), while the versioned `python3.13` binary is located in `bin/`.

This path follows the standard Homebrew pattern used throughout homebrew-core formulae (e.g., `Formula["python@3.14"].opt_bin/"python3.14"`).

## Testing

- `brew audit --cask --online gcloud-cli` passes (exit code 0)
- `brew style --fix gcloud-cli` passes with no offenses
- Tested installation via `brew install --cask gcloud-cli` on macOS
- Virtualenv creation succeeds and gcloud commands function correctly