### PR TITLE
Update qlc+ checksum

### DIFF
--- a/Casks/q/qlc+.rb
+++ b/Casks/q/qlc+.rb
@@ -3,7 +3,7 @@ cask "qlc+" do
 
   on_arm do
     version "5.0.1"
-    sha256 "00bab5cd80f3140cc981be72f3d0ad092f30436931e223955255d0a36205b254"
+    sha256 "f83ae54f05ececc67e47a2104cee4e602bf6826d1b594f68a5f90e93a4cf40e7"
 
     livecheck do
       url "https://www.qlcplus.org/download"


### PR DESCRIPTION
QLC+ 5.0.1 dmg file has different checksum on the download page now. They probably updated it.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
