### PR TITLE
mplab*: update livecheck

### DIFF
--- a/Casks/m/mplab-xc16.rb
+++ b/Casks/m/mplab-xc16.rb
@@ -8,7 +8,8 @@ cask "mplab-xc16" do
   homepage "https://www.microchip.com/mplab/compilers"
 
   livecheck do
-    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc16"
+    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc16",
+        user_agent: :browser
     regex(%r{href=.*?ProductDocuments/SoftwareTools/xc16[._-]v?(\d+(?:\.\d+)+)-full-install-osx64-installer\.dmg}i)
   end
 

--- a/Casks/m/mplab-xc32.rb
+++ b/Casks/m/mplab-xc32.rb
@@ -9,7 +9,8 @@ cask "mplab-xc32" do
   homepage "https://www.microchip.com/mplab/compilers"
 
   livecheck do
-    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc32"
+    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc32",
+        user_agent: :browser
     regex(%r{href=.*?SoftwareTools/xc32[._-]v?(\d+(?:\.\d+)+)[._-]full[._-]install[._-]osx[._-]installer\.dmg}i)
   end
 

--- a/Casks/m/mplab-xc8.rb
+++ b/Casks/m/mplab-xc8.rb
@@ -8,7 +8,8 @@ cask "mplab-xc8" do
   homepage "https://www.microchip.com/mplab/compilers"
 
   livecheck do
-    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc8"
+    url "https://www.microchip.com/en-us/tools-resources/develop/mplab-xc-compilers/xc8",
+        user_agent: :browser
     regex(%r{href=.*?ProductDocuments/SoftwareTools/xc8[._-]v?(\d+(?:\.\d+)+)-full-install-macos-x64-installer\.dmg}i)
   end
 

--- a/Casks/m/mplabx-ide.rb
+++ b/Casks/m/mplabx-ide.rb
@@ -9,7 +9,7 @@ cask "mplabx-ide" do
   homepage "https://www.microchip.com/en-us/tools-resources/develop/mplab-x-ide"
 
   livecheck do
-    url :homepage
+    url :homepage, user_agent: :browser
     regex(/href=.*?MPLABX[._-]v?(\d+(?:\.\d+)+)-osx-installer\.dmg/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` blocks for `mplab-x8`, `mplab-x16`, `mplab-x32`, and `mplabx-ide` fail with the default user agent but work after falling back to the `:browser` user agent. This adds an explicit `user_agent: :browser` argument, so they will continue to work after removing the user agent fallback behavior in livecheck.

Edit: I set this to skip the homepage because it predictably returns a 403 (Forbidden) response without a user agent (as we can't set one for the homepage).