### PR TITLE
msty: deprecate as old gen app, replace with mstystudio

### DIFF
--- a/Casks/m/msty.rb
+++ b/Casks/m/msty.rb
@@ -3,13 +3,11 @@ cask "msty" do
   version "1.9.2"
   sha256 :no_check
 
-  url "https://assets.msty.app/prod/latest/mac/Msty_#{arch}.dmg"
   name "Msty"
   desc "Run LLMs locally"
   homepage "https://msty.app/"
 
   deprecate! date: "2026-01-02", because: :discontinued, replacement_cask: "mstystudio"
-             because: "is being replaced by Msty Studio. Users are recommended to export their data and migrate to the new app", replacement_cask: "mstystudio"
 
   auto_updates true
 

--- a/Casks/m/msty.rb
+++ b/Casks/m/msty.rb
@@ -8,7 +8,7 @@ cask "msty" do
   desc "Run LLMs locally"
   homepage "https://msty.app/"
 
-  deprecate! date: "2025-11-14",
+  deprecate! date: "2026-01-02", because: :discontinued, replacement_cask: "mstystudio"
              because: "is being replaced by Msty Studio. Users are recommended to export their data and migrate to the new app", replacement_cask: "mstystudio"
 
   auto_updates true

--- a/Casks/m/msty.rb
+++ b/Casks/m/msty.rb
@@ -9,11 +9,8 @@ cask "msty" do
   desc "Run LLMs locally"
   homepage "https://msty.app/"
 
-  livecheck do
-    url "https://assets.msty.app/prod/latest/mac/latest-mac.yml"
-    strategy :electron_builder
-  end
-
+  deprecate! date: "2025-11-14", because: "is being replaced by Msty Studio. Users are recommended to export their data and migrate to the new app", replacement_cask: "mstystudio"
+  
   auto_updates true
 
   app "Msty.app"

--- a/Casks/m/msty.rb
+++ b/Casks/m/msty.rb
@@ -1,6 +1,5 @@
 cask "msty" do
   arch arm: "arm64", intel: "x64"
-
   version "1.9.2"
   sha256 :no_check
 
@@ -9,8 +8,9 @@ cask "msty" do
   desc "Run LLMs locally"
   homepage "https://msty.app/"
 
-  deprecate! date: "2025-11-14", because: "is being replaced by Msty Studio. Users are recommended to export their data and migrate to the new app", replacement_cask: "mstystudio"
-  
+  deprecate! date: "2025-11-14",
+             because: "is being replaced by Msty Studio. Users are recommended to export their data and migrate to the new app", replacement_cask: "mstystudio"
+
   auto_updates true
 
   app "Msty.app"

--- a/Casks/m/msty.rb
+++ b/Casks/m/msty.rb
@@ -3,6 +3,7 @@ cask "msty" do
   version "1.9.2"
   sha256 :no_check
 
+  url "https://assets.msty.app/prod/latest/mac/Msty_#{arch}.dmg"
   name "Msty"
   desc "Run LLMs locally"
   homepage "https://msty.app/"

--- a/Casks/m/msty.rb
+++ b/Casks/m/msty.rb
@@ -1,5 +1,6 @@
 cask "msty" do
   arch arm: "arm64", intel: "x64"
+
   version "1.9.2"
   sha256 :no_check
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
**Additional Context**

I am not affiliated with Msty so I can only assume that the deprecation date for the old version occurred on [11/14/25](https://msty.ai/changelog#msty-2.0.0) since this is when they have officially stated that msty studio is out of beta. 

Additionally, according to https://assets.msty.app/latest-mac.yml their last update for standard Msty was on ```releaseDate: "2024-10-22"```.  
