### PR TITLE
font-eb-garamond: add livecheck

### DIFF
--- a/Casks/font/font-e/font-eb-garamond.rb
+++ b/Casks/font/font-e/font-eb-garamond.rb
@@ -7,6 +7,13 @@ cask "font-eb-garamond" do
   name "EB Garamond"
   homepage "https://github.com/georgd/EB-Garamond"
 
+  # The Bitbucket downloads page no longer lists any files, so the `Bitbucket`
+  # strategy doesn't work, so this checks the Git tags instead.
+  livecheck do
+    url "https://bitbucket.org/georgd/eb-garamond.git"
+    regex(/^v?(\d+(?:\.\d+)+[a-z]?)$/i)
+  end
+
   font "EBGaramond-#{version}/otf/EBGaramond-Initials.otf"
   font "EBGaramond-#{version}/otf/EBGaramond-InitialsF1.otf"
   font "EBGaramond-#{version}/otf/EBGaramond-InitialsF2.otf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck tries to use the `Bitbucket` strategy for `font-eb-garamond` but this fails because the download page no longer lists any files (though the artifact URL still works), so livecheck falls back to checking Git tags from the homepage GitHub repository. This adds a `livecheck` block that checks the Git tags from the Bitbucket project instead, as it's closer to the artifact source (and the `README` on GitHub still refers to Bitbucket downloads).