### PR TITLE
outguess: disable

### DIFF
--- a/Casks/o/outguess.rb
+++ b/Casks/o/outguess.rb
@@ -5,6 +5,7 @@ cask "outguess" do
   url "https://www.rbcafe.com/download/outguess.zip",
       user_agent: :browser
   name "Outguess"
+  desc "Steganography tool to hide a document in an image"
   homepage "https://www.rbcafe.com/software/outguess/"
 
   livecheck do

--- a/Casks/o/outguess.rb
+++ b/Casks/o/outguess.rb
@@ -3,12 +3,12 @@ cask "outguess" do
   sha256 :no_check
 
   url "https://www.rbcafe.com/download/outguess.zip",
-      user_agent: :fake
+      user_agent: :browser
   name "Outguess"
   homepage "https://www.rbcafe.com/software/outguess/"
 
   livecheck do
-    url :homepage
+    url :homepage, user_agent: :browser
     regex(/Version\s+(\d+(?:\.\d+)+)/i)
   end
 

--- a/Casks/o/outguess.rb
+++ b/Casks/o/outguess.rb
@@ -8,10 +8,8 @@ cask "outguess" do
   desc "Steganography tool to hide a document in an image"
   homepage "https://www.rbcafe.com/software/outguess/"
 
-  livecheck do
-    url :homepage, user_agent: :browser
-    regex(/Version\s+(\d+(?:\.\d+)+)/i)
-  end
+  # The zip file URL is consistently unreachable in CI despite working locally
+  disable! date: "2026-02-08", because: :unreachable
 
   app "Outguess.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

~The existing `livecheck` block for `outguess` checks the homepage but requests to www.rbcafe.com fail with the default user agent, so this check fails and retries with the `:browser` user agent (which works). This adds `user_agent: :browser` to the `livecheck` block URL, so it will continue to work after we remove the user agent fallback behavior in livecheck.~

~I've set this to skip the homepage audit because it will predictably fail without a `:browser` user agent.~

The artifact URL for `outguess` is consistently unreachable in CI (despite working locally), so this disables the cask accordingly.