### PR TITLE
inkscape 1.4.3

### DIFF
--- a/Casks/i/inkscape.rb
+++ b/Casks/i/inkscape.rb
@@ -1,18 +1,21 @@
 cask "inkscape" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "1.4.333103"
-  sha256 arm:   "4fdf98784a4023faa3adcd65414891bcd4ca359feb2bf2e178d01dddf656f78a",
-         intel: "9521745442820d912ada41489e2b09a9a1850164781b9d2e566a0b41f4b15fef"
+  version "1.4.3,"
+  sha256 arm:   "f4aa9c9b2e06db432c6f81a494ad9aa59b87cb7d9539cd7e6f6000002cb9edff",
+         intel: "c4e7056dee4faaa623730e93a94ad1bfa017643eb85a58f9d25419397ccc5073"
 
-  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version}_#{arch}.dmg"
+  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version.csv.first}#{version.csv.second}_#{arch}.dmg"
   name "Inkscape"
   desc "Vector graphics editor"
   homepage "https://inkscape.org/"
 
   livecheck do
     url "https://inkscape.org/release/all/mac-os-x/"
-    regex(/Inkscape[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
+    regex(/Inkscape[._-]v?(\d+(?:\.\d+)*\.\d)(\d*)[._-]#{arch}\.dmg">/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+    end
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check

--- a/Casks/i/inkscape.rb
+++ b/Casks/i/inkscape.rb
@@ -1,20 +1,30 @@
 cask "inkscape" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "1.4.3,"
+  version "1.4.3"
   sha256 arm:   "f4aa9c9b2e06db432c6f81a494ad9aa59b87cb7d9539cd7e6f6000002cb9edff",
          intel: "c4e7056dee4faaa623730e93a94ad1bfa017643eb85a58f9d25419397ccc5073"
 
-  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version.csv.first}#{version.csv.second}_#{arch}.dmg"
+  url "https://media.inkscape.org/dl/resources/file/Inkscape-#{version.csv.second || version.csv.first}_#{arch}.dmg"
   name "Inkscape"
   desc "Vector graphics editor"
   homepage "https://inkscape.org/"
 
+  # Inkscape releases use a version format like 1.4, 1.4.1, etc. but the file
+  # name version can sometimes use a longer number (e.g. 1.4.230579 for 1.4.2,
+  # 1.3.0 for 1.3, etc.).
   livecheck do
     url "https://inkscape.org/release/all/mac-os-x/"
-    regex(/Inkscape[._-]v?(\d+(?:\.\d+)*\.\d)(\d*)[._-]#{arch}\.dmg">/i)
+    regex(%r{/inkscape[._-]v?(\d+(?:\.\d+)+)/?["' >].*?Inkscape[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}im)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "#{match[0]},#{match[1]}" }
+      # Match within individual row elements to ensure the regex doesn't capture
+      # a release version and file name version from separate releases
+      page.scan(%r{<tr[^>]*?>(.*?)</tr>}im).filter_map do |row|
+        match = row[0].match(regex)
+        next unless match
+
+        (match[1] == match[2]) ? match[1] : "#{match[1]},#{match[2]}"
+      end
     end
   end
 

--- a/Casks/i/inkscape.rb
+++ b/Casks/i/inkscape.rb
@@ -18,8 +18,6 @@ cask "inkscape" do
     end
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
   depends_on macos: ">= :big_sur"
 
   app "Inkscape.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
The Inkscape project is a bit inconsistent with their download links; sometimes they include what I can only assume to be a build number (outside this page and the background image on their disk images, this number is not shown anywhere else). Since they do not separate it from the patch number, the previous regex was a bit problematic (I'm guessing this is also why the livecheck was never able to detect the v1.4.1 update).

To complicate things further, the old regex produced a false positive for v1.4.3, as it could match on two different links:
* `https://inkscape.org/gallery/item/58921/Inkscape-1.4.3_x86_64.dmg`
* `https://media.inkscape.org/media/resources/sigs/Inkscape-1.4.333103_x86_64.dmg_yNMTy6L.sha256`

It just so happens to be that there is a download link at https://media.inkscape.org/dl/resources/file/Inkscape-1.4.333103_x86_64.dmg, which is almost identical to https://media.inkscape.org/dl/resources/file/Inkscape-1.4.3_x86_64.dmg except for the fact that the artifact from the former is not notarised, while the one from the latter is.

I'm not too happy with the new regex I'm proposing - what if the patch number went up to 10? In the past five years, they have never gone higher than 5, so this is not an immediate concern. Still, I would prefer to use something more robust, but unfortunately I could not find an alternative URL to use for the livecheck.