### PR TITLE
termius: add Linux support

### DIFF
--- a/Casks/t/termius.rb
+++ b/Casks/t/termius.rb
@@ -55,11 +55,11 @@ cask "termius" do
     artifact icon_file, target: "~/.local/share/icons/hicolor/512x512/apps/termius-app.png"
 
     preflight do
-      system_command "/usr/bin/ar",
+      system_command "ar",
                      args:  ["-x", "#{staged_path}/Termius.deb"],
                      chdir: staged_path
 
-      system_command "/usr/bin/tar",
+      system_command "tar",
                      args:  ["-xf", "#{staged_path}/data.tar.xz"],
                      chdir: staged_path
 

--- a/Casks/t/termius.rb
+++ b/Casks/t/termius.rb
@@ -48,9 +48,11 @@ cask "termius" do
     termius_dir = "#{staged_path}/opt/Termius"
     shimscript = "#{staged_path}/termius.wrapper.sh"
     desktop_file = "#{staged_path}/termius.desktop"
+    icon_file = "#{staged_path}/usr/share/icons/hicolor/512x512/apps/termius-app.png"
 
     binary shimscript, target: "termius"
-    artifact desktop_file, target: "#{Dir.home}/.local/share/applications/termius.desktop"
+    artifact desktop_file, target: "~/.local/share/applications/termius.desktop"
+    artifact icon_file, target: "~/.local/share/icons/hicolor/512x512/apps/termius-app.png"
 
     preflight do
       system_command "/usr/bin/ar",
@@ -73,7 +75,7 @@ cask "termius" do
         Exec=#{HOMEBREW_PREFIX}/bin/termius %U
         Terminal=false
         Type=Application
-        Icon=#{staged_path}/usr/share/icons/hicolor/512x512/apps/termius-app.png
+        Icon=#{Dir.home}/.local/share/icons/hicolor/512x512/apps/termius-app.png
         StartupWMClass=Termius
         Comment=SSH client
         MimeType=x-scheme-handler/termius;


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Adds Linux (x86_64) support to the existing Termius cask, which is currently macOS-only.

- Downloads `.deb` package from autoupdate.termius.com
- Extracts using `ar` and `tar` in preflight
- Installs binary wrapper to `$(brew --prefix)/bin/termius`
- Installs `.desktop` file for application menu integration
- Properly cleans up on uninstall

Tested on Bazzite 43 with Homebrew on Linux.
