### PR TITLE
lazycat 1.6.6 (arm only)

### DIFF
--- a/Casks/l/lazycat.rb
+++ b/Casks/l/lazycat.rb
@@ -1,9 +1,14 @@
 cask "lazycat" do
   arch arm: "arm64", intel: "x64"
 
-  version "1.6.4"
-  sha256 arm:   "2fe68b5362743edcabc1f8025f6e06d880460fe7ab5fd6a48acb95abbb0fabde",
-         intel: "3a874619459da92aafad196b1cd1da3876a8227b6237c7d45420402095fda943"
+  on_arm do
+    version "1.6.6"
+    sha256 "a442a0ea786f311f478f6433216a65f63ba10e044018da1a366b30c3ea1af552"
+  end
+  on_intel do
+    version "1.6.4"
+    sha256 "3a874619459da92aafad196b1cd1da3876a8227b6237c7d45420402095fda943"
+  end
 
   url "https://dl.lazycat.cloud/client/desktop/stable/lzc-client-desktop_v#{version}_#{arch}.dmg"
   name "LazyCat"


### PR DESCRIPTION
lazycat 1.6.6

---

autobump failed, bump manually.