### PR TITLE
macdown-3000: add cli binary link

### DIFF
--- a/Casks/m/macdown-3000.rb
+++ b/Casks/m/macdown-3000.rb
@@ -8,9 +8,11 @@ cask "macdown-3000" do
   desc "Markdown editor with live preview and syntax highlighting"
   homepage "https://macdown.app/"
 
+  conflicts_with cask: "macdown"
   depends_on macos: ">= :big_sur"
 
   app "MacDown 3000.app"
+  binary "#{appdir}/MacDown 3000.app/Contents/SharedSupport/bin/macdown"
 
   zap trash: [
     "~/Library/Application Support/MacDown 3000",

--- a/Casks/m/macdown.rb
+++ b/Casks/m/macdown.rb
@@ -19,7 +19,7 @@ cask "macdown" do
     end
   end
 
-  deprecate! date: "2026-01-05", because: :unmaintained
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   conflicts_with cask: "macdown-3000"

--- a/Casks/m/macdown.rb
+++ b/Casks/m/macdown.rb
@@ -20,6 +20,7 @@ cask "macdown" do
   end
 
   auto_updates true
+  conflicts_with cask: "macdown-3000"
 
   app "MacDown.app"
   binary "#{appdir}/MacDown.app/Contents/SharedSupport/bin/macdown"

--- a/Casks/m/macdown.rb
+++ b/Casks/m/macdown.rb
@@ -19,6 +19,8 @@ cask "macdown" do
     end
   end
 
+  deprecate! date: "2026-01-05", because: :unmaintained
+
   auto_updates true
   conflicts_with cask: "macdown-3000"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Link the CLI binary `macdown` to enable command line access.
