### PR TITLE
macs-fan-control: fix sha256

### DIFF
--- a/Casks/m/macs-fan-control.rb
+++ b/Casks/m/macs-fan-control.rb
@@ -1,6 +1,6 @@
 cask "macs-fan-control" do
   version "1.5.20"
-  sha256 "6d9b52e5bc35ec5cb0d9f83374b503f3b3faac8125e3ca90ab29d72097326af3"
+  sha256 "085d2f5d68142760db378d78fca4bc68b739a8ae771d87f18ea902807cf13ca8"
 
   url "https://github.com/crystalidea/macs-fan-control/releases/download/v#{version}/macsfancontrol.zip",
       verified: "github.com/crystalidea/macs-fan-control/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

<img width="1240" height="407" alt="image" src="https://github.com/user-attachments/assets/bbdbefeb-e689-4f0d-846d-3aa30730cd4e" />

```
==> Upgrading 1 outdated package:
macs-fan-control 1.5.19 -> 1.5.20
==> Upgrading macs-fan-control
==> Purging files for version 1.5.20 of Cask macs-fan-control
Error: macs-fan-control: SHA-256 mismatch
Expected: 6d9b52e5bc35ec5cb0d9f83374b503f3b3faac8125e3ca90ab29d72097326af3
  Actual: 085d2f5d68142760db378d78fca4bc68b739a8ae771d87f18ea902807cf13ca8
    File: ...
```