### PR TITLE
Add quotio cask

### DIFF
--- a/Casks/q/quotio.rb
+++ b/Casks/q/quotio.rb
@@ -1,0 +1,26 @@
+cask "quotio" do
+  version "0.4.4"
+  sha256 "753161726375b9b4aa11595ab584227f026c2417c7cd6cfc80e95994e945de7f"
+
+  url "https://github.com/nguyenphutrong/quotio/releases/download/v#{version}/Quotio-#{version}.dmg"
+  name "Quotio"
+  desc "Menu bar app for managing multiple AI coding assistants"
+  homepage "https://github.com/nguyenphutrong/quotio"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sequoia"
+
+  app "Quotio.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.quotio.app",
+    "~/Library/Caches/com.quotio.app",
+    "~/Library/HTTPStorages/com.quotio.app",
+    "~/Library/Preferences/com.quotio.app.plist",
+    "~/Library/Saved Application State/com.quotio.app.savedState",
+  ]
+end


### PR DESCRIPTION
Quotio is a menu bar app for managing multiple AI coding assistants. It serves as a unified command center and local proxy server for handling various AI provider accounts, with support for quota tracking, automatic agent configuration, and intelligent request routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
