### PR TITLE
aranet4 1.0.0 (new cask)

### DIFF
--- a/Casks/a/aranet4.rb
+++ b/Casks/a/aranet4.rb
@@ -1,0 +1,21 @@
+cask "aranet4" do
+  version "1.0.0"
+  sha256 "4777feb5f6c008da30c02630518d0ce33f7c5ec0a18c46c9e8ddaf8ce97d947b"
+
+  url "https://github.com/robjama/Aranet4MenuBar/releases/download/v#{version}/Aranet4-v#{version}.zip"
+  name "Aranet4"
+  desc "Menu bar app for monitoring Aranet4 air quality sensor"
+  homepage "https://github.com/robjama/Aranet4MenuBar"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Aranet4.app"
+
+  zap trash: [
+    "~/Library/Caches/com.aranet.menubar",
+    "~/Library/Preferences/com.aranet.menubar.plist",
+  ]
+end


### PR DESCRIPTION
Add Aranet4, a macOS menu bar app for monitoring Aranet4 air quality sensors via Bluetooth.

**Features:**
- Real-time CO2, temperature, humidity, pressure, and battery readings
- Auto-connect to Aranet4 device via Bluetooth
- Auto-refresh every 5 minutes
- High CO2 alerts with system notifications
- Native macOS design with minimal battery impact

**Homepage:** https://github.com/robjama/Aranet4MenuBar
**Release:** https://github.com/robjama/Aranet4MenuBar/releases/tag/v1.0.0