### PR TITLE
boss: update 8.15.0

### DIFF
--- a/Casks/b/boss.rb
+++ b/Casks/b/boss.rb
@@ -1,6 +1,6 @@
 cask "boss" do
-  version "8.14.10"
-  sha256 "48de6e8516d585b56e91500c5c448a6c53aae894cdb8b92b1514fb2ed8ce861d"
+  version "8.15.0"
+  sha256 "b624c69244bf4da72a554cbec7bf1fdffb19907d539979b066edb68f20bf73dd"
 
   url "https://github.com/risa-labs-inc/BOSS-Releases/releases/download/v#{version}/BOSS-#{version}-Universal.dmg",
       verified: "github.com/risa-labs-inc/BOSS-Releases/"


### PR DESCRIPTION
Updates boss cask to version 8.15.0

  **Release Information:**
  - Version: 8.15.0  
  - SHA256: `b624c69244bf4da72a554cbec7bf1fdffb19907d539979b066edb68f20bf73dd`
  - Release URL: https://github.com/risa-labs-inc/BossConsole-Releases/releases/tag/v8.15.0

  **Changes:**
  - Updated version from previous to 8.15.0
  - Updated SHA256 hash for new release asset

  BOSS is an AI-powered workspace for complex business operations.