### PR TITLE
font-cantarell: update livecheck

### DIFF
--- a/Casks/font/font-c/font-cantarell.rb
+++ b/Casks/font/font-c/font-cantarell.rb
@@ -7,7 +7,8 @@ cask "font-cantarell" do
   homepage "https://cantarell.gnome.org/"
 
   livecheck do
-    url "https://gitlab.gnome.org/GNOME/cantarell-fonts.git"
+    url :homepage
+    regex(/href=.*?cantarell-fonts[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   font "cantarell-fonts-#{version}/prebuilt/Cantarell-VF.otf"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `font-cantarell` checks the upstream Git repository and this returns 0.311 but a corresponding tarball isn't available yet, so autobump is predictably failing. This updates the `livecheck` block to check the homepage, as it links to the tarball that the cask uses.