### PR TITLE
prismlauncher 10.0.0

### DIFF
--- a/Casks/p/prismlauncher.rb
+++ b/Casks/p/prismlauncher.rb
@@ -1,14 +1,29 @@
 cask "prismlauncher" do
-  version "9.4"
-
   on_catalina :or_older do
+    version "9.4"
     sha256 "ad5e4d12d91631e4aeec69499e244b0c6fc255d9abe3e26f4f45571a6736206c"
 
     url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-Legacy-#{version}.zip",
         verified: "github.com/PrismLauncher/PrismLauncher/"
+
+    livecheck do
+      skip "Legacy version"
+    end
   end
-  on_big_sur :or_newer do
+  on_big_sur do
+    version "9.4"
     sha256 "5cc0148e427d28c632978a9e83e2da3fc02f5072990d9e7732dff3fdb1912ae4"
+
+    url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-#{version}.zip",
+        verified: "github.com/PrismLauncher/PrismLauncher/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
+  on_monterey :or_newer do
+    version "10.0.0"
+    sha256 "46013c4b6f81775f0ea4d27a19fd49ca5ee67872e604db76fed02c1eb21152ef"
 
     url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-#{version}.zip",
         verified: "github.com/PrismLauncher/PrismLauncher/"

--- a/Casks/p/prismlauncher.rb
+++ b/Casks/p/prismlauncher.rb
@@ -27,16 +27,16 @@ cask "prismlauncher" do
 
     url "https://github.com/PrismLauncher/PrismLauncher/releases/download/#{version}/PrismLauncher-macOS-#{version}.zip",
         verified: "github.com/PrismLauncher/PrismLauncher/"
+
+    livecheck do
+      url "https://prismlauncher.org/feed/appcast.xml"
+      strategy :sparkle
+    end
   end
 
   name "Prism Launcher"
   desc "Minecraft launcher"
   homepage "https://prismlauncher.org/"
-
-  livecheck do
-    url "https://prismlauncher.org/feed/appcast.xml"
-    strategy :sparkle
-  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Prism Launcher [dropped support](https://github.com/PrismLauncher/PrismLauncher/pull/3611) for macOS 11 since 10.0.0, and following [official guidance](https://prismlauncher.org/wiki/overview/troubleshooting/#-legacy-operating-systems), Big Sur users are recommended to use the 9.4 Qt 6 build. Therefore, the version string for 10.15 and 11 is frozen at 9.4 for now.