### PR TITLE
kiro-cli: add binary artifact for CLI symlink

### DIFF
--- a/Casks/k/kiro-cli.rb
+++ b/Casks/k/kiro-cli.rb
@@ -19,6 +19,7 @@ cask "kiro-cli" do
   depends_on macos: ">= :big_sur"
 
   app "Kiro CLI.app"
+  binary "#{appdir}/Kiro CLI.app/Contents/MacOS/kiro-cli"
 
   zap trash: [
     "~/.kiro",


### PR DESCRIPTION
The kiro-cli cask installs a macOS app that contains CLI binaries, but doesn't create a symlink in PATH. Users have to manually find and symlink the binary or rely on the app's own setup process which doesn't always work reliably.

This adds a `binary` artifact to create a symlink to `kiro-cli` in `/opt/homebrew/bin/`, matching what the `kiro` cask (the GUI) already does for its CLI.

**Before:** `kiro-cli` command not available after `brew install --cask kiro-cli`
**After:** `kiro-cli` command available immediately in PATH

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
