### PR TITLE
Add sanebar cask

### DIFF
--- a/Casks/s/sanebar.rb
+++ b/Casks/s/sanebar.rb
@@ -1,0 +1,18 @@
+cask "sanebar" do
+  version "1.0.0"
+  sha256 "dabd78706a334f57c2a282d93f60049a27b6fa49c195a800789e017d01abc555"
+
+  url "https://github.com/stephanjoseph/SaneBar/releases/download/v#{version}/SaneBar-#{version}.dmg"
+  name "SaneBar"
+  desc "Privacy-focused menu bar manager for macOS"
+  homepage "https://github.com/stephanjoseph/SaneBar"
+
+  depends_on macos: ">= :sonoma"
+
+  app "SaneBar.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.sanevideo.SaneBar.plist",
+    "~/Library/Application Support/SaneBar",
+  ]
+end

--- a/Casks/s/sanebar.rb
+++ b/Casks/s/sanebar.rb
@@ -1,6 +1,6 @@
 cask "sanebar" do
   version "1.0.0"
-  sha256 "dabd78706a334f57c2a282d93f60049a27b6fa49c195a800789e017d01abc555"
+  sha256 "3967b087399cb375de2bab78f1fcdee85cb9890f89e0589813c5a1c98fea2447"
 
   url "https://github.com/stephanjoseph/SaneBar/releases/download/v#{version}/SaneBar-#{version}.dmg"
   name "SaneBar"


### PR DESCRIPTION
## Description

Adds SaneBar, a privacy-focused menu bar manager for macOS.

**Homepage:** https://github.com/stephanjoseph/SaneBar

## Features

- One-click hide/show menu bar icons
- Cmd+drag to organize icons
- Auto-hide with configurable delay
- Global hotkeys and per-icon shortcuts
- Smart triggers: hover, app launch, WiFi networks
- 100% on-device - no analytics, telemetry, or network requests

## Artifact verification

- Download URL: https://github.com/stephanjoseph/SaneBar/releases/download/v1.0.0/SaneBar-1.0.0.dmg
- SHA256: `dabd78706a334f57c2a282d93f60049a27b6fa49c195a800789e017d01abc555`
- Signed with Developer ID: Stephan Joseph (M78L6FXD48)

## Requirements

- macOS 14.0 (Sonoma) or later