### PR TITLE
omnioutliner 6.0

### DIFF
--- a/Casks/o/omnioutliner.rb
+++ b/Casks/o/omnioutliner.rb
@@ -1,5 +1,5 @@
 cask "omnioutliner" do
-  on_monterey :or_older do
+  on_sonoma :or_older do
     on_catalina :or_older do
       version "5.8.5"
       sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"

--- a/Casks/o/omnioutliner.rb
+++ b/Casks/o/omnioutliner.rb
@@ -1,5 +1,5 @@
 cask "omnioutliner" do
-  on_big_sur :or_older do
+  on_monterey :or_older do
     on_catalina :or_older do
       version "5.8.5"
       sha256 "4439e6f700e71e3ec182fd16be9eca3de3afa3db4c4894c396297ba59b0f6b10"
@@ -12,16 +12,22 @@ cask "omnioutliner" do
 
       url "https://downloads.omnigroup.com/software/macOS/11/OmniOutliner-#{version}.dmg"
     end
+    on_monterey :or_newer do
+      version "5.15"
+      sha256 "264c43d26fd090dc46395a6e40d0f7be22503b8c3c91df8a4c5bcacc6ed22857"
+
+      url "https://downloads.omnigroup.com/software/macOS/12/OmniOutliner-#{version}.dmg"
+    end
 
     livecheck do
       skip "Legacy version"
     end
   end
-  on_monterey :or_newer do
-    version "5.15"
-    sha256 "264c43d26fd090dc46395a6e40d0f7be22503b8c3c91df8a4c5bcacc6ed22857"
+  on_sequoia :or_newer do
+    version "6.0"
+    sha256 "b0eeaf9892c8343f765d32f1a2fa7ed6a9262d808e2a0a331996c72939f6194a"
 
-    url "https://downloads.omnigroup.com/software/macOS/12/OmniOutliner-#{version}.dmg"
+    url "https://downloads.omnigroup.com/software/macOS/15/OmniOutliner-#{version}.dmg"
 
     livecheck do
       url "https://www.omnigroup.com/download/latest/omnioutliner/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`omnioutliner` is autobumped but the workflow failed to update to version 6.0 because the dmg URL now references macOS 15, due to the macOS requirement changing in this major release. This updates the version and adjusts the on_os blocks accordingly.