### PR TITLE
kitlangton-hex 0.6.5 (new cask)

### DIFF
--- a/Casks/k/kitlangton-hex.rb
+++ b/Casks/k/kitlangton-hex.rb
@@ -1,0 +1,16 @@
+cask "kitlangton-hex" do
+  version "0.6.5"
+  sha256 "49408c980ddbbbcc523389833bddfdecd73f8b85986c7dcdc7b585a983455c99"
+
+  url "https://github.com/kitlangton/Hex/releases/download/v#{version}/Hex-#{version}.dmg",
+      verified: "github.com/kitlangton/Hex/"
+  name "Hex"
+  desc "Voice-to-text transcription and paste tool"
+  homepage "https://hex.kitlangton.com/"
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :sequoia"
+
+  app "Hex.app"
+end

--- a/Casks/k/kitlangton-hex.rb
+++ b/Casks/k/kitlangton-hex.rb
@@ -13,4 +13,9 @@ cask "kitlangton-hex" do
   depends_on macos: ">= :sequoia"
 
   app "Hex.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.kitlangton.Hex",
+    "~/Library/Containers/com.kitlangton.Hex",
+  ]
 end


### PR DESCRIPTION
## Summary
- add kitlangton-hex 0.6.5 (new cask)
- use vendor-prefixed token to avoid conflict with homebrew/core 'hex'

## Testing
- brew audit --strict --online --cask kitlangton-hex
- brew style --cask kitlangton-hex
- HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask --appdir=/tmp/hex-cask-test kitlangton-hex
- brew uninstall --cask kitlangton-hex
