### PR TITLE
cmd/lib/check: skip shared google resources

### DIFF
--- a/cmd/lib/check.rb
+++ b/cmd/lib/check.rb
@@ -8,6 +8,8 @@ APPLE_LAUNCHJOBS_REGEX =
   (AppStore|installer|Preview|Safari|systemevents|systempreferences|Terminal)
   (?:\.|$)/x
 
+GOOGLE_LAUNCHJOBS_REGEX = /com\.google\.(keystone|GoogleUpdater)/
+
 module Check
   # TODO: replace with public API like Utils.safe_popen_read that's less likely to be volatile to changes
   # see https://github.com/Homebrew/brew/pull/16540#issuecomment-1913737000
@@ -30,6 +32,7 @@ module Check
         .children
         .grep(/\.plist$/)
         .map { |path| path.basename.to_s.sub(/\.plist$/, "") }
+        .grep_v(/^com\.google\.Keystone/)
     },
     installed_launchjobs: lambda {
       format_launchjob = lambda { |file|
@@ -50,6 +53,7 @@ module Check
       ].map { |p| Pathname(p).expand_path }
         .select(&:directory?)
         .flat_map(&:children)
+        .grep_v(GOOGLE_LAUNCHJOBS_REGEX)
         .select { |child| child.extname == ".plist" }
         .select(&:exist?)
         .map(&format_launchjob)
@@ -60,12 +64,14 @@ module Check
           .stdout
           .lines.drop(1)
           .grep_v(APPLE_LAUNCHJOBS_REGEX)
+          .grep_v(GOOGLE_LAUNCHJOBS_REGEX)
       end
 
       [false, true]
         .flat_map(&launchctl)
         .map { |l| l.split(/\s+/)[2] }
         .grep_v(/^com\.apple\./)
+        .grep_v(GOOGLE_LAUNCHJOBS_REGEX)
     },
   }.freeze
   private_constant :CHECKS
@@ -138,6 +144,7 @@ module Check
                    .added
                    .grep(/\.\d+\Z/)
                    .grep_v(APPLE_LAUNCHJOBS_REGEX)
+                   .grep_v(GOOGLE_LAUNCHJOBS_REGEX)
                    .map { |id| id.sub(/\A(?:application\.)?(.*?)(?:\.\d+){0,2}\Z/, '\1') }
 
     loaded_launchjobs = diff[:loaded_launchjobs]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Alternative to https://github.com/Homebrew/homebrew-cask/pull/243495

We consistently apply the `ci-skip-install` label to Google casks, because they install some shared libraries that shouldn't be installed on every upgrade, or when an individual cask is uninstalled.

The downside with using the label is that it could cause false-positives when other errors arise.

This change adjusts the `check.rb` file to skip the `pkgutil` and `launchctl` items that we don't want to include in the `uninstall` items.