### PR TITLE
cask/cursor: fix livecheck to avoid 0.0.0 “legacy” update track

### DIFF
--- a/Casks/c/cursor.rb
+++ b/Casks/c/cursor.rb
@@ -11,7 +11,7 @@ cask "cursor" do
   homepage "https://www.cursor.com/"
 
   livecheck do
-    url "https://api2.cursor.sh/updates/api/update/darwin-#{arch}/cursor/0.0.0/stable"
+    url "https://api2.cursor.sh/updates/api/update/darwin-#{arch}/cursor/2.3.0/stable"
     regex(%r{/production/(\h+)/darwin/#{arch}/Cursor[._-]darwin[._-]#{arch}\.zip}i)
     strategy :json do |json, regex|
       match = json["url"]&.match(regex)

--- a/Casks/c/cursor.rb
+++ b/Casks/c/cursor.rb
@@ -1,9 +1,9 @@
 cask "cursor" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.2.44,20adc1003928b0f1b99305dbaf845656ff81f5d4"
-  sha256 arm:   "3109421b676cacce16114b67578a986c40784218e73623699ea342bd39598d36",
-         intel: "8ff30a790029804580e6a84997a1723214d27815693a7c3c18643ccc8a1ec4a9"
+  version "2.3.26,bdbdd3f2cf698f583c5cdd2a6dc0f5aec4ed5f97"
+  sha256 arm:   "d3acde8e1abba0e83041b4af410a4e883754d0e1aca9201689d8638ecb80f5cb",
+         intel: "fa40ba59079deaa530c101320c0070f62a456314e3a53cee0342dbeefe1d53f3"
 
   url "https://downloads.cursor.com/production/#{version.csv.second}/darwin/#{arch}/Cursor-darwin-#{arch}.zip"
   name "Cursor"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This PR fixes cursor cask livecheck.

Cursor’s update API endpoint behaves like an “update-from” service (it returns the update you’d receive from the version you pass in), not a “latest release” endpoint. When livecheck queries with 0.0.0, the API consistently returns 2.2.44, so brew livecheck gets stuck on that version even when newer releases exist.

Example:
.../cursor/0.0.0/stable returns "name": "2.2.44"
Passing a recent base version returns newer releases; e.g. .../cursor/2.3.21/ returns "name": "2.3.26" 

Fix: point livecheck at the same endpoint but with a 2.3.x base version (e.g. 2.3.0) so it tracks the current stable channel rather than the legacy result produced for 0.0.0.