### PR TITLE
logi-options+: urgent certificate fix

### DIFF
--- a/Casks/l/logi-options+.rb
+++ b/Casks/l/logi-options+.rb
@@ -34,7 +34,7 @@ cask "logi-options+" do
   end
   on_ventura :or_newer do
     version "1.98.809639"
-    sha256 :no_check
+    sha256 "b5002974fa64e8d35658d500027bc24d25e641ae88d1bed1c2f2149b08de357f"
 
     url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip",
         verified: "download01.logi.com/web/ftp/pub/techsupport/optionsplus/"


### PR DESCRIPTION
## Summary

Logitech Options+ has an expired certificate that causes the app to malfunction on macOS. Logitech has released a patched installer but did not bump the version number, so existing Homebrew users won't receive the update.

This PR adds a specific SHA256 checksum to replace `:no_check`, which will trigger Homebrew to re-download the patched installer for existing users.

**Logitech's advisory:** https://support.logi.com/hc/en-us/articles/37493733117847-Options-and-G-HUB-macOS-Certificate-Issue

---

**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
