### PR TITLE
logitech-g-hub: urgent certificate fix

### DIFF
--- a/Casks/l/logitech-g-hub.rb
+++ b/Casks/l/logitech-g-hub.rb
@@ -1,6 +1,6 @@
 cask "logitech-g-hub" do
   version "2025.9.814157"
-  sha256 :no_check
+  sha256 "c9cd149fd18bafc7457030bf5358a2fe3a0a618f36c6552706301262f43ffef7"
 
   url "https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.zip",
       verified: "download01.logi.com/"


### PR DESCRIPTION
## Summary

Similar to #243551

Logitech G HUB has an expired certificate that causes the app to malfunction on macOS. Logitech has released a patched installer but did not bump the version number, so existing Homebrew users won't receive the update.

This PR adds a specific SHA256 checksum to replace `:no_check`, which will trigger Homebrew to re-download the patched installer for existing users.

**Logitech's advisory:** https://support.logi.com/hc/en-us/articles/37493733117847-Options-and-G-HUB-macOS-Certificate-Issue

---

**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
