### PR TITLE
gcloud-cli: Capture virtualenv module installation errors 

### DIFF
--- a/Casks/g/gcloud-cli.rb
+++ b/Casks/g/gcloud-cli.rb
@@ -47,7 +47,7 @@ cask "gcloud-cli" do
   end
 
   postflight do
-    # HACK: Allow existing shell profiles to work by linking the current version to the `latest` directory.
+    # Allow existing shell profiles to work by linking the current version to the `latest` directory.
     unless (latest_path = staged_path.dirname/"latest").directory?
       FileUtils.ln_s staged_path, latest_path, force: true
     end
@@ -69,6 +69,8 @@ cask "gcloud-cli" do
     system_command  "#{google_cloud_sdk_root}/bin/gcloud",
                     args:      ["version"],
                     reset_uid: true
+  rescue RuntimeError
+    # capture any runtime error to let installation succeed.
   end
 
   uninstall trash: staged_path.dirname/"latest"


### PR DESCRIPTION
Update gcloud-cli cask cask to capture virtualenv modules installation errors to ensure gcloud install succeed.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
