### PR TITLE
claude-code 2.1.1

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -2,11 +2,11 @@ cask "claude-code" do
   arch arm: "arm64", intel: "x64"
   os macos: "darwin", linux: "linux"
 
-  version "2.0.76"
-  sha256 arm:          "b76f6d4d09233e67295897b0a1ed2e22d7afa406431529d8b1b532b63b8cbcbd",
-         x86_64:       "9d94582f0af5d2201f1c907bf24ff8d216104b897ee0b24795a6c081f40e08d7",
-         x86_64_linux: "5dcdb480f91ba0df0bc8bd6aff148d3dfd3883f0899eeb5b9427a8b0abe7a687",
-         arm64_linux:  "f64a994c8e5bfb84d7242cebbec75d6919db2ee46d50b8fc7a88d5066db193f9"
+  version "2.1.1"
+  sha256 arm:          "c7939fb4bd10bd0e5aca07f8cbc4cea85c6fccc71d367a58566d254eb13f2098",
+         x86_64:       "fe723b101d23f13443c262026297f1705ce7fe5fd89572278a5833c98a1e0d46",
+         x86_64_linux: "7d630126bd6fa8372720a48055a85869741b076b143440045c89565cf3c65a28",
+         arm64_linux:  "3ec039081a8bdd141fbd7f49ea68af747a070164925f9221b1b1218a8b4a5b27"
 
   url "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/#{version}/#{os}-#{arch}/claude",
       verified: "storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/"


### PR DESCRIPTION
This PR initially targeted 2.1.0 but that version was broken, 2.1.1 is released and works.
Claude Code shows `Update available! Run: brew upgrade claude-code`,
But running that command shows:
```shell
$ brew upgrade claude-code && claude --version
Warning: Not upgrading claude-code, the latest version is already installed
2.0.76 (Claude Code)
```

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
