### PR TITLE
picgo 2.4.2

### DIFF
--- a/Casks/p/picgo.rb
+++ b/Casks/p/picgo.rb
@@ -1,9 +1,9 @@
 cask "picgo" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.4.1"
-  sha256 arm:   "7232d7c6d5ee8ee7291d1c17aa2c13e19e942186864a1f120305ef43a38f6e2f",
-         intel: "35f8ca140e791a9c7bb85319a8a906716cf842e78d1e3045caa267b0cba53c52"
+  version "2.4.2"
+  sha256 arm:   "10d33289a9e85713dedd31778b1f2b19a8dc8e1cd4b51b3aa12a843b4990bbe0",
+         intel: "abe897eec83c76401c19ef8394be11f1f92e09a97809631e10abf84479b65d4a"
 
   url "https://github.com/Molunerfinn/PicGo/releases/download/v#{version}/PicGo-#{version}-#{arch}.dmg"
   name "PicGo"
@@ -14,8 +14,6 @@ cask "picgo" do
     url :url
     strategy :github_latest
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`picgo` is autobumped but the workflow failed to update to version 2.4.2 because `brew audit` failed with a "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. I confirmed the app passes Gatekeeper locally (it's signed and notarized), so this updates the version and removes the `disable!` call accordingly.