### PR TITLE
doxygen-app 1.16.0

### DIFF
--- a/Casks/d/doxygen-app.rb
+++ b/Casks/d/doxygen-app.rb
@@ -1,20 +1,23 @@
 cask "doxygen-app" do
-  version "1.15.0"
-  sha256 "b7630eaa0d97bb50b0333929ef5dc1c18f9e38faf1e22dca3166189a9718faf0"
+  arch arm: "arm", intel: "intel"
 
-  url "https://www.doxygen.nl/files/Doxygen-#{version}.dmg"
+  version "1.16.0"
+  sha256 arm:   "25c612024d32105ad95307a7a3763715f2df2d58cb1ca64db286e7e23ba34752",
+         intel: "a98870e3bfe6856772eb85756ffb2017c723b7adc0b20d4e3ab51fef5c13eeff"
+
+  url "https://www.doxygen.nl/files/Doxygen-#{version}-#{arch}.dmg"
   name "Doxygen"
   desc "Generate documentation from source code"
   homepage "https://www.doxygen.nl/"
 
   livecheck do
     url "https://www.doxygen.nl/download.html"
-    regex(%r{href=.*?/Doxygen-(\d+(?:\.\d+)+)\.dmg}i)
+    regex(/href=.*?Doxygen[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg/i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :sequoia"
 
   app "Doxygen.app"
 
@@ -23,8 +26,4 @@ cask "doxygen-app" do
     "~/Library/Preferences/org.doxygen.plist",
     "~/Library/Saved Application State/org.doxygen.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`doxygen-app` is autobumped but the workflow failed to update to version 1.16.0 because the `livecheck` block is producing an "Unable to get versions" error, as the dmg file names now include an arch suffix. This updates the version and adjusts the cask to handle the arch setup accordingly.