### PR TITLE
gologin 4.0.2

### DIFF
--- a/Casks/g/gologin.rb
+++ b/Casks/g/gologin.rb
@@ -2,28 +2,22 @@ cask "gologin" do
   arch arm: "-arm64"
   livecheck_arch = on_arch_conditional arm: "-arm"
 
-  version "3.5.1"
-  sha256 arm:   "279916a2d5d94d126e726caf8ca082c31794bb264b39c1beb7ea6e316b68e13a",
-         intel: "f80f9c56238b10655f8faaef73df1b417ad173fd7ab3a0aebf964c8a28f700f8"
+  version "4.0.2"
+  sha256 arm:   "1d1a4bc328be1ddee555985cf7a496d813027335079ca1787e074334c06561a8",
+         intel: "9be05690fbb6f13cea5b935678478cb73a6954a7eefff8c4cb5abd8ccd540c85"
 
   url "https://releases#{livecheck_arch}.gologin.com/GoLogin-#{version}#{arch}.dmg"
   name "GoLogin"
   desc "Antidetect browser"
   homepage "https://gologin.com/"
 
-  # The `latest-mac.yml` file is served with a `Content-Encoding: aws-chunked`
-  # header, which will cause curl to error if the `--compressed` option is used.
-  # This checks the version on the first-party release notes page until we can
-  # account for this situation in livecheck.
   livecheck do
-    url "https://gologin.com/release-notes/"
-    regex(%r{href=.*?/release/gologin[._-]v?(\d+(?:[.-]\d+)+)}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match[0].tr("-", ".") }
-    end
+    url "https://releases.gologin.com/latest-mac.yml"
+    strategy :electron_builder
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "GoLogin.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gologin` is autobumped but the workflow failed to update to version 4.0.2 because the `livecheck` block is producing an "Unable to get versions" error, as the upstream Release Notes page no longer links to versioned releases. This updates the version and adjusts the `livecheck` block to check the appcast that the app uses, as the response no longer includes a `Content-Encoding: aws-chunked` header that produces a curl error when the `--compressed` option is used.