### PR TITLE
icon-composer 1.2

### DIFF
--- a/Casks/i/icon-composer.rb
+++ b/Casks/i/icon-composer.rb
@@ -1,15 +1,16 @@
 cask "icon-composer" do
-  version "1.1"
-  sha256 "7c60d4fdedc1e9c7af26f583a3a311bf9dba2ffbb9a2af957cbb6aff499164af"
+  version "1.2"
+  sha256 "dce4d78a615e543832fb2cdca3b28a31355cf21d57b6b4ab96f5b278ed7d5af6"
 
   url "https://devimages-cdn.apple.com/design/resources/download/Icon-Composer-#{version}.dmg"
   name "Icon Composer"
   desc "Apple tool to create multi-platform icons"
   homepage "https://developer.apple.com/icon-composer/"
 
+  # The homepage no longer provides version information. The download link on
+  # the page points to an Icon Composer download page but it's behind a login.
   livecheck do
-    url :homepage
-    regex(/Icon[._-]Composer[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    skip "No version information available"
   end
 
   depends_on macos: ">= :sequoia"

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -1,5 +1,6 @@
 {
   "ai-studio": "all",
   "epic-games": "intel",
+  "icon-composer": "intel",
   "shotcut": "intel"
 }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`icon-composer` is autobumped but the workflow failed to update to version 1.2 because the `livecheck` block produces an "Unable to get versions" error, as the homepage no longer lists any version information. The download links direct to a page that lists Icon Composer versions (with links to the dmg files) but this is behind a login, so we can't check it. This updates the cask to 1.2 and sets the `livecheck` block to skip, as there doesn't appear to be any checkable source of version information at the moment.