### PR TITLE
kaleidoscope@3: update livecheck

### DIFF
--- a/Casks/k/kaleidoscope@3.rb
+++ b/Casks/k/kaleidoscope@3.rb
@@ -7,17 +7,8 @@ cask "kaleidoscope@3" do
   desc "Spot and merge differences in text and image files or folders"
   homepage "https://kaleidoscope.app/"
 
-  # Upstream also includes the newest version across all major versions, so we
-  # have to omit items with a different major version.
   livecheck do
-    url "https://updates.kaleidoscope.app/v#{version.major}/prod/appcast"
-    strategy :sparkle do |items|
-      items.map do |item|
-        next if item.short_version&.split(".")&.first != version.major
-
-        item.nice_version
-      end
-    end
+    skip "Legacy version"
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The existing `livecheck` block for `kaleidoscope@3` produces an "Unable to get versions" error, as the appcast only contains version information for a 6.4 version and the `strategy` block skips versions that don't have the same major. This is a legacy version that isn't receiving any further updates, so this sets the `livecheck` block to skip.