### PR TITLE
kdenlive 25.12.0

### DIFF
--- a/Casks/k/kdenlive.rb
+++ b/Casks/k/kdenlive.rb
@@ -1,11 +1,11 @@
 cask "kdenlive" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "25.08.3"
-  sha256 arm:   "f732804355d11f7626ba0878bb0de9993f8aed7704f2fed5285246f7fb6e3e1d",
-         intel: "4b7bd952b6505f474147f30660a61795fe859b419e4742a391f88bfff8c1f7cc"
+  version "25.12.0,B"
+  sha256 arm:   "7405035f17de36e3d710684524466e90151f0016e49ca9a1e0c3344a41c2f982",
+         intel: "978db98669a6170ede39b3fa287050759d8f36949b479eded9afd4133856cbdd"
 
-  url "https://cdn.download.kde.org/stable/kdenlive/#{version.csv.first.major_minor}/macOS/kdenlive-#{version.csv.first}-#{arch}#{"_#{version.csv.second}" if version.csv.second}.dmg",
+  url "https://cdn.download.kde.org/stable/kdenlive/#{version.csv.first.major_minor}/macOS/kdenlive-#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
       verified: "cdn.download.kde.org/stable/kdenlive/"
   name "Kdenlive"
   desc "Free and Open Source Video Editor"
@@ -13,7 +13,7 @@ cask "kdenlive" do
 
   livecheck do
     url "https://kdenlive.org/download/"
-    regex(/href=.*?kdenlive[._-]v?(\d+(?:[.-]\d+)+)-#{arch}(?:[._-]([A-Z]?))?\.dmg/i)
+    regex(/href=.*?kdenlive[._-]v?(\d+(?:[.-]\d+)+)(?:[._-]([A-Z]?))?[._-]#{arch}\.dmg/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| match[1] ? "#{match[0]},#{match[1]}" : match[0] }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`kdenlive` is autobumped but the workflow failed to update to 25.12.0 because the dmg file names include a letter suffix (`-B`) before the arch suffix rather than after, causing the `livecheck` block regex to not be able to match the version from the dmg file names. This updates the version and adjusts the cask accordingly. Hopefully upstream will be consistent about the file name format going forward but this could fail if they change the position of this optional suffix again in the future.