### PR TITLE
picoscope 7.2.10.7893

### DIFF
--- a/Casks/p/picoscope.rb
+++ b/Casks/p/picoscope.rb
@@ -1,20 +1,20 @@
 cask "picoscope" do
-  version "7.1.50.5777"
-  sha256 "5c914b19bb8252339a92026d6537a2c617abce5f391bd002608b9707b410cd1e"
+  version "7.2.10.7893"
+  sha256 "466471314827a6d70e9adde9f572b31e801cabbf5613b8ded668d1e327e63197"
 
-  url "https://www.picotech.com/download/software/sr/PicoScope_#{version.major}_TandM_#{version}.pkg"
+  url "https://www.picotech.com/download/software/sr/PicoScope_#{version.major}_TandM_#{version}.x64.pkg"
   name "PicoScope"
   desc "Test and measurement oscilloscope software for PicoScope oscilloscopes"
   homepage "https://www.picotech.com/"
 
   livecheck do
     url "https://www.picotech.com/downloads/_lightbox/picoscope-#{version.major}-stable-for-macos"
-    regex(%r{href=.*?/PicoScope[._-]#{version.major}[._-]T(?:and|n)M[._-]v?(\d+(?:\.\d+)+)\.pkg}i)
+    regex(%r{href=.*?/PicoScope[._-]#{version.major}[._-]T(?:and|n)M[._-]v?(\d+(?:\.\d+)+)(?:[._-]x64)?\.pkg}i)
   end
 
   conflicts_with cask: "picoscope@beta"
 
-  pkg "PicoScope_#{version.major}_TandM_#{version}.pkg"
+  pkg "PicoScope_#{version.major}_TandM_#{version}.x64.pkg"
 
   uninstall pkgutil: "com.picotech.picoscope#{version.major}tnm"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`picoscope` is autobumped but the workflow failed to update to version 7.2.10.7893 because the `livecheck` block produced an "Unable to get versions" error, as the pkg file now includes a `.x64` suffix. This updates the version and adjusts the cask accordingly.