### PR TITLE
privatevpn: disable

### DIFF
--- a/Casks/p/privatevpn.rb
+++ b/Casks/p/privatevpn.rb
@@ -7,10 +7,7 @@ cask "privatevpn" do
   desc "VPN provider"
   homepage "https://privatevpn.com/"
 
-  livecheck do
-    url "https://privatevpn.com/why-privatevpn/view-our-software"
-    regex(/\\"macVersion\\"\s*:\s*\\"(\d+(?:\.\d+)+)\\"/i)
-  end
+  disable! date: "2026-01-07", because: :unreachable
 
   app "PrivateVPN.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The privatevpn.com URLs in the `privatevpn` cask are no longer accessible outside of a browser due to Cloudflare protections, so this disables the cask as it's not usable in this state.