### PR TITLE
screaming-frog-seo-spider 23.2

### DIFF
--- a/Casks/s/screaming-frog-seo-spider.rb
+++ b/Casks/s/screaming-frog-seo-spider.rb
@@ -1,18 +1,19 @@
 cask "screaming-frog-seo-spider" do
   arch arm: "aarch64", intel: "x86_64"
 
-  version "23.1"
-  sha256 arm:   "4b246a5e379e20503aaf8ffe7b7c563540ba9b3e160a1880a1710ca701686d3a",
-         intel: "32519ad0e70f02bff4942c803bdbd3bf1259a9c367ab9bda1f55fac8d8398177"
+  version "23.2"
+  sha256 arm:   "03326e627b796c0d44135a6a215ae01f50f973f8ebd624ab2e0ea52c15b2fc4d",
+         intel: "504d125ed8984fc7653036d15dbb8476649f245ad749cfb25e6caa67c3347347"
 
   url "https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-#{version}-#{arch}.dmg"
   name "Screaming Frog SEO Spider"
   desc "SEO site audit tool"
   homepage "https://www.screamingfrog.co.uk/seo-spider/"
 
+  # The homepage links to the latest dmg files but Cloudflare protections
+  # prevent us from fetching it, so it must be checked manually.
   livecheck do
-    url :homepage
-    regex(%r{href=.*?/ScreamingFrogSEOSpider[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
+    skip "Cannot be fetched due to Cloudflare protections"
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`screaming-frog-seo-spider` is autobumped but the workflow failed to update to version 23.2 because the `livecheck` block is producing an "Unable to get versions" error as the homepage is now inaccessible due to Cloudflare protections. This updates the version and sets the `livecheck` block to skip.