### PR TITLE
widelands-app 1.3

### DIFF
--- a/Casks/w/widelands-app.rb
+++ b/Casks/w/widelands-app.rb
@@ -1,20 +1,30 @@
 cask "widelands-app" do
-  version "1.2.1"
+  version "1.3"
 
-  on_ventura :or_older do
-    arch arm: "12-x86", intel: "12-x86"
+  on_sonoma :or_older do
+    on_arm do
+      on_ventura :or_older do
+        arch arm: "12_arm64"
 
-    sha256 "de55c686a82c904c4e585cf93802af3b475ed330e5420b3ef9b4a23d649e6b9e"
+        sha256 "a6eaff7b271b0d046e779f976f0d8aa037886d645b4fd64c939a9f979651cca9"
+      end
+      on_sonoma do
+        arch arm: "14_arm64"
 
-    caveats do
-      requires_rosetta
+        sha256 "e3ae23a9415645c0321e86a64be1666102c524d2e970155979c61aac9aac2845"
+      end
+    end
+    on_intel do
+      arch intel: "12_x86"
+
+      sha256 "9370b6771f2ca9140b77c7c38b59bcda3bd3602d6d90ba0a5d6237185a768fa7"
     end
   end
-  on_sonoma :or_newer do
-    arch arm: "14-arm64", intel: "12-x86"
+  on_sequoia :or_newer do
+    arch arm: "15_arm64", intel: "15_x86"
 
-    sha256 arm:   "7067e26809ba92395644b58ced3d99b2ecd5f83844c913c1cae7290351cc6f38",
-           intel: "de55c686a82c904c4e585cf93802af3b475ed330e5420b3ef9b4a23d649e6b9e"
+    sha256 arm:   "578fbbf53acc805fa807d37f5bea0136d3442514cd57bc4f963275086a623a72",
+           intel: "92bec98b8078a6caf0efed6fffb7f01f5ba82cba0016a185ee61e2a5d009da7f"
   end
 
   url "https://github.com/widelands/widelands/releases/download/v#{version}/Widelands-#{version}-MacOS#{arch}.dmg",
@@ -24,13 +34,18 @@ cask "widelands-app" do
   homepage "https://www.widelands.org/"
 
   livecheck do
-    url "https://www.widelands.org/wiki/Download/"
-    regex(/href=.*?Widelands[._-]v?(\d+(?:\.\d+)+)[._-]MacOS#{arch}\.dmg/i)
+    url :url
+    regex(/Widelands[._-]v?(\d+(?:\.\d+)+)[._-]MacOS#{arch.gsub(/[._-]/, "[._-]")}\.dmg/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.filter_map do |asset|
+        asset["browser_download_url"]&.[](regex, 1)
+      end
+    end
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :big_sur"
 
   app "Widelands.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`widelands-app` is autobumped but the workflow failed to update to version 1.3 because the `livecheck` block produces an "Unable to get versions" error due to the current macOS version suffixes not using the expected format. The delimiter is now an underscore instead of a hyphen and there are now a variety of macOS/arch combinations. the first-party download page also doesn't link to all of the dmg files that are available in the 1.3 release.

This updates the version and modifies the `livecheck` block to check the release assets from the latest GitHub release instead. This required some creative restructuring of the app to handle the OS/arch combinations, as there isn't an Intel release for macOS 14. This was the only configuration that I could find that passed both `brew style` and `brew audit` for all OS/arch combinations locally.