### PR TITLE
robloxstudio: fix uninstall

### DIFF
--- a/Casks/r/robloxstudio.rb
+++ b/Casks/r/robloxstudio.rb
@@ -26,8 +26,7 @@ cask "robloxstudio" do
 
   app "RobloxStudio.app"
 
-  uninstall quit:   "com.roblox.RobloxStudio",
-            delete: "/Applications/RobloxStudio.app"
+  uninstall quit: "com.roblox.RobloxStudio"
 
   zap trash: [
     "~/Library/Preferences/com.roblox.RobloxStudio.plist",


### PR DESCRIPTION
Upgrading currently fails since we remove the app and then try to remove it again in the `uninstall` stanza.

```
==> Upgrading robloxstudio
==> Removing files:
/Applications/RobloxStudio.app
==> Purging files for version 0.703.0.7031352,92f2c43d9adb4c52 of Cask robloxstudio
Error: robloxstudio: It seems the App source '/Applications/RobloxStudio.app' is not there.
```