### PR TITLE
segue 1.0.1 (new cask)

### DIFF
--- a/Casks/s/segue.rb
+++ b/Casks/s/segue.rb
@@ -1,0 +1,26 @@
+cask "segue" do
+  version "1.0.1"
+  sha256 "d25899378c881084dafd6d74353836251e2ab123ef71035155f96294b67da20b"
+
+  url "https://segue.pylondev.com/releases/Segue-#{version}.dmg"
+  name "Segue"
+  desc "Focus overlay that dims everything except your active window"
+  homepage "https://segue.pylondev.com/"
+
+  livecheck do
+    url "https://segue.pylondev.com/appcast.xml"
+    strategy :sparkle
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Segue.app"
+
+  zap trash: [
+    "~/Library/Application Support/Segue",
+    "~/Library/Caches/com.segue.app",
+    "~/Library/HTTPStorages/com.segue.app",
+    "~/Library/Preferences/com.segue.app.plist",
+    "~/Library/Saved Application State/com.segue.app.savedState",
+  ]
+end


### PR DESCRIPTION
### Description
Segue is a focus overlay app for macOS that dims everything except your active window, helping users concentrate on their current task.

### Features
- Full-screen blur/dim overlay behind active window
- Two modes: Deep (full coverage) and Ambient (subtle gradient)
- Adjustable Gaussian blur, tint colors, and gradients
- Dynamic shader animations (Breathing, Drift, Pulse)
- Multi-display support
- Global keyboard shortcuts
- URL scheme automation
- Auto-updates via Sparkle

### Cask checklist
- [x] Cask installs and uninstalls successfully
- [x] brew style passes
- [x] App is signed and notarized
- [x] Download URL is stable and versioned

### Links
- Homepage: https://segue.pylondev.com
- Download: https://segue.pylondev.com/releases/Segue-1.0.1.dmg