### PR TITLE
seafile-client 9.0.16

### DIFF
--- a/Casks/s/seafile-client.rb
+++ b/Casks/s/seafile-client.rb
@@ -1,9 +1,9 @@
 cask "seafile-client" do
-  version "9.0.15"
-  sha256 "d899e827e68d77503ea204884276a8accfe565d7b012e31983ced6f449647eb6"
+  version "9.0.16"
+  sha256 "131668cdb2b7e23936f3ca075c61eba92a39de7076fc09b62ecc0039d382a870"
 
-  url "https://s3.eu-central-1.amazonaws.com/download.seadrive.org/seafile-client-#{version}.dmg",
-      verified: "s3.eu-central-1.amazonaws.com/download.seadrive.org/"
+  url "https://sos-ch-dk-2.exo.io/seafile-downloads/seafile-client-#{version}.dmg",
+      verified: "sos-ch-dk-2.exo.io/seafile-downloads/"
   name "Seafile Client"
   desc "File syncing client"
   homepage "https://www.seafile.com/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`seafile-client` is autobumped but the workflow failed to update to version 9.0.16 because the dmg URL changed with this version. This updates the version and aligns the cask `url` with the URL on the download page that the `livecheck` block checks.