### PR TITLE
presonus-universal-control 4.7.2-108537, fix livecheck

### DIFF
--- a/Casks/p/presonus-universal-control.rb
+++ b/Casks/p/presonus-universal-control.rb
@@ -1,6 +1,6 @@
 cask "presonus-universal-control" do
-  version "4.7.1.107907,10118"
-  sha256 "727b1140980b00f62ebfc4a2acebfa71053d6171cf3e3e1d0186df817520d4b0"
+  version "4.7.2-108537,10121"
+  sha256 "15db9f847dc3383a19d9348bb482b4fd73c63444a160b3ac34fe30d71f2ed199"
 
   url "https://www.fmicassets.com/Damroot/Original/#{version.csv.second}/PreSonus_Universal_Control_v#{version.csv.first.dots_to_underscores}.dmg",
       verified: "fmicassets.com/Damroot/Original/"
@@ -12,7 +12,7 @@ cask "presonus-universal-control" do
   # so we return the downloads from one of the popular products
   livecheck do
     url "https://www.presonus.com/products/audiobox-usb-96-studio"
-    regex(%r{href=.*?/(\d+)/PreSonus[._-]Universal[._-]Control[._-]v?(\d+(?:[._]\d+)+)\.dmg}i)
+    regex(%r{href=.*?/(\d+)/PreSonus[._-]Universal[._-]Control[._-]v?(\d+(?:[._-]\d+)+)\.dmg}i)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[1].tr("_", ".")},#{match[0]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

I wasn't sure if this should be two separate PRs so I did it this way.
Previously, one of the separators in the livecheck url was an underscore, causing it to fail to detect the new version, so this updates the livecheck to make it slightly more lenient.