### PR TITLE
ausweisapp 2.4.0 (new cask)

### DIFF
--- a/Casks/a/ausweisapp.rb
+++ b/Casks/a/ausweisapp.rb
@@ -1,0 +1,26 @@
+cask "ausweisapp" do
+  version "2.4.0"
+  sha256 "bce7cfeb988a6f50e99c45a3cb66f32b1b4effcb2b1e72bfdbc51363209b24b4"
+
+  url "https://github.com/Governikus/AusweisApp/releases/download/#{version}/AusweisApp-#{version}.dmg",
+      verified: "github.com/Governikus/AusweisApp/"
+  name "AusweisApp"
+  desc "Official eID-Client of the Federal Government of Germany"
+  homepage "https://www.ausweisapp.bund.de/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "AusweisApp.app"
+
+  zap trash: "~/Library/Application Scripts/com.governikus.ausweisapp2"
+
+  caveats do
+    requires_rosetta
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Add AusweisApp, an ID card authentication app for Germany

**About AusweisApp:** AusweisApp is an open-source, cross-platform app which enables the user to authenticate with German government services (and other services) using their ID card.

**Download Source:** The cask downloads from `Governikus/AusweisApp` which provides properly signed and notarized versions of the macOS app.

**Key Details:**
* Upstream project: https://github.com/Governikus/AusweisApp
* All DMG files are properly code-signed and notarized for macOS
* Supports Intel (x64) architectures (and Apple Silicon via Rosetta 2)
* Requires macOS Ventura or later

**Testing:**

- [x] `brew audit --new --cask ausweisapp` completed
- [x] `brew style --fix ausweisapp` completed
- [x] Cask follows Homebrew style guidelines

Note: I am including the "App" suffix here based on this exception from the [token reference](https://docs.brew.sh/Cask-Cookbook#simplified-names-of-apps):
> when “app” is an inseparable part of the name, without which the name would be inherently nonsensical