### PR TITLE
wispr-flow 1.4.171 (arm only)

### DIFF
--- a/Casks/w/wispr-flow.rb
+++ b/Casks/w/wispr-flow.rb
@@ -2,8 +2,8 @@ cask "wispr-flow" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.4.168"
-    sha256 "3a9a2d48add5c1949cd43e91a0de86cffca2d13f3b3a9daed3da3ab7d344f60f"
+    version "1.4.171"
+    sha256 "e28caf551282cc1c53714d59e8db6f276df3b3bafcb475f3797eb975ef036632"
   end
   on_intel do
     version "1.4.154"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wispr-flow` is autobumped but the workflow failed to update to version 1.4.171 for ARM because the duplicate PR check failed for the unchanged Intel version, so this manually updates the version.