### PR TITLE
msgfiler: update livecheck

### DIFF
--- a/Casks/m/msgfiler.rb
+++ b/Casks/m/msgfiler.rb
@@ -14,7 +14,7 @@ cask "msgfiler" do
     url "https://files.msgfiler.com/"
     regex(/
       href=.*?MsgFiler[._-]v?(\d+(?:\.\d+)+)[._-](\d+)[._-](\d+)\.dmg[^>]*?>
-      \s*MsgFiler\s+v?\d+(?:\.\d+)+(?:\s+on\s+Gumroad)?\s*<
+      \s*MsgFiler\s+v?\d+(?:\.\d+)+(?:\s+\(?Build\s+\d+\)?)?(?:\s+on\s+Gumroad)?\s*<
     /imx)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` block for `msgfiler` uses a regex that is explicit about the inner text of the dmg link, in an attempt to avoid unstable versions (as they use the same file name format as stable versions). The inner text is now using a "MsgFiler 4.3.1 (Build 66) on Gumroad" format and the regex doesn't match that, so the `livecheck` block produces an "Unable to get versions" error. This updates the regex to account for the optional "(Build 66)" text, allowing the regex to also match the current format.