### PR TITLE
thinlinc-client 4.20.0_4284

### DIFF
--- a/Casks/t/thinlinc-client.rb
+++ b/Casks/t/thinlinc-client.rb
@@ -1,15 +1,15 @@
 cask "thinlinc-client" do
-  version "4.19.0_4005"
-  sha256 "b0ddaaf86a6e2a8f147d36361e6c29bfba9cd716ee72febb48ae9447a76097fa"
+  version "4.20.0_4284"
+  sha256 "5a762511077829a004e0acb45bd5b7e6b4ae2dfe12cb62ec04425937d173f230"
 
-  url "https://www.cendio.com/downloads/clients/tl-#{version}-client-macos.iso"
+  url "https://www.cendio.com/downloads/clients/tl-#{version}-client-macos.dmg"
   name "ThinLinc"
   desc "Linux remote desktop server"
   homepage "https://www.cendio.com/thinlinc/what-is-thinlinc/"
 
   livecheck do
     url "https://www.cendio.com/thinlinc/download/"
-    regex(/tl[._-]v?(\d+(?:[._]\d+)+)[._-]client[._-]macos\.iso/i)
+    regex(/tl[._-]v?(\d+(?:[._]\d+)+)[._-]client[._-]macos\.(?:dmg|iso)/i)
   end
 
   app "ThinLinc Client.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`thinlinc-client` is autobumped but the workflow failed to update to version 4.20.0_4284 because the file for macOS is now a dmg instead of an iso and the `livecheck` block regex doesn't match as a result. This updates the version and adjusts the cask `url` and `livecheck` block regex accordingly.