### PR TITLE
betaflight-configurator: update `disable`

### DIFF
--- a/Casks/b/betaflight-configurator.rb
+++ b/Casks/b/betaflight-configurator.rb
@@ -8,7 +8,7 @@ cask "betaflight-configurator" do
   homepage "https://github.com/betaflight/betaflight-configurator"
 
   deprecate! date: "2025-12-26", because: :discontinued
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  disable! date: "2026-12-26", because: :discontinued
 
   app "Betaflight Configurator.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

When casks are disabled with `fails_gatekeeper_check` we continue to check them with autobump in case new version become correctly signed and notarized. It makes more sense to deprecate and disable this cask because it has been discontinued upstream in favour of a PWA.