### PR TITLE
switchresx: update livecheck

### DIFF
--- a/Casks/s/switchresx.rb
+++ b/Casks/s/switchresx.rb
@@ -8,8 +8,8 @@ cask "switchresx" do
   homepage "https://www.madrau.com/"
 
   livecheck do
-    url "https://www.madrau.com/srx_download/download.html"
-    regex(/latest\s+version\s+\(v?(\d+(?:\.\d+)+)\)/i)
+    url "https://www.madrau.com/SRXCurrentVersion#{version.major}"
+    regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `livecheck` block for `switchresx` produces an "Unable to get versions" error, as the download page no longer contains any version information. The page now makes a request to the `/SRXCurrentVersion4` endpoint, which returns the newest 4.x version in the response body. The app uses the same endpoint to check for new version information, so this updates the `livecheck` block to check it.

This may not surface a new major version unless the endpoint also returns that version but there doesn't seem to be any alternative (e.g., the URL is hardcoded in a JavaScript file that uses a unique identifier in the filename, so we couldn't reasonably identify the file to check to find the newest URL even if we wanted to).