### PR TITLE
Add aquaskk@prerelease 4.7.8

### DIFF
--- a/Casks/a/aquaskk.rb
+++ b/Casks/a/aquaskk.rb
@@ -15,4 +15,10 @@ cask "aquaskk" do
   pkg "AquaSKK-#{version}.pkg"
 
   uninstall pkgutil: "org.codefirst.aquaskk.pkg"
+
+  zap trash: [
+    "~/Library/Application Support/AquaSKK",
+    "~/Library/Preferences/jp.sourceforge.inputmethod.aquaskk.plist",
+    "~/Library/Preferences/jp.sourceforge.inputmethod.aquaskk.preferences.plist",
+  ]
 end

--- a/Casks/a/aquaskk.rb
+++ b/Casks/a/aquaskk.rb
@@ -4,6 +4,7 @@ cask "aquaskk" do
 
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.pkg"
   name "AquaSKK"
+  desc "Input method without morphological analysis"
   homepage "https://github.com/codefirst/aquaskk"
 
   livecheck do

--- a/Casks/a/aquaskk@prerelease.rb
+++ b/Casks/a/aquaskk@prerelease.rb
@@ -1,0 +1,31 @@
+cask "aquaskk@prerelease" do
+  version "4.7.8"
+  sha256 "e0c28724ff6eb5a01f95585a25d25a08c4296a657ca3590ee14cfd97318df95e"
+
+  url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.pkg"
+  name "AquaSKK"
+  desc "Input method without morphological analysis"
+  homepage "https://github.com/codefirst/aquaskk"
+
+  # This uses the `GithubReleases` strategy and includes ONLY releases marked as
+  # "pre-release", excluding stable releases.
+  livecheck do
+    url :url
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next unless release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
+  conflicts_with cask: "aquaskk"
+
+  pkg "AquaSKK-#{version}.pkg"
+
+  uninstall pkgutil: "org.codefirst.aquaskk.pkg"
+end

--- a/Casks/a/aquaskk@prerelease.rb
+++ b/Casks/a/aquaskk@prerelease.rb
@@ -28,4 +28,10 @@ cask "aquaskk@prerelease" do
   pkg "AquaSKK-#{version}.pkg"
 
   uninstall pkgutil: "org.codefirst.aquaskk.pkg"
+
+  zap trash: [
+    "~/Library/Application Support/AquaSKK",
+    "~/Library/Preferences/jp.sourceforge.inputmethod.aquaskk.plist",
+    "~/Library/Preferences/jp.sourceforge.inputmethod.aquaskk.preferences.plist",
+  ]
 end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -2,6 +2,7 @@
   "aerial@beta": "any",
   "agent-tars": "all",
   "amethyst": "any",
+  "aquaskk@prerelease": "all",
   "bitbar": "all",
   "calibrite-profiler": "any",
   "chime@alpha": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Adds prerelease version of AquaSKK (4.7.8) as a separate cask. Also adds description stanza to stable aquaskk cask.

Motivation: The stable version (4.7.3) does not work on M3 MacBooks. This prerelease version (4.7.8, built with Xcode 26 RC) resolves the compatibility issue.
