### PR TITLE
novation-play 1.0.0 (new cask)

### DIFF
--- a/Casks/n/novation-play.rb
+++ b/Casks/n/novation-play.rb
@@ -1,0 +1,27 @@
+cask "novation-play" do
+  version "1.0.0"
+  sha256 "5d664d6fbf59c4f7f54cbb438bec9b92b15b1d9df1f66a9074b3714bf931d9c4"
+
+  url "https://play.novationmusic.com/Play_#{version.dots_to_underscores}.dmg"
+  name "Novation Play"
+  desc "Virtual instrument for Novation Launchkey MK4 hardware"
+  homepage "https://novationmusic.com/software/novation-play/"
+
+  livecheck do
+    url :url
+    strategy :extract_plist
+  end
+
+  depends_on macos: ">= :ventura"
+
+  pkg "Play.pkg"
+
+  uninstall pkgutil: "^com.novation.pkg.play(?:..+)?$"
+
+  zap trash: [
+    "/Library/Application Support/Novation/Play",
+    "~/Library/Application Support/Novation/Play",
+    "~/Library/Caches/com.Novation.Play",
+    "~/Library/HTTPStorages/com.Novation.Play",
+  ]
+end

--- a/Casks/n/novation-play.rb
+++ b/Casks/n/novation-play.rb
@@ -8,15 +8,17 @@ cask "novation-play" do
   homepage "https://novationmusic.com/software/novation-play/"
 
   livecheck do
-    url :url
-    strategy :extract_plist
+    url "https://klevgrand.com/api/play/version"
+    strategy :json do |json|
+      json ["version"]
+    end
   end
 
   depends_on macos: ">= :ventura"
 
   pkg "Play.pkg"
 
-  uninstall pkgutil: "^com.novation.pkg.play(?:..+)?$"
+  uninstall pkgutil: "com.novation.pkg.play*"
 
   zap trash: [
     "/Library/Application Support/Novation/Play",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

The button to download the app is only accessible on the site from a page blocked by a login, but the download link itself is freely accessible. If this doesn't meet inclusion standards, I apologize!

I looked for a long while and couldn't find any method to get the version of the app; and since the page with the download url is behind a login, that doesn't work. That's why I used `ExtractPlist`, but if there's any other version information others can find I'll be happy to add it as a livecheck.