### PR TITLE
Add spotifly 1.2.0

### DIFF
--- a/Casks/s/spotifly.rb
+++ b/Casks/s/spotifly.rb
@@ -1,0 +1,21 @@
+cask "spotifly" do
+  version "1.2.0"
+  sha256 "4dd600be959f95fa9376469249a419573b1e1b5cf2bdb989e604611987aeb730"
+
+  url "https://github.com/ralph/spotifly/releases/download/v#{version}/Spotifly-#{version}.zip"
+  name "Spotifly"
+  desc "Lightweight Spotify player"
+  homepage "https://github.com/ralph/spotifly"
+
+  depends_on macos: ">= :tahoe"
+
+  app "Spotifly.app"
+
+  zap trash: [
+    "~/Library/Application Support/Spotifly",
+    "~/Library/Caches/rvdh.Spotifly",
+    "~/Library/HTTPStorages/rvdh.Spotifly",
+    "~/Library/Preferences/rvdh.Spotifly.plist",
+    "~/Library/Saved Application State/rvdh.Spotifly.savedState",
+  ]
+end


### PR DESCRIPTION
## Description

Adds Spotifly - a lightweight Spotify player for macOS.

## Features

- Native macOS app built with SwiftUI
- Spotify Web API integration
- Recently played tracks, albums, artists, and playlists
- Queue management with drag-and-drop reordering
- Playback controls
- Search functionality
- Favorites management
- Miniplayer mode

## Requirements

- macOS Sequoia (26.2) or later
- Spotify Premium account
- User's own Spotify Client ID (setup instructions in README)

## Links

- Homepage: https://github.com/ralph/spotifly
- Release: https://github.com/ralph/spotifly/releases/tag/v1.2.0

The app is signed and notarized with Apple Developer ID.