### PR TITLE
fastmail: add intel arch

### DIFF
--- a/Casks/f/fastmail.rb
+++ b/Casks/f/fastmail.rb
@@ -1,20 +1,23 @@
 cask "fastmail" do
-  version "1.0.7"
-  sha256 "4d039e5e02b182d0c5eec3654783708e66b8844d6f63c65924cb08c974a01a44"
+  arch arm: "arm64", intel: "x64"
+  arch_suffix = on_arch_conditional arm: "-#{arch}"
 
-  url "https://dl.fastmailcdn.com/desktop/production/mac/arm64/Fastmail-#{version}-arm64-mac.zip",
+  version "1.0.7"
+  sha256 arm:   "4d039e5e02b182d0c5eec3654783708e66b8844d6f63c65924cb08c974a01a44",
+         intel: "ccbb2327b865c4adac12daccb031e6f79bc18f72a4b47a9d9e9fb91dde3917b2"
+
+  url "https://dl.fastmailcdn.com/desktop/production/mac/#{arch}/Fastmail-#{version}#{arch_suffix}-mac.zip",
       verified: "dl.fastmailcdn.com/"
   name "Fastmail"
   desc "Email client"
   homepage "https://www.fastmail.com/"
 
   livecheck do
-    url "https://dl.fastmailcdn.com/desktop/production/mac/arm64/latest-mac.yml"
+    url "https://dl.fastmailcdn.com/desktop/production/mac/#{arch}/latest-mac.yml"
     strategy :electron_builder
   end
 
   auto_updates true
-  depends_on arch: :arm64
   depends_on macos: ">= :monterey"
 
   app "Fastmail.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR adds support for the Intel version of the Fastmail cask.