### PR TITLE
BoltAI: update to 2.5.1; add boltai@1

### DIFF
--- a/Casks/b/boltai.rb
+++ b/Casks/b/boltai.rb
@@ -16,7 +16,7 @@ cask "boltai" do
   auto_updates true
   depends_on macos: ">= :ventura"
 
-  app "BoltAI 2.app"
+  app "BoltAI #{version.major}.app"
 
   zap trash: [
     "~/Library/Application Scripts/co.podzim.boltai-mobile",

--- a/Casks/b/boltai.rb
+++ b/Casks/b/boltai.rb
@@ -23,12 +23,4 @@ cask "boltai" do
     "~/Library/Containers/co.podzim.boltai-mobile",
     "~/Library/Saved Application State/co.podzim.boltai-mobile.savedState",
   ]
-
-  caveats do
-    <<~EOS
-      You installed BoltAI v2 (incompatible with v1).
-      If you need v1 (maintenance mode), install:
-        brew install --cask boltai@1
-    EOS
-  end
 end

--- a/Casks/b/boltai.rb
+++ b/Casks/b/boltai.rb
@@ -1,9 +1,8 @@
 cask "boltai" do
-  version "2.5.1"
-  sha256 "17470b9455b4aed39e25b193353c530e558fa8548cd57526a8f8c24be31b6822"
+  version "2.6.0"
+  sha256 "0994524c2b5d85008130e0966cbfb9f0f2de25d711b71ef65116669cd09ded99"
 
   url "https://updates.boltai.com/dmg/BoltAI-#{version}.dmg"
-  name "BoltAI"
   name "BoltAI 2"
   desc "AI chat client"
   homepage "https://boltai.com/"

--- a/Casks/b/boltai.rb
+++ b/Casks/b/boltai.rb
@@ -10,9 +10,7 @@ cask "boltai" do
 
   livecheck do
     url "https://updates.boltai.com/appcast.xml"
-    strategy :sparkle do |items|
-      items.map(&:short_version)
-    end
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/b/boltai.rb
+++ b/Casks/b/boltai.rb
@@ -1,35 +1,36 @@
 cask "boltai" do
-  version "1.36.5"
-  sha256 "3391e8133eb4be2d48c36af5921f3dbc34a847728d32962d476f065ab38161f5"
+  version "2.5.1"
+  sha256 "17470b9455b4aed39e25b193353c530e558fa8548cd57526a8f8c24be31b6822"
 
-  url "https://download.boltai.com/releases/BoltAI-#{version}.dmg"
+  url "https://updates.boltai.com/dmg/BoltAI-#{version}.dmg"
   name "BoltAI"
+  name "BoltAI 2"
   desc "AI chat client"
   homepage "https://boltai.com/"
 
-  # The Sparkle feed can contain items on the "beta" channel, so we restrict
-  # matching to the default channel.
   livecheck do
-    url "https://boltai.com/sparkle/appcast.xml"
+    url "https://updates.boltai.com/appcast.xml"
     strategy :sparkle do |items|
-      items.find { |item| item.channel.nil? }&.short_version
+      items.map(&:short_version)
     end
   end
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: ">= :ventura"
 
-  app "BoltAI.app"
+  app "BoltAI 2.app"
 
   zap trash: [
-    "~/.boltai",
-    "~/Library/Application Support/co.podzim.BoltGPT",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.podzim.BoltGPT.*",
-    "~/Library/Caches/co.podzim.BoltGPT",
-    "~/Library/Caches/SentryCrash/BoltAI",
-    "~/Library/HTTPStorages/co.podzim.BoltGPT",
-    "~/Library/Preferences/co.podzim.BoltGPT.plist",
-    "~/Library/Saved Application State/co.podzim.BoltGPT.savedState",
-    "~/Library/WebKit/co.podzim.BoltGPT",
+    "~/Library/Application Scripts/co.podzim.boltai-mobile",
+    "~/Library/Containers/co.podzim.boltai-mobile",
+    "~/Library/Saved Application State/co.podzim.boltai-mobile.savedState",
   ]
+
+  caveats do
+    <<~EOS
+      You installed BoltAI v2 (incompatible with v1).
+      If you need v1 (maintenance mode), install:
+        brew install --cask boltai@1
+    EOS
+  end
 end

--- a/Casks/b/boltai@1.rb
+++ b/Casks/b/boltai@1.rb
@@ -7,17 +7,15 @@ cask "boltai@1" do
   desc "AI chat client"
   homepage "https://boltai.com/"
 
-  # The Sparkle feed can contain items on the "beta" channel, so we restrict
-  # matching to the default channel.
   livecheck do
     url "https://boltai.com/sparkle/appcast.xml"
-    strategy :sparkle do |items|
-      items.find { |item| item.channel.nil? }&.short_version
-    end
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true
   depends_on macos: ">= :monterey"
+
+  disable! date: "2026-06-01", because: :unmaintained
 
   app "BoltAI.app"
 
@@ -32,12 +30,4 @@ cask "boltai@1" do
     "~/Library/Saved Application State/co.podzim.BoltGPT.savedState",
     "~/Library/WebKit/co.podzim.BoltGPT",
   ]
-
-  caveats do
-    <<~EOS
-      BoltAI v1 is in maintenance mode.
-      For the actively developed v2 (incompatible), install:
-        brew install --cask boltai
-    EOS
-  end
 end

--- a/Casks/b/boltai@1.rb
+++ b/Casks/b/boltai@1.rb
@@ -12,10 +12,10 @@ cask "boltai@1" do
     strategy :sparkle, &:short_version
   end
 
+  disable! date: "2026-06-01", because: :unmaintained
+
   auto_updates true
   depends_on macos: ">= :monterey"
-
-  disable! date: "2026-06-01", because: :unmaintained
 
   app "BoltAI.app"
 

--- a/Casks/b/boltai@1.rb
+++ b/Casks/b/boltai@1.rb
@@ -1,0 +1,43 @@
+cask "boltai@1" do
+  version "1.36.5"
+  sha256 "3391e8133eb4be2d48c36af5921f3dbc34a847728d32962d476f065ab38161f5"
+
+  url "https://download.boltai.com/releases/BoltAI-#{version}.dmg"
+  name "BoltAI"
+  desc "AI chat client"
+  homepage "https://boltai.com/"
+
+  # The Sparkle feed can contain items on the "beta" channel, so we restrict
+  # matching to the default channel.
+  livecheck do
+    url "https://boltai.com/sparkle/appcast.xml"
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.short_version
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "BoltAI.app"
+
+  zap trash: [
+    "~/.boltai",
+    "~/Library/Application Support/co.podzim.BoltGPT",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/co.podzim.BoltGPT.*",
+    "~/Library/Caches/co.podzim.BoltGPT",
+    "~/Library/Caches/SentryCrash/BoltAI",
+    "~/Library/HTTPStorages/co.podzim.BoltGPT",
+    "~/Library/Preferences/co.podzim.BoltGPT.plist",
+    "~/Library/Saved Application State/co.podzim.BoltGPT.savedState",
+    "~/Library/WebKit/co.podzim.BoltGPT",
+  ]
+
+  caveats do
+    <<~EOS
+      BoltAI v1 is in maintenance mode.
+      For the actively developed v2 (incompatible), install:
+        brew install --cask boltai
+    EOS
+  end
+end


### PR DESCRIPTION
_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online boltai` is error-free.
- [x] `brew style --fix boltai ` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new boltai` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask boltai` worked successfully.
- [x] `brew uninstall --cask boltai` worked successfully.

---
