### PR TITLE
packages: re-enable and switch to github releases

### DIFF
--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -1,14 +1,12 @@
 cask "packages" do
   version "1.2.10"
-  sha256 :no_check
+  sha256 "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
 
-  url "http://s.sudre.free.fr/Software/files/Packages.dmg"
+  url "https://github.com/packagesdev/packages/releases/download/v#{version}/Packages.dmg"
+      verified: "https://github.com/packagesdev/packages/"
   name "Packages"
   desc "Integrated packaging environment"
   homepage "http://s.sudre.free.fr/Software/Packages/about.html"
-
-  # Artifact not available over HTTPS
-  disable! date: "2025-12-23", because: :no_longer_meets_criteria
 
   auto_updates true
 

--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -3,7 +3,7 @@ cask "packages" do
   sha256 "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
 
   url "https://github.com/packagesdev/packages/releases/download/v#{version}/Packages.dmg",
-      verified: "https://github.com/packagesdev/packages/"
+      verified: "https://github.com/packagesdev/packages/download/"
   name "Packages"
   desc "Integrated packaging environment"
   homepage "http://s.sudre.free.fr/Software/Packages/about.html"

--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -2,7 +2,7 @@ cask "packages" do
   version "1.2.10"
   sha256 "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
 
-  url "https://github.com/packagesdev/packages/releases/download/v#{version}/Packages.dmg"
+  url "https://github.com/packagesdev/packages/releases/download/v#{version}/Packages.dmg",
       verified: "https://github.com/packagesdev/packages/"
   name "Packages"
   desc "Integrated packaging environment"

--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -3,7 +3,7 @@ cask "packages" do
   sha256 "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
 
   url "https://github.com/packagesdev/packages/releases/download/v#{version}/Packages.dmg",
-      verified: "https://github.com/packagesdev/packages/download/"
+      verified: "https://github.com/packagesdev/packages/"
   name "Packages"
   desc "Integrated packaging environment"
   homepage "http://s.sudre.free.fr/Software/Packages/about.html"

--- a/Casks/p/packages.rb
+++ b/Casks/p/packages.rb
@@ -3,10 +3,15 @@ cask "packages" do
   sha256 "9d9a73a64317ea6697a380014d2e5c8c8188b59d5fb8ce8872e56cec06cd78e8"
 
   url "https://github.com/packagesdev/packages/releases/download/v#{version}/Packages.dmg",
-      verified: "https://github.com/packagesdev/packages/"
+      verified: "github.com/packagesdev/packages/"
   name "Packages"
   desc "Integrated packaging environment"
   homepage "http://s.sudre.free.fr/Software/Packages/about.html"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

Packages releases are now being served via GitHub releases: https://github.com/packagesdev/packages/issues/170

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
