### PR TITLE
double-commander: 1.1.32

### DIFF
--- a/Casks/d/double-commander.rb
+++ b/Casks/d/double-commander.rb
@@ -2,21 +2,18 @@ cask "double-commander" do
   arch arm: "aarch64", intel: "x86_64"
 
   version "1.1.32"
-  sha256 arm:   "044592bc65aa43086aeaa8dc8026844a51462255c25d292dde6459e4f7e4313f",
-         intel: "d795cdba799ffce80faeb61e64898b6440d001598026cddcbed6aba12201321a"
+  sha256 arm:   "dfbf339a2ef78e2346ad2a874a9961f5b725c2a8d8b32c33bc7751348488792b",
+         intel: "f2b39a06bcd4da63768db3f21cc36395223b9b289671479439adb6f66c594c15"
 
-  url "https://downloads.sourceforge.net/doublecmd/doublecmd-#{version.tr(",", "-")}.cocoa.#{arch}.dmg",
-      verified: "downloads.sourceforge.net/doublecmd/"
+  url "https://github.com/doublecmd/doublecmd/releases/download/v#{version}/doublecmd-#{version}.cocoa.#{arch}.dmg",
+      verified: "github.com/doublecmd/doublecmd/releases/"
   name "Double Commander"
   desc "File manager with two panels"
   homepage "https://doublecmd.sourceforge.io/"
 
   livecheck do
-    url "https://sourceforge.net/projects/doublecmd/rss?path=/macOS"
-    regex(%r{url=.*?/doublecmd[._-](\d+(?:[.-]\d+)+)[^"' ]*?\.dmg}i)
-    strategy :sourceforge do |page, regex|
-      page.scan(regex).map { |match| match[0].tr("-", ",") }
-    end
+    url :url
+    strategy :github_latest
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
- switch to github releases https://github.com/doublecmd/doublecmd
- fix checksums

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
