### PR TITLE
Fix poedit 3.8.1 hash

### DIFF
--- a/Casks/p/poedit.rb
+++ b/Casks/p/poedit.rb
@@ -1,6 +1,6 @@
 cask "poedit" do
   version "3.8.1"
-  sha256 "f50133b8b4095834182db20fa878d4c99d59f5da45ae1fa4bce578ff7da50f09"
+  sha256 "b3e2b91b5577d05be02e73e8833d1aa316d4c28030de137366d88768d3b6a067"
 
   url "https://download.poedit.net/Poedit-#{version}.zip"
   name "Poedit"


### PR DESCRIPTION
Not sure how this got set to the first value

```
==> Fetching downloads for: poedit
✘ Cask poedit (3.8.1)                                                                                                                                                             Verifying    38.5MB/ 38.5MB
Error: Cask reports different checksum:     f50133b8b4095834182db20fa878d4c99d59f5da45ae1fa4bce578ff7da50f09
       SHA-256 checksum of downloaded file: b3e2b91b5577d05be02e73e8833d1aa316d4c28030de137366d88768d3b6a067
==> Upgrading 1 outdated package:
poedit 3.8 -> 3.8.1
==> Upgrading poedit
==> Purging files for version 3.8.1 of Cask poedit
Error: poedit: SHA-256 mismatch
Expected: f50133b8b4095834182db20fa878d4c99d59f5da45ae1fa4bce578ff7da50f09
  Actual: b3e2b91b5577d05be02e73e8833d1aa316d4c28030de137366d88768d3b6a067
    File: /xxx/Caches/Homebrew/downloads/e1e744dec5dee63814362781a61c5a87ec9b4736e56feab09631bba6714c24d9--Poedit-3.8.1.zip
To retry an incomplete download, remove the file above.
```

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
