### PR TITLE
logi-options+ 1.99.822783

### DIFF
--- a/Casks/l/logi-options+.rb
+++ b/Casks/l/logi-options+.rb
@@ -33,7 +33,7 @@ cask "logi-options+" do
     end
   end
   on_ventura :or_newer do
-    version "1.98.824948"
+    version "1.99.822783"
     sha256 :no_check
 
     url "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.zip",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This PR bumps Logi Options+ cask version from `1.98.824948` to `1.99.822783`.
Fixes [Options+ macOS Certificate Issue](https://support.logi.com/hc/en-us/articles/37493733117847-Options-and-G-HUB-macOS-Certificate-Issue):
> A new ‘patch’ installer for Logi Options+ and G HUB is now available to fix an issue that caused the apps to stop working on macOS.
> The problem was caused by an expired certificate required for the apps to run. Because the certificate also affected the in‑app updater, you will need to manually download and install the updated version of the app, please do not uninstall the app and follow the steps below.

Tested on:
```
ProductName:		macOS
ProductVersion:		15.7.3
BuildVersion:		24G419
```