### PR TITLE
insta360-link-controller 2.2.1

### DIFF
--- a/Casks/i/insta360-link-controller.rb
+++ b/Casks/i/insta360-link-controller.rb
@@ -1,8 +1,8 @@
 cask "insta360-link-controller" do
-  version "2.0.6,build6,72fc6ee5e25db0752bba3b7c0484e4f5"
-  sha256 "0a63260a01a7a083dc5253bbb613d04c18e8ba77cb53e6c5da2c6cfef64b47e9"
+  version "2.2.1,build19,6e1596fcceda4e3698801460a00c8244"
+  sha256 "95ac8359fc7d9014d68e2a6fd933a73f5278205ce4a7278f0022bb3b132f6b07"
 
-  url "https://file.insta360.com/static/#{version.csv.third}/Insta360LinkController_#{version.csv.first}(#{version.csv.second}).pkg"
+  url "https://wassets.insta360.com/common/#{version.csv.third}/Insta360LinkController_#{version.csv.first}(#{version.csv.second}).pkg"
   name "Insta360 Link Controller"
   desc "Controller for Insta360 webcams"
   homepage "https://www.insta360.com/"
@@ -10,7 +10,6 @@ cask "insta360-link-controller" do
   livecheck do
     url "https://openapi.insta360.com/app/appDownload/getGroupApp?group=insta360-link&X-Language=en-us"
     regex(%r{/(\h+)/Insta360LinkController_\d+\.\d+\.\d+\((build\d+)\)\.pkg}i)
-
     strategy :json do |json, regex|
       # Find the Insta360 Link Controller app
       app = json.dig("data", "apps")&.find { |item| item["app_id"] == 100 }


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`insta360-link-controller` is autobumped but the workflow failed to update to version 2.2.1 because the URL changed with this version. This updates the version and adjusts the cask `url` to reflect the new URL found in the JSON data that the `livecheck` block checks.