### PR TITLE
sf-symbols 7.1

### DIFF
--- a/Casks/s/sf-symbols.rb
+++ b/Casks/s/sf-symbols.rb
@@ -24,11 +24,11 @@ cask "sf-symbols" do
     end
   end
   on_sonoma :or_newer do
-    version "7.0,115"
+    version "7.1,116"
     sha256 :no_check # required as upstream package is updated in-place
 
     livecheck do
-      url "https://developer.apple.com/sf-symbols/"
+      url :homepage
       regex(%r{href=.*?/SF[._-]Symbols[._-]v?(\d+(?:\.\d+)*)\.dmg}i)
       strategy :page_match do |page, regex|
         major_version = page[regex, 1]
@@ -44,7 +44,7 @@ cask "sf-symbols" do
   url "https://devimages-cdn.apple.com/design/resources/download/SF-Symbols-#{version.major}.dmg"
   name "SF Symbols"
   desc "Tool that provides consistent, highly configurable symbols for apps"
-  homepage "https://developer.apple.com/design/human-interface-guidelines/sf-symbols/overview/"
+  homepage "https://developer.apple.com/sf-symbols/"
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`sf-symbols` is autobumped but the workflow failed to update to version 7.1 because `brew audit` failed due to the homepage not existing anymore. This updates the version and switches the homepage to the developer.apple.com page that the `livecheck` block checks, as that seems to be the homepage nowadays.