### PR TITLE
tsh: fix `tsh` replacement cask

### DIFF
--- a/Casks/t/tsh.rb
+++ b/Casks/t/tsh.rb
@@ -8,8 +8,8 @@ cask "tsh" do
   desc "SSH server for teams managing distributed infrastructure"
   homepage "https://goteleport.com/"
 
-  deprecate! date: "2024-11-18", because: :unmaintained, replacement_cask: "teleport"
-  disable! date: "2025-11-18", because: :unmaintained, replacement_cask: "teleport"
+  deprecate! date: "2024-11-18", because: :unmaintained, replacement_cask: "teleport-suite"
+  disable! date: "2025-11-18", because: :unmaintained, replacement_cask: "teleport-suite"
 
   conflicts_with cask: [
     "teleport-suite",


### PR DESCRIPTION
The `teleport` cask no longer exists. The `teleport-suite` cask is the correct replacement.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
