### PR TITLE
pibar: add livecheck

### DIFF
--- a/Casks/p/pibar.rb
+++ b/Casks/p/pibar.rb
@@ -8,6 +8,13 @@ cask "pibar" do
   desc "Pi-hole(s) management in the menu bar"
   homepage "https://github.com/amiantos/pibar"
 
+  # The GitHub release descriptions contain a link to the AWS zip file, so we
+  # check releases instead of Git tags.
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
   app "PiBar.app"
 
   zap trash: [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

By default, livecheck checks the Git tags for `pibar` and this works but the zip file isn't hosted on GitHub, so the check doesn't align with the artifact source. A link to the zip file is provided in the GitHub release description, so this adds a `livecheck` block that uses the `GithubLatest` strategy to better align with the upstream release process.