### PR TITLE
async-profiler 4.2.1 (new cask)

### DIFF
--- a/Casks/a/async-profiler.rb
+++ b/Casks/a/async-profiler.rb
@@ -1,0 +1,26 @@
+cask "async-profiler" do
+  arch arm: "arm64", intel: "x64"
+  os macos: "macos", linux: "linux-#{arch}"
+
+  ext = on_system_conditional macos: "zip", linux: "tar.gz"
+
+  version "4.2.1"
+
+  on_macos do
+    sha256 "37482fada5ce53595257546178c0fb753696cec24969b3e8c97884e2bf1aa4b8"
+  end
+  on_linux do
+    sha256 arm64_linux:  "b7f58eead5973d5b04a920380f278e75cf190b49435974c3569869d298639664",
+           x86_64_linux: "e4d764f27d06a1d339d13df4f2e1599558b69fcfb01d4c811d13b8c895d7ea63"
+  end
+
+  url "https://github.com/async-profiler/async-profiler/releases/download/v#{version}/async-profiler-#{version}-#{os}.#{ext}"
+  name "async-profiler"
+  desc "Low overhead sampling profiler for Java"
+  homepage "https://github.com/async-profiler/async-profiler"
+
+  binary "async-profiler-#{version}-#{os}/bin/asprof"
+  binary "async-profiler-#{version}-#{os}/bin/jfrconv"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

There's one audit error with one of the installed binary `jfrconv`, but no issue with `asprof` (the main binary) though:
> fatal error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo: can't figure out the architecture type of: /private/tmp/cask-audit20260115-66869-az5q5j/async-profiler-4.2.1-macos/bin/jfrconv