### PR TITLE
anaconda 2025.12-2 (arm only)

### DIFF
--- a/Casks/a/anaconda.rb
+++ b/Casks/a/anaconda.rb
@@ -2,8 +2,8 @@ cask "anaconda" do
   arch arm: "arm64", intel: "x86_64"
 
   on_arm do
-    version "2025.12-1"
-    sha256 "f998f0918b9f06e08c3444f2b2c897fd3036da6725441ca064aa71ad47c75481"
+    version "2025.12-2"
+    sha256 "8d0b858358456d4ee159feb0c4ee6d635590b777f8b9ffa4aa7553c469aae2b6"
   end
   on_intel do
     version "2025.06-1"
@@ -21,7 +21,7 @@ cask "anaconda" do
 
   livecheck do
     url "https://repo.anaconda.com/archive/"
-    regex(/Anaconda3-(\d+(?:\.\d+)+[._-]*\d+)-MacOSX-#{arch}\.sh/i)
+    regex(/href=.*?Anaconda3[._-]v?(\d+(?:[.-]\d+)+)[._-]MacOSX?[._-]#{arch}\.sh/i)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`anaconda` is autobumped but the workflow failed to update to version 2025.12-2 for ARM because the Intel version hasn't changed. This updates the ARM version accordingly.

This also tweaks the `livecheck` block regex to bring it more in line with prevailing standards.