### PR TITLE
retrospective: fix checksum

### DIFF
--- a/Casks/r/retrospective.rb
+++ b/Casks/r/retrospective.rb
@@ -1,6 +1,6 @@
 cask "retrospective" do
   version "7.1.0"
-  sha256 "26d9a99d38b513cad6ae774ed271793db54f379cdea17503ad5aed66666479e0"
+  sha256 "ca73643fb5ca3e426124c2cad47d67eae3b037d81ebfb0f801aee6603851d992"
 
   url "https://resources.centeractive.com/software/#{version}/retrospective-#{version.dots_to_underscores}-macos-jre.dmg"
   name "Retrospective"


### PR DESCRIPTION
We had to redeploy a new installable of our version 7.1.0, because there was an error in the software.
Now installation fails because of the wrong checksum
Sorry for the additional work caused by our mistake

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.
_In the following questions `<cask>` is the token of the cask you're submitting._
After making any changes to a cask, existing or new, verify:
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---
