### PR TITLE
codebuddy, codebuddy-cn 4.3.2.17787057 (new cask)

### DIFF
--- a/Casks/c/codebuddy-cn.rb
+++ b/Casks/c/codebuddy-cn.rb
@@ -1,0 +1,39 @@
+cask "codebuddy-cn" do
+  arch arm: "arm64", intel: "x64"
+
+  version "4.3.2.17787057,5f7842a9cf,c146e3ea"
+  sha256 arm:   "2d4537b8ec3eb2b9fa8e064f4c3f95e4d7cb836ff135d984d28e83e78521daed",
+         intel: "823d26e350d3f5988e967d89eedd26b50e7fc07f542fcc29d93545baaadef6f7"
+
+  url "https://acc-1258344699.cos.accelerate.myqcloud.com/aiide/darwin-#{arch}/CodeBuddy-darwin-#{arch}-#{version.csv.first}-#{version.csv.second}-#{version.csv.third}-cn.zip",
+      verified: "acc-1258344699.cos.accelerate.myqcloud.com/aiide/"
+  name "CodeBuddy CN"
+  desc "AI-powered adaptive IDE (Chinese version)"
+  homepage "https://copilot.tencent.com/ide/"
+
+  livecheck do
+    url "https://copilot.tencent.com/v2/update?platform=ide-darwin-#{arch}&version=1.0.0&x-machine-id=default"
+    regex(%r{/CodeBuddy[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)-(\h+)-(\h+)[._-]cn\.zip}i)
+    strategy :json do |json, regex|
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]},#{match[3]}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "CodeBuddy CN.app"
+
+  zap trash: [
+    "~/.codebuddycn",
+    "~/Library/Application Support/CodeBuddy CN",
+    "~/Library/Application Support/CodeBuddyExtension",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.tencent.codebuddycn.sfl*",
+    "~/Library/Caches/com.tencent.codebuddycn",
+    "~/Library/Caches/com.tencent.codebuddycn.ShipIt",
+    "~/Library/Preferences/com.tencent.codebuddycn.plist",
+  ]
+end

--- a/Casks/c/codebuddy.rb
+++ b/Casks/c/codebuddy.rb
@@ -1,0 +1,40 @@
+cask "codebuddy" do
+  arch arm: "arm64", intel: "x64"
+
+  version "4.3.2.17787057,5f7842a9cf,c146e3ea"
+  sha256 arm:   "4e9ca5304685d9b12d874084272e98d8d5f7759e29bb0c21395c3f669e1b9656",
+         intel: "ecf2081e5d75c5f72087a4ddc2cd1a4d3bc7326c6c448e3b825e6f4964e97c58"
+
+  url "https://codebuddy-1328495429.cos.accelerate.myqcloud.com/aiide/darwin-#{arch}/CodeBuddy-darwin-#{arch}-#{version.csv.first}-#{version.csv.second}-#{version.csv.third}.zip",
+      verified: "codebuddy-1328495429.cos.accelerate.myqcloud.com/aiide/"
+  name "CodeBuddy"
+  desc "AI-powered adaptive IDE"
+  homepage "https://www.codebuddy.ai/ide/"
+
+  livecheck do
+    url "https://www.codebuddy.ai/v2/update?platform=ide-darwin-#{arch}&version=1.0.0&x-machine-id=default"
+    regex(%r{/CodeBuddy[._-]darwin[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)-(\h+)-(\h+)\.zip}i)
+    strategy :json do |json, regex|
+      match = json["url"]&.match(regex)
+      next if match.blank?
+
+      "#{match[1]},#{match[2]},#{match[3]}"
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "CodeBuddy.app"
+
+  zap trash: [
+    "~/.codebuddy",
+    "~/Library/Application Support/CodeBuddy",
+    "~/Library/Application Support/CodeBuddyExtension/Cache/CodeBuddyIDE/CodeBuddy",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.tencent.codebuddy.sfl*",
+    "~/Library/Caches/com.tencent.codebuddy",
+    "~/Library/Caches/com.tencent.codebuddy.ShipIt",
+    "~/Library/HTTPStorages/com.tencent.codebuddy",
+    "~/Library/Preferences/com.tencent.codebuddy.plist",
+  ]
+end


### PR DESCRIPTION
## Summary
- Add **CodeBuddy** (International version) and **CodeBuddy CN** (Domestic version).
- CodeBuddy is a next-generation AI Code Editor powered by Tencent.
- Verified with `brew audit --new --cask` and `brew style --cask`.

## Details
- **Homepage (Intl):** https://www.codebuddy.ai/ide
- **Homepage (CN):** https://copilot.tencent.com/ide/
- Supported architectures: `arm64` and `x64`.
- Minimum macOS version: `Big Sur` (11.0).