### PR TITLE
adobe-acrobat-reader: quit on upgrade

### DIFF
--- a/Casks/a/adobe-acrobat-reader.rb
+++ b/Casks/a/adobe-acrobat-reader.rb
@@ -15,6 +15,7 @@ cask "adobe-acrobat-reader" do
   end
 
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   pkg "AcroRdrDC_#{version.no_dots}_MUI.pkg"
 

--- a/Casks/a/adobe-acrobat-reader.rb
+++ b/Casks/a/adobe-acrobat-reader.rb
@@ -18,25 +18,26 @@ cask "adobe-acrobat-reader" do
 
   pkg "AcroRdrDC_#{version.no_dots}_MUI.pkg"
 
-  uninstall launchctl: [
+  uninstall launchctl:  [
               "com.adobe.ARMDC.Communicator",
               "com.adobe.ARMDC.SMJobBlessHelper",
               "com.adobe.ARMDCHelper.cc24aef4a1b90ed56a725c38014c95072f92651fb65e1bf9c8e43c37a23d420d",
             ],
-            quit:      [
+            quit:       [
               "com.adobe.AdobeRdrCEF",
               "com.adobe.AdobeRdrCEFHelper",
               "com.adobe.Reader",
             ],
-            pkgutil:   [
+            pkgutil:    [
               "com.adobe.acrobat.DC.reader.*",
               "com.adobe.armdc.app.pkg",
               "com.adobe.RdrServicesUpdater",
             ],
-            delete:    [
+            delete:     [
               "/Applications/Adobe Acrobat Reader.app",
               "/Library/Preferences/com.adobe.reader.DC.WebResource.plist",
-            ]
+            ],
+            on_upgrade: :quit
 
   zap trash: [
     "~/Library/Application Support/Adobe/Acrobat",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

The `pkg` installer fails if the application is running, so we need to ensure it has been quit before attempting to install.

- I'm not sure if there is any alternative here, as there is a small risk of loss of user-data, but the `quit` stanza should hopefully prompt users in app if they have unsaved files.