### PR TITLE
mixxx@snapshot 2.7-alpha-142-gc4a64f1883

### DIFF
--- a/Casks/m/mixxx@snapshot.rb
+++ b/Casks/m/mixxx@snapshot.rb
@@ -1,14 +1,9 @@
 cask "mixxx@snapshot" do
   arch arm: "arm", intel: "intel"
 
-  on_arm do
-    version "2.7-alpha-138-g09b6d3d774"
-    sha256 "504b3f5d03d98371b28b49133c396f4a06540c42522cba3f8f24569ec3c6ce93"
-  end
-  on_intel do
-    version "2.7-alpha-137-g1d48bbcd10"
-    sha256 "06578fd4564296c37a46e13d91ea5077e99191b67f7017d9d8a90ebc9fe8a63f"
-  end
+  version "2.7-alpha-142-gc4a64f1883"
+  sha256 arm:   "e2a295c9bfb8f1233a1d02023bc173083faf29175323615141f7c51e86ab6123",
+         intel: "3f2f579dfce3d754694b9e10a6c2e0fa05f85d3b7e06272900c157ed898b0d1b"
 
   url "https://downloads.mixxx.org/snapshots/main/mixxx-#{version}-macos#{arch}.dmg"
   name "Mixxx"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mixxx@snapshot` is autobumped but the workflow failed to update to version 2.7-alpha-142-gc4a64f1883 because the `livecheck` block produced an "Unable to get versions" error. This updates the version and removes the on_arch blocks, as both archs currently share the same version. For what it's worth, the `livecheck` block worked fine for me locally.