### PR TITLE
font-noto-serif-hebrew: update source and homepage to google

### DIFF
--- a/Casks/font/font-n/font-noto-serif-hebrew.rb
+++ b/Casks/font/font-n/font-noto-serif-hebrew.rb
@@ -2,47 +2,12 @@ cask "font-noto-serif-hebrew" do
   version :latest
   sha256 :no_check
 
-  url "https://noto-website-2.storage.googleapis.com/pkgs/NotoSerifHebrew-unhinted.zip",
-      verified: "noto-website-2.storage.googleapis.com/"
+  url "https://github.com/google/fonts/raw/main/ofl/notoserifhebrew/NotoSerifHebrew%5Bwdth,wght%5D.ttf",
+      verified: "github.com/google/fonts/"
   name "Noto Serif Hebrew"
-  homepage "https://www.google.com/get/noto/#serif-hebr"
+  homepage "https://fonts.google.com/noto/specimen/Noto+Serif+Hebrew"
 
-  font "NotoSerifHebrew-Black.ttf"
-  font "NotoSerifHebrew-Bold.ttf"
-  font "NotoSerifHebrew-Condensed.ttf"
-  font "NotoSerifHebrew-CondensedBlack.ttf"
-  font "NotoSerifHebrew-CondensedBold.ttf"
-  font "NotoSerifHebrew-CondensedExtraBold.ttf"
-  font "NotoSerifHebrew-CondensedExtraLight.ttf"
-  font "NotoSerifHebrew-CondensedLight.ttf"
-  font "NotoSerifHebrew-CondensedMedium.ttf"
-  font "NotoSerifHebrew-CondensedSemiBold.ttf"
-  font "NotoSerifHebrew-CondensedThin.ttf"
-  font "NotoSerifHebrew-ExtraBold.ttf"
-  font "NotoSerifHebrew-ExtraCondensed.ttf"
-  font "NotoSerifHebrew-ExtraCondensedBlack.ttf"
-  font "NotoSerifHebrew-ExtraCondensedBold.ttf"
-  font "NotoSerifHebrew-ExtraCondensedExtraBold.ttf"
-  font "NotoSerifHebrew-ExtraCondensedExtraLight.ttf"
-  font "NotoSerifHebrew-ExtraCondensedLight.ttf"
-  font "NotoSerifHebrew-ExtraCondensedMedium.ttf"
-  font "NotoSerifHebrew-ExtraCondensedSemiBold.ttf"
-  font "NotoSerifHebrew-ExtraCondensedThin.ttf"
-  font "NotoSerifHebrew-ExtraLight.ttf"
-  font "NotoSerifHebrew-Light.ttf"
-  font "NotoSerifHebrew-Medium.ttf"
-  font "NotoSerifHebrew-Regular.ttf"
-  font "NotoSerifHebrew-SemiBold.ttf"
-  font "NotoSerifHebrew-SemiCondensed.ttf"
-  font "NotoSerifHebrew-SemiCondensedBlack.ttf"
-  font "NotoSerifHebrew-SemiCondensedBold.ttf"
-  font "NotoSerifHebrew-SemiCondensedExtraBold.ttf"
-  font "NotoSerifHebrew-SemiCondensedExtraLight.ttf"
-  font "NotoSerifHebrew-SemiCondensedLight.ttf"
-  font "NotoSerifHebrew-SemiCondensedMedium.ttf"
-  font "NotoSerifHebrew-SemiCondensedSemiBold.ttf"
-  font "NotoSerifHebrew-SemiCondensedThin.ttf"
-  font "NotoSerifHebrew-Thin.ttf"
+  font "NotoSerifHebrew[wdth,wght].ttf"
 
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Changed source and homepage to google one.
Homepage is usually fonts.google.com/specimen/* but it is redirected to /noto/specimen for some noto fonts, so I am not sure we leave it as /specimen or fix to /noto/specimen for noto fonts. 

- https://github.com/Homebrew/homebrew-cask/issues/172732#issuecomment-3764584020