### PR TITLE
Add glance cask

### DIFF
--- a/Casks/g/glance.rb
+++ b/Casks/g/glance.rb
@@ -1,0 +1,18 @@
+cask "glance" do
+  version "0.1.0"
+  sha256 "a9e302d427d5fc846edf76d89a361d2f8c1502707ec4294b775fdf6b4b1af582"
+
+  url "https://github.com/TristanLaR/glance/releases/download/v#{version}/glance-macos.tar.gz"
+  name "Glance"
+  desc "Minimal markdown viewer with live preview"
+  homepage "https://github.com/TristanLaR/glance"
+
+  app "glance.app"
+  binary "glance.app/Contents/MacOS/glance"
+
+  zap trash: [
+    "~/Library/Application Support/com.glance.app",
+    "~/Library/Caches/com.glance.app",
+    "~/Library/Preferences/com.glance.app.plist",
+  ]
+end


### PR DESCRIPTION
## Description

Add [Glance](https://github.com/TristanLaR/glance), a minimal markdown viewer with live preview.

### Features
- Live file watching with auto-reload
- Syntax highlighting for code blocks
- Mermaid diagram support
- System theme support (light/dark)
- Zoom controls

## Cask details

- **Name:** glance
- **Version:** 0.1.0
- **Homepage:** https://github.com/TristanLaR/glance
- **Download URL:** https://github.com/TristanLaR/glance/releases/download/v0.1.0/glance-macos.tar.gz

The cask includes a `binary` stanza to make the CLI available as `glance`.