### PR TITLE
dynamic-notch 1.0.1 (new cask)

### DIFF
--- a/Casks/d/dynamic-notch.rb
+++ b/Casks/d/dynamic-notch.rb
@@ -1,0 +1,20 @@
+cask "dynamic-notch" do
+  version "1.0.1"
+  sha256 "795c33f8194052c874b7d3ca18a66bafaa551fa454a5e16ef584a53dfdcbec4e"
+
+  url "https://github.com/ryanch741/dynamic-notch/releases/download/v#{version}/dynamic-notch-#{version}.dmg"
+  name "Dynamic Notch"
+  name "灵动刘海"
+  desc "Utility for Dynamic Island-style interaction on MacBook Pro with notch"
+  homepage "https://github.com/ryanch741/dynamic-notch"
+
+  depends_on macos: ">= :sonoma"
+
+  app "灵动刘海.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.hianzuo.NotchIsland",
+    "~/Library/Preferences/com.hianzuo.NotchIsland.plist",
+    "~/Library/Saved Application State/com.hianzuo.NotchIsland.savedState",
+  ]
+end


### PR DESCRIPTION
Dynamic Notch is a native macOS utility designed for Dynamic Island-style interaction on MacBook Pro with notch.

**Features:**
- Smart expansion when mouse approaches the notch
- Time & Date display
- Shortcuts (apps, websites, folders)
- Pomodoro Timer
- Music Control (Apple Music, Spotify, NetEase Cloud Music, QQ Music)
- To-do List
- Multi-display support
- Auto-start at login
- Internationalization (English/Chinese)

**Links:**
- Homepage: https://github.com/ryanch741/dynamic-notch
- License: MIT
- Release: https://github.com/ryanch741/dynamic-notch/releases/tag/v1.0.1

**Requirements:**
- macOS 14.0 (Sonoma) or higher
- MacBook Pro with notch (recommended)