### PR TITLE
goland / intellij-idea: fix shim-script

### DIFF
--- a/Casks/g/goland.rb
+++ b/Casks/g/goland.rb
@@ -33,7 +33,7 @@ cask "goland" do
   preflight do
     File.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{appdir}/GoLand.app/Contents/MacOS/goland' "$@"
+      open -na "GoLand.app" --args "$@"
     EOS
   end
 

--- a/Casks/i/intellij-idea.rb
+++ b/Casks/i/intellij-idea.rb
@@ -34,7 +34,7 @@ cask "intellij-idea" do
   preflight do
     File.write shimscript, <<~EOS
       #!/bin/sh
-      exec '#{appdir}/IntelliJ IDEA.app/Contents/MacOS/idea' "$@"
+      open -na "IntelliJ IDEA.app" --args "$@"
     EOS
   end
 


### PR DESCRIPTION
Per the docs:
- https://www.jetbrains.com/help/go/working-with-the-ide-features-from-command-line.html#macos
- https://www.jetbrains.com/help/idea/working-with-the-ide-features-from-command-line.html#toolbox

the shimscript should be of the form:
```shell
open -na "$APP_NAME.app" --args "$@"
```

Likely all/most other JetBrains apps will need a similar update, though I'm not a frequent user so perhaps the existing scripts do work.

See https://github.com/Homebrew/homebrew-cask/pull/241516 for a similar change to the RubyMine install script.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
