### PR TITLE
engine-dj: update livecheck

### DIFF
--- a/Casks/e/engine-dj.rb
+++ b/Casks/e/engine-dj.rb
@@ -8,15 +8,22 @@ cask "engine-dj" do
   desc "DJ software suite"
   homepage "https://enginedj.com/"
 
+  # The file name regex needs to be anchored to avoid matching the variant for
+  # SYSTEM ONE users, which uses the same file name format but has a different
+  # version.
   livecheck do
     url "https://enginedj.com/downloads"
-    regex(
-      %r{href=.*?/Engine/(\d+(?:\.\d+)+)/Release/(\w*)/Engine[._-]DJ[._-]\d+(?:\.\d+)+[._-](\w*?)[._-]Setup\.dmg}i,
-    )
+    regex(%r{
+      MacDownloadButton.+?
+      href=.*?/Engine/v?(\d+(?:\.\d+)+)/Release/(\h+)/
+      Engine[._-]DJ[._-]v?\d+(?:\.\d+)+[._-](\h+?)[._-]Setup\.dmg
+    }imx)
     strategy :page_match do |page, regex|
       page.scan(regex).map { |match| "#{match[0]},#{match[1]},#{match[2]}" }
     end
   end
+
+  depends_on macos: ">= :monterey"
 
   pkg "Engine DJ_#{version.csv.first}_Setup.pkg"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Upstream has introduced a second stream with a newer version number that we don't want to include here.
Thankfully it is hosted on a different domain name, so we can anchor the regex to just the versions we want to match.

This does make the regex less flexible, but I cannot think of a better solution for now.