### PR TITLE
mos@beta 4.0.0-beta-1201 (new cask)

### DIFF
--- a/Casks/m/mos.rb
+++ b/Casks/m/mos.rb
@@ -8,6 +8,8 @@ cask "mos" do
   desc "Smooths scrolling and set mouse scroll directions independently"
   homepage "https://mos.caldis.me/"
 
+  conflicts_with cask: "mos@beta"
+
   app "Mos.app"
 
   zap trash: "~/Library/Preferences/com.caldis.Mos.plist"

--- a/Casks/m/mos.rb
+++ b/Casks/m/mos.rb
@@ -8,8 +8,6 @@ cask "mos" do
   desc "Smooths scrolling and set mouse scroll directions independently"
   homepage "https://mos.caldis.me/"
 
-  conflicts_with cask: "mos@beta"
-
   app "Mos.app"
 
   zap trash: "~/Library/Preferences/com.caldis.Mos.plist"

--- a/Casks/m/mos@beta.rb
+++ b/Casks/m/mos@beta.rb
@@ -1,0 +1,33 @@
+cask "mos@beta" do
+  version "4.0.0-beta-1201,123826"
+  sha256 "c238e3ad61d20b2142a857891165ded7928e0b04e2359a86fb9c9d6ae1ca500a"
+
+  url "https://github.com/Caldis/Mos/releases/download/#{version.csv.first}/Mos.Versions.#{version.csv.first}-#{version.csv.second}.zip",
+      verified: "github.com/Caldis/Mos/"
+  name "Mos"
+  desc "Smooths scrolling and set mouse scroll directions independently"
+  homepage "https://mos.caldis.me/"
+
+  livecheck do
+    url :url
+    regex(/Mos\.Versions\.v?(\d+(?:\.\d+)+-beta-\d+)[._-](\d+)\.zip/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next unless release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["name"]&.match(regex)
+          next if match.blank?
+
+          "#{match[1]},#{match[2]}"
+        end
+      end.flatten.compact
+    end
+  end
+
+  conflicts_with cask: "mos"
+
+  app "Mos.app"
+
+  zap trash: "~/Library/Preferences/com.caldis.Mos.plist"
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -37,6 +37,7 @@
   "magicavoxel": "all",
   "messenger-native": "all",
   "mongotron": "all",
+  "mos@beta": "any",
   "mouseless@preview": "any",
   "mullvad-vpn@beta": "any",
   "my-budget": "all",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

This cask is for the beta releases of the existing cask "Mos" from https://github.com/Caldis/Mos. Mos's release has stayed on version 3.5.0 for more than a year now and has since been pushing updates via 4.0.0-beta versions. Having discussed the prospect of adding a beta version cask in https://github.com/Caldis/Mos/issues/824 I was advised by @Syrupdesu to create a PR to add the beta version cask myself.

AI was used to create this cask in the form of ChatGPT Codex. It wrote the ruby file for the cask, ran checks for conflicts and compliance in accordance to homebrew acceptable casks documentation. I ensured `brew audit` and `brew style` checks are all correct.