### PR TITLE
browseros 0.37.0.3

### DIFF
--- a/Casks/b/browseros.rb
+++ b/Casks/b/browseros.rb
@@ -1,15 +1,28 @@
 cask "browseros" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.36.2"
-  sha256 arm:   "48f940639d0de182016cbf633ba8b041c9118fb8d7aa1370dda7a51e2df73eee",
-         intel: "45e34bce7cee0bd9a8934e16bea8130cb28ee79048207283c188fc4a38aa8567"
+  version "0.37.0.3,0.37.0"
+  sha256 arm:   "0d52b4766c31587c09f70b65203f91353ba71aef417289aef37c84504fb67f19",
+         intel: "d65bff2d2ff8eb153cea52f457b8ef54907b1db57e6fa8872cc4689bd9768703"
 
-  url "https://github.com/browseros-ai/BrowserOS/releases/download/v#{version}/BrowserOS_v#{version}_#{arch}.dmg",
+  url "https://github.com/browseros-ai/BrowserOS/releases/download/v#{version.csv.second || version.csv.first}/BrowserOS_v#{version.csv.first}_#{arch}.dmg",
       verified: "github.com/browseros-ai/BrowserOS/"
   name "BrowserOS"
   desc "Open-source agentic browser"
   homepage "https://www.browseros.com/"
+
+  livecheck do
+    url :url
+    regex(%r{/v?(\d+(?:\.\d+)+)/BrowserOS[._-]v?(\d+(?:\.\d+)*)[._-]#{arch}\.dmg}i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["browser_download_url"]&.match(regex)
+        next if match.blank?
+
+        (match[2] == match[1]) ? match[1] : "#{match[2]},#{match[1]}"
+      end
+    end
+  end
 
   depends_on macos: ">= :monterey"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`browseros` is autobumped but the workflow failed to update to version 0.37.0.3 because the version in the file name is 0.37.0.3 but the tag is simply `v0.37.0`. This has happened before, so this updates the version and adjusts the cask to be able to handle this mismatch.