### PR TITLE
ddnet 19.7

### DIFF
--- a/Casks/d/ddnet.rb
+++ b/Casks/d/ddnet.rb
@@ -1,6 +1,6 @@
 cask "ddnet" do
-  version "19.6"
-  sha256 "074f8fc809f3a469ec2b880556231bb0f81773b2e91f137dcd53a3f13c24a5f6"
+  version "19.7"
+  sha256 "be00de1c6a6960f0c2768e54a0d1eb6e0d3528897b82efe926e689fa366b79d9"
 
   url "https://ddnet.org/downloads/DDNet-#{version}-macos.dmg"
   name "DDNet"
@@ -11,8 +11,6 @@ cask "ddnet" do
     url "https://ddnet.org/downloads/"
     regex(/href=.*?DDNet[._-]v?(\d+(?:\.\d+)+)[^"' >]*?\.dmg/i)
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`ddnet` is autobumped but the workflow failed to update to version 19.7 because `brew audit` failed with a "Cask is deprecated because it failed Gatekeeper checks but all artifacts now pass!" error. I manually verified that the apps now pass Gatekeeper, so this updates the version and removes the `disable!` call.