### PR TITLE
graalvm-jdk@25 25.0.2 (arm only)

### DIFF
--- a/Casks/g/graalvm-jdk@25.rb
+++ b/Casks/g/graalvm-jdk@25.rb
@@ -1,26 +1,35 @@
 cask "graalvm-jdk@25" do
   arch arm: "aarch64", intel: "x64"
 
-  version "25.0.1,8"
-  sha256 arm:   "19dfd49ad112e6e6c2bdedc507c6859bf21294fa4c164f1be670d469c65b7993",
-         intel: "a762ca1d9a163e32790b9286f3af4c16369729ff27999d8dbab60d7be16cff2f"
+  on_arm do
+    version "25.0.2,10"
+    sha256 "48584aa5ae0f4df088d63da7bfdf415858ea3407385fb4f559bc4d7e1b300151"
+
+    livecheck do
+      url "https://java.oraclecloud.com/currentJavaReleases/#{version.major}"
+      regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
+      strategy :json do |json, regex|
+        match = json["releaseFullVersion"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
+  end
+  on_intel do
+    version "25.0.1,8"
+    sha256 "a762ca1d9a163e32790b9286f3af4c16369729ff27999d8dbab60d7be16cff2f"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
 
   url "https://download.oracle.com/graalvm/#{version.major}/archive/graalvm-jdk-#{version.csv.first}_macos-#{arch}_bin.tar.gz",
       verified: "download.oracle.com/"
   name "GraalVM Java Development Kit"
   desc "GraalVM from Oracle"
   homepage "https://www.graalvm.org/"
-
-  livecheck do
-    url "https://java.oraclecloud.com/currentJavaReleases/#{version.major}"
-    regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
-    strategy :json do |json, regex|
-      match = json["releaseFullVersion"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
 
   # FIXME: Change 11 back to #{version.csv.second} on the next release
   artifact "graalvm-jdk-#{version.csv.first}+#{version.csv.second}.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`graalvm-jdk@25` is autobumped but the workflow failed to update to version 25.0.2 because [upstream has removed support for x64 from this version onward](https://www.graalvm.org/release-notes/JDK_25/), making it clear that 25.0.1 was the last supported version for Intel. This updates the ARM version and adjusts the cask accordingly.