### PR TITLE
graalvm-jdk@21 21.0.10 (arm only)

### DIFF
--- a/Casks/g/graalvm-jdk@21.rb
+++ b/Casks/g/graalvm-jdk@21.rb
@@ -1,26 +1,35 @@
 cask "graalvm-jdk@21" do
   arch arm: "aarch64", intel: "x64"
 
-  version "21.0.9,7"
-  sha256 arm:   "cda0e0ee16fe06ba0a3203ae77a680c6e696b592b697851e161ae92b66c683a6",
-         intel: "aaf06b193ea1a05662d4a5a05e899eb51f8881eee4319db044707e79dcabbb32"
+  on_arm do
+    version "21.0.10,8"
+    sha256 "9e5d8c3b23b793ac3cc92462454edb9465208cb6eee18a0066971748ef5ce197"
+
+    livecheck do
+      url "https://java.oraclecloud.com/currentJavaReleases/#{version.major}"
+      regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
+      strategy :json do |json, regex|
+        match = json["releaseFullVersion"]&.match(regex)
+        next if match.blank?
+
+        "#{match[1]},#{match[2]}"
+      end
+    end
+  end
+  on_intel do
+    version "21.0.9,7"
+    sha256 "aaf06b193ea1a05662d4a5a05e899eb51f8881eee4319db044707e79dcabbb32"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
 
   url "https://download.oracle.com/graalvm/#{version.major}/archive/graalvm-jdk-#{version.csv.first}_macos-#{arch}_bin.tar.gz",
       verified: "download.oracle.com/"
   name "GraalVM Java Development Kit"
   desc "GraalVM from Oracle"
   homepage "https://www.graalvm.org/"
-
-  livecheck do
-    url "https://java.oraclecloud.com/currentJavaReleases/#{version.major}"
-    regex(/(?:jdk[._-])?(\d+(?:\.\d+)*)(?:-\d+)?\+(\d+)/i)
-    strategy :json do |json, regex|
-      match = json["releaseFullVersion"]&.match(regex)
-      next if match.blank?
-
-      "#{match[1]},#{match[2]}"
-    end
-  end
 
   artifact "graalvm-jdk-#{version.csv.first}+#{version.csv.second}.1", target: "/Library/Java/JavaVirtualMachines/graalvm-#{version.major}.jdk"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`graalvm-jdk@21` is autobumped but the workflow failed to update to version 21.0.10 because there isn't an x64 artifact for this version. Upstream mentioned in the [25.0.2 release notes](https://www.graalvm.org/release-notes/JDK_25/) that they removed support for x64, so presumably this also applies to 21.0.10. This updates the ARM version and adjusts the cask accordingly.