### PR TITLE
tribler 8.3.1

### DIFF
--- a/Casks/t/tribler.rb
+++ b/Casks/t/tribler.rb
@@ -1,17 +1,18 @@
 cask "tribler" do
-  version "8.2.3"
-  sha256 "68d22bbc7d7fcbb290959a9d5f9c99cdf7b9d0f801114b6af707f21142d3cf76"
+  version "8.3.1"
+  sha256 "6a37959aa4b89464d863ee663be869459faaf1bc38189797fea69a5b9293b719"
 
-  url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg",
-      verified: "github.com/Tribler/tribler/"
+  url "https://github.com/Tribler/tribler/releases/download/v#{version}/Tribler-#{version}.dmg"
   name "Tribler"
   desc "Privacy enhanced BitTorrent client with P2P content discovery"
-  homepage "https://www.tribler.org/"
+  homepage "https://github.com/Tribler/tribler"
 
   livecheck do
     url :url
     strategy :github_latest
   end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Tribler.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tribler` is autobumped but the workflow failed to update to version 8.3.1 because the homepage does not respond and the app fails Gatekeeper checks. This updates the version, sets the homepage to the GitHub repository, and adds a `disable!` call with the future date we've been using for this scenario.