### PR TITLE
boss 8.16.1

### DIFF
--- a/Casks/b/boss.rb
+++ b/Casks/b/boss.rb
@@ -1,6 +1,6 @@
 cask "boss" do
-  version "8.15.28"
-  sha256 "6a66e12a8f94365be8eaee2d87433a7b06b06fc035010a8921e72b70f8593b08"
+  version "8.16.1"
+  sha256 "ce51f29b39e4167b42aa7c2adf841f33401a6b07d389264409706916cceaa9df"
 
   url "https://github.com/risa-labs-inc/BOSS-Releases/releases/download/v#{version}/BOSS-#{version}-Universal.dmg",
       verified: "github.com/risa-labs-inc/BOSS-Releases/"


### PR DESCRIPTION
Updates boss cask to version 8.16.0

  **Release Information:**
  - Version: 8.16.0  
  - SHA256: `c4dee4b8fabbba60841166f06e9fd45c36da5d49d7730fb287267022a88cd010`
  - Release URL: https://github.com/risa-labs-inc/BossConsole-Releases/releases/tag/v8.16.0

  **Changes:**
  - Updated version from previous to 8.16.0
  - Updated SHA256 hash for new release asset

  BOSS is an AI-powered workspace for complex business operations.