### PR TITLE
Add appvolume cask

### DIFF
--- a/Casks/a/appvolume.rb
+++ b/Casks/a/appvolume.rb
@@ -1,21 +1,11 @@
 cask "appvolume" do
+  arch arm: "arm64", intel: "x86_64"
+
   version "0.1.31"
+  sha256 arm:   "4e4a954ee72ad8a884526b3be509c3f397ca8a2054ebd852c01dfae9234c0693",
+         intel: "771d556061a30722598b95a7e4115593cd1386bc0d8d22edb4acf82c7c16be7e"
 
-  on_arm do
-    sha256 "4e4a954ee72ad8a884526b3be509c3f397ca8a2054ebd852c01dfae9234c0693"
-
-    url "https://releases.appvolume.app/AppVolume-#{version}-arm64.pkg"
-
-    pkg "AppVolume-#{version}-arm64.pkg"
-  end
-  on_intel do
-    sha256 "771d556061a30722598b95a7e4115593cd1386bc0d8d22edb4acf82c7c16be7e"
-
-    url "https://releases.appvolume.app/AppVolume-#{version}-x86_64.pkg"
-
-    pkg "AppVolume-#{version}-x86_64.pkg"
-  end
-
+  url "https://releases.appvolume.app/AppVolume-#{version}-#{arch}.pkg"
   name "AppVolume"
   desc "Per-application volume control"
   homepage "https://appvolume.app/"
@@ -29,6 +19,8 @@ cask "appvolume" do
 
   auto_updates true
   depends_on macos: ">= :sonoma"
+
+  pkg "AppVolume-#{version}-#{arch}.pkg"
 
   uninstall launchctl: "io.appvolume.daemon",
             quit:      "io.appvolume",

--- a/Casks/a/appvolume.rb
+++ b/Casks/a/appvolume.rb
@@ -1,0 +1,47 @@
+cask "appvolume" do
+  version "0.1.31"
+
+  on_arm do
+    sha256 "4e4a954ee72ad8a884526b3be509c3f397ca8a2054ebd852c01dfae9234c0693"
+
+    url "https://releases.appvolume.app/AppVolume-#{version}-arm64.pkg"
+
+    pkg "AppVolume-#{version}-arm64.pkg"
+  end
+  on_intel do
+    sha256 "771d556061a30722598b95a7e4115593cd1386bc0d8d22edb4acf82c7c16be7e"
+
+    url "https://releases.appvolume.app/AppVolume-#{version}-x86_64.pkg"
+
+    pkg "AppVolume-#{version}-x86_64.pkg"
+  end
+
+  name "AppVolume"
+  desc "Per-application volume control"
+  homepage "https://appvolume.app/"
+
+  livecheck do
+    url "https://releases.appvolume.app/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  uninstall launchctl: "io.appvolume.daemon",
+            quit:      "io.appvolume",
+            pkgutil:   [
+              "io.appvolume.daemon",
+              "io.appvolume.driver",
+              "io.appvolume.ui",
+            ],
+            delete:    "/Library/Audio/Plug-Ins/HAL/AppVolumeAudioDevice.driver"
+
+  zap trash: [
+    "~/Library/Application Support/AppVolume",
+    "~/Library/Caches/io.appvolume",
+    "~/Library/Preferences/io.appvolume.plist",
+  ]
+end

--- a/Casks/a/appvolume.rb
+++ b/Casks/a/appvolume.rb
@@ -33,6 +33,7 @@ cask "appvolume" do
   uninstall launchctl: "io.appvolume.daemon",
             quit:      "io.appvolume",
             pkgutil:   [
+              "io.appvolume.app",
               "io.appvolume.daemon",
               "io.appvolume.driver",
               "io.appvolume.ui",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---

Thanks for taking the time to review my application. Here are some clarifying details on this new submission. In particular the notability evidence as AppVolume is not open source, thus might otherwise be considered too obscure. Hopefully you can make an exception!

## Notability Evidence

- Public website: https://appvolume.app
- Reddit traction: [r/macapps post](https://www.reddit.com/r/macapps/comments/1pczrny/macos_still_doesnt_have_perapp_volume_control_so/) with significant engagement
- Similar apps in homebrew-cask: `soundsource`, `background-music`

## AI Usage

Claude Opus 4.5 assisted with generating the initial cask formula structure. All changes were manually reviewed. Everything was verified by running all audit commands and performing a full install/uninstall test on ARM64.

## Technical Details

- Signed & notarized with Developer ID
- Native app (SwiftUI) + Rust daemon + CoreAudio HAL driver
- Supports both Apple Silicon and Intel Macs
- macOS Sonoma (14.0) or later required

## Licensing and free trial

AppVolume is currently free during Early Access. After this phase, it will still install without a license and include a 14-day free trial. A license is only required for continued use beyond the trial. In the future, some features may remain free without a license.