### PR TITLE
developer/bin/import_google_fonts: skip `font-noto-sans-n-ko`

### DIFF
--- a/developer/bin/import_google_fonts
+++ b/developer/bin/import_google_fonts
@@ -308,6 +308,10 @@ Download the or clone the repository from https://github.com/google/fonts, then 
         if cask.token() == 'font-ek-mukta':
           continue
 
+        # The google/fonts repo contains an incomplete legacy font.
+        if cask.token() == 'font-noto-sans-n-ko':
+           continue
+
         # Skip cask if already handled (i.e. if it exists in multiple license sub-directories).
         if cask.token() in added_casks or cask.token() in updated_casks:
           continue


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

This PR adds a skip to the `import_google_fonts` function to prevent importing a broken font from the google/fonts repo.