### PR TITLE
captains-deck 1.0.8 (new cask)

### DIFF
--- a/Casks/c/captains-deck.rb
+++ b/Casks/c/captains-deck.rb
@@ -1,0 +1,27 @@
+cask "captains-deck" do                                                                                                                                                   
+    version "1.0.8"                                                                                                                                                         
+    sha256 "7375e0ea351c1f9d0f7bd07eeec342e57ea2728126666b02de949d88185e6772"                                                                                               
+                                                                                                                                                                            
+    url "https://captains-deck.com/downloads/CaptainsDeck.dmg"                                                                                                              
+    name "Captain's Deck"                                                                                                                                                   
+    desc "Dual-pane file manager for macOS inspired by Norton Commander"                                                                                                    
+    homepage "https://captains-deck.com/"                                                                                                                                   
+                                                                                                                                                                            
+    livecheck do                                                                                                                                                            
+      url "https://captains-deck.com/appcast.xml"                                                                                                                           
+      strategy :sparkle                                                                                                                                                     
+    end                                                                                                                                                                     
+                                                                                                                                                                            
+    auto_updates true                                                                                                                                                       
+    depends_on macos: ">= :sonoma"                                                                                                                                          
+                                                                                                                                                                            
+    app "Captain's Deck.app"                                                                                                                                                
+                                                                                                                                                                            
+    zap trash: [                                                                                                                                                            
+      "~/Library/Application Support/Captain's Deck",                                                                                                                       
+      "~/Library/Caches/com.captainsdeck.app",                                                                                                                              
+      "~/Library/HTTPStorages/com.captainsdeck.app",                                                                                                                        
+      "~/Library/Preferences/com.captainsdeck.app.plist",                                                                                                                   
+      "~/Library/Saved Application State/com.captainsdeck.app.savedState",                                                                                                  
+    ]                                                                                                                                                                       
+  end

--- a/Casks/c/captains-deck.rb
+++ b/Casks/c/captains-deck.rb
@@ -1,27 +1,27 @@
-cask "captains-deck" do                                                                                                                                                   
-    version "1.0.8"                                                                                                                                                         
-    sha256 "7375e0ea351c1f9d0f7bd07eeec342e57ea2728126666b02de949d88185e6772"                                                                                               
-                                                                                                                                                                            
-    url "https://captains-deck.com/downloads/CaptainsDeck.dmg"                                                                                                              
-    name "Captain's Deck"                                                                                                                                                   
-    desc "Dual-pane file manager for macOS inspired by Norton Commander"                                                                                                    
-    homepage "https://captains-deck.com/"                                                                                                                                   
-                                                                                                                                                                            
-    livecheck do                                                                                                                                                            
-      url "https://captains-deck.com/appcast.xml"                                                                                                                           
-      strategy :sparkle                                                                                                                                                     
-    end                                                                                                                                                                     
-                                                                                                                                                                            
-    auto_updates true                                                                                                                                                       
-    depends_on macos: ">= :sonoma"                                                                                                                                          
-                                                                                                                                                                            
-    app "Captain's Deck.app"                                                                                                                                                
-                                                                                                                                                                            
-    zap trash: [                                                                                                                                                            
-      "~/Library/Application Support/Captain's Deck",                                                                                                                       
-      "~/Library/Caches/com.captainsdeck.app",                                                                                                                              
-      "~/Library/HTTPStorages/com.captainsdeck.app",                                                                                                                        
-      "~/Library/Preferences/com.captainsdeck.app.plist",                                                                                                                   
-      "~/Library/Saved Application State/com.captainsdeck.app.savedState",                                                                                                  
-    ]                                                                                                                                                                       
+cask "captains-deck" do
+  version "1.0.8"
+  sha256 "7375e0ea351c1f9d0f7bd07eeec342e57ea2728126666b02de949d88185e6772"
+
+  url "https://captains-deck.com/downloads/CaptainsDeck.dmg"
+  name "Captain's Deck"
+  desc "Dual-pane file manager for macOS inspired by Norton Commander"
+  homepage "https://captains-deck.com/"
+
+  livecheck do
+    url "https://captains-deck.com/appcast.xml"
+    strategy :sparkle
   end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Captain's Deck.app"
+
+  zap trash: [
+    "~/Library/Application Support/Captain's Deck",
+    "~/Library/Caches/com.captainsdeck.app",
+    "~/Library/HTTPStorages/com.captainsdeck.app",
+    "~/Library/Preferences/com.captainsdeck.app.plist",
+    "~/Library/Saved Application State/com.captainsdeck.app.savedState",
+  ]
+end

--- a/Casks/c/captains-deck.rb
+++ b/Casks/c/captains-deck.rb
@@ -9,7 +9,7 @@ cask "captains-deck" do
 
   livecheck do
     url "https://captains-deck.com/appcast.xml"
-    strategy :sparkle
+    strategy :sparkle, &:short_version
   end
 
   auto_updates true

--- a/Casks/c/captains-deck.rb
+++ b/Casks/c/captains-deck.rb
@@ -2,9 +2,9 @@ cask "captains-deck" do
   version "1.0.8"
   sha256 "7375e0ea351c1f9d0f7bd07eeec342e57ea2728126666b02de949d88185e6772"
 
-  url "https://captains-deck.com/downloads/CaptainsDeck.dmg"
+  url "https://captains-deck.com/downloads/CaptainsDeck-#{version}.dmg"
   name "Captain's Deck"
-  desc "Dual-pane file manager for macOS inspired by Norton Commander"
+  desc "Dual-pane file manager inspired by Norton Commander"
   homepage "https://captains-deck.com/"
 
   livecheck do

--- a/Casks/c/captains-deck.rb
+++ b/Casks/c/captains-deck.rb
@@ -18,10 +18,10 @@ cask "captains-deck" do
   app "Captain's Deck.app"
 
   zap trash: [
-    "~/Library/Application Support/Captain's Deck",
+    "~/Library/Application Support/CaptainsDeck",
     "~/Library/Caches/com.captainsdeck.app",
     "~/Library/HTTPStorages/com.captainsdeck.app",
     "~/Library/Preferences/com.captainsdeck.app.plist",
-    "~/Library/Saved Application State/com.captainsdeck.app.savedState",
+    "~/Library/WebKit/com.captainsdeck.app",
   ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
*Claude was used to help generate the cask file. The cask was manually verified by:                                                                     
  - Running `brew audit --cask --online captains-deck`                                                                                                                      
  - Running `brew style captains-deck`                                                                                                                                      
  - Testing installation with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask captains-deck`                                                                            
  - Testing uninstallation with `brew uninstall --cask captains-deck

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

---
