### PR TITLE
appvolume: fix stale virtual device after uninstall

### DIFF
--- a/Casks/a/appvolume.rb
+++ b/Casks/a/appvolume.rb
@@ -22,6 +22,12 @@ cask "appvolume" do
 
   pkg "AppVolume-#{version}-#{arch}.pkg"
 
+  uninstall_postflight do
+    system_command "/usr/bin/killall",
+                   args: ["coreaudiod"],
+                   sudo: true
+  end
+
   uninstall launchctl: "io.appvolume.daemon",
             quit:      "io.appvolume",
             pkgutil:   [
@@ -30,7 +36,10 @@ cask "appvolume" do
               "io.appvolume.driver",
               "io.appvolume.ui",
             ],
-            delete:    "/Library/Audio/Plug-Ins/HAL/AppVolumeAudioDevice.driver"
+            delete:    [
+              "/Library/Audio/Plug-Ins/HAL/AppVolumeAudioDevice.driver",
+              "~/Library/LaunchAgents/io.appvolume.daemon.plist",
+            ]
 
   zap trash: [
     "~/Library/Application Support/AppVolume",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

---

The LaunchAgent plist is created at runtime by the daemon (not by the PKG installer), so it wasn't being removed during uninstall. With `KeepAlive: true`, launchd would restart the daemon after `launchctl unload`. This resulted in a trailing virtual device.

Changes:
- Add `~/Library/LaunchAgents/io.appvolume.daemon.plist` to `delete` stanza
- Add `uninstall_postflight` to restart coreaudiod so it unloads the driver and removes the virtual device from system audio devices
