### PR TITLE
antigravity: use shimscript to fix xattr permission error

### DIFF
--- a/Casks/a/antigravity.rb
+++ b/Casks/a/antigravity.rb
@@ -27,7 +27,16 @@ cask "antigravity" do
   depends_on macos: ">= :big_sur"
 
   app "Antigravity.app"
-  binary "#{appdir}/Antigravity.app/Contents/Resources/app/bin/antigravity", target: "agy"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  agy_shimscript = "#{staged_path}/agy.wrapper.sh"
+  binary agy_shimscript, target: "agy"
+
+  preflight do
+    File.write agy_shimscript, <<~EOS
+      #!/bin/sh
+      exec '#{appdir}/Antigravity.app/Contents/Resources/app/bin/antigravity' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/.antigravity/",


### PR DESCRIPTION
Fixes: https://github.com/Homebrew/homebrew-cask/issues/246183

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

**AI Usage:** Used Claude to identify the root cause (xattr permission error on signed binary inside app bundle). The fix was implemented manually based on existing shimscript patterns in the repo (kitty, vlc, firefox casks - see #18809). Verified by running `brew style --fix` with no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
