### PR TITLE
picview: update sha256 for version 4.1.1

### DIFF
--- a/Casks/p/picview.rb
+++ b/Casks/p/picview.rb
@@ -2,8 +2,8 @@ cask "picview" do
   arch arm: "arm64", intel: "x64"
 
   version "4.1.1"
-  sha256 arm:   "bb1d7af15a369035256700205121f0d2f71118ee1ad46a7b191049cbbf4f544e",
-         intel: "401c85723c77bc9ddeafc2e0d9b3ce4f044cc98930d2faa82c28ca4a58a80444"
+  sha256 arm:   "c9cde9f35073962dd603c93daaacfd9dbf1f44473b62b44b4fff1d1be3e2287c",
+         intel: "3b15078b3d03e0c6f6f0cabbef9142b41f3cf2b516da4a36c5eab3cd0fe73beb"
 
   url "https://github.com/Ruben2776/PicView/releases/download/#{version}/PicView-#{version}-macOS-#{arch}.dmg",
       verified: "github.com/Ruben2776/PicView/"


### PR DESCRIPTION
Fixes SHA-256 mismatch for picview 4.1.1.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
