### PR TITLE
seam-app 0.0.4 (new cask)

### DIFF
--- a/Casks/b/brave-browser@nightly.rb
+++ b/Casks/b/brave-browser@nightly.rb
@@ -2,9 +2,9 @@ cask "brave-browser@nightly" do
   arch arm: "arm64", intel: "x64"
   folder = on_arch_conditional arm: "nightly-arm64", intel: "nightly"
 
-  version "1.88.58.0"
-  sha256 arm:   "9e47f15f46f9a3abf0e08ed68e939e73bc1e30daebb65bc8efc3e240c5a6f589",
-         intel: "7ad3c72cf222e67bf31e3f67b91967529bb2bb359dcc252edb4719de86c02e23"
+  version "1.88.63.0"
+  sha256 arm:   "a76361804ceef2bbe78347b24e3e0668ca815aa0b48af1dec2d21161b1e2acbf",
+         intel: "9a7ebbf64874bc937c0db133ce7b102d6744bbe319ca82499562edf84b81f0a7"
 
   url "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/#{folder}/#{version.major_minor_patch.sub(".", "")}/Brave-Browser-Nightly-#{arch}.dmg",
       verified: "updates-cdn.bravesoftware.com/sparkle/Brave-Browser/"

--- a/Casks/s/seam-app.rb
+++ b/Casks/s/seam-app.rb
@@ -1,0 +1,27 @@
+cask "seam-app" do
+  version "0.0.4"
+  sha256 "e7b14939ee263377ca81851bb2689a9b060378af93a9e2dfda05fbe3a3bdc1b5"
+
+  url "https://releases.getseam.app/#{version}/Seam.dmg"
+  name "Seam"
+  desc "Clean Dynamic Island for macOS"
+  homepage "https://getseam.app/"
+
+  livecheck do
+    url "https://releases.getseam.app/latest/release.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "Seam.app"
+
+  zap trash: [
+    "~/Library/Caches/app.seam",
+    "~/Library/Logs/Seam",
+    "~/Library/Preferences/seam.app.plist",
+  ]
+end


### PR DESCRIPTION
**After checking the [contribution guidelines](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md), I confirm that:**

- [x] This target is a **stable version**.
- [x] `brew audit --cask --online seam-app` did not reveal any problems.
- [x] `brew style --fix seam-app` reported no violations.
- [x] AI was used to help draft this PR. The cask was manually verified: installed, launched, and uninstalled successfully on macOS Sonoma.

**For new casks:**

- [x] The cask was named per the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] The cask was not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=seam-app&type=Issues).
- [x] `brew audit --cask --new seam-app` did not reveal any problems.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask seam-app` worked successfully.
- [x] `brew uninstall --cask seam-app` worked successfully.

---

## Description

Seam is a productivity-focused Dynamic Island for macOS.

**Features:** Volume/brightness HUD, battery monitoring, device alerts, calendar notifications, focus mode, music controls.

### Notability

- **Commercial product** with established website: [getseam.app](https://getseam.app)
- **Paid application** with paying customers  
- **Professional distribution**: Apple Developer ID signed & notarized, dedicated CDN
- **Similar accepted casks**: `alcove`, `notchmeister`, `boring-notch`

### Name

Named `seam-app` to avoid conflict with existing `seam` CLI formula (seamapi.com IoT platform).