### PR TITLE
gogs 0.13.4

### DIFF
--- a/Casks/g/gogs.rb
+++ b/Casks/g/gogs.rb
@@ -5,13 +5,13 @@ cask "gogs" do
   on_macos do
     arch arm: "arm64", intel: "amd64"
   end
-  os macos: ".darwin", linux: "linux"
+  os macos: "darwin", linux: "linux"
 
-  version "0.13.3"
-  sha256 arm:          "23804e5e246f054f53c2dce1d735f73710d348adc91cd461631a922351097cea",
-         intel:        "98e5728e9a18aeef1d182492a3cba9d78d7a17df5d7c54a34db93082970f2fb1",
-         arm64_linux:  "c78c0d2a751cb956081bc0f06ed7df4e02f8417a765df90da25a21639c74c607",
-         x86_64_linux: "cb146291e29bbf1e7a8dc13e71a23eb47b5ec55eec44680e8bd8777aa0bdaeb4"
+  version "0.13.4"
+  sha256 arm:          "ddc99b9d54aa8eb1af86552cbf167b34f06f3f59ffca41a83510407b42a785fb",
+         intel:        "a31fa6928732a30d3dda6ef605f2ae0e1aa3c980f4bf69c3802f1a8e1eb3a77c",
+         arm64_linux:  "8118465584774788393e0e39c9be21e8a9f31348c7cb2902b04c2b23b20c6d50",
+         x86_64_linux: "ac03642810b0d1bd50aca8bc6c307ecc25366bfe6fb188c8bbc20af783ce08a4"
 
   url "https://github.com/gogs/gogs/releases/download/v#{version}/gogs_#{version}_#{os}_#{arch}.zip",
       verified: "github.com/gogs/gogs/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`gogs` is autobumped but the workflow failed to update to version 0.13.4 because the os suffix for macOS uses `.darwin` instead of simply `darwin`, so the resulting URL doesn't work. This updates the version and adjusts the OS string for macOS accordingly.