### PR TITLE
mater 2.0.3 (arm only)

### DIFF
--- a/Casks/m/mater.rb
+++ b/Casks/m/mater.rb
@@ -1,21 +1,38 @@
 cask "mater" do
-  version "1.0.10"
-  sha256 "613dba1cd8ca8dee74b30a456d3d2cb87896020b5305d6ff25f5f324499c4ee7"
+  on_arm do
+    version "2.0.3"
+    sha256 "3475eac057163616e5f2ad7d91ff02faeca9bfd267bfc963e78ca284212a20f3"
 
-  url "https://github.com/jasonlong/mater/releases/download/#{version}/Mater-darwin-x64.zip"
+    url "https://github.com/jasonlong/mater/releases/download/v#{version}/Mater-#{version}-arm64.dmg"
+
+    depends_on macos: ">= :monterey"
+
+    app "Mater.app"
+  end
+  on_intel do
+    version "1.0.10"
+    sha256 "613dba1cd8ca8dee74b30a456d3d2cb87896020b5305d6ff25f5f324499c4ee7"
+
+    url "https://github.com/jasonlong/mater/releases/download/#{version}/Mater-darwin-x64.zip"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    depends_on macos: ">= :catalina"
+
+    app "Mater-darwin-x64/Mater.app"
+  end
+
   name "Mater"
   desc "Menubar pomodoro app"
   homepage "https://github.com/jasonlong/mater"
 
-  app "Mater-darwin-x64/Mater.app"
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   zap trash: [
     "~/Library/Application Support/mater",
     "~/Library/Preferences/com.electron.mater.plist",
     "~/Library/Saved Application State/com.electron.mater.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`mater` is autobumped but the workflow failed to update to version 2.0.3 because the versions from 2.0.0 onward appear to be only for ARM on macOS. The previous 1.0.10 release is from 2021-01-18 and 2.0.0 was released on 2026-01-25 with a different build process, which only seems to cover ARM for macOS. This splits the versions based on arch and updates the ARM version. The app doesn't pass Gatekeeper checks, so this adds a `disable!` call with the future date we've been using for this scenario.