### PR TITLE
luanti 5.15.0

### DIFF
--- a/Casks/l/luanti.rb
+++ b/Casks/l/luanti.rb
@@ -1,9 +1,9 @@
 cask "luanti" do
-  arch arm: "arm64", intel: "x86_64_flag_O1"
+  arch arm: "arm64", intel: "x86_64"
 
-  version "5.14.0,11.3"
-  sha256 arm:   "c9a0a084e74c21010dd2b3577453cefab3090d73d2599ffe4e40a1ecd5402233",
-         intel: "fbacfe1b56661e99e3d8f65608f0504de5d287cb1e4c564e1a6a123f4b5ea136"
+  version "5.15.0,12.3"
+  sha256 arm:   "f1c4506acd50c243181124e1caa30b8aa16d978efa7a35b3e15d25127f637a83",
+         intel: "570df1c2586ef83557115bf81535bc06a9a519d1e192bf2e7fd99943a187df95"
 
   url "https://github.com/minetest/minetest/releases/download/#{version.csv.first}/luanti_#{version.csv.first}-macos#{version.csv.second}_#{arch}.zip",
       verified: "github.com/minetest/minetest/"
@@ -19,7 +19,7 @@ cask "luanti" do
     end
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "Luanti.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`luanti` is autobumped but the workflow failed to update to version 5.15.0 because livecheck failed on the most recent run, though the check works locally. However, this would have failed anyway, as the `arch` suffix for Intel is simply `x86_64` in this version and the macOS requirement is 12.3 or higher. This updates the version and adjusts the cask accordingly.