### PR TITLE
start 0.301.22416

### DIFF
--- a/Casks/s/start.rb
+++ b/Casks/s/start.rb
@@ -1,13 +1,10 @@
 cask "start" do
-  arch arm: "arm", intel: "x86"
-  folder_arch = on_arch_conditional arm: "m1/"
   livecheck_arch = on_arch_conditional arm: "-arm"
 
-  version "0.301.22224"
-  sha256 arm:   "7f7b0fff50840076cbdab99e75d21700f78943265060a4edea56c7d97e96ec41",
-         intel: "e71d90b54de4712cbd4426362054f048fdbefc6a28ae0c1becc57a2d4f168915"
+  version "0.301.22416"
+  sha256 "cc9109c1e160c4cb1665c7ab483317fbda9058b0ad645ed1b0746adb44bde965"
 
-  url "https://imgcdn.start.qq.com/cdn/mac.client/installer/#{folder_arch}START-Installer-#{arch}-#{version}.dmg"
+  url "https://imgcdn.start.qq.com/cdn/mac.client/installer/START-Installer-universal-#{version}.dmg"
   name "START"
   name "腾讯云游戏"
   desc "Tencent cloud gaming platform"
@@ -15,7 +12,7 @@ cask "start" do
 
   livecheck do
     url "https://api.start.qq.com/cfg/get?biztypes=macos-update-info#{livecheck_arch}"
-    regex(/START-Installer[._-]#{arch}[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
+    regex(/START-Installer(?:-universal)?[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
     strategy :json do |json, regex|
       match = json.dig("configs", "macos-update-info#{livecheck_arch}", "value")&.match(regex)
       next if match.blank?
@@ -25,6 +22,7 @@ cask "start" do
   end
 
   auto_updates true
+  depends_on macos: ">= :big_sur"
 
   app "START.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`start` is autobumped but the workflow failed to update to version 0.301.22416 because the `livecheck` block is producing an "Unable to get versions" error, due to a change in the file name format. Upstream has switched from separate ARM and Intel dmg files to one universal dmg and this is reflected in both the data that the `livecheck` block checks and on the upstream download page. This updates the version and reworks the cask to account for this change.