### PR TITLE
Revert "whatsapp 2.26.4.15"

### DIFF
--- a/Casks/w/whatsapp.rb
+++ b/Casks/w/whatsapp.rb
@@ -1,6 +1,6 @@
 cask "whatsapp" do
-  version "2.26.4.15"
-  sha256 "9a67b77d6e4e081684b5310e87d88c606dafde461c8c809ecd8f5816bc465c07"
+  version "2.26.3.18"
+  sha256 "51ead7862cc142985ef80b26d96bb8281f2e97d542178f041d0017c209e766d5"
 
   url "https://web.whatsapp.com/desktop/mac_native/release/?version=#{version}&extension=zip&configuration=Release&branch=master&is_buck=true"
   name "WhatsApp"


### PR DESCRIPTION
Seems to be a cancelled update

This reverts commit 938930796289995569e62ffaa7af370d0a26770a.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

---
