### PR TITLE
fix(keybase): use DMG download URLs instead of broken ZIP URLs

### DIFF
--- a/Casks/k/keybase.rb
+++ b/Casks/k/keybase.rb
@@ -1,5 +1,5 @@
 cask "keybase" do
-  arch arm: "arm64-"
+  arch arm: "-arm64"
 
   on_arm do
     version "6.5.4,20250917154415,52400b6f28"

--- a/Casks/k/keybase.rb
+++ b/Casks/k/keybase.rb
@@ -3,14 +3,15 @@ cask "keybase" do
 
   on_arm do
     version "6.5.4,20250917154415,52400b6f28"
-    sha256 "6e76006267d80b40e182d3110bb18c940a05aca41b9bb29a2a4ccc64967f8745"
+    url "https://prerelease.keybase.io/Keybase-arm64.dmg"
   end
   on_intel do
     version "6.5.4,20250917153314,52400b6f28"
-    sha256 "4dc3a84c3ba33467928b5c340d2296ad6d368009b47f4e24cb8baa75ae90da44"
+    url "https://prerelease.keybase.io/Keybase.dmg"
   end
 
-  url "https://prerelease.keybase.io/darwin-#{arch}updates/Keybase-#{version.csv.first}-#{version.csv.second}%2B#{version.csv.third}.zip"
+  sha256 :no_check
+
   name "Keybase"
   desc "End-to-end encryption software"
   homepage "https://keybase.io/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

Description:

The versioned ZIP download URLs return 403 Forbidden. This switches to the stable DMG download URLs which are publicly accessible:
  
  - Intel: https://prerelease.keybase.io/Keybase.dmg
  - ARM64: https://prerelease.keybase.io/Keybase-arm64.dmg

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
