### PR TITLE
seam-app 0.0.5 (new cask)

### DIFF
--- a/Casks/s/seam-app.rb
+++ b/Casks/s/seam-app.rb
@@ -1,0 +1,28 @@
+cask "seam-app" do
+  version "0.0.5"
+  sha256 "833844229459d22357acbd2a12972f540403e14019592ca2668faa22bda293ae"
+
+  url "https://releases.getseam.app/#{version}/Seam.dmg"
+  name "Seam"
+  desc "Dynamic Island with system HUDs and notifications"
+  homepage "https://getseam.app/"
+
+  livecheck do
+    url "https://releases.getseam.app/latest/release.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+  depends_on arch: :arm64
+
+  app "Seam.app"
+
+  zap trash: [
+    "~/Library/Caches/app.seam",
+    "~/Library/Logs/Seam",
+    "~/Library/Preferences/seam.app.plist",
+  ]
+end

--- a/Casks/s/seam-app.rb
+++ b/Casks/s/seam-app.rb
@@ -16,7 +16,6 @@ cask "seam-app" do
 
   auto_updates true
   depends_on macos: ">= :sonoma"
-  depends_on arch: :arm64
 
   app "Seam.app"
 


### PR DESCRIPTION
After following the [contribution guidelines](https://github.com/Homebrew/homebrew-cask/blob/HEAD/CONTRIBUTING.md):

- [x] Targets a stable version
- [x] `brew audit --cask --online seam-app` passes
- [x] `brew style --fix seam-app` reports no violations

For new casks:

- [x] Named per the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference)
- [x] Not [already refused](https://github.com/Homebrew/homebrew-cask/search?q=seam-app&type=Issues)
- [x] `brew audit --cask --new seam-app` passes
- [x] Install and uninstall tested

---

Seam is a Dynamic Island for macOS with volume/brightness HUD, battery monitoring, device alerts, and focus mode.

- Website: [getseam.app](https://getseam.app)
- Signed and notarized with Apple Developer ID