### PR TITLE
Add wifibuddy cask v1.0.0

### DIFF
--- a/Casks/w/wifibuddy.rb
+++ b/Casks/w/wifibuddy.rb
@@ -1,0 +1,20 @@
+cask "wifibuddy" do
+  version "1.0.0"
+  sha256 "646289f08b99ad43b88ac5f96a1cd2884e87ee9846b2327805a84c1bacfb1ba1"
+
+  url "https://github.com/ken7y/MacWifiBuddy/releases/download/v#{version}/WiFiBuddy-#{version}.zip"
+  name "WiFiBuddy"
+  desc "WiFi diagnostics and network monitoring for macOS menu bar"
+  homepage "https://github.com/ken7y/MacWifiBuddy"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "WiFiBuddy.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.wifibuddy.app.plist",
+  ]
+end


### PR DESCRIPTION
Cask submission for WiFiBuddy v1.0.0

WiFiBuddy is a free, open-source macOS menu bar app for WiFi diagnostics and network monitoring.

### Features
- Real-time WiFi signal monitoring (RSSI, SNR, noise, link rate)
- Router and internet connectivity testing
- DNS performance monitoring
- Speed test with bufferbloat detection
- Security scanning for vulnerable networks
- WiFi channel congestion analysis
- Network comparison and smart suggestions
- Historical graphs for all metrics

### Homepage
https://github.com/ken7y/MacWifiBuddy

### Installation Test
Tested locally with `brew install --cask ./Casks/w/wifibuddy.rb`