### PR TITLE
mochi: fix 1.20.8 sha256

### DIFF
--- a/Casks/m/mochi.rb
+++ b/Casks/m/mochi.rb
@@ -2,8 +2,8 @@ cask "mochi" do
   arch arm: "-arm64"
 
   version "1.20.8"
-  sha256 arm:   "a4d57699732d0fd3a594aa2935b3efab4c57808b8b0df98962c5615ab8c39c87",
-         intel: "989ecbc36bd5da9ed065584b3eb46666cad808d64d4215fa585cf1931e0cb580"
+  sha256 arm:   "714ec8c00bf2a9995b125f03201f97bb053155abb2be8871f04d906303482089",
+         intel: "92afffd256d47e6ec62b4241d0b70081f6d3b48a41a4510b469ac982a3cdb7b3"
 
   url "https://download.mochi.cards/releases/Mochi-#{version}#{arch}.dmg"
   name "Mochi"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.

I am not sure if I did this step correctly, I followed the steps [here](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#cask-related-pull-request), which gets the sha-256 mismatch error

```
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask mochi
-- output
Error: SHA-256 mismatch
Expected: a4d57699732d0fd3a594aa2935b3efab4c57808b8b0df98962c5615ab8c39c87
  Actual: 714ec8c00bf2a9995b125f03201f97bb053155abb2be8871f04d906303482089
    File: /Users/aashishsharma/Library/Caches/Homebrew/downloads/8fd514ef0c6076f593ad3f403c816dd8274f4c2a60dbf06070844cd4549a00bd--Mochi-1.20.8-arm64.dmg
To retry an incomplete download, remove the file above.
-- output
brew uninstall --cask mochi
brew audit --strict --online --cask mochi
-- output
==> Downloading and extracting artifacts
==> Downloading https://download.mochi.cards/releases/Mochi-1.20.8-arm64.dmg
Already downloaded: /Users/aashishsharma/Library/Caches/Homebrew/downloads/8fd514ef0c6076f593ad3f403c816dd8274f4c2a60dbf06070844cd4549a00bd--Mochi-1.20.8-arm64.dmg
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
audit for mochi: failed
 - exception while auditing mochi: SHA-256 mismatch
Expected: a4d57699732d0fd3a594aa2935b3efab4c57808b8b0df98962c5615ab8c39c87
  Actual: 714ec8c00bf2a9995b125f03201f97bb053155abb2be8871f04d906303482089
    File: /Users/aashishsharma/Library/Caches/Homebrew/downloads/8fd514ef0c6076f593ad3f403c816dd8274f4c2a60dbf06070844cd4549a00bd--Mochi-1.20.8-arm64.dmg
To retry an incomplete download, remove the file above.
mochi
  * exception while auditing mochi: SHA-256 mismatch
    Expected: a4d57699732d0fd3a594aa2935b3efab4c57808b8b0df98962c5615ab8c39c87
      Actual: 714ec8c00bf2a9995b125f03201f97bb053155abb2be8871f04d906303482089
        File: /Users/aashishsharma/Library/Caches/Homebrew/downloads/8fd514ef0c6076f593ad3f403c816dd8274f4c2a60dbf06070844cd4549a00bd--Mochi-1.20.8-arm64.dmg
    To retry an incomplete download, remove the file above.
Error: 1 problem in 1 cask detected.
-- output 
```

if I go into `cd "$(brew --repository homebrew/cask)"` then make the changes to `mochi.rb` there with the same sha-256 as in this PR then the following commands don't show any error. This is the output of the audit command after that.
```
==> Downloading and extracting artifacts
==> Downloading https://download.mochi.cards/releases/Mochi-1.20.8-arm64.dmg
Already downloaded: /Users/aashishsharma/Library/Caches/Homebrew/downloads/8fd514ef0c6076f593ad3f403c816dd8274f4c2a60dbf06070844cd4549a00bd--Mochi-1.20.8-arm64.dmg
==> Downloading https://download.mochi.cards/releases/Mochi-1.20.8-arm64.dmg
Already downloaded: /Users/aashishsharma/Library/Caches/Homebrew/downloads/8fd514ef0c6076f593ad3f403c816dd8274f4c2a60dbf06070844cd4549a00bd--Mochi-1.20.8-arm64.dmg
```


- [x] `brew style --fix <cask>` reports no offenses.
<img width="802" height="60" alt="Screenshot 2026-01-27 at 5 22 36 PM" src="https://github.com/user-attachments/assets/1c034d8f-6d13-4920-a6d0-21a17df9d954" />

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Ran into issue when updating the mochi cask that the cask reports different checksum

```
Error: Cask reports different checksum:     a4d57699732d0fd3a594aa2935b3efab4c57808b8b0df98962c5615ab8c39c87
       SHA-256 checksum of downloaded file: 714ec8c00bf2a9995b125f03201f97bb053155abb2be8871f04d906303482089
`brew bundle` failed! Failed to fetch mochi
```

AI:
Used 5.2 codex high to walk me through the steps of verifying the right checksum for mochi.
Manually verified by going to mochi's download [page](https://mochi.cards/download), downloading the dmg for apple silicon and intel and ran the following commands

```
shasum -a 256 ~/Downloads/Mochi-1.20.8-arm64.dmg
shasum -a 256 ~/Downloads/Mochi-1.20.8.dmg
```

after making the changes check that the cask downloaded successfully with 
```
brew tap aashish2057/homebrew-cask /Users/aashishsharma/Dev/homebrew-cask
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask aashish2057/homebrew-cask/mochi
```

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
