### PR TITLE
seam-app: fix sha256 checksum

### DIFF
--- a/Casks/s/seam-app.rb
+++ b/Casks/s/seam-app.rb
@@ -1,6 +1,6 @@
 cask "seam-app" do
   version "0.1.0"
-  sha256 "a54bb0a6fe10fe3dc05ef242deb2061a086ff20fdfeab463171a753f58b71a9e"
+  sha256 "79aa0b0217e4d03f7df2d5e95255cce457b91a133fa74e26a831085240eca369"
 
   url "https://releases.getseam.app/#{version}/Seam.dmg"
   name "Seam"


### PR DESCRIPTION
The DMG for seam-app 0.1.0 was re-signed after the initial cask submission, causing a SHA-256 mismatch that prevents installation:

```
Error: SHA-256 mismatch
Expected: a54bb0a6fe10fe3dc05ef242deb2061a086ff20fdfeab463171a753f58b71a9e
  Actual: 79aa0b0217e4d03f7df2d5e95255cce457b91a133fa74e26a831085240eca369
```

This updates the sha256 to match the current DMG served from `releases.getseam.app/0.1.0/Seam.dmg`.