### PR TITLE
seam-app 0.1.1

### DIFF
--- a/Casks/s/seam-app.rb
+++ b/Casks/s/seam-app.rb
@@ -1,10 +1,10 @@
 cask "seam-app" do
-  version "0.1.0"
-  sha256 "79aa0b0217e4d03f7df2d5e95255cce457b91a133fa74e26a831085240eca369"
+  version "0.1.1"
+  sha256 "9eb52ee46c7ab5ea4ca0982415da99fded1b7d7354f75e50847bdae6cb44eb66"
 
   url "https://releases.getseam.app/#{version}/Seam.dmg"
   name "Seam"
-  desc "Dynamic Island with system HUDs and notifications"
+  desc "Productivity-first Dynamic Island for your Notch"
   homepage "https://getseam.app/"
 
   livecheck do


### PR DESCRIPTION
Bump version `0.1.0` → `0.1.1` and update description.

**Context:** `0.1.0` was the first stable public release of Seam. This is a patch follow-up with bug fixes (music playback, XPC reliability). The previous description was outdated — updated to match the app's current positioning.

**Changes:**
- Version: `0.1.0` → `0.1.1`
- SHA256: updated to match new DMG
- Description: `Dynamic Island with system HUDs and notifications` → `Productivity-first Dynamic Island for your Notch`