### PR TITLE
appflowy 0.11.1

### DIFF
--- a/Casks/a/appflowy.rb
+++ b/Casks/a/appflowy.rb
@@ -1,11 +1,11 @@
 cask "appflowy" do
   arch arm: "arm64", intel: "x86_64"
 
-  version "0.11.0"
-  sha256 arm:   "92d0c600c34fbe5cea8f0323fdbb6d5b093829e294ec13273065f9ee6c712257",
-         intel: "e1fcaf8bfe16228e003981e837a7da13eed6d96ca3366f07b4121ad442458828"
+  version "0.11.1"
+  sha256 arm:   "e303a8911ed60f84fa5f964bda745b9013327054ad2ef5964e2a36bd4725e685",
+         intel: "9263d236e969437653b13fd932150ebccd4e608a4ef982d376fdabad22f4a38b"
 
-  url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-#{arch}.dmg",
+  url "https://github.com/AppFlowy-IO/AppFlowy/releases/download/#{version}/Appflowy-#{version}-macos-#{arch}.zip",
       verified: "github.com/AppFlowy-IO/AppFlowy/"
   name "AppFlowy"
   desc "Open-source project and knowledge management tool"
@@ -18,7 +18,7 @@ cask "appflowy" do
 
   depends_on macos: ">= :big_sur"
 
-  app "AppFlowy.app"
+  app "AppFlowy-#{arch}.app", target: "AppFlowy.app"
 
   zap trash: [
     "~/Library/Application Scripts/com.appflowy.macos",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`appflowy` is autobumped but the workflow failed to update to version 0.11.1 because the GitHub release is missing an ARM dmg file. I had previously switched the cask to use dmg files instead of zip files to work around a temporary issue, so this returns to using zip files to work around this new issue. This updates the version and `url` accordingly and adjusts the `app` call to account for the arch-specific app names in the zip files.