### PR TITLE
arm-performance-libraries 26.01

### DIFF
--- a/Casks/a/arm-performance-libraries.rb
+++ b/Casks/a/arm-performance-libraries.rb
@@ -1,13 +1,13 @@
 cask "arm-performance-libraries" do
-  version "25.07.1"
-  install_suffix="#{version}_flang-20"
-  sha256 "f6f69249933e78153bbe31ef9649c8c7cd003a1f4823c252634209f74f62a28c"
+  version "26.01"
+  install_suffix="#{version}_flang-21"
+  sha256 "f69da819aad0faf4817df1503b270832ea67d2decec6240dda99c9891dd2bc2f"
 
   url "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_#{version}/arm-performance-libraries_#{version}_macOS.tgz",
       user_agent: :curl
   name "Arm Performance Libraries"
   desc "Optimized standard core math libraries for Arm processors"
-  homepage "https://developer.arm.com/downloads/-/arm-performance-libraries"
+  homepage "https://developer.arm.com/Tools%20and%20Software/Arm%20Performance%20Libraries"
 
   livecheck do
     url :homepage,

--- a/audit_exceptions/simple_user_agent_for_homepage.json
+++ b/audit_exceptions/simple_user_agent_for_homepage.json
@@ -1,4 +1,5 @@
 [
+  "arm-performance-libraries",
   "microsoft-excel",
   "microsoft-office",
   "microsoft-office-businesspro",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`arm-performance-libraries` is autobumped but the workflow failed to update to version 26.01 because the homepage is inaccessible without a `curl` user agent, so `brew audit` predictably fails when trying to check the homepage. This manually updates the version and adds the cask to the `simple_user_agent_for_homepage.json` file, allowing the audit to work correctly. Besides that, this updates the homepage URL to resolve a redirection.