### PR TITLE
atuin-desktop 0.2.19 (arm only)

### DIFF
--- a/Casks/a/atuin-desktop.rb
+++ b/Casks/a/atuin-desktop.rb
@@ -1,20 +1,29 @@
 cask "atuin-desktop" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.2.17"
-  sha256 arm:   "c8b42c16c5a5778d49a4e001c0cd8034427b18ff937737d76abec4d6ad104fb2",
-         intel: "af263d709c5e0db897ee25947ae2a13247d5dfe0f622309bf07a71db838a809d"
+  on_arm do
+    version "0.2.19"
+    sha256 "6c8bd7398fb812183f959cc9c0cf496eab1f4106bf52b4bd47f41fa5148d4daa"
+
+    livecheck do
+      url :url
+      strategy :github_latest
+    end
+  end
+  on_intel do
+    version "0.2.17"
+    sha256 "af263d709c5e0db897ee25947ae2a13247d5dfe0f622309bf07a71db838a809d"
+
+    livecheck do
+      skip "Legacy version"
+    end
+  end
 
   url "https://github.com/atuinsh/desktop/releases/download/v#{version}/Atuin_#{version}_#{arch}.dmg",
       verified: "github.com/atuinsh/desktop/"
   name "Atuin Desktop"
   desc "Runbook editor for terminal workflows"
   homepage "https://atuin.sh/"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
 
   app "Atuin.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`atuin-desktop` is autobumped but the workflow failed to update to version 0.2.19 because Intel builds were removed in 0.2.18, so the Intel dmg URL predictably fails for versions after 0.2.17. This updates the version and adjusts the cask accordingly.