### PR TITLE
lobehub 2.0.9

### DIFF
--- a/Casks/l/lobehub.rb
+++ b/Casks/l/lobehub.rb
@@ -1,24 +1,38 @@
 cask "lobehub" do
   arch arm: "-arm64"
 
-  version "1.143.2"
-  sha256 arm:   "695d687e62debcaba8c1a20156d7155b4434ca54a269beaed93166ab7468479d",
-         intel: "62dba5fb0bd457d04df1ed67e675b0e72a217ab61e3ee0c0edd1567799c51d71"
+  version "2.0.9"
+  sha256 arm:   "84ecbff254f1d648aafa2b5910c02450a3fe54a9c314ff9febd3a4a71fda428a",
+         intel: "63551a2deeee020b41bf5e6001dae4e1f5176174e8ea97741799131d566e065c"
 
-  url "https://github.com/lobehub/lobe-chat/releases/download/v#{version}/LobeHub-Beta-#{version}#{arch}-mac.zip"
+  url "https://github.com/lobehub/lobe-chat/releases/download/v#{version}/LobeHub-#{version}#{arch}-mac.zip"
   name "LobeHub"
   desc "AI chat framework"
   homepage "https://github.com/lobehub/lobe-chat"
 
+  # Not every release on GitHub has assets, so we have to find the newest one
+  # with the files the cask uses.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/LobeHub[._-]v?(\d+(?:\.\d+)+)#{arch}[._-]mac\.zip/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
 
   auto_updates true
   depends_on macos: ">= :monterey"
 
-  app "LobeHub-Beta.app"
+  app "LobeHub.app"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.lobehub.lobehub-desktop-beta.sfl*",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`lobehub` is autobumped but the workflow failed to update to stable 2.x versions because the file (and app) name doesn't include the "-Beta" suffix now but also some of the the releases on GitHub don't have any release assets. This updates the version and adds a `livecheck` block that uses the `GithubReleases` strategy, as it's necessary to go through recent releases to find the newest version that has the files the cask uses.