### PR TITLE
loop-messenger 6.0.3

### DIFF
--- a/Casks/l/loop-messenger.rb
+++ b/Casks/l/loop-messenger.rb
@@ -1,11 +1,11 @@
 cask "loop-messenger" do
   arch arm: "m1", intel: "x64"
 
-  version "5.13.0"
-  sha256 arm:   "c1756453102fa0d214894a5458babd3f56b9f41bb73da40b10133d6be3bfe88e",
-         intel: "c63a87cd734fb49e4851d79f2be94f4c78d6bf5f64307c5938d1ad7101a6a7d1"
+  version "6.0.3"
+  sha256 arm:   "e0cc5604ba65178b1064769e6d72d38d5944bf46fba87e8103443873b2d8ce49",
+         intel: "be760a6a2538d328fd3f3902b1f99b77e8ed5cf8bc94b0c844371e3ecc622032"
 
-  url "https://artifacts.wilix.dev/repository/loop-files/loop-#{version.major_minor}/loop-desktop-#{version}-mac-#{arch}.dmg",
+  url "https://artifacts.wilix.dev/repository/loop-files/loop-#{version}/loop-desktop-#{version}-mac-#{arch}.dmg",
       verified: "artifacts.wilix.dev/"
   name "Loop"
   desc "Team messenger for business communication"
@@ -16,7 +16,7 @@ cask "loop-messenger" do
     regex(/loop[._-]desktop[._-]v?(\d+(?:\.\d+)+).+?\.dmg/i)
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "LOOP.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`loop-messenger` is autobumped but the workflow failed to update to version 6.0.3 because the dmg URLs use the full version in the path instead of the major/minor in earlier versions. This updates the version, adjusts the URL, and updates the `depends_on macos:` value to address `brew audit` errors.