### PR TITLE
tentacle-sync-studio 1.37

### DIFF
--- a/Casks/t/tentacle-sync-studio.rb
+++ b/Casks/t/tentacle-sync-studio.rb
@@ -1,8 +1,8 @@
 cask "tentacle-sync-studio" do
-  version "1.36"
-  sha256 "879118fdabbde5551fb0f0120f73b796dfd94a952954c1199837c58fb2407344"
+  version "1.37"
+  sha256 "383cd519b647594254ffc6deb744e47c5f939932d96711a60158e6e40d2fe16e"
 
-  url "https://cms.tentaclesync.com/assets/downloads/download-files/ttsyncstudio-v#{version.dots_to_underscores}.dmg"
+  url "https://cms.tentaclesync.com/assets/ttsyncstudio-v#{version.dots_to_underscores}.dmg"
   name "Tentacle Sync Studio"
   desc "Automatically synchronise video and audio via timecode"
   homepage "https://tentaclesync.com/"
@@ -14,6 +14,8 @@ cask "tentacle-sync-studio" do
       page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "Tentacle Sync Studio.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`tentacle-sync-studio` is autobumped but the workflow failed to update to version 1.37 because the URL path is shorter for this version. This updates the version, adjusts the `url`, and adds a `depends_on macos:` value to resolve the related `brew audit` error.