### PR TITLE
vimcal 1.0.42 (arm), 1.0.41 (intel)

### DIFF
--- a/Casks/v/vimcal.rb
+++ b/Casks/v/vimcal.rb
@@ -3,12 +3,12 @@ cask "vimcal" do
   host_suffix = on_arch_conditional arm: "m1", intel: "production"
 
   on_arm do
-    version "1.0.41"
-    sha256 "dd7e588498e0376ab23054c0a8c7c5aa9a0bbf2e292c2f93527dd2c484afe1e2"
+    version "1.0.42"
+    sha256 "3d283925792893a43934c9f26da60025cd393d1918e04ed9c6d9b6c849776d39"
   end
   on_intel do
-    version "1.0.40"
-    sha256 "c3d12755f990b7aa6bedf55c94f2105138e9aa07ab01cb91e673d633f737083b"
+    version "1.0.41"
+    sha256 "9957db43ab0be349174f7ae3f046a3604ab8cee4dc65d165531a41452618d69d"
   end
 
   url "https://vimcal-#{host_suffix}.s3.amazonaws.com/Vimcal-#{version}#{arch}.dmg",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`vimcal` is autobumped but the workflow failed to update to version 1.0.42 for ARM and 1.0.41 for Intel because the 1.0.41 update for Intel triggers a duplicate PR for a previous ARM update of the same version number. This manually updates the versions to move it forward.