### PR TITLE
wispr-flow 1.4.227 (arm only)

### DIFF
--- a/Casks/w/wispr-flow.rb
+++ b/Casks/w/wispr-flow.rb
@@ -2,8 +2,8 @@ cask "wispr-flow" do
   arch arm: "arm64", intel: "x64"
 
   on_arm do
-    version "1.4.205"
-    sha256 "013d27a3591fd008320860a3373ddbb070441012c5ae797a4693746522fb02a6"
+    version "1.4.227"
+    sha256 "8f6e8eb3d72bfd402c0dd1d0b4afaaa4d20b910f02e5ffb1e358f5e9088f1025"
   end
   on_intel do
     version "1.4.154"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

`wispr-flow` is autobumped but the workflow failed to update to version 1.4.227 for ARM because the Intel version remains unchanged and triggers a duplicate PR error. This manually updates the ARM version to move it forward.