### PR TITLE
gog-galaxy: update SHA256 checksum

### DIFF
--- a/Casks/g/gog-galaxy.rb
+++ b/Casks/g/gog-galaxy.rb
@@ -1,6 +1,6 @@
 cask "gog-galaxy" do
   version "2.0.94.27"
-  sha256 "0ce78d8024066f8294085cb179e6def098ec21bed5148dbff9c25227bae315dc"
+  sha256 "511942a75d8792728ed4ca5047515a1f49931df48966fd6bda0b38b6106207fb"
 
   url "https://gog-cdn-fastly.gog.com/open/galaxy/client/galaxy_client_#{version}.pkg"
   name "GOG Galaxy"


### PR DESCRIPTION
Correcting erroneous SHA256 checksum.  Matches what is currently being downloaded both through Homebrew and directly from gog.com.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
