### PR TITLE
doubao: add auto_updates true

### DIFF
--- a/Casks/d/doubao.rb
+++ b/Casks/d/doubao.rb
@@ -14,6 +14,7 @@ cask "doubao" do
     end
   end
 
+  auto_updates true
   depends_on macos: ">= :big_sur"
 
   app "doubao.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
[Doubao](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/d/doubao.rb) includes an in-app auto-update feature, so the cask should specify `auto_updates true`. Auto-upgrading within the application causes Homebrew to retain an outdated version record, leading `brew update` and `brew outdated` to repeatedly report Doubao as outdated, even though it is current.
![Snipaste_2026-01-30_19-49-12](https://github.com/user-attachments/assets/652067fa-080d-4cd3-a59a-a700854a50ed)