### PR TITLE
libation 13.1.5 (new cask)

### DIFF
--- a/Casks/l/libation.rb
+++ b/Casks/l/libation.rb
@@ -1,0 +1,26 @@
+cask "libation" do
+  arch arm: "arm64", intel: "x64"
+
+  version "13.1.5"
+  sha256 arm:   "b67f56b4266155fc1a47191b971a3d5897718f6cb583e1db7a28294418d9bb2f",
+         intel: "f2807f266247adf278d1387ffd338cfff8241f485eb0618f3f797fd39a1b7bfd"
+
+  url "https://github.com/rmcrackan/Libation/releases/download/v#{version}/Libation.#{version}-macOS-chardonnay-#{arch}.dmg"
+  name "Libation"
+  desc "Audible audiobook manager"
+  homepage "https://github.com/rmcrackan/Libation"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Libation.app"
+
+  zap trash: [
+    "~/Library/Application Support/Libation",
+    "~/Library/Caches/Libation",
+    "~/Library/Preferences/com.libation.plist",
+    "~/Library/Saved Application State/com.libation.savedState",
+  ]
+end


### PR DESCRIPTION
## Description
New cask for Libation, an Audible audiobook manager that can download, decrypt, and organize audiobooks.

- **Homepage**: https://github.com/rmcrackan/Libation
- **License**: GPL-3.0
- **Supports**: macOS ARM64 and x86_64

## Testing
- [x] `brew audit --new --cask libation` passes
- [x] `brew style libation` passes
- [x] Installation tested successfully

---
This cask was created with assistance from Claude (AI).