### PR TITLE
commander 0.5.456 (new cask)

### DIFF
--- a/Casks/c/commander.rb
+++ b/Casks/c/commander.rb
@@ -3,7 +3,6 @@ cask "commander" do
   sha256 "b9ab081489d48fd5a01a5f6d6837c445ed58d729347ecdc3fa1349a7ed6048f8"
 
   url "https://download.commanderai.app/release/Commander-#{version}.zip"
-
   name "Commander"
   desc "AI agent operator"
   homepage "https://commanderai.app/"

--- a/Casks/c/commander.rb
+++ b/Casks/c/commander.rb
@@ -2,8 +2,7 @@ cask "commander" do
   version "0.5.456"
   sha256 "b9ab081489d48fd5a01a5f6d6837c445ed58d729347ecdc3fa1349a7ed6048f8"
 
-  url "https://download.commanderai.app/release/Commander-#{version}.zip",
-      verified: "download.commanderai.app/release/"
+  url "https://download.commanderai.app/release/Commander-#{version}.zip"
 
   name "Commander"
   desc "AI agent operator"
@@ -15,6 +14,7 @@ cask "commander" do
   end
 
   auto_updates true
+  depends_on macos: :sequoia
 
   app "Commander.app"
 

--- a/Casks/c/commander.rb
+++ b/Casks/c/commander.rb
@@ -14,7 +14,7 @@ cask "commander" do
   end
 
   auto_updates true
-  depends_on macos: :sequoia
+  depends_on macos: ">= :sequoia"
 
   app "Commander.app"
 

--- a/Casks/c/commander.rb
+++ b/Casks/c/commander.rb
@@ -22,6 +22,6 @@ cask "commander" do
     "~/Library/Application Support/Commander",
     "~/Library/Caches/Commander",
     "~/Library/Commander",
-    "~/Library/Preferences/com.krzyzanowskim.Commander.plist"
+    "~/Library/Preferences/com.krzyzanowskim.Commander.plist",
   ]
 end

--- a/Casks/c/commander.rb
+++ b/Casks/c/commander.rb
@@ -1,0 +1,27 @@
+cask "commander" do
+  version "0.5.456"
+  sha256 "b9ab081489d48fd5a01a5f6d6837c445ed58d729347ecdc3fa1349a7ed6048f8"
+
+  url "https://download.commanderai.app/release/Commander-#{version}.zip",
+      verified: "download.commanderai.app/release/"
+
+  name "Commander"
+  desc "AI agent operator"
+  homepage "https://commanderai.app/"
+
+  livecheck do
+    url "https://softwareupdate.commanderai.app/appcast/commanderai-appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+
+  app "Commander.app"
+
+  zap trash: [
+    "~/Library/Application Support/Commander",
+    "~/Library/Caches/Commander",
+    "~/Library/Commander",
+    "~/Library/Preferences/com.krzyzanowskim.Commander.plist"
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----



commander 0.5.456 (new cask)

This cask installs the Commander app, an AI agent operator.

I believe it classifies as the notability exception https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold covered already in
- https://iosdevweekly.com/issues/740/
- https://fatbobman.com/en/weekly/issue-120/
and others

My previous cask https://github.com/Homebrew/homebrew-cask/pull/237377#issuecomment-3558315223