### PR TITLE
picmal 1.3.5 (new cask)

### DIFF
--- a/Casks/p/picmal.rb
+++ b/Casks/p/picmal.rb
@@ -1,0 +1,29 @@
+# typed: strict
+# frozen_string_literal: true
+
+cask "picmal" do
+  version "1.3.5"
+  sha256 "de12994e502004720f51e34ca8bc8a2d7e8eb72ee0ec96118757623336dd9ea5"
+
+  url "https://github.com/albertogalca/picmal-releases/releases/download/v#{version}/Picmal.dmg",
+      verified: "github.com/albertogalca/picmal-releases/"
+  name "Picmal"
+  desc "Convert and compress your media files locally"
+  homepage "https://picmal.app/"
+
+  livecheck do
+    url "https://github.com/albertogalca/picmal-releases/releases/latest"
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sonoma"
+
+  app "Picmal.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.albertogallego.picmal",
+    "~/Library/Caches/com.albertogallego.picmal",
+    "~/Library/Preferences/com.albertogallego.picmal.plist",
+    "~/Library/Saved Application State/com.albertogallego.picmal.savedState",
+  ]
+end


### PR DESCRIPTION
**Name**: Picmal
**Description**: Convert and compress your media files locally
**Homepage**: https://picmal.app/

### Features
- Native macOS UI
- Zero installation required
- Drag & drop interface
- Batch processing
- Professional format support (PSD, RAW, SVG, PDF)
- Advanced compression options

### Verification
- [x] Cask passes `brew style`
- [x] App is code-signed and notarized
- [x] Tested on macOS Sonoma (14.0+)