### PR TITLE
Add pinster 1.2.2

### DIFF
--- a/Casks/p/pinster.rb
+++ b/Casks/p/pinster.rb
@@ -1,0 +1,15 @@
+cask "pinster" do
+  version "1.2.2"
+  sha256 "bf467b6cfb5535b11166f3d913ebe0806a2b215dd827fa3067dc38a402833d2d"
+
+  url "https://github.com/nickustinov/pinster-macos/releases/download/v#{version}/Pinster-#{version}.dmg"
+  name "Pinster"
+  desc "Lightweight menu bar app for quick access to pinned websites"
+  homepage "https://github.com/nickustinov/pinster-macos"
+
+  depends_on macos: ">= :ventura"
+
+  app "Pinster.app"
+
+  zap trash: "~/Library/Preferences/com.pinster.app.plist"
+end


### PR DESCRIPTION
New cask for [Pinster](https://github.com/nickustinov/pinster-macos) — a lightweight menu bar app for quick access to pinned websites.

- **App name:** Pinster
- **Homepage:** https://github.com/nickustinov/pinster-macos
- **Download:** DMG from GitHub Releases
- **macOS:** 13+ (Ventura)
- **Architecture:** Universal (arm64 + x86_64)