### PR TITLE
updated mos@beta.rb to match the new version number pattern

### DIFF
--- a/Casks/m/mos@beta.rb
+++ b/Casks/m/mos@beta.rb
@@ -15,14 +15,14 @@ cask "mos@beta" do
       json.map do |release|
         next unless release["prerelease"]
 
-        asset_versions = release["assets"]&.map do |asset|
+        asset_versions = release["assets"]&.filter_map do |asset|
           match = asset["name"]&.match(regex)
           next if match.blank?
 
           match[2] ? "#{match[1]},#{match[2]}" : match[1]
-        end.compact
+        end&.compact
 
-        next asset_versions unless asset_versions.blank?
+        next asset_versions if asset_versions.present?
 
         tag_match = release["tag_name"]&.match(/v?(\d+(?:\.\d+)+-beta-\d+(?:\.\d+)?)/i)
         next if tag_match.blank?

--- a/Casks/m/mos@beta.rb
+++ b/Casks/m/mos@beta.rb
@@ -1,8 +1,8 @@
 cask "mos@beta" do
-  version "4.0.0-beta-1201,123826"
-  sha256 "c238e3ad61d20b2142a857891165ded7928e0b04e2359a86fb9c9d6ae1ca500a"
+  version "4.0.0-beta-20260201.1"
+  sha256 "c1da629077f453eaa142f553176311c6ef588ab5d2bce5d1aa231e1670389c9a"
 
-  url "https://github.com/Caldis/Mos/releases/download/#{version.csv.first}/Mos.Versions.#{version.csv.first}-#{version.csv.second}.zip",
+  url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.zip",
       verified: "github.com/Caldis/Mos/"
   name "Mos"
   desc "Smooths scrolling and set mouse scroll directions independently"
@@ -10,17 +10,24 @@ cask "mos@beta" do
 
   livecheck do
     url :url
-    regex(/Mos\.Versions\.v?(\d+(?:\.\d+)+-beta-\d+)[._-](\d+)\.zip/i)
+    regex(/Mos\.Versions\.v?(\d+(?:\.\d+)+-beta-\d+(?:\.\d+)?)(?:[._-](\d+))?\.zip/i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next unless release["prerelease"]
 
-        release["assets"]&.map do |asset|
+        asset_versions = release["assets"]&.map do |asset|
           match = asset["name"]&.match(regex)
           next if match.blank?
 
-          "#{match[1]},#{match[2]}"
-        end
+          match[2] ? "#{match[1]},#{match[2]}" : match[1]
+        end.compact
+
+        next asset_versions unless asset_versions.blank?
+
+        tag_match = release["tag_name"]&.match(/v?(\d+(?:\.\d+)+-beta-\d+(?:\.\d+)?)/i)
+        next if tag_match.blank?
+
+        tag_match[1]
       end.flatten.compact
     end
   end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

[Latest Mos beta release](https://github.com/Caldis/Mos/releases/tag/4.0.0-beta-20260201.1) used a new version number pattern which broke the original ruby file, hence the update to the new app version and the new pattern.

AI was used to make the changes in the form of ChatGPT Codex. It made the edits while I ran the homebrew checks and verified that it's all correct.