### PR TITLE
plasticity 25.3.8 (new cask)

### DIFF
--- a/Casks/p/plasticity.rb
+++ b/Casks/p/plasticity.rb
@@ -1,0 +1,27 @@
+cask "plasticity" do
+  arch arm: "arm64", intel: "x64"
+
+  version "25.3.8"
+  sha256 arm:   "4b56669ec1c33b241bd76b0b2a0554c7bf34935d6cac53553d4f3f197ad5c2be",
+         intel: "43ea2cd7a205dd806491ea96f425282781d79aeb08b7eba409794f20e7fe69fc"
+
+  url "https://github.com/nkallen/plasticity/releases/download/v#{version}/Plasticity-darwin-#{arch}-#{version}.zip",
+      verified: "github.com/nkallen/plasticity/"
+  name "Plasticity"
+  desc "3D modeling software for concept artists and designers"
+  homepage "https://www.plasticity.xyz/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "Plasticity.app"
+
+  zap trash: [
+    "~/Library/Application Support/Plasticity",
+    "~/Library/Preferences/com.electron.plasticity.plist",
+  ]
+end


### PR DESCRIPTION
Adds cask for plasticity - tested on macOS 26.2 (25C56)

* https://www.plasticity.xyz
* https://github.com/nkallen/plasticity

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----
