### PR TITLE
bricklink-studio: fix non-updated sha256

### DIFF
--- a/Casks/b/bricklink-studio.rb
+++ b/Casks/b/bricklink-studio.rb
@@ -1,6 +1,6 @@
 cask "bricklink-studio" do
   version "2.26.1_1"
-  sha256 "07a91b3c2f6bfa6e697ce03ae9729890e44012b3333fb76d8bb62b94d35531ba"
+  sha256 "9d6aaf049386278cf1eaa573122e235fb67007360757909ef346260c31f65594"
 
   url "https://studio.download.bricklink.info/Studio#{version.major}.0/Studio+#{version.major}.0.pkg",
       verified: "studio.download.bricklink.info/"

--- a/Casks/b/bricklink-studio.rb
+++ b/Casks/b/bricklink-studio.rb
@@ -2,7 +2,7 @@ cask "bricklink-studio" do
   version "2.26.1_1"
   sha256 "9d6aaf049386278cf1eaa573122e235fb67007360757909ef346260c31f65594"
 
-  url "https://studio.download.bricklink.info/Studio#{version.major}.0/Studio+#{version.major}.0.pkg",
+  url "https://studio.download.bricklink.info/Studio#{version.major}.0/Archive/#{version}/Studio+#{version.major}.0.pkg",
       verified: "studio.download.bricklink.info/"
   name "Studio"
   desc "Build, render, and create LEGO instructions"


### PR DESCRIPTION
I'm unable to install cask `bricklink-studio` due to a failed sha256 checksum match and the git history for the cask confirms that the expected checksum hasn't changed for several version bumps. I have downloaded the current version of the `.pkg` from the official download page and confirmed that the checksum matches the actual result reported by homebrew when it fails. Obviously my checksum should be verified by reviewers before being merged!

This is my first PR for a cask change – I know the checksum is normally updated when version bumps are commited, so this may not be an accepted way to fix the mismatch. Please let me know if there's a preferred way to fix this issue. I tested `brew bump --open-pr` as listed in the contributing guidelines to see if it would trigger the hash to be refreshed but this errors with `Error: No available formula with the name "bricklink-studio".` which is a weird parallel to the errors in the checklist below.

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  -  This fails with error `Error: Cask 'bricklink-studio' is unavailable: No Cask with this name exists.`
- [ ] `brew style --fix <cask>` reports no offenses.
  - This reports `0 files inspected, no offenses detected`
