### PR TITLE
ijdevc 2025.2 (new cask)

### DIFF
--- a/Casks/i/ijdevc.rb
+++ b/Casks/i/ijdevc.rb
@@ -1,0 +1,30 @@
+cask "ijdevc" do
+  version "2025.2,252.21735.61"
+  sha256 "426cbb11c4f2f739fb00f984a31f01787eb318243e3b23962bab0426179fe707"
+
+  url "https://download.jetbrains.com/resources/intellij/dev-containers/#{version.csv.last}/intellij-devcontainers-cli.zip"
+  name "IntelliJ Dev Container CLI"
+  desc "This allows you to build a container from a terminal without using the IDE, open it from the IDE, and automate the Dev Container’s actions"
+  homepage "https://www.jetbrains.com/ijdevc/download"
+
+  livecheck do
+    url "https://data.services.jetbrains.com/products/releases?code=IJDCT&latest=true&type=eap"
+    strategy :json do |json|
+      json["IJDCT"]&.map do |release|
+        version = release["version"]
+        build = release["build"]
+        next if version.blank? || build.blank?
+
+        "#{version},#{build}"
+      end
+    end
+  end
+
+  binary "ijdevc/ijdevc"
+
+  # No zap stanza required
+
+  caveats do
+    depends_on_java "17+"
+  end
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.


-----

I haven’t checked "stable version" as JetBrains hasn’t released a stable version, only EAP, and the section on exceptions appears to be missing from the linked document. This may need @eap adding, but unsure on nomenclature here when there is only EAP available.