### PR TITLE
Revert "slack 4.48.86"

### DIFF
--- a/Casks/s/slack.rb
+++ b/Casks/s/slack.rb
@@ -14,9 +14,9 @@ cask "slack" do
     end
   end
   on_monterey :or_newer do
-    version "4.48.86"
-    sha256 arm:   "3917fc6c74794931de720e9346590399226edcef10e1af1be0e9871640c448b4",
-           intel: "4d6f9fc4bed55d606744b65c1c8ebeb7d8410c29627f3fd9e9da6e263be9730a"
+    version "4.47.72"
+    sha256 arm:   "02284c4008cc3115897ed40ea7d827202fdd7fc9e7aca9e4a51ca6f2c76d5240",
+           intel: "1f50eab65ab3d45c43aaae2201926c4e4ba02e9f96554f5f281f87d7d97ebee8"
 
     url "https://downloads.slack-edge.com/desktop-releases/mac/#{arch}/#{version}/Slack-#{version}-macOS.dmg",
         verified: "downloads.slack-edge.com/"


### PR DESCRIPTION
This release appears to have been pulled.

Reverts Homebrew/homebrew-cask#247463