### PR TITLE
seam-app: disable due to url behind cf

### DIFF
--- a/Casks/s/seam-app.rb
+++ b/Casks/s/seam-app.rb
@@ -14,6 +14,9 @@ cask "seam-app" do
     end
   end
 
+  # Download url is unreachable due to Cloudflare protections
+  disable! date: "2026-02-04", because: :unreachable
+
   auto_updates true
   depends_on macos: ">= :sonoma"
 


### PR DESCRIPTION
seam-app 1.0.0

`https://releases.getseam.app/latest/release.json`

```
{
  "version": "1.0.0",
  "downloadURL": "https://releases.getseam.app/latest/Seam.dmg",
  "signature": "Q4FVMQIyp8MGFXUVbjGLHvpKZ/hm3IwsGRWUWCWAx8lxnzDq9oD2J5sAZhJXgVO228lohMMhRcsDtiDJVmUvBQ==",
  "size": 6589535,
  "publishedAt": "2026-02-04T15:28:04Z",
  "releaseNotes": "## Features\n- **Volume HUD** - See your volume level right in the notch, with a color mode that shifts from green to red as you go louder\n- **Brightness HUD** - Brightness control that lives in your notch, with a gradient style that mimics light increasing\n- **Device connections** - Know instantly when your AirPods or Bluetooth devices connect or switch\n- **Battery status** - Battery level with charging indicator, always visible\n- **Lock screen** - Lock screen notifications at a glance\n- **Focus mode** - See when Do Not Disturb and Focus modes are active\n- **Keyboard shortcuts** - Quick actions at your fingertips\n- **Homebrew support** - Install with `brew install --cask seam-app`\n- Replaces the default macOS volume and brightness overlays with something better\n- Smooth, fluid animations that feel right at home on your Mac\n- Automatically hides during screen recordings and screenshots\n- Keeps up with you when adjusting volume quickly\n- Filters out tiny AirPods Pro volume adjustments so you only see real changes\n- Works alongside transcription apps without false triggers\n- Notifications stay visible while you hover over them\n- Automatic updates built in\n"
}
```