### PR TITLE
various: use rmdir for dot config directory

### DIFF
--- a/Casks/c/claude-code.rb
+++ b/Casks/c/claude-code.rb
@@ -22,13 +22,13 @@ cask "claude-code" do
   binary "claude"
 
   zap trash: [
-    "~/.cache/claude",
-    "~/.claude",
-    "~/.claude.json*",
-    "~/.config/claude",
-    "~/.local/bin/claude",
-    "~/.local/share/claude",
-    "~/.local/state/claude",
-    "~/Library/Caches/claude-cli-nodejs",
-  ]
+        "~/.cache/claude",
+        "~/.claude.json*",
+        "~/.config/claude",
+        "~/.local/bin/claude",
+        "~/.local/share/claude",
+        "~/.local/state/claude",
+        "~/Library/Caches/claude-cli-nodejs",
+      ],
+      rmdir: "~/.claude"
 end

--- a/Casks/c/codex-app.rb
+++ b/Casks/c/codex-app.rb
@@ -22,14 +22,14 @@ cask "codex-app" do
   uninstall quit: "com.openai.codex"
 
   zap trash: [
-    "~/.codex",
-    "~/Library/Application Support/Codex",
-    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.openai.codex.sfl*",
-    "~/Library/Caches/com.openai.codex",
-    "~/Library/HTTPStorages/com.openai.codex",
-    "~/Library/HTTPStorages/com.openai.codex.binarycookies",
-    "~/Library/Logs/com.openai.codex",
-    "~/Library/Preferences/com.openai.codex.plist",
-    "~/Library/Saved Application State/com.openai.codex.savedState",
-  ]
+        "~/Library/Application Support/Codex",
+        "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.openai.codex.sfl*",
+        "~/Library/Caches/com.openai.codex",
+        "~/Library/HTTPStorages/com.openai.codex",
+        "~/Library/HTTPStorages/com.openai.codex.binarycookies",
+        "~/Library/Logs/com.openai.codex",
+        "~/Library/Preferences/com.openai.codex.plist",
+        "~/Library/Saved Application State/com.openai.codex.savedState",
+      ],
+      rmdir: "~/.codex"
 end

--- a/Casks/c/codex-app.rb
+++ b/Casks/c/codex-app.rb
@@ -1,6 +1,6 @@
 cask "codex-app" do
-  version "260203.1501"
-  sha256 "64e1b65863685e3445416f31192a498778dea5f7d6e97c1514ce16553a943d36"
+  version "260204.1342"
+  sha256 "1e9f4f7e17c5b8a69c841c23dd648b46ba569b7d4797533db9c536a7a820a79e"
 
   url "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-#{version}.zip",
       verified: "persistent.oaistatic.com/codex-app-prod/"

--- a/Casks/c/codex.rb
+++ b/Casks/c/codex.rb
@@ -23,5 +23,5 @@ cask "codex" do
 
   binary "codex-#{arch}-#{os}", target: "codex"
 
-  zap trash: "~/.codex"
+  zap rmdir: "~/.codex"
 end

--- a/Casks/g/gemini.rb
+++ b/Casks/g/gemini.rb
@@ -24,12 +24,13 @@ cask "gemini" do
   app "Gemini #{version.major}.app"
 
   zap trash: [
-    "/Users/Shared/Gemini #{version.major}",
-    "~/Library/Application Support/Gemini*",
-    "~/Library/Caches/com.macpaw.site.Gemini*",
-    "~/Library/Cookies/com.macpaw.site.Gemini*.binarycookies",
-    "~/Library/Logs/com.macpaw.site.Gemini*",
-    "~/Library/Preferences/com.macpaw.site.Gemini*",
-    "~/Library/Saved Application State/com.macpaw.site.Gemini*",
-  ]
+        "/Users/Shared/Gemini #{version.major}",
+        "~/Library/Application Support/Gemini*",
+        "~/Library/Caches/com.macpaw.site.Gemini*",
+        "~/Library/Cookies/com.macpaw.site.Gemini*.binarycookies",
+        "~/Library/Logs/com.macpaw.site.Gemini*",
+        "~/Library/Preferences/com.macpaw.site.Gemini*",
+        "~/Library/Saved Application State/com.macpaw.site.Gemini*",
+      ],
+      rmdir: "~/.gemini"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

I noticed in the `codex` cask while working with @chenrui333 that we had set the `~/.codex` directory to be marked as `zap trash`, but this directory contains user created files such as Skills or AGENTS.md.

I moved this to `rmdir` instead to prevent deleting user created files.  In reality this will never fire because the directory is not empty so we can either leave this as-is or we can remove it entirely and annotate that we are not removing the dot directory in the `zap`

I've also made the same updates to `claude-code` and `gemini`

edit: updated `codex-app` version while I was here.