### PR TITLE
Add quicklaunch cask

### DIFF
--- a/Casks/q/quicklaunch.rb
+++ b/Casks/q/quicklaunch.rb
@@ -1,0 +1,17 @@
+cask "quicklaunch" do
+  version "1.0.1"
+  sha256 "2fc73c8ec3cb4a3e5aa2fe1bb532ce475bda6a49e7fa5573aac715e2ee44bd9c"
+
+  url "https://github.com/vorojar/QuickLaunch/releases/download/v#{version}/QuickLaunch-v#{version}.dmg"
+  name "QuickLaunch"
+  desc "Fast app launcher for macOS"
+  homepage "https://github.com/vorojar/QuickLaunch"
+
+  depends_on macos: ">= :sonoma"
+
+  app "QuickLaunch.app"
+
+  zap trash: [
+    "~/Library/Application Support/QuickLaunch",
+  ]
+end


### PR DESCRIPTION
## Description

Add QuickLaunch - a fast, native app launcher for macOS that recreates the classic Launchpad experience.

### Features
- Full-screen launchpad with blurred wallpaper background
- Drag & drop to create folders
- Real-time search with Chinese pinyin support
- Global hotkey (⌘⇧Space)
- Auto organize by app category
- Bilingual (Chinese/English)

### Links
- **Homepage:** https://github.com/vorojar/QuickLaunch
- **Download:** https://github.com/vorojar/QuickLaunch/releases

### Requirements
- macOS 14.0 (Sonoma) or later
- App is signed and notarized by Apple