### PR TITLE
opera@beta: deprecate

### DIFF
--- a/Casks/o/opera@beta.rb
+++ b/Casks/o/opera@beta.rb
@@ -7,10 +7,8 @@ cask "opera@beta" do
   desc "Web browser"
   homepage "https://www.opera.com/computer/beta"
 
-  livecheck do
-    url "https://get.geo.opera.com/pub/opera-beta/"
-    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
+  # https://blogs.opera.com/desktop/2026/01/opera-126-0-5750-30-beta-update
+  deprecate! date: "2026-02-05", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

-----

Opera Beta was [discontinued](https://blogs.opera.com/desktop/2026/01/opera-126-0-5750-30-beta-update/#:~:text=Opera%20Beta%20is%20retiring%2C%20and%20with%20version%20126.0.5750.30%20we%E2%80%99re%20publishing%20the%20final%20Beta%20release.) 3 weeks ago.