### PR TITLE
Standardize ExtractPlist strategy blocks

### DIFF
--- a/Casks/c/choice-financial-terminal.rb
+++ b/Casks/c/choice-financial-terminal.rb
@@ -12,8 +12,8 @@ cask "choice-financial-terminal" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |item|
-      item["com.eastmoney.choice"]&.short_version
+    strategy :extract_plist do |items|
+      items["com.eastmoney.choice"]&.short_version
     end
   end
 

--- a/Casks/c/copyclip.rb
+++ b/Casks/c/copyclip.rb
@@ -9,8 +9,8 @@ cask "copyclip" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |item|
-      item["com.fiplab.copyclip#{version.major}"]&.short_version
+    strategy :extract_plist do |items|
+      items["com.fiplab.copyclip#{version.major}"]&.short_version
     end
   end
 

--- a/Casks/g/google-chrome.rb
+++ b/Casks/g/google-chrome.rb
@@ -9,8 +9,8 @@ cask "google-chrome" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |versions|
-      versions.values.filter_map(&:short_version).first
+    strategy :extract_plist do |items|
+      items["com.google.Chrome"]&.short_version
     end
   end
 

--- a/Casks/g/google-drive.rb
+++ b/Casks/g/google-drive.rb
@@ -11,8 +11,8 @@ cask "google-drive" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |item|
-      item["com.google.drivefs"]&.version
+    strategy :extract_plist do |items|
+      items["com.google.drivefs"]&.version
     end
   end
 

--- a/Casks/m/memory-clean-3.rb
+++ b/Casks/m/memory-clean-3.rb
@@ -10,8 +10,8 @@ cask "memory-clean-3" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |item|
-      item["com.fiplab.memoryclean3"]&.short_version
+    strategy :extract_plist do |items|
+      items["com.fiplab.memoryclean3"]&.short_version
     end
   end
 

--- a/Casks/n/noun-project.rb
+++ b/Casks/n/noun-project.rb
@@ -10,8 +10,8 @@ cask "noun-project" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |item|
-      item["com.thenounproject.Noun-Project"]&.short_version
+    strategy :extract_plist do |items|
+      items["com.thenounproject.Noun-Project"]&.short_version
     end
   end
 

--- a/Casks/p/paragon-camptune.rb
+++ b/Casks/p/paragon-camptune.rb
@@ -9,8 +9,8 @@ cask "paragon-camptune" do
 
   livecheck do
     url :url
-    strategy :extract_plist do |versions|
-      versions.values.filter_map(&:short_version).first
+    strategy :extract_plist do |items|
+      items["com.paragon-software.camptunex"]&.short_version
     end
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

This updates livecheck `ExtractPlist` `strategy` blocks to standardize them. Namely, this:

* Uniformly uses `items` as the strategy block parameter name, as it's a hash with `ExtractPlist::Item` values (so `item` doesn't make sense) and `items` is the name we use within the strategy.
* Uniformly uses an `items["..."]&.short_version` approach. Something like `items.values.filter_map(&:short_version)` works if we can't reliably target one specific key but it doesn't seem necessary in `google-chrome` and `paragon-camptune`.

I've run all of these checks locally to confirm that they work as expected, so I'm setting this as syntax-only to ease the CI burden.