### PR TITLE
font-dejavu-sans 2.37 (new formula)

### DIFF
--- a/Casks/font/font-d/font-dejavu-sans.rb
+++ b/Casks/font/font-d/font-dejavu-sans.rb
@@ -1,0 +1,17 @@
+cask "font-dejavu-sans" do
+  version "2.37"
+  sha256 "5c6e497a2f36552cb5ffb112c413a6af39c0f3c47653662b90b4fa6499822fd7"
+
+  url "https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_#{version}/dejavu-sans-ttf-#{version}.zip"
+  name "DejaVu Sans"
+  homepage "https://github.com/dejavu-fonts/dejavu-fonts"
+
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
+  font "dejavu-sans-ttf-#{version}/ttf/DejaVuSans.ttf"
+
+  # No zap stanza required
+end


### PR DESCRIPTION
Add new cask for DejaVu Sans minimal package.

This adds a lightweight alternative to the full `font-dejavu` cask, containing only the regular weight DejaVuSans.ttf font (407KB vs 5.5MB for the full package).

**Source**: https://github.com/dejavu-fonts/dejavu-fonts/releases/latest

---

- [x] The submission is for a stable version.
- [x] `brew style --fix font-dejavu-sans` reports no offenses.
- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.

**AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR.
- [x] I have personally reviewed, tested and verified all changes.

**How AI was used**: AI assistant (Claude) helped create the cask definition, calculate SHA256 checksum, and verify the file structure against Homebrew Cask guidelines. All changes have been manually reviewed and syntax validated with `brew style` and `ruby -c`.