### PR TITLE
netlogo: update URLs

### DIFF
--- a/Casks/n/netlogo.rb
+++ b/Casks/n/netlogo.rb
@@ -5,14 +5,14 @@ cask "netlogo" do
   sha256 arm:   "14fb4870415fe78e7391641a62aaab96e570b4531ac3cd82d8d16ad8f60a24ca",
          intel: "79ecc61c231559681f1d2f0f79943956ae681c538fc65fef1c781e483ae6b5e6"
 
-  url "https://ccl.northwestern.edu/netlogo/#{version}/NetLogo-#{version}-#{arch}.dmg"
+  url "https://downloads.netlogo.org/#{version}/NetLogo-#{version}-#{arch}.dmg"
   name "NetLogo"
   desc "Multi-agent programmable modelling environment"
-  homepage "https://ccl.northwestern.edu/netlogo/"
+  homepage "https://www.netlogo.org/"
 
   livecheck do
-    url "https://ccl.northwestern.edu/netlogo/oldversions.shtml"
-    regex(/NetLogo\s*(\d+(?:\.\d+)+)/i)
+    url "https://docs.netlogo.org/versions"
+    regex(/Version\s*(\d+(?:\.\d+)+)/i)
   end
 
   suite "NetLogo #{version}"


### PR DESCRIPTION
The old URL redirects to this new one.

Fixes https://github.com/Homebrew/homebrew-cask/issues/247809.