### PR TITLE
Add nukemymac cask

### DIFF
--- a/Casks/n/nukemymac.rb
+++ b/Casks/n/nukemymac.rb
@@ -1,0 +1,27 @@
+cask "nukemymac" do
+  version "1.1.0"
+  sha256 "f4cf03c5037b4eebb1bc101e835997e3049b6258772decceee9ab77286814b41"
+
+  url "https://nukemymac-website.bukhari-kibuka7.workers.dev/api/download/dmg"
+  name "NukeMyMac"
+  desc "macOS system cleaner and disk space optimizer"
+  homepage "https://nukemymac-website.bukhari-kibuka7.workers.dev/"
+
+  livecheck do
+    url "https://nukemymac-website.bukhari-kibuka7.workers.dev/api/download"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "NukeMyMac.app"
+
+  zap trash: [
+    "~/Library/Application Support/NukeMyMac",
+    "~/Library/Caches/com.nukemymac.driver.NukeMyMac",
+    "~/Library/Preferences/com.nukemymac.driver.NukeMyMac.plist",
+  ]
+end


### PR DESCRIPTION
## Description
Add NukeMyMac - a macOS system cleaner and disk space optimizer.

**App details:**
- Name: NukeMyMac
- Version: 1.1.0
- Homepage: https://nukemymac-website.bukhari-kibuka7.workers.dev/
- Download: Proxied through website API (serves from private GitHub releases)

**Features:**
- Scans and cleans system junk, caches, logs
- Removes Xcode derived data and iOS device support
- Cleans Rust target directories
- Visualizes disk usage with treemap and sunburst charts
- Safe deletion (moves to Trash by default)

**Requirements:**
- macOS Ventura (13.0) or later
- Native SwiftUI app, notarized

Tested installation locally with `brew install --cask /tmp/nukemymac.rb`.