### PR TITLE
Add markjason cask v0.26

### DIFF
--- a/Casks/m/markjason.rb
+++ b/Casks/m/markjason.rb
@@ -1,0 +1,27 @@
+cask "markjason" do
+  version "0.26"
+  sha256 "8e22459ec64bc61d78b3751fb5c06dcee478f48fc0746a88645c873cade95d1f"
+
+  url "https://github.com/gijsverheijke/markjason-landing/releases/download/v0.1-3/markjason-#{version}.dmg",
+      verified: "github.com/gijsverheijke/markjason-landing/"
+  name "markjason"
+  desc "Lightweight macOS editor for Markdown, JSON, and .env files"
+  homepage "https://markjason.sh"
+
+  livecheck do
+    url "https://github.com/gijsverheijke/markjason-landing/releases/latest/download/appcast.xml"
+    strategy :sparkle
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "markjason.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.markjason.app",
+    "~/Library/Caches/com.markjason.app",
+    "~/Library/Preferences/com.markjason.app.plist",
+    "~/Library/Saved Application State/com.markjason.app.savedState",
+  ]
+end


### PR DESCRIPTION
## Description

Add a new cask for [markjason](https://markjason.sh), a lightweight native macOS editor for Markdown, JSON, and .env files.

- **App name:** markjason
- **Version:** 0.26
- **Homepage:** https://markjason.sh
- **Notarized:** Yes (Developer ID, stapled)
- **Architecture:** Universal (arm64 + x86_64)
- **Auto-updates:** Yes (via Sparkle)
- **Min macOS:** Sonoma (14.0)