### PR TITLE
devtunnel: add Linux support

### DIFF
--- a/Casks/d/devtunnel.rb
+++ b/Casks/d/devtunnel.rb
@@ -1,12 +1,29 @@
 cask "devtunnel" do
   arch arm: "arm64", intel: "x64"
+  os macos: "osx", linux: "linux"
 
   version "1.0.1516+7e996fe917"
-  sha256 arm:   "fb5787bb949d6b86b5dcaeb596be740648760cd383956644f2f7ae46a6dec7b9",
-         intel: "ee6c1217158c09065882d7f59520770854220b52099e04028c300b1d63e0e06d"
+  sha256 arm:          "fb5787bb949d6b86b5dcaeb596be740648760cd383956644f2f7ae46a6dec7b9",
+         intel:        "ee6c1217158c09065882d7f59520770854220b52099e04028c300b1d63e0e06d",
+         arm64_linux:  "1525720aed29204ae8d13a020caf001b9605e0644006cc5009f89a9bc1e33510",
+         x86_64_linux: "9912746ed118fa36b7e22d6c8b8ca426f1add53d31425630fe7808c3d015e8ca"
 
-  url "https://tunnelsassetsprod.blob.core.windows.net/cli/#{version}/osx-#{arch}-devtunnel-zip",
-      verified: "tunnelsassetsprod.blob.core.windows.net/cli/"
+  on_macos do
+    url "https://tunnelsassetsprod.blob.core.windows.net/cli/#{version}/#{os}-#{arch}-devtunnel-zip",
+        verified: "tunnelsassetsprod.blob.core.windows.net/cli/"
+
+    binary "devtunnel"
+  end
+
+  on_linux do
+    url "https://tunnelsassetsprod.blob.core.windows.net/cli/#{version}/#{os}-#{arch}-devtunnel",
+        verified: "tunnelsassetsprod.blob.core.windows.net/cli/"
+
+    container type: :naked
+
+    binary "#{os}-#{arch}-devtunnel", target: "devtunnel"
+  end
+
   name "Microsoft Dev Tunnels"
   desc "Provides developers secure tunnels to share local web services"
   homepage "https://aka.ms/devtunnels/docs"
@@ -17,8 +34,6 @@ cask "devtunnel" do
       json["version"]
     end
   end
-
-  binary "devtunnel"
 
   # No zap stanza required
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `devtunnel` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

AI (Claude Code with Opus 4.5) was used to implement Linux support for the `devtunnel` cask. I had Claude Code review the **Cask Cookbook** as well as other Casks for similar pattens. I reviewed each line change against the **Cask Cookbook** and the implementation was manually tested on Linux ARM64. Installation, version check, and uninstallation all verified working.

-----

Microsoft provides Linux binaries for Dev Tunnels, but only offers a [shell script for installation](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=linux#install). This PR adds Linux support to the existing cask, allowing Linux users of Homebrew to install `devtunnel` with the same experience as macOS users.