### PR TITLE
groask 1.6.7 (new cask)

### DIFF
--- a/Casks/g/groask.rb
+++ b/Casks/g/groask.rb
@@ -1,0 +1,29 @@
+cask "groask" do
+  version "1.6.7"
+  sha256 "6d2d4a6232402afb73ec5534570c28ef0d74fc17adde5d7a95ecf8fca469038b"
+
+  url "https://github.com/ThinkerJack/groask-release/releases/download/v#{version}/GroAsk.dmg",
+      verified: "github.com/ThinkerJack/groask-release/"
+  name "GroAsk"
+  desc "Menu bar AI launcher for ChatGPT, Claude, and Gemini"
+  homepage "https://groask.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "GroAsk.app"
+
+  uninstall quit: "com.gro.ask"
+
+  zap trash: [
+    "~/Library/Application Support/com.gro.ask",
+    "~/Library/Caches/com.gro.ask",
+    "~/Library/HTTPStorages/com.gro.ask",
+    "~/Library/Preferences/com.gro.ask.plist",
+    "~/Library/Saved Application State/com.gro.ask.savedState",
+  ]
+end


### PR DESCRIPTION
## App description

**GroAsk** is a native macOS menu bar AI launcher. Press `⌥Space` to send text to multiple AI services (ChatGPT, Claude, Gemini, DeepSeek) and CLI agents (Claude Code, Gemini CLI) with a single hotkey. It uses your existing web subscriptions directly — no API keys needed.

- **Homepage:** https://groask.com
- **Download:** [GitHub Releases](https://github.com/ThinkerJack/groask-release/releases)
- **Signed & notarized** by Apple Developer (Team ID: 4KT56S2BX6)
- **macOS 13.0+ (Ventura)**, Apple Silicon & Intel

## Cask details

- Token: `groask`
- Version: 1.6.7
- Artifact: DMG containing `GroAsk.app`
- Livecheck: `strategy :github_latest`