### PR TITLE
stik 0.4.3 (new cask)

### DIFF
--- a/Casks/s/stik.rb
+++ b/Casks/s/stik.rb
@@ -5,7 +5,8 @@ cask "stik" do
   sha256 arm:   "ac7a1da2a3a5fa1ea63d8e158bca726dc0af5401f36a276295842bd3cc7bb422",
          intel: "f15e2360df4b2d1b9708a9d5548a85777e1d313c1d4b60d98061786753d11cb8"
 
-  url "https://github.com/0xMassi/stik_app/releases/download/v#{version}/Stik_#{version}_#{arch}.dmg"
+  url "https://github.com/0xMassi/stik_app/releases/download/v#{version}/Stik_#{version}_#{arch}.dmg",
+      verified: "github.com/0xMassi/stik_app/"
   name "Stik"
   desc "Keyboard-first note capture app for macOS"
   homepage "https://www.stik.ink"

--- a/Casks/s/stik.rb
+++ b/Casks/s/stik.rb
@@ -1,0 +1,23 @@
+cask "stik" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "0.4.3"
+  sha256 arm:   "ac7a1da2a3a5fa1ea63d8e158bca726dc0af5401f36a276295842bd3cc7bb422",
+         intel: "f15e2360df4b2d1b9708a9d5548a85777e1d313c1d4b60d98061786753d11cb8"
+
+  url "https://github.com/0xMassi/stik_app/releases/download/v#{version}/Stik_#{version}_#{arch}.dmg"
+  name "Stik"
+  desc "Keyboard-first note capture app for macOS"
+  homepage "https://www.stik.ink"
+
+  depends_on macos: ">= :catalina"
+
+  app "Stik.app"
+
+  zap trash: [
+    "~/Documents/Stik",
+    "~/.stik",
+    "~/Library/Caches/com.stik.app",
+    "~/Library/WebKit/com.stik.app",
+  ]
+end


### PR DESCRIPTION
## What
- Add new cask: stik (v0.4.3)
- Intel/Apple Silicon SHA256 included
- Added verified for GitHub-hosted release URL

## Validation
- brew audit --strict --online --new --cask 0xmassi/stikpr2/stik

Current remaining audit blocker:
- GitHub repository notability threshold (<30 forks, <30 watchers, <75 stars)

Repo metrics at submission time:
- Stars: 73
- Forks: 1
- Watchers: 1
