### PR TITLE
filebot 5.2.1

### DIFF
--- a/Casks/f/filebot.rb
+++ b/Casks/f/filebot.rb
@@ -1,11 +1,11 @@
 cask "filebot" do
   arch arm: "arm64", intel: "x64"
 
-  version "5.2.0"
-  sha256 arm:   "71bb89a968a30fa076ffd5a3e2443143f68d60b8487110915611659e7d5acad0",
-         intel: "a32ddf766a55a9831c5aefbcaeecfbc5897b641a3b2f8490d476f17d27223735"
+  version "5.2.1"
+  sha256 arm:   "16bd651406b235ad505b8838d28fcb512d39e28389973476da0728d085ed73ca",
+         intel: "522ed754478285d2970969d127b86f6a122181a3d1cd7ff3356129c147c50e59"
 
-  url "https://get.filebot.net/filebot/FileBot_#{version}/FileBot_#{version}_#{arch}.app.tar.xz"
+  url "https://get.filebot.net/filebot/FileBot_#{version}/FileBot_#{version}_#{arch}.pkg"
   name "FileBot"
   desc "Tool for organising and renaming movies, TV shows, anime or music"
   homepage "https://www.filebot.net/"
@@ -15,11 +15,11 @@ cask "filebot" do
     regex(/href=.*?FileBot[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.pkg/i)
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
-  app "FileBot.app"
-  binary "#{appdir}/FileBot.app/Contents/MacOS/filebot.sh", target: "filebot"
+  pkg "FileBot_#{version}_#{arch}.pkg"
   bash_completion "#{appdir}/FileBot.app/Contents/Resources/bash_completion.d/filebot_completion", target: "filebot"
+
+  uninstall pkgutil: "net.filebot.FileBot.pkg",
+            delete:  "/Applications/FileBot.app"
 
   zap trash: [
     "~/Library/Application Scripts/net.filebot.FileBot",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`filebot` is autobumped but the workflow failed to update to version 5.2.1 because upstream has switched to a pkg file for this version. This updates the version and adjusts the artifact `url` accordingly. Besides that, the app for 5.2.1 now passes Gatekeeper checks, so this removes the `disable` call.

I've removed the `binary` call, as the pkg postinstall script creates a symbolic link from `filebot.sh` to `/usr/local/bin/filebot` and the `binary` call was causing an error in CI due to the file already existing (though it only failed on macOS 15 Intel, for some odd reason).