### PR TITLE
android-studio-preview@canary 2025.3.2.3

### DIFF
--- a/Casks/a/android-studio-preview@canary.rb
+++ b/Casks/a/android-studio-preview@canary.rb
@@ -1,19 +1,24 @@
 cask "android-studio-preview@canary" do
   arch arm: "mac_arm", intel: "mac"
 
-  version "2025.3.1.5"
-  sha256 arm:   "9cc52ce290cf40f3fb9c2c9262680b533a92b938c89adae63a5a1916ef307b6d",
-         intel: "68ef43f87cb0c08fc01ba82e13bbf64616545f96e657627c2ab4aae47d3c5fa9"
+  version "2025.3.2.3,panda2-canary3"
+  sha256 arm:   "7b747cb1752aabfdafd7726b3c1213943cc76facf3c8e7a37bcd45bb26d76498",
+         intel: "80d3131da8b6f309bc066d25f74f5bf1740658da6b466cb0d66cee69a9b03fc5"
 
-  url "https://redirector.gvt1.com/edgedl/android/studio/install/#{version}/android-studio-#{version}-#{arch}.dmg",
-      verified: "redirector.gvt1.com/edgedl/android/studio/install/"
+  url "https://edgedl.me.gvt1.com/android/studio/install/#{version.csv.first}/android-studio#{"-#{version.csv.second}" if version.csv.second}-#{arch}.dmg",
+      verified: "edgedl.me.gvt1.com/android/studio/install/"
   name "Android Studio Preview (Canary)"
   desc "Tools for building Android applications"
   homepage "https://developer.android.com/studio/preview/"
 
   livecheck do
     url :homepage
-    regex(%r{href=.*?/android[._-]studio[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}\.dmg}i)
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/android[._-]studio(?:[._-]([^"' >]+))?[._-]#{arch}\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        match[1].present? ? "#{match[0]},#{match[1]}" : match[0]
+      end
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `android-studio-preview@canary` is producing an "Unable to get versions" error, as the regex doesn't match the current dmg file names. The file name format has changed and now the dmg URLs include a code name/number (e.g., `panda2-canary3`) instead of the version. This modifies the `livecheck` block to capture the code name/number text from the file name and include it in the cask `version`. This updates the cask to 2025.3.2.3 and adjusts the `url` to handle this new setup.