### PR TITLE
thecommander 1.0.50 (new cask)

### DIFF
--- a/Casks/t/thecommander.rb
+++ b/Casks/t/thecommander.rb
@@ -1,0 +1,27 @@
+cask "thecommander" do
+  version "1.0.50"
+  sha256 "0cd83248640ef465463acff338678c19bd871815a96718868d6ca32ee73b7a9d"
+
+  url "https://die-gutbrods.de/thecommander/updates/TheCommander-#{version}.dmg"
+  name "TheCommander"
+  desc "Dual-panel file manager inspired by Total Commander"
+  homepage "https://die-gutbrods.de/thecommander/"
+
+  livecheck do
+    url "https://die-gutbrods.de/thecommander/updates/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "TheCommander.app"
+
+  zap trash: [
+    "~/Library/Application Support/de.die-gutbrods.TheCommander",
+    "~/Library/Caches/de.die-gutbrods.TheCommander",
+    "~/Library/HTTPStorages/de.die-gutbrods.TheCommander",
+    "~/Library/Preferences/de.die-gutbrods.TheCommander.plist",
+    "~/Library/Saved Application State/de.die-gutbrods.TheCommander.savedState",
+  ]
+end


### PR DESCRIPTION
### Description

Adds a new cask for [TheCommander](https://die-gutbrods.de/thecommander/), a dual-panel file manager for macOS inspired by Total Commander, by Norbert Gutbrod. It is freeware (proprietary).

- **Token:** `thecommander`
- **Version:** 1.0.50
- **Homepage:** https://die-gutbrods.de/thecommander/
- **Bundle ID:** `de.die-gutbrods.TheCommander`
- **Min macOS:** 14.0 (Sonoma)
- **Livecheck:** Sparkle appcast (`&:short_version`)
- `brew audit --strict --online` passes
- `brew style` passes
- Installs and uninstalls cleanly

### AI Disclosure

This cask was authored with the assistance of Claude Code (Claude Opus 4.6, Anthropic). The human author reviewed, verified, and tested the final result.