### PR TITLE
firestorm 7.2.3.80036

### DIFF
--- a/Casks/f/firestorm.rb
+++ b/Casks/f/firestorm.rb
@@ -1,6 +1,6 @@
 cask "firestorm" do
-  version "7.2.2.79439"
-  sha256 "446c00b2b812e1797e4e0aabbefd802bdc3d512f28851d92dfddbf909d5c3630"
+  version "7.2.3.80036"
+  sha256 "22677ce38d50215e875e25d4754c7dde2af4f945612545a96cffe65ea8b11d4c"
 
   url "https://downloads.firestormviewer.org/release/mac/Phoenix-Firestorm-Releasex64_AVX2-#{version.dots_to_hyphens}.dmg"
   name "Phoenix Firestorm viewer for Second Life"
@@ -24,8 +24,4 @@ cask "firestorm" do
     "~/Library/Logs/DiagnosticReports/Firestorm*",
     "~/Library/Preferences/Firestorm.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
Autobump failed because upstream now builds for arm
Now that package is a universal binary, no need for rosetta caveat

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----
