### PR TITLE
Add EasyGit: lightweight native macOS Git GUI

### DIFF
--- a/Casks/e/easygit.rb
+++ b/Casks/e/easygit.rb
@@ -1,0 +1,15 @@
+cask "easygit" do
+  version "1.0.0"
+  sha256 "1c6cfada75b1b9a11d1567d59674e23dc2311e96198a84da1db447c2fd029201"
+
+  url "https://github.com/shohamtal/EasyGit/releases/download/v#{version}/EasyGit.zip"
+  name "EasyGit"
+  desc "Lightweight native Git GUI built with SwiftUI"
+  homepage "https://github.com/shohamtal/EasyGit"
+
+  depends_on macos: ">= :sonoma"
+
+  app "EasyGit.app"
+
+  zap trash: "~/Library/Preferences/com.easygit.app.plist"
+end


### PR DESCRIPTION
## Description

[EasyGit](https://github.com/shohamtal/EasyGit) is a lightweight, native macOS Git GUI built with SwiftUI.

**Features:**
- Three-panel layout: repos, changes, diffs
- Visual staging with line-level drag selection
- Built-in terminal with command history
- Push, pull, branch, prune, create PR
- Protected branch warnings & sensitive data detection before push
- 4 themes (Dark, Light, Light Blue, Glitter)
- Resizable panels, live file watching
- VS Code `.code-workspace` import

**Requirements:** macOS 14 (Sonoma) or later

- **Homepage:** https://github.com/shohamtal/EasyGit
- **Download:** https://github.com/shohamtal/EasyGit/releases/download/v1.0.0/EasyGit.zip
- **License:** MIT