### PR TITLE
20260211 dotnet req fix

### DIFF
--- a/Casks/d/dotnet-sdk@8.rb
+++ b/Casks/d/dotnet-sdk@8.rb
@@ -26,7 +26,6 @@ cask "dotnet-sdk@8" do
     end
   end
 
-  depends_on cask: "dotnet-sdk"
   depends_on macos: ">= :big_sur"
 
   pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"

--- a/Casks/d/dotnet-sdk@9.rb
+++ b/Casks/d/dotnet-sdk@9.rb
@@ -26,7 +26,6 @@ cask "dotnet-sdk@9" do
     end
   end
 
-  depends_on cask: "dotnet-sdk"
   depends_on macos: ">= :monterey"
 
   pkg "dotnet-sdk-#{version.csv.first}-osx-#{arch}.pkg"


### PR DESCRIPTION
- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.

-----

I'm not sure why the versioned dotnet-sdk casks (dotnet-sdk@8, dotnet-sdk@9) have the unversioned cask (dotnet-sdk) listed as a requirement. They can be installed standalone. I'm actually trying to stay on version 8 and do not need or want version 10 installed yet. Having it "required" is causing me some issues.