### PR TITLE
mozregression-gui 7.1.0

### DIFF
--- a/Casks/m/mozregression-gui.rb
+++ b/Casks/m/mozregression-gui.rb
@@ -1,8 +1,8 @@
 cask "mozregression-gui" do
-  version "7.0.0"
-  sha256 "cca56b22a22079c82d170289e2b6b19f942b0a24f027beefcda8463e8df36203"
+  version "7.1.0"
+  sha256 "1b02196cd4e406f663b87b6be8503f71cf4c4638ab08ebfb04bac926cc89f328"
 
-  url "https://github.com/mozilla/mozregression/releases/download/#{version}/mozregression-gui.dmg",
+  url "https://github.com/mozilla/mozregression/releases/download/#{version}/mozregression-gui-app-bundle.tar.gz",
       verified: "github.com/mozilla/mozregression/"
   name "mozregression-gui"
   desc "Interactive regression range finder for Firefox and other Mozilla products"
@@ -13,9 +13,11 @@ cask "mozregression-gui" do
     strategy :github_latest
   end
 
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
   depends_on macos: ">= :big_sur"
 
-  app "mozregression GUI.app"
+  app "mozregression-gui-app-bundle/mozregression GUI.app"
 
   zap trash: "~/Library/Preferences/org.mozilla.mozregression-gui.plist"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`mozregression-gui` is autobumped but the workflow failed to update to version 7.1.0 because the release asset file name has changed. This updates the version and adjusts the cask accordingly. The app fails Gatekeeper checks due to only having an ad-hoc signature, so this also adds a `disable!` call with the future date we've been using for this situation.