### PR TITLE
psiphon-conduit 1.8.0-RC.2 (new cask)

### DIFF
--- a/Casks/p/psiphon-conduit.rb
+++ b/Casks/p/psiphon-conduit.rb
@@ -1,0 +1,32 @@
+cask "psiphon-conduit" do
+  version "1.8.0-RC.2"
+  sha256 "56a6be1708a2e458965fcc31743cfd8ecd186f3b6e739baaa9e027996bbf1ae4"
+
+  url "https://github.com/Psiphon-Inc/conduit/releases/download/release-mac-#{version}/conduit.dmg",
+      verified: "github.com/Psiphon-Inc/conduit/"
+  name "Psiphon Conduit"
+  desc "Internet freedom tool that turns your device into a proxy for the Psiphon net"
+  homepage "https://conduit.psiphon.ca/"
+
+  livecheck do
+    url :url
+    regex(/^release-mac[._-]v?(\d+(?:\.\d+)+(?:[._-]RC(?:[._]?\d+)?)?)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"]
+        next unless (match = release["tag_name"]&.match(regex))
+
+        match[1]
+      end
+    end
+  end
+
+  depends_on macos: ">= :monterey"
+
+  app "Conduit.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/ca.psiphon.conduit",
+    "~/Library/Containers/ca.psiphon.conduit",
+  ]
+end

--- a/Casks/p/psiphon-conduit.rb
+++ b/Casks/p/psiphon-conduit.rb
@@ -5,7 +5,7 @@ cask "psiphon-conduit" do
   url "https://github.com/Psiphon-Inc/conduit/releases/download/release-mac-#{version}/conduit.dmg",
       verified: "github.com/Psiphon-Inc/conduit/"
   name "Psiphon Conduit"
-  desc "Internet freedom tool that turns your device into a proxy for the Psiphon net"
+  desc "Psiphon network proxy tool"
   homepage "https://conduit.psiphon.ca/"
 
   livecheck do

--- a/Casks/p/psiphon-conduit.rb
+++ b/Casks/p/psiphon-conduit.rb
@@ -11,14 +11,6 @@ cask "psiphon-conduit" do
   livecheck do
     url :url
     regex(/^release-mac[._-]v?(\d+(?:\.\d+)+(?:[._-]RC(?:[._]?\d+)?)?)$/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"]
-        next unless (match = release["tag_name"]&.match(regex))
-
-        match[1]
-      end
-    end
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
> - [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

(It is the same version hosted on their website, but the script uses Github repo for downloading.)

> - [x] `brew audit --cask --online <cask>` is error-free.
> - [x] `brew style --fix <cask>` reports no offenses.
>
> Additionally, **if adding a new cask**:
>
> - [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).

The suggested name, "conduit", was already taken.

> - [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
> - [x] `brew audit --cask --new <cask>` worked successfully.
> - [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
> - [x] `brew uninstall --cask <cask>` worked successfully.

-----

> **If AI was used to generate or assist with generating the PR**:
> 
> - [x] I used AI to generate or assist with generating this PR.
> - [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

I used Google Gemini 3 Pro for the following tasks. I am not a ruby coder, so I have not enough confidence to check the second item.

* Initiating the file
* Fixing livecheck to target the specific release tags to ignore the CLI releases which were published with different version code in the same repo.
* Fixing the `zap` stanza 
The initial `zap` paths did not exist on my mac. I gave more info about the structure of the app and its reposiroty, and received the included result, which existed on my mac.
  > Since the app is built with Mac Catalyst and React Native, it runs inside a sandbox. This explains why you didn't find the files in the standard ~/Library/Application Support/Conduit folder.
  > 
  > Instead, the system isolates the app's data in the ~/Library/Containers directory.
  > ...
  > #### Explanation of the zap Stanza
  > - `~/Library/Containers/ca.psiphon.conduit`: This is the main sandbox container for the application. Deleting this removes all local data, settings, and downloaded states specific to the app.
  > - `~/Library/Application Scripts/ca.psiphon.conduit`: This directory contains scripts allowed to run by the sandboxed app (often empty, but standard practice to clean up for Catalyst apps).