### PR TITLE
itch 26.6.0 - use darwin-universal installer instead of amd64 (which no longer exists)

### DIFF
--- a/Casks/i/itch.rb
+++ b/Casks/i/itch.rb
@@ -2,7 +2,7 @@ cask "itch" do
   version "26.6.0"
   sha256 :no_check
 
-  url "https://broth.itch.zone/install-itch/darwin-amd64/LATEST/archive/default",
+  url "https://broth.itch.zone/install-itch/darwin-universal/LATEST/archive/default",
       verified: "broth.itch.zone/"
   name "itch"
   desc "Game client for itch.io"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [v] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [v] `brew audit --cask --online <cask>` is error-free.
- [v] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [v] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

I just changed one line, possibly can remove the rosetta requirement but I can only test on my M1 mac (no Intel Mac in possession).