### PR TITLE
kaku: replace deprecated music player with terminal emulator

### DIFF
--- a/Casks/k/kaku.rb
+++ b/Casks/k/kaku.rb
@@ -1,18 +1,17 @@
 cask "kaku" do
-  version "2.0.2"
-  sha256 "ba89cd59a49b7c21d7ccde09044e2fed7e2deeb617798ac45281f83130e313ca"
+  version "0.2.0"
+  sha256 "9dd01fac2df72578ca0ecb243cbf3c7964a6b8c9701c6eabcd57cfef70d4ec72"
 
-  url "https://github.com/EragonJ/Kaku/releases/download/#{version}/Kaku-#{version}.dmg",
-      verified: "github.com/EragonJ/Kaku/"
+  url "https://github.com/tw93/Kaku/releases/download/V#{version}/Kaku.dmg",
+      verified: "github.com/tw93/Kaku/"
   name "Kaku"
-  homepage "https://kaku.rocks/"
+  desc "A fast, out-of-the-box terminal built for AI coding"
+  homepage "https://github.com/tw93/Kaku"
 
-  deprecate! date: "2024-07-17", because: :unmaintained
-  disable! date: "2025-07-17", because: :unmaintained
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   app "Kaku.app"
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----


## Reason for change

The current cask `kaku` points to a deprecated music player (EragonJ/Kaku) that has not been maintained since 2021. This cask was deprecated on 2024-07-17 and will be disabled on 2025-07-17.

This PR replaces it with **Kaku** (https://github.com/tw93/Kaku), a modern macOS-native terminal emulator built for AI coding workflows. It's a fork of WezTerm, optimized for AI developers.

- Terminal emulator is a core developer tool with much higher utility
- The old music player has only ~24K downloads/year and is effectively abandoned
- The current token conflict causes confusion when users run `brew upgrade kaku`

## Verification

- [x] `brew audit --cask --online kaku` passes
- [x] `brew install --cask kaku` installs correctly