### PR TITLE
morgen: add auto_updates

### DIFF
--- a/Casks/m/morgen.rb
+++ b/Casks/m/morgen.rb
@@ -24,6 +24,7 @@ cask "morgen" do
     end
   end
 
+  auto_updates true
   depends_on macos: ">= :big_sur"
 
   app "Morgen.app"


### PR DESCRIPTION
morgen updates itself automatically, so we should add `auto_updates true` to the cask definition.

- [X] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [X] `brew audit --cask --online <cask>` is error-free.
- [X] `brew style --fix <cask>` reports no offenses.
