### PR TITLE
cctalk 7.10.17.3

### DIFF
--- a/Casks/c/cctalk.rb
+++ b/Casks/c/cctalk.rb
@@ -1,5 +1,5 @@
 cask "cctalk" do
-  version "7.10.17-1394"
+  version "7.10.17.3"
   sha256 :no_check
 
   url "https://www.cctalk.com/webapi/basic/v1.1/version/down?apptype=1&terminalType=8&versionType=103"
@@ -9,7 +9,7 @@ cask "cctalk" do
 
   livecheck do
     url :url
-    regex(/(\d+(?:\.\d+)+-*\d*)\.dmg/i)
+    regex(/CCtalk[._-]v?(\d+(?:[.-]\d+)+)\.dmg/i)
     strategy :header_match
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`cctalk` is autobumped but the workflow failed to update to version 7.10.17.3 because livecheck compares the number in the existing version regex to the last digit of the upstream version and 1394 is higher than 3, so the cask version is seen as newer than upstream. Upstream seems to switch back and forth between these version formats, so this manually updates the cask.

This also updates the `livecheck` block regex to better align with prevailing standards (namely, using `[.-]` in the repeating part of the version instead of manually accounting for the optional version suffix).