### PR TITLE
flykey 1.7.1

### DIFF
--- a/Casks/f/flykey.rb
+++ b/Casks/f/flykey.rb
@@ -1,15 +1,23 @@
 cask "flykey" do
-  version "1.6.7,2024082401"
-  sha256 "e08311dd732f5f31282c01f91c8dec9b9d9db27dc628bfd4f8b574b8f46781d6"
+  version "1.7.1,2025121201"
+  sha256 "983462ef05ae9b935c351a0dc67e70491414eac600ea9a2b90d06791360b0243"
 
   url "https://cdn.better365.cn/FlyKey/#{version.csv.second[0..3]}/FlyKey#{version.csv.first}_#{version.csv.second}.zip"
   name "FlyKey"
   desc "One-click display of shortcuts"
   homepage "https://www.better365.cn/FlyKey.html"
 
+  # The version suffix in the file name can differ from the `sparkle:version`,
+  # so we match the values from the file name in the URL.
   livecheck do
-    url "https://www.better365.cn/FlyKey.xml"
-    strategy :sparkle
+    url "https://www.better365.cn/flykeyofflineupdate.xml"
+    regex(/FlyKey[._-]?v?(\d+(?:\.\d+)+)[_-](\d+)/)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next unless match
+
+      "#{match[1]},#{match[2]}"
+    end
   end
 
   app "FlyKey.app"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`flykey` is autobumped but the workflow failed to update to version 1.7.1 because the appcast that is out of date and livecheck is returning 1.6.6 as newest. This updates the version and modifies the `livecheck` block to use the appcast that the current app is using. The newest version in the appcast has a `sparkle:version` value that doesn't align with the suffix in the file name, so it was necessary to add a regex and a `strategy` block to match the version from the file name instead.