### PR TITLE
stremio 5.1.14

### DIFF
--- a/Casks/s/stremio.rb
+++ b/Casks/s/stremio.rb
@@ -1,15 +1,25 @@
 cask "stremio" do
-  version "4.4.172"
-  sha256 "a91fc0aa92f6e5593718c69b5558a383b02abde0e56901a13ec21d5365b6e1e0"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://dl.strem.io/shell-osx/v#{version}/Stremio+#{version}.dmg"
+  version "5.1.14"
+  sha256 arm:   "7e7c9a7a433b7d3b9491ecde10afe64ca0912a3e5c39126f0d04da6f14484bd9",
+         intel: "c23ab8260314aa92038508fe2677f12837218f16b028f51ee9e6d3a8f7beb933"
+
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
+
+  url "https://dl.strem.io/stremio-shell-macos/v#{version}/Stremio_#{arch}.dmg"
   name "Stremio"
   desc "Open-source media center"
   homepage "https://www.strem.io/"
 
   livecheck do
-    url "https://www.strem.io/download?platform=mac&four=true"
-    strategy :header_match
+    url "https://www.stremio.com/downloads"
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/Stremio[._-]#{arch}\.dmg}i)
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
@@ -24,8 +34,4 @@ cask "stremio" do
     "~/Library/Preferences/com.stremio.Stremio.plist",
     "~/Library/Saved Application State/com.smartcodeltd.stremio.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`stremio` is autobumped but the workflow failed to update to version 5.1.14 because the `livecheck` block URL does not return the latest version (it's currently giving 4.4.116 as newest). This updates the version and modifies the `livecheck` block to check the download page, which links to the current dmg files.