### PR TITLE
vienna 3.10.0

### DIFF
--- a/Casks/v/vienna.rb
+++ b/Casks/v/vienna.rb
@@ -1,8 +1,8 @@
 cask "vienna" do
-  version "3.9.5"
-  sha256 "ad42b17574fd91741fe1b80717e0d713e09a451d127e975f6b5746031236db0f"
+  version "3.10.0"
+  sha256 "801e25f6057c55c9bc769358855813c9e1518a7ed91d3c98fa799812246bdd8b"
 
-  url "https://downloads.sourceforge.net/vienna-rss/v_#{version}/Vienna#{version}.tgz",
+  url "https://downloads.sourceforge.net/vienna-rss/v_#{version}/Vienna#{version}.dmg",
       verified: "downloads.sourceforge.net/vienna-rss/"
   name "Vienna"
   desc "RSS and Atom reader"
@@ -10,7 +10,7 @@ cask "vienna" do
 
   livecheck do
     url "https://www.vienna-rss.com/sparkle-files/changelog.xml"
-    regex(/Vienna[._-]?v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/Vienna[._-]?v?(\d+(?:\.\d+)+)/i)
     strategy :sparkle do |items, regex|
       items.map { |item| item.url[regex, 1] }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`vienna` is autobumped but the workflow failed to update to version 3.10.0 because livecheck wasn't able to surface the newest version. The regex is set up to match tarballs but version 3.10.0 uses a dmg file. This updates the version and loosens the `livecheck` block regex to allow it to match regardless of file type (sometimes a bad idea but okay in this particular context).