### PR TITLE
jumpshare: update sha256 for 3.4.22

### DIFF
--- a/Casks/j/jumpshare.rb
+++ b/Casks/j/jumpshare.rb
@@ -1,6 +1,6 @@
 cask "jumpshare" do
   version "3.4.22"
-  sha256 "e90384be0f0fdd72c2152cc4b91a52296b40b0d720a6d261b53aabf5c01f6e4c"
+  sha256 "310cae76f0c4d3cc0feca8a0ab89f6de707dd349e7ff4dc526a0e90d38e43383"
 
   url "https://d21hi1or3tbtjm.cloudfront.net/desktop/mac/updates/Jumpshare-#{version}.tar.bz2",
       verified: "d21hi1or3tbtjm.cloudfront.net/desktop/mac/updates/"


### PR DESCRIPTION
The upstream binary for Jumpshare 3.4.22 was republished with a different checksum, causing installation to fail:

```
Error: Cask reports different checksum:     e90384be0f0fdd72c2152cc4b91a52296b40b0d720a6d261b53aabf5c01f6e4c
       SHA-256 checksum of downloaded file: 310cae76f0c4d3cc0feca8a0ab89f6de707dd349e7ff4dc526a0e90d38e43383
```

This updates the sha256 to match the current download.