### PR TITLE
iloader 2.0.2 (new cask)

### DIFF
--- a/Casks/i/iloader.rb
+++ b/Casks/i/iloader.rb
@@ -1,0 +1,14 @@
+cask "iloader" do
+  version "2.0.2"
+  sha256 "d39a73b9d2b6232dde6b618c040106e0ecdb38d8ab290b848e26f3194d59a379"
+
+  url "https://github.com/nab138/iloader/releases/download/v#{version}/iloader-darwin-universal.dmg",
+      verified: "github.com/nab138/iloader/"
+  name "iloader"
+  desc "iOS Sideloading Companion"
+  homepage "https://iloader.app/"
+
+  app "iloader.app"
+
+  zap trash: "~/Library/Application Support/me.nabdev.iloader"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
        https://github.com/eseiker/homebrew-cask/pull/1: I used codex to prototype the cask file
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

<details>
<summary>checks</summary>

```
brew update
brew audit --cask --online iloader
brew style --fix iloader
brew audit --cask --new iloader
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask iloader
brew uninstall --cask iloader

==> Updating Homebrew...
Already up-to-date.
==> Downloading https://github.com/nab138/iloader/releases/download/v2.0.2/iloader-darwin-universal.dmg
==> Downloading from https://release-assets.githubusercontent.com/github-production-release-asset/1087993542/fc3f6c
############################################################################################################ 100.0%
==> Downloading and extracting artifacts
==> Downloading https://github.com/nab138/iloader/releases/download/v2.0.2/iloader-darwin-universal.dmg
Already downloaded: /Users/mizuki/Library/Caches/Homebrew/downloads/33c87e45c0b522dc0dc1aac93147c6b9a789fa6632fff1a96f101ce6f41e4144--iloader-darwin-universal.dmg

1 file inspected, no offenses detected
==> Downloading https://github.com/nab138/iloader/releases/download/v2.0.2/iloader-darwin-universal.dmg
Already downloaded: /Users/mizuki/Library/Caches/Homebrew/downloads/33c87e45c0b522dc0dc1aac93147c6b9a789fa6632fff1a96f101ce6f41e4144--iloader-darwin-universal.dmg
==> Downloading and extracting artifacts
==> Downloading https://github.com/nab138/iloader/releases/download/v2.0.2/iloader-darwin-universal.dmg
Already downloaded: /Users/mizuki/Library/Caches/Homebrew/downloads/33c87e45c0b522dc0dc1aac93147c6b9a789fa6632fff1a96f101ce6f41e4144--iloader-darwin-universal.dmg
==> Downloading https://github.com/nab138/iloader/releases/download/v2.0.2/iloader-darwin-universal.dmg
Already downloaded: /Users/mizuki/Library/Caches/Homebrew/downloads/33c87e45c0b522dc0dc1aac93147c6b9a789fa6632fff1a96f101ce6f41e4144--iloader-darwin-universal.dmg
==> Installing Cask iloader
==> Moving App 'iloader.app' to '/Applications/iloader.app'
🍺  iloader was successfully installed!
==> Uninstalling Cask iloader
==> Backing App 'iloader.app' up to '/opt/homebrew/Caskroom/iloader/2.0.2/iloader.app'
==> Removing App '/Applications/iloader.app'
==> Purging files for version 2.0.2 of Cask iloader
```
</details>