### PR TITLE
claude-devtools 0.4.1 (new cask)

### DIFF
--- a/Casks/c/claude-devtools.rb
+++ b/Casks/c/claude-devtools.rb
@@ -1,0 +1,34 @@
+cask "claude-devtools" do
+  version "0.4.1"
+
+  on_arm do
+    sha256 "e6796cf0fdec123a882ac4781fe8935ff9bb4597553cf6392a72877bb4385717"
+
+    url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}-arm64.dmg"
+  end
+  on_intel do
+    sha256 "828612ce5080871acdc016d0ab3117d823b140bc3cbff3bef1c6d91140a68628"
+
+    url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}.dmg"
+  end
+
+  name "Claude DevTools"
+  desc "Visualize and analyze Claude Code session executions"
+  homepage "https://github.com/matt1398/claude-devtools"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+  auto_updates true
+
+  app "claude-devtools.app"
+
+  zap trash: [
+    "~/Library/Application Support/claude-devtools",
+    "~/Library/Caches/com.claudecode.context",
+    "~/Library/Preferences/com.claudecode.context.plist",
+  ]
+end


### PR DESCRIPTION
## Summary
- New cask for [Claude DevTools](https://github.com/matt1398/claude-devtools) — Electron app that visualizes and analyzes Claude Code session executions
- 600+ GitHub stars, macOS app with code signing and notarization
- Supports both ARM and Intel architectures

## Testing
- `brew install --cask claude-devtools` — installed successfully
- `brew uninstall --cask claude-devtools` — uninstalled successfully
- `brew style --fix` — no offenses
- `brew audit --cask --new claude-devtools` — passes except for repo age (<30 days), requesting maintainer discretion

Built and tested locally on macOS Sequoia (ARM).

> **Note:** The GitHub repository is less than 30 days old. Requesting maintainer discretion given the project's traction (600+ stars).

- [x] AI-assisted: Used Claude Code for cask file generation. Manually reviewed, tested, and verified all changes including `zap` stanza paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)