### PR TITLE
claude-devtools 0.4.4 (new cask)

### DIFF
--- a/Casks/c/claude-devtools.rb
+++ b/Casks/c/claude-devtools.rb
@@ -1,19 +1,13 @@
 cask "claude-devtools" do
+  arch arm: "-arm64", intel: ""
+
   version "0.4.2"
+  sha256 arm:   "66b8c0dd5cb39d6ee2771c3ef483e4a903f518054e7abfeb37746aad2145a4cc",
+         intel: "25794c903788e69d52d49acdee2a141caf82f3bac3a4f624eb2d51f96b7f50d0"
 
-  on_arm do
-    sha256 "66b8c0dd5cb39d6ee2771c3ef483e4a903f518054e7abfeb37746aad2145a4cc"
-
-    url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}-arm64.dmg"
-  end
-  on_intel do
-    sha256 "25794c903788e69d52d49acdee2a141caf82f3bac3a4f624eb2d51f96b7f50d0"
-
-    url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}.dmg"
-  end
-
+  url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}#{arch}.dmg"
   name "Claude DevTools"
-  desc "Visualize and analyze Claude Code session executions"
+  desc "Visualise and analyse Claude Code session executions"
   homepage "https://github.com/matt1398/claude-devtools"
 
   livecheck do
@@ -21,8 +15,8 @@ cask "claude-devtools" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :monterey"
   auto_updates true
+  depends_on macos: ">= :monterey"
 
   app "claude-devtools.app"
 

--- a/Casks/c/claude-devtools.rb
+++ b/Casks/c/claude-devtools.rb
@@ -1,0 +1,34 @@
+cask "claude-devtools" do
+  version "0.4.1"
+
+  on_arm do
+    sha256 "e6796cf0fdec123a882ac4781fe8935ff9bb4597553cf6392a72877bb4385717"
+
+    url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}-arm64.dmg"
+  end
+  on_intel do
+    sha256 "828612ce5080871acdc016d0ab3117d823b140bc3cbff3bef1c6d91140a68628"
+
+    url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}.dmg"
+  end
+
+  name "Claude DevTools"
+  desc "Visualize and analyze Claude Code session executions"
+  homepage "https://github.com/matt1398/claude-devtools"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :monterey"
+  auto_updates true
+
+  app "claude-devtools.app"
+
+  zap trash: [
+    "~/Library/Application Support/claude-devtools",
+    "~/Library/Caches/com.claudecode.context",
+    "~/Library/Preferences/com.claudecode.context.plist",
+  ]
+end

--- a/Casks/c/claude-devtools.rb
+++ b/Casks/c/claude-devtools.rb
@@ -1,13 +1,13 @@
 cask "claude-devtools" do
-  version "0.4.1"
+  version "0.4.2"
 
   on_arm do
-    sha256 "e6796cf0fdec123a882ac4781fe8935ff9bb4597553cf6392a72877bb4385717"
+    sha256 "66b8c0dd5cb39d6ee2771c3ef483e4a903f518054e7abfeb37746aad2145a4cc"
 
     url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}-arm64.dmg"
   end
   on_intel do
-    sha256 "828612ce5080871acdc016d0ab3117d823b140bc3cbff3bef1c6d91140a68628"
+    sha256 "25794c903788e69d52d49acdee2a141caf82f3bac3a4f624eb2d51f96b7f50d0"
 
     url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}.dmg"
   end

--- a/Casks/c/claude-devtools.rb
+++ b/Casks/c/claude-devtools.rb
@@ -1,9 +1,9 @@
 cask "claude-devtools" do
-  arch arm: "-arm64", intel: ""
+  arch arm: "-arm64"
 
-  version "0.4.2"
-  sha256 arm:   "66b8c0dd5cb39d6ee2771c3ef483e4a903f518054e7abfeb37746aad2145a4cc",
-         intel: "25794c903788e69d52d49acdee2a141caf82f3bac3a4f624eb2d51f96b7f50d0"
+  version "0.4.4"
+  sha256 arm:   "2fde2fe7304a2ba66141499888838a453b226972cf3a834c0d46d348f21b3001",
+         intel: "6df46ba3d690bf313486fb3ef6eb5b51d7d6e0fcc896d59f0af33b2e2eb2a6ab"
 
   url "https://github.com/matt1398/claude-devtools/releases/download/v#{version}/claude-devtools-#{version}#{arch}.dmg"
   name "Claude DevTools"


### PR DESCRIPTION
## Summary
- New cask for [Claude DevTools](https://github.com/matt1398/claude-devtools) — Electron app that visualizes and analyzes Claude Code session executions
- 600+ GitHub stars, macOS app with code signing and notarization
- Supports both ARM and Intel architectures

## Testing
- `brew install --cask claude-devtools` — installed successfully
- `brew uninstall --cask claude-devtools` — uninstalled successfully
- `brew style --fix` — no offenses
- `brew audit --cask --new claude-devtools` — passes except for repo age (<30 days), requesting maintainer discretion

Built and tested locally on macOS Sequoia (ARM).

> **Note:** The GitHub repository is less than 30 days old. Requesting maintainer discretion given the project's traction (600+ stars).

- [x] AI-assisted: Used Claude Code for cask file generation. Manually reviewed, tested, and verified all changes including `zap` stanza paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)