### PR TITLE
fix: download expandrive using their api url

### DIFF
--- a/Casks/e/expandrive.rb
+++ b/Casks/e/expandrive.rb
@@ -1,9 +1,8 @@
 cask "expandrive" do
   version "2026.02.09.821"
-  sha256 "62892ba317fe186befed61204894fb2316a4691f7a0b72405c0372c661ac90c9"
+  sha256 :no_check
 
-  url "https://files-com-public-builds.s3.us-east-1.amazonaws.com/builds/ExpanDrive/#{version}/mac/ExpanDrive_#{version.major_minor_patch}.dmg",
-      verified: "files-com-public-builds.s3.us-east-1.amazonaws.com/builds/ExpanDrive/"
+  url "https://www.expandrive.com/api/download/expandrive?platform=macos"
   name "ExpanDrive"
   desc "Network drive and browser for cloud storage"
   homepage "https://www.expandrive.com/apps/expandrive/"


### PR DESCRIPTION
Expandrive API url redirects to a parameterized Amazon AWS download link, with limited validity. The unparameterized version no longer works. Unfortunately, there is no version support in this API, so the sha256 check needed to be dropped as well.

Fixes #250166

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----
