### PR TITLE
clipcascade 3.1.0 (new cask)

### DIFF
--- a/Casks/c/clipcascade.rb
+++ b/Casks/c/clipcascade.rb
@@ -1,0 +1,28 @@
+cask "clipcascade" do
+  arch arm: "ARM_M-Series", intel: "Intel-Series"
+
+  version "3.1.0"
+  sha256 arm:   "2187a3103397bab6569204f1942fee6419bb6e34c48d848d79ddc9163253a8f8",
+         intel: "7421ad6bbe961fee5af6b2fcc8a1b49a3aae993591f38069eec598a43b0d04de"
+
+  url "https://github.com/Sathvik-Rao/ClipCascade/releases/download/#{version}/ClipCascade-Apple_macOS.#{arch}.zip"
+  name "ClipCascade"
+  desc "Automatically sync clipboard across devices"
+  homepage "https://github.com/Sathvik-Rao/ClipCascade"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+
+  depends_on macos: ">= :big_sur"
+
+  app "ClipCascade-Apple_macOS(#{arch})/ClipCascade.app"
+
+  zap trash: [
+    "~/Library/Application Support/ClipCascade",
+    "~/Library/Preferences/ClipCascade.plist",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

AI was used to draft the initial cask and iterate on validation fixes.

Built and tested locally on macOS 26.3.

Adds a new `clipcascade` cask and marks it for current Gatekeeper limitation via `disable! ... :fails_gatekeeper_check`.
