### PR TITLE
dot 2.0.9 (new cask)

### DIFF
--- a/Casks/d/dot.rb
+++ b/Casks/d/dot.rb
@@ -5,7 +5,7 @@ cask "dot" do
   url "https://github.com/prateekkeshari/dot-releases/releases/download/v#{version}/Dot-#{version}.dmg",
       verified: "github.com/prateekkeshari/dot-releases/"
   name "Dot"
-  desc "Menu bar calendar for Mac with meeting reminders"
+  desc "Menu bar calendar with meeting reminders"
   homepage "https://www.trydot.app/"
 
   livecheck do

--- a/Casks/d/dot.rb
+++ b/Casks/d/dot.rb
@@ -1,0 +1,25 @@
+cask "dot" do
+  version "2.0.9"
+  sha256 "b4f7832c9107a79277875e02bcaf8505b1ecf848aafb7d46d8e4ebae3e7d59c7"
+
+  url "https://github.com/prateekkeshari/dot-releases/releases/download/v#{version}/Dot-#{version}.dmg",
+      verified: "github.com/prateekkeshari/dot-releases/"
+  name "Dot"
+  desc "Menu bar calendar for Mac with meeting reminders"
+  homepage "https://www.trydot.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "Dot.app"
+
+  zap trash: [
+    "~/Library/Application Scripts/com.dot.app/",
+    "~/Library/Caches/com.dot.app/",
+    "~/Library/Containers/com.dot.app/",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Note: the audit failed the notability requirement. However the software has been favourably reviewed on [_The Verge_](https://www.theverge.com/tech/879114/best-big-tech-app-alternatives-installer), [_Macstories_](https://www.macstories.net/reviews/dot-the-menu-bar-calendar-thats-become-my-main-calendar/) and [_MacSources_](https://macsources.com/dot-calendar-review/) and the GitHub account is only used for distributing releases (the app is not sold in the Mac App Store).