### PR TITLE
Add aeroftp cask

### DIFF
--- a/Casks/a/aeroftp.rb
+++ b/Casks/a/aeroftp.rb
@@ -1,0 +1,23 @@
+cask "aeroftp" do
+  version "2.5.1"
+  sha256 "73470234520a5a6f582f8ac4622987513d1e79a4a39e7cf58aa7a10007473369"
+
+  url "https://github.com/axpnet/aeroftp/releases/download/v#{version}/AeroFTP_#{version}_aarch64.dmg"
+  name "AeroFTP"
+  desc "Multi-protocol file manager with AI assistant, cloud sync, and encryption"
+  homepage "https://github.com/axpnet/aeroftp"
+
+  depends_on macos: ">= :catalina"
+  depends_on arch: :arm64
+
+  app "AeroFTP.app"
+
+  zap trash: [
+    "~/.config/aeroftp",
+    "~/Library/Application Support/com.aeroftp.AeroFTP",
+    "~/Library/Caches/com.aeroftp.AeroFTP",
+    "~/Library/Preferences/com.aeroftp.AeroFTP.plist",
+    "~/Library/Saved Application State/com.aeroftp.AeroFTP.savedState",
+    "~/Library/WebKit/com.aeroftp.AeroFTP",
+  ]
+end


### PR DESCRIPTION
### Description

New cask for **AeroFTP** — an open-source, multi-protocol file manager built with Tauri 2 (Rust + React 18).

- **Homepage:** https://github.com/axpnet/aeroftp
- **License:** GPL-3.0
- **Architecture:** Apple Silicon (aarch64)
- **Version:** 2.5.1

Supports 16 protocols (FTP, SFTP, WebDAV, S3, and 12 cloud providers), integrated AI assistant, encrypted vaults (AES-256-GCM-SIV), and real-time sync. Available in 47 languages.

### Checklist

- [x] Cask token matches the app name
- [x] SHA256 hash calculated from direct download
- [x] `zap` block includes Application Support, Caches, Preferences, Saved Application State, and WebKit
- [x] `depends_on arch: :arm64` specified (only aarch64 DMG available)