### PR TITLE
extradock 4.1.5 (new cask)

### DIFF
--- a/Casks/e/extradock.rb
+++ b/Casks/e/extradock.rb
@@ -1,0 +1,28 @@
+cask "extradock" do
+  version "4.1.5"
+  sha256 "8872c2af89d6ee4168d40355703e993e24d301778c39edf493bfb1c04cd8b2a0"
+
+  url "https://github.com/AppitStudio/extra-dock-updates/releases/download/v#{version}/extraDock.dmg",
+      verified: "github.com/AppitStudio/"
+  name "ExtraDock"
+  desc "Add fully customizable extra docks"
+  homepage "https://extradock.app/"
+
+  livecheck do
+    url "https://raw.githubusercontent.com/AppitStudio/extra-dock-updates/refs/heads/main/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "ExtraDock.app"
+
+  zap trash: [
+    "~/Library/Application Support/ExtraDock",
+    "~/Library/Caches/dignicy.extraDock",
+    "~/Library/HTTPStorages/dignicy.extraDock",
+    "~/Library/Preferences/dignicy.extraDock.plist",
+    "~/Library/Saved Application State/dignicy.extraDock.savedState",
+  ]
+end


### PR DESCRIPTION
This pull request adds ExtraDock 4.1.5, a commercial macOS application for adding fully customizable extra docks.

- URL: uses GitHub release downloads with version interpolation
- sha256: `8872c2af89d6ee4168d40355703e993e24d301778c39edf493bfb1c04cd8b2a0`
- verified: `github.com/AppitStudio/`
- depends_on: macOS >= Big Sur
- zap: cleans up user data and preferences

ExtraDock is a proprietary, paid app from the same developer as DockFlow and currently has 680+ users.
Requesting `ci-skip-repository` (GitHub notability exception), similar to DockFlow PR #232830.

Website: https://extradock.app/
GitHub: https://github.com/AppitStudio/extra-dock-updates

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.  
  Local run hit a tap-level issue unrelated to this cask (`cask_renames.json`), so leaving unchecked.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.  
  Fails only on GitHub notability; requesting `ci-skip-repository`.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Used Codex to validate the correctness of the changes and draft the PR texts.
Validated it manually after the process was done.