### PR TITLE
brood 0.2.3

### DIFF
--- a/Casks/b/brood.rb
+++ b/Casks/b/brood.rb
@@ -3,7 +3,6 @@ cask "brood" do
   sha256 "3be11616ee6759c3bfb398417b3081f547995ff5584b8e9b9085723a1cda70bf"
 
   url "https://github.com/kevinshowkat/brood/releases/download/v#{version}/Brood_#{version}_universal.dmg",
-      verified: "github.com/kevinshowkat/brood/"
   name "Brood"
   desc "Reference-first AI image editing desktop for developers"
   homepage "https://github.com/kevinshowkat/brood"

--- a/Casks/b/brood.rb
+++ b/Casks/b/brood.rb
@@ -1,0 +1,24 @@
+cask "brood" do
+  version "0.2.3"
+  sha256 "3be11616ee6759c3bfb398417b3081f547995ff5584b8e9b9085723a1cda70bf"
+
+  url "https://github.com/kevinshowkat/brood/releases/download/v#{version}/Brood_#{version}_universal.dmg",
+      verified: "github.com/kevinshowkat/brood/"
+  name "Brood"
+  desc "Reference-first AI image editing desktop for developers"
+  homepage "https://github.com/kevinshowkat/brood"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Brood.app"
+
+  zap trash: [
+    "~/.brood",
+    "~/Library/Caches/com.brood.app",
+    "~/Library/Preferences/com.brood.app.plist",
+    "~/Library/Saved Application State/com.brood.app.savedState",
+  ]
+end

--- a/Casks/b/brood.rb
+++ b/Casks/b/brood.rb
@@ -2,7 +2,7 @@ cask "brood" do
   version "0.2.3"
   sha256 "3be11616ee6759c3bfb398417b3081f547995ff5584b8e9b9085723a1cda70bf"
 
-  url "https://github.com/kevinshowkat/brood/releases/download/v#{version}/Brood_#{version}_universal.dmg",
+  url "https://github.com/kevinshowkat/brood/releases/download/v#{version}/Brood_#{version}_universal.dmg"
   name "Brood"
   desc "Reference-first AI image editing desktop for developers"
   homepage "https://github.com/kevinshowkat/brood"


### PR DESCRIPTION
## Summary
Add a new cask for Brood, a reference-first AI image editing desktop app for macOS.

## Checklist
- [x] Cask follows Homebrew style conventions
- [x] `brew style Casks/b/brood.rb` passes locally
- [x] URL points to a versioned, publicly accessible release artifact

## App
- Homepage: https://github.com/kevinshowkat/brood
- Release used: https://github.com/kevinshowkat/brood/releases/tag/v0.2.3
