### PR TITLE
bucketmate 1.0 (new cask)

### DIFF
--- a/Casks/b/bucketmate.rb
+++ b/Casks/b/bucketmate.rb
@@ -1,0 +1,27 @@
+cask "bucketmate" do
+  version "1.0"
+  sha256 "43e8e9aa0b2921b49ed1326657eaaef2f0b48111df8ff28d435449c2bcaa56e1"
+
+  url "https://github.com/davidtranjs/bucketmate-releases/releases/download/v#{version}/BucketMate-#{version}.dmg",
+      verified: "github.com/davidtranjs/bucketmate-releases/"
+  name "BucketMate"
+  desc "S3-compatible GUI client"
+  homepage "https://bucketmate.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "BucketMate.app"
+
+  zap trash: [
+    "~/Library/Application Support/BucketMate",
+    "~/Library/Caches/app.bucketmate.mac",
+    "~/Library/Preferences/app.bucketmate.mac.plist",
+    "~/Library/Saved Application State/app.bucketmate.mac.savedState",
+  ]
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.

After making all changes to a cask, verify:

- [x] `brew audit --cask Casks/b/bucketmate.rb` is error-free.
- [x] `brew style --fix Casks/b/bucketmate.rb` reports no offenses.
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-stanza-details).
- [x] Checked the cask was not [already refused](https://github.com/Homebrew/homebrew-cask/pulls?q=is%3Apr+is%3Aclosed+is%3Aunmerged+). 
- [x] Checked the cask is submitted to [the correct repo](https://docs.brew.sh/Acceptable-Casks#finding-a-home-for-your-cask).

---

**App Details:**
- **Name:** BucketMate
- **Description:** S3-compatible GUI client
- **Homepage:** https://bucketmate.app/
- **Download:** https://github.com/davidtranjs/bucketmate-releases/releases/download/v1.0/BucketMate-1.0.dmg
- **Version:** 1.0
- **SHA256:** 43e8e9aa0b2921b49ed1326657eaaef2f0b48111df8ff28d435449c2bcaa56e1

**Note:** This is a new app submission. The repository may not yet meet Homebrew's notability requirements (90 forks, 90 watchers, 225 stars). Please consider if an exception is appropriate or waiting until the app gains more community adoption.