### PR TITLE
configurador-fnmt 5.1.1 (new cask)

### DIFF
--- a/Casks/c/configurador-fnmt.rb
+++ b/Casks/c/configurador-fnmt.rb
@@ -16,8 +16,8 @@ cask "configurador-fnmt" do
 
   pkg "InstaladorConfiguradorFnmt_#{version}.pkg"
 
-  uninstall pkgutil: "es.gob.fnmt.cert.certrerquest",
-            quit:    "es.gob.fnmt.cert.certrerquest"
+  uninstall quit:    "es.gob.fnmt.cert.certrerquest",
+            pkgutil: "es.gob.fnmt.cert.certrerquest"
 
   zap trash: [
     "~/Library/Application Support/Configurador FNMT",

--- a/Casks/c/configurador-fnmt.rb
+++ b/Casks/c/configurador-fnmt.rb
@@ -1,0 +1,27 @@
+cask "configurador-fnmt" do
+  version "5.1.1"
+  sha256 "004ff8daa0f812728942df21ccbf835f0ea4bad35ba4bc1d02e28359de7c9391"
+
+  url "https://descargas.cert.fnmt.es/Mac/InstaladorConfiguradorFnmt_#{version}.pkg",
+      verified: "cert.fnmt.es/"
+  name "Configurador FNMT"
+  desc "Key generation and certificate request tool for FNMT digital certificates"
+  homepage "https://www.sede.fnmt.gob.es/certificados/persona-fisica/obtener-certificado-software/configuracion-previa"
+
+  livecheck do
+    url "https://www.sede.fnmt.gob.es/certificados/persona-fisica/obtener-certificado-software/configuracion-previa"
+    regex(/InstaladorConfiguradorFnmt[._-](\d+(?:\.\d+)+)\.pkg/i)
+    strategy :page_match
+  end
+
+  pkg "InstaladorConfiguradorFnmt_#{version}.pkg"
+
+  uninstall pkgutil: "es.gob.fnmt.cert.certrerquest",
+            quit:    "es.gob.fnmt.cert.certrerquest"
+
+  zap trash: [
+    "~/Library/Application Support/Configurador FNMT",
+    "~/Library/Caches/es.gob.fnmt.cert.certrerquest",
+    "~/Library/Preferences/es.gob.fnmt.cert.certrerquest.plist",
+  ]
+end

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -1,5 +1,6 @@
 {
   "ai-studio": "all",
+  "configurador-fnmt": "all",
   "icon-composer": "intel",
   "plover": "intel"
 }


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online configurador-fnmt` is error-free.
- [x] `brew style --fix configurador-fnmt` reports no offenses.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new configurador-fnmt` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask configurador-fnmt` worked successfully.
- [x] `brew uninstall --cask configurador-fnmt` worked successfully.

**If AI was used to generate or assist with generating the PR:**
- [x] I used AI to generate or assist with generating this PR. Please specify below how you used AI to help you.

*I used an AI assistant to help write the Ruby syntax and research the correct bundle ID, homepage URL, and zap paths.*

- [x] I have personally reviewed, tested and verified **all** changes/additions, including [zap stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

---

Adds the [Configurador FNMT](https://www.sede.fnmt.gob.es/certificados/persona-fisica/obtener-certificado-software/configuracion-previa), the official macOS app from Spain's FNMT (Fábrica Nacional de Moneda y Timbre) required to generate cryptographic keys and request digital certificates.

**Notes for reviewers:**
- The PKG is signed with a "3rd Party Mac Developer Installer" certificate instead of "Developer ID Installer", which causes `spctl --assess` to reject it. This is a signing issue on FNMT's side. Added `configurador-fnmt` to `audit_exceptions/signing_audit_skiplist.json` accordingly.
- Livecheck uses `strategy :page_match` against the official FNMT download page.