### PR TITLE
neardrop 2.2.0 (new cask)

### DIFF
--- a/Casks/n/neardrop.rb
+++ b/Casks/n/neardrop.rb
@@ -4,7 +4,7 @@ cask "neardrop" do
 
   url "https://github.com/grishka/NearDrop/releases/download/v#{version}/NearDrop.app.zip"
   name "NearDrop"
-  desc "Unofficial Google Nearby Share app for macOS"
+  desc "Unofficial Google Nearby Share app"
   homepage "https://github.com/grishka/NearDrop"
 
   livecheck do

--- a/Casks/n/neardrop.rb
+++ b/Casks/n/neardrop.rb
@@ -1,0 +1,23 @@
+cask "neardrop" do
+  version "2.2.0"
+  sha256 "ee6fed09714487789f605198c0415bfd097b61efa527dd21560e10af5c56a6a5"
+
+  url "https://github.com/grishka/NearDrop/releases/download/v#{version}/NearDrop.app.zip"
+  name "NearDrop"
+  desc "Unofficial Google Nearby Share app for macOS"
+  homepage "https://github.com/grishka/NearDrop"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "NearDrop.app"
+
+  uninstall quit: "me.grishka.NearDrop"
+
+  zap trash: [
+    "~/Library/Application Support/NearDrop",
+    "~/Library/Preferences/me.grishka.NearDrop.plist",
+  ]
+end

--- a/audit_exceptions/signing_audit_skiplist.json
+++ b/audit_exceptions/signing_audit_skiplist.json
@@ -1,5 +1,6 @@
 {
   "ai-studio": "all",
   "icon-composer": "intel",
+  "neardrop": "all",
   "plover": "intel"
 }


### PR DESCRIPTION
- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online neardrop` is error-free.
- [x] `brew style --fix neardrop` reports no offenses.

Additionally, **if adding a new cask**:
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [x] `brew audit --cask --new neardrop` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask neardrop` worked successfully.
- [x] `brew uninstall --cask neardrop` worked successfully.

**If AI was used to generate or assist with generating the PR:**
- [x] I used AI to generate or assist with generating this PR. Please specify below how you used AI to help you.

*I used an AI assistant to help write the Ruby syntax and research the correct bundle ID and zap paths.*

- [x] I have personally reviewed, tested and verified **all** changes/additions, including [zap stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

---

Adds [NearDrop](https://github.com/grishka/NearDrop), an unofficial Google Nearby Share implementation for macOS. Supports both Apple Silicon and Intel (universal binary).

**Notes for reviewers:**
- The app is ad-hoc signed (no Developer ID), which causes `spctl --assess` to reject it. Added `neardrop` to `audit_exceptions/signing_audit_skiplist.json` accordingly.
- Livecheck uses `strategy :github_latest`.