### PR TITLE
mos 4.0.0

### DIFF
--- a/Casks/m/mos.rb
+++ b/Casks/m/mos.rb
@@ -1,14 +1,17 @@
 cask "mos" do
-  version "3.5.0"
-  sha256 "a361f871f32e763a101df29e57839188ef7fb33a289853f420fe83e9e70c008e"
+  version "4.0.0,20260220.1"
+  sha256 "c717bf8e8115a0daf607e7bde7a7f8b07816a175b916c3a8f6134afc8c18a9c4"
 
-  url "https://github.com/Caldis/Mos/releases/download/#{version}/Mos.Versions.#{version}.dmg",
+  url "https://github.com/Caldis/Mos/releases/download/#{version.csv.first}/Mos.Versions.#{version.csv.first}#{"-#{version.csv.second}" if version.csv.second}.zip",
       verified: "github.com/Caldis/Mos/"
   name "Mos"
   desc "Smooths scrolling and set mouse scroll directions independently"
   homepage "https://mos.caldis.me/"
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  livecheck do
+    url "https://mos.caldis.me/appcast.xml"
+    strategy :sparkle
+  end
 
   conflicts_with cask: "mos@beta"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`mos` is autobumped but the workflow failed to update to version 4.0.0 because the file name includes a date-based suffix and is now a zip instead of a dmg. Besides that, the app now passes the Gatekeeper check. This updates the version and url, removes the `disable!` call, and updates the `livecheck` block to check the Sparkle appcast that the current app checks.