### PR TITLE
soundanchor 1.6.1

### DIFF
--- a/Casks/s/soundanchor.rb
+++ b/Casks/s/soundanchor.rb
@@ -1,9 +1,9 @@
 cask "soundanchor" do
-  version "1.6.0"
-  sha256 "035065faf2fdd3e5e9b2c7e43d09f17254cf637c6882d34b78d8c0f4d81868cb"
+  version "1.6.1"
+  sha256 "90872e7cd66aeed0b9cf3ecab132be4f5b27743d485d5dc60903d5d0c9567444"
 
-  url "https://kopiro.s3.eu-west-1.amazonaws.com/soundanchor/SoundAnchor-#{version}.dmg",
-      verified: "kopiro.s3.eu-west-1.amazonaws.com/soundanchor/"
+  url "https://kopiro.s3.amazonaws.com/soundanchor/soundanchor-#{version}.dmg",
+      verified: "kopiro.s3.amazonaws.com/soundanchor/"
   name "SoundAnchor"
   desc "Audio device utility"
   homepage "https://apps.kopiro.me/soundanchor/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`soundanchor` is autobumped but the workflow failed to update to version 1.6.1 because the AWS domain upstream uses and the file name format has changed. This updates the version and adjusts the `url` to align with the file URL used in the appcast.