### PR TITLE
cahier: disable

### DIFF
--- a/Casks/c/cahier.rb
+++ b/Casks/c/cahier.rb
@@ -7,10 +7,7 @@ cask "cahier" do
   desc "Knowledge base with native support for research"
   homepage "https://getcahier.com/"
 
-  livecheck do
-    url "https://getcahier.com/releases-macos/appcast.xml"
-    strategy :sparkle
-  end
+  disable! date: "2026-02-23", because: :discontinued
 
   auto_updates true
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Various URLs for `cahier` redirect to a "Project Archives" page that states "Thank you for your interest in this project, but the software is archived as of February 2026." The dmg file no longer resolves, so this removes the `livecheck` block and disables the cask.

For what it's worth, I was temporarily having trouble pushing to `origin` (it simply hung), so I created this branch on my fork as a temporary workaround. It seems like pushing to origin works again for me now.