### PR TITLE
ytmdesktop-youtube-music 2.0.11

### DIFF
--- a/Casks/y/ytmdesktop-youtube-music.rb
+++ b/Casks/y/ytmdesktop-youtube-music.rb
@@ -1,21 +1,12 @@
 cask "ytmdesktop-youtube-music" do
   arch arm: "arm64", intel: "x64"
 
-  on_arm do
-    version "2.0.0"
-    sha256 "c7a7734d295eaa3a8a7d42db2c2013618fd3fc06e9600d1c1485e1eec153b0cd"
+  version "2.0.11"
+  sha256 arm:   "a316f258d35f9f2b13c2bc883eafbe70cc50960060af4418e969c9466d83daba",
+         intel: "beca2759e23325cfdfc813c0d4a3b2e38d3be1b72bd87471a404c97b4d6927f7"
 
-    url "https://github.com/ytmdesktop/ytmdesktop/releases/download/v#{version}/YouTube-Music-Desktop-App-darwin-#{arch}-#{version}.zip",
-        verified: "github.com/ytmdesktop/ytmdesktop/"
-  end
-  on_intel do
-    version "2.0.10"
-    sha256 "4c401fe2c6c8b128c62bc5ff5e44f909c5230285dc82660e0b9dbff706177de0"
-
-    url "https://github.com/ytmdesktop/ytmdesktop/releases/download/v#{version}/YouTube.Music.Desktop.App-darwin-#{arch}-#{version}.zip",
-        verified: "github.com/ytmdesktop/ytmdesktop/"
-  end
-
+  url "https://github.com/ytmdesktop/ytmdesktop/releases/download/v#{version}/YouTube.Music.Desktop.App-darwin-#{arch}-#{version}.zip",
+      verified: "github.com/ytmdesktop/ytmdesktop/"
   name "YouTube Music Desktop App"
   desc "YouTube music client"
   homepage "https://ytmdesktop.app/"
@@ -41,7 +32,7 @@ cask "ytmdesktop-youtube-music" do
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :monterey"
 
   app "YouTube Music Desktop App.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`ytmdesktop-youtube-music` is autobumped but the workflow failed to update to version 2.0.11 because there's now an ARM version again but the file name format changed in the interim time. This updates the version and reworks the cask to return to a one version setup for now.

I've left the `livecheck` block checking multiple releases with `GithubReleases` for now. If/when upstream reliably publishes both ARM and Intel versions going forward, we can/should switch back to `GithubLatest`.