### PR TITLE
expressvpn 12.1.0.12141

### DIFF
--- a/Casks/e/expressvpn.rb
+++ b/Casks/e/expressvpn.rb
@@ -1,6 +1,6 @@
 cask "expressvpn" do
-  version "12.1.0.12128"
-  sha256 "7605841cd443f55f8ba3938c273f93c6e47f74aa768a23757d01085de5ed8887"
+  version "12.1.0.12141"
+  sha256 "427a1b5a9fcad0e202cfe237203d91d0f6e4cf143dc984a1b51254701f4b8b11"
 
   url "https://www.expressvpn.works/clients/mac/expressvpn-macos-universal-#{version}_release.zip"
   name "ExpressVPN"
@@ -8,7 +8,7 @@ cask "expressvpn" do
   homepage "https://www.expressvpn.works/"
 
   livecheck do
-    url "https://www.expressvpn.works/vpn-download/vpn-mac"
+    url "https://portal.expressvpn.com/latest"
     regex(/href=.*?expressvpn[._-]macos[._-]universal[._-]v?(\d+(?:\.\d+)+)[._-]release\.zip/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`expressvpn` is autobumped` but the workflow failed to update to version 12.1.0.12141 because the `livecheck` block was producing an "Unable to get versions" error due to the page linking to a separate download page instead of including download links. This updates the version and modifies the `livecheck` block to check the page where the latest download links are found.