### PR TITLE
hdfview 3.4.1

### DIFF
--- a/Casks/h/hdfview.rb
+++ b/Casks/h/hdfview.rb
@@ -1,8 +1,11 @@
 cask "hdfview" do
-  version "3.3.2"
-  sha256 "40d111afc43fe9f1138692d1fb40c1330ea4f4416a2163e5dc4b4c398fb779bf"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://github.com/HDFGroup/hdfview/releases/download/v#{version}/HDFView-#{version}-Darwin.tar.gz",
+  version "3.4.1"
+  sha256 arm:   "a1669bb6cbd32f65cfd3f0c1839a094cd29bcec1ad3697cfb95d704dfaefd603",
+         intel: "776a87f2f6106d8b10183c8976aec303da88518de0412fa0440d433d95596c03"
+
+  url "https://github.com/HDFGroup/hdfview/releases/download/v#{version}/HDFView-#{version}App-Darwin-#{arch}.tar.gz",
       verified: "github.com/HDFGroup/hdfview/"
   name "HDFView"
   desc "Tool for browsing and editing HDF files"
@@ -17,10 +20,8 @@ cask "hdfview" do
   # `HDFView-3.3.99` isn't marked as pre-release).
   livecheck do
     url :homepage
-    regex(/HDFView[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/HDFView[._-]v?(\d+(?:\.\d+)+)[._-]?App[._-]Darwin[._-]#{arch}\.t/i)
   end
-
-  container nested: "HDFView-#{version}.dmg"
 
   app "HDFView.app"
 
@@ -29,8 +30,4 @@ cask "hdfview" do
     "~/Library/Preferences/HDFView.hdfgroup.org.plist",
     "~/Library/Saved Application State/hdf.view.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`hdfview` is autobumped but the workflow failed to update to version 3.4.1 because the `livecheck` block produced an "Unable to get versions" error as the file name format has changed (so the regex doesn't match it). This updates the version (adjusting the cask to handle the arch-specific files) and updates the `livecheck` block regex accordingly. For what it's worth, the "latest" release on GitHub is version 3.4.1, so we may be able to switch to the `GithubLatest` strategy but I've left this as-is for now (allowing some time to pass to see if the "latest" release is consistently a stable release going forward).