### PR TITLE
insta360-link-controller: update url, livecheck

### DIFF
--- a/Casks/i/insta360-link-controller.rb
+++ b/Casks/i/insta360-link-controller.rb
@@ -1,15 +1,15 @@
 cask "insta360-link-controller" do
-  version "2.2.1,build24,520b33b77a91490dae31c63154e36934"
-  sha256 "f714c73ae6b8eb895ba501667e4405b80b6e9ab1e51c1ea0bcad7ab22c3a6c96"
+  version "2.2.1,build24,_20260202_115048_signed_1770004724733,da87dfa499b745129aa20d51113aab71"
+  sha256 "47e626ce250ec39ea457e53ae538ccaac0cc3e2bc73d04f4c8801eb0b5a6c3e1"
 
-  url "https://wassets.insta360.com/common/#{version.csv.third}/Insta360LinkController_#{version.csv.first}(#{version.csv.second}).pkg"
+  url "https://wassets.insta360.com/common/#{version.csv.fourth}/Insta360LinkController_#{version.csv.first}(#{version.csv.second})#{version.csv.third}.pkg"
   name "Insta360 Link Controller"
   desc "Controller for Insta360 webcams"
   homepage "https://www.insta360.com/"
 
   livecheck do
     url "https://openapi.insta360.com/app/appDownload/getGroupApp?group=insta360-link&X-Language=en-us"
-    regex(%r{/(\h+)/Insta360LinkController_\d+\.\d+\.\d+\((build\d+)\)\.pkg}i)
+    regex(%r{/(\h+)/Insta360(?:[._-]|%20)?LinkController(?:[._-]|%20)v?(\d+(?:\.\d+)+)[._-]?(.+?)\.(?:pkg|zip)}i)
     strategy :json do |json, regex|
       # Find the Insta360 Link Controller app
       app = json.dig("data", "apps")&.find { |item| item["app_id"] == 100 }
@@ -24,16 +24,14 @@ cask "insta360-link-controller" do
       channel = newest_release["channels"]&.find { |item| item["channel"] == "official" }
       next if channel.blank?
 
-      # Collect the version parts
-      version = newest_release["version"]
       match = channel["download_url"]&.match(regex)
-      next if version.blank? || match.blank?
+      next unless match
 
-      "#{version.split("_").first},#{match[2]},#{match[1]}"
+      "#{match[2]},#{match[3].tr("()", ",")},#{match[1]}".gsub(/,{2,}/, ",")
     end
   end
 
-  pkg "Insta360LinkController_#{version.csv.first}(#{version.csv.second}).pkg"
+  pkg "Insta360LinkController_#{version.csv.first}(#{version.csv.second})#{version.csv.third}.pkg"
 
   uninstall quit:    "com.insta360.linkcontroller",
             pkgutil: "com.insta360.webcam"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `insta360-link-controller` is producing an "Unable to get versions" error, as the file in the JSON now uses a horrifying format similar to `insta360-studio`. The version/build remains the same but this updates the version/url to use the current pkg file URL and adjusts the `livecheck` block to borrow some of the logic from `insta360-studio`. This is going to inevitably break again but it works for now.