### PR TITLE
jamovi 2.7.18.0

### DIFF
--- a/Casks/j/jamovi.rb
+++ b/Casks/j/jamovi.rb
@@ -1,17 +1,19 @@
 cask "jamovi" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.7.17.0"
-  sha256 arm:   "22a55e3d9becd5cd8cca0d302689df848f579fc052a49cfc77385848f95b9e72",
-         intel: "cc8301aa3f8017d4d951ff0af729fbab141f4749db011fd7955f9b3127146b82"
+  version "2.7.18.0"
+  sha256 arm:   "0757defb5a5b03281f67ec95ffea3fcd3c20ffa2e2313ed348d5c380e10c02e3",
+         intel: "98df4905af57a6ac43217a1e68d2d92beaa019901e60a08d103887daef69fa8a"
 
   url "https://www.jamovi.org/downloads/jamovi-#{version}-macos-#{arch}.dmg"
   name "jamovi"
   desc "Statistical software"
   homepage "https://www.jamovi.org/"
 
+  # The download page will redirect to the homepage unless a `referer` is used.
   livecheck do
-    url "https://www.jamovi.org/download.html"
+    url "https://www.jamovi.org/download.html",
+        referer: "https://www.jamovi.org"
     regex(/href=.*?jamovi[._-]v?(\d+(?:\.\d+)+)[._-]macos[._-]#{arch}\.dmg/i)
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`jamovi` is autobumped but the workflow failed to update to version 2.7.18.0 because the `livecheck` block produces an "Unable to get versions" error due to the download page redirecting to the homepage unless a `referer` is used. This updates the version and modifies the `livecheck` block accordingly.