### PR TITLE
keycue: update livecheck

### DIFF
--- a/Casks/k/keycue.rb
+++ b/Casks/k/keycue.rb
@@ -9,8 +9,8 @@ cask "keycue" do
   homepage "https://ergonis.com/keycue"
 
   livecheck do
-    url "https://ergonis.com/keycue/download"
-    regex(/<h\d.*?KeyCue\sv?(\d+(?:\.\d+)+)/i)
+    url "https://ergonis.com/en/keycue/download"
+    regex(%r{/keycue/mac/v?(\d+(?:\.\d+)+)/}i)
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `keycue` produces an "Unable to get versions" error, as the page contents have changed and the regex no longer matches. This updates the regex to match the version from the link to the versioned download page and updates the URL to avoid a redirection (and ensure we're checking a specific page, for the sake of reliability).