### PR TITLE
laserpecker-design-space 2.11.0

### DIFF
--- a/Casks/l/laserpecker-design-space.rb
+++ b/Casks/l/laserpecker-design-space.rb
@@ -1,9 +1,9 @@
 cask "laserpecker-design-space" do
   arch arm: "M1", intel: "Mac"
 
-  version "2.10.0"
-  sha256 arm:   "8dc17a4b35038d00cd0c30efdaa9b1ca558654538d17527d6e73fd108c426a7d",
-         intel: "249058f8b1a57b3ba8e6df182a62518ff8ef4117098c5a50b89b478017643938"
+  version "2.11.0"
+  sha256 arm:   "3d09f0377ea4ee79a995feaa97f0ebec6e020e3ae5cc51f51bf2d540206f6fca",
+         intel: "65830a128fac9d500571550874f16386f5f7ff0517c1b11fc81a2e171a9bba64"
 
   url "https://laserpecker-prod.oss-cn-hongkong.aliyuncs.com/apply/software/pc/LaserPecker-Design-Space-#{arch}-#{version}.dmg",
       verified: "laserpecker-prod.oss-cn-hongkong.aliyuncs.com/"
@@ -12,8 +12,8 @@ cask "laserpecker-design-space" do
   homepage "https://laserpecker.net/"
 
   livecheck do
-    url "https://laserpecker.net/pages/software-download"
-    regex(/href=.*LaserPecker[._-]Design[._-]Space[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
+    url "https://www.laserpecker.net/pages/software"
+    regex(/LaserPecker[._-]Design[._-]Space[._-]#{arch}[._-]v?(\d+(?:\.\d+)+)\.dmg/i)
   end
 
   depends_on macos: ">= :big_sur"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`laserpecker-design-space` is autobumped but the workflow failed to update to version 2.11.0 because the `livecheck` block produces an "Unable to get versions" error, as the dmg URL is no longer in an `href` attribute. This updates the version and modifies the `livecheck` block to loosen the regex and update the URL to resolve a redirection.