### PR TITLE
monotype 7.7.0

### DIFF
--- a/Casks/m/monotype.rb
+++ b/Casks/m/monotype.rb
@@ -1,15 +1,18 @@
 cask "monotype" do
-  version "7.6.3"
-  sha256 "435c115e8ef85f3504be01385ff20ceae0d5fca6d8b03dd3c39170e77dc75ab4"
+  arch arm: "Arm", intel: "Intel"
 
-  url "https://monotypeapp.monotype.com/release/#{version.no_dots}/mac/MTFInstallerMacOS.zip"
+  version "7.7.0"
+  sha256 arm:   "9c462812d2440afff4cbd3673b9f1d9865f7f6e70dc41d001cdc22623a15dc1e",
+         intel: "c3f7dea86d87e186e836902bb92e43984ffe23512653acb643894b74222ca205"
+
+  url "https://monotypeapp.monotype.com/release/#{version.no_dots}/mac/#{arch.downcase}/MTFInstallerMacOs#{arch}.zip"
   name "Monotype Desktop App"
   desc "Font finder and organiser"
   homepage "https://support.monotype.com/en/articles/7860542-monotype-desktop-app"
 
   livecheck do
     url "https://support.monotype.com/en/articles/8617063-release-notes"
-    regex(/>\s*Version\s*v?(\d+(?:\.\d+)+)\s*["'<]/im)
+    regex(/>\s*v?(\d+(?:\.\d+)+)\s*["'<]/im)
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`monotype` is autobumped but the workflow failed to update to version 7.7.0 because the text on the page that `livecheck` checks has changed in a way that the regex no longer matches. This updates the version (adjusting the cask to handle the new arch-specific files) and updates the `livecheck` block regex to match the current version text (e.g., versions like "v7.7.0" in table cells).