### PR TITLE
moves 1.9.1

### DIFF
--- a/Casks/m/moves.rb
+++ b/Casks/m/moves.rb
@@ -1,15 +1,15 @@
 cask "moves" do
-  version "1.8.0"
-  sha256 "c1476ffc9835468ed7b4a214521fa046a1be3b7724eaab6085c49f7d6589d376"
+  version "1.9.1"
+  sha256 "3371e4388eadfeab13714a2fccdb7becb200eb313d4f2014cac6740c82d4eded"
 
-  url "https://github.com/mikker/Moves/releases/download/v#{version}/Moves.app.zip",
-      verified: "github.com/mikker/Moves/"
+  url "https://github.com/mikker/Moves.app/releases/download/v#{version}/Moves.app.zip",
+      verified: "github.com/mikker/Moves.app/"
   name "Moves"
   desc "Window manager"
   homepage "https://mikkelmalmberg.com/moves"
 
   livecheck do
-    url "https://mikker.github.io/Moves/appcast.xml"
+    url "https://mikker.github.io/Moves.app/appcast.xml"
     strategy :sparkle, &:short_version
   end
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`moves` is autobumped but the workflow failed to update to version 1.9.1 because the appcast URL changed to use `Moves.app` in the path, like the change in the GitHub repository name, so the `livecheck` block produced an "Unable to get versions" error. This updates the version and adjusts the URLs accordingly.