### PR TITLE
navicat-data-modeler 4.3.9

### DIFF
--- a/Casks/n/navicat-data-modeler.rb
+++ b/Casks/n/navicat-data-modeler.rb
@@ -1,27 +1,30 @@
 cask "navicat-data-modeler" do
-  version "3.1.4"
+  version "4.3.9,040"
   sha256 :no_check
 
-  url "https://download3.navicat.com/download/modeler0#{version.major_minor.no_dots}_en.dmg"
+  url "https://download3.navicat.com/updater/navicatdatamodeler#{version.csv.second}_mac_en.zip"
   name "Navicat Data Modeler"
   desc "Database design tool"
   homepage "https://www.navicat.com/products/navicat-data-modeler"
 
   livecheck do
-    url "https://updater.navicat.com/mac/navicat_updates.php?appName=Navicat%20Data%20Modeler&appLang=en"
-    strategy :sparkle
+    url "https://updater.navicat.com/mac/v17/navicat_updates.php?appName=Navicat%20Data%20Modeler"
+    regex(%r{/navicatdatamodeler[._-]?v?(\d+(?:\.\d+)*)}i)
+    strategy :sparkle do |item, regex|
+      match = item.url&.match(regex)
+      next if !item.short_version || !match
+
+      "#{item.short_version},#{match[1]}"
+    end
   end
+
+  depends_on macos: ">= :big_sur"
 
   app "Navicat Data Modeler.app"
 
   zap trash: [
-    "~/Library/Application Support/PremiumSoft CyberTech/Navicat CC/Navicat Data Modeler",
-    "~/Library/Caches/com.apple.helpd/Generated/Navicat Data Modeler Help*",
-    "~/Library/Preferences/com.prect.NavicatDataModeler#{version.major}.plist",
-    "~/Library/Saved Application State/com.prect.NavicatDataModeler#{version.major}.savedState",
+    "~/Library/Group Containers/*.com.preact.Navicat.launcherGroup",
+    "~/Library/HTTPStorages/com.navicat.NavicatDataModeler",
+    "~/Library/Preferences/com.navicat.NavicatDataModeler.plist",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`navicat-data-modeler` is autobumped but the workflow failed to update to version 4.3.9 because the `livecheck` block produces an "Unable to get versions" error due to the URL not working anymore. The cask hadn't been updated to 3.x versions beyond 3.1.4, so the appcast may have been broken for much longer than that. This updates the version and modifies the `livecheck` block to check the appcast that the current app uses, however this contains `v17` in the URL, so it may be version specific. An alternative is to check the release notes page (https://www.navicat.com/en/products/navicat-data-modeler-release-note) but it doesn't contain download URLs, so we wouldn't be able to tell if the dotless version in the file name changes (it was previously derived from major/minor but it remains 040 for even version 4.3.9). This works but it's probably still fragile.