### PR TITLE
navicat-data-modeler-essentials: deprecate

### DIFF
--- a/Casks/n/navicat-data-modeler-essentials.rb
+++ b/Casks/n/navicat-data-modeler-essentials.rb
@@ -7,9 +7,7 @@ cask "navicat-data-modeler-essentials" do
   desc "Database design tool"
   homepage "https://www.navicat.com/products/navicat-data-modeler"
 
-  livecheck do
-    cask "navicat-data-modeler"
-  end
+  deprecate! date: "2026-02-23", because: :discontinued
 
   app "Navicat Data Modeler Essentials.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`navicat-data-modeler-essentials` hasn't been updated beyond 3.1.4 because the appcast for `navicat-data-modeler` seemingly stopped updating at some point and it was only clear when the URL completely broke recently. I wasn't able to identify new URLs for the Essentials version, so I don't see a way to upgrade this cask beyond 3.1.4. References to the Essentials version on the upstream website are sparse, so it may have been replaced by the Data Modeler Lite product as the free offering.

The `navicat-premium-essentials` cask has already been disabled as discontinued, so this deprecates `navicat-data-modeler-essentials`, as we can't reasonably maintain it in this state. I've held off on creating a `navicat-data-modeler-lite` cask, as it may be better to wait for a user to request it or submit a PR rather than preemptively introducing a cask that may not be used.