### PR TITLE
pktriot 1.0.0

### DIFF
--- a/Casks/p/pktriot.rb
+++ b/Casks/p/pktriot.rb
@@ -1,21 +1,19 @@
 cask "pktriot" do
-  arch arm: ".arm64"
+  arch arm: "arm64", intel: "intel"
 
-  version "0.16.1"
-  sha256 arm:   "92f15b025e248347326c65eac7942b0459882a97fa03536e32f5113341b158ef",
-         intel: "1407db738a5ffc7e0af1be800f38eca1b0aa573759720026481fe49a636bdaaf"
+  version "1.0.0"
+  sha256 arm:   "2534af4c55f84717cd8255e2b6e819d6c8cae6852c4c29b2e7df8e8db3e42f82",
+         intel: "d87d7bdc3002f121f57b2d9dfb9241753f8cdd7b3c053a17cfbba1e8191d3a45"
 
-  url "https://download.packetriot.com/macos/pktriot-#{version}.macos#{arch}.tar.gz"
+  url "https://download.packetriot.com/macos/pktriot-#{version}.macos.#{arch}.zip"
   name "pktriot"
   desc "Host server applications and static websites"
   homepage "https://packetriot.com/"
 
   livecheck do
     url "https://packetriot.com/downloads"
-    regex(/href=.*?pktriot[._-](\d+(?:\.\d+)+)\.macos#{arch}\.t/i)
+    regex(/href=.*?pktriot[._-](\d+(?:\.\d+)+)[._-]macos[._-]?#{arch}\.(?:t|zip)/i)
   end
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   binary "pktriot-#{version}/pktriot"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`pktriot` is autobumped but the workflow failed to update to version 1.0.0 because the file name format and type has changed with this version and the `livecheck` block regex doesn't match it. This updates the version and updates the `livecheck` block regex to match the current file names. This also removes the `disable!` call, as the binaries appear to be notarized now.