### PR TITLE
sfm: update livecheck

### DIFF
--- a/Casks/s/sfm.rb
+++ b/Casks/s/sfm.rb
@@ -10,11 +10,11 @@ cask "sfm" do
 
   # Upstream is unable to publish the standalone version of the macOS client, so
   # we have to temporarily check all releases to find the newest version with an
-  # SFM dmg. TODO: Remove this `livecheck` block or switch to `GithubLatest`
-  # once this is resolved.
+  # SFM file for macOS. TODO: Remove this `livecheck` block or switch to
+  # `GithubLatest` once this is resolved.
   livecheck do
     url :url
-    regex(/SFM[._-]v?(\d+(?:\.\d+)+)(?:[._-]universal)?\.dmg/i)
+    regex(/SFM[._-]v?(\d+(?:\.\d+)+)(?:[._-]universal)?\.(?:dmg|pkg)/i)
     strategy :github_releases do |json, regex|
       json.map do |release|
         next if release["draft"] || release["prerelease"]


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `sfm` is producing an "Unable to get versions" error as there isn't a stable version in the most recent releases that has files for SFM. There are newer unstable versions with SFM files but they're pkg files instead of dmg. This updates the `livecheck` block regex to be able to match both dmg and pkg files, so this stands a better chance of picking up a new stable version with SFM files. This continues to fail at the moment but it at least gives us some reassurance that this failure is due to the upstream release situation rather than a regex issue.