### PR TITLE
volta-app: disable

### DIFF
--- a/Casks/v/volta-app.rb
+++ b/Casks/v/volta-app.rb
@@ -11,10 +11,7 @@ cask "volta-app" do
   desc "GitHub issues and notifications"
   homepage "https://volta.net/"
 
-  livecheck do
-    url "https://s3.fr-par.scw.cloud/volta-build/latest-mac.yml"
-    strategy :electron_builder
-  end
+  disable! date: "2026-02-23", because: :no_longer_available
 
   auto_updates true
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The asset URL and `livecheck` block URL for `volta-app` return a 404 (Not Found) response and the homepage only contains a button to initiate authorization for upstream's GitHub app, so it seems like they've pivoted and discontinued the desktop app. This disables the cask, as it's not usable in this state.