### PR TITLE
Add maklock 1.0.0

### DIFF
--- a/Casks/m/maklock.rb
+++ b/Casks/m/maklock.rb
@@ -4,7 +4,7 @@ cask "maklock" do
 
   url "https://github.com/dutkiewiczmaciej/MakLock/releases/download/v#{version}/MakLock-#{version}.dmg"
   name "MakLock"
-  desc "Lock macOS apps with Touch ID, Apple Watch, or password"
+  desc "Lock apps with Touch ID, Apple Watch, or password"
   homepage "https://github.com/dutkiewiczmaciej/MakLock"
 
   livecheck do
@@ -18,9 +18,9 @@ cask "maklock" do
   app "MakLock.app"
 
   zap trash: [
-    "~/Library/Preferences/com.makmak.MakLock.plist",
-    "~/Library/Caches/com.makmak.MakLock",
     "~/Library/Application Support/com.makmak.MakLock",
+    "~/Library/Caches/com.makmak.MakLock",
     "~/Library/HTTPStorages/com.makmak.MakLock",
+    "~/Library/Preferences/com.makmak.MakLock.plist",
   ]
 end

--- a/Casks/m/maklock.rb
+++ b/Casks/m/maklock.rb
@@ -1,0 +1,26 @@
+cask "maklock" do
+  version "1.0.0"
+  sha256 "1f6126b739049f862ada24b1867b05200cd015df422f9c4fc17feabaf104d7d1"
+
+  url "https://github.com/dutkiewiczmaciej/MakLock/releases/download/v#{version}/MakLock-#{version}.dmg"
+  name "MakLock"
+  desc "Lock macOS apps with Touch ID, Apple Watch, or password"
+  homepage "https://github.com/dutkiewiczmaciej/MakLock"
+
+  livecheck do
+    url "https://dutkiewiczmaciej.github.io/maklock/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on macos: ">= :ventura"
+
+  app "MakLock.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.makmak.MakLock.plist",
+    "~/Library/Caches/com.makmak.MakLock",
+    "~/Library/Application Support/com.makmak.MakLock",
+    "~/Library/HTTPStorages/com.makmak.MakLock",
+  ]
+end


### PR DESCRIPTION
**Name:** MakLock
**Description:** Lock macOS apps with Touch ID, Apple Watch, or password
**Homepage:** https://github.com/dutkiewiczmaciej/MakLock
**Download:** https://github.com/dutkiewiczmaciej/MakLock/releases/download/v1.0.0/MakLock-1.0.0.dmg

---

MakLock is a free, open-source menu bar app that locks macOS applications with Touch ID, Apple Watch proximity, or password. It uses full-screen blur overlays and supports auto-lock on idle/sleep.

- Signed with Developer ID and notarized by Apple
- Auto-updates via Sparkle 2
- MIT license
- macOS 13+ (Ventura)