### PR TITLE
Add quickdown

### DIFF
--- a/Casks/q/quickdown.rb
+++ b/Casks/q/quickdown.rb
@@ -1,0 +1,15 @@
+cask "quickdown" do
+  version "0.4.0"
+  sha256 "1d8985324b525864f682fdc7042791141f77606640a2e7385c25835267649c8d"
+
+  url "https://github.com/tennyson-mccalla/QuickDown/releases/download/v#{version}/QuickDown.dmg"
+  name "QuickDown"
+  desc "Fast, native Markdown previewer for macOS with QuickLook integration"
+  homepage "https://github.com/tennyson-mccalla/QuickDown"
+
+  app "QuickDown.app"
+
+  zap trash: [
+    "~/Library/Preferences/com.tennyson.QuickDown.plist",
+  ]
+end

--- a/Casks/q/quickdown.rb
+++ b/Casks/q/quickdown.rb
@@ -4,12 +4,10 @@ cask "quickdown" do
 
   url "https://github.com/tennyson-mccalla/QuickDown/releases/download/v#{version}/QuickDown.dmg"
   name "QuickDown"
-  desc "Fast, native Markdown previewer for macOS with QuickLook integration"
+  desc "Fast, native Markdown previewer with QuickLook integration"
   homepage "https://github.com/tennyson-mccalla/QuickDown"
 
   app "QuickDown.app"
 
-  zap trash: [
-    "~/Library/Preferences/com.tennyson.QuickDown.plist",
-  ]
+  zap trash: "~/Library/Preferences/com.tennyson.QuickDown.plist"
 end


### PR DESCRIPTION
## quickdown

A fast, native Markdown previewer for macOS with QuickLook integration.

- Homepage: https://github.com/tennyson-mccalla/QuickDown
- Version: 0.4.0
- App Store: https://apps.apple.com/app/quickdown/id6759303233

Installs `QuickDown.app` from a signed, notarized DMG.