### PR TITLE
Re-enable deadbolt

### DIFF
--- a/Casks/d/deadbolt.rb
+++ b/Casks/d/deadbolt.rb
@@ -15,8 +15,6 @@ cask "deadbolt" do
     strategy :github_latest
   end
 
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
-
   app "Deadbolt.app"
 
   zap trash: [

--- a/Casks/d/deadbolt.rb
+++ b/Casks/d/deadbolt.rb
@@ -1,9 +1,9 @@
 cask "deadbolt" do
   arch arm: "-arm64"
 
-  version "2.1.0"
-  sha256 arm:   "0469c775850f3199a0b34394aaa5af5f46766420b341e27eee698ac0c0d3dde7",
-         intel: "6ce5e4bab48ae0eb48523b9c00f76b5cf7c89eeb60bf43d1be7fb570126e790a"
+  version "2.1.1"
+  sha256 arm:   "c8ce77caf427d24730fe0e9abd34cc49ebcb1650952cbbc79a2da180e7c8bee0",
+         intel: "4b3950a09cb8e46ce31bfc5d54853264217810641684d298d30ecf3a05a8a4fd"
 
   url "https://github.com/alichtman/deadbolt/releases/download/v#{version}/Deadbolt-#{version}#{arch}.dmg"
   name "Deadbolt"


### PR DESCRIPTION
https://github.com/alichtman/deadbolt/releases/tag/v2.1.1 adds signing for deadbolt macOS releases.

It was disabled because it was missing this in https://github.com/alichtman/homebrew-cask/commit/0f84ba10ddfd40b1f0ed68d31a2c3c219ac63440. Hoping to re-enable it now that the signing is in place.

(Also, for the future, is it possible to open an issue on the upstream repo to ask for a signed release? I didn't know about this until recently...)
