### PR TITLE
cmux 0.61.0 (new cask)

### DIFF
--- a/Casks/c/cmux.rb
+++ b/Casks/c/cmux.rb
@@ -1,0 +1,30 @@
+cask "cmux" do
+  version "0.61.0"
+  sha256 "a113c6a43c18e323dfa91f2e39f19e20811cbac4605b639b99f9e3a9f338a528"
+
+  url "https://github.com/manaflow-ai/cmux/releases/download/v#{version}/cmux-macos.dmg",
+      verified: "github.com/manaflow-ai/cmux/"
+  name "cmux"
+  desc "Ghostty-based terminal with vertical tabs and notifications for AI coding agents"
+  homepage "https://www.cmux.dev/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "cmux.app"
+
+  zap trash: [
+    "~/Library/Application Support/cmux",
+    "~/Library/Application Support/com.cmuxterm.app",
+    "~/Library/Caches/cmux",
+    "~/Library/Caches/com.cmuxterm.app",
+    "~/Library/HTTPStorages/com.cmuxterm.app",
+    "~/Library/Preferences/com.cmuxterm.app.plist",
+    "~/Library/WebKit/com.cmuxterm.app",
+  ]
+end


### PR DESCRIPTION
New cask for https://www.cmux.dev/ — a Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents.

~`brew audit --cask --new` passes except for "GitHub repository too new (<30 days)" which clears Feb 27 (tomorrow). All other checks pass.~ All checks now pass.

AI was used to scaffold the cask file. I verified all fields (sha256, bundle ID, zap paths, macOS minimum version) by inspecting the DMG and Info.plist.

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online cmux` is error-free.
- [x] `brew style --fix cmux` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new cmux` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask cmux` worked successfully.
- [x] `brew uninstall --cask cmux` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. AI (Claude Code) was used to scaffold the cask file, look up the sha256, bundle identifier, and minimum macOS version from the DMG, and identify zap stanza paths. All fields were manually verified: sha256 against the downloaded DMG, bundle ID and macOS minimum from Info.plist, zap paths confirmed via AppCleaner, and install/uninstall  tested locally.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----
