### PR TITLE
connectiq-sdk-manager 1.0.15 (new cask)

### DIFF
--- a/Casks/c/connectiq-sdk-manager.rb
+++ b/Casks/c/connectiq-sdk-manager.rb
@@ -1,0 +1,22 @@
+cask "connectiq-sdk-manager" do
+  version "1.0.15"
+  sha256 :no_check
+
+  url "https://developer.garmin.com/downloads/connect-iq/sdk-manager/connectiq-sdk-manager.dmg"
+  name "Connect IQ SDK Manager"
+  desc "Manage SDKs and download device definitions for Garmin Connect IQ development"
+  homepage "https://developer.garmin.com/connect-iq/sdk/"
+
+  livecheck do
+    url "https://developer.garmin.com/downloads/connect-iq/sdk-manager/sdk-manager.json"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "SdkManager.app"
+
+  zap trash: "~/Library/Preferences/com.garmin.connectiq.sdkmanager.plist"
+end


### PR DESCRIPTION
## connectiq-sdk-manager

The Garmin Connect IQ SDK Manager is a standalone application for managing Connect IQ SDK versions and downloading device definitions. It is a prerequisite for Connect IQ development that is currently not available via Homebrew, despite the SDK itself being available as the `connectiq` cask.

### Why this cask is needed

The existing `connectiq` cask installs the compiler (`monkeyc`) and simulator, but not the SDK Manager. Without the SDK Manager:

- VS Code's Monkey C extension cannot locate the installed SDK (it reads `~/Library/Application Support/Garmin/ConnectIQ/current-sdk.cfg` which the SDK Manager writes)
- Device definitions cannot be downloaded, causing `monkeyc` to fail with "Device ids not recognized" for all build targets

### Cask details

- **App**: `SdkManager.app`
- **Bundle ID**: `com.garmin.connectiq.sdkmanager`
- **Version**: `1.0.15`
- **Download URL**: https://developer.garmin.com/downloads/connect-iq/sdk-manager/connectiq-sdk-manager.dmg
- **Livecheck**: JSON endpoint at https://developer.garmin.com/downloads/connect-iq/sdk-manager/sdk-manager.json

### Verification

```
sha256sum connectiq-sdk-manager.dmg
ae4dbb6f73b49817afef58e092e56123aceb3d84a8d24d09aadbbe44515a24e7
```

### Checklist

- [x] `brew audit --cask connectiq-sdk-manager` passes
- [x] `brew install --cask connectiq-sdk-manager` installs successfully
- [x] `brew uninstall --cask connectiq-sdk-manager` uninstalls cleanly
- [x] App launches correctly after install