### PR TITLE
8x8-work 8.31.3-1

### DIFF
--- a/Casks/8/8x8-work.rb
+++ b/Casks/8/8x8-work.rb
@@ -1,14 +1,14 @@
 cask "8x8-work" do
   arch arm: "-arm64"
 
-  version "8.30.2-10"
-  sha256 arm:   "77235dfbaeaf5391c5055ba71eca0c8b6ba033b556fd20466ef973ffbce561fe",
-         intel: "099a263e1c440858ed43c96b874a6a7fe5da29092f40275a4c236919334e72d0"
+  version "8.31.3-1"
+  sha256 arm:   "298446c6581c8da07eee245603695de77a935c93a0babddda8dd956f81c170d0",
+         intel: "058c48e123d8352c876c51ed33ff158b3175cc77218610fca37dd60874021a6c"
 
   url "https://work-desktop-assets.8x8.com/prod-publish/ga/work#{arch}-dmg-v#{version}.dmg"
   name "8x8_work"
   desc "Communications application with voice, video, chat, and web conferencing"
-  homepage "https://www.8x8.com/products/apps"
+  homepage "https://docs.8x8.com/8x8WebHelp/8x8-work-for-desktop/Content/workd/about-the-app.htm"
 
   livecheck do
     url "https://support-portal.8x8.com/helpcenter/docrenderservice/services/rest/documents/8bff4970-6fbf-4daf-842d-8ae9b533153d"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`8x8-work` is autobumped but the workflow failed to update to version 8.31.3-1 because the homepage is inaccessible due to www.8x8.com being behind a Vercel challenge. This updates the version and switches the homepage to a documentation page about the 8x8 Work desktop app, as docs.8x8.com doesn't have the same issue.