### PR TITLE
fpc-laz: update livecheck

### DIFF
--- a/Casks/f/fpc-laz.rb
+++ b/Casks/f/fpc-laz.rb
@@ -10,7 +10,7 @@ cask "fpc-laz" do
 
   livecheck do
     url "https://sourceforge.net/projects/lazarus/rss?path=/Lazarus%20macOS%20x86-64"
-    regex(%r{url=.*?/Lazarus(?:%20|[._-])v?(\d+(?:\.\d+)+)/fpc[._-]v?(\d+(?:\.\d+)+)[^"' >]+?\.(?:dmg|pkg)}i)
+    regex(%r{url=.*?/Lazarus(?:%20|[._-])v?(\d+(?:\.\d+)+)/fpc[._-]v?(\d+(?:\.\d+)+)[._-][^"' >]+?\.(?:dmg|pkg)}i)
     strategy :sourceforge do |page, regex|
       page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
     end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `fpc-laz` checks versions from the related SourceForge RSS feed but it's returning "3.2.4,4.6" as the newest version, from an unstable `fpc-3.2.4rc1a.intelarm64-macosx.dmg` file. This occurs because the `[^"' >]+?` part of the regex matches the `rc1a` part of the version. This addresses the issue by adding a `[._-]` delimiter before this part of the regex, which better represents our intention of glossing over the suffix part of the file name.