### PR TITLE
gologin 4.0.12

### DIFF
--- a/Casks/g/gologin.rb
+++ b/Casks/g/gologin.rb
@@ -2,12 +2,12 @@ cask "gologin" do
   arch arm: "-arm64"
   livecheck_arch = on_arch_conditional arm: "-arm"
 
-  version "4.0.11"
-  sha256 arm:   "bd2888ace394255b293190f9543d21dd8820c827f1f9b0313ced21a8ce682271",
-         intel: "55c0310d53bbf3adbfbd648aa5bd6d097a9b0743516bc05db79b047a91442a0e"
+  version "4.0.12"
+  sha256 arm:   "16f787ccfee83ceb1a1bff977ffaf9bdbb977a5e5d38a2ab1bba0e1703c66593",
+         intel: "c40ea810652a865bd0016aa710653adc2f6afd30541341c333aec4f013ca3800"
 
-  url "https://releases#{livecheck_arch}.gologin.com/GoLogin-#{version}#{arch}.dmg"
-  name "GoLogin"
+  url "https://releases#{livecheck_arch}.gologin.com/Gologin-#{version}#{arch}.dmg"
+  name "Gologin"
   desc "Antidetect browser"
   homepage "https://gologin.com/"
 
@@ -19,12 +19,12 @@ cask "gologin" do
   auto_updates true
   depends_on macos: ">= :monterey"
 
-  app "GoLogin.app"
+  app "Gologin.app"
 
   zap trash: [
     "~/.gologin",
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.gologin.desktop.sfl*",
-    "~/Library/Application Support/GoLogin",
+    "~/Library/Application Support/Gologin",
     "~/Library/Preferences/com.gologin.desktop.plist",
     "~/Library/Preferences/com.gologin.orbita.plist",
     "~/Library/Saved Application State/com.gologin.desktop.savedState",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`gologin` is autobumped but the workflow failed to update to version 4.0.12 because the file name prefix is now "Gologin", as upstream has tweaked their branding. This updates the version and adjusts the cask accordingly. The change to the `zap` arguments was done after opening the 4.0.12 app and running `brew createzap gologin`.