### PR TITLE
braille-blaster 3.2.1 (new cask)

### DIFF
--- a/Casks/b/braille-blaster.rb
+++ b/Casks/b/braille-blaster.rb
@@ -1,0 +1,32 @@
+cask "braille-blaster" do
+  arch arm: "aarch64", intel: "amd64"
+
+  version "3.2.1"
+  sha256 arm:   "086f00d17b5b29d0851915f5885bef9021ed7ada22208bbdf48e87642640b13a",
+         intel: "d974dc3cff9facc08b7c1f7c2b312a00fb56c3b53eb52e6983802cdad7ac9053"
+
+  url "https://github.com/aphtech/brailleblaster/releases/download/release/#{version}/brailleblaster-#{version}-mac-#{arch}.zip",
+      verified: "github.com/aphtech/brailleblaster/"
+  name "BrailleBlaster"
+  desc "Braille transcription program for creating braille textbooks"
+  homepage "https://www.brailleblaster.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+    regex(%r{release/v?(\d+(?:\.\d+)+)}i)
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "BrailleBlaster.app"
+
+  zap trash: [
+    "~/Library/Application Support/BrailleBlaster",
+    "~/Library/Caches/org.aph.brailleblaster",
+    "~/Library/HTTPStorages/org.aph.brailleblaster",
+    "~/Library/Preferences/org.aph.brailleblaster.plist",
+    "~/Library/Saved Application State/org.aph.brailleblaster.savedState",
+  ]
+end


### PR DESCRIPTION
## Summary

BrailleBlaster is a free, open-source (GPL-3.0) braille transcription program developed by the [American Printing House for the Blind (APH)](https://www.aph.org/), the world's largest company devoted exclusively to creating products and services for people who are blind and visually impaired.

BrailleBlaster streamlines the creation of braille textbooks so that students who are blind can receive their materials on the first day of class. It supports both UEB (Unified English Braille) and EBAE (English Braille American Edition) standards.

- **Homepage:** https://www.brailleblaster.org/
- **Source:** https://github.com/aphtech/brailleblaster
- **License:** GPL-3.0
- **Code-signed:** Developer ID Application: American Printing House for the Blind (XADMDG5729)
- **macOS architectures:** Apple Silicon (aarch64) and Intel (amd64)
- **Minimum macOS:** Sequoia (15.0)

### Notability note

While the GitHub repository metrics are currently below the standard cask thresholds, BrailleBlaster has significant real-world adoption:
- Developed and maintained by APH, a federally chartered nonprofit founded in 1858
- Used by braille transcribers, educators, and schools across the United States
- APH is the official source of educational materials for students who are legally blind in the U.S.
- The software addresses a critical accessibility need with no comparable free alternative

### Disclosure

This PR was prepared with assistance from Claude (Anthropic AI). All content has been reviewed and verified.

## Test plan

- [x] `brew audit --cask --strict --online braille-blaster` passes
- [x] `brew style --cask braille-blaster` passes (no offenses)
- [x] SHA256 checksums verified for both architectures
- [x] Code signing verified: Developer ID Application: American Printing House for the Blind (XADMDG5729)
- [ ] `brew install --cask braille-blaster` installs successfully
- [ ] `brew uninstall --cask braille-blaster` uninstalls cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)