### PR TITLE
copilot-for-xcode: update sha256

### DIFF
--- a/Casks/c/copilot-for-xcode.rb
+++ b/Casks/c/copilot-for-xcode.rb
@@ -1,6 +1,6 @@
 cask "copilot-for-xcode" do
   version "0.38.0"
-  sha256 "66b05b0af7444bc13d04d68cd1e0bb5a23690e5e8ddb6e7879cc5f27ec8e541a"
+  sha256 "e9c90f708427b98b7a3a9dac77f6d7b0188f7ec4d6a3dc122cf2b6555ad671ba"
 
   url "https://github.com/intitni/CopilotForXcode/releases/download/#{version}/Copilot.for.Xcode.app.zip"
   name "Copilot for Xcode"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `sha256` for version 0.38.0 of `copilot-for-xcode` has changed since the cask was last updated. Based on the appcast, upstream appears to have re-released 0.38.0, so this updates the `sha256` to the current value.

For what it's worth, I ran into an [issue in the github/CopilotForXcode repository](https://github.com/github/CopilotForXcode/issues/761) where someone was reporting a checksum mismatch for this cask, not realizing that the cask for the GitHub software is `github-copilot-for-xcode` (not `copilot-for-xcode`).