### PR TITLE
bettercapture 2026.2.1 (new cask)

### DIFF
--- a/Casks/b/bettercapture.rb
+++ b/Casks/b/bettercapture.rb
@@ -2,15 +2,12 @@ cask "bettercapture" do
   version "2026.2.1"
   sha256 "2d7f843e4eedea42720f68febb6f1c0eec925f7f10cc95db97b8414ba3879cc1"
 
-  url "https://github.com/jsattler/BetterCapture/releases/download/v#{version}/BetterCapture-#{version}-arm64.dmg"
-  name "BetterCapture"
-  desc "Free and open source screen recorder"
-  homepage "https://github.com/jsattler/BetterCapture"
   url "https://github.com/jsattler/BetterCapture/releases/download/v#{version}/BetterCapture-#{version}-arm64.dmg",
       verified: "github.com/jsattler/BetterCapture/"
   name "BetterCapture"
-  desc "Free and open source screen recorder for the rest of us"
+  desc "Free and open source screen recorder"
   homepage "https://bettercapture.app/"
+
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/b/bettercapture.rb
+++ b/Casks/b/bettercapture.rb
@@ -16,6 +16,7 @@ cask "bettercapture" do
     strategy :github_latest
   end
 
+  auto_updates true
   depends_on macos: ">= :sequoia"
   depends_on arch: :arm64
 

--- a/Casks/b/bettercapture.rb
+++ b/Casks/b/bettercapture.rb
@@ -1,0 +1,25 @@
+cask "bettercapture" do
+  version "2026.2.1"
+  sha256 "2d7f843e4eedea42720f68febb6f1c0eec925f7f10cc95db97b8414ba3879cc1"
+
+  url "https://github.com/jsattler/BetterCapture/releases/download/v#{version}/BetterCapture-#{version}-arm64.dmg"
+  name "BetterCapture"
+  desc "Free and open source screen recorder for the rest of us"
+  homepage "https://github.com/jsattler/BetterCapture"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :sequoia"
+  depends_on arch: :arm64
+
+  app "BetterCapture.app"
+
+  zap trash: [
+    "~/Library/Application Support/BetterCapture",
+    "~/Library/Caches/com.sattlerjoshua.BetterCapture",
+    "~/Library/Preferences/com.sattlerjoshua.BetterCapture.plist",
+  ]
+end

--- a/Casks/b/bettercapture.rb
+++ b/Casks/b/bettercapture.rb
@@ -6,7 +6,11 @@ cask "bettercapture" do
   name "BetterCapture"
   desc "Free and open source screen recorder"
   homepage "https://github.com/jsattler/BetterCapture"
-
+  url "https://github.com/jsattler/BetterCapture/releases/download/v#{version}/BetterCapture-#{version}-arm64.dmg",
+      verified: "github.com/jsattler/BetterCapture/"
+  name "BetterCapture"
+  desc "Free and open source screen recorder for the rest of us"
+  homepage "https://bettercapture.app/"
   livecheck do
     url :url
     strategy :github_latest

--- a/Casks/b/bettercapture.rb
+++ b/Casks/b/bettercapture.rb
@@ -4,7 +4,7 @@ cask "bettercapture" do
 
   url "https://github.com/jsattler/BetterCapture/releases/download/v#{version}/BetterCapture-#{version}-arm64.dmg"
   name "BetterCapture"
-  desc "Free and open source screen recorder for the rest of us"
+  desc "Free and open source screen recorder"
   homepage "https://github.com/jsattler/BetterCapture"
 
   livecheck do

--- a/Casks/b/bettercapture.rb
+++ b/Casks/b/bettercapture.rb
@@ -5,7 +5,7 @@ cask "bettercapture" do
   url "https://github.com/jsattler/BetterCapture/releases/download/v#{version}/BetterCapture-#{version}-arm64.dmg",
       verified: "github.com/jsattler/BetterCapture/"
   name "BetterCapture"
-  desc "Free and open source screen recorder"
+  desc "Screen recorder"
   homepage "https://bettercapture.app/"
 
   livecheck do


### PR DESCRIPTION
## Summary

New cask for BetterCapture — a free and open source screen recorder.

- **Homepage:** https://github.com/jsattler/BetterCapture
- **arm64 only**, requires macOS Sequoia or later
- App is signed and notarized
- `brew audit --new --cask bettercapture` and `brew style` pass cleanly