### PR TITLE
cmux: add binary stanza for CLI

### DIFF
--- a/Casks/c/cmux.rb
+++ b/Casks/c/cmux.rb
@@ -17,6 +17,7 @@ cask "cmux" do
   depends_on macos: ">= :sonoma"
 
   app "cmux.app"
+  binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"
 
   zap trash: [
     "~/Library/Application Support/cmux",


### PR DESCRIPTION
Adds a `binary` stanza so that `cmux` CLI is available in `$PATH` after `brew install --cask cmux`.

The CLI binary ships inside the app bundle at `cmux.app/Contents/Resources/bin/cmux`. It communicates with the running app over a Unix socket and provides workspace management, terminal I/O, browser automation, and more.

This is a follow-up to https://github.com/Homebrew/homebrew-cask/pull/251309 which added the initial cask.