### PR TITLE
pkgsmith 1.0.0

### DIFF
--- a/Casks/p/pkgsmith.rb
+++ b/Casks/p/pkgsmith.rb
@@ -1,0 +1,15 @@
+cask "pkgsmith" do
+  version "1.0.0"
+  sha256 "b6879d30121f348c22cf39ce425eaff0a1fed3270f8f348006046f6c744c259a"
+
+  url "https://github.com/Fogh/pkg-updates/releases/download/#{version}/PKGSmith-#{version}-macos.zip"
+  name "PKGSmith"
+  desc "Create signed PKG and DMG installers from reusable project definitions"
+  homepage "https://pkgsmith.app/"
+
+  auto_updates true
+  depends_on macos: ">= :tahoe"
+
+  app "PKGSmith.app"
+  binary "PKGSmith.app/Contents/MacOS/PKGSmith", target: "pkgsmith"
+end


### PR DESCRIPTION
## Summary
- add new `pkgsmith` cask
- source asset: `PKGSmith-1.0.0-macos.zip` from `Fogh/pkg-updates` release `1.0.0`
- set homepage to `https://pkgsmith.app/`

## Checks
- `brew style --fix Casks/p/pkgsmith.rb`
- `brew audit --cask --new --online pkgsmith --tap Fogh/homebrew-cask`

## Release
- https://github.com/Fogh/pkg-updates/releases/tag/1.0.0
