### PR TITLE
pika: fix sha256 for re-signed 1.4.0 DMG

### DIFF
--- a/Casks/p/pika.rb
+++ b/Casks/p/pika.rb
@@ -1,6 +1,6 @@
 cask "pika" do
   version "1.4.0"
-  sha256 "3d0b9404f09367a8bd4f3005b2d0943846cefc46e694a9202256e327361e0c0e"
+  sha256 "55a8dc20e491bdfe3fa24692fb8d1af165731861374958e964f857b3fa31616c"
 
   url "https://github.com/superhighfives/pika/releases/download/#{version}/Pika-#{version}.dmg",
       verified: "github.com/superhighfives/pika/"


### PR DESCRIPTION
The 1.4.0 DMG was re-signed with the correct Developer ID Application certificate and re-notarized (the original was accidentally signed with an Apple Development certificate, causing Gatekeeper to reject it). This updates the sha256 to match the corrected DMG.

Fixes https://github.com/superhighfives/pika/issues/179