### PR TITLE
Add zenfirst

### DIFF
--- a/Casks/z/zenfirst.rb
+++ b/Casks/z/zenfirst.rb
@@ -1,0 +1,17 @@
+cask "zenfirst" do
+  version "0.1.11"
+  sha256 "34a93330fd02899effcb1ee04c7d0ca99faff5d2d40518cf62d02e28aebe803a"
+
+  url "https://github.com/takatakayone/zen_first-releases/releases/download/v#{version}/ZenFirst_#{version}_universal.dmg"
+  name "ZenFirst"
+  desc "Lock your screen until your routine is complete"
+  homepage "https://zen-first.com"
+
+  app "ZenFirst.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.zenfirst.app",
+    "~/Library/Caches/com.zenfirst.app",
+    "~/Library/Preferences/com.zenfirst.app.plist",
+  ]
+end


### PR DESCRIPTION
## Description

ZenFirst is a desktop app that locks your screen until your morning routine is complete. Built-in meditation, journaling, and task planning.

- **Homepage**: https://zen-first.com
- **Download**: https://github.com/takatakayone/zen_first-releases/releases
- **App bundle ID**: com.zenfirst.app
- **Platform**: macOS (universal binary - Apple Silicon + Intel)