### PR TITLE
fix(mactex): upgrade to 20260301 to avoid 404

### DIFF
--- a/Casks/m/mactex-no-gui.rb
+++ b/Casks/m/mactex-no-gui.rb
@@ -1,6 +1,6 @@
 cask "mactex-no-gui" do
-  version "2025.0308"
-  sha256 "be084f849e545d9e9511b791da07ca4f9f33d85d42bb69dade636e345421ab7c"
+  version "2026.0301"
+  sha256 "61f8ec54441b9f4ac831df9728ab149c0a39ecdaceff04302fabf7301a57c346"
 
   url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"
@@ -17,24 +17,25 @@ cask "mactex-no-gui" do
     "mactex",
   ]
   depends_on formula: "ghostscript"
+  depends_on macos: ">= :big_sur"
 
   pkg "mactex-#{version.no_dots}.pkg",
       choices: [
         {
           # Ghostscript
-          "choiceIdentifier" => "org.tug.mactex.ghostscript10.04.0",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.06.0",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },
         {
           # Ghostscript Dynamic Library
-          "choiceIdentifier" => "org.tug.mactex.ghostscript10.04.0-libgs",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.06.0-libgs",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },
         {
           # Ghostscript Mutool
-          "choiceIdentifier" => "org.tug.mactex.ghostscript10.04.0-mutool",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.06.0-mutool",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },

--- a/Casks/m/mactex.rb
+++ b/Casks/m/mactex.rb
@@ -1,6 +1,6 @@
 cask "mactex" do
-  version "2025.0308"
-  sha256 "be084f849e545d9e9511b791da07ca4f9f33d85d42bb69dade636e345421ab7c"
+  version "2026.0301"
+  sha256 "61f8ec54441b9f4ac831df9728ab149c0a39ecdaceff04302fabf7301a57c346"
 
   url "https://mirror.ctan.org/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
       verified: "mirror.ctan.org/systems/mac/mactex/"
@@ -24,24 +24,25 @@ cask "mactex" do
     "mactex-no-gui",
   ]
   depends_on formula: "ghostscript"
+  depends_on macos: ">= :big_sur"
 
   pkg "mactex-#{version.no_dots}.pkg",
       choices: [
         {
           # Ghostscript
-          "choiceIdentifier" => "org.tug.mactex.ghostscript10.04.0",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.06.0",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },
         {
           # Ghostscript Dynamic Library
-          "choiceIdentifier" => "org.tug.mactex.ghostscript10.04.0-libgs",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.06.0-libgs",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },
         {
           # Ghostscript Mutool
-          "choiceIdentifier" => "org.tug.mactex.ghostscript10.04.0-mutool",
+          "choiceIdentifier" => "org.tug.mactex.ghostscript10.06.0-mutool",
           "choiceAttribute"  => "selected",
           "attributeSetting" => 0,
         },


### PR DESCRIPTION
After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online mactex` is error-free.
```bash
~> brew audit --strict --new --online --cask toomai/homebrew-cask/mactex
==> Downloading https://mirror.ctan.org/systems/mac/mactex/mactex-20260301.pkg
Already downloaded: /Users/xxx/Library/Caches/Homebrew/downloads/7bbe262ac1de665266f353e20dc041ce0ee4e0c693c2a1481661e4251378a910--mactex-20260301.pkg
==> Downloading and extracting artifacts
==> Downloading https://mirror.ctan.org/systems/mac/mactex/mactex-20260301.pkg
Already downloaded: /Users/xxxx/Library/Caches/Homebrew/downloads/7bbe262ac1de665266f353e20dc041ce0ee4e0c693c2a1481661e4251378a910--mactex-20260301.pkg
```
```bash
~> brew audit --strict --new --online --cask toomai/homebrew-cask/mactex-no-gui
==> Downloading https://mirror.ctan.org/systems/mac/mactex/mactex-20260301.pkg
Already downloaded: /Users/xxx/Library/Caches/Homebrew/downloads/7bbe262ac1de665266f353e20dc041ce0ee4e0c693c2a1481661e4251378a910--mactex-20260301.pkg
==> Downloading and extracting artifacts
==> Downloading https://mirror.ctan.org/systems/mac/mactex/mactex-20260301.pkg
Already downloaded: /Users/xxx/Library/Caches/Homebrew/downloads/7bbe262ac1de665266f353e20dc041ce0ee4e0c693c2a1481661e4251378a910--mactex-20260301.pkg
```
- [x] `brew style --fix <cask>` reports no offenses.
```bash
~> brew style --fix toomai/homebrew-cask/mactex

1 file inspected, no offenses detected
```
```bash
~> brew style --fix toomai/homebrew-cask/mactex-no-gui

1 file inspected, no offenses detected
```
Additionally, **if adding a new cask**:
 
Update to existing cask
-----

**If AI was used to generate or assist with generating the PR**:

No AI was used

-----
