### PR TITLE
Add LumiMax cask

### DIFF
--- a/Casks/l/lumimax.rb
+++ b/Casks/l/lumimax.rb
@@ -5,10 +5,8 @@ cask "lumimax" do
   url "https://github.com/Joowonoil/LumiMax/releases/download/v#{version}/LumiMax.dmg",
       verified: "github.com/Joowonoil/LumiMax/"
   name "LumiMax"
-  desc "XDR brightness boost for Mac displays up to 1600 nits"
+  desc "XDR brightness boost for displays up to 1600 nits"
   homepage "https://ramterstudio.com/lumimax/"
-
-  depends_on macos: ">= :ventura"
 
   livecheck do
     url :url
@@ -16,13 +14,14 @@ cask "lumimax" do
   end
 
   auto_updates true
+  depends_on macos: ">= :ventura"
 
   app "LumiMax.app"
 
   uninstall quit: "com.ramster.LumiMax"
 
   zap trash: [
-    "~/Library/Preferences/com.ramster.LumiMax.plist",
     "~/Library/Caches/com.ramster.LumiMax",
+    "~/Library/Preferences/com.ramster.LumiMax.plist",
   ]
 end

--- a/Casks/l/lumimax.rb
+++ b/Casks/l/lumimax.rb
@@ -2,10 +2,13 @@ cask "lumimax" do
   version "1.3.2"
   sha256 "6733d9e404122d265d4349a9af61f011629023ac830a8353e07464784a070511"
 
-  url "https://github.com/Joowonoil/LumiMax/releases/download/v#{version}/LumiMax.dmg"
+  url "https://github.com/Joowonoil/LumiMax/releases/download/v#{version}/LumiMax.dmg",
+      verified: "github.com/Joowonoil/LumiMax/"
   name "LumiMax"
   desc "XDR brightness boost for Mac displays up to 1600 nits"
   homepage "https://ramterstudio.com/lumimax/"
+
+  depends_on macos: ">= :ventura"
 
   livecheck do
     url :url

--- a/Casks/l/lumimax.rb
+++ b/Casks/l/lumimax.rb
@@ -1,0 +1,25 @@
+cask "lumimax" do
+  version "1.3.2"
+  sha256 "6733d9e404122d265d4349a9af61f011629023ac830a8353e07464784a070511"
+
+  url "https://github.com/Joowonoil/LumiMax/releases/download/v#{version}/LumiMax.dmg"
+  name "LumiMax"
+  desc "XDR brightness boost for Mac displays up to 1600 nits"
+  homepage "https://ramterstudio.com/lumimax/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+
+  app "LumiMax.app"
+
+  uninstall quit: "com.ramster.LumiMax"
+
+  zap trash: [
+    "~/Library/Preferences/com.ramster.LumiMax.plist",
+    "~/Library/Caches/com.ramster.LumiMax",
+  ]
+end


### PR DESCRIPTION
## Description

Add [LumiMax](https://ramterstudio.com/lumimax/) — an XDR brightness boost app for Mac that pushes displays up to 1600 nits using Apple's native EDR overlay.

- **Homepage**: https://ramterstudio.com/lumimax/
- **Mac App Store**: https://apps.apple.com/app/id6758426477?mt=12
- **GitHub**: https://github.com/Joowonoil/LumiMax

## Details

- Uses GitHub Releases for downloads (stable URL with versioning)
- Livecheck configured via `strategy :github_latest`
- Auto-updates via Sparkle
- One-time purchase with 3-day free trial