### PR TITLE
fix: telegram SHA-256 mismatch

### DIFF
--- a/Casks/t/telegram.rb
+++ b/Casks/t/telegram.rb
@@ -1,6 +1,6 @@
 cask "telegram" do
   version "12.5,278815"
-  sha256 "571c5c28766cf08ded4413f3f8418cd166a1b3a5e4a35e004b5d19fe4159ca6e"
+  sha256 "efd3b3a40e6b9bec521dbfda7ab1cb3e7d0557c96f76b33776124be087a986cd"
 
   url "https://osx.telegram.org/updates/Telegram-#{version.csv.first}.#{version.csv.second}.app.zip"
   name "Telegram for macOS"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.
-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

[Related](https://github.com/Homebrew/homebrew-cask/pull/251920#issuecomment-3993923625)
> ```
> ~ % brew install --cask telegram
> ==> Downloading https://osx.telegram.org/updates/Telegram-12.5.278815.app.zip
> ############################################################################################################################## 100.0%
> Error: SHA-256 mismatch
> Expected: 571c5c28766cf08ded4413f3f8418cd166a1b3a5e4a35e004b5d19fe4159ca6e
>   Actual: efd3b3a40e6b9bec521dbfda7ab1cb3e7d0557c96f76b33776124be087a986cd
>     File: /Users/.../Library/Caches/Homebrew/downloads/dd3e38b73b16a4616c8e0f322268abb90e49b79b6798755593b0e465bcab9ae2--Telegram-12.5.278815.app.zip
> To retry an incomplete download, remove the file above.
> ```