### PR TITLE
sfm 1.13.0

### DIFF
--- a/Casks/s/sfm.rb
+++ b/Casks/s/sfm.rb
@@ -1,40 +1,25 @@
 cask "sfm" do
-  version "1.12.12"
-  sha256 "32ebc14def5125e70723559d313cf71f22c51874639456012ae598a4e5936fcb"
+  version "1.13.0"
+  sha256 "a7d90cf8e33e628c954e142846c44b5e017878dd5bb5df72b5a153b57745554e"
 
-  url "https://github.com/SagerNet/sing-box/releases/download/v#{version}/SFM-#{version}-universal.dmg",
+  url "https://github.com/SagerNet/sing-box/releases/download/v#{version}/SFM-#{version}-Universal.pkg",
       verified: "github.com/SagerNet/sing-box/"
   name "SFM"
   desc "Standalone client for sing-box, the universal proxy platform"
   homepage "https://sing-box.sagernet.org/"
 
-  # Upstream is unable to publish the standalone version of the macOS client, so
-  # we have to temporarily check all releases to find the newest version with an
-  # SFM file for macOS. TODO: Remove this `livecheck` block or switch to
-  # `GithubLatest` once this is resolved.
   livecheck do
     url :url
-    regex(/SFM[._-]v?(\d+(?:\.\d+)+)(?:[._-]universal)?\.(?:dmg|pkg)/i)
-    strategy :github_releases do |json, regex|
-      json.map do |release|
-        next if release["draft"] || release["prerelease"]
-
-        release["assets"]&.map do |asset|
-          match = asset["browser_download_url"]&.match(regex)
-          next if match.blank?
-
-          match[1]
-        end
-      end.flatten
-    end
+    strategy :github_latest
   end
 
   depends_on macos: ">= :ventura"
 
-  app "SFM.app"
+  pkg "SFM-#{version}-Universal.pkg"
 
   uninstall quit:       "io.nekohasekai.sfa.independent",
-            login_item: "SFM"
+            login_item: "SFM",
+            pkgutil:    "io.nekohasekai.sfavt.standalone"
 
   zap trash: "~/Library/Group Containers/group.io.nekohasekai.sfa"
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----
Built and tested locally on macOS 26.4.

Upstream switched the macOS release artifact from a universal `.dmg` to separate `.pkg` installers starting with 1.13.0 https://github.com/SagerNet/sing-box/releases/tag/v1.13.0. 
Updated the cask accordingly and simplified the `livecheck` to `strategy :github_latest` now that SFM is included in every Latest release.