### PR TITLE
rustdesk: fix Intel sha256

### DIFF
--- a/Casks/r/rustdesk.rb
+++ b/Casks/r/rustdesk.rb
@@ -3,7 +3,7 @@ cask "rustdesk" do
 
   version "1.4.6"
   sha256 arm:   "0cd498e3f99c878bfa3c54996089b9671fdd15aee5d1ac160444841f95ea01bc",
-         intel: "902837c8f1cf0fae9564d28eae314e126e416586b107187872e757925865b15e"
+         intel: "7d0daf81a80a9861661c0e89321f302760fad9e384247f2c1a9acd9f45705c55"
 
   url "https://github.com/rustdesk/rustdesk/releases/download/#{version}/rustdesk-#{version}-#{arch}.dmg",
       verified: "github.com/rustdesk/rustdesk/"


### PR DESCRIPTION
ref. https://github.com/Homebrew/homebrew-cask/commit/83cf9d0953c293680c0607a3fd82b7369159b8a5 @ https://github.com/rustdesk/rustdesk/releases/tag/1.4.6