### PR TITLE
obsidian: use shim script for CLI binary

### DIFF
--- a/Casks/o/obsidian.rb
+++ b/Casks/o/obsidian.rb
@@ -19,7 +19,16 @@ cask "obsidian" do
   depends_on macos: ">= :monterey"
 
   app "Obsidian.app"
-  binary "#{appdir}/Obsidian.app/Contents/MacOS/Obsidian", target: "obsidian"
+  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
+  shimscript = "#{staged_path}/obsidian.wrapper.sh"
+  binary shimscript, target: "obsidian"
+
+  preflight do
+    File.write shimscript, <<~EOS
+      #!/bin/bash
+      exec '#{appdir}/Obsidian.app/Contents/MacOS/Obsidian' "$@"
+    EOS
+  end
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/md.obsidian.sfl*",


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

---

_This PR was authored with assistance from Claude (Anthropic, claude-opus-4-6), used for researching the root cause and generating the cask change; all code has been reviewed and tested locally. Fixes reported issue #252423._

---

The `binary` stanza added in #251791 creates a symlink to the raw Electron binary at `Contents/MacOS/Obsidian`. On macOS, this crashes with:

```
[FATAL:electron/shell/app/electron_main_delegate_mac.mm:65] Unable to find helper app
GPU process isn't usable. Goodbye.
zsh: trace trap  obsidian
```

**Root cause:** When launched via symlink, `NSBundle.mainBundle.bundlePath` resolves to the symlink's parent directory (e.g. `/opt/homebrew/bin`) rather than the `.app` bundle. Chromium's `AmIBundled()` returns `false`, and Electron cannot locate its helper processes (GPU, Renderer, Plugin), causing a fatal crash.

This is a known limitation of all Electron apps on macOS — symlinks to the raw binary inside a `.app` bundle don't work. See [electron-builder#6962](https://github.com/electron-userland/electron-builder/issues/6962) and [posit-dev/positron#5911](https://github.com/posit-dev/positron/issues/5911) for the same issue in other apps.

**Fix:** Use a shim script (as established for OBS, Firefox, and LibreWolf in #142090) that `exec`s the binary from its real path. When `exec` replaces the process, `_NSGetExecutablePath()` returns the actual path inside the `.app` bundle, and helper app resolution succeeds.

Verified on macOS Sequoia (arm64):
- Symlink: crashes with 18 FATAL errors
- Shim script with `exec`: works with zero errors