### PR TITLE
Add cask for paseo

### DIFF
--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -1,6 +1,6 @@
 cask "paseo" do
-  version "0.1.17"
-  sha256 "487171ad6942da5977df1e62f692961b72f933e340feec45757451c09a54aca5"
+  version "0.1.18"
+  sha256 "acded7f3eaf3f99c94332ef96e15beabe11d7dce2c018cb87c7bbde7f1c49075"
 
   url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo_#{version}_universal.dmg",
       verified: "github.com/getpaseo/paseo/"

--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -1,10 +1,8 @@
 cask "paseo" do
-  arch arm: "aarch64"
+  version "0.1.17"
+  sha256 "487171ad6942da5977df1e62f692961b72f933e340feec45757451c09a54aca5"
 
-  version "0.1.16"
-  sha256 arm: "f546d4bb57fe432934ac1c07ebfc4065242ee1d00272c6630f3fb376d7a2ffcf"
-
-  url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo_#{version}_#{arch}.dmg",
+  url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo_#{version}_universal.dmg",
       verified: "github.com/getpaseo/paseo/"
   name "Paseo"
   desc "Orchestrate coding agents from anywhere"

--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -8,6 +8,11 @@ cask "paseo" do
   desc "Orchestrate coding agents from anywhere"
   homepage "https://paseo.sh/"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   depends_on macos: ">= :ventura"
 
   app "Paseo.app"

--- a/Casks/p/paseo.rb
+++ b/Casks/p/paseo.rb
@@ -1,0 +1,24 @@
+cask "paseo" do
+  arch arm: "aarch64"
+
+  version "0.1.16"
+  sha256 arm: "f546d4bb57fe432934ac1c07ebfc4065242ee1d00272c6630f3fb376d7a2ffcf"
+
+  url "https://github.com/getpaseo/paseo/releases/download/v#{version}/Paseo_#{version}_#{arch}.dmg",
+      verified: "github.com/getpaseo/paseo/"
+  name "Paseo"
+  desc "Orchestrate coding agents from anywhere"
+  homepage "https://paseo.sh/"
+
+  depends_on macos: ">= :ventura"
+
+  app "Paseo.app"
+
+  zap trash: [
+    "~/Library/Application Support/dev.paseo.desktop",
+    "~/Library/Caches/dev.paseo.desktop",
+    "~/Library/Logs/dev.paseo.desktop",
+    "~/Library/Preferences/dev.paseo.desktop.plist",
+    "~/Library/Saved Application State/dev.paseo.desktop.savedState",
+  ]
+end


### PR DESCRIPTION
## Cask info

| | |
|---|---|
| **name** | Paseo |
| **desc** | Orchestrate coding agents from anywhere |
| **homepage** | https://paseo.sh/ |
| **version** | 0.1.17 |
| **bundle id** | dev.paseo.desktop |

Universal binary (Apple Silicon + Intel) built with Tauri.