### PR TITLE
jamovi 2.7.23.0

### DIFF
--- a/Casks/j/jamovi.rb
+++ b/Casks/j/jamovi.rb
@@ -1,11 +1,12 @@
 cask "jamovi" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.7.22.0"
-  sha256 arm:   "7c410dd7df256c79e052cf3ca8e08fb2268c938e21b8cb0e7457970e85d13a74",
-         intel: "131db68ac163960fb598eec9b348ad6663b37e4dfc4e985cd06dae762b3f6122"
+  version "2.7.23.0"
+  sha256 arm:   "d772b80766dcb6db58d30c9e3f24dd4e4a22c1acb58a4d0980b8f32cc7c9b1a9",
+         intel: "88f987296fa1922fe1f9b253788db6c8dd0f62ed4d899ba1003f72c6aeadcffb"
 
-  url "https://www.jamovi.org/downloads/jamovi-#{version}-macos-#{arch}.dmg"
+  url "https://www.jamovi.org/downloads/jamovi-#{version}-macos-#{arch}.dmg",
+      referer: "https://www.jamovi.org/download.html"
   name "jamovi"
   desc "Statistical software"
   homepage "https://www.jamovi.org/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`jamovi` is autobumped but the workflow failed to update to version 2.7.23.0 because the dmg URLs redirect to a 404 page if a referer is not present. This updates the version and adds a `referer` value to the cask `url`.