### PR TITLE
pomotroid 1.0.0

### DIFF
--- a/Casks/p/pomotroid.rb
+++ b/Casks/p/pomotroid.rb
@@ -1,8 +1,8 @@
 cask "pomotroid" do
-  version "0.13.0"
-  sha256 "fab1a8598490db267639609b42312a8947ee2de075164935d0eba60c57790788"
+  version "1.0.0"
+  sha256 "eae5e0a48601a4ee2e2b80ea22301c2979c682e24784d9b9e1d550fb9c4b24cd"
 
-  url "https://github.com/Splode/pomotroid/releases/download/v#{version}/pomotroid-#{version}-macos.dmg"
+  url "https://github.com/Splode/pomotroid/releases/download/v#{version}/Pomotroid_#{version}_universal.dmg"
   name "Pomotroid"
   desc "Timer application"
   homepage "https://github.com/Splode/pomotroid"
@@ -16,8 +16,4 @@ cask "pomotroid" do
     "~/Library/Preferences/com.splode.pomotroid.plist",
     "~/Library/Saved Application State/com.splode.pomotroid.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`pomotroid` is autobumped but the workflow failed to update to version 1.0.0 because the dmg file name format changed. This updates the version and adjusts the cask accordingly.