### PR TITLE
copilot-cli,copilot-cli@prerelease: add auto_updates

### DIFF
--- a/Casks/c/copilot-cli.rb
+++ b/Casks/c/copilot-cli.rb
@@ -18,6 +18,7 @@ cask "copilot-cli" do
     strategy :github_latest
   end
 
+  auto_updates true
   conflicts_with cask: "copilot-cli@prerelease"
   depends_on macos: ">= :ventura"
 

--- a/Casks/c/copilot-cli@prerelease.rb
+++ b/Casks/c/copilot-cli@prerelease.rb
@@ -28,6 +28,7 @@ cask "copilot-cli@prerelease" do
     end
   end
 
+  auto_updates true
   conflicts_with cask: "copilot-cli"
   depends_on macos: ">= :ventura"
 


### PR DESCRIPTION
GitHub Copilot CLI automatically checks for and downloads updates on launch. This is enabled by default and can be controlled via the `--no-auto-update` flag, the `COPILOT_AUTO_UPDATE` environment variable, or the `auto_update` setting in `config.json`.

Reference: https://docs.github.com/en/copilot/how-tos/copilot-cli/command-reference