### PR TITLE
t3-code 0.0.4 (new cask)

### DIFF
--- a/Casks/t/t3-code.rb
+++ b/Casks/t/t3-code.rb
@@ -5,10 +5,11 @@ cask "t3-code" do
   sha256 arm:   "14ab774434354b02dfe9f3adb4ae5f2029ddf1965612f209a825ada8da9dff99",
          intel: "9c7d7bd2a71bc5213599b98e96180cfe1677afde823617218e18c75bec3cb84b"
 
-  url "https://github.com/pingdotgg/t3code/releases/download/v#{version}/T3-Code-#{version}-#{arch}.dmg"
+  url "https://github.com/pingdotgg/t3code/releases/download/v#{version}/T3-Code-#{version}-#{arch}.dmg",
+      verified: "github.com/pingdotgg/t3code/"
   name "T3 Code"
   desc "Minimal GUI for code agents like Codex and Claude Code"
-  homepage "https://github.com/pingdotgg/t3code"
+  homepage "https://t3.codes/"
 
   livecheck do
     url :url

--- a/Casks/t/t3-code.rb
+++ b/Casks/t/t3-code.rb
@@ -1,0 +1,32 @@
+cask "t3-code" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.0.4"
+  sha256 arm:   "14ab774434354b02dfe9f3adb4ae5f2029ddf1965612f209a825ada8da9dff99",
+         intel: "9c7d7bd2a71bc5213599b98e96180cfe1677afde823617218e18c75bec3cb84b"
+
+  url "https://github.com/pingdotgg/t3code/releases/download/v#{version}/T3-Code-#{version}-#{arch}.dmg"
+  name "T3 Code"
+  desc "Minimal GUI for code agents like Codex and Claude Code"
+  homepage "https://github.com/pingdotgg/t3code"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "T3 Code (Alpha).app"
+
+  zap trash: [
+    "~/.t3/userdata",
+    "~/Library/Application Support/T3 Code (Alpha)",
+    "~/Library/Caches/com.t3tools.t3code",
+    "~/Library/HTTPStorages/com.t3tools.t3code",
+    "~/Library/Preferences/com.t3tools.t3code.plist",
+    "~/Library/Saved Application State/com.t3tools.t3code.savedState",
+  ]
+end


### PR DESCRIPTION
Supersedes accidental prior attempt: https://github.com/Homebrew/homebrew-cask/pull/252699

Minimal GUI for code agents like Codex and Claude Code.

- Upstream: https://github.com/pingdotgg/t3code
- Release used: `v0.0.4`
- macOS artifacts:
  - `T3-Code-0.0.4-arm64.dmg`
  - `T3-Code-0.0.4-x64.dmg`

After making any changes to a cask, existing or new, verify:

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, if adding a new cask:

- [x] Named the cask according to the token reference.
- [x] Checked the cask was not already refused.
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

Audit notes:

- `brew audit --cask --new --online t3-code` currently reports one remaining issue:
  - `GitHub repository too new (<30 days old)`
- Upstream repo `pingdotgg/t3code` was created on `2026-02-08T23:46:22Z`; this check should clear after `2026-03-10T23:46:22Z`.

If AI was used to generate or assist with generating the PR:

- [x] I used AI to generate or assist with generating this PR.
- [x] I have personally reviewed, tested and verified all changes/additions, including zap stanza paths.

AI usage details:

- Used Codex to draft and validate the initial cask file, compute checksums, and run Homebrew checks.
- Verified notarization/signature locally on both DMGs (`arm64` and `x64`).
