### PR TITLE
mattermost 6.1.0

### DIFF
--- a/Casks/m/mattermost.rb
+++ b/Casks/m/mattermost.rb
@@ -1,18 +1,22 @@
 cask "mattermost" do
-  arch arm: "m1", intel: "x64"
+  arch arm: "arm64", intel: "x64"
 
-  version "6.0.4"
-  sha256 arm:   "86d5063c9ccdc81fa89dd9f49b4dd7585e601c4d960be56fef25d116ed90f446",
-         intel: "c545516566e42647135caf8c3379fdda36a7aa075c28283579789ae2181b8722"
+  version "6.1.0"
+  sha256 arm:   "25795723da17c4b07394321fc89a3f2e4cfd57cf23c0716b28d806f09e2509db",
+         intel: "d813c3e862229fabac9f28aa07d84640bc0f7a4a0d2a671aaebb813216fc4ee4"
 
   url "https://releases.mattermost.com/desktop/#{version}/mattermost-desktop-#{version}-mac-#{arch}.zip"
   name "Mattermost"
   desc "Open-source, self-hosted Slack-alternative"
   homepage "https://mattermost.com/"
 
+  # The electron-builder `latest-mac.yml` file can include unstable versions.
+  # The upstream website points to the GitHub releases as the place to find
+  # download URLs (linked in the release body text), so we check the latest
+  # GitHub release instead.
   livecheck do
-    url "https://releases.mattermost.com/desktop/latest-mac.yml"
-    strategy :electron_builder
+    url "https://github.com/mattermost/desktop/"
+    strategy :github_latest
   end
 
   depends_on macos: ">= :monterey"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`mattermost` is autobumped but the workflow failed to update to version 6.1.0 because the `latest-mac.yml` file has been using 6.2.0-nightly.20260304 as the latest version. The ARM suffix has also changed to "-arm64" in this version. This updates the version and ARM suffix accordingly.

The upstream website links to the GitHub releases as the place to find the download URLs (linked in the release body text), so this updates the `livecheck` block to check the latest GitHub release instead. Upstream seems to maintain multiple major versions at the same time and a 5.x release may come after a 6.x release but it looks like they only mark the highest version as "latest", so this should be fine (e.g., 5.13.3 and 5.13.4 were released after 6.0.4 but the latter continued to be the "latest" version).