### PR TITLE
pencil2d 0.7.1

### DIFF
--- a/Casks/p/pencil2d.rb
+++ b/Casks/p/pencil2d.rb
@@ -1,15 +1,29 @@
 cask "pencil2d" do
-  version "0.7.0"
-  sha256 "2e0d6a2cce4577e0f0f673189658893ec2182e6a16d4332d98dde21c55899595"
+  on_arm do
+    version "0.7.1"
+    sha256 "a4bb4472c0cdc2a15e396dd057d81ede401e25698caf5b580adda39e278c162f"
 
-  url "https://github.com/pencil2d/pencil/releases/download/v#{version}/pencil2d-mac-#{version}.zip",
-      verified: "github.com/pencil2d/pencil/"
+    url "https://github.com/pencil2d/pencil/releases/download/v#{version}/pencil2d-mac-v#{version}.dmg",
+        verified: "github.com/pencil2d/pencil/"
+  end
+  on_intel do
+    version "0.7.0"
+    sha256 "2e0d6a2cce4577e0f0f673189658893ec2182e6a16d4332d98dde21c55899595"
+
+    url "https://github.com/pencil2d/pencil/releases/download/v#{version}/pencil2d-mac-#{version}.zip",
+        verified: "github.com/pencil2d/pencil/"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    disable! date: "2026-09-01", because: :fails_gatekeeper_check
+  end
+
   name "Pencil2D"
   name "Pencil2D Animation"
   desc "Open-source tool to make 2D hand-drawn animations"
   homepage "https://www.pencil2d.org/"
-
-  disable! date: "2026-09-01", because: :fails_gatekeeper_check
 
   app "Pencil2D.app"
 
@@ -18,8 +32,4 @@ cask "pencil2d" do
     "~/Library/Preferences/com.pencil.Pencil.plist",
     "~/Library/Saved Application State/com.pencil2d.Pencil2D.savedState",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`pencil2d` is autobumped but the workflow failed to update to version 0.7.1 because the file name format has changed (including a "v" before the version) and upstream now only publishes a dmg file for macOS (instead of a zip). Previous versions were Intel-only but 0.7.1 is now Apple Silicon-only. This maintains 0.7.0 as a legacy version for Intel and updates the version for ARM to 0.7.1. The 0.7.1 app also passes the Gatekeeper check and I've manually confirmed that it's signed and notarized, so this drops the `disable!` call for the ARM version.