### PR TITLE
the-unofficial-homestuck-collection: update livecheck

### DIFF
--- a/Casks/t/the-unofficial-homestuck-collection.rb
+++ b/Casks/t/the-unofficial-homestuck-collection.rb
@@ -8,9 +8,25 @@ cask "the-unofficial-homestuck-collection" do
   desc "Offline viewer for the webcomic Homestuck"
   homepage "https://bambosh.github.io/unofficial-homestuck-collection/"
 
+  # Upstream has stopped publishing macOS versions due to GitHub dropping
+  # support for macOS 13 and it's unclear whether this will be addressed going
+  # forward due to the project maintenance status. For the time being, we check
+  # multiple GitHub releases to identify the newest version with a dmg file.
   livecheck do
     url :url
-    strategy :github_latest
+    regex(/v?(\d+(?:\.\d+)+).*?\.dmg/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        release["assets"]&.map do |asset|
+          match = asset["browser_download_url"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end
+      end.flatten
+    end
   end
 
   disable! date: "2026-09-01", because: :fails_gatekeeper_check


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `the-unofficial-homestuck-collection` is reporting 2.8.0 as the newest version but this release doesn't have any assets for macOS. Upstream has stopped publishing macOS versions due to GitHub dropping support for macOS 13 and it's unclear whether this will be addressed going forward due to the project maintenance status. For the time being, this updates the `livecheck` block to check multiple GitHub releases to identify the newest version with a dmg file. For what it's worth, I've used a loose regex for now, to allow it to continue to match if upstream adds an arch suffix, changes the prefix, etc. and we can tighten this if/when the upstream situation clarifies.

Alternatively, we could update the `livecheck` block to skip but I figured we could start here and see how the upstream release situation plays out. This cask is deprecated due to failing the Gatekeeper check, so it won't be around forever at this rate anyway.