### PR TITLE
ticktick 8.0.21

### DIFF
--- a/Casks/t/ticktick.rb
+++ b/Casks/t/ticktick.rb
@@ -1,12 +1,12 @@
 cask "ticktick" do
-  version "8.0.20,461"
-  sha256 "d61cf6e4991acf3d81f002c1f712a34d1766e480906aff9c85fab724f7b57f01"
+  version "8.0.21,463"
+  sha256 "a82dfb6dd1561ec95962e8af61c1e6ead0ad56e21b500c12d5d4b4ffe57808df"
 
-  url "https://ticktick-download-mac.s3.amazonaws.com/download/mac/TickTick_#{version.csv.first}_#{version.csv.second}.dmg",
-      verified: "ticktick-download-mac.s3.amazonaws.com/download/mac/"
+  url "https://download.ticktick.app/download/mac/TickTick_#{version.csv.first}_#{version.csv.second}.dmg",
+      verified: "download.ticktick.app/download/mac/"
   name "TickTick"
   desc "To-do & task list manager"
-  homepage "https://www.ticktick.com/home"
+  homepage "https://www.ticktick.com/"
 
   livecheck do
     url "https://pull.ticktick.com/mac/release_note/mac_appcast.xml"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`ticktick` is autobumped but the workflow failed to update to version 8.0.21 because the cask asset URL domain doesn't work for this version. This updates the version and modifies the `url` to use the new download domain (as seen in the redirection from the download URL in the appcast). Besides that, this removes the path from the homepage URL, as it appears to be the same as the main page of the website.