### PR TITLE
tidal 2.40.0

### DIFF
--- a/Casks/t/tidal.rb
+++ b/Casks/t/tidal.rb
@@ -1,14 +1,15 @@
 cask "tidal" do
   arch arm: "arm64", intel: "x64"
 
-  version "2.39.5"
-  sha256 arm:   "4ba8a1a8e33f6069617916a94533fe143bea2ed4b42b375ba7deab88ecd6362e",
-         intel: "49d8c6632b08e0527106c8140b02e72c0ebb97f611afc7404be167f4d3497a22"
+  version "2.40.0"
+  sha256 arm:   "f98aa088289599a41b95a68f8977803cc7af5932983725a229d76e4ac6d468d1",
+         intel: "507552651b3211de69657886ae76c61313a2ee38ebcb3053754565005febff95"
 
   url "https://download.tidal.com/desktop/mac/TIDAL.#{arch}.#{version}.zip"
   name "TIDAL"
   desc "Music streaming service with high fidelity sound and hi-def video quality"
-  homepage "https://tidal.com/"
+  # The main website is inaccessible due to using a verification system.
+  homepage "https://support.tidal.com/hc/en-us"
 
   livecheck do
     url "https://download.tidal.com/desktop/mac/update-#{arch}.json"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`tidal` is autobumped but the workflow failed to update to version 2.40.0 because the homepage is unreachable due to the website using a JavaScript verification step. This issue occurs regardless of user agent or IP address. This updates the version and switches the homepage to the main Tidal support page, allowing this to continue to be autobumped for now. We may want to consider adding a homepage skiplist (e.g., we have one for using a curl user agent) if it's preferable to maintain the existing homepage (i.e., it may be better for users but we have to automatically skip the audit).