### PR TITLE
topaz-photo 1.3.1

### DIFF
--- a/Casks/t/topaz-photo.rb
+++ b/Casks/t/topaz-photo.rb
@@ -1,22 +1,26 @@
 cask "topaz-photo" do
-  version "1.2.1"
-  sha256 "895e8b3f7e1990ad4f2e961ea40d46cd6b7abf4522ef52fb7355f91cc32b6021"
+  arch arm: "arm64", intel: "x86_64"
+  livecheck_arch = on_arch_conditional intel: "/intel"
 
-  url "https://downloads.topazlabs.com/deploy/TopazPhoto/#{version}/TopazPhoto-#{version}.pkg"
+  version "1.3.1"
+  sha256 arm:   "2361088732275bf4a64c363a63700c93aff04f59a21f045c68451a769591dd13",
+         intel: "333ac5f4b8d27786de05208fedc6be1cc95b5f9534a878f9b7274c846e0b1c57"
+
+  url "https://downloads.topazlabs.com/deploy/TopazPhoto/#{version}/TopazPhoto-#{version}-#{arch}.pkg"
   name "Topaz Photo"
   desc "AI image enhancer"
   homepage "https://www.topazlabs.com/topaz-photo"
 
   livecheck do
-    url "https://topazlabs.com/d/photostudio/latest/mac/full"
+    url "https://topazlabs.com/d/photostudio/latest/mac#{livecheck_arch}/full"
+    regex(/TopazPhoto[._-]v?(\d+(?:\.\d+)+)[._-]#{arch}/i)
     strategy :header_match
   end
 
   auto_updates true
-  depends_on arch:  :arm64,
-             macos: ">= :monterey"
+  depends_on macos: ">= :monterey"
 
-  pkg "TopazPhoto-#{version}.pkg"
+  pkg "TopazPhoto-#{version}-#{arch}.pkg"
 
   uninstall pkgutil: "com.topazlabs.TopazPhoto",
             delete:  [


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`topaz-photo` is autobumped but the workflow failed to update to version 1.3.1 because upstream now publishes separate ARM and Intel packages and livecheck incorrectly returns 64 as the newest version, matched from the `arm64` suffix in the file name. The existing `livecheck` block URL redirects to the ARM pkg and there's a separate URL for Intel. This updates the version and adjusts the cask to handle the separate arch files.