### PR TITLE
wireless-workbench 7.8.1

### DIFF
--- a/Casks/w/wireless-workbench.rb
+++ b/Casks/w/wireless-workbench.rb
@@ -1,20 +1,26 @@
 cask "wireless-workbench" do
-  version "7.8.0"
-  sha256 "c2abb9f1eedd6f44589acc0994a7220136d8adb8309c67c0813b7e2aff3d271c"
+  version "7.8.1,56"
+  sha256 "d543614acf0b8a9293dae4859f8ccd73f7eace9e92c8d34ba7ab1ab6353959fe"
 
-  url "https://content-files.shure.com/Software/wireless-workbench/#{version.dots_to_hyphens}/Wireless-Workbench-macOS-#{version}.pkg"
+  url "https://content-files.shure.com/Software/wireless-workbench/#{version.csv.first.dots_to_hyphens}/Wireless-Workbench-macOS-#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.pkg"
   name "Wireless Workbench"
   desc "Desktop app for RF coordination and wireless system management"
   homepage "https://www.shure.com/en-US/products/software/wwb?variant=WWB"
 
   livecheck do
     url "https://www.shure.com/en-US/sw/wwb-mac"
-    strategy :header_match
+    regex(/Wireless[._-]Workbench(?:[._-]macOS)?[._-]v?(\d+(?:\.\d+){1,2})((?:\.\d+)*)?\.pkg/)
+    strategy :header_match do |headers, regex|
+      match = headers["location"]&.match(regex)
+      next unless match
+
+      match[2].present? ? "#{match[1]},#{match[2].delete_prefix(".")}" : match[1]
+    end
   end
 
   depends_on macos: ">= :ventura"
 
-  pkg "Wireless-Workbench-macOS-#{version}.pkg"
+  pkg "Wireless-Workbench-macOS-#{version.csv.first}#{".#{version.csv.second}" if version.csv.second}.pkg"
 
   uninstall pkgutil: "com.shure.WWB"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`wireless-workbench` is autobumped but the workflow failed to update to version 7.8.1 because the version in the file name is 7.8.1.56 but the version in the path directory is 7.8.1. The upstream website references the version as 7.8.1, so we have to account for extra number(s) in the version. This updates the version and reworks the `livecheck` block to split off any extra numbers into a secondary part. This should work regardless of how many extra numbers there are beyond major/minor/patch, if any.