### PR TITLE
ltx-desktop 1.0.1 (new cask)

### DIFF
--- a/Casks/l/ltx-desktop.rb
+++ b/Casks/l/ltx-desktop.rb
@@ -1,4 +1,4 @@
-cask "ltx" do
+cask "ltx-desktop" do
   version "1.0.1"
   sha256 "db21abb544da6ca730732498878bba75e98128a40f0b1b81886ee9b9649b18dd"
 

--- a/Casks/l/ltx-desktop.rb
+++ b/Casks/l/ltx-desktop.rb
@@ -8,11 +8,6 @@ cask "ltx-desktop" do
   desc "Desktop app for generating videos with LTX models"
   homepage "https://ltx.io/ltx-desktop"
 
-  livecheck do
-    url "https://github.com/Lightricks/LTX-Desktop/releases/latest/download/latest-mac.yml"
-    strategy :electron_builder
-  end
-
   auto_updates true
   depends_on arch: :arm64
 

--- a/Casks/l/ltx.rb
+++ b/Casks/l/ltx.rb
@@ -1,0 +1,27 @@
+cask "ltx" do
+  version "1.0.1"
+  sha256 "db21abb544da6ca730732498878bba75e98128a40f0b1b81886ee9b9649b18dd"
+
+  url "https://github.com/Lightricks/LTX-Desktop/releases/download/v#{version}/LTX-Desktop-arm64.dmg",
+      verified: "github.com/Lightricks/LTX-Desktop/"
+  name "LTX Desktop"
+  desc "Desktop app for generating videos with LTX models"
+  homepage "https://ltx.io/ltx-desktop"
+
+  livecheck do
+    url "https://github.com/Lightricks/LTX-Desktop/releases/latest/download/latest-mac.yml"
+    strategy :electron_builder
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+
+  app "LTX Desktop.app"
+
+  uninstall quit: "com.lightricks.ltx-desktop"
+
+  zap trash: [
+    "~/Library/Preferences/com.lightricks.ltx-desktop.plist",
+    "~/Library/Saved Application State/com.lightricks.ltx-desktop.savedState",
+  ]
+end


### PR DESCRIPTION
https://ltx.io/ltx-desktop

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

> **Note:** `brew audit --cask --new` reports "GitHub repository too new (<30 days old)" — `Lightricks/LTX-Desktop` was created 2026-03-04. All other checks pass.

-----

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

AI was used to assist with drafting the cask and running validation checks. All changes were manually reviewed and the cask was installed and tested locally on macOS 26.3.
