### PR TITLE
aqua-voice 0.12.1

### DIFF
--- a/Casks/a/aqua-voice.rb
+++ b/Casks/a/aqua-voice.rb
@@ -1,15 +1,15 @@
 cask "aqua-voice" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.11.9"
-  sha256 arm:   "d1f8a3f0febcbbe49081dfde016a841faca8fb724b4706ba6d616fb4a230969b",
-         intel: "59f65c28bf6843ea10d3105285ca331b2255c72c3d33901d2d8586521c198c2f"
+  version "0.12.1"
+  sha256 arm:   "a2fc413fe92642b569f9cc0359757db177c0fb3d2f0d047c5ae23cc5d51c6818",
+         intel: "caa2a132a7644374ebafd55822b6aa1d344a4e9d84a66e5a6fce2498f564d1ac"
 
-  url "https://d1a1dx1sgvjqrz.cloudfront.net/aqua-voice-updates/darwin/#{arch}/Aqua+Voice-#{version}-#{arch}.dmg",
+  url "https://d1a1dx1sgvjqrz.cloudfront.net/aqua-voice-updates/darwin/#{arch}/Aqua%20Voice-darwin-#{arch}-#{version}.zip",
       verified: "d1a1dx1sgvjqrz.cloudfront.net/"
   name "Aqua Voice"
   desc "Speech-to-text system"
-  homepage "https://withaqua.com/"
+  homepage "https://aquavoice.com/"
 
   livecheck do
     url "https://aqua-desktop-builds.s3.amazonaws.com/aqua-voice-updates/darwin/#{arch}/RELEASES.json"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`aqua-voice` is autobumped but the workflow failed to update to version 0.12.1, as the versioned dmg file URLs don't resolve. I wasn't able to find new versioned dmg files, so this updates the version and modifies the cask to use the versioned zip files that are referenced in the JSON file that livecheck checks.