### PR TITLE
Create Cask for AppPorts 1.5.1

### DIFF
--- a/Casks/a/appports.rb
+++ b/Casks/a/appports.rb
@@ -1,0 +1,31 @@
+cask "appports" do
+  version "1.5.1"
+  sha256 "94400dc77d0bc558cdd4088a85cd72fb5548afc6f74b0752c872ea4e4b220384"
+
+  url "https://github.com/wzh4869/AppPorts/releases/download/#{version}/AppPorts#{version}.dmg"
+  name "AppPorts"
+  desc "Application migration and linking tool"
+  homepage "https://github.com/wzh4869/AppPorts"
+
+  livecheck do
+    url :url
+    strategy :github_releases
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sonoma"
+
+  app "AppPorts.app"
+
+  zap trash: [
+    "~/Library/Application Support/AppPorts",
+    "~/Library/Caches/com.shimoko.AppPorts",
+    "~/Library/Preferences/com.shimoko.AppPorts.plist",
+    "~/Library/Saved Application State/com.shimoko.AppPorts.savedState",
+  ]
+
+  caveats <<~EOS
+    AppPorts is not signed by an Apple Developer. To open it, you may need to run:
+      xattr -rd com.apple.quarantine /Applications/AppPorts.app
+  EOS
+end


### PR DESCRIPTION
AppPorts is a native macOS application migration and linking tool. It allows users to move large applications to external storage while keeping a functional "App Portal" in the original location using a specialized "Contents Linking" strategy.
Add Cask for AppPorts version 1.5.1 with dependencies and caveats.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----
