### PR TITLE
prayertimes 2.3.0 (new cask)

### DIFF
--- a/Casks/p/prayertimes.rb
+++ b/Casks/p/prayertimes.rb
@@ -1,0 +1,22 @@
+cask "prayertimes" do
+  version "2.3.0"
+  sha256 "28439f45535bf275c23c20b81889c2ba7f2f1ef50933e4822a1433a608bb5805"
+
+  url "https://github.com/abd3lraouf/PrayerTimes/releases/download/v#{version}/PrayerTimes-#{version}.dmg"
+  name "PrayerTimes"
+  desc "Menu bar app for Islamic prayer times with Hijri calendar"
+  homepage "https://github.com/abd3lraouf/PrayerTimes"
+
+  depends_on macos: ">= :ventura"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "PrayerTimes.app"
+
+  uninstall quit: "com.abd3lraouf.PrayerTimes"
+
+  zap trash: "~/Library/Preferences/com.abd3lraouf.PrayerTimes.plist"
+end


### PR DESCRIPTION
New cask for [PrayerTimes](https://github.com/abd3lraouf/PrayerTimes) — a macOS menu bar app for Islamic prayer times with Hijri calendar.

- Ad-hoc signed, open source
- Tested with `brew audit` and `brew style`