### PR TITLE
gearsystem 3.9.0

### DIFF
--- a/Casks/g/gearsystem.rb
+++ b/Casks/g/gearsystem.rb
@@ -1,11 +1,11 @@
 cask "gearsystem" do
-  arch arm: "arm", intel: "intel"
+  arch arm: "arm64", intel: "intel"
 
-  version "3.8.6"
-  sha256 arm:   "f85017e23960359a7ac740b3fd1aad1a358c1b34c73c176bb33b1737bb27fd24",
-         intel: "a10df0621dc0ce03fffd10c0e84ea07f6c62d4b56cd3af6cce51dec6a2cd6ea9"
+  version "3.9.0"
+  sha256 arm:   "412467a0c80219861ae66aea5642ab5e6a7135c3a882bd30a1e402fd81605ada",
+         intel: "c9f54ed5d89108a0bfebdd0ee44a4c9eab157d44f2750a4b3bf86968951dcd5d"
 
-  url "https://github.com/drhelius/Gearsystem/releases/download/#{version}/Gearsystem-#{version}-macos-#{arch}.zip"
+  url "https://github.com/drhelius/Gearsystem/releases/download/#{version}/Gearsystem-#{version}-desktop-macos-#{arch}.zip"
   name "Gearsystem"
   desc "Sega Master System, Game Gear and SG-1000 emulator"
   homepage "https://github.com/drhelius/Gearsystem"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`gearsystem` is autobumped but the workflow failed to update to version 3.9.0 because the zip file names now includes a "desktop" suffix and the ARM suffix is "arm64" instead of "arm". This updates the version adjusts the cask accordingly.