### PR TITLE
vlc@nightly 4.0.0,20260308-0431,f12988ae

### DIFF
--- a/Casks/v/vlc@nightly.rb
+++ b/Casks/v/vlc@nightly.rb
@@ -3,12 +3,12 @@ cask "vlc@nightly" do
   livecheck_arch = on_arch_conditional arm: "arm64", intel: "intel64"
 
   on_arm do
-    version "4.0.0,20260301-0416,1499dace"
-    sha256 "5d86e036cc0574edb0e84d2e07c4a598cc906b86102ee16dbab2fa6cbffc7da3"
+    version "4.0.0,20260308-0431,f12988ae"
+    sha256 "f45a3b6b7628b603eff67d76697070c792d5a1399a43410207a72a05bc54c6b0"
   end
   on_intel do
-    version "4.0.0,20260301-0416,1499dace"
-    sha256 "a677aa42b3ceba2b987f3dfa79a6a4e62554e2ebed8a7f7db5289a47dde92dac"
+    version "4.0.0,20260308-0411,f12988ae"
+    sha256 "f4cf57bd25a1ac20ca0796623977f6c820bad2431abe888bdfd0cfbdf4f41e9d"
   end
 
   url "https://artifacts.videolan.org/vlc/nightly-macos-#{arch}/#{version.csv.second}/vlc-#{version.csv.first}-dev-#{livecheck_arch}-#{version.csv.third}.dmg"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`vlc@nightly` is autobumped but the workflow failed to update to version 4.0.0,20260308-0431,f12988ae for ARM and 4.0.0,20260308-0411,f12988ae for Intel, as the versions differ but the on_arch blocks have duplicate `version` values, which trips up `brew bump`. This should have been using one `version` value but `brew bump` can't split one version into arch-specific versions, so it would have to be updated manually anyway. This updates the versions to keep this moving forward.