### PR TITLE
Combine duplicate arch-specific versions

### DIFF
--- a/Casks/e/eigent.rb
+++ b/Casks/e/eigent.rb
@@ -1,15 +1,9 @@
 cask "eigent" do
   arch arm: "-arm64"
 
+  version "0.0.87"
   sha256 arm:   "ad4d2e1aae1bffb7875ac48a312e5a53033cb38385f48c9aa169a8a74477b706",
          intel: "bfb1e0d2d4a3ee2c08f3e2bad959545dc87386ff8f6062d2b07e104bbb4ad621"
-
-  on_arm do
-    version "0.0.87"
-  end
-  on_intel do
-    version "0.0.87"
-  end
 
   url "https://github.com/eigent-ai/eigent/releases/download/v#{version}/Eigent-#{version}#{arch}.dmg",
       verified: "github.com/eigent-ai/eigent/"

--- a/Casks/n/nao.rb
+++ b/Casks/n/nao.rb
@@ -1,14 +1,9 @@
 cask "nao" do
   arch arm: "arm64", intel: "x64"
 
-  on_arm do
-    version "0.16.5"
-    sha256 "778ebfdf9d0fc205e5b5d54c2d9cd066b5289773a9e666e0aff9a1ff1b82004b"
-  end
-  on_intel do
-    version "0.16.5"
-    sha256 "a56c9dae8ccc3e726d35e58a31fdac2211dba512eb522a44c9c5baa5a853ac5c"
-  end
+  version "0.16.5"
+  sha256 arm:   "778ebfdf9d0fc205e5b5d54c2d9cd066b5289773a9e666e0aff9a1ff1b82004b",
+         intel: "a56c9dae8ccc3e726d35e58a31fdac2211dba512eb522a44c9c5baa5a853ac5c"
 
   url "https://storage.googleapis.com/nao-releases/nao/darwin-#{arch}/#{version}/nao.#{arch}.#{version}.dmg",
       verified: "storage.googleapis.com/nao-releases/nao/"

--- a/Casks/v/vimcal.rb
+++ b/Casks/v/vimcal.rb
@@ -2,14 +2,9 @@ cask "vimcal" do
   arch arm: "-arm64"
   host_suffix = on_arch_conditional arm: "m1", intel: "production"
 
-  on_arm do
-    version "1.0.45"
-    sha256 "4151242d0d6ab9304fcdb22be8e680022a64b3709d893860088b10989c75854b"
-  end
-  on_intel do
-    version "1.0.45"
-    sha256 "e2b06d0933da575053faedf0c18d0abca75ffc286ff4d47eac6f88c533ccec8a"
-  end
+  version "1.0.45"
+  sha256 arm:   "4151242d0d6ab9304fcdb22be8e680022a64b3709d893860088b10989c75854b",
+         intel: "e2b06d0933da575053faedf0c18d0abca75ffc286ff4d47eac6f88c533ccec8a"
 
   url "https://vimcal-#{host_suffix}.s3.amazonaws.com/Vimcal-#{version}#{arch}.dmg",
       verified: "vimcal-#{host_suffix}.s3.amazonaws.com/"

--- a/Casks/w/wispr-flow.rb
+++ b/Casks/w/wispr-flow.rb
@@ -1,14 +1,9 @@
 cask "wispr-flow" do
   arch arm: "arm64", intel: "x64"
 
-  on_arm do
-    version "1.4.484"
-    sha256 "4cab9dcfe0a42f1a3ca98c652d18a5491eea0d9343c0010b268b159bfccc0d25"
-  end
-  on_intel do
-    version "1.4.484"
-    sha256 "66f4350cace0a9ca11e2d00f8ca92c31b719ca54a6aada3827762ba13c66a62b"
-  end
+  version "1.4.484"
+  sha256 arm:   "4cab9dcfe0a42f1a3ca98c652d18a5491eea0d9343c0010b268b159bfccc0d25",
+         intel: "66f4350cace0a9ca11e2d00f8ca92c31b719ca54a6aada3827762ba13c66a62b"
 
   url "https://dl.wisprflow.com/wispr-flow/darwin/#{arch}/dmgs/Flow-v#{version}.dmg",
       verified: "dl.wisprflow.com/wispr-flow/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

A few casks use `on_arm`/`on_intel` blocks solely to define arch-specific versions but the `version` values are identical. The arch-specific version setup was originally added to these casks when the versions differed but now the versions align. `bump` isn't capable of switching casks to or from arch-specific or single-version setups but it was capable of updating the versions, so we ended up with this setup.

I [recently made changes to `brew bump`](https://github.com/Homebrew/brew/pull/21692) to detect these situations and print a warning (saying to manually handle the update) instead of updating the versions, so `bump` shouldn't produce this type of situation going forward. This means that maintainers will have to manually migrate casks between arch-specific and single-version setups but that's a pre-existing limitation.

With that in mind, this modifies existing casks using duplicate arch-specific versions to use a single `version` and `sha256`, as we would expect.