### PR TITLE
Add namespace 1.0

### DIFF
--- a/Casks/n/namespace.rb
+++ b/Casks/n/namespace.rb
@@ -12,6 +12,8 @@ cask "namespace" do
     strategy :github_latest
   end
 
+  depends_on macos: ">= :ventura"
+
   app "NameSpace.app"
 
   zap trash: "~/Library/Preferences/com.ivanhofer.NameSpace.plist"

--- a/Casks/n/namespace.rb
+++ b/Casks/n/namespace.rb
@@ -1,0 +1,18 @@
+cask "namespace" do
+  version "1.0"
+  sha256 "b7fdf24b47b997e57f469d93cf3e9af26004d318eb65a4d73bb9423aa0de8b83"
+
+  url "https://github.com/AduroIdea/NameSpace/releases/download/v#{version}/NameSpace-#{version}.dmg"
+  name "NameSpace"
+  desc "Name your desktops and switch between them from the menu bar"
+  homepage "https://github.com/AduroIdea/NameSpace"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "NameSpace.app"
+
+  zap trash: "~/Library/Preferences/com.ivanhofer.NameSpace.plist"
+end


### PR DESCRIPTION
## Cask PR Checklist

- [x] I have read the [contribution guidelines](https://github.com/Homebrew/homebrew-cask/blob/master/CONTRIBUTING.md).
- [x] I have verified the cask works locally.
- [x] The app is notarized by Apple (Notarized Developer ID).
- [x] Version is up to date (1.0).

## Description

**NameSpace** is a macOS menu bar app that lets users rename their virtual desktops (Spaces) and switch between them with a single click.

- Runs in the menu bar (no Dock icon)
- Rename any desktop inline
- Single mode: shows current desktop name
- All mode: shows all desktops, highlights the active one
- Notarized with Developer ID: Aduro ideja d.o.o.