### PR TITLE
ibm-aspera-connect 4.2.19.956-HEAD (intel only)

### DIFF
--- a/Casks/i/ibm-aspera-connect.rb
+++ b/Casks/i/ibm-aspera-connect.rb
@@ -6,13 +6,17 @@ cask "ibm-aspera-connect" do
   on_arm do
     version "4.2.13.820"
     sha256 "58b42f814c95168e149491d330acb286920fcc19c581e958168305b78c8aa478"
+
+    url "https://delivery04-mul.dhe.ibm.com/sar/CMA/OSA/#{folder}/0/ibm-aspera-connect_#{version}_macOS_#{arch}.pkg"
   end
   on_intel do
-    version "4.2.14.855-HEAD"
-    sha256 "3b1d2fefe897e4e04b2ff68f26220e2e75c93cf566b8504048f72076b42da23d"
+    version "4.2.19.956-HEAD"
+    sha256 "5f6b88d3b5fdf3d1e1dbeb4c49e366be12942100712622aa582571e4d7d3feef"
+
+    url "https://d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/ibm-aspera-connect_#{version}_macOS_#{arch}.pkg",
+        verified: "d3gcli72yxqn2z.cloudfront.net/downloads/connect/latest/bin/"
   end
 
-  url "https://delivery04-mul.dhe.ibm.com/sar/CMA/OSA/#{folder}/0/ibm-aspera-connect_#{version}_macOS_#{arch}.pkg"
   name "IBM Aspera Connect"
   desc "Facilitate uploads and downloads with an Aspera transfer server"
   homepage "https://www.ibm.com/aspera/connect/"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`ibm-aspera-connect` is autobumped but the workflow failed to update to version 4.2.19.956-HEAD for Intel because the URL is different. I confirmed that the current ARM version can't use the same domain and path but I'm not quite sure of the current URL, as the homepage only links to the Intel pkg and the "See all installers" page requires a login to download files. This updates the Intel version and modifies the cask to use arch-specific URLs for now.