### PR TITLE
Add pangoterm 1.0.4

### DIFF
--- a/Casks/p/pangoterm.rb
+++ b/Casks/p/pangoterm.rb
@@ -1,0 +1,34 @@
+cask "pangoterm" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "1.0.4"
+
+  on_arm do
+    sha256 "6d836a70e68e330354a5dbc10b779dd7e6bd025fae98e6a4ba5649520cbb20ff"
+  end
+  on_intel do
+    sha256 "1784deddc99ed7ee868f54e29abb18181fd96e8ba264af0e6844130e3f733214"
+  end
+
+  url "https://github.com/fpaitoo/pangoterm-releases/releases/download/v#{version}/PangoTerm_#{version}_#{arch}.dmg"
+  name "PangoTerm"
+  desc "Modern cross-platform SSH client with SFTP, port forwarding, and terminal emulation"
+  homepage "https://pangoterm.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :catalina"
+
+  app "PangoTerm.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.pangoterm.desktop",
+    "~/Library/Caches/com.pangoterm.desktop",
+    "~/Library/Saved Application State/com.pangoterm.desktop.savedState",
+    "~/Library/WebKit/com.pangoterm.desktop",
+  ]
+end


### PR DESCRIPTION
### Description

Add [PangoTerm](https://pangoterm.com/) — a modern cross-platform SSH client built with Tauri.

**Features:**
- Terminal emulation with multiple tabs
- SFTP file management with drag-and-drop
- Port forwarding
- System monitoring widgets
- Snippet management
- SSH key and keychain support

### Checklist

- [x] Cask is for macOS
- [x] App name does not conflict with existing casks
- [x] `sha256` is provided for both `arm64` and `intel` architectures
- [x] `homepage` is reachable
- [x] Download URL is publicly accessible
- [x] `livecheck` is configured
- [x] `depends_on macos: ">= :catalina"` matches minimum system requirement
- [x] `zap` stanza included