### PR TITLE
handy: set `auto_updates true`

### DIFF
--- a/Casks/h/handy.rb
+++ b/Casks/h/handy.rb
@@ -11,6 +11,7 @@ cask "handy" do
   desc "Speech to text application"
   homepage "https://handy.computer/"
 
+  auto_updates true
   depends_on macos: ">= :ventura"
 
   app "Handy.app"


### PR DESCRIPTION
Handy uses [Tauri's built-in updater plugin](https://v2.tauri.app/plugin/updater/) to self-update. Without `auto_updates true`, Homebrew marks the cask as outdated when the app updates itself ahead of the formula, causing `brew upgrade` to unnecessarily redownload the same version.

- [x] The submission is for a stable version or documented exception.
- [x] `brew audit --cask --online handy` is error-free.
- [x] `brew style --fix handy` reports no offenses.