### PR TITLE
dorico 6.2

### DIFF
--- a/Casks/d/dorico.rb
+++ b/Casks/d/dorico.rb
@@ -1,6 +1,6 @@
 cask "dorico" do
   version "6.2,375be65a-7dd0-43b6-8af0-03b7422373fa"
-  sha256 "890cbaf877eb5bde79fe38c8677c640be3231eaf0a845b3a1e116515d1489b75"
+  sha256 "16ae9c019b82d22fcf03038d82c6f874b8b965e821a0594f2448c44e6689eb33"
 
   url "https://download.steinberg.net/automated_updates/sda_downloads/#{version.csv.second}/Dorico_#{version.csv.first}_Installer_mac.dmg"
   name "Dorico"

--- a/Casks/d/dorico.rb
+++ b/Casks/d/dorico.rb
@@ -1,15 +1,18 @@
 cask "dorico" do
-  version "6.1.10"
+  version "6.2,375be65a-7dd0-43b6-8af0-03b7422373fa"
   sha256 "890cbaf877eb5bde79fe38c8677c640be3231eaf0a845b3a1e116515d1489b75"
 
-  url "https://download.steinberg.net/support/temporary/Dorico_#{version}/Dorico_#{version}_Installer_mac.dmg"
+  url "https://download.steinberg.net/automated_updates/sda_downloads/#{version.csv.second}/Dorico_#{version.csv.first}_Installer_mac.dmg"
   name "Dorico"
   desc "Scoring software"
   homepage "https://www.steinberg.net/dorico/"
 
   livecheck do
     url "https://o.steinberg.net/en/support/downloads/dorico_#{version.major}.html"
-    regex(%r{href=.*?/Dorico[._-]v?(\d+(?:\.\d+)*)[._-]Installer[._-]mac\.dmg}i)
+    regex(%r{href=.*?/([\h-]+)/Dorico[._-]v?(\d+(?:\.\d+)*)[._-]Installer[._-]mac\.dmg}i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| "#{match[1]},#{match[0]}" }
+    end
   end
 
   auto_updates true


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`dorico` is autobumped but the workflow failed to update to version 6.2 because the URL format has changed. The dmg URLs on the download page now use a hash with hyphen delimiters in the path, so we also have to capture that using the `livecheck` block regex. This updates the version and adjusts the cask accordingly.