### PR TITLE
glkvm 1.4.0

### DIFF
--- a/Casks/g/glkvm.rb
+++ b/Casks/g/glkvm.rb
@@ -1,8 +1,8 @@
 cask "glkvm" do
-  version "1.3.0,1765244166600,release1"
-  sha256 "0af45164cda49a10aea78556fd7b5c5655ec84b4d51e72eb177b6169600c877c"
+  version "1.4.0,1772531687978,release2"
+  sha256 "250a730385a68c10324d4b1b22befd3d322bf374d42352753159378d96794c93"
 
-  url "https://static.gl-inet.com/edge-app/kvm-mac/#{version.csv.first}#{"-#{version.csv.third}" if version.csv.third}/#{version.csv.second}/gl-kvm-#{version.csv.first}.dmg"
+  url "https://static.gl-inet.com/edge-app-staging/kvm-mac/#{version.csv.first}#{"-#{version.csv.third}" if version.csv.third}/#{version.csv.second}/gl-kvm-#{version.csv.first}#{"-#{version.csv.third}" if version.csv.third}.dmg"
   name "GLKVM"
   desc "App for controlling GL.iNet KVM devices"
   homepage "https://www.gl-inet.com/app-rm/"
@@ -17,14 +17,12 @@ cask "glkvm" do
     end
   end
 
+  depends_on macos: ">= :big_sur"
+
   app "GLKVM.app"
 
   zap trash: [
     "~/Library/Application Support/gl-kvm",
     "~/Library/Logs/gl-kvm",
   ]
-
-  caveats do
-    requires_rosetta
-  end
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

`glkvm` is autobumped but the workflow failed to update to version 1.4.0 because the URL uses "edge-app-staging" instead of "edge-app" in the path and the file name also includes the "-release2" suffix. This updates the version and adjusts the asset `url`. If it changes again in the future, we may have to add more variable URL parts to the cask `version` but let's see how things go after this.