### PR TITLE
Rename `postgres-unofficial` cask to `postgres-app`

### DIFF
--- a/Casks/p/postgres-app.rb
+++ b/Casks/p/postgres-app.rb
@@ -1,4 +1,4 @@
-cask "postgres-unofficial" do
+cask "postgres-app" do
   version "2.9.4,14-15-16-17-18"
   sha256 "c73a65789546935c26baf3522bb9c44aa8da09ef1d4409efcdb98a567a34e158"
 

--- a/cask_renames.json
+++ b/cask_renames.json
@@ -146,6 +146,7 @@
   "phpwebstudy": "flyenv",
   "pivy": "pivy-app",
   "pop": "pop-app",
+  "postgres-unofficial": "postgres-app",
   "posturr": "dorso",
   "ppsspp": "ppsspp-emulator",
   "protonmail-bridge": "proton-mail-bridge",


### PR DESCRIPTION
Addresses https://github.com/Homebrew/homebrew-cask/pull/217076#pullrequestreview-3925684681 after @MikeMcQuaid approved the idea.

> I came across this old thread: [#105712 (review)](https://github.com/Homebrew/homebrew-cask/pull/105712#pullrequestreview-659585488) where @SMillerDev commented on this change:
> 
> ```diff
> diff --git a/Casks/postgres.rb b/Casks/postgres-unofficial.rb
> similarity index 94%
> rename from Casks/postgres.rb
> rename to Casks/postgres-unofficial.rb
> index 345e1bd1f1cfe..6fc5d5d6ce56e 100644
> --- a/Casks/postgres.rb
> +++ b/Casks/postgres-unofficial.rb
> @@ -1,10 +1,11 @@
> -cask "postgres" do
> +cask "postgres-unofficial" do
>    version "2.4.2"
> ```
> 
> saying:
> 
> > I think it makes sense to call this postgres-app since that's also the project name on github.
> 
> but the replies indicate that at that time the `-app` suffix was not acceptable.
> 
> It seems that is no longer the case, though, given that this (much more recent) PR renamed many casks with the `-app` suffix. So now I'm curious: is Homebrew now open to renaming the cask for https://github.com/PostgresApp/PostgresApp / https://postgresapp.com / Postgres.app from `postgres-unofficial` to `postgres-app`?

-----

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
  - errors with `Error: Cask 'postgres-app' is unavailable: No Cask with this name exists.` due to the chicken-and-egg problem with renaming a cask. CI passed, though
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**: N/A

**If AI was used to generate or assist with generating the PR**: AI was not used