### PR TITLE
nteract 1.4.1 (arm only)

### DIFF
--- a/Casks/n/nteract.rb
+++ b/Casks/n/nteract.rb
@@ -1,32 +1,61 @@
 cask "nteract" do
-  version "0.28.0"
-  sha256 "de65abe5ed76489217a9c29bcc177aa5b2ee2f0657cd017301af33280ca8a737"
+  on_arm do
+    version "1.4.1,202603102148"
+    sha256 "04ac771e428c08926a0f53845f52c8e2414b3504d58849b5420f36a5100b8522"
 
-  url "https://github.com/nteract/nteract/releases/download/v#{version}/nteract-#{version}.dmg"
+    url "https://github.com/nteract/desktop/releases/download/v#{version.csv.first}-stable.#{version.csv.second}/nteract-stable-darwin-arm64.dmg"
+
+    livecheck do
+      url "https://github.com/nteract/desktop/releases/download/stable-latest/latest.json"
+      regex(/v?(\d+(?:\.\d+)+)(?:[._-]stable)?[._-](\d+(?:\.\d+)*)/i)
+      strategy :json do |json, regex|
+        match = json["version"]&.match(regex)
+        next unless match
+
+        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+      end
+    end
+
+    uninstall delete: [
+      "/usr/local/bin/nb",
+      "/usr/local/bin/runt",
+    ]
+
+    zap trash: [
+      "~/Library/Application Support/nteract",
+      "~/Library/Application Support/org.nteract.desktop",
+      "~/Library/Caches/org.nteract.desktop",
+      "~/Library/WebKit/org.nteract.desktop",
+    ]
+  end
+  on_intel do
+    version "0.28.0"
+    sha256 "de65abe5ed76489217a9c29bcc177aa5b2ee2f0657cd017301af33280ca8a737"
+
+    url "https://github.com/nteract/archived-desktop-app/releases/download/v#{version}/nteract-#{version}.dmg"
+
+    livecheck do
+      skip "Legacy version"
+    end
+
+    deprecate! date: "2026-03-07", because: :discontinued
+
+    auto_updates true
+
+    uninstall delete: "/usr/local/bin/nteract"
+
+    zap trash: [
+      "~/Library/Application Support/Caches/nteract-updater",
+      "~/Library/Application Support/nteract",
+      "~/Library/Logs/nteract",
+      "~/Library/Preferences/io.nteract.nteract.plist",
+      "~/Library/Saved Application State/io.nteract.nteract.savedState",
+    ]
+  end
+
   name "nteract"
   desc "Interactive computing suite"
-  homepage "https://github.com/nteract/nteract"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  auto_updates true
+  homepage "https://github.com/nteract/desktop"
 
   app "nteract.app"
-
-  uninstall delete: "/usr/local/bin/nteract"
-
-  zap trash: [
-    "~/Library/Application Support/Caches/nteract-updater",
-    "~/Library/Application Support/nteract",
-    "~/Library/Logs/nteract",
-    "~/Library/Preferences/io.nteract.nteract.plist",
-    "~/Library/Saved Application State/io.nteract.nteract.savedState",
-  ]
-
-  caveats do
-    requires_rosetta
-  end
 end

--- a/Casks/n/nteract.rb
+++ b/Casks/n/nteract.rb
@@ -1,61 +1,36 @@
 cask "nteract" do
-  on_arm do
-    version "1.4.1,202603102148"
-    sha256 "04ac771e428c08926a0f53845f52c8e2414b3504d58849b5420f36a5100b8522"
+  version "1.4.1,202603102148"
+  sha256 "04ac771e428c08926a0f53845f52c8e2414b3504d58849b5420f36a5100b8522"
 
-    url "https://github.com/nteract/desktop/releases/download/v#{version.csv.first}-stable.#{version.csv.second}/nteract-stable-darwin-arm64.dmg"
-
-    livecheck do
-      url "https://github.com/nteract/desktop/releases/download/stable-latest/latest.json"
-      regex(/v?(\d+(?:\.\d+)+)(?:[._-]stable)?[._-](\d+(?:\.\d+)*)/i)
-      strategy :json do |json, regex|
-        match = json["version"]&.match(regex)
-        next unless match
-
-        match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
-      end
-    end
-
-    uninstall delete: [
-      "/usr/local/bin/nb",
-      "/usr/local/bin/runt",
-    ]
-
-    zap trash: [
-      "~/Library/Application Support/nteract",
-      "~/Library/Application Support/org.nteract.desktop",
-      "~/Library/Caches/org.nteract.desktop",
-      "~/Library/WebKit/org.nteract.desktop",
-    ]
-  end
-  on_intel do
-    version "0.28.0"
-    sha256 "de65abe5ed76489217a9c29bcc177aa5b2ee2f0657cd017301af33280ca8a737"
-
-    url "https://github.com/nteract/archived-desktop-app/releases/download/v#{version}/nteract-#{version}.dmg"
-
-    livecheck do
-      skip "Legacy version"
-    end
-
-    deprecate! date: "2026-03-07", because: :discontinued
-
-    auto_updates true
-
-    uninstall delete: "/usr/local/bin/nteract"
-
-    zap trash: [
-      "~/Library/Application Support/Caches/nteract-updater",
-      "~/Library/Application Support/nteract",
-      "~/Library/Logs/nteract",
-      "~/Library/Preferences/io.nteract.nteract.plist",
-      "~/Library/Saved Application State/io.nteract.nteract.savedState",
-    ]
-  end
-
+  url "https://github.com/nteract/desktop/releases/download/v#{version.csv.first}-stable.#{version.csv.second}/nteract-stable-darwin-arm64.dmg"
   name "nteract"
   desc "Interactive computing suite"
   homepage "https://github.com/nteract/desktop"
 
+  livecheck do
+    url "https://github.com/nteract/desktop/releases/download/stable-latest/latest.json"
+    regex(/v?(\d+(?:\.\d+)+)(?:[._-]stable)?[._-](\d+(?:\.\d+)*)/i)
+    strategy :json do |json, regex|
+      match = json["version"]&.match(regex)
+      next unless match
+
+      match[2].present? ? "#{match[1]},#{match[2]}" : match[1]
+    end
+  end
+
+  depends_on arch: :arm64
+
   app "nteract.app"
+
+  uninstall delete: [
+    "/usr/local/bin/nb",
+    "/usr/local/bin/runt",
+  ]
+
+  zap trash: [
+    "~/Library/Application Support/nteract",
+    "~/Library/Application Support/org.nteract.desktop",
+    "~/Library/Caches/org.nteract.desktop",
+    "~/Library/WebKit/org.nteract.desktop",
+  ]
 end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The old `nteract` app that supported Intel has been discontinued and is being replaced by a new app that only supports ARM. This updates the cask to use the new app on ARM and updates the URL for the old Intel app to the archived-desktop-app repository to fix the URL (the nteract/nteract repository was repurposed and does not contain the old or new app).

I've set this as a draft for now, to allow us to discuss whether this is the best approach for handling this migration.