### PR TITLE
adobe-connect: update livecheck

### DIFF
--- a/Casks/a/adobe-connect.rb
+++ b/Casks/a/adobe-connect.rb
@@ -12,7 +12,7 @@ cask "adobe-connect" do
   livecheck do
     url "https://helpx.adobe.com/adobe-connect/connect-downloads-updates.html",
         user_agent: :browser
-    regex(/macOS.*?v?(\d+(?:\.\d+)+)[< "]/im)
+    regex(/Download\s+for\s+macOS.*?v?(\d+(?:\.\d+)+)[< "]/im)
     strategy :page_match do |page, regex|
       version = page.scan(regex)&.flatten&.first
       directory = page.scan(/href=.*ConnectMac(\d+)Plus/i)&.flatten&.first


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

The `livecheck` block for `adobe-connect` matches version text like "v2025.8.157" that appears after "macOS" on the upstream download page but this no longer works as intended. The page now includes "macOS" text that appears earlier in the page content and it's followed by "Adobe Connect 12.11 release", so the check wrongly returns "12.11,11" as the newest version. This addresses the issue by modifying the regex to use "Download for macOS" as the anchor text instead of "macOS".