### PR TITLE
proton-pass: update url

### DIFF
--- a/Casks/p/proton-pass.rb
+++ b/Casks/p/proton-pass.rb
@@ -2,7 +2,7 @@ cask "proton-pass" do
   version "1.35.0"
   sha256 "cf05758c16eda6533b4dd4b52a4122f35dd9d9ec78e73dc13f6640ef6b3aa711"
 
-  url "https://proton.me/download/PassDesktop/darwin/universal/ProtonPass_#{version}.dmg"
+  url "https://proton.me/download/pass/macos/ProtonPass_#{version}.dmg"
   name "Proton Pass"
   desc "Desktop client for Proton Pass"
   homepage "https://proton.me/pass"


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [ ] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [ ] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

Some users have reported issues with Proton casks and I had some intermittent issues when testing but it was either due to upstream issues that resolved on their own or the server is sensitive to IP address (I can't account for it). This updates the asset URL for `proton-pass` to align with the URL in the JSON file that the `livecheck` block checks, just in case it has an impact. I tested the existing URL and the updated URL and they both served the same file to me without issue, so the issues that users are experiencing may be unrelated and out of our control.