### PR TITLE
Add mtmr-designer cask

### DIFF
--- a/Casks/m/mtmr-designer.rb
+++ b/Casks/m/mtmr-designer.rb
@@ -1,0 +1,24 @@
+cask "mtmr-designer" do
+  version "2026.1,build.16"
+  sha256 "20821b01fbe109e8ec34e3fceef8623ca25771d2bbf0dfa6067faeda9d3f6990"
+
+  url "https://github.com/josmanvis/mtmr-designer/releases/download/v#{version.csv.second}/MTMR-2026-#{version.csv.first}.dmg"
+  name "MTMR Designer"
+  desc "Visual drag-and-drop designer for Touch Bar presets"
+  homepage "https://github.com/josmanvis/mtmr-designer"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :high_sierra"
+
+  app "MTMR 2026.app"
+
+  zap trash: [
+    "~/Library/Application Support/MTMR",
+    "~/Library/Caches/com.mtmr-designer.mtmr2026",
+    "~/Library/Preferences/com.mtmr-designer.mtmr2026.plist",
+  ]
+end

--- a/Casks/m/mtmr-designer.rb
+++ b/Casks/m/mtmr-designer.rb
@@ -2,7 +2,7 @@ cask "mtmr-designer" do
   version "2026.1,build.16"
   sha256 "20821b01fbe109e8ec34e3fceef8623ca25771d2bbf0dfa6067faeda9d3f6990"
 
-  url "https://github.com/josmanvis/mtmr-designer/releases/download/v#{version.csv.second}/MTMR-2026-#{version.csv.first}.dmg"
+  url "https://github.com/josmanvis/mtmr-designer/releases/download/v#{version.csv.first}-#{version.csv.second}/MTMR-2026-#{version.csv.first}.dmg"
   name "MTMR Designer"
   desc "Visual drag-and-drop designer for Touch Bar presets"
   homepage "https://github.com/josmanvis/mtmr-designer"

--- a/Casks/m/mtmr-designer.rb
+++ b/Casks/m/mtmr-designer.rb
@@ -12,8 +12,6 @@ cask "mtmr-designer" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :high_sierra"
-
   app "MTMR 2026.app"
 
   zap trash: [


### PR DESCRIPTION
This adds MTMR Designer, a visual drag-and-drop designer for Touch Bar presets.

Homepage: https://github.com/josmanvis/mtmr-designer

- [x] `brew style` passes
- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference)
- [x] `brew livecheck` will automatically detect the latest version

## About MTMR Designer

MTMR Designer is a visual editor for creating custom Touch Bar configurations for the [MTMR](https://github.com/ToxBlah/MTMR) app. It features:
- Visual drag-and-drop editor
- 39 element types (buttons, sliders, native plugins)
- Live JSON preview and editing
- Preset management system
- Direct MTMR integration

The app is distributed via GitHub Releases as a DMG file.