### PR TITLE
Add clashx cask

### DIFF
--- a/Casks/c/clashx.rb
+++ b/Casks/c/clashx.rb
@@ -5,7 +5,7 @@ cask "clashx" do
   url "https://github.com/ClashX-Pro/ClashX/releases/download/#{version}/ClashX.dmg",
       verified: "github.com/ClashX-Pro/ClashX/"
   name "ClashX"
-  desc "Rule-based custom proxy with GUI based on Clash for macOS"
+  desc "Rule-based custom proxy with GUI based on Clash"
   homepage "https://clashx.tech/"
 
   livecheck do
@@ -18,9 +18,9 @@ cask "clashx" do
   app "ClashX.app"
 
   zap trash: [
+    "~/.config/clash",
     "~/Library/Application Support/com.west2online.ClashX",
     "~/Library/Caches/com.west2online.ClashX",
     "~/Library/Preferences/com.west2online.ClashX.plist",
-    "~/.config/clash",
   ]
 end

--- a/Casks/c/clashx.rb
+++ b/Casks/c/clashx.rb
@@ -14,7 +14,6 @@ cask "clashx" do
   end
 
   auto_updates true
-  depends_on macos: ">= :mojave"
 
   app "ClashX.app"
 

--- a/Casks/c/clashx.rb
+++ b/Casks/c/clashx.rb
@@ -1,0 +1,27 @@
+cask "clashx" do
+  version "1.122.0"
+  sha256 "dec7865d9f6cae9d060ee2cc1393125cabb1cc19414959bf62442e1f35e5ca28"
+
+  url "https://github.com/ClashX-Pro/ClashX/releases/download/#{version}/ClashX.dmg",
+      verified: "github.com/ClashX-Pro/ClashX/"
+  name "ClashX"
+  desc "Rule-based custom proxy with GUI based on Clash for macOS"
+  homepage "https://clashx.tech/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :mojave"
+
+  app "ClashX.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.west2online.ClashX",
+    "~/Library/Caches/com.west2online.ClashX",
+    "~/Library/Preferences/com.west2online.ClashX.plist",
+    "~/.config/clash",
+  ]
+end


### PR DESCRIPTION
## Description

Add a new cask for [ClashX](https://clashx.tech/), a rule-based custom proxy client with GUI for macOS, based on the Clash core.

- **App name:** ClashX
- **Version:** 1.122.0
- **Homepage:** https://clashx.tech/
- **Repository:** https://github.com/ClashX-Pro/ClashX (272+ stars)
- **License:** AGPL-3.0
- **Architecture:** Universal binary (x86_64 + arm64)
- **Minimum macOS:** 10.14 (Mojave)
- **Download format:** DMG containing ClashX.app

ClashX is a widely-used macOS proxy tool in the Clash ecosystem. Similar tools like [clash-verge-rev](https://formulae.brew.sh/cask/clash-verge-rev) and clash-mi are already available as Homebrew casks.

### Verification

- SHA256 verified against official GitHub release
- Universal binary confirmed via `lipo -archs`
- Bundle identifier: `com.west2online.ClashX`
- Livecheck configured with `strategy :github_latest`
- `auto_updates true` (app has built-in Sparkle updater)
- `zap` stanza includes Application Support, Caches, Preferences, and config directory