### PR TITLE
Inkwell 1.1 (new cask)

### DIFF
--- a/Casks/i/inkwell.rb
+++ b/Casks/i/inkwell.rb
@@ -1,0 +1,11 @@
+cask "inkwell" do
+  version "1.1"
+  sha256 "163376222aed647c8744f2f28b607f79ae4eca79c5d35f983906a130fc677e8a"
+
+  url "https://github.com/4worlds4w-svg/inkwell/releases/download/v#{version}/Inkwell_#{version}_aarch64.dmg"
+  name "Inkwell"
+  desc "Lightweight Markdown editor with split view, live preview, themes, and focus mode"
+  homepage "https://github.com/4worlds4w-svg/inkwell"
+
+  app "Inkwell.app"
+end

--- a/Casks/i/inkwell.rb
+++ b/Casks/i/inkwell.rb
@@ -4,7 +4,7 @@ cask "inkwell" do
 
   url "https://github.com/4worlds4w-svg/inkwell/releases/download/v#{version}/Inkwell_#{version}_aarch64.dmg"
   name "Inkwell"
-  desc "Lightweight Markdown editor with split view, live preview, themes, and focus mode"
+  desc "Markdown editor with split view, live preview, themes, and focus mode"
   homepage "https://github.com/4worlds4w-svg/inkwell"
 
   app "Inkwell.app"


### PR DESCRIPTION
Lightweight Markdown editor with split view, live preview, themes, focus mode, and diff viewer.

- **Homepage**: https://github.com/4worlds4w-svg/inkwell
- **License**: Freeware
- **Architecture**: aarch64 (Apple Silicon)
- **Download**: DMG from GitHub Releases