### PR TITLE
libation 13.3.0 (new cask)

### DIFF
--- a/Casks/l/libation.rb
+++ b/Casks/l/libation.rb
@@ -1,0 +1,24 @@
+cask "libation" do
+  arch arm: "arm64", intel: "x64"
+
+  version "13.3.0"
+  sha256 arm:   "6cdcbfb3a2851c5c1713008600b1e069ebda42423e1cbac465bec23d5ee14f0f",
+         intel: "c511d6a836d5b0e3310d34f7bc26ea6e87f1579d2aa5b83769c978517c56c6ad"
+
+  url "https://github.com/rmcrackan/Libation/releases/download/v#{version}/Libation.#{version}-macOS-chardonnay-#{arch}.dmg",
+      verified: "github.com/rmcrackan/Libation/"
+  name "Libation"
+  desc "Audible audiobook manager and library tool"
+  homepage "https://getlibation.com/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :catalina"
+
+  app "Libation.app"
+
+  zap trash: "~/Library/Application Support/Libation"
+end


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [x] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [x] `brew audit --cask --new <cask>` worked successfully.
- [x] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [x] `brew uninstall --cask <cask>` worked successfully.

-----

**If AI was used to generate or assist with generating the PR**:

- [x] I used AI to generate or assist with generating this PR. *Please specify below how you used AI to help you*.
- [x] I have personally reviewed, tested and verified *all* changes/additions, including [`zap` stanza](https://docs.brew.sh/Cask-Cookbook#stanza-zap) paths.

-----

AI was used for drafting the initial cask file. I personally manually completed all audits, tested installation, uninstallation, with and without zap, and performed gatekeeper verification.

Note: Prior PRs (#244250, #247162) were closed due to notarization concerns. Libation has been signed and notarized since v12.7.2.

Here are the release notes for the libation version adding macOS signed disk images:
https://github.com/rmcrackan/Libation/releases/tag/v12.7.2

Please see gatekeeper verification below:

<details>
<summary>Gatekeeper verification</summary>

```
$ spctl --assess --verbose=4 --type install /Applications/Libation.app
/Applications/Libation.app: accepted
source=Notarized Developer ID
```

```
$ codesign -dv --verbose=2 /Applications/Libation.app                 
Executable=/Applications/Libation.app/Contents/MacOS/Libation
Identifier=org.libation.macos
Format=bundle with Mach-O thin (arm64)
CodeDirectory v=20500 size=1342 flags=0x10000(runtime) hashes=31+7 location=embedded
Signature size=8999
Authority=Developer ID Application: MICHAEL PAUL BUCARI-TOVO (5TUHF7W9P9)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
Timestamp=Mar 12, 2026 at 6:45:17 AM
Info.plist entries=9
TeamIdentifier=5TUHF7W9P9
Runtime Version=15.5.0
Sealed Resources version=2 rules=13 files=320
Internal requirements count=1 size=180
```

</details>